### PR TITLE
 kubectl helpers test: remove core dependencies

### DIFF
--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -61,9 +61,7 @@ go_test(
     srcs = ["helpers_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/testapi:go_default_library",
-        "//pkg/api/testing:go_default_library",
-        "//pkg/apis/core:go_default_library",
+        "//pkg/kubectl/scheme:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/kubectl/cmd/util/helpers_test.go
+++ b/pkg/kubectl/cmd/util/helpers_test.go
@@ -24,7 +24,7 @@ import (
 	"syscall"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -32,15 +32,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/kubernetes/pkg/api/testapi"
-	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/utils/exec"
 )
 
 func TestMerge(t *testing.T) {
 	grace := int64(30)
-	enableServiceLinks := v1.DefaultEnableServiceLinks
+	enableServiceLinks := corev1.DefaultEnableServiceLinks
 	tests := []struct {
 		obj       runtime.Object
 		fragment  string
@@ -48,33 +46,44 @@ func TestMerge(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			obj: &api.Pod{
+			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
 			},
 			fragment: fmt.Sprintf(`{ "apiVersion": "%s" }`, "v1"),
-			expected: &api.Pod{
+			expected: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: apitesting.DeepEqualSafePodSpec(),
+				Spec: corev1.PodSpec{
+					RestartPolicy:                 corev1.RestartPolicyAlways,
+					DNSPolicy:                     corev1.DNSClusterFirst,
+					TerminationGracePeriodSeconds: &grace,
+					SecurityContext:               &corev1.PodSecurityContext{},
+					SchedulerName:                 corev1.DefaultSchedulerName,
+					EnableServiceLinks:            &enableServiceLinks,
+				},
 			},
 		},
 		/* TODO: uncomment this test once Merge is updated to use
 		strategic-merge-patch. See #8449.
 		{
-			obj: &api.Pod{
+			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						api.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						corev1.Container{
 							Name:  "c1",
 							Image: "red-image",
 						},
-						api.Container{
+						corev1.Container{
 							Name:  "c2",
 							Image: "blue-image",
 						},
@@ -82,17 +91,17 @@ func TestMerge(t *testing.T) {
 				},
 			},
 			fragment: fmt.Sprintf(`{ "apiVersion": "%s", "spec": { "containers": [ { "name": "c1", "image": "green-image" } ] } }`, schema.GroupVersion{Group:"", Version: "v1"}.String()),
-			expected: &api.Pod{
+			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						api.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						corev1.Container{
 							Name:  "c1",
 							Image: "green-image",
 						},
-						api.Container{
+						corev1.Container{
 							Name:  "c2",
 							Image: "blue-image",
 						},
@@ -101,59 +110,67 @@ func TestMerge(t *testing.T) {
 			},
 		}, */
 		{
-			obj: &api.Pod{
+			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
 			},
 			fragment: fmt.Sprintf(`{ "apiVersion": "%s", "spec": { "volumes": [ {"name": "v1"}, {"name": "v2"} ] } }`, "v1"),
-			expected: &api.Pod{
+			expected: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: api.PodSpec{
-					Volumes: []api.Volume{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
 						{
 							Name:         "v1",
-							VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}},
+							VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 						},
 						{
 							Name:         "v2",
-							VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}},
+							VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 						},
 					},
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
+					RestartPolicy:                 corev1.RestartPolicyAlways,
+					DNSPolicy:                     corev1.DNSClusterFirst,
 					TerminationGracePeriodSeconds: &grace,
-					SecurityContext:               &api.PodSecurityContext{},
-					SchedulerName:                 api.DefaultSchedulerName,
+					SecurityContext:               &corev1.PodSecurityContext{},
+					SchedulerName:                 corev1.DefaultSchedulerName,
 					EnableServiceLinks:            &enableServiceLinks,
 				},
 			},
 		},
 		{
-			obj:       &api.Pod{},
+			obj:       &corev1.Pod{},
 			fragment:  "invalid json",
-			expected:  &api.Pod{},
+			expected:  &corev1.Pod{},
 			expectErr: true,
 		},
 		{
-			obj:       &api.Service{},
+			obj:       &corev1.Service{},
 			fragment:  `{ "apiVersion": "badVersion" }`,
 			expectErr: true,
 		},
 		{
-			obj: &api.Service{
-				Spec: api.ServiceSpec{},
+			obj: &corev1.Service{
+				Spec: corev1.ServiceSpec{},
 			},
 			fragment: fmt.Sprintf(`{ "apiVersion": "%s", "spec": { "ports": [ { "port": 0 } ] } }`, "v1"),
-			expected: &api.Service{
-				Spec: api.ServiceSpec{
+			expected: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				Spec: corev1.ServiceSpec{
 					SessionAffinity: "None",
-					Type:            api.ServiceTypeClusterIP,
-					Ports: []api.ServicePort{
+					Type:            corev1.ServiceTypeClusterIP,
+					Ports: []corev1.ServicePort{
 						{
-							Protocol: api.ProtocolTCP,
+							Protocol: corev1.ProtocolTCP,
 							Port:     0,
 						},
 					},
@@ -161,18 +178,22 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		{
-			obj: &api.Service{
-				Spec: api.ServiceSpec{
+			obj: &corev1.Service{
+				Spec: corev1.ServiceSpec{
 					Selector: map[string]string{
 						"version": "v1",
 					},
 				},
 			},
 			fragment: fmt.Sprintf(`{ "apiVersion": "%s", "spec": { "selector": { "version": "v2" } } }`, "v1"),
-			expected: &api.Service{
-				Spec: api.ServiceSpec{
+			expected: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				Spec: corev1.ServiceSpec{
 					SessionAffinity: "None",
-					Type:            api.ServiceTypeClusterIP,
+					Type:            corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"version": "v2",
 					},
@@ -181,12 +202,14 @@ func TestMerge(t *testing.T) {
 		},
 	}
 
+	codec := runtime.NewCodec(scheme.DefaultJSONEncoder(),
+		scheme.Codecs.UniversalDecoder(scheme.Scheme.PrioritizedVersionsAllGroups()...))
 	for i, test := range tests {
-		out, err := Merge(testapi.Default.Codec(), test.obj, test.fragment)
+		out, err := Merge(codec, test.obj, test.fragment)
 		if !test.expectErr {
 			if err != nil {
 				t.Errorf("testcase[%d], unexpected error: %v", i, err)
-			} else if !apiequality.Semantic.DeepEqual(out, test.expected) {
+			} else if !apiequality.Semantic.DeepEqual(test.expected, out) {
 				t.Errorf("\n\ntestcase[%d]\nexpected:\n%+v\nsaw:\n%+v", i, test.expected, out)
 			}
 		}
@@ -205,22 +228,22 @@ type checkErrTestCase struct {
 func TestCheckInvalidErr(t *testing.T) {
 	testCheckError(t, []checkErrTestCase{
 		{
-			errors.NewInvalid(api.Kind("Invalid1"), "invalidation", field.ErrorList{field.Invalid(field.NewPath("field"), "single", "details")}),
+			errors.NewInvalid(corev1.SchemeGroupVersion.WithKind("Invalid1").GroupKind(), "invalidation", field.ErrorList{field.Invalid(field.NewPath("field"), "single", "details")}),
 			"The Invalid1 \"invalidation\" is invalid: field: Invalid value: \"single\": details\n",
 			DefaultErrorExitCode,
 		},
 		{
-			errors.NewInvalid(api.Kind("Invalid2"), "invalidation", field.ErrorList{field.Invalid(field.NewPath("field1"), "multi1", "details"), field.Invalid(field.NewPath("field2"), "multi2", "details")}),
+			errors.NewInvalid(corev1.SchemeGroupVersion.WithKind("Invalid2").GroupKind(), "invalidation", field.ErrorList{field.Invalid(field.NewPath("field1"), "multi1", "details"), field.Invalid(field.NewPath("field2"), "multi2", "details")}),
 			"The Invalid2 \"invalidation\" is invalid: \n* field1: Invalid value: \"multi1\": details\n* field2: Invalid value: \"multi2\": details\n",
 			DefaultErrorExitCode,
 		},
 		{
-			errors.NewInvalid(api.Kind("Invalid3"), "invalidation", field.ErrorList{}),
+			errors.NewInvalid(corev1.SchemeGroupVersion.WithKind("Invalid3").GroupKind(), "invalidation", field.ErrorList{}),
 			"The Invalid3 \"invalidation\" is invalid",
 			DefaultErrorExitCode,
 		},
 		{
-			errors.NewInvalid(api.Kind("Invalid4"), "invalidation", field.ErrorList{field.Invalid(field.NewPath("field4"), "multi4", "details"), field.Invalid(field.NewPath("field4"), "multi4", "details")}),
+			errors.NewInvalid(corev1.SchemeGroupVersion.WithKind("Invalid4").GroupKind(), "invalidation", field.ErrorList{field.Invalid(field.NewPath("field4"), "multi4", "details"), field.Invalid(field.NewPath("field4"), "multi4", "details")}),
 			"The Invalid4 \"invalidation\" is invalid: field4: Invalid value: \"multi4\": details\n",
 			DefaultErrorExitCode,
 		},


### PR DESCRIPTION
* Removes dependency on core testapi.
* Removes dependency on core testing library.
* Replaces internal Pod and Service resource with external/corev1 resources.
* Various other small cleanups.

Helps address:
https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
