### PR TITLE
Added ':' in environment variable name valid characters list

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -83269,7 +83269,7 @@
       "x-kubernetes-patch-strategy": "merge"
      },
      "envFrom": {
-      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+      "description": "List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except '='. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
@@ -83761,7 +83761,7 @@
       "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource"
      },
      "prefix": {
-      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+      "description": "An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed.",
       "type": "string"
      },
      "secretRef": {
@@ -83777,7 +83777,7 @@
     ],
     "properties": {
      "name": {
-      "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+      "description": "Name of the environment variable. Except '=' character all other characters allowed.",
       "type": "string"
      },
      "value": {

--- a/api/swagger-spec/apps_v1.json
+++ b/api/swagger-spec/apps_v1.json
@@ -8202,7 +8202,7 @@
       "items": {
        "$ref": "v1.EnvFromSource"
       },
-      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
+      "description": "List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except '='. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
      },
      "env": {
       "type": "array",
@@ -8308,7 +8308,7 @@
     "properties": {
      "prefix": {
       "type": "string",
-      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER."
+      "description": "An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed."
      },
      "configMapRef": {
       "$ref": "v1.ConfigMapEnvSource",
@@ -8357,7 +8357,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name of the environment variable. Must be a C_IDENTIFIER."
+      "description": "Name of the environment variable. Except '=' character all other characters allowed."
      },
      "value": {
       "type": "string",

--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -5714,7 +5714,7 @@
       "items": {
        "$ref": "v1.EnvFromSource"
       },
-      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
+      "description": "List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except '='. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
      },
      "env": {
       "type": "array",
@@ -5820,7 +5820,7 @@
     "properties": {
      "prefix": {
       "type": "string",
-      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER."
+      "description": "An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed."
      },
      "configMapRef": {
       "$ref": "v1.ConfigMapEnvSource",
@@ -5869,7 +5869,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name of the environment variable. Must be a C_IDENTIFIER."
+      "description": "Name of the environment variable. Except '=' character all other characters allowed."
      },
      "value": {
       "type": "string",

--- a/api/swagger-spec/apps_v1beta2.json
+++ b/api/swagger-spec/apps_v1beta2.json
@@ -8202,7 +8202,7 @@
       "items": {
        "$ref": "v1.EnvFromSource"
       },
-      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
+      "description": "List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except '='. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
      },
      "env": {
       "type": "array",
@@ -8308,7 +8308,7 @@
     "properties": {
      "prefix": {
       "type": "string",
-      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER."
+      "description": "An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed."
      },
      "configMapRef": {
       "$ref": "v1.ConfigMapEnvSource",
@@ -8357,7 +8357,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name of the environment variable. Must be a C_IDENTIFIER."
+      "description": "Name of the environment variable. Except '=' character all other characters allowed."
      },
      "value": {
       "type": "string",

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -2898,7 +2898,7 @@
       "items": {
        "$ref": "v1.EnvFromSource"
       },
-      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
+      "description": "List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except '='. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
      },
      "env": {
       "type": "array",
@@ -3004,7 +3004,7 @@
     "properties": {
      "prefix": {
       "type": "string",
-      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER."
+      "description": "An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed."
      },
      "configMapRef": {
       "$ref": "v1.ConfigMapEnvSource",
@@ -3053,7 +3053,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name of the environment variable. Must be a C_IDENTIFIER."
+      "description": "Name of the environment variable. Except '=' character all other characters allowed."
      },
      "value": {
       "type": "string",

--- a/api/swagger-spec/batch_v1beta1.json
+++ b/api/swagger-spec/batch_v1beta1.json
@@ -2953,7 +2953,7 @@
       "items": {
        "$ref": "v1.EnvFromSource"
       },
-      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
+      "description": "List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except '='. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
      },
      "env": {
       "type": "array",
@@ -3059,7 +3059,7 @@
     "properties": {
      "prefix": {
       "type": "string",
-      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER."
+      "description": "An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed."
      },
      "configMapRef": {
       "$ref": "v1.ConfigMapEnvSource",
@@ -3108,7 +3108,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name of the environment variable. Must be a C_IDENTIFIER."
+      "description": "Name of the environment variable. Except '=' character all other characters allowed."
      },
      "value": {
       "type": "string",

--- a/api/swagger-spec/batch_v2alpha1.json
+++ b/api/swagger-spec/batch_v2alpha1.json
@@ -2953,7 +2953,7 @@
       "items": {
        "$ref": "v1.EnvFromSource"
       },
-      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
+      "description": "List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except '='. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
      },
      "env": {
       "type": "array",
@@ -3059,7 +3059,7 @@
     "properties": {
      "prefix": {
       "type": "string",
-      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER."
+      "description": "An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed."
      },
      "configMapRef": {
       "$ref": "v1.ConfigMapEnvSource",
@@ -3108,7 +3108,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name of the environment variable. Must be a C_IDENTIFIER."
+      "description": "Name of the environment variable. Except '=' character all other characters allowed."
      },
      "value": {
       "type": "string",

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -8898,7 +8898,7 @@
       "items": {
        "$ref": "v1.EnvFromSource"
       },
-      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
+      "description": "List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except '='. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
      },
      "env": {
       "type": "array",
@@ -9004,7 +9004,7 @@
     "properties": {
      "prefix": {
       "type": "string",
-      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER."
+      "description": "An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed."
      },
      "configMapRef": {
       "$ref": "v1.ConfigMapEnvSource",
@@ -9053,7 +9053,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name of the environment variable. Must be a C_IDENTIFIER."
+      "description": "Name of the environment variable. Except '=' character all other characters allowed."
      },
      "value": {
       "type": "string",

--- a/api/swagger-spec/settings.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/settings.k8s.io_v1alpha1.json
@@ -1443,7 +1443,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name of the environment variable. Must be a C_IDENTIFIER."
+      "description": "Name of the environment variable. Except '=' character all other characters allowed."
      },
      "value": {
       "type": "string",
@@ -1563,7 +1563,7 @@
     "properties": {
      "prefix": {
       "type": "string",
-      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER."
+      "description": "An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed."
      },
      "configMapRef": {
       "$ref": "v1.ConfigMapEnvSource",

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -22118,7 +22118,7 @@
       "items": {
        "$ref": "v1.EnvFromSource"
       },
-      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
+      "description": "List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except '='. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
      },
      "env": {
       "type": "array",
@@ -22224,7 +22224,7 @@
     "properties": {
      "prefix": {
       "type": "string",
-      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER."
+      "description": "An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed."
      },
      "configMapRef": {
       "$ref": "v1.ConfigMapEnvSource",
@@ -22273,7 +22273,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name of the environment variable. Must be a C_IDENTIFIER."
+      "description": "Name of the environment variable. Except '=' character all other characters allowed."
      },
      "value": {
       "type": "string",

--- a/docs/api-reference/apps/v1/definitions.html
+++ b/docs/api-reference/apps/v1/definitions.html
@@ -2287,7 +2287,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">prefix</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5690,7 +5690,7 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">envFrom</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except <em>=</em>. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_envfromsource">v1.EnvFromSource</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -7336,7 +7336,7 @@ The StatefulSet guarantees that a given network identity will always map to the 
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/apps/v1beta1/definitions.html
+++ b/docs/api-reference/apps/v1beta1/definitions.html
@@ -2302,7 +2302,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">prefix</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5825,7 +5825,7 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">envFrom</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except <em>=</em>. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_envfromsource">v1.EnvFromSource</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6856,7 +6856,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/apps/v1beta2/definitions.html
+++ b/docs/api-reference/apps/v1beta2/definitions.html
@@ -2704,7 +2704,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">prefix</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6159,7 +6159,7 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">envFrom</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except <em>=</em>. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_envfromsource">v1.EnvFromSource</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -7252,7 +7252,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/batch/v1/definitions.html
+++ b/docs/api-reference/batch/v1/definitions.html
@@ -1823,7 +1823,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">prefix</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4582,7 +4582,7 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">envFrom</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except <em>=</em>. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_envfromsource">v1.EnvFromSource</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5744,7 +5744,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/batch/v1beta1/definitions.html
+++ b/docs/api-reference/batch/v1beta1/definitions.html
@@ -1864,7 +1864,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">prefix</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4733,7 +4733,7 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">envFrom</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except <em>=</em>. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_envfromsource">v1.EnvFromSource</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5764,7 +5764,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/batch/v2alpha1/definitions.html
+++ b/docs/api-reference/batch/v2alpha1/definitions.html
@@ -1823,7 +1823,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">prefix</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4589,7 +4589,7 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">envFrom</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except <em>=</em>. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_envfromsource">v1.EnvFromSource</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5647,7 +5647,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -2898,7 +2898,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">prefix</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6537,7 +6537,7 @@ If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Po
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">envFrom</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except <em>=</em>. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_envfromsource">v1.EnvFromSource</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -7867,7 +7867,7 @@ If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Po
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/settings.k8s.io/v1alpha1/definitions.html
+++ b/docs/api-reference/settings.k8s.io/v1alpha1/definitions.html
@@ -2362,7 +2362,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">prefix</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2870,7 +2870,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -1666,7 +1666,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">prefix</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">An optional identifier to prepend to each key in the ConfigMap. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -10567,7 +10567,7 @@ More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifec
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">envFrom</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except <em>=</em>. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_envfromsource">v1.EnvFromSource</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -11329,7 +11329,7 @@ More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifec
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Must be a C_IDENTIFIER.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the environment variable. Except <em>=</em> character all other characters allowed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -1676,7 +1676,7 @@ type VolumeDevice struct {
 
 // EnvVar represents an environment variable present in a Container.
 type EnvVar struct {
-	// Required: This must be a C_IDENTIFIER.
+	// Required: Name of the environment variable. Except '=' character all other characters allowed.
 	Name string
 	// Optional: no more than one of the following may be specified.
 	// Optional: Defaults to ""; variable references $(VAR_NAME) are expanded
@@ -1953,9 +1953,8 @@ type Container struct {
 	// +optional
 	Ports []ContainerPort
 	// List of sources to populate environment variables in the container.
-	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-	// will be reported as an event when the container is starting. When a key exists in multiple
-	// sources, the value associated with the last source will take precedence.
+	// All invalid keys will be reported as an event when the container is starting.
+	// When a key exists in multiple sources, the value associated with the last source will take precedence.
 	// Values defined by an Env with a duplicate key will take precedence.
 	// Cannot be updated.
 	// +optional

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -43,7 +43,7 @@ import (
 const (
 	dnsLabelErrMsg          = "a DNS-1123 label must consist of"
 	dnsSubdomainLabelErrMsg = "a DNS-1123 subdomain"
-	envVarNameErrMsg        = "a valid environment variable name must consist of"
+	envVarNameErrMsg        = "a valid environment variable name must not contain '=' character"
 )
 
 func newHostPathType(pathType string) *core.HostPathType {
@@ -4446,24 +4446,9 @@ func TestValidateEnv(t *testing.T) {
 			expectedError: "[0].name: Required value",
 		},
 		{
-			name:          "illegal character",
-			envs:          []core.EnvVar{{Name: "a!b"}},
-			expectedError: `[0].name: Invalid value: "a!b": ` + envVarNameErrMsg,
-		},
-		{
-			name:          "dot only",
-			envs:          []core.EnvVar{{Name: "."}},
-			expectedError: `[0].name: Invalid value: ".": must not be`,
-		},
-		{
-			name:          "double dots only",
-			envs:          []core.EnvVar{{Name: ".."}},
-			expectedError: `[0].name: Invalid value: "..": must not be`,
-		},
-		{
-			name:          "leading double dots",
-			envs:          []core.EnvVar{{Name: "..abc"}},
-			expectedError: `[0].name: Invalid value: "..abc": must not start with`,
+			name:          "name with '=' character",
+			envs:          []core.EnvVar{{Name: "a=b"}},
+			expectedError: `[0].name: Invalid value: "a=b": ` + envVarNameErrMsg,
 		},
 		{
 			name: "value and valueFrom specified",
@@ -4778,12 +4763,12 @@ func TestValidateEnvFrom(t *testing.T) {
 			name: "invalid prefix",
 			envs: []core.EnvFromSource{
 				{
-					Prefix: "a!b",
+					Prefix: "=a!b",
 					ConfigMapRef: &core.ConfigMapEnvSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "abc"}},
 				},
 			},
-			expectedError: `field[0].prefix: Invalid value: "a!b": ` + envVarNameErrMsg,
+			expectedError: `field[0].prefix: Invalid value: "=a!b": ` + envVarNameErrMsg,
 		},
 		{
 			name: "zero-length name",
@@ -4809,12 +4794,12 @@ func TestValidateEnvFrom(t *testing.T) {
 			name: "invalid prefix",
 			envs: []core.EnvFromSource{
 				{
-					Prefix: "a!b",
+					Prefix: "=a!b",
 					SecretRef: &core.SecretEnvSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "abc"}},
 				},
 			},
-			expectedError: `field[0].prefix: Invalid value: "a!b": ` + envVarNameErrMsg,
+			expectedError: `field[0].prefix: Invalid value: "=a!b": ` + envVarNameErrMsg,
 		},
 		{
 			name: "no refs",
@@ -5473,7 +5458,7 @@ func TestValidateContainers(t *testing.T) {
 				ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"},
 		},
 		"invalid env var name": {
-			{Name: "abc", Image: "image", Env: []core.EnvVar{{Name: "ev!1"}}, ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"},
+			{Name: "abc", Image: "image", Env: []core.EnvVar{{Name: "=ev!1"}}, ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"},
 		},
 		"unknown volume name": {
 			{Name: "abc", Image: "image", VolumeMounts: []core.VolumeMount{{Name: "anything", MountPath: "/foo"}},

--- a/pkg/kubectl/generate/versioned/env_file_test.go
+++ b/pkg/kubectl/generate/versioned/env_file_test.go
@@ -37,7 +37,10 @@ func Test_processEnvFileLine(t *testing.T) {
 			append(utf8bom, 'a', '=', 'c'), 0, "a", "c", ""},
 
 		{"the utf8bom is NOT trimmed on the second line",
-			append(utf8bom, 'a', '=', 'c'), 1, "", "", "not a valid key name"},
+			append(utf8bom, 'a', '=', 'c'), 1, "\ufeffa", "c", ""},
+
+		{"the key should not contain '='",
+			[]byte{' ', '=', '=', 'c'}, 0, "", "", "not a valid key name"},
 
 		{"no key is returned on a comment line",
 			[]byte{' ', '#', 'c'}, 0, "", "", ""},

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -612,9 +612,9 @@ message Container {
   repeated ContainerPort ports = 6;
 
   // List of sources to populate environment variables in the container.
-  // The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-  // will be reported as an event when the container is starting. When a key exists in multiple
-  // sources, the value associated with the last source will take precedence.
+  // The keys defined within a source can contain all characters except '='. All invalid keys
+  // will be reported as an event when the container is starting.
+  // When a key exists in multiple sources, the value associated with the last source will take precedence.
   // Values defined by an Env with a duplicate key will take precedence.
   // Cannot be updated.
   // +optional
@@ -1046,7 +1046,7 @@ message EndpointsList {
 
 // EnvFromSource represents the source of a set of ConfigMaps
 message EnvFromSource {
-  // An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+  // An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed.
   // +optional
   optional string prefix = 1;
 
@@ -1061,7 +1061,7 @@ message EnvFromSource {
 
 // EnvVar represents an environment variable present in a Container.
 message EnvVar {
-  // Name of the environment variable. Must be a C_IDENTIFIER.
+  // Name of the environment variable. Except '=' character all other characters allowed.
   optional string name = 1;
 
   // Variable references $(VAR_NAME) are expanded

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -1769,7 +1769,7 @@ type VolumeDevice struct {
 
 // EnvVar represents an environment variable present in a Container.
 type EnvVar struct {
-	// Name of the environment variable. Must be a C_IDENTIFIER.
+	// Name of the environment variable. Except '=' character all other characters allowed.
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// Optional: no more than one of the following may be specified.
@@ -1852,7 +1852,7 @@ type SecretKeySelector struct {
 
 // EnvFromSource represents the source of a set of ConfigMaps
 type EnvFromSource struct {
-	// An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+	// An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed.
 	// +optional
 	Prefix string `json:"prefix,omitempty" protobuf:"bytes,1,opt,name=prefix"`
 	// The ConfigMap to select from
@@ -2089,9 +2089,9 @@ type Container struct {
 	// +listMapKey=protocol
 	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort" protobuf:"bytes,6,rep,name=ports"`
 	// List of sources to populate environment variables in the container.
-	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-	// will be reported as an event when the container is starting. When a key exists in multiple
-	// sources, the value associated with the last source will take precedence.
+	// The keys defined within a source can contain all characters except '='. All invalid keys
+	// will be reported as an event when the container is starting.
+	// When a key exists in multiple sources, the value associated with the last source will take precedence.
 	// Values defined by an Env with a duplicate key will take precedence.
 	// Cannot be updated.
 	// +optional

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -317,7 +317,7 @@ var map_Container = map[string]string{
 	"args":                     "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
 	"workingDir":               "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
 	"ports":                    "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
-	"envFrom":                  "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+	"envFrom":                  "List of sources to populate environment variables in the container. The keys defined within a source can contain all characters except '='. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
 	"env":                      "List of environment variables to set in the container. Cannot be updated.",
 	"resources":                "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
 	"volumeMounts":             "Pod volumes to mount into the container's filesystem. Cannot be updated.",
@@ -528,7 +528,7 @@ func (EndpointsList) SwaggerDoc() map[string]string {
 
 var map_EnvFromSource = map[string]string{
 	"":             "EnvFromSource represents the source of a set of ConfigMaps",
-	"prefix":       "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+	"prefix":       "An optional identifier to prepend to each key in the ConfigMap. Except '=' character all other characters allowed.",
 	"configMapRef": "The ConfigMap to select from",
 	"secretRef":    "The Secret to select from",
 }
@@ -539,7 +539,7 @@ func (EnvFromSource) SwaggerDoc() map[string]string {
 
 var map_EnvVar = map[string]string{
 	"":          "EnvVar represents an environment variable present in a Container.",
-	"name":      "Name of the environment variable. Must be a C_IDENTIFIER.",
+	"name":      "Name of the environment variable. Except '=' character all other characters allowed.",
 	"value":     "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
 	"valueFrom": "Source for the environment variable's value. Cannot be used if value is not empty.",
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -303,20 +303,17 @@ func IsHTTPHeaderName(value string) []string {
 	return nil
 }
 
-const envVarNameFmt = "[-._a-zA-Z][-._a-zA-Z0-9]*"
-const envVarNameFmtErrMsg string = "a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit"
+const envVarNameFmt = "[^=]+"
+const envVarNameFmtErrMsg string = "a valid environment variable name must not contain '=' character"
 
 var envVarNameRegexp = regexp.MustCompile("^" + envVarNameFmt + "$")
 
 // IsEnvVarName tests if a string is a valid environment variable name.
 func IsEnvVarName(value string) []string {
-	var errs []string
 	if !envVarNameRegexp.MatchString(value) {
-		errs = append(errs, RegexError(envVarNameFmtErrMsg, envVarNameFmt, "my.env-name", "MY_ENV.NAME", "MyEnvName1"))
+		return []string{RegexError(envVarNameFmtErrMsg, envVarNameFmt, "my.env-name", "MY_ENV.NAME", "MyEnvName1")}
 	}
-
-	errs = append(errs, hasChDirPrefix(value)...)
-	return errs
+	return nil
 }
 
 const configMapKeyFmt = `[-._a-zA-Z0-9]+`

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -539,3 +539,28 @@ func TestIsValidSocketAddr(t *testing.T) {
 		}
 	}
 }
+
+func TestIsEnvVarName(t *testing.T) {
+	goodValues := []string{
+		"-", ":", "_", "a", "A", "a-", "$a",
+		"a.", "a..", "a:", "a_", "aa", "aA",
+		"a0", "a-a", "a.a", "a:a", "a_a", "aAz",
+		"a0a", "a9", "a a", "_9", ".9", "a9a",
+		"0a", "0 a",
+	}
+	for _, val := range goodValues {
+		if msgs := IsEnvVarName(val); len(msgs) != 0 {
+			t.Errorf("expected true for '%s': %v", val, msgs)
+		}
+	}
+
+	badValues := []string{
+		"", "=", "a=", "1=a", "a=b", "#%=&&",
+		"= =", "=a", "a=",
+	}
+	for _, val := range badValues {
+		if msgs := IsEnvVarName(val); len(msgs) == 0 {
+			t.Errorf("expected false for '%s'", val)
+		}
+	}
+}

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -107,7 +107,7 @@ var _ = Describe("[sig-node] ConfigMap", func() {
 								ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: name}},
 							},
 							{
-								Prefix:       "p_",
+								Prefix:       "0$#@..//TEST p_",
 								ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: name}},
 							},
 						},
@@ -119,7 +119,7 @@ var _ = Describe("[sig-node] ConfigMap", func() {
 
 		f.TestContainerOutput("consume configMaps", pod, 0, []string{
 			"data_1=value-1", "data_2=value-2", "data_3=value-3",
-			"p_data_1=value-1", "p_data_2=value-2", "p_data_3=value-3",
+			"0$#@..//TEST p_data_1=value-1", "0$#@..//TEST p_data_2=value-2", "0$#@..//TEST p_data_3=value-3",
 		})
 	})
 })

--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -53,7 +53,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 						Command: []string{"sh", "-c", "env"},
 						Env: []v1.EnvVar{
 							{
-								Name:  "FOO",
+								Name:  "/\\%~*A55&&!!__F{}OO..T:E$T",
 								Value: "foo-value",
 							},
 							{
@@ -62,7 +62,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 							},
 							{
 								Name:  "FOOBAR",
-								Value: "$(FOO);;$(BAR)",
+								Value: "$(/\\%~*A55&&!!__F{}OO..T:E$T);;$(BAR)",
 							},
 						},
 					},
@@ -72,7 +72,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		}
 
 		f.TestContainerOutput("env composition", pod, 0, []string{
-			"FOO=foo-value",
+			"/\\%~*A55&&!!__F{}OO..T:E$T=foo-value",
 			"BAR=bar-value",
 			"FOOBAR=foo-value;;bar-value",
 		})
@@ -229,7 +229,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 						Image: imageutils.GetE2EImage(imageutils.BusyBox),
 						Env: []v1.EnvVar{
 							{
-								Name:  "POD_NAME",
+								Name:  "POD_NAM{E}@#$",
 								Value: "..",
 							},
 						},
@@ -237,7 +237,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 							{
 								Name:      "workdir1",
 								MountPath: "/logscontainer",
-								SubPath:   "$(POD_NAME)",
+								SubPath:   "$(POD_NAM{E}@#$)",
 							},
 						},
 					},

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -58,7 +58,7 @@ var _ = Describe("[sig-api-machinery] Secrets", func() {
 						Command: []string{"sh", "-c", "env"},
 						Env: []v1.EnvVar{
 							{
-								Name: "SECRET_DATA",
+								Name: "0{}&&!!55__SECRET_$DATA",
 								ValueFrom: &v1.EnvVarSource{
 									SecretKeyRef: &v1.SecretKeySelector{
 										LocalObjectReference: v1.LocalObjectReference{
@@ -76,7 +76,7 @@ var _ = Describe("[sig-api-machinery] Secrets", func() {
 		}
 
 		f.TestContainerOutput("consume secrets", pod, 0, []string{
-			"SECRET_DATA=value-1",
+			"0{}&&!!55__SECRET_$DATA=value-1",
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR changes allows ':' in environment variable name for the containers. This is bug fix of issue
https://github.com/kubernetes/kubectl/issues/47 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubectl/issues/47

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
Allowed ':' in environment variable names
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Relaxed restrictions on environment variable name characters. A valid environment variable name should not start with a digit. Older version of Kubelet ignores the environment variable names having other than [-._a-zA-Z0-9] characters and using these variables names will prevent apiserver rollback to older versions.
```
