### PR TITLE
glusterfs: Allow admin to enable or disable custom endpoint/service names

### DIFF
--- a/pkg/volume/glusterfs/glusterfs_test.go
+++ b/pkg/volume/glusterfs/glusterfs_test.go
@@ -261,6 +261,7 @@ func TestParseClassParameters(t *testing.T) {
 				gidMax:             2147483647,
 				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
 				thinPoolSnapFactor: float32(1.0),
+				customEpNamePrefix: "glusterfs-dynamic",
 			},
 		},
 		{
@@ -283,6 +284,7 @@ func TestParseClassParameters(t *testing.T) {
 				gidMax:             2147483647,
 				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
 				thinPoolSnapFactor: float32(1.0),
+				customEpNamePrefix: "glusterfs-dynamic",
 			},
 		},
 		{
@@ -299,6 +301,7 @@ func TestParseClassParameters(t *testing.T) {
 				gidMax:             2147483647,
 				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
 				thinPoolSnapFactor: float32(1.0),
+				customEpNamePrefix: "glusterfs-dynamic",
 			},
 		},
 		{
@@ -437,6 +440,7 @@ func TestParseClassParameters(t *testing.T) {
 				gidMax:             2147483647,
 				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
 				thinPoolSnapFactor: float32(1.0),
+				customEpNamePrefix: "glusterfs-dynamic",
 			},
 		},
 		{
@@ -454,6 +458,7 @@ func TestParseClassParameters(t *testing.T) {
 				gidMax:             5000,
 				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
 				thinPoolSnapFactor: float32(1.0),
+				customEpNamePrefix: "glusterfs-dynamic",
 			},
 		},
 		{
@@ -472,6 +477,7 @@ func TestParseClassParameters(t *testing.T) {
 				gidMax:             5000,
 				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
 				thinPoolSnapFactor: float32(1.0),
+				customEpNamePrefix: "glusterfs-dynamic",
 			},
 		},
 
@@ -492,6 +498,7 @@ func TestParseClassParameters(t *testing.T) {
 				gidMax:             5000,
 				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 4}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
 				thinPoolSnapFactor: float32(1.0),
+				customEpNamePrefix: "glusterfs-dynamic",
 			},
 		},
 
@@ -512,6 +519,7 @@ func TestParseClassParameters(t *testing.T) {
 				gidMax:             5000,
 				volumeType:         gapi.VolumeDurabilityInfo{Type: "disperse", Replicate: gapi.ReplicaDurability{Replica: 0}, Disperse: gapi.DisperseDurability{Data: 4, Redundancy: 2}},
 				thinPoolSnapFactor: float32(1.0),
+				customEpNamePrefix: "glusterfs-dynamic",
 			},
 		},
 		{
@@ -532,6 +540,7 @@ func TestParseClassParameters(t *testing.T) {
 				gidMax:             5000,
 				volumeType:         gapi.VolumeDurabilityInfo{Type: "disperse", Replicate: gapi.ReplicaDurability{Replica: 0}, Disperse: gapi.DisperseDurability{Data: 4, Redundancy: 2}},
 				thinPoolSnapFactor: float32(50),
+				customEpNamePrefix: "glusterfs-dynamic",
 			},
 		},
 
@@ -555,6 +564,7 @@ func TestParseClassParameters(t *testing.T) {
 				volumeType:         gapi.VolumeDurabilityInfo{Type: "disperse", Replicate: gapi.ReplicaDurability{Replica: 0}, Disperse: gapi.DisperseDurability{Data: 4, Redundancy: 2}},
 				thinPoolSnapFactor: float32(50),
 				volumeNamePrefix:   "dept-dev",
+				customEpNamePrefix: "glusterfs-dynamic",
 			},
 		},
 		{
@@ -640,6 +650,84 @@ func TestParseClassParameters(t *testing.T) {
 				"resturl":         "https://localhost:8080",
 				"restauthenabled": "false",
 				"snapfactor":      "120",
+			},
+			&secret,
+			true, // expect error
+			nil,
+		},
+
+		{
+			"enable custom ep/svc name: customEpNamePrefix: myprefix",
+			map[string]string{
+				"resturl":            "https://localhost:8080",
+				"restauthenabled":    "false",
+				"gidMin":             "4000",
+				"gidMax":             "5000",
+				"volumetype":         "replicate:4",
+				"customEpNamePrefix": "myprefix",
+			},
+			&secret,
+			false, // expect error
+			&provisionerConfig{
+				url:                "https://localhost:8080",
+				gidMin:             4000,
+				gidMax:             5000,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 4}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				thinPoolSnapFactor: float32(1.0),
+				customEpNamePrefix: "myprefix",
+			},
+		},
+		{
+			"empty custom ep/svc name: customEpNamePrefix:''",
+			map[string]string{
+				"resturl":            "https://localhost:8080",
+				"restauthenabled":    "false",
+				"gidMin":             "4000",
+				"gidMax":             "5000",
+				"volumetype":         "replicate:4",
+				"customEpNamePrefix": "",
+			},
+			&secret,
+			false, // expect error
+			&provisionerConfig{
+				url:                "https://localhost:8080",
+				gidMin:             4000,
+				gidMax:             5000,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 4}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				thinPoolSnapFactor: float32(1.0),
+				customEpNamePrefix: "",
+			},
+		},
+		{
+			"custom ep/svc name with 26 chars: customEpNamePrefix:'charstringhastwentysixchar'",
+			map[string]string{
+				"resturl":            "https://localhost:8080",
+				"restauthenabled":    "false",
+				"gidMin":             "4000",
+				"gidMax":             "5000",
+				"volumetype":         "replicate:4",
+				"customEpNamePrefix": "charstringhastwentysixchar",
+			},
+			&secret,
+			false, // expect error
+			&provisionerConfig{
+				url:                "https://localhost:8080",
+				gidMin:             4000,
+				gidMax:             5000,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 4}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				thinPoolSnapFactor: float32(1.0),
+				customEpNamePrefix: "charstringhastwentysixchar",
+			},
+		},
+		{
+			"invalid customepnameprefix ( ie >26 chars) parameter",
+			map[string]string{
+				"resturl":            "https://localhost:8080",
+				"restauthenabled":    "false",
+				"gidMin":             "4000",
+				"gidMax":             "5000",
+				"volumetype":         "replicate:4",
+				"customEpNamePrefix": "myprefixhasmorethan26characters",
 			},
 			&secret,
 			true, // expect error


### PR DESCRIPTION
    This patch introduces a new SC parameter called `customepnameprefix`
    in glusterfs plugin. This new storageclass parameter allow admins
    to create endpoints and services with mentioned value of this
    parameter. If this parameter has not been set or if its empty,
    default prefix string ie "glusterfs-dynamic-" will be used for ep/svc
    name.
        
This patch address below issues#
https://github.com/kubernetes/kubernetes/issues/53939
https://github.com/kubernetes/kubernetes/issues/56379

Additional Ref# https://github.com/kubernetes/kubernetes/pull/56380

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
