### PR TITLE
kubeadm: do not panic if etcd local alpha phase is called when an external etcd config is used

### DIFF
--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -37,6 +37,9 @@ const (
 
 // CreateLocalEtcdStaticPodManifestFile will write local etcd static pod manifest file.
 func CreateLocalEtcdStaticPodManifestFile(manifestDir string, cfg *kubeadmapi.InitConfiguration) error {
+	if cfg.ClusterConfiguration.Etcd.External != nil {
+		return fmt.Errorf("etcd static pod manifest cannot be generated for cluster using external etcd")
+	}
 	glog.V(1).Infoln("creating local etcd static pod manifest file")
 	// gets etcd StaticPodSpec, actualized for the current InitConfiguration
 	spec := GetEtcdPodSpec(cfg)

--- a/cmd/kubeadm/test/util.go
+++ b/cmd/kubeadm/test/util.go
@@ -143,6 +143,17 @@ func AssertFileExists(t *testing.T, dirName string, fileNames ...string) {
 	}
 }
 
+// AssertError checks that the provided error matches the expected output
+func AssertError(t *testing.T, err error, expected string) {
+	if err == nil {
+		t.Errorf("no error was found, but '%s' was expected", expected)
+		return
+	}
+	if err.Error() != expected {
+		t.Errorf("error '%s' does not match expected error: '%s'", err.Error(), expected)
+	}
+}
+
 // GetDefaultInternalConfig returns a defaulted kubeadmapi.InitConfiguration
 func GetDefaultInternalConfig(t *testing.T) *kubeadmapi.InitConfiguration {
 	internalcfg, err := configutil.ConfigFileAndDefaultsToInternalConfig("", &kubeadmapiv1alpha3.InitConfiguration{})


### PR DESCRIPTION
**What this PR does / why we need it**:

If etcd local alpha phase is called manually while the kubeadm configuration
points to an external etcd cluster kubeadm panics.

**Which issue(s) this PR fixes**
Fixes https://github.com/kubernetes/kubeadm/issues/1127

**Special notes for your reviewer**:
None

**Release note**:
```release-note
kubeadm: Fix a crash if the etcd local alpha phase is called when the configuration contains an external etcd cluster
```

/kind bug
