### PR TITLE
Use --force flag for reconciling addons

### DIFF
--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -167,12 +167,12 @@ function reconcile_addons() {
   log INFO "== Reconciling with deprecated label =="
   ${KUBECTL} ${KUBECTL_OPTS} apply -f ${ADDON_PATH} \
     -l ${CLUSTER_SERVICE_LABEL}=true,${ADDON_MANAGER_LABEL}!=EnsureExists \
-    --prune=true ${prune_whitelist_flags} --recursive | grep -v configured
+    --prune=true ${prune_whitelist_flags} --recursive --force | grep -v configured
 
   log INFO "== Reconciling with addon-manager label =="
   ${KUBECTL} ${KUBECTL_OPTS} apply -f ${ADDON_PATH} \
     -l ${CLUSTER_SERVICE_LABEL}!=true,${ADDON_MANAGER_LABEL}=Reconcile \
-    --prune=true ${prune_whitelist_flags} --recursive | grep -v configured
+    --prune=true ${prune_whitelist_flags} --recursive --force | grep -v configured
 
   log INFO "== Kubernetes addon reconcile completed at $(date -Is) =="
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Addon manager should use kubectl `--force` flag when reconciling addons. Without it, following scenario breaks the cluster:

- `kubectl delete` on any resource with immutable fields, i.e. kube-dns service
- immediately `kubectl create` your own resource with the same name, but different value for the immutable field, for example service `kube-dns` with ClusterIP = 10.35.240.12

After that, Addon Manager fails to reconcile this resource. A failure in this steps leads to further failures, for example Addon Manager doesn't attempt to prune not-wanted addons.

**Release note**:
```release-note
Fix Addon Manager failure to reconcile addons with immutable fields.
```
