### PR TITLE
Add FieldSelector member to MetricListOptions

### DIFF
--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/types.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/types.go
@@ -68,12 +68,12 @@ type MetricValue struct {
 }
 
 // allObjects is a wildcard used to select metrics
-// for all objects matching the given label selector
+// for all objects matching the given field and label selectors
 const AllObjects = "*"
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// MetricListOptions is used to select metrics by their label selectors
+// MetricListOptions is used to select metrics by their field and label selectors
 type MetricListOptions struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -85,6 +85,11 @@ type MetricListOptions struct {
 	// A selector to restrict the list of returned metrics by their labels
 	// +optional
 	MetricLabelSelector string `json:"metricLabelSelector,omitempty" protobuf:"bytes,2,opt,name=metricLabelSelector"`
+
+	// A selector to restrict the list of returned objects by their fields.
+	// Defaults to everything.
+	// +optional
+	FieldSelector string `json:"fieldSelector,omitempty" protobuf:"bytes,3,opt,name=fieldSelector"`
 }
 
 // NOTE: ObjectReference is copied from k8s.io/kubernetes/pkg/api/types.go. We

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/types.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/types.go
@@ -67,7 +67,7 @@ type MetricValue struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// MetricListOptions is used to select metrics by their label selectors
+// MetricListOptions is used to select metrics by their field and label selectors
 type MetricListOptions struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -79,8 +79,13 @@ type MetricListOptions struct {
 	// A selector to restrict the list of returned metrics by their labels
 	// +optional
 	MetricLabelSelector string `json:"metricLabelSelector,omitempty" protobuf:"bytes,2,opt,name=metricLabelSelector"`
+
+	// A selector to restrict the list of returned objects by their fields.
+	// Defaults to everything.
+	// +optional
+	FieldSelector string `json:"fieldSelector,omitempty" protobuf:"bytes,3,opt,name=fieldSelector"`
 }
 
 // allObjects is a wildcard used to select metrics
-// for all objects matching the given label selector
+// for all objects matching the given field and label selectors
 const AllObjects = "*"

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/zz_generated.conversion.go
@@ -81,6 +81,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 func autoConvert_v1beta1_MetricListOptions_To_custom_metrics_MetricListOptions(in *MetricListOptions, out *custommetrics.MetricListOptions, s conversion.Scope) error {
 	out.LabelSelector = in.LabelSelector
 	out.MetricLabelSelector = in.MetricLabelSelector
+	out.FieldSelector = in.FieldSelector
 	return nil
 }
 
@@ -92,6 +93,7 @@ func Convert_v1beta1_MetricListOptions_To_custom_metrics_MetricListOptions(in *M
 func autoConvert_custom_metrics_MetricListOptions_To_v1beta1_MetricListOptions(in *custommetrics.MetricListOptions, out *MetricListOptions, s conversion.Scope) error {
 	out.LabelSelector = in.LabelSelector
 	out.MetricLabelSelector = in.MetricLabelSelector
+	out.FieldSelector = in.FieldSelector
 	return nil
 }
 

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta2/types.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta2/types.go
@@ -70,12 +70,12 @@ type MetricValue struct {
 }
 
 // AllObjects is a wildcard used to select metrics
-// for all objects matching the given label selector
+// for all objects matching the given field and label selectors
 const AllObjects = "*"
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// MetricListOptions is used to select metrics by their label selectors
+// MetricListOptions is used to select metrics by their field and label selectors
 type MetricListOptions struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -87,4 +87,9 @@ type MetricListOptions struct {
 	// A selector to restrict the list of returned metrics by their labels
 	// +optional
 	MetricLabelSelector string `json:"metricLabelSelector,omitempty" protobuf:"bytes,2,opt,name=metricLabelSelector"`
+
+	// A selector to restrict the list of returned objects by their fields.
+	// Defaults to everything.
+	// +optional
+	FieldSelector string `json:"fieldSelector,omitempty" protobuf:"bytes,3,opt,name=fieldSelector"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This enables to restrict the list of returned objects by their fields when using the wildcard filter for custom metrics requests.

It is to be used in [kubernetes-incubator/custom-metrics-apiserver](https://github.com/kubernetes-incubator/custom-metrics-apiserver) and provides consistency to the generic `ListOptions`.

**Release note**:

```release-note
NONE
```