### PR TITLE
kubeadm: Allow mixing Init and Join Configurations

### DIFF
--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -93,19 +93,19 @@ func DetectUnsupportedVersion(b []byte) error {
 		}
 		knownKinds[gvk.Kind] = true
 	}
-	// InitConfiguration, MasterConfiguration and NodeConfiguration are mutually exclusive, error if more than one are specified
+
+	// InitConfiguration and JoinConfiguration may not apply together, warn if more than one is specified
 	mutuallyExclusive := []string{constants.InitConfigurationKind, constants.JoinConfigurationKind}
-	foundOne := false
+	mutuallyExclusiveCount := 0
 	for _, kind := range mutuallyExclusive {
 		if knownKinds[kind] {
-			if !foundOne {
-				foundOne = true
-				continue
-			}
-
-			return fmt.Errorf("invalid configuration: kinds %v are mutually exclusive", mutuallyExclusive)
+			mutuallyExclusiveCount++
 		}
 	}
+	if mutuallyExclusiveCount > 1 {
+		glog.Warningf("WARNING: Detected resource kinds that may not apply: %v", mutuallyExclusive)
+	}
+
 	return nil
 }
 

--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -163,25 +163,27 @@ func TestDetectUnsupportedVersion(t *testing.T) {
 			name:         "Ignore other Kind",
 			fileContents: bytes.Join([][]byte{files["Foo"], files["Master_v1beta1"]}, []byte(constants.YAMLDocumentSeparator)),
 		},
+		// CanMixInitJoin cases used to be MustNotMixInitJoin, however due to UX issues DetectUnsupportedVersion had to tolerate that.
+		// So the following tests actually verify, that Init and Join can be mixed together with no error.
 		{
-			name:         "MustNotMixInitJoin v1alpha3",
+			name:         "CanMixInitJoin v1alpha3",
 			fileContents: bytes.Join([][]byte{files["Init_v1alpha3"], files["Join_v1alpha3"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  true,
+			expectedErr:  false,
 		},
 		{
-			name:         "MustNotMixInitJoin v1alpha3 - v1beta1",
+			name:         "CanMixInitJoin v1alpha3 - v1beta1",
 			fileContents: bytes.Join([][]byte{files["Init_v1alpha3"], files["Join_v1beta1"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  true,
+			expectedErr:  false,
 		},
 		{
-			name:         "MustNotMixInitJoin v1beta1 - v1alpha3",
+			name:         "CanMixInitJoin v1beta1 - v1alpha3",
 			fileContents: bytes.Join([][]byte{files["Init_v1beta1"], files["Join_v1alpha3"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  true,
+			expectedErr:  false,
 		},
 		{
-			name:         "MustNotMixInitJoin v1beta1",
+			name:         "CanMixInitJoin v1beta1",
 			fileContents: bytes.Join([][]byte{files["Init_v1beta1"], files["Join_v1beta1"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  true,
+			expectedErr:  false,
 		},
 	}
 

--- a/cmd/kubeadm/app/util/config/nodeconfig.go
+++ b/cmd/kubeadm/app/util/config/nodeconfig.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
 	"github.com/golang/glog"
 
@@ -27,6 +28,7 @@ import (
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
 // SetJoinDynamicDefaults checks and sets configuration values for the JoinConfiguration object
@@ -61,7 +63,23 @@ func NodeConfigFileAndDefaultsToInternalConfig(cfgPath string, defaultversionedc
 			return nil, err
 		}
 
-		if err := runtime.DecodeInto(kubeadmscheme.Codecs.UniversalDecoder(), b, internalcfg); err != nil {
+		gvkmap, err := kubeadmutil.SplitYAMLDocuments(b)
+		if err != nil {
+			return nil, err
+		}
+
+		joinBytes := []byte{}
+		for gvk, bytes := range gvkmap {
+			if gvk.Kind == constants.JoinConfigurationKind {
+				joinBytes = bytes
+			}
+		}
+
+		if len(joinBytes) == 0 {
+			return nil, fmt.Errorf("no %s found in config file %q", constants.JoinConfigurationKind, cfgPath)
+		}
+
+		if err := runtime.DecodeInto(kubeadmscheme.Codecs.UniversalDecoder(), joinBytes, internalcfg); err != nil {
 			return nil, err
 		}
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This change allows mixing InitConfiguration/ClusterConfiguration with
JoinConfiguration in a single YAML file, by performing the following changes:

- Replace the explicit error in `DetectUnsupportedVersion` with a warning.
- Modify `NodeConfigFileAndDefaultsToInternalConfig` to use only
  `JoinConfiguration`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Refs kubernetes/kubeadm#1152 (This is the short-term 1.12 solution to unblock the community).

**Special notes for your reviewer**:
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/kind bug
/assign @fabriziopandini
/assign @timothysc
/cc @neolit123

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm now allows mixing of init/cluster and join configuration in a single YAML file (although a warning gets printed in this case). 
```
