### PR TITLE
Update stack walk tests for go 1.11

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/naming/from_stack_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/naming/from_stack_test.go
@@ -19,37 +19,53 @@ package naming
 import "testing"
 
 func TestGetNameFromCallsite(t *testing.T) {
+	// We do some tests which ignore our package, and therefore walk
+	// into our caller, which is the testing framework.  That callsite
+	// varies by go version.
+	testingCallsites := []string{
+		"testing/testing.go:777", // go 1.10
+		"testing/testing.go:827", // go 1.11
+	}
+
 	tests := []struct {
 		name            string
 		ignoredPackages []string
-		expected        string
+		expected        []string
 	}{
 		{
 			name:     "simple",
-			expected: "k8s.io/apimachinery/pkg/util/naming/from_stack_test.go:50",
+			expected: []string{"k8s.io/apimachinery/pkg/util/naming/from_stack_test.go:58"},
 		},
 		{
 			name:            "ignore-package",
 			ignoredPackages: []string{"k8s.io/apimachinery/pkg/util/naming"},
-			expected:        "testing/testing.go:827",
+			expected:        testingCallsites,
 		},
 		{
 			name:            "ignore-file",
 			ignoredPackages: []string{"k8s.io/apimachinery/pkg/util/naming/from_stack_test.go"},
-			expected:        "testing/testing.go:827",
+			expected:        testingCallsites,
 		},
 		{
 			name:            "ignore-multiple",
 			ignoredPackages: []string{"k8s.io/apimachinery/pkg/util/naming/from_stack_test.go", "testing/testing.go"},
-			expected:        "????",
+			expected:        []string{"????"},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := GetNameFromCallsite(tc.ignoredPackages...)
-			if tc.expected != actual {
-				t.Fatalf("expected %q, got %q", tc.expected, actual)
+			match := false
+			for _, e := range tc.expected {
+				if e == actual {
+					match = true
+					break
+				}
+			}
+
+			if !match {
+				t.Errorf("expected one of %v, got %q", tc.expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
We test for the callsite inside the go testing framework.  That callsite
has moved in go 1.11

Establish a list of matchers, so we aren't as tied to a particular k8s
version.