### PR TITLE
Populate ClientCA in delegating auth setup

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -192,9 +192,11 @@ func (s *DelegatingAuthenticationOptions) ApplyTo(c *server.AuthenticationInfo, 
 	}
 
 	// configure AuthenticationInfo config
+	cfg.ClientCAFile = s.ClientCert.ClientCA
 	if err = c.ApplyClientCert(s.ClientCert.ClientCA, servingInfo); err != nil {
 		return fmt.Errorf("unable to load client CA file: %v", err)
 	}
+
 	cfg.RequestHeaderConfig = s.RequestHeader.ToAuthenticationRequestHeaderConfig()
 	if err = c.ApplyClientCert(s.RequestHeader.ClientCAFile, servingInfo); err != nil {
 		return fmt.Errorf("unable to load client CA file: %v", err)


### PR DESCRIPTION
kubernetes/kubernetes#67768 accidentally removed population of the the ClientCA
in the delegating auth setup code.  This appears to have broken the ability to talk directly
to aggregated API servers with client certs (e.g. admin certs).

/kind bug

```release-note
Fix client cert setup in delegating authentication logic
```
