### PR TITLE
Improve reliability of kms-plugin integration tests.

### DIFF
--- a/test/integration/master/BUILD
+++ b/test/integration/master/BUILD
@@ -123,8 +123,12 @@ go_library(
     importpath = "k8s.io/kubernetes/test/integration/master",
     deps = [
         "//cmd/kube-apiserver/app/testing:go_default_library",
+        "//pkg/apis/core:go_default_library",
+        "//pkg/apis/core/install:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/value:go_default_library",

--- a/test/integration/master/kms_plugin_mock.go
+++ b/test/integration/master/kms_plugin_mock.go
@@ -94,12 +94,12 @@ func (s *base64Plugin) Decrypt(ctx context.Context, request *kmsapi.DecryptReque
 func (s *base64Plugin) Encrypt(ctx context.Context, request *kmsapi.EncryptRequest) (*kmsapi.EncryptResponse, error) {
 	glog.Infof("Received Encrypt Request for DEK: %x", request.Plain)
 	s.encryptRequest <- request
-	return base64Encode(request)
+	return base64Encode(request), nil
 }
 
 // base64Encode base64 encodes EncryptRequest, thus simulating transformation.
-func base64Encode(request *kmsapi.EncryptRequest) (*kmsapi.EncryptResponse, error) {
-	return &kmsapi.EncryptResponse{Cipher: []byte(base64.StdEncoding.EncodeToString(request.Plain))}, nil
+func base64Encode(request *kmsapi.EncryptRequest) *kmsapi.EncryptResponse {
+	return &kmsapi.EncryptResponse{Cipher: []byte(base64.StdEncoding.EncodeToString(request.Plain))}
 }
 
 // base64Decode base64 decodes DecryptRequest, thus simulating transformation.

--- a/test/integration/master/kms_transformation_test.go
+++ b/test/integration/master/kms_transformation_test.go
@@ -147,15 +147,16 @@ func mustSetupTest(t *testing.T) (*base64Plugin, *transformTest) {
 	}
 
 	// Ensuring that the test secret has been cached - written to etcd and read back by cacher.
+	var restErr error
 	pollErr := wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
-		_, err := test.restClient.CoreV1().Secrets(test.ns.Name).Get(test.secret.Name, metav1.GetOptions{ResourceVersion: "0"})
-		return err == nil, nil
+		_, restErr = test.restClient.CoreV1().Secrets(test.ns.Name).Get(test.secret.Name, metav1.GetOptions{ResourceVersion: "0"})
+		return restErr == nil, nil
 	})
 
 	if pollErr == wait.ErrWaitTimeout {
 		pluginMock.cleanUp()
 		test.cleanUp()
-		t.Fatalf("failed to retrieve secret from cache within the alloted time period: %d", wait.ForeverTestTimeout)
+		t.Fatalf("failed to retrieve secret from cache within the alloted time period: %d, error: %v", wait.ForeverTestTimeout, restErr)
 	}
 
 	return pluginMock, test

--- a/test/integration/master/kms_transformation_test.go
+++ b/test/integration/master/kms_transformation_test.go
@@ -20,18 +20,19 @@ package master
 
 import (
 	"bytes"
-	"context"
 	"crypto/aes"
 	"encoding/binary"
 	"fmt"
-	"strings"
+	"reflect"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage/value"
 	aestransformer "k8s.io/apiserver/pkg/storage/value/encrypt/aes"
-
 	kmsapi "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1"
+	"k8s.io/kubernetes/pkg/apis/core"
 )
 
 const (
@@ -47,7 +48,6 @@ resources:
     providers:
     - kms:
        name: grpc-kms-provider
-       cachesize: 1000
        endpoint: unix:///@kms-provider.sock
 `
 )
@@ -80,30 +80,13 @@ func (r rawDEKKEKSecret) getPayload() []byte {
 // 4. The payload (ex. Secret) should be encrypted via AES CBC transform
 // 5. Prefix-EncryptedDEK-EncryptedPayload structure should be deposited to ETCD
 func TestKMSProvider(t *testing.T) {
-	pluginMock, err := NewBase64Plugin()
-	if err != nil {
-		t.Fatalf("failed to create mock of KMS Plugin: %v", err)
-	}
+	pluginMock, test := mustSetupTest(t)
 	defer pluginMock.cleanUp()
-	serveErr := make(chan error, 1)
-	go func() {
-		serveErr <- pluginMock.grpcServer.Serve(pluginMock.listener)
-	}()
-
-	test, err := newTransformTest(t, kmsConfigYAML)
-	if err != nil {
-		t.Fatalf("failed to start KUBE API Server with encryptionConfig\n %s", kmsConfigYAML)
-	}
 	defer test.cleanUp()
-
-	// As part of newTransformTest a new secret was created, so KMS Mock should have been exercised by this point.
-	if len(serveErr) != 0 {
-		t.Fatalf("KMSPlugin failed while serving requests: %v", <-serveErr)
-	}
 
 	secretETCDPath := test.getETCDPath()
 	var rawSecretAsSeenByETCD rawDEKKEKSecret
-	rawSecretAsSeenByETCD, err = test.getRawSecretFromETCD()
+	rawSecretAsSeenByETCD, err := test.getRawSecretFromETCD()
 	if err != nil {
 		t.Fatalf("failed to read %s from etcd: %v", secretETCDPath, err)
 	}
@@ -118,8 +101,8 @@ func TestKMSProvider(t *testing.T) {
 		t.Fatalf("failed to get DEK from KMS: %v", err)
 	}
 
-	decryptResponse, err := pluginMock.Decrypt(context.Background(),
-		&kmsapi.DecryptRequest{Version: kmsAPIVersion, Cipher: rawSecretAsSeenByETCD.getDEK()})
+	// KMS Mock uses base64 encoding to simulate encryption.
+	decryptResponse, err := base64Decode(&kmsapi.DecryptRequest{Version: kmsAPIVersion, Cipher: rawSecretAsSeenByETCD.getDEK()})
 	if err != nil {
 		t.Fatalf("failed to decrypt DEK, %v", err)
 	}
@@ -135,30 +118,75 @@ func TestKMSProvider(t *testing.T) {
 		t.Fatalf("failed to transform from storage via AESCBC, err: %v", err)
 	}
 
-	if !strings.Contains(string(plainSecret), secretVal) {
-		t.Fatalf("expected %q after decryption, but got %q", secretVal, string(plainSecret))
+	if !reflect.DeepEqual(test.secret.Data, plainSecret.Data) {
+		t.Fatalf("got:%v after decryption\nwant:\n%v", plainSecret, test.secret)
 	}
 
 	// Secrets should be un-enveloped on direct reads from Kube API Server.
-	s, err := test.restClient.CoreV1().Secrets(testNamespace).Get(testSecret, metav1.GetOptions{})
-	if secretVal != string(s.Data[secretKey]) {
-		t.Fatalf("expected %s from KubeAPI, but got %s", secretVal, string(s.Data[secretKey]))
-	}
+	mustReadSecret(t, test, true)
 	test.printMetrics()
 }
 
-func getDEKFromKMSPlugin(pluginMock *base64Plugin) ([]byte, error) {
-	// We expect KMS to already have seen an encryptRequest. Hence non-blocking call.
-	e, ok := <-pluginMock.encryptRequest
-
-	if !ok {
-		return nil, fmt.Errorf("failed to sense encryptRequest from KMS Plugin Mock")
+func mustSetupTest(t *testing.T) (*base64Plugin, *transformTest) {
+	pluginMock, err := NewBase64Plugin()
+	if err != nil {
+		t.Fatalf("failed to create mock of KMS Plugin: %v", err)
 	}
 
-	return e.Plain, nil
+	test, err := newTransformTest(t, kmsConfigYAML)
+	if err != nil {
+		pluginMock.cleanUp()
+		t.Fatalf("failed to start KUBE API Server with encryptionConfig\n %s", kmsConfigYAML)
+	}
+
+	// As part of newTransformTest a new secret was created, so KMS Mock should have been exercised by this point.
+	if len(pluginMock.errorChan) != 0 {
+		pluginMock.cleanUp()
+		test.cleanUp()
+		t.Fatalf("KMSPlugin failed while serving requests: %v", <-pluginMock.errorChan)
+	}
+
+	// Ensuring that the test secret has been cached - written to etcd and read back by cacher.
+	pollErr := wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		_, err := test.restClient.CoreV1().Secrets(test.ns.Name).Get(test.secret.Name, metav1.GetOptions{ResourceVersion: "0"})
+		return err == nil, nil
+	})
+
+	if pollErr == wait.ErrWaitTimeout {
+		pluginMock.cleanUp()
+		test.cleanUp()
+		t.Fatalf("failed to retrieve secret from cache within the alloted time period: %d", wait.ForeverTestTimeout)
+	}
+
+	return pluginMock, test
 }
 
-func decryptPayload(key []byte, secret rawDEKKEKSecret, secretETCDPath string) ([]byte, error) {
+func mustReadSecret(t *testing.T, test *transformTest, bypassCache bool) {
+	// ResourceVersion 0 implies cache will be checked, "" implies that cache will be bypassed.
+	resourceVersion := "0"
+	if bypassCache {
+		resourceVersion = ""
+	}
+
+	s, err := test.restClient.CoreV1().Secrets(test.ns.Name).Get(test.secret.Name, metav1.GetOptions{ResourceVersion: resourceVersion})
+	if err != nil {
+		t.Fatalf("failed to get %s, error: %v", test.secret.Name, err)
+	}
+	if secretVal != string(s.Data[secretKey]) {
+		t.Fatalf("expected %s from KubeAPI, but got %s", secretVal, string(s.Data[secretKey]))
+	}
+}
+
+func getDEKFromKMSPlugin(pluginMock *base64Plugin) ([]byte, error) {
+	select {
+	case e := <-pluginMock.encryptRequest:
+		return e.Plain, nil
+	case <-time.After(wait.ForeverTestTimeout):
+		return nil, fmt.Errorf("expected encryptRequest to be received by KMS Plugin within %v", wait.ForeverTestTimeout)
+	}
+}
+
+func decryptPayload(key []byte, secret rawDEKKEKSecret, secretETCDPath string) (*core.Secret, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize AES Cipher: %v", err)
@@ -171,5 +199,10 @@ func decryptPayload(key []byte, secret rawDEKKEKSecret, secretETCDPath string) (
 		return nil, fmt.Errorf("failed to transform from storage via AESCBC, err: %v", err)
 	}
 
-	return plainSecret, nil
+	decodedSecret, err := decodeSecret(plainSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode secret, err: %v", err)
+	}
+
+	return decodedSecret, nil
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Improve reliability of kms-plugin integration tests.

NewBase64Plugin returns an error chan instead of blocking
mustSetupTest polls for the completion of a create secret operation
mustSetupTest provides an option to wait for the secret under test to be cached by the cacher


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
