### PR TITLE
[aws] allow true/false in lb annotations

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -3330,7 +3330,9 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 	// Determine if this is tagged as an Internal ELB
 	internalELB := false
 	internalAnnotation := apiService.Annotations[ServiceAnnotationLoadBalancerInternal]
-	if internalAnnotation != "" {
+	if internalAnnotation == "false" {
+		internalELB = false
+	} else if internalAnnotation != "" {
 		internalELB = true
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates internal load balancer annotation to allow true/false instead of just empty string.

**Which issue(s) this PR fixes**:
Fixes #69237

**Special notes for your reviewer**:

**Release note**:
```release-note
service.beta.kubernetes.io/aws-load-balancer-internal now supports true and false values, previously it only supported non-empty strings
```
/sig aws
/cc @d-nishi @jsafrane
/kind bug