### PR TITLE
Move minimum set of dynamic provisioning e2e test to testsuites

### DIFF
--- a/test/e2e/storage/drivers/base.go
+++ b/test/e2e/storage/drivers/base.go
@@ -81,11 +81,13 @@ type DriverInfo struct {
 	Name       string // Name of the driver
 	FeatureTag string // FeatureTag for the driver
 
-	MaxFileSize        int64       // Max file size to be tested for this driver
-	SupportedFsType    sets.String // Map of string for supported fs type
-	IsPersistent       bool        // Flag to represent whether it provides persistency
-	IsFsGroupSupported bool        // Flag to represent whether it supports fsGroup
-	IsBlockSupported   bool        // Flag to represent whether it supports Block Volume
+	MaxFileSize          int64       // Max file size to be tested for this driver
+	SupportedFsType      sets.String // Map of string for supported fs type
+	SupportedMountOption sets.String // Map of string for supported mount option
+	RequiredMountOption  sets.String // Map of string for required mount option (Optional)
+	IsPersistent         bool        // Flag to represent whether it provides persistency
+	IsFsGroupSupported   bool        // Flag to represent whether it supports fsGroup
+	IsBlockSupported     bool        // Flag to represent whether it supports Block Volume
 
 	// Parameters below will be set inside test loop by using SetCommonDriverParameters.
 	// Drivers that implement TestDriver is required to set all the above parameters
@@ -104,8 +106,8 @@ func GetDriverNameWithFeatureTags(driver TestDriver) string {
 	return fmt.Sprintf("[Driver: %s]%s", dInfo.Name, dInfo.FeatureTag)
 }
 
+// CreateVolume creates volume for test unless dynamicPV test
 func CreateVolume(driver TestDriver, volType testpatterns.TestVolType) interface{} {
-	// Create Volume for test unless dynamicPV test
 	switch volType {
 	case testpatterns.InlineVolume:
 		fallthrough
@@ -121,8 +123,8 @@ func CreateVolume(driver TestDriver, volType testpatterns.TestVolType) interface
 	return nil
 }
 
+// DeleteVolume deletes volume for test unless dynamicPV test
 func DeleteVolume(driver TestDriver, volType testpatterns.TestVolType, testResource interface{}) {
-	// Delete Volume for test unless dynamicPV test
 	switch volType {
 	case testpatterns.InlineVolume:
 		fallthrough

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -88,9 +88,11 @@ func InitNFSDriver() TestDriver {
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
-			IsPersistent:       true,
-			IsFsGroupSupported: false,
-			IsBlockSupported:   false,
+			SupportedMountOption: sets.NewString("proto=tcp", "nosuid"),
+			RequiredMountOption:  sets.NewString("vers=4.1"),
+			IsPersistent:         true,
+			IsFsGroupSupported:   false,
+			IsBlockSupported:     false,
 		},
 	}
 }
@@ -673,7 +675,7 @@ var _ TestDriver = &hostPathDriver{}
 var _ PreprovisionedVolumeTestDriver = &hostPathDriver{}
 var _ InlineVolumeTestDriver = &hostPathDriver{}
 
-// InitHostpathDriver returns hostPathDriver that implements TestDriver interface
+// InitHostPathDriver returns hostPathDriver that implements TestDriver interface
 func InitHostPathDriver() TestDriver {
 	return &hostPathDriver{
 		driverInfo: DriverInfo{
@@ -1118,9 +1120,10 @@ func InitGcePdDriver() TestDriver {
 				"ext4",
 				"xfs",
 			),
-			IsPersistent:       true,
-			IsFsGroupSupported: true,
-			IsBlockSupported:   true,
+			SupportedMountOption: sets.NewString("debug", "nouid32"),
+			IsPersistent:         true,
+			IsFsGroupSupported:   true,
+			IsBlockSupported:     true,
 		},
 	}
 }
@@ -1460,9 +1463,10 @@ func InitAwsDriver() TestDriver {
 				"", // Default fsType
 				"ext3",
 			),
-			IsPersistent:       true,
-			IsFsGroupSupported: true,
-			IsBlockSupported:   true,
+			SupportedMountOption: sets.NewString("debug", "nouid32"),
+			IsPersistent:         true,
+			IsFsGroupSupported:   true,
+			IsBlockSupported:     true,
 		},
 	}
 }

--- a/test/e2e/storage/generic_persistent_volume-disruptive.go
+++ b/test/e2e/storage/generic_persistent_volume-disruptive.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -85,9 +86,9 @@ var _ = utils.SIGDescribe("GenericPersistentVolume[Disruptive]", func() {
 
 func createPodPVCFromSC(f *framework.Framework, c clientset.Interface, ns string) (*v1.Pod, *v1.PersistentVolumeClaim, *v1.PersistentVolume) {
 	var err error
-	test := storageClassTest{
-		name:      "default",
-		claimSize: "2Gi",
+	test := testsuites.StorageClassTest{
+		Name:      "default",
+		ClaimSize: "2Gi",
 	}
 	pvc := newClaim(test, ns, "default")
 	pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)

--- a/test/e2e/storage/in_tree_volumes.go
+++ b/test/e2e/storage/in_tree_volumes.go
@@ -50,6 +50,7 @@ var testSuites = []func() testsuites.TestSuite{
 	testsuites.InitVolumeIOTestSuite,
 	testsuites.InitVolumeModeTestSuite,
 	testsuites.InitSubPathTestSuite,
+	testsuites.InitProvisioningTestSuite,
 }
 
 // This executes testSuites for in-tree volumes.

--- a/test/e2e/storage/mounted_volume_resize.go
+++ b/test/e2e/storage/mounted_volume_resize.go
@@ -31,6 +31,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/client/conditions"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -72,9 +73,9 @@ var _ = utils.SIGDescribe("Mounted volume expand[Slow]", func() {
 			isNodeLabeled = true
 		}
 
-		test := storageClassTest{
-			name:      "default",
-			claimSize: "2Gi",
+		test := testsuites.StorageClassTest{
+			Name:      "default",
+			ClaimSize: "2Gi",
 		}
 		resizableSc, err = createResizableStorageClass(test, ns, "resizing", c)
 		Expect(err).NotTo(HaveOccurred(), "Error creating resizable storage class")

--- a/test/e2e/storage/pvc_protection.go
+++ b/test/e2e/storage/pvc_protection.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/slice"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -47,8 +48,8 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 		By("Creating a PVC")
 		suffix := "pvc-protection"
 		defaultSC := getDefaultStorageClassName(client)
-		testStorageClass := storageClassTest{
-			claimSize: "1Gi",
+		testStorageClass := testsuites.StorageClassTest{
+			ClaimSize: "1Gi",
 		}
 		pvc = newClaim(testStorageClass, nameSpace, suffix)
 		pvc.Spec.StorageClassName = &defaultSC

--- a/test/e2e/storage/regional_pd.go
+++ b/test/e2e/storage/regional_pd.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/providers/gce"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -90,19 +91,19 @@ func testVolumeProvisioning(c clientset.Interface, ns string) {
 
 	// This test checks that dynamic provisioning can provision a volume
 	// that can be used to persist data among pods.
-	tests := []storageClassTest{
+	tests := []testsuites.StorageClassTest{
 		{
-			name:           "HDD Regional PD on GCE/GKE",
-			cloudProviders: []string{"gce", "gke"},
-			provisioner:    "kubernetes.io/gce-pd",
-			parameters: map[string]string{
+			Name:           "HDD Regional PD on GCE/GKE",
+			CloudProviders: []string{"gce", "gke"},
+			Provisioner:    "kubernetes.io/gce-pd",
+			Parameters: map[string]string{
 				"type":             "pd-standard",
 				"zones":            strings.Join(cloudZones, ","),
 				"replication-type": "regional-pd",
 			},
-			claimSize:    "1.5Gi",
-			expectedSize: "2Gi",
-			pvCheck: func(volume *v1.PersistentVolume) error {
+			ClaimSize:    "1.5Gi",
+			ExpectedSize: "2Gi",
+			PvCheck: func(volume *v1.PersistentVolume) error {
 				err := checkGCEPD(volume, "pd-standard")
 				if err != nil {
 					return err
@@ -111,16 +112,16 @@ func testVolumeProvisioning(c clientset.Interface, ns string) {
 			},
 		},
 		{
-			name:           "HDD Regional PD with auto zone selection on GCE/GKE",
-			cloudProviders: []string{"gce", "gke"},
-			provisioner:    "kubernetes.io/gce-pd",
-			parameters: map[string]string{
+			Name:           "HDD Regional PD with auto zone selection on GCE/GKE",
+			CloudProviders: []string{"gce", "gke"},
+			Provisioner:    "kubernetes.io/gce-pd",
+			Parameters: map[string]string{
 				"type":             "pd-standard",
 				"replication-type": "regional-pd",
 			},
-			claimSize:    "1.5Gi",
-			expectedSize: "2Gi",
-			pvCheck: func(volume *v1.PersistentVolume) error {
+			ClaimSize:    "1.5Gi",
+			ExpectedSize: "2Gi",
+			PvCheck: func(volume *v1.PersistentVolume) error {
 				err := checkGCEPD(volume, "pd-standard")
 				if err != nil {
 					return err
@@ -138,7 +139,7 @@ func testVolumeProvisioning(c clientset.Interface, ns string) {
 		class := newStorageClass(test, ns, "" /* suffix */)
 		claim := newClaim(test, ns, "" /* suffix */)
 		claim.Spec.StorageClassName = &class.Name
-		testDynamicProvisioning(test, c, claim, class)
+		testsuites.TestDynamicProvisioning(test, c, claim, class)
 	}
 }
 
@@ -278,15 +279,15 @@ func testZonalFailover(c clientset.Interface, ns string) {
 }
 
 func testRegionalDelayedBinding(c clientset.Interface, ns string) {
-	test := storageClassTest{
-		name:        "Regional PD storage class with waitForFirstConsumer test on GCE",
-		provisioner: "kubernetes.io/gce-pd",
-		parameters: map[string]string{
+	test := testsuites.StorageClassTest{
+		Name:        "Regional PD storage class with waitForFirstConsumer test on GCE",
+		Provisioner: "kubernetes.io/gce-pd",
+		Parameters: map[string]string{
 			"type":             "pd-standard",
 			"replication-type": "regional-pd",
 		},
-		claimSize:    "2Gi",
-		delayBinding: true,
+		ClaimSize:    "2Gi",
+		DelayBinding: true,
 	}
 
 	suffix := "delayed-regional"
@@ -305,15 +306,15 @@ func testRegionalDelayedBinding(c clientset.Interface, ns string) {
 }
 
 func testRegionalAllowedTopologies(c clientset.Interface, ns string) {
-	test := storageClassTest{
-		name:        "Regional PD storage class with allowedTopologies test on GCE",
-		provisioner: "kubernetes.io/gce-pd",
-		parameters: map[string]string{
+	test := testsuites.StorageClassTest{
+		Name:        "Regional PD storage class with allowedTopologies test on GCE",
+		Provisioner: "kubernetes.io/gce-pd",
+		Parameters: map[string]string{
 			"type":             "pd-standard",
 			"replication-type": "regional-pd",
 		},
-		claimSize:    "2Gi",
-		expectedSize: "2Gi",
+		ClaimSize:    "2Gi",
+		ExpectedSize: "2Gi",
 	}
 
 	suffix := "topo-regional"
@@ -322,20 +323,20 @@ func testRegionalAllowedTopologies(c clientset.Interface, ns string) {
 	addAllowedTopologiesToStorageClass(c, class, zones)
 	claim := newClaim(test, ns, suffix)
 	claim.Spec.StorageClassName = &class.Name
-	pv := testDynamicProvisioning(test, c, claim, class)
+	pv := testsuites.TestDynamicProvisioning(test, c, claim, class)
 	checkZonesFromLabelAndAffinity(pv, sets.NewString(zones...), true)
 }
 
 func testRegionalAllowedTopologiesWithDelayedBinding(c clientset.Interface, ns string) {
-	test := storageClassTest{
-		name:        "Regional PD storage class with allowedTopologies and waitForFirstConsumer test on GCE",
-		provisioner: "kubernetes.io/gce-pd",
-		parameters: map[string]string{
+	test := testsuites.StorageClassTest{
+		Name:        "Regional PD storage class with allowedTopologies and waitForFirstConsumer test on GCE",
+		Provisioner: "kubernetes.io/gce-pd",
+		Parameters: map[string]string{
 			"type":             "pd-standard",
 			"replication-type": "regional-pd",
 		},
-		claimSize:    "2Gi",
-		delayBinding: true,
+		ClaimSize:    "2Gi",
+		DelayBinding: true,
 	}
 
 	suffix := "topo-delayed-regional"

--- a/test/e2e/storage/testsuites/BUILD
+++ b/test/e2e/storage/testsuites/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "base.go",
+        "provisioning.go",
         "subpath.go",
         "volume_io.go",
         "volumemode.go",

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
 )
 
-// TestSuite represents an interface for a set of tests whchi works with TestDriver
+// TestSuite represents an interface for a set of tests which works with TestDriver
 type TestSuite interface {
 	// getTestSuiteInfo returns the TestSuiteInfo for this TestSuite
 	getTestSuiteInfo() TestSuiteInfo
@@ -44,6 +44,7 @@ type TestSuite interface {
 	execTest(drivers.TestDriver, testpatterns.TestPattern)
 }
 
+// TestSuiteInfo represents a set of parameters for TestSuite
 type TestSuiteInfo struct {
 	name         string                     // name of the TestSuite
 	featureTag   string                     // featureTag for the TestSuite
@@ -132,7 +133,7 @@ type genericVolumeTestResource struct {
 
 var _ TestResource = &genericVolumeTestResource{}
 
-// SetupResource sets up genericVolumeTestResource
+// setupResource sets up genericVolumeTestResource
 func (r *genericVolumeTestResource) setupResource(driver drivers.TestDriver, pattern testpatterns.TestPattern) {
 	r.driver = driver
 	dInfo := driver.GetDriverInfo()
@@ -186,7 +187,7 @@ func (r *genericVolumeTestResource) setupResource(driver drivers.TestDriver, pat
 	}
 }
 
-// CleanupResource clean up genericVolumeTestResource
+// cleanupResource cleans up genericVolumeTestResource
 func (r *genericVolumeTestResource) cleanupResource(driver drivers.TestDriver, pattern testpatterns.TestPattern) {
 	dInfo := driver.GetDriverInfo()
 	f := dInfo.Framework

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -1,0 +1,367 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/drivers"
+	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+)
+
+// StorageClassTest represents parameters to be used by provisioning tests
+type StorageClassTest struct {
+	Name               string
+	CloudProviders     []string
+	Provisioner        string
+	Parameters         map[string]string
+	DelayBinding       bool
+	ClaimSize          string
+	ExpectedSize       string
+	PvCheck            func(volume *v1.PersistentVolume) error
+	NodeName           string
+	SkipWriteReadCheck bool
+	VolumeMode         *v1.PersistentVolumeMode
+}
+
+type provisioningTestSuite struct {
+	tsInfo TestSuiteInfo
+}
+
+var _ TestSuite = &provisioningTestSuite{}
+
+// InitProvisioningTestSuite returns provisioningTestSuite that implements TestSuite interface
+func InitProvisioningTestSuite() TestSuite {
+	return &provisioningTestSuite{
+		tsInfo: TestSuiteInfo{
+			name: "provisioning",
+			testPatterns: []testpatterns.TestPattern{
+				testpatterns.DefaultFsDynamicPV,
+			},
+		},
+	}
+}
+
+func (p *provisioningTestSuite) getTestSuiteInfo() TestSuiteInfo {
+	return p.tsInfo
+}
+
+func (p *provisioningTestSuite) skipUnsupportedTest(pattern testpatterns.TestPattern, driver drivers.TestDriver) {
+}
+
+func createProvisioningTestInput(driver drivers.TestDriver, pattern testpatterns.TestPattern) (provisioningTestResource, provisioningTestInput) {
+	// Setup test resource for driver and testpattern
+	resource := provisioningTestResource{}
+	resource.setupResource(driver, pattern)
+
+	input := provisioningTestInput{
+		testCase: StorageClassTest{
+			ClaimSize:    resource.claimSize,
+			ExpectedSize: resource.claimSize,
+		},
+		cs:    driver.GetDriverInfo().Framework.ClientSet,
+		pvc:   resource.pvc,
+		sc:    resource.sc,
+		dInfo: driver.GetDriverInfo(),
+	}
+
+	if driver.GetDriverInfo().Config.ClientNodeName != "" {
+		input.testCase.NodeName = driver.GetDriverInfo().Config.ClientNodeName
+	}
+
+	return resource, input
+}
+
+func (p *provisioningTestSuite) execTest(driver drivers.TestDriver, pattern testpatterns.TestPattern) {
+	Context(getTestNameStr(p, pattern), func() {
+		var (
+			resource     provisioningTestResource
+			input        provisioningTestInput
+			needsCleanup bool
+		)
+
+		BeforeEach(func() {
+			needsCleanup = false
+			// Skip unsupported tests to avoid unnecessary resource initialization
+			skipUnsupportedTest(p, driver, pattern)
+			needsCleanup = true
+
+			// Create test input
+			resource, input = createProvisioningTestInput(driver, pattern)
+		})
+
+		AfterEach(func() {
+			if needsCleanup {
+				resource.cleanupResource(driver, pattern)
+			}
+		})
+
+		// Ginkgo's "Global Shared Behaviors" require arguments for a shared function
+		// to be a single struct and to be passed as a pointer.
+		// Please see https://onsi.github.io/ginkgo/#global-shared-behaviors for details.
+		testProvisioning(&input)
+	})
+}
+
+type provisioningTestResource struct {
+	driver drivers.TestDriver
+
+	claimSize string
+	sc        *storage.StorageClass
+	pvc       *v1.PersistentVolumeClaim
+}
+
+var _ TestResource = &provisioningTestResource{}
+
+func (p *provisioningTestResource) setupResource(driver drivers.TestDriver, pattern testpatterns.TestPattern) {
+	// Setup provisioningTest resource
+	switch pattern.VolType {
+	case testpatterns.DynamicPV:
+		if dDriver, ok := driver.(drivers.DynamicPVTestDriver); ok {
+			p.sc = dDriver.GetDynamicProvisionStorageClass("")
+			if p.sc == nil {
+				framework.Skipf("Driver %q does not define Dynamic Provision StorageClass - skipping", driver.GetDriverInfo().Name)
+			}
+			p.driver = driver
+			p.claimSize = "2Gi"
+			p.pvc = getClaim(p.claimSize, driver.GetDriverInfo().Framework.Namespace.Name)
+			p.pvc.Spec.StorageClassName = &p.sc.Name
+			framework.Logf("In creating storage class object and pvc object for driver - sc: %v, pvc: %v", p.sc, p.pvc)
+		}
+	default:
+		framework.Failf("Dynamic Provision test doesn't support: %s", pattern.VolType)
+	}
+}
+
+func (p *provisioningTestResource) cleanupResource(driver drivers.TestDriver, pattern testpatterns.TestPattern) {
+}
+
+type provisioningTestInput struct {
+	testCase StorageClassTest
+	cs       clientset.Interface
+	pvc      *v1.PersistentVolumeClaim
+	sc       *storage.StorageClass
+	dInfo    *drivers.DriverInfo
+}
+
+func testProvisioning(input *provisioningTestInput) {
+	It("should provision storage", func() {
+		TestDynamicProvisioning(input.testCase, input.cs, input.pvc, input.sc)
+	})
+
+	It("should provision storage with mount options", func() {
+		if input.dInfo.SupportedMountOption == nil {
+			framework.Skipf("Driver %q does not define supported mount option - skipping", input.dInfo.Name)
+		}
+
+		input.sc.MountOptions = input.dInfo.SupportedMountOption.Union(input.dInfo.RequiredMountOption).List()
+		TestDynamicProvisioning(input.testCase, input.cs, input.pvc, input.sc)
+	})
+
+	It("should provision storage with non-default reclaim policy Retain", func() {
+		retain := v1.PersistentVolumeReclaimRetain
+		input.sc.ReclaimPolicy = &retain
+		pv := TestDynamicProvisioning(input.testCase, input.cs, input.pvc, input.sc)
+
+		By(fmt.Sprintf("waiting for the provisioned PV %q to enter phase %s", pv.Name, v1.VolumeReleased))
+		framework.ExpectNoError(framework.WaitForPersistentVolumePhase(v1.VolumeReleased, input.cs, pv.Name, 1*time.Second, 30*time.Second))
+
+		By(fmt.Sprintf("deleting the PV %q", pv.Name))
+		framework.ExpectNoError(framework.DeletePersistentVolume(input.cs, pv.Name), "Failed to delete PV ", pv.Name)
+		framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(input.cs, pv.Name, 1*time.Second, 30*time.Second))
+	})
+
+	It("should create and delete block persistent volumes [Feature:BlockVolume]", func() {
+		if !input.dInfo.IsBlockSupported {
+			framework.Skipf("Driver %q does not support BlockVolume - skipping", input.dInfo.Name)
+		}
+		block := v1.PersistentVolumeBlock
+		input.testCase.VolumeMode = &block
+		input.testCase.SkipWriteReadCheck = true
+		input.pvc.Spec.VolumeMode = &block
+		TestDynamicProvisioning(input.testCase, input.cs, input.pvc, input.sc)
+	})
+}
+
+// TestDynamicProvisioning tests dynamic provisioning with specified StorageClassTest and storageClass
+func TestDynamicProvisioning(t StorageClassTest, client clientset.Interface, claim *v1.PersistentVolumeClaim, class *storage.StorageClass) *v1.PersistentVolume {
+	var err error
+	if class != nil {
+		By("creating a StorageClass " + class.Name)
+		class, err = client.StorageV1().StorageClasses().Create(class)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			framework.Logf("deleting storage class %s", class.Name)
+			framework.ExpectNoError(client.StorageV1().StorageClasses().Delete(class.Name, nil))
+		}()
+	}
+
+	By("creating a claim")
+	claim, err = client.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(claim)
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		framework.Logf("deleting claim %q/%q", claim.Namespace, claim.Name)
+		// typically this claim has already been deleted
+		err = client.CoreV1().PersistentVolumeClaims(claim.Namespace).Delete(claim.Name, nil)
+		if err != nil && !apierrs.IsNotFound(err) {
+			framework.Failf("Error deleting claim %q. Error: %v", claim.Name, err)
+		}
+	}()
+	err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, claim.Namespace, claim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("checking the claim")
+	// Get new copy of the claim
+	claim, err = client.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(claim.Name, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Get the bound PV
+	pv, err := client.CoreV1().PersistentVolumes().Get(claim.Spec.VolumeName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Check sizes
+	expectedCapacity := resource.MustParse(t.ExpectedSize)
+	pvCapacity := pv.Spec.Capacity[v1.ResourceName(v1.ResourceStorage)]
+	Expect(pvCapacity.Value()).To(Equal(expectedCapacity.Value()), "pvCapacity is not equal to expectedCapacity")
+
+	requestedCapacity := resource.MustParse(t.ClaimSize)
+	claimCapacity := claim.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
+	Expect(claimCapacity.Value()).To(Equal(requestedCapacity.Value()), "claimCapacity is not equal to requestedCapacity")
+
+	// Check PV properties
+	By("checking the PV")
+	expectedAccessModes := []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+	Expect(pv.Spec.AccessModes).To(Equal(expectedAccessModes))
+	Expect(pv.Spec.ClaimRef.Name).To(Equal(claim.ObjectMeta.Name))
+	Expect(pv.Spec.ClaimRef.Namespace).To(Equal(claim.ObjectMeta.Namespace))
+	if class == nil {
+		Expect(pv.Spec.PersistentVolumeReclaimPolicy).To(Equal(v1.PersistentVolumeReclaimDelete))
+	} else {
+		Expect(pv.Spec.PersistentVolumeReclaimPolicy).To(Equal(*class.ReclaimPolicy))
+		Expect(pv.Spec.MountOptions).To(Equal(class.MountOptions))
+	}
+	if t.VolumeMode != nil {
+		Expect(pv.Spec.VolumeMode).NotTo(BeNil())
+		Expect(*pv.Spec.VolumeMode).To(Equal(*t.VolumeMode))
+	}
+
+	// Run the checker
+	if t.PvCheck != nil {
+		err = t.PvCheck(pv)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	if !t.SkipWriteReadCheck {
+		// We start two pods:
+		// - The first writes 'hello word' to the /mnt/test (= the volume).
+		// - The second one runs grep 'hello world' on /mnt/test.
+		// If both succeed, Kubernetes actually allocated something that is
+		// persistent across pods.
+		By("checking the created volume is writable and has the PV's mount options")
+		command := "echo 'hello world' > /mnt/test/data"
+		// We give the first pod the secondary responsibility of checking the volume has
+		// been mounted with the PV's mount options, if the PV was provisioned with any
+		for _, option := range pv.Spec.MountOptions {
+			// Get entry, get mount options at 6th word, replace brackets with commas
+			command += fmt.Sprintf(" && ( mount | grep 'on /mnt/test' | awk '{print $6}' | sed 's/^(/,/; s/)$/,/' | grep -q ,%s, )", option)
+		}
+		runInPodWithVolume(client, claim.Namespace, claim.Name, t.NodeName, command)
+
+		By("checking the created volume is readable and retains data")
+		runInPodWithVolume(client, claim.Namespace, claim.Name, t.NodeName, "grep 'hello world' /mnt/test/data")
+	}
+	By(fmt.Sprintf("deleting claim %q/%q", claim.Namespace, claim.Name))
+	framework.ExpectNoError(client.CoreV1().PersistentVolumeClaims(claim.Namespace).Delete(claim.Name, nil))
+
+	// Wait for the PV to get deleted if reclaim policy is Delete. (If it's
+	// Retain, there's no use waiting because the PV won't be auto-deleted and
+	// it's expected for the caller to do it.) Technically, the first few delete
+	// attempts may fail, as the volume is still attached to a node because
+	// kubelet is slowly cleaning up the previous pod, however it should succeed
+	// in a couple of minutes. Wait 20 minutes to recover from random cloud
+	// hiccups.
+	if pv.Spec.PersistentVolumeReclaimPolicy == v1.PersistentVolumeReclaimDelete {
+		By(fmt.Sprintf("deleting the claim's PV %q", pv.Name))
+		framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(client, pv.Name, 5*time.Second, 20*time.Minute))
+	}
+
+	return pv
+}
+
+// runInPodWithVolume runs a command in a pod with given claim mounted to /mnt directory.
+func runInPodWithVolume(c clientset.Interface, ns, claimName, nodeName, command string) {
+	pod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "pvc-volume-tester-",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "volume-tester",
+					Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+					Command: []string{"/bin/sh"},
+					Args:    []string{"-c", command},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "my-volume",
+							MountPath: "/mnt/test",
+						},
+					},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+			Volumes: []v1.Volume{
+				{
+					Name: "my-volume",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: claimName,
+							ReadOnly:  false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if len(nodeName) != 0 {
+		pod.Spec.NodeName = nodeName
+	}
+	pod, err := c.CoreV1().Pods(ns).Create(pod)
+	framework.ExpectNoError(err, "Failed to create pod: %v", err)
+	defer func() {
+		framework.DeletePodOrFail(c, ns, pod.Name)
+	}()
+	framework.ExpectNoError(framework.WaitForPodSuccessInNamespaceSlow(c, pod.Name, pod.Namespace))
+}

--- a/test/e2e/storage/utils/utils.go
+++ b/test/e2e/storage/utils/utils.go
@@ -338,7 +338,7 @@ func StartExternalProvisioner(c clientset.Interface, ns string, externalPluginNa
 			Containers: []v1.Container{
 				{
 					Name:  "nfs-provisioner",
-					Image: "quay.io/kubernetes_incubator/nfs-provisioner:v2.1.0-k8s1.11",
+					Image: "quay.io/kubernetes_incubator/nfs-provisioner:v2.2.0-k8s1.12",
 					SecurityContext: &v1.SecurityContext{
 						Capabilities: &v1.Capabilities{
 							Add: []v1.Capability{"DAC_READ_SEARCH"},

--- a/test/e2e/storage/volume_expand.go
+++ b/test/e2e/storage/volume_expand.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -54,9 +55,9 @@ var _ = utils.SIGDescribe("Volume expand [Slow]", func() {
 		c = f.ClientSet
 		ns = f.Namespace.Name
 		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
-		test := storageClassTest{
-			name:      "default",
-			claimSize: "2Gi",
+		test := testsuites.StorageClassTest{
+			Name:      "default",
+			ClaimSize: "2Gi",
 		}
 		resizableSc, err = createResizableStorageClass(test, ns, "resizing", c)
 		Expect(err).NotTo(HaveOccurred(), "Error creating resizable storage class")
@@ -133,7 +134,7 @@ var _ = utils.SIGDescribe("Volume expand [Slow]", func() {
 	})
 })
 
-func createResizableStorageClass(t storageClassTest, ns string, suffix string, c clientset.Interface) (*storage.StorageClass, error) {
+func createResizableStorageClass(t testsuites.StorageClassTest, ns string, suffix string, c clientset.Interface) (*storage.StorageClass, error) {
 	stKlass := newStorageClass(t, ns, suffix)
 	allowExpansion := true
 	stKlass.AllowVolumeExpansion = &allowExpansion

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -31,6 +31,7 @@ import (
 	kubeletmetrics "k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/metrics"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -52,9 +53,9 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		defaultScName := getDefaultStorageClassName(c)
 		verifyDefaultStorageClass(c, defaultScName, true)
 
-		test := storageClassTest{
-			name:      "default",
-			claimSize: "2Gi",
+		test := testsuites.StorageClassTest{
+			Name:      "default",
+			ClaimSize: "2Gi",
 		}
 
 		pvc = newClaim(test, ns, "default")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves minimum set of dynamic provisioning e2e test to testsuites.
It will make all in-tree drivers do the dynamic provisioning test that CSI drivers are currently doing.

This is needed for https://github.com/kubernetes/kubernetes/issues/68024 and separated from https://github.com/kubernetes/kubernetes/pull/68025. By this separation, https://github.com/kubernetes/kubernetes/pull/68025 can focus only on making CSI drivers call the testsuites that is defined for in-tree drivers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/sig storage

**Release note**:
```release-note
NONE
```
