### PR TITLE
kubectl rolling update: removes podutil and deploymentutil dependencies

### DIFF
--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -110,7 +110,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubectl",
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
-        "//pkg/api/v1/pod:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/v1:go_default_library",
         "//pkg/apis/extensions:go_default_library",


### PR DESCRIPTION
* Removes podutil dependency by copying code from kubernetes core podutil.
* Removes deploymentutil dependency by copying code from kubernetes core deploymentutil.
* SIG CLI already agreed that copying code in order to move kubectl out of core was approved.

Helps address:
https://github.com/kubernetes/kubectl/issues/80

```release-note
NONE
```
