### PR TITLE
Cherry pick of #67110: CSI plugin now calls NodeGetInfo() to get driver's node ID

### DIFF
--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	"context"
+
 	"github.com/golang/glog"
 	api "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,6 +79,7 @@ type csiDriversStore struct {
 	sync.RWMutex
 }
 
+// TODO (verult) consider using a struct instead of global variables
 // csiDrivers map keep track of all registered CSI drivers on the node and their
 // corresponding sockets
 var csiDrivers csiDriversStore
@@ -93,16 +96,32 @@ func RegistrationCallback(pluginName string, endpoint string, versions []string,
 	if endpoint == "" {
 		endpoint = socketPath
 	}
-	// Calling nodeLabelManager to update label for newly registered CSI driver
-	err := lm.AddLabels(pluginName)
-	if err != nil {
-		return err, nil
-	}
+
 	// Storing endpoint of newly registered CSI driver into the map, where CSI driver name will be the key
 	// all other CSI components will be able to get the actual socket of CSI drivers by its name.
 	csiDrivers.Lock()
 	defer csiDrivers.Unlock()
 	csiDrivers.driversMap[pluginName] = csiDriver{driverName: pluginName, driverEndpoint: endpoint}
+
+	// Get node info from the driver.
+	csi := newCsiDriverClient(pluginName)
+	// TODO (verult) retry with exponential backoff, possibly added in csi client library.
+	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
+	defer cancel()
+	driverNodeID, _, _, err := csi.NodeGetInfo(ctx)
+	if err != nil {
+		return fmt.Errorf("error during CSI NodeGetInfo() call: %v", err), nil
+	}
+
+	// Calling nodeLabelManager to update annotations and labels for newly registered CSI driver
+	err = lm.AddLabels(pluginName, driverNodeID)
+	if err != nil {
+		// Unregister the driver and return error
+		csiDrivers.Lock()
+		defer csiDrivers.Unlock()
+		delete(csiDrivers.driversMap, pluginName)
+		return err, nil
+	}
 
 	return nil, nil
 }

--- a/pkg/volume/csi/fake/fake_client.go
+++ b/pkg/volume/csi/fake/fake_client.go
@@ -61,6 +61,7 @@ type NodeClient struct {
 	nodePublishedVolumes map[string]string
 	nodeStagedVolumes    map[string]string
 	stageUnstageSet      bool
+	nodeGetInfoResp      *csipb.NodeGetInfoResponse
 	nextErr              error
 }
 
@@ -76,6 +77,10 @@ func NewNodeClient(stageUnstageSet bool) *NodeClient {
 // SetNextError injects next expected error
 func (f *NodeClient) SetNextError(err error) {
 	f.nextErr = err
+}
+
+func (f *NodeClient) SetNodeGetInfoResp(resp *csipb.NodeGetInfoResponse) {
+	f.nodeGetInfoResp = resp
 }
 
 // GetNodePublishedVolumes returns node published volumes
@@ -177,6 +182,14 @@ func (f *NodeClient) NodeUnstageVolume(ctx context.Context, req *csipb.NodeUnsta
 // NodeGetId implements method
 func (f *NodeClient) NodeGetId(ctx context.Context, in *csipb.NodeGetIdRequest, opts ...grpc.CallOption) (*csipb.NodeGetIdResponse, error) {
 	return nil, nil
+}
+
+// NodeGetId implements csi method
+func (f *NodeClient) NodeGetInfo(ctx context.Context, in *csipb.NodeGetInfoRequest, opts ...grpc.CallOption) (*csipb.NodeGetInfoResponse, error) {
+	if f.nextErr != nil {
+		return nil, f.nextErr
+	}
+	return f.nodeGetInfoResp, nil
 }
 
 // NodeGetCapabilities implements csi method

--- a/pkg/volume/csi/labelmanager/labelmanager.go
+++ b/pkg/volume/csi/labelmanager/labelmanager.go
@@ -34,7 +34,6 @@ const (
 	// Name of node annotation that contains JSON map of driver names to node
 	// names
 	annotationKey = "csi.volume.kubernetes.io/nodeid"
-	csiPluginName = "kubernetes.io/csi"
 )
 
 // labelManagementStruct is struct of channels used for communication between the driver registration
@@ -46,7 +45,7 @@ type labelManagerStruct struct {
 
 // Interface implements an interface for managing labels of a node
 type Interface interface {
-	AddLabels(driverName string) error
+	AddLabels(driverName string, driverNodeId string) error
 }
 
 // NewLabelManager initializes labelManagerStruct and returns available interfaces
@@ -59,8 +58,8 @@ func NewLabelManager(nodeName types.NodeName, kubeClient kubernetes.Interface) I
 
 // nodeLabelManager waits for labeling requests initiated by the driver's registration
 // process.
-func (lm labelManagerStruct) AddLabels(driverName string) error {
-	err := verifyAndAddNodeId(string(lm.nodeName), lm.k8s.CoreV1().Nodes(), driverName, string(lm.nodeName))
+func (lm labelManagerStruct) AddLabels(driverName string, driverNodeId string) error {
+	err := verifyAndAddNodeId(string(lm.nodeName), lm.k8s.CoreV1().Nodes(), driverName, driverNodeId)
 	if err != nil {
 		return fmt.Errorf("failed to update node %s's annotation with error: %+v", lm.nodeName, err)
 	}


### PR DESCRIPTION
Cherry pick of #67110 on release-1.11.

#67110: CSI plugin now calls NodeGetInfo() to get driver's node ID

Added a fix for the driver map deadlock, in addition to the cherrypick. The deadlock fix is already in 1.12 as part of a separate PR.

Fixes #69189 

```release-note
Bug fix: Kubelet CSI driver registration now correctly registers node ID reported by the driver, rather than the k8s node name.
```

/sig storage
/cc @davidz627 @vladimirvivien @jsafrane
/kind bug