### PR TITLE
kubectl env resolve: copy core fieldpath and resource dependencies into kubectl

### DIFF
--- a/pkg/kubectl/cmd/set/env/BUILD
+++ b/pkg/kubectl/cmd/set/env/BUILD
@@ -10,12 +10,13 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubectl/cmd/set/env",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/api/v1/resource:go_default_library",
-        "//pkg/fieldpath:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
     ],
 )

--- a/pkg/kubectl/cmd/set/env/env_resolve.go
+++ b/pkg/kubectl/cmd/set/env/env_resolve.go
@@ -18,31 +18,36 @@ package env
 
 import (
 	"fmt"
+	"math"
+	"strconv"
+	"strings"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/pkg/api/v1/resource"
-	"k8s.io/kubernetes/pkg/fieldpath"
 )
 
 // ResourceStore defines a new resource store data structure.
 type ResourceStore struct {
-	SecretStore    map[string]*v1.Secret
-	ConfigMapStore map[string]*v1.ConfigMap
+	SecretStore    map[string]*corev1.Secret
+	ConfigMapStore map[string]*corev1.ConfigMap
 }
 
 // NewResourceStore returns a pointer to a new resource store data structure.
 func NewResourceStore() *ResourceStore {
 	return &ResourceStore{
-		SecretStore:    make(map[string]*v1.Secret),
-		ConfigMapStore: make(map[string]*v1.ConfigMap),
+		SecretStore:    make(map[string]*corev1.Secret),
+		ConfigMapStore: make(map[string]*corev1.ConfigMap),
 	}
 }
 
 // getSecretRefValue returns the value of a secret in the supplied namespace
-func getSecretRefValue(client kubernetes.Interface, namespace string, store *ResourceStore, secretSelector *v1.SecretKeySelector) (string, error) {
+func getSecretRefValue(client kubernetes.Interface, namespace string, store *ResourceStore, secretSelector *corev1.SecretKeySelector) (string, error) {
 	secret, ok := store.SecretStore[secretSelector.Name]
 	if !ok {
 		var err error
@@ -60,7 +65,7 @@ func getSecretRefValue(client kubernetes.Interface, namespace string, store *Res
 }
 
 // getConfigMapRefValue returns the value of a configmap in the supplied namespace
-func getConfigMapRefValue(client kubernetes.Interface, namespace string, store *ResourceStore, configMapSelector *v1.ConfigMapKeySelector) (string, error) {
+func getConfigMapRefValue(client kubernetes.Interface, namespace string, store *ResourceStore, configMapSelector *corev1.ConfigMapKeySelector) (string, error) {
 	configMap, ok := store.ConfigMapStore[configMapSelector.Name]
 	if !ok {
 		var err error
@@ -77,17 +82,149 @@ func getConfigMapRefValue(client kubernetes.Interface, namespace string, store *
 }
 
 // getFieldRef returns the value of the supplied path in the given object
-func getFieldRef(obj runtime.Object, from *v1.EnvVarSource) (string, error) {
-	return fieldpath.ExtractFieldPathAsString(obj, from.FieldRef.FieldPath)
+func getFieldRef(obj runtime.Object, from *corev1.EnvVarSource) (string, error) {
+	return extractFieldPathAsString(obj, from.FieldRef.FieldPath)
+}
+
+// extractFieldPathAsString extracts the field from the given object
+// and returns it as a string.  The object must be a pointer to an
+// API type.
+func extractFieldPathAsString(obj interface{}, fieldPath string) (string, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", nil
+	}
+
+	if path, subscript, ok := splitMaybeSubscriptedPath(fieldPath); ok {
+		switch path {
+		case "metadata.annotations":
+			if errs := validation.IsQualifiedName(strings.ToLower(subscript)); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetAnnotations()[subscript], nil
+		case "metadata.labels":
+			if errs := validation.IsQualifiedName(subscript); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetLabels()[subscript], nil
+		default:
+			return "", fmt.Errorf("fieldPath %q does not support subscript", fieldPath)
+		}
+	}
+
+	switch fieldPath {
+	case "metadata.annotations":
+		return formatMap(accessor.GetAnnotations()), nil
+	case "metadata.labels":
+		return formatMap(accessor.GetLabels()), nil
+	case "metadata.name":
+		return accessor.GetName(), nil
+	case "metadata.namespace":
+		return accessor.GetNamespace(), nil
+	case "metadata.uid":
+		return string(accessor.GetUID()), nil
+	}
+
+	return "", fmt.Errorf("unsupported fieldPath: %v", fieldPath)
+}
+
+// splitMaybeSubscriptedPath checks whether the specified fieldPath is
+// subscripted, and
+//  - if yes, this function splits the fieldPath into path and subscript, and
+//    returns (path, subscript, true).
+//  - if no, this function returns (fieldPath, "", false).
+//
+// Example inputs and outputs:
+//  - "metadata.annotations['myKey']" --> ("metadata.annotations", "myKey", true)
+//  - "metadata.annotations['a[b]c']" --> ("metadata.annotations", "a[b]c", true)
+//  - "metadata.labels['']"           --> ("metadata.labels", "", true)
+//  - "metadata.labels"               --> ("metadata.labels", "", false)
+func splitMaybeSubscriptedPath(fieldPath string) (string, string, bool) {
+	if !strings.HasSuffix(fieldPath, "']") {
+		return fieldPath, "", false
+	}
+	s := strings.TrimSuffix(fieldPath, "']")
+	parts := strings.SplitN(s, "['", 2)
+	if len(parts) < 2 {
+		return fieldPath, "", false
+	}
+	if len(parts[0]) == 0 {
+		return fieldPath, "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// formatMap formats map[string]string to a string.
+func formatMap(m map[string]string) (fmtStr string) {
+	// output with keys in sorted order to provide stable output
+	keys := sets.NewString()
+	for key := range m {
+		keys.Insert(key)
+	}
+	for _, key := range keys.List() {
+		fmtStr += fmt.Sprintf("%v=%q\n", key, m[key])
+	}
+	fmtStr = strings.TrimSuffix(fmtStr, "\n")
+
+	return
 }
 
 // getResourceFieldRef returns the value of a resource in the given container
-func getResourceFieldRef(from *v1.EnvVarSource, c *v1.Container) (string, error) {
-	return resource.ExtractContainerResourceValue(from.ResourceFieldRef, c)
+func getResourceFieldRef(from *corev1.EnvVarSource, container *corev1.Container) (string, error) {
+	return extractContainerResourceValue(from.ResourceFieldRef, container)
+}
+
+// ExtractContainerResourceValue extracts the value of a resource
+// in an already known container
+func extractContainerResourceValue(fs *corev1.ResourceFieldSelector, container *corev1.Container) (string, error) {
+	divisor := resource.Quantity{}
+	if divisor.Cmp(fs.Divisor) == 0 {
+		divisor = resource.MustParse("1")
+	} else {
+		divisor = fs.Divisor
+	}
+
+	switch fs.Resource {
+	case "limits.cpu":
+		return convertResourceCPUToString(container.Resources.Limits.Cpu(), divisor)
+	case "limits.memory":
+		return convertResourceMemoryToString(container.Resources.Limits.Memory(), divisor)
+	case "limits.ephemeral-storage":
+		return convertResourceEphemeralStorageToString(container.Resources.Limits.StorageEphemeral(), divisor)
+	case "requests.cpu":
+		return convertResourceCPUToString(container.Resources.Requests.Cpu(), divisor)
+	case "requests.memory":
+		return convertResourceMemoryToString(container.Resources.Requests.Memory(), divisor)
+	case "requests.ephemeral-storage":
+		return convertResourceEphemeralStorageToString(container.Resources.Requests.StorageEphemeral(), divisor)
+	}
+
+	return "", fmt.Errorf("Unsupported container resource : %v", fs.Resource)
+}
+
+// convertResourceCPUToString converts cpu value to the format of divisor and returns
+// ceiling of the value.
+func convertResourceCPUToString(cpu *resource.Quantity, divisor resource.Quantity) (string, error) {
+	c := int64(math.Ceil(float64(cpu.MilliValue()) / float64(divisor.MilliValue())))
+	return strconv.FormatInt(c, 10), nil
+}
+
+// convertResourceMemoryToString converts memory value to the format of divisor and returns
+// ceiling of the value.
+func convertResourceMemoryToString(memory *resource.Quantity, divisor resource.Quantity) (string, error) {
+	m := int64(math.Ceil(float64(memory.Value()) / float64(divisor.Value())))
+	return strconv.FormatInt(m, 10), nil
+}
+
+// convertResourceEphemeralStorageToString converts ephemeral storage value to the format of divisor and returns
+// ceiling of the value.
+func convertResourceEphemeralStorageToString(ephemeralStorage *resource.Quantity, divisor resource.Quantity) (string, error) {
+	m := int64(math.Ceil(float64(ephemeralStorage.Value()) / float64(divisor.Value())))
+	return strconv.FormatInt(m, 10), nil
 }
 
 // GetEnvVarRefValue returns the value referenced by the supplied EnvVarSource given the other supplied information.
-func GetEnvVarRefValue(kc kubernetes.Interface, ns string, store *ResourceStore, from *v1.EnvVarSource, obj runtime.Object, c *v1.Container) (string, error) {
+func GetEnvVarRefValue(kc kubernetes.Interface, ns string, store *ResourceStore, from *corev1.EnvVarSource, obj runtime.Object, c *corev1.Container) (string, error) {
 	if from.SecretKeyRef != nil {
 		return getSecretRefValue(kc, ns, store, from.SecretKeyRef)
 	}
@@ -108,7 +245,7 @@ func GetEnvVarRefValue(kc kubernetes.Interface, ns string, store *ResourceStore,
 }
 
 // GetEnvVarRefString returns a text description of whichever field is set within the supplied EnvVarSource argument.
-func GetEnvVarRefString(from *v1.EnvVarSource) string {
+func GetEnvVarRefString(from *corev1.EnvVarSource) string {
 	if from.ConfigMapKeyRef != nil {
 		return fmt.Sprintf("configmap %s, key %s", from.ConfigMapKeyRef.Name, from.ConfigMapKeyRef.Key)
 	}


### PR DESCRIPTION
* Copies function used in core pkg/fieldpath into env_resolve.go.
* Copies function used in core pkg/api/v1/resource into env_resolve.go.
* SIG CLI has discussed and approved this copying to facilitate the removal of kubectl from Kubernetes core.

Helps address:
https://github.com/kubernetes/kubectl/issues/80

```release-note
NONE
```
