### PR TITLE
Sort bind options in JoinMountOptions

### DIFF
--- a/pkg/volume/awsebs/aws_ebs_test.go
+++ b/pkg/volume/awsebs/aws_ebs_test.go
@@ -371,7 +371,7 @@ func TestMountOptions(t *testing.T) {
 		t.Errorf("Expected success, got: %v", err)
 	}
 	mountOptions := fakeMounter.MountPoints[0].Opts
-	expectedMountOptions := []string{"bind", "_netdev"}
+	expectedMountOptions := []string{"_netdev", "bind"}
 	if !reflect.DeepEqual(mountOptions, expectedMountOptions) {
 		t.Errorf("Expected mount options to be %v got %v", expectedMountOptions, mountOptions)
 	}

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -766,7 +766,7 @@ func JoinMountOptions(userOptions []string, systemOptions []string) []string {
 	for _, mountOption := range systemOptions {
 		allMountOptions.Insert(mountOption)
 	}
-	return allMountOptions.UnsortedList()
+	return allMountOptions.List()
 }
 
 // ValidateZone returns:


### PR DESCRIPTION
We were not sorting them previously, which made the order
non-deterministic.  If we believe the order doesn't matter, let's pick a
consistent order to minimize the chances of a rare flake.

This also simplifies the unit tests, which were flaking not-very-rarely,
e.g. with

`bazel test //pkg/volume/awsebs/... --runs_per_test=8`