### PR TITLE
Update elasticsearch to v6.3.0

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
@@ -54,7 +54,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: elasticsearch-logging
-    version: v6.2.5
+    version: v6.3.0
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -63,17 +63,17 @@ spec:
   selector:
     matchLabels:
       k8s-app: elasticsearch-logging
-      version: v6.2.5
+      version: v6.3.0
   template:
     metadata:
       labels:
         k8s-app: elasticsearch-logging
-        version: v6.2.5
+        version: v6.3.0
         kubernetes.io/cluster-service: "true"
     spec:
       serviceAccountName: elasticsearch-logging
       containers:
-      - image: k8s.gcr.io/elasticsearch:v6.2.5
+      - image: k8s.gcr.io/elasticsearch:v6.3.0
         name: elasticsearch-logging
         resources:
           # need more cpu upon initialization, therefore burstable class


### PR DESCRIPTION
According to commit "updates es-image to elasticsearch 6.3.2" and "updates kibana to 6.3.2",
the old yaml elasticsearch version is v6.2.5, it will cause kibana raise:
```
{"type":"log","@timestamp":"2018-10-05T01:34:37Z","tags":["status","plugin:elasticsearch@6.3.2","error"],"pid":1,"state":"red","message":"Status changed from red to red - This version of Kibana requires Elasticsearch v6.3.2 on all nodes. I found the following incompatible nodes in your cluster: v6.2.4 @ 10.4.3.129:9200 (10.4.3.129), v6.2.4 @ 10.4.4.145:9200 (10.4.4.145)","prevState":"red","prevMsg":"Unable to connect to Elasticsearch at http://elasticsearch-logging:9200."}
```
so update image version to v6.3.0 and from k8s.gcr.io/elasticsearch.

```release-note
NONE
```