### PR TITLE
Dashboard: Work around bug in the dashboard that prevents settings from saving

### DIFF
--- a/cluster/addons/dashboard/dashboard-configmap.yaml
+++ b/cluster/addons/dashboard/dashboard-configmap.yaml
@@ -7,3 +7,5 @@ metadata:
     addonmanager.kubernetes.io/mode: EnsureExists
   name: kubernetes-dashboard-settings
   namespace: kube-system
+data:
+  _global: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a bug in the dashboard that prevents settings from being saved if the configmap exists but does not have any data in it. [I opened a PR to fix it in the dashboard code](https://github.com/kubernetes/dashboard/pull/3280), but by merging this PR it will be fixed for all versions. I imagine a lot of people apply this with:

```
kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/dashboard/dashboard-configmap.yaml
```

Anyone who applies this configmap is currently affected by the bug.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/dashboard/issues/3149

**Special notes for your reviewer**:
Can't think of anything special.

**Release note**:
```release-note
NONE
```
