### PR TITLE
delete node from aws if it is terminated

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1386,7 +1386,9 @@ func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID str
 	}
 	if len(instances) == 0 {
 		glog.Warningf("the instance %s does not exist anymore", providerID)
-		return true, nil
+		// returns false, because otherwise node is not deleted from cluster
+		// false means that it will continue to check InstanceExistsByProviderID
+		return false, nil
 	}
 	if len(instances) > 1 {
 		return false, fmt.Errorf("multiple instances found for instance: %s", instanceID)
@@ -1396,7 +1398,7 @@ func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID str
 	if instance.State != nil {
 		state := aws.StringValue(instance.State.Name)
 		// valid state for detaching volumes
-		if state == ec2.InstanceStateNameStopped || state == ec2.InstanceStateNameTerminated {
+		if state == ec2.InstanceStateNameStopped {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: currently (1.12 ->) nodes are not deleted from cluster if those are terminated

**Which issue(s) this PR fixes**: 
Fixes #69409

**Special notes for your reviewer**: When we remove terminated state from shutdown function. Then it does not add shutdown taint if node is terminated - instead it will delete node. 

Also if we see that instance does not exist already in shutdown function, we should continue forward. Otherwise the node is not deleted either. It is little bit stupid to retrieve same instance status twice but thats not easy to modify because all cloudproviders are using it.

**Release note**:
```release-note
NONE
```
/sig aws
/kind bug
/cc @sjenning @gnufied 