### PR TITLE
Increase time-out of kms gRPC service concurrency tests.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go
@@ -160,10 +160,6 @@ func TestUnsupportedVersion(t *testing.T) {
 	}
 }
 
-func TestConcurrentAccess(t *testing.T) {
-
-}
-
 // Normal encryption and decryption operation.
 func TestGRPCService(t *testing.T) {
 	// Start a test gRPC server.
@@ -208,14 +204,14 @@ func TestGRPCServiceConcurrentAccess(t *testing.T) {
 	defer f.server.Stop()
 
 	// Create the gRPC client service.
-	service, err := NewGRPCService(endpoint, 1*time.Second)
+	service, err := NewGRPCService(endpoint, 15*time.Second)
 	if err != nil {
 		t.Fatalf("failed to create envelope service, error: %v", err)
 	}
 	defer destroyService(service)
 
 	var wg sync.WaitGroup
-	n := 1000
+	n := 100
 	wg.Add(n)
 	for i := 0; i < n; i++ {
 		go func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
k8s.io/apiserver/pkg/storage/value/encrypt/envelope:go_default_test has been failing intermittently due to a time-out on a grRPC client - increasing timeout from 1s to 15s.
Ex. https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/69386/pull-kubernetes-bazel-test/62546

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
