### PR TITLE
Correctly handle named pipe host mounts for Windows

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -216,7 +216,7 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 
 		// Docker Volume Mounts fail on Windows if it is not of the form C:/
 		if volumeutil.IsWindowsLocalPath(runtime.GOOS, hostPath) {
-			hostPath = "c:" + hostPath
+			hostPath = volumeutil.MakeAbsolutePath(runtime.GOOS, hostPath)
 		}
 
 		containerPath := mount.MountPath

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -219,6 +219,8 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 		containerPath := mount.MountPath
 		if runtime.GOOS == "windows" {
 			// Append C: only if it looks like a local path. Do not process UNC path/SMB shares/named pipes
+			// NOTE: strings.HasPrefix(hostPath, "\\") checks for prefix "\" as in "\foo\bar" and not "\\foo\bar"
+			// IsWindowsUNCPath checks for prefix "\\" as in "\\foo\bar" and not "\foo\bar"
 			if (strings.HasPrefix(hostPath, "/") || strings.HasPrefix(hostPath, "\\")) && !strings.Contains(hostPath, ":") && !volumeutil.IsWindowsUNCPath(runtime.GOOS, hostPath) {
 				hostPath = "c:" + hostPath
 			}

--- a/pkg/kubelet/kubelet_pods_windows_test.go
+++ b/pkg/kubelet/kubelet_pods_windows_test.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
 Copyright 2017 The Kubernetes Authors.
 
@@ -50,6 +48,21 @@ func TestMakeMountsWindows(t *testing.T) {
 				Name:      "disk5",
 				ReadOnly:  false,
 			},
+			{
+				MountPath: `\mnt\path6`,
+				Name:      "disk6",
+				ReadOnly:  false,
+			},
+			{
+				MountPath: `/mnt/path7`,
+				Name:      "disk7",
+				ReadOnly:  false,
+			},
+			{
+				MountPath: `\\.\pipe\pipe1`,
+				Name:      "pipe1",
+				ReadOnly:  false,
+			},
 		},
 	}
 
@@ -57,6 +70,9 @@ func TestMakeMountsWindows(t *testing.T) {
 		"disk":  kubecontainer.VolumeInfo{Mounter: &stubVolume{path: "c:/mnt/disk"}},
 		"disk4": kubecontainer.VolumeInfo{Mounter: &stubVolume{path: "c:/mnt/host"}},
 		"disk5": kubecontainer.VolumeInfo{Mounter: &stubVolume{path: "c:/var/lib/kubelet/podID/volumes/empty/disk5"}},
+		"disk6": kubecontainer.VolumeInfo{Mounter: &stubVolume{path: `/mnt/disk6`}},
+		"disk7": kubecontainer.VolumeInfo{Mounter: &stubVolume{path: `\mnt\disk7`}},
+		"pipe1": kubecontainer.VolumeInfo{Mounter: &stubVolume{path: `\\.\pipe\pipe1`}},
 	}
 
 	pod := v1.Pod{
@@ -94,6 +110,27 @@ func TestMakeMountsWindows(t *testing.T) {
 			Name:           "disk5",
 			ContainerPath:  "c:/mnt/path5",
 			HostPath:       "c:/var/lib/kubelet/podID/volumes/empty/disk5",
+			ReadOnly:       false,
+			SELinuxRelabel: false,
+		},
+		{
+			Name:           "disk6",
+			ContainerPath:  `c:\mnt\path6`,
+			HostPath:       `c:/mnt/disk6`,
+			ReadOnly:       false,
+			SELinuxRelabel: false,
+		},
+		{
+			Name:           "disk7",
+			ContainerPath:  `c:/mnt/path7`,
+			HostPath:       `c:\mnt\disk7`,
+			ReadOnly:       false,
+			SELinuxRelabel: false,
+		},
+		{
+			Name:           "pipe1",
+			ContainerPath:  `\\.\pipe\pipe1`,
+			HostPath:       `\\.\pipe\pipe1`,
 			ReadOnly:       false,
 			SELinuxRelabel: false,
 		},

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -945,6 +945,13 @@ func CheckPersistentVolumeClaimModeBlock(pvc *v1.PersistentVolumeClaim) bool {
 	return utilfeature.DefaultFeatureGate.Enabled(features.BlockVolume) && pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == v1.PersistentVolumeBlock
 }
 
+func IsWindowsNamedPipe(goos, path string) bool {
+	if goos == "windows" && strings.HasPrefix(path, `\\.\pipe\`) {
+		return true
+	}
+	return false
+}
+
 // MakeAbsolutePath convert path to absolute path according to GOOS
 func MakeAbsolutePath(goos, path string) string {
 	if goos != "windows" {

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -945,8 +945,15 @@ func CheckPersistentVolumeClaimModeBlock(pvc *v1.PersistentVolumeClaim) bool {
 	return utilfeature.DefaultFeatureGate.Enabled(features.BlockVolume) && pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == v1.PersistentVolumeBlock
 }
 
-func IsWindowsNamedPipe(goos, path string) bool {
-	if goos == "windows" && strings.HasPrefix(path, `\\.\pipe\`) {
+// IsWindowsUNCPath checks if path is prefixed with \\
+// This can be used to skip any processing of paths
+// that point to SMB shares, local named pipes and local UNC path
+func IsWindowsUNCPath(goos, path string) bool {
+	if goos != "windows" {
+		return false
+	}
+	// Check for UNC prefix \\
+	if strings.HasPrefix(path, `\\`) {
 		return true
 	}
 	return false

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -959,6 +959,24 @@ func IsWindowsUNCPath(goos, path string) bool {
 	return false
 }
 
+// IsWindowsLocalPath checks if path is a local path
+// prefixed with "/" or "\" like "/foo/bar" or "\foo\bar"
+func IsWindowsLocalPath(goos, path string) bool {
+	if goos != "windows" {
+		return false
+	}
+	if IsWindowsUNCPath(goos, path) {
+		return false
+	}
+	if strings.Contains(path, ":") {
+		return false
+	}
+	if !(strings.HasPrefix(path, `/`) || strings.HasPrefix(path, `\`)) {
+		return false
+	}
+	return true
+}
+
 // MakeAbsolutePath convert path to absolute path according to GOOS
 func MakeAbsolutePath(goos, path string) string {
 	if goos != "windows" {

--- a/pkg/volume/util/util_test.go
+++ b/pkg/volume/util/util_test.go
@@ -2373,6 +2373,47 @@ func TestGetWindowsPath(t *testing.T) {
 	}
 }
 
+func TestIsWindowsNamedPipe(t *testing.T) {
+	tests := []struct {
+		goos        string
+		path        string
+		isNamedPipe bool
+	}{
+		{
+			goos:        "linux",
+			path:        `/usr/bin`,
+			isNamedPipe: false,
+		},
+		{
+			goos:        "linux",
+			path:        `\\.\pipe\foo`,
+			isNamedPipe: false,
+		},
+		{
+			goos:        "windows",
+			path:        `C:\foo`,
+			isNamedPipe: false,
+		},
+		{
+			goos:        "windows",
+			path:        `\\.\invalid`,
+			isNamedPipe: false,
+		},
+		{
+			goos:        "windows",
+			path:        `\\.\pipe\valid_pipe`,
+			isNamedPipe: true,
+		},
+	}
+
+	for _, test := range tests {
+		result := IsWindowsNamedPipe(test.goos, test.path)
+		if result != test.isNamedPipe {
+			t.Errorf("IsWindowsNamedPipe(%v) returned (%v), expected (%v)", test.path, result, test.isNamedPipe)
+		}
+	}
+}
+
 func TestMakeAbsolutePath(t *testing.T) {
 	tests := []struct {
 		goos         string

--- a/pkg/volume/util/util_test.go
+++ b/pkg/volume/util/util_test.go
@@ -2373,43 +2373,53 @@ func TestGetWindowsPath(t *testing.T) {
 	}
 }
 
-func TestIsWindowsNamedPipe(t *testing.T) {
+func TestIsWindowsUNCPath(t *testing.T) {
 	tests := []struct {
-		goos        string
-		path        string
-		isNamedPipe bool
+		goos      string
+		path      string
+		isUNCPath bool
 	}{
 		{
-			goos:        "linux",
-			path:        `/usr/bin`,
-			isNamedPipe: false,
+			goos:      "linux",
+			path:      `/usr/bin`,
+			isUNCPath: false,
 		},
 		{
-			goos:        "linux",
-			path:        `\\.\pipe\foo`,
-			isNamedPipe: false,
+			goos:      "linux",
+			path:      `\\.\pipe\foo`,
+			isUNCPath: false,
 		},
 		{
-			goos:        "windows",
-			path:        `C:\foo`,
-			isNamedPipe: false,
+			goos:      "windows",
+			path:      `C:\foo`,
+			isUNCPath: false,
 		},
 		{
-			goos:        "windows",
-			path:        `\\.\invalid`,
-			isNamedPipe: false,
+			goos:      "windows",
+			path:      `\\server\share\foo`,
+			isUNCPath: true,
 		},
 		{
-			goos:        "windows",
-			path:        `\\.\pipe\valid_pipe`,
-			isNamedPipe: true,
+			goos:      "windows",
+			path:      `\\?\server\share`,
+			isUNCPath: true,
+		},
+		{
+			goos:      "windows",
+			path:      `\\?\c:\`,
+			isUNCPath: true,
+		},
+		{
+			goos:      "windows",
+			path:      `\\.\pipe\valid_pipe`,
+			isUNCPath: true,
 		},
 	}
 
 	for _, test := range tests {
-		result := IsWindowsNamedPipe(test.goos, test.path)
-		if result != test.isNamedPipe {
-			t.Errorf("IsWindowsNamedPipe(%v) returned (%v), expected (%v)", test.path, result, test.isNamedPipe)
+		result := IsWindowsUNCPath(test.goos, test.path)
+		if result != test.isUNCPath {
+			t.Errorf("IsWindowsUNCPath(%v) returned (%v), expected (%v)", test.path, result, test.isUNCPath)
 		}
 	}
 }

--- a/pkg/volume/util/util_test.go
+++ b/pkg/volume/util/util_test.go
@@ -2424,6 +2424,97 @@ func TestIsWindowsUNCPath(t *testing.T) {
 	}
 }
 
+func TestIsWindowsLocalPath(t *testing.T) {
+	tests := []struct {
+		goos               string
+		path               string
+		isWindowsLocalPath bool
+	}{
+		{
+			goos:               "linux",
+			path:               `/usr/bin`,
+			isWindowsLocalPath: false,
+		},
+		{
+			goos:               "linux",
+			path:               `\\.\pipe\foo`,
+			isWindowsLocalPath: false,
+		},
+		{
+			goos:               "windows",
+			path:               `C:\foo`,
+			isWindowsLocalPath: false,
+		},
+		{
+			goos:               "windows",
+			path:               `:\foo`,
+			isWindowsLocalPath: false,
+		},
+		{
+			goos:               "windows",
+			path:               `X:\foo`,
+			isWindowsLocalPath: false,
+		},
+		{
+			goos:               "windows",
+			path:               `\\server\share\foo`,
+			isWindowsLocalPath: false,
+		},
+		{
+			goos:               "windows",
+			path:               `\\?\server\share`,
+			isWindowsLocalPath: false,
+		},
+		{
+			goos:               "windows",
+			path:               `\\?\c:\`,
+			isWindowsLocalPath: false,
+		},
+		{
+			goos:               "windows",
+			path:               `\\.\pipe\valid_pipe`,
+			isWindowsLocalPath: false,
+		},
+		{
+			goos:               "windows",
+			path:               `foo`,
+			isWindowsLocalPath: false,
+		},
+		{
+			goos:               "windows",
+			path:               `:foo`,
+			isWindowsLocalPath: false,
+		},
+		{
+			goos:               "windows",
+			path:               `\foo`,
+			isWindowsLocalPath: true,
+		},
+		{
+			goos:               "windows",
+			path:               `\foo\bar`,
+			isWindowsLocalPath: true,
+		},
+		{
+			goos:               "windows",
+			path:               `/foo`,
+			isWindowsLocalPath: true,
+		},
+		{
+			goos:               "windows",
+			path:               `/foo/bar`,
+			isWindowsLocalPath: true,
+		},
+	}
+
+	for _, test := range tests {
+		result := IsWindowsLocalPath(test.goos, test.path)
+		if result != test.isWindowsLocalPath {
+			t.Errorf("isWindowsLocalPath(%v) returned (%v), expected (%v)", test.path, result, test.isWindowsLocalPath)
+		}
+	}
+}
+
 func TestMakeAbsolutePath(t *testing.T) {
 	tests := []struct {
 		goos         string


### PR DESCRIPTION
**What this PR does / why we need it**:
Windows named pipes in host mounts were not being correctly handled and passed through to the container runtime. This PR adds support to detect named pipes in Windows and skip the processing associated with regular file system based host mount paths in Windows.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes/kubernetes/issues/67147

**Special notes for your reviewer**:
Tested the following spec spawns up the pod container on Windows with the mount paths to \\\\.\pipe\docker_pipe correctly configured:

```
apiVersion: v1
kind: Pod
metadata:
  name: docker-pipe-windows
spec:
  nodeSelector:
    beta.kubernetes.io/os: windows
  containers:
    - name: main
      image: microsoft/windowsservercore:1803
      command:
        - powershell
        - Start-Sleep
        - "-s 3600"
      volumeMounts:
        - mountPath: \\.\pipe\docker-engine
          name: docker-pipe
  volumes:
    - name: docker-pipe
      hostPath: 
        path: \\.\pipe\docker-engine
        type: null
  restartPolicy: Never
```

`docker inspect` output for above container:
```
...
        "Mounts": [
            {
                "Type": "npipe",
                "Source": "\\\\.\\pipe\\docker-engine",
                "Destination": "\\\\.\\pipe\\docker-engine",
                "Mode": "",
                "RW": true,
                "Propagation": ""
            },
            {
                "Type": "bind",
                "Source": "c:\\var\\lib\\kubelet\\pods\\1e664368-c8f7-11e8-97bc-000d3a35a802\\volumes\\kubernetes.io~secret\\default-token-5kttv",
                "Destination": "c:\\var\\run\\secrets\\kubernetes.io\\serviceaccount",
                "Mode": "",
                "RW": false,
                "Propagation": ""
            }
        ],
...
```

**Release note**:
```release-note
Handle Windows named pipes in host mounts.
```
