### PR TITLE
Optimize node authorizer graph algorithms to avoid interface calls

### DIFF
--- a/third_party/forked/gonum/graph/simple/directed_acyclic.go
+++ b/third_party/forked/gonum/graph/simple/directed_acyclic.go
@@ -29,12 +29,9 @@ func (g *DirectedAcyclicGraph) From(n graph.Node) []graph.Node {
 		return nil
 	}
 
-	fid := n.ID()
 	nodes := make([]graph.Node, 0, g.UndirectedGraph.edges[n.ID()].Len())
-	g.UndirectedGraph.edges[n.ID()].Visit(func(neighbor int, edge graph.Edge) {
-		if edge.From().ID() == fid {
-			nodes = append(nodes, g.UndirectedGraph.nodes[edge.To().ID()])
-		}
+	g.UndirectedGraph.edges[n.ID()].VisitEdgesFromSelf(func(toNodeID int, edge graph.Edge) {
+		nodes = append(nodes, g.UndirectedGraph.nodes[toNodeID])
 	})
 	return nodes
 }
@@ -43,12 +40,9 @@ func (g *DirectedAcyclicGraph) VisitFrom(n graph.Node, visitor func(neighbor gra
 	if !g.Has(n) {
 		return
 	}
-	fid := n.ID()
-	g.UndirectedGraph.edges[n.ID()].Visit(func(neighbor int, edge graph.Edge) {
-		if edge.From().ID() == fid {
-			if !visitor(g.UndirectedGraph.nodes[edge.To().ID()]) {
-				return
-			}
+	g.UndirectedGraph.edges[n.ID()].VisitEdgesFromSelf(func(toNodeID int, edge graph.Edge) {
+		if !visitor(g.UndirectedGraph.nodes[toNodeID]) {
+			return
 		}
 	})
 }
@@ -58,12 +52,9 @@ func (g *DirectedAcyclicGraph) To(n graph.Node) []graph.Node {
 		return nil
 	}
 
-	tid := n.ID()
 	nodes := make([]graph.Node, 0, g.UndirectedGraph.edges[n.ID()].Len())
-	g.UndirectedGraph.edges[n.ID()].Visit(func(neighbor int, edge graph.Edge) {
-		if edge.To().ID() == tid {
-			nodes = append(nodes, g.UndirectedGraph.nodes[edge.From().ID()])
-		}
+	g.UndirectedGraph.edges[n.ID()].VisitEdgesToSelf(func(fromNodeID int, edge graph.Edge) {
+		nodes = append(nodes, g.UndirectedGraph.nodes[fromNodeID])
 	})
 	return nodes
 }
@@ -72,12 +63,9 @@ func (g *DirectedAcyclicGraph) VisitTo(n graph.Node, visitor func(neighbor graph
 	if !g.Has(n) {
 		return
 	}
-	tid := n.ID()
-	g.UndirectedGraph.edges[n.ID()].Visit(func(neighbor int, edge graph.Edge) {
-		if edge.To().ID() == tid {
-			if !visitor(g.UndirectedGraph.nodes[edge.From().ID()]) {
-				return
-			}
+	g.UndirectedGraph.edges[n.ID()].VisitEdgesToSelf(func(fromNodeID int, edge graph.Edge) {
+		if !visitor(g.UndirectedGraph.nodes[fromNodeID]) {
+			return
 		}
 	})
 }

--- a/third_party/forked/gonum/graph/simple/edgeholder.go
+++ b/third_party/forked/gonum/graph/simple/edgeholder.go
@@ -2,10 +2,29 @@ package simple
 
 import "k8s.io/kubernetes/third_party/forked/gonum/graph"
 
+// This code is in a frequently-hit code path (node authorizer), and
+// interface calls were looming large in the profile.  But we also
+// want to keep memory usage sensible.  The majority of the interface
+// calls were to establish the direction of edges, because we only
+// want to visit "out" edges in the node authorizer (grant, not
+// grantee).  So the sliceEdgeHolder and mapEdgeHolder memoize their
+// neighbor, which saves most of the calls.  But the hot code path
+// still needs to walk and check direction, and so
+// splitDirectionEdgeHolder keeps the from & to edges in two separate
+// lists.  Then we can convert the directional VisitEdgesFromSelf call
+// into a non-directional Visit call on the edgsFromSelf list. This
+// avoids most of the interface calls, and is still reasonably memory
+// efficient.  For leaf splitDirectionEdgeHolders, one of those lists
+// is going to be nil anyway.
+
 // edgeHolder represents a set of edges, with no more than one edge to or from a particular neighbor node
 type edgeHolder interface {
-	// Visit invokes visitor with each edge and the id of the neighbor node in the edge
-	Visit(visitor func(neighbor int, edge graph.Edge))
+	// VisitEdges invokes visitor for each edge, pasing the edge and the id of the neighbor node in the edge
+	VisitEdges(visitor func(neighbor int, edge graph.Edge))
+	// VisitEdgesFromSelf invokes visitor for each edge that is directed from self
+	VisitEdgesFromSelf(visitor func(toNodeID int, edge graph.Edge))
+	// VisitEdgesToSelf invokes visitor for each edge that is directed to self
+	VisitEdgesToSelf(visitor func(fromNodeID int, edge graph.Edge))
 	// Delete removes edges to or from the specified neighbor
 	Delete(neighbor int) edgeHolder
 	// Set stores the edge to or from the specified neighbor
@@ -16,32 +35,47 @@ type edgeHolder interface {
 	Len() int
 }
 
+// edgeInfo caches the neighbor, avoid interface calls From()/To()/ID()
+type edgeInfo struct {
+	neighbor int
+	edge     graph.Edge
+}
+
 // sliceEdgeHolder holds a list of edges to or from self
 type sliceEdgeHolder struct {
 	self  int
-	edges []graph.Edge
+	edges []edgeInfo
 }
 
-func (e *sliceEdgeHolder) Visit(visitor func(neighbor int, edge graph.Edge)) {
+func (e *sliceEdgeHolder) VisitEdges(visitor func(neighbor int, edge graph.Edge)) {
 	for _, edge := range e.edges {
-		if edge.From().ID() == e.self {
-			visitor(edge.To().ID(), edge)
-		} else {
-			visitor(edge.From().ID(), edge)
+		visitor(edge.neighbor, edge.edge)
+	}
+}
+
+func (e *sliceEdgeHolder) VisitEdgesFromSelf(visitor func(toNodeID int, edge graph.Edge)) {
+	// Note this call is not cheap, hence we wrap this in a splitDirectionEdgeHolder
+	for _, ei := range e.edges {
+		if ei.edge.From().ID() == e.self {
+			visitor(ei.neighbor, ei.edge)
 		}
 	}
 }
+
+func (e *sliceEdgeHolder) VisitEdgesToSelf(visitor func(toNodeID int, edge graph.Edge)) {
+	// Note this call is not cheap, hence we wrap this in a splitDirectionEdgeHolder
+	for _, ei := range e.edges {
+		if ei.edge.To().ID() == e.self {
+			visitor(ei.neighbor, ei.edge)
+		}
+	}
+}
+
 func (e *sliceEdgeHolder) Delete(neighbor int) edgeHolder {
 	edges := e.edges[:0]
 	for i, edge := range e.edges {
-		if edge.From().ID() == e.self {
-			if edge.To().ID() == neighbor {
-				continue
-			}
-		} else {
-			if edge.From().ID() == neighbor {
-				continue
-			}
+		if edge.neighbor == neighbor {
+			continue
 		}
 		edges = append(edges, e.edges[i])
 	}
@@ -49,46 +83,32 @@ func (e *sliceEdgeHolder) Delete(neighbor int) edgeHolder {
 	return e
 }
 func (e *sliceEdgeHolder) Set(neighbor int, newEdge graph.Edge) edgeHolder {
-	for i, edge := range e.edges {
-		if edge.From().ID() == e.self {
-			if edge.To().ID() == neighbor {
-				e.edges[i] = newEdge
-				return e
-			}
-		} else {
-			if edge.From().ID() == neighbor {
-				e.edges[i] = newEdge
-				return e
-			}
+	for i := range e.edges {
+		if e.edges[i].neighbor == neighbor {
+			e.edges[i].edge = newEdge
+			return e
 		}
 	}
 
 	if len(e.edges) < 4 {
-		e.edges = append(e.edges, newEdge)
+		e.edges = append(e.edges, edgeInfo{edge: newEdge, neighbor: neighbor})
 		return e
 	}
 
-	h := mapEdgeHolder(make(map[int]graph.Edge, len(e.edges)+1))
-	for i, edge := range e.edges {
-		if edge.From().ID() == e.self {
-			h[edge.To().ID()] = e.edges[i]
-		} else {
-			h[edge.From().ID()] = e.edges[i]
-		}
+	h := &mapEdgeHolder{
+		self:  e.self,
+		edges: make(map[int]graph.Edge, len(e.edges)+1),
 	}
-	h[neighbor] = newEdge
+	for _, ei := range e.edges {
+		h.edges[ei.neighbor] = ei.edge
+	}
+	h.edges[neighbor] = newEdge
 	return h
 }
 func (e *sliceEdgeHolder) Get(neighbor int) (graph.Edge, bool) {
-	for _, edge := range e.edges {
-		if edge.From().ID() == e.self {
-			if edge.To().ID() == neighbor {
-				return edge, true
-			}
-		} else {
-			if edge.From().ID() == neighbor {
-				return edge, true
-			}
+	for i := range e.edges {
+		if e.edges[i].neighbor == neighbor {
+			return e.edges[i].edge, true
 		}
 	}
 	return nil, false
@@ -98,25 +118,143 @@ func (e *sliceEdgeHolder) Len() int {
 }
 
 // mapEdgeHolder holds a map of neighbors to edges
-type mapEdgeHolder map[int]graph.Edge
+type mapEdgeHolder struct {
+	self  int
+	edges map[int]graph.Edge
+}
 
-func (e mapEdgeHolder) Visit(visitor func(neighbor int, edge graph.Edge)) {
-	for neighbor, edge := range e {
+func (e *mapEdgeHolder) VisitEdges(visitor func(neighbor int, edge graph.Edge)) {
+	for neighbor, edge := range e.edges {
 		visitor(neighbor, edge)
 	}
 }
-func (e mapEdgeHolder) Delete(neighbor int) edgeHolder {
-	delete(e, neighbor)
+
+func (e *mapEdgeHolder) VisitEdgesFromSelf(visitor func(toNodeID int, edge graph.Edge)) {
+	// Note this call is not cheap, hence we wrap this in a splitDirectionEdgeHolder
+	for neighbor, edge := range e.edges {
+		if edge.From().ID() == e.self {
+			visitor(neighbor, edge)
+		}
+	}
+}
+
+func (e *mapEdgeHolder) VisitEdgesToSelf(visitor func(toNodeID int, edge graph.Edge)) {
+	// Note this call is not cheap, hence we wrap this in a splitDirectionEdgeHolder
+	for neighbor, edge := range e.edges {
+		if edge.To().ID() == e.self {
+			visitor(neighbor, edge)
+		}
+	}
+}
+func (e *mapEdgeHolder) Delete(neighbor int) edgeHolder {
+	delete(e.edges, neighbor)
 	return e
 }
-func (e mapEdgeHolder) Set(neighbor int, edge graph.Edge) edgeHolder {
-	e[neighbor] = edge
+func (e *mapEdgeHolder) Set(neighbor int, edge graph.Edge) edgeHolder {
+	e.edges[neighbor] = edge
 	return e
 }
-func (e mapEdgeHolder) Get(neighbor int) (graph.Edge, bool) {
-	edge, ok := e[neighbor]
+func (e *mapEdgeHolder) Get(neighbor int) (graph.Edge, bool) {
+	edge, ok := e.edges[neighbor]
 	return edge, ok
 }
-func (e mapEdgeHolder) Len() int {
-	return len(e)
+func (e *mapEdgeHolder) Len() int {
+	return len(e.edges)
+}
+
+type splitDirectionEdgeHolder struct {
+	self          int
+	edgesFromSelf edgeHolder
+	edgesToSelf   edgeHolder
+}
+
+func (h *splitDirectionEdgeHolder) VisitEdges(visitor func(neighbor int, edge graph.Edge)) {
+	if h.edgesFromSelf != nil {
+		h.edgesFromSelf.VisitEdges(visitor)
+	}
+	if h.edgesToSelf != nil {
+		h.edgesToSelf.VisitEdges(visitor)
+	}
+}
+
+func (h *splitDirectionEdgeHolder) VisitEdgesFromSelf(visitor func(toNodeID int, edge graph.Edge)) {
+	// Note the big win here - we switch to a Visit, which does not check direction
+	// (we also don't visit edgesToSelf, but that is a smaller win)
+	if h.edgesFromSelf != nil {
+		h.edgesFromSelf.VisitEdges(visitor)
+	}
+}
+
+func (h *splitDirectionEdgeHolder) VisitEdgesToSelf(visitor func(toNodeID int, edge graph.Edge)) {
+	if h.edgesToSelf != nil {
+		h.edgesToSelf.VisitEdges(visitor)
+	}
+}
+
+func (h *splitDirectionEdgeHolder) Delete(neighbor int) edgeHolder {
+	if h.edgesFromSelf != nil {
+		h.edgesFromSelf.Delete(neighbor)
+	}
+	if h.edgesToSelf != nil {
+		h.edgesToSelf.Delete(neighbor)
+	}
+	return h
+}
+
+func (h *splitDirectionEdgeHolder) Set(neighbor int, edge graph.Edge) edgeHolder {
+	if edge.From().ID() == h.self {
+		if h.edgesFromSelf == nil {
+			h.edgesFromSelf = &sliceEdgeHolder{self: h.self}
+		}
+		h.edgesFromSelf = h.edgesFromSelf.Set(neighbor, edge)
+
+		// Mostly to keep the tests happy - this behaviour is pretty unexpected
+		if h.edgesToSelf != nil {
+			h.edgesToSelf = h.edgesToSelf.Delete(neighbor)
+		}
+		return h
+	}
+
+	if edge.To().ID() == h.self {
+		if h.edgesToSelf == nil {
+			h.edgesToSelf = &sliceEdgeHolder{self: h.self}
+		}
+		h.edgesToSelf = h.edgesToSelf.Set(neighbor, edge)
+
+		// Mostly to keep the tests happy - this behaviour is pretty unexpected
+		if h.edgesFromSelf != nil {
+			h.edgesFromSelf = h.edgesFromSelf.Delete(neighbor)
+		}
+
+		return h
+	}
+
+	panic("constraint violated: wrong edge list")
+}
+
+func (h *splitDirectionEdgeHolder) Get(neighbor int) (graph.Edge, bool) {
+	if h.edgesFromSelf != nil {
+		e, ok := h.edgesFromSelf.Get(neighbor)
+		if ok {
+			return e, true
+		}
+	}
+	if h.edgesToSelf != nil {
+		e, ok := h.edgesToSelf.Get(neighbor)
+		if ok {
+			return e, true
+		}
+	}
+	return nil, false
+}
+
+func (h *splitDirectionEdgeHolder) Len() int {
+	n := 0
+	if h.edgesFromSelf != nil {
+		n += h.edgesFromSelf.Len()
+	}
+	if h.edgesToSelf != nil {
+		n += h.edgesToSelf.Len()
+	}
+	return n
 }

--- a/third_party/forked/gonum/graph/simple/undirected.go
+++ b/third_party/forked/gonum/graph/simple/undirected.go
@@ -66,7 +66,7 @@ func (g *UndirectedGraph) AddNode(n graph.Node) {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.edges[n.ID()] = &sliceEdgeHolder{self: n.ID()}
+	g.edges[n.ID()] = &splitDirectionEdgeHolder{self: n.ID()}
 
 	g.freeIDs.Remove(n.ID())
 	g.usedIDs.Insert(n.ID())
@@ -80,7 +80,7 @@ func (g *UndirectedGraph) RemoveNode(n graph.Node) {
 	}
 	delete(g.nodes, n.ID())
 
-	g.edges[n.ID()].Visit(func(neighbor int, edge graph.Edge) {
+	g.edges[n.ID()].VisitEdges(func(neighbor int, edge graph.Edge) {
 		g.edges[neighbor] = g.edges[neighbor].Delete(n.ID())
 	})
 	delete(g.edges, n.ID())
@@ -159,7 +159,7 @@ func (g *UndirectedGraph) Edges() []graph.Edge {
 
 	seen := make(map[[2]int]struct{})
 	for _, u := range g.edges {
-		u.Visit(func(neighbor int, e graph.Edge) {
+		u.VisitEdges(func(neighbor int, e graph.Edge) {
 			uid := e.From().ID()
 			vid := e.To().ID()
 			if _, ok := seen[[2]int{uid, vid}]; ok {
@@ -182,7 +182,7 @@ func (g *UndirectedGraph) From(n graph.Node) []graph.Node {
 
 	nodes := make([]graph.Node, g.edges[n.ID()].Len())
 	i := 0
-	g.edges[n.ID()].Visit(func(neighbor int, edge graph.Edge) {
+	g.edges[n.ID()].VisitEdges(func(neighbor int, edge graph.Edge) {
 		nodes[i] = g.nodes[neighbor]
 		i++
 	})


### PR DESCRIPTION
The graph visits were coming up on profiling, particularly the interface
calls.

The bulk of the interface calls were needed to determine the direction of
edges, because we only want to visit "out" edges in the node authorizer
(grant, not grantee).

Changed the sliceEdgeHolder to memoize the neighbor, which saves some of
the calls (and the mapEdgeHolder was already doing this).

Introduced splitDirectionEdgeHolder, which keeps the from & to edges in two
separate lists (themselves edgeHolders).  Then we can convert a new
directional VisitEdgesFromSelf call into a non-directional Visit call on
the edgsFromSelf list. This avoids most of the interface calls, while still
being reasonably memory efficient.

We will use slightly more memory: we have an extra
splitDirectionEdgeHolder, (though for leaves one of the lists is going to
be nil anyway), and we've added an int node id memoization to
sliceEdgeHolder.

```release-note
Optimize performance on node authorizer on large clusters
```
