### PR TITLE
Cleanup lint failures from pkg/kubeapiserver/options

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -122,7 +122,6 @@ pkg/credentialprovider/gcp
 pkg/credentialprovider/rancher
 pkg/features
 pkg/kubeapiserver
-pkg/kubeapiserver/options
 pkg/kubectl
 pkg/kubectl/apps
 pkg/kubectl/cmd/annotate

--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -29,6 +29,7 @@ import (
 	authzmodes "k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
 )
 
+// BuiltInAuthorizationOptions holds the authorization options for the APIServer
 type BuiltInAuthorizationOptions struct {
 	Modes                       []string
 	PolicyFile                  string
@@ -37,6 +38,7 @@ type BuiltInAuthorizationOptions struct {
 	WebhookCacheUnauthorizedTTL time.Duration
 }
 
+// NewBuiltInAuthorizationOptions returns a default version of a BuiltInAuthorizationOptions
 func NewBuiltInAuthorizationOptions() *BuiltInAuthorizationOptions {
 	return &BuiltInAuthorizationOptions{
 		Modes:                       []string{authzmodes.ModeAlwaysAllow},
@@ -45,6 +47,7 @@ func NewBuiltInAuthorizationOptions() *BuiltInAuthorizationOptions {
 	}
 }
 
+// Validate confirms that the authorization options appear to be consistent.
 func (s *BuiltInAuthorizationOptions) Validate() []error {
 	if s == nil {
 		return nil
@@ -88,6 +91,7 @@ func (s *BuiltInAuthorizationOptions) Validate() []error {
 	return allErrors
 }
 
+// AddFlags populates the authorization options from the passed in command line flags.
 func (s *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&s.Modes, "authorization-mode", s.Modes, ""+
 		"Ordered list of plug-ins to do authorization on secure port. Comma-delimited list of: "+
@@ -109,6 +113,7 @@ func (s *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 		"The duration to cache 'unauthorized' responses from the webhook authorizer.")
 }
 
+// ToAuthorizationConfig creates a Config from this options object
 func (s *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFactory versionedinformers.SharedInformerFactory) authorizer.Config {
 	return authorizer.Config{
 		AuthorizationModes:          s.Modes,

--- a/pkg/kubeapiserver/options/cloudprovider.go
+++ b/pkg/kubeapiserver/options/cloudprovider.go
@@ -20,20 +20,24 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CloudProviderOptions holds the CloudProvider options for the server
 type CloudProviderOptions struct {
 	CloudConfigFile string
 	CloudProvider   string
 }
 
+// NewCloudProviderOptions returns the default cloud provider options
 func NewCloudProviderOptions() *CloudProviderOptions {
 	return &CloudProviderOptions{}
 }
 
+// Validate ensures the the cloud provider options appear to be consistent
 func (s *CloudProviderOptions) Validate() []error {
 	allErrors := []error{}
 	return allErrors
 }
 
+// AddFlags populates the cloud provider options from the passed in command line flags.
 func (s *CloudProviderOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.CloudProvider, "cloud-provider", s.CloudProvider,
 		"The provider for cloud services. Empty string for no provider.")

--- a/pkg/kubeapiserver/options/options.go
+++ b/pkg/kubeapiserver/options/options.go
@@ -26,6 +26,7 @@ import (
 var DefaultServiceNodePortRange = utilnet.PortRange{Base: 30000, Size: 2768}
 
 // DefaultServiceIPCIDR is a CIDR notation of IP range from which to allocate service cluster IPs
-var DefaultServiceIPCIDR net.IPNet = net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)}
+var DefaultServiceIPCIDR = net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)}
 
+// DefaultEtcdPathPrefix is prefix used for the keys of all Kubernetes data stored in Etcd.
 const DefaultEtcdPathPrefix = "/registry"


### PR DESCRIPTION
What this PR does / why we need it:
Fixes lint errors in pkg/kubeapiserver/options.
Enables lint testing of pkg/kubeapiserver/options.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes part of issues/68026

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
