### PR TITLE
WIP: webhook admission: proper non-500 errors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/errors/statuserror.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/errors/statuserror.go
@@ -18,27 +18,72 @@ package errors
 
 import (
 	"fmt"
+	"net/http"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
 )
 
 // ToStatusErr returns a StatusError with information about the webhook plugin
-func ToStatusErr(webhookName string, result *metav1.Status) *apierrors.StatusError {
-	deniedBy := fmt.Sprintf("admission webhook %q denied the request", webhookName)
-	const noExp = "without explanation"
-
+func ToStatusErr(attr admission.Attributes, webhookName string, result *metav1.Status) *apierrors.StatusError {
 	if result == nil {
-		result = &metav1.Status{Status: metav1.StatusFailure}
+		result = &metav1.Status{}
+	} else {
+		// deepcopy before mutating it
+		result = result.DeepCopy()
 	}
 
+	gr := attr.GetResource().GroupResource()
+	name := attr.GetName()
+	if len(name) == 0 {
+		name = "Unknown"
+	}
+
+	// sanitize status
+	if result.Code == 0 {
+		result.Code = http.StatusForbidden
+	}
+	if len(result.Status) == 0 {
+		result.Status = metav1.StatusFailure
+	}
+
+	deniedBy := fmt.Sprintf("admission webhook %q denied the request", webhookName)
 	switch {
 	case len(result.Message) > 0:
 		result.Message = fmt.Sprintf("%s: %s", deniedBy, result.Message)
 	case len(result.Reason) > 0:
 		result.Message = fmt.Sprintf("%s: %s", deniedBy, result.Reason)
 	default:
-		result.Message = fmt.Sprintf("%s %s", deniedBy, noExp)
+		result.Message = fmt.Sprintf("%s without explanation", deniedBy)
+	}
+
+	if result.Details == nil {
+		if result.Code == http.StatusInternalServerError {
+			result.Details = &metav1.StatusDetails{
+				Causes: []metav1.StatusCause{{Message: result.Message}},
+			}
+		} else {
+			result.Details = &metav1.StatusDetails{
+				Group: attr.GetResource().Group,
+				Kind:  attr.GetResource().Resource, // yes, this is odd. But we replicate apierrors.NewForbidden here which does the same.
+				Name:  name,
+			}
+		}
+	}
+
+	prefix := fmt.Sprintf("%s %q is forbidden", gr.String(), name)
+	if result.Code == http.StatusInternalServerError {
+		prefix = "Internal error occurred"
+	}
+	result.Message = fmt.Sprintf("%s: %s", prefix, result.Message)
+
+	if len(result.Reason) == 0 {
+		if result.Code == http.StatusInternalServerError {
+			result.Reason = metav1.StatusReasonInternalError
+		} else {
+			result.Reason = metav1.StatusReasonForbidden
+		}
 	}
 
 	return &apierrors.StatusError{

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/errors/statuserror_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/errors/statuserror_test.go
@@ -18,56 +18,132 @@ package errors
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 func TestToStatusErr(t *testing.T) {
 	hookName := "foo"
 	deniedBy := fmt.Sprintf("admission webhook %q denied the request", hookName)
 	tests := []struct {
-		name          string
-		result        *metav1.Status
-		expectedError string
+		name       string
+		attributes mockAttributes
+		result     *metav1.Status
+		expected   metav1.Status
 	}{
 		{
 			"nil result",
+			mockAttributes{"example"},
 			nil,
-			deniedBy + " without explanation",
+			admission.NewForbidden(mockAttributes{"example"}, fmt.Errorf(deniedBy+" without explanation")).(*apierrors.StatusError).Status(),
 		},
 		{
 			"only message",
+			mockAttributes{"example"},
 			&metav1.Status{
 				Message: "you shall not pass",
 			},
-			deniedBy + ": you shall not pass",
+			admission.NewForbidden(mockAttributes{"example"}, fmt.Errorf(deniedBy+": you shall not pass")).(*apierrors.StatusError).Status(),
 		},
 		{
 			"only reason",
+			mockAttributes{"example"},
 			&metav1.Status{
 				Reason: metav1.StatusReasonForbidden,
 			},
-			deniedBy + ": Forbidden",
+			admission.NewForbidden(mockAttributes{"example"}, fmt.Errorf(deniedBy+": Forbidden")).(*apierrors.StatusError).Status(),
 		},
 		{
 			"message and reason",
+			mockAttributes{"example"},
 			&metav1.Status{
 				Message: "you shall not pass",
 				Reason:  metav1.StatusReasonForbidden,
 			},
-			deniedBy + ": you shall not pass",
+			admission.NewForbidden(mockAttributes{"example"}, fmt.Errorf(deniedBy+": you shall not pass")).(*apierrors.StatusError).Status(),
 		},
 		{
 			"no message, no reason",
+			mockAttributes{"example"},
 			&metav1.Status{},
-			deniedBy + " without explanation",
+			admission.NewForbidden(mockAttributes{"example"}, fmt.Errorf(deniedBy+" without explanation")).(*apierrors.StatusError).Status(),
+		},
+		{
+			"unknown name",
+			mockAttributes{},
+			&metav1.Status{},
+			admission.NewForbidden(mockAttributes{}, fmt.Errorf(deniedBy+" without explanation")).(*apierrors.StatusError).Status(),
+		},
+		{
+			"500 error",
+			mockAttributes{},
+			&metav1.Status{Code: http.StatusInternalServerError, Message: "internal error"},
+			apierrors.NewInternalError(fmt.Errorf(deniedBy + ": internal error")).Status(),
 		},
 	}
 	for _, test := range tests {
-		err := ToStatusErr(hookName, test.result)
-		if err == nil || err.Error() != test.expectedError {
-			t.Errorf("%s: expected an error saying %q, but got %v", test.name, test.expectedError, err)
+		err := ToStatusErr(test.attributes, hookName, test.result)
+		if err == nil || !equality.Semantic.DeepEqual(err.Status(), test.expected) {
+			t.Errorf("%s: unexpected error (got A, expected B):\n%s", test.name, diff.ObjectDiff(err.Status(), test.expected))
 		}
 	}
+}
+
+type mockAttributes struct {
+	name string
+}
+
+var _ admission.Attributes = &mockAttributes{}
+
+func (a mockAttributes) GetKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "foo", Version: "v1", Kind: "Bar"}
+}
+
+func (a mockAttributes) GetNamespace() string {
+	return "default"
+}
+
+func (a mockAttributes) GetName() string {
+	return a.name
+}
+
+func (a mockAttributes) GetResource() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "foo", Version: "v1", Resource: "bars"}
+}
+
+func (a mockAttributes) GetSubresource() string {
+	return ""
+}
+
+func (a mockAttributes) GetOperation() admission.Operation {
+	return admission.Create
+}
+
+func (a mockAttributes) IsDryRun() bool {
+	return false
+}
+
+func (a mockAttributes) GetObject() runtime.Object {
+	return nil
+}
+
+func (a mockAttributes) GetOldObject() runtime.Object {
+	return nil
+}
+
+func (a mockAttributes) GetUserInfo() user.Info {
+	return nil
+}
+
+func (a mockAttributes) AddAnnotation(key, value string) error {
+	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/interfaces.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"k8s.io/api/admissionregistration/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
 )
@@ -41,5 +42,5 @@ type VersionedAttributes struct {
 // Dispatcher dispatches webhook call to a list of webhooks with admission attributes as argument.
 type Dispatcher interface {
 	// Dispatch a request to the webhooks using the given webhooks. A non-nil error means the request is rejected.
-	Dispatch(ctx context.Context, a *VersionedAttributes, hooks []*v1beta1.Webhook) error
+	Dispatch(ctx context.Context, a *VersionedAttributes, hooks []*v1beta1.Webhook) *apierrors.StatusError
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
@@ -156,12 +156,9 @@ func (a *Webhook) ShouldCallHook(h *v1beta1.Webhook, attr admission.Attributes) 
 }
 
 // Dispatch is called by the downstream Validate or Admit methods.
-func (a *Webhook) Dispatch(attr admission.Attributes) error {
+func (a *Webhook) Dispatch(attr admission.Attributes) *apierrors.StatusError {
 	if rules.IsWebhookConfigurationResource(attr) {
 		return nil
-	}
-	if !a.WaitForReady() {
-		return admission.NewForbidden(attr, fmt.Errorf("not yet ready to handle request"))
 	}
 	hooks := a.hookSource.Webhooks()
 	ctx := context.TODO()

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin.go
@@ -92,5 +92,11 @@ func (a *Plugin) ValidateInitialization() error {
 
 // Admit makes an admission decision based on the request attributes.
 func (a *Plugin) Admit(attr admission.Attributes) error {
-	return a.Webhook.Dispatch(attr)
+	if !a.WaitForReady() {
+		return admission.NewForbidden(attr, fmt.Errorf("not yet ready to handle request"))
+	}
+	if err := a.Webhook.Dispatch(attr); err != nil {
+		return err
+	}
+	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
@@ -98,10 +98,11 @@ func TestAdmit(t *testing.T) {
 		if tt.ErrorContains != "" {
 			if err == nil || !strings.Contains(err.Error(), tt.ErrorContains) {
 				t.Errorf("%s: expected an error saying %q, but got: %v", tt.Name, tt.ErrorContains, err)
+			} else if statusErr, ok := err.(*errors.StatusError); !ok {
+				t.Errorf("%s: expected a StatusError, got %T", tt.Name, err)
+			} else if statusErr.Status().Code != 403 {
+				t.Errorf("%s: expected a 403 StatusError, got %d", tt.Name, statusErr.Status().Code)
 			}
-		}
-		if _, isStatusErr := err.(*errors.StatusError); err != nil && !isStatusErr {
-			t.Errorf("%s: expected a StatusError, got %T", tt.Name, err)
 		}
 		fakeAttr, ok := attr.(*webhooktesting.FakeAttributes)
 		if !ok {


### PR DESCRIPTION
Any admission error (even simple admission denies) are returned as 500 error. This is wrong.

This PR passes through 403 and 500 error.

Are there other error we want to pass through?

```release-note
Webhook admission 403 and 500 errors are pass through to the caller of the apiserver.
```