### PR TITLE
Sets HostNetwork to False for tests which do not require it

### DIFF
--- a/test/e2e/framework/networking_utils.go
+++ b/test/e2e/framework/networking_utils.go
@@ -68,8 +68,8 @@ const (
 var NetexecImageName = imageutils.GetE2EImage(imageutils.Netexec)
 
 // NewNetworkingTestConfig creates and sets up a new test config helper.
-func NewNetworkingTestConfig(f *Framework) *NetworkingTestConfig {
-	config := &NetworkingTestConfig{f: f, Namespace: f.Namespace.Name}
+func NewNetworkingTestConfig(f *Framework, hostNetwork bool) *NetworkingTestConfig {
+	config := &NetworkingTestConfig{f: f, Namespace: f.Namespace.Name, HostNetwork: hostNetwork}
 	By(fmt.Sprintf("Performing setup for networking test in namespace %v", config.Namespace))
 	config.setup(getServiceSelector())
 	return config
@@ -77,7 +77,7 @@ func NewNetworkingTestConfig(f *Framework) *NetworkingTestConfig {
 
 // NewNetworkingTestNodeE2EConfig creates and sets up a new test config helper for Node E2E.
 func NewCoreNetworkingTestConfig(f *Framework) *NetworkingTestConfig {
-	config := &NetworkingTestConfig{f: f, Namespace: f.Namespace.Name}
+	config := &NetworkingTestConfig{f: f, Namespace: f.Namespace.Name, HostNetwork: false}
 	By(fmt.Sprintf("Performing setup for networking test in namespace %v", config.Namespace))
 	config.setupCore(getServiceSelector())
 	return config
@@ -98,9 +98,10 @@ type NetworkingTestConfig struct {
 	// TestContaienrPod is a test pod running the netexec image. It is capable
 	// of executing tcp/udp requests against ip:port.
 	TestContainerPod *v1.Pod
-	// HostTestContainerPod is a pod running with hostNetworking=true, and the
-	// hostexec image.
+	// HostTestContainerPod is a pod running using the hostexec image.
 	HostTestContainerPod *v1.Pod
+	// if the HostTestContainerPod is running with HostNetwork=true.
+	HostNetwork bool
 	// EndpointPods are the pods belonging to the Service created by this
 	// test config. Each invocation of `setup` creates a service with
 	// 1 pod per node running the netexecImage.
@@ -513,7 +514,7 @@ func (config *NetworkingTestConfig) DeleteNodePortService() {
 
 func (config *NetworkingTestConfig) createTestPods() {
 	testContainerPod := config.createTestPodSpec()
-	hostTestContainerPod := NewHostExecPodSpec(config.Namespace, hostTestPodName)
+	hostTestContainerPod := NewExecPodSpec(config.Namespace, hostTestPodName, config.HostNetwork)
 
 	config.createPod(testContainerPod)
 	config.createPod(hostTestContainerPod)

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -459,14 +459,14 @@ func NodeOSDistroIs(supportedNodeOsDistros ...string) bool {
 	return false
 }
 
-func ProxyMode(f *Framework) (string, error) {
+func ProxyMode(f *Framework, hostNetwork bool) (string, error) {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kube-proxy-mode-detector",
 			Namespace: f.Namespace.Name,
 		},
 		Spec: v1.PodSpec{
-			HostNetwork: true,
+			HostNetwork: hostNetwork,
 			Containers: []v1.Container{
 				{
 					Name:    "detector",
@@ -3409,8 +3409,8 @@ func IssueSSHCommand(cmd, provider string, node *v1.Node) error {
 	return nil
 }
 
-// NewHostExecPodSpec returns the pod spec of hostexec pod
-func NewHostExecPodSpec(ns, name string) *v1.Pod {
+// NewExecPodSpec returns the pod spec of hostexec pod
+func NewExecPodSpec(ns, name string, hostNetwork bool) *v1.Pod {
 	immediate := int64(0)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3425,7 +3425,7 @@ func NewHostExecPodSpec(ns, name string) *v1.Pod {
 					ImagePullPolicy: v1.PullIfNotPresent,
 				},
 			},
-			HostNetwork:                   true,
+			HostNetwork:                   hostNetwork,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &immediate,
 		},
@@ -3467,8 +3467,8 @@ func RunHostCmdWithRetries(ns, name, cmd string, interval, timeout time.Duration
 
 // LaunchHostExecPod launches a hostexec pod in the given namespace and waits
 // until it's Running
-func LaunchHostExecPod(client clientset.Interface, ns, name string) *v1.Pod {
-	hostExecPod := NewHostExecPodSpec(ns, name)
+func LaunchHostExecPod(client clientset.Interface, ns, name string, hostNetwork bool) *v1.Pod {
+	hostExecPod := NewExecPodSpec(ns, name, hostNetwork)
 	pod, err := client.CoreV1().Pods(ns).Create(hostExecPod)
 	ExpectNoError(err)
 	err = WaitForPodRunningInNamespace(client, pod)

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -87,7 +87,7 @@ var _ = SIGDescribe("Networking", func() {
 	It("should check kube-proxy urls", func() {
 		// TODO: this is overkill we just need the host networking pod
 		// to hit kube-proxy urls.
-		config := framework.NewNetworkingTestConfig(f)
+		config := framework.NewNetworkingTestConfig(f, true)
 
 		By("checking kube-proxy URLs")
 		config.GetSelfURL(ports.ProxyHealthzPort, "/healthz", "200 OK")
@@ -101,7 +101,7 @@ var _ = SIGDescribe("Networking", func() {
 	Describe("Granular Checks: Services [Slow]", func() {
 
 		It("should function for pod-Service: http", func() {
-			config := framework.NewNetworkingTestConfig(f)
+			config := framework.NewNetworkingTestConfig(f, false)
 			By(fmt.Sprintf("dialing(http) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, framework.ClusterHttpPort))
 			config.DialFromTestContainer("http", config.ClusterIP, framework.ClusterHttpPort, config.MaxTries, 0, config.EndpointHostnames())
 
@@ -110,7 +110,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		It("should function for pod-Service: udp", func() {
-			config := framework.NewNetworkingTestConfig(f)
+			config := framework.NewNetworkingTestConfig(f, false)
 			By(fmt.Sprintf("dialing(udp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, framework.ClusterUdpPort))
 			config.DialFromTestContainer("udp", config.ClusterIP, framework.ClusterUdpPort, config.MaxTries, 0, config.EndpointHostnames())
 
@@ -119,7 +119,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		It("should function for node-Service: http", func() {
-			config := framework.NewNetworkingTestConfig(f)
+			config := framework.NewNetworkingTestConfig(f, false)
 			By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (config.clusterIP)", config.NodeIP, config.ClusterIP, framework.ClusterHttpPort))
 			config.DialFromNode("http", config.ClusterIP, framework.ClusterHttpPort, config.MaxTries, 0, config.EndpointHostnames())
 
@@ -128,7 +128,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		It("should function for node-Service: udp", func() {
-			config := framework.NewNetworkingTestConfig(f)
+			config := framework.NewNetworkingTestConfig(f, false)
 			By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (config.clusterIP)", config.NodeIP, config.ClusterIP, framework.ClusterUdpPort))
 			config.DialFromNode("udp", config.ClusterIP, framework.ClusterUdpPort, config.MaxTries, 0, config.EndpointHostnames())
 
@@ -137,7 +137,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		It("should function for endpoint-Service: http", func() {
-			config := framework.NewNetworkingTestConfig(f)
+			config := framework.NewNetworkingTestConfig(f, false)
 			By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (config.clusterIP)", config.EndpointPods[0].Name, config.ClusterIP, framework.ClusterHttpPort))
 			config.DialFromEndpointContainer("http", config.ClusterIP, framework.ClusterHttpPort, config.MaxTries, 0, config.EndpointHostnames())
 
@@ -146,7 +146,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		It("should function for endpoint-Service: udp", func() {
-			config := framework.NewNetworkingTestConfig(f)
+			config := framework.NewNetworkingTestConfig(f, false)
 			By(fmt.Sprintf("dialing(udp) %v (endpoint) --> %v:%v (config.clusterIP)", config.EndpointPods[0].Name, config.ClusterIP, framework.ClusterUdpPort))
 			config.DialFromEndpointContainer("udp", config.ClusterIP, framework.ClusterUdpPort, config.MaxTries, 0, config.EndpointHostnames())
 
@@ -155,7 +155,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		It("should update endpoints: http", func() {
-			config := framework.NewNetworkingTestConfig(f)
+			config := framework.NewNetworkingTestConfig(f, false)
 			By(fmt.Sprintf("dialing(http) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, framework.ClusterHttpPort))
 			config.DialFromTestContainer("http", config.ClusterIP, framework.ClusterHttpPort, config.MaxTries, 0, config.EndpointHostnames())
 
@@ -166,7 +166,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		It("should update endpoints: udp", func() {
-			config := framework.NewNetworkingTestConfig(f)
+			config := framework.NewNetworkingTestConfig(f, false)
 			By(fmt.Sprintf("dialing(udp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, framework.ClusterUdpPort))
 			config.DialFromTestContainer("udp", config.ClusterIP, framework.ClusterUdpPort, config.MaxTries, 0, config.EndpointHostnames())
 
@@ -178,7 +178,7 @@ var _ = SIGDescribe("Networking", func() {
 
 		// Slow because we confirm that the nodePort doesn't serve traffic, which requires a period of polling.
 		It("should update nodePort: http [Slow]", func() {
-			config := framework.NewNetworkingTestConfig(f)
+			config := framework.NewNetworkingTestConfig(f, false)
 			By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP)", config.NodeIP, config.NodeIP, config.NodeHttpPort))
 			config.DialFromNode("http", config.NodeIP, config.NodeHttpPort, config.MaxTries, 0, config.EndpointHostnames())
 
@@ -190,7 +190,7 @@ var _ = SIGDescribe("Networking", func() {
 
 		// Slow because we confirm that the nodePort doesn't serve traffic, which requires a period of polling.
 		It("should update nodePort: udp [Slow]", func() {
-			config := framework.NewNetworkingTestConfig(f)
+			config := framework.NewNetworkingTestConfig(f, false)
 			By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP)", config.NodeIP, config.NodeIP, config.NodeUdpPort))
 			config.DialFromNode("udp", config.NodeIP, config.NodeUdpPort, config.MaxTries, 0, config.EndpointHostnames())
 
@@ -201,7 +201,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		It("should function for client IP based session affinity: http", func() {
-			config := framework.NewNetworkingTestConfig(f)
+			config := framework.NewNetworkingTestConfig(f, false)
 			By(fmt.Sprintf("dialing(http) %v --> %v:%v", config.TestContainerPod.Name, config.SessionAffinityService.Spec.ClusterIP, framework.ClusterHttpPort))
 
 			// Check if number of endpoints returned are exactly one.
@@ -218,7 +218,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		It("should function for client IP based session affinity: udp", func() {
-			config := framework.NewNetworkingTestConfig(f)
+			config := framework.NewNetworkingTestConfig(f, false)
 			By(fmt.Sprintf("dialing(udp) %v --> %v:%v", config.TestContainerPod.Name, config.SessionAffinityService.Spec.ClusterIP, framework.ClusterUdpPort))
 
 			// Check if number of endpoints returned are exactly one.

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -251,7 +251,7 @@ var _ = SIGDescribe("Services", func() {
 
 		// This behavior is not supported if Kube-proxy is in "userspace" mode.
 		// So we check the kube-proxy mode and skip this test if that's the case.
-		if proxyMode, err := framework.ProxyMode(f); err == nil {
+		if proxyMode, err := framework.ProxyMode(f, false); err == nil {
 			if proxyMode == "userspace" {
 				framework.Skipf("The test doesn't work with kube-proxy in userspace mode")
 			}
@@ -490,7 +490,7 @@ var _ = SIGDescribe("Services", func() {
 		jig.TestReachableHTTP(nodeIP, nodePort, framework.KubeProxyLagTimeout)
 
 		By("verifying the node port is locked")
-		hostExec := framework.LaunchHostExecPod(f.ClientSet, f.Namespace.Name, "hostexec")
+		hostExec := framework.LaunchHostExecPod(f.ClientSet, f.Namespace.Name, "hostexec", true)
 		// Even if the node-ip:node-port check above passed, this hostexec pod
 		// might fall on a node with a laggy kube-proxy.
 		cmd := fmt.Sprintf(`for i in $(seq 1 300); do if ss -ant46 'sport = :%d' | grep ^LISTEN; then exit 0; fi; sleep 1; done; exit 1`, nodePort)
@@ -1183,7 +1183,7 @@ var _ = SIGDescribe("Services", func() {
 		err = t.DeleteService(serviceName)
 		Expect(err).NotTo(HaveOccurred())
 
-		hostExec := framework.LaunchHostExecPod(f.ClientSet, f.Namespace.Name, "hostexec")
+		hostExec := framework.LaunchHostExecPod(f.ClientSet, f.Namespace.Name, "hostexec", false)
 		cmd := fmt.Sprintf(`! ss -ant46 'sport = :%d' | tail -n +2 | grep LISTEN`, nodePort)
 		var stdout string
 		if pollErr := wait.PollImmediate(framework.Poll, framework.KubeProxyLagTimeout, func() (bool, error) {
@@ -1469,7 +1469,7 @@ var _ = SIGDescribe("Services", func() {
 		//  a pod to test the service.
 		By("hitting the internal load balancer from pod")
 		framework.Logf("creating pod with host network")
-		hostExec := framework.LaunchHostExecPod(f.ClientSet, f.Namespace.Name, "ilb-host-exec")
+		hostExec := framework.LaunchHostExecPod(f.ClientSet, f.Namespace.Name, "ilb-host-exec", false)
 
 		framework.Logf("Waiting up to %v for service %q's internal LB to respond to requests", createTimeout, serviceName)
 		tcpIngressIP := framework.GetIngressPoint(lbIngress)

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -957,7 +957,7 @@ func setupLocalVolumeDirectory(config *localTestConfig, node *v1.Node) *localTes
 // launchNodeExecPodForLocalPV launches a hostexec pod for local PV and waits
 // until it's Running.
 func launchNodeExecPodForLocalPV(client clientset.Interface, ns, node string) *v1.Pod {
-	hostExecPod := framework.NewHostExecPodSpec(ns, fmt.Sprintf("hostexec-%s", node))
+	hostExecPod := framework.NewExecPodSpec(ns, fmt.Sprintf("hostexec-%s", node), true)
 	hostExecPod.Spec.NodeName = node
 	hostExecPod.Spec.Volumes = []v1.Volume{
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Some tests are setting HostNetwork=true, even if it is not required
for them to pass.

This patch will set the HostNetwork to false for those tests, allowing
them to be run on Windows nodes as well.

/sig testing

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69559

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
