### PR TITLE
[WIP] kubectl conversion util: replace legacyscheme reference with kubectl scheme

### DIFF
--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//pkg/kubectl/cmd/templates:go_default_library",
         "//pkg/kubectl/cmd/util/openapi:go_default_library",
         "//pkg/kubectl/cmd/util/openapi/validation:go_default_library",
+        "//pkg/kubectl/scheme:go_default_library",
         "//pkg/kubectl/validation:go_default_library",
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",

--- a/pkg/kubectl/cmd/util/conversion.go
+++ b/pkg/kubectl/cmd/util/conversion.go
@@ -20,15 +20,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
 // AsDefaultVersionedOrOriginal returns the object as a Go object in the external form if possible (matching the
 // group version kind of the mapping if provided, a best guess based on serialization if not provided, or obj if it cannot be converted.
 // TODO update call sites to specify the scheme they want on their builder.
 func AsDefaultVersionedOrOriginal(obj runtime.Object, mapping *meta.RESTMapping) runtime.Object {
-	converter := runtime.ObjectConvertor(legacyscheme.Scheme)
-	groupVersioner := runtime.GroupVersioner(schema.GroupVersions(legacyscheme.Scheme.PrioritizedVersionsAllGroups()))
+	converter := runtime.ObjectConvertor(scheme.Scheme)
+	groupVersioner := runtime.GroupVersioner(schema.GroupVersions(scheme.Scheme.PrioritizedVersionsAllGroups()))
 	if mapping != nil {
 		groupVersioner = mapping.GroupVersionKind.GroupVersion()
 	}

--- a/pkg/kubectl/cmd/util/helpers_test.go
+++ b/pkg/kubectl/cmd/util/helpers_test.go
@@ -37,8 +37,6 @@ import (
 )
 
 func TestMerge(t *testing.T) {
-	grace := int64(30)
-	enableServiceLinks := corev1.DefaultEnableServiceLinks
 	tests := []struct {
 		obj       runtime.Object
 		fragment  string
@@ -59,14 +57,6 @@ func TestMerge(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
-				},
-				Spec: corev1.PodSpec{
-					RestartPolicy:                 corev1.RestartPolicyAlways,
-					DNSPolicy:                     corev1.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-					SecurityContext:               &corev1.PodSecurityContext{},
-					SchedulerName:                 corev1.DefaultSchedulerName,
-					EnableServiceLinks:            &enableServiceLinks,
 				},
 			},
 		},
@@ -127,20 +117,12 @@ func TestMerge(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name:         "v1",
-							VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+							Name: "v1",
 						},
 						{
-							Name:         "v2",
-							VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+							Name: "v2",
 						},
 					},
-					RestartPolicy:                 corev1.RestartPolicyAlways,
-					DNSPolicy:                     corev1.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-					SecurityContext:               &corev1.PodSecurityContext{},
-					SchedulerName:                 corev1.DefaultSchedulerName,
-					EnableServiceLinks:            &enableServiceLinks,
 				},
 			},
 		},
@@ -166,12 +148,9 @@ func TestMerge(t *testing.T) {
 					APIVersion: "v1",
 				},
 				Spec: corev1.ServiceSpec{
-					SessionAffinity: "None",
-					Type:            corev1.ServiceTypeClusterIP,
 					Ports: []corev1.ServicePort{
 						{
-							Protocol: corev1.ProtocolTCP,
-							Port:     0,
+							Port: 0,
 						},
 					},
 				},
@@ -192,8 +171,6 @@ func TestMerge(t *testing.T) {
 					APIVersion: "v1",
 				},
 				Spec: corev1.ServiceSpec{
-					SessionAffinity: "None",
-					Type:            corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"version": "v2",
 					},


### PR DESCRIPTION
* Replace legacyscheme reference with `kubectl scheme`.
* This is possible because all of the callers of `AsDefaultVersionedOrOriginal` have now moved to `kubectl scheme`.

Helps address:
https://github.com/kubernetes/kubectl/issues/80

```release-note
NONE
```
