### PR TITLE
rename method on Indexer interface for greater clarity

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/index.go
+++ b/staging/src/k8s.io/client-go/tools/cache/index.go
@@ -28,8 +28,9 @@ type Indexer interface {
 	Store
 	// Retrieve list of objects that match on the named indexing function
 	Index(indexName string, obj interface{}) ([]interface{}, error)
-	// IndexKeys returns the set of keys that match on the named indexing function.
-	IndexKeys(indexName, indexKey string) ([]string, error)
+	// GetIndexedObjectsKeys returns the set of keys for the list of objects
+	// that match on the named indexing function.
+	GetIndexedObjectsKeys(indexName, indexKey string) ([]string, error)
 	// ListIndexFuncValues returns the list of generated values of an Index func
 	ListIndexFuncValues(indexName string) []string
 	// ByIndex lists object that match on the named indexing function with the exact key

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
@@ -121,7 +121,7 @@ func (c *mutationCache) ByIndex(name string, indexKey string) ([]interface{}, er
 	if c.indexer == nil {
 		return nil, fmt.Errorf("no indexer has been provided to the mutation cache")
 	}
-	keys, err := c.indexer.IndexKeys(name, indexKey)
+	keys, err := c.indexer.GetIndexedObjectsKeys(name, indexKey)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store.go
@@ -172,8 +172,10 @@ func (c *cache) Index(indexName string, obj interface{}) ([]interface{}, error) 
 	return c.cacheStorage.Index(indexName, obj)
 }
 
-func (c *cache) IndexKeys(indexName, indexKey string) ([]string, error) {
-	return c.cacheStorage.IndexKeys(indexName, indexKey)
+// GetIndexedObjectsKeys returns the keys for the items which match on the
+// index function.
+func (c *cache) GetIndexedObjectsKeys(indexName, indexKey string) ([]string, error) {
+	return c.cacheStorage.GetIndexedObjectsKeys(indexName, indexKey)
 }
 
 // ListIndexFuncValues returns the list of generated values of an Index func

--- a/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go
@@ -43,7 +43,7 @@ type ThreadSafeStore interface {
 	ListKeys() []string
 	Replace(map[string]interface{}, string)
 	Index(indexName string, obj interface{}) ([]interface{}, error)
-	IndexKeys(indexName, indexKey string) ([]string, error)
+	GetIndexedObjectsKeys(indexName, indexKey string) ([]string, error)
 	ListIndexFuncValues(name string) []string
 	ByIndex(indexName, indexKey string) ([]interface{}, error)
 	GetIndexers() Indexers
@@ -185,9 +185,9 @@ func (c *threadSafeMap) ByIndex(indexName, indexKey string) ([]interface{}, erro
 	return list, nil
 }
 
-// IndexKeys returns a list of keys that match on the index function.
-// IndexKeys is thread-safe so long as you treat all items as immutable.
-func (c *threadSafeMap) IndexKeys(indexName, indexKey string) ([]string, error) {
+// GetIndexedObjectsKeys returns a list of keys that match on the index function.
+// GetIndexedObjectsKeys is thread-safe so long as you treat all items as immutable.
+func (c *threadSafeMap) GetIndexedObjectsKeys(indexName, indexKey string) ([]string, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

There two levels of keys at play in the Indexer which currently makes it a little confusing. `IndexerFunc`s (for instance) take in an object and return a set of keys through which you can later retrieve the object; that object can be considered indexed by those keys (for that index). Objects which are stored (and possibly indexed) are also assumed to be key-able, i.e. retrievable by some unique string. As such, you can retrieve a stored object by it's 'key' or retrieve a set of objects by various keyed index values. 

So, let's say we have the following objects: 
```
obj1 = {id: "1", name: "foo", indexedAttrs: "a,b"}
obj2 = {id: "2", name: "bar", indexedAttrs: "b,c"}
obj3 = {id: "3", name: "baz", indexedAttrs: "a,c"}
```
Then we have the following object "keys": `["1", "2", "3"]`, which means we can get obj1 by `getById` with "1" and so on.

We also have the following index keys `["a", "b", "c"]`, which means that if we get `ByIndex`, the index key "a" would return obj1 and obj3.

Previously, the method named `IndexKeys` took two parameters: (1) the name of the index and (2) the index key with which we wanted to retrieve objects (i.e. "a", "b", or "c") **and then** returned the object keys (or the object ID). For instance:
```indexer.IndexKeys("index-name", "a")``` 
would return 
```["1", "3"]``` 

This PR just renames that method, so that it is clear that we are returning the keys of the objects which we retrieved via our index, so that it looks like this:
```indexer.GetIndexedObjectsKeys("index-name", "a")``` 
would return 
```["1", "3"]``` 


**Which issue(s) this PR fixes**:
Fixes #69319

**Todo**
In a future PR, I would also like to rename the Index and ByIndex methods to `GetByIndex` and `GetByIndexKey` but these methods permeate a much larger percentage of the codebase, so for now I would like to localize this change. 
