### PR TITLE
Fix find-binary to locate bazel e2e tests

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -163,11 +163,11 @@ kube::util::find-binary-for-platform() {
     "${KUBE_ROOT}/platforms/${platform}/${lookfor}"
   )
   # Also search for binary in bazel build tree.
-  # The bazel go rules place binaries in subtrees like
+  # The bazel go rules place some binaries in subtrees like
   # "bazel-bin/source/path/linux_amd64_pure_stripped/binaryname", so make sure
   # the platform name is matched in the path.
   locations+=($(find "${KUBE_ROOT}/bazel-bin/" -type f -executable \
-    -path "*/${platform/\//_}*/${lookfor}" 2>/dev/null || true) )
+    \( -path "*/${platform/\//_}*/${lookfor}" -o -path "*/${lookfor}" \) 2>/dev/null || true) )
 
   # List most recently-updated location.
   local -r bin=$( (ls -t "${locations[@]}" 2>/dev/null || true) | head -1 )


### PR DESCRIPTION
**What this PR does / why we need it**:

`bazel build test/e2e/e2e.test` places the output in `bazel-bin/test/e2e/e2e.test`, NOT in `bazel-bin/test/e2e/linux_amd64_stripped/e2e.test` as it does with other binaries. This change extends `kube::util::find-binary-for-platform()` to include the not platform-subpath in the search.

**Special notes for your reviewer**:

Insert: ["I have no idea what I'm doing" meme.](https://i.kym-cdn.com/entries/icons/original/000/008/342/ihave.jpg)

Could this break anything?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig testing