### PR TITLE
Fix WaitTimeoutForPodEvent logic

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1465,10 +1465,10 @@ func podRunning(c clientset.Interface, podName, namespace string) wait.Condition
 
 // WaitTimeoutForPodEvent waits for an event to occur for a pod
 func WaitTimeoutForPodEvent(c clientset.Interface, podName, namespace, eventSelector, msg string, timeout time.Duration) error {
-	return wait.PollImmediate(Poll, timeout, eventOccured(c, podName, namespace, eventSelector, msg))
+	return wait.PollImmediate(Poll, timeout, eventOccurred(c, podName, namespace, eventSelector, msg))
 }
 
-func eventOccured(c clientset.Interface, podName, namespace, eventSelector, msg string) wait.ConditionFunc {
+func eventOccurred(c clientset.Interface, podName, namespace, eventSelector, msg string) wait.ConditionFunc {
 	options := metav1.ListOptions{FieldSelector: eventSelector}
 	return func() (bool, error) {
 		events, err := c.CoreV1().Events(namespace).List(options)
@@ -1476,13 +1476,9 @@ func eventOccured(c clientset.Interface, podName, namespace, eventSelector, msg 
 			return false, fmt.Errorf("got error while getting pod events: %s", err)
 		}
 		if len(events.Items) == 0 {
-			return false, fmt.Errorf("no events found")
+			return false, nil // no events have occurred yet
 		}
-		if strings.Contains(events.Items[0].Message, msg) {
-			return false, fmt.Errorf("%q error not found", msg)
-		} else {
-			return true, nil
-		}
+		return strings.Contains(events.Items[0].Message, msg), nil
 	}
 }
 

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -597,7 +597,7 @@ func testPodFailSubpathError(f *framework.Framework, pod *v1.Pod, errorMsg strin
 		"reason":                   "Failed",
 	}.AsSelector().String()
 	err = framework.WaitTimeoutForPodEvent(f.ClientSet, pod.Name, f.Namespace.Name, selector, errorMsg, framework.PodEventTimeout)
-	Expect(err).To(HaveOccurred(), "while waiting for failed event to occur")
+	Expect(err).NotTo(HaveOccurred(), "while waiting for failed event to occur")
 }
 
 // Tests that the existing subpath mount is detected when a container restarts


### PR DESCRIPTION
**What this PR does / why we need it**:

The framework method `WaitTimeoutForPodEvent` was returning an error when an event was found with the correct error message. The only test calling this method compensated by expecting the event to occur, but didn't distinguish what triggered the error.

This PR inverts the logic of the helper method (look for an event with the matching string), and flips the corresponding test logic.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/area test
/assign @mrunalp 