### PR TITLE
Allow an empty "" runtimeHandler

### DIFF
--- a/cluster/addons/runtimeclass/runtimeclass_crd.yaml
+++ b/cluster/addons/runtimeclass/runtimeclass_crd.yaml
@@ -23,4 +23,4 @@ spec:
           properties:
             runtimeHandler:
               type: string
-              pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+              pattern: '^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?$'


### PR DESCRIPTION
**What this PR does / why we need it**:

The empty `""` runtimeHandler should be allowed to enable creation of a RuntimeClass representing the default handler.

**Special notes for your reviewer**:

This is a candidate for cherry-picking to 1.12

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The runtimeHandler field on the RuntimeClass resource now accepts the empty string.
```

/sig node
/assign @yujuhong 