### PR TITLE
Add import restrictions for cloud-provider

### DIFF
--- a/hack/import-restrictions.yaml
+++ b/hack/import-restrictions.yaml
@@ -152,3 +152,9 @@
   - k8s.io/api
   - k8s.io/apimachinery
   - k8s.io/cluster-bootstrap
+
+- baseImportPath: "./vendor/k8s.io/cloud-provider/"
+  allowedImports:
+  - k8s.io/api
+  - k8s.io/apimachinery
+  - k8s.io/client-go

--- a/staging/README.md
+++ b/staging/README.md
@@ -12,6 +12,7 @@ Repositories currently staged here:
 - [`k8s.io/apiserver`](https://github.com/kubernetes/apiserver)
 - [`k8s.io/cli-runtime`](https://github.com/kubernetes/cli-runtime)
 - [`k8s.io/client-go`](https://github.com/kubernetes/client-go)
+- [`k8s.io/cloud-provider`](https://github.com/kubernetes/cloud-provider)
 - [`k8s.io/cluster-bootstrap`](https://github.com/kubernetes/cluster-bootstrap)
 - [`k8s.io/code-generator`](https://github.com/kubernetes/code-generator)
 - [`k8s.io/csi-api`](https://github.com/kubernetes/csi-api)


### PR DESCRIPTION
List of dependencies: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cloud-provider/Godeps/Godeps.json

/cc @dims @sttts @andrewsykim @cheftako 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
