### PR TITLE
fix GetVolumeLimits log flushing issue

### DIFF
--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -144,8 +144,7 @@ func (plugin *azureDataDiskPlugin) GetVolumeLimits() (map[string]int64, error) {
 		// hoping external CCM or admin can set it. Returning
 		// default values from here will mean, no one can
 		// override them.
-		glog.Errorf("failed to get azure cloud in GetVolumeLimits, plugin.host: %s", plugin.host.GetHostName())
-		return volumeLimits, nil
+		return nil, fmt.Errorf("failed to get azure cloud in GetVolumeLimits, plugin.host: %s", plugin.host.GetHostName())
 	}
 
 	instances, ok := az.Instances()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR is to fix the flushing log issue on k8s cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69503

**Special notes for your reviewer**:
In v1.12, GetVolumeLimits is enabled by default, take aws ebs for example, it will return error directly if it could not get cloud provider:
https://github.com/kubernetes/kubernetes/blob/f9acfd8e384488d2216b18196152dcb7b3cc92d8/pkg/volume/awsebs/aws_ebs.go#L111

And logging as V(4):
https://github.com/kubernetes/kubernetes/blob/f9acfd8e384488d2216b18196152dcb7b3cc92d8/pkg/kubelet/nodestatus/setters.go#L775

I suppose V(4) logs won't display in logs. Let me make the same change.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
fix GetVolumeLimits log flushing issue
```

/assign @gnufied 
cc @turchanov