### PR TITLE
Opt out of chowning and chmoding from kubectl cp.

### DIFF
--- a/pkg/kubectl/cmd/cp/BUILD
+++ b/pkg/kubectl/cmd/cp/BUILD
@@ -23,6 +23,7 @@ go_test(
     srcs = ["cp_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/kubectl/cmd/exec:go_default_library",
         "//pkg/kubectl/cmd/testing:go_default_library",
         "//pkg/kubectl/scheme:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/kubectl/cmd/cp/cp_test.go
+++ b/pkg/kubectl/cmd/cp/cp_test.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -35,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest/fake"
+	kexec "k8s.io/kubernetes/pkg/kubectl/cmd/exec"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
@@ -573,7 +575,7 @@ func TestCopyToPod(t *testing.T) {
 		}
 		opts.Complete(tf, cmd)
 		t.Run(name, func(t *testing.T) {
-			err = opts.copyToPod(src, dest)
+			err = opts.copyToPod(src, dest, &kexec.ExecOptions{})
 			//If error is NotFound error , it indicates that the
 			//request has been sent correctly.
 			//Treat this as no error.
@@ -582,6 +584,68 @@ func TestCopyToPod(t *testing.T) {
 			}
 			if !test.expectedErr && !errors.IsNotFound(err) {
 				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestCopyToPodNoPreserve(t *testing.T) {
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	ns := scheme.Codecs
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.Client = &fake.RESTClient{
+		GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			responsePod := &v1.Pod{}
+			return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(codec, responsePod))))}, nil
+		}),
+	}
+
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+
+	cmd := NewCmdCp(tf, ioStreams)
+
+	srcFile, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		t.FailNow()
+	}
+	defer os.RemoveAll(srcFile)
+
+	tests := map[string]struct {
+		expectedCmd []string
+		nopreserve  bool
+	}{
+		"copy to pod no preserve user and permissions": {
+			expectedCmd: []string{"tar", "--no-same-permissions", "--no-same-owner", "-xf", "-", "-C", "."},
+			nopreserve:  true,
+		},
+		"copy to pod preserve user and permissions": {
+			expectedCmd: []string{"tar", "-xf", "-", "-C", "."},
+			nopreserve:  false,
+		},
+	}
+	opts := NewCopyOptions(ioStreams)
+	src := fileSpec{
+		File: srcFile,
+	}
+	dest := fileSpec{
+		PodNamespace: "pod-ns",
+		PodName:      "pod-name",
+		File:         "foo",
+	}
+	opts.Complete(tf, cmd)
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			options := &kexec.ExecOptions{}
+			opts.NoPreserve = test.nopreserve
+			err = opts.copyToPod(src, dest, options)
+			if !(reflect.DeepEqual(test.expectedCmd, options.Command)) {
+				t.Errorf("expected cmd: %v, got: %v", test.expectedCmd, options.Command)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubectl cp` relies on tar to extract the copied file/directory in the
container, tar by default attempts to chown/chmod the extracted file
after extraction if the user is the "superuser"(root)

```
--same-owner
try extracting files with the same ownership as exists in the archive
(default for superuser)
-p, --preserve-permissions, --same-permissions
extract information about file permissions (default for superuser)
```

This fails in environment where the container runs as root but is not
granted the OWNER or CHOWN capability.

Before this patch below was the behavior of `kubectl cp`

```
kubectl cp README.md foo-67b6fcbd4c-qjlt6:/tmp
tar: README.md: Cannot change ownership to uid 1000, gid 1000: Operation
not permitted
tar: Exiting with failure status due to previous errors
command terminated with exit code 2
kubectl exec -it foo-67b6fcbd4c-qjlt6 -- ls -l /tmp/README.md
-rw------- 1 1000 1000 3179 Oct  7 22:00 /tmp/README.md
```

After this patch

```
kubectl cp -x a foo-67b6fcbd4c-qjlt6:/
kubectl exec -it foo-67b6fcbd4c-qjlt6 -- ls -l /tmp/README.md
-rw-r--r-- 1 root root 3179 Oct  7 22:00 /tmp/README.md
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69572

**Special notes for your reviewer**:

I chose the short flag `-x` randomly, I don't know if there's an existing convention around selecting flags, also I don't have any tests for this, but if there's some e2e test that needs to be updated I'll appreciate pointers

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Opt out of chowning and chmoding from kubectl cp.
```
