### PR TITLE
Check loopback interfaces for unicast IP in ChooseBindAddress

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
@@ -395,6 +395,16 @@ func chooseHostInterfaceFromRoute(routes []Route, nw networkInterfacer) (net.IP,
 				klog.V(4).Infof("Found active IP %v ", finalIP)
 				return finalIP, nil
 			}
+			klog.V(4).Infof("Default route exists for IPv%d, however interface %q does not have global unicast addresses. Checking loopback interface", uint(family), route.Interface)
+			loopbackIP, err := getIPFromInterface("lo", family, nw)
+			if err != nil {
+				return nil, err
+			}
+			if loopbackIP != nil {
+				klog.V(4).Infof("Found active IP %v on loopback interface", loopbackIP)
+				return loopbackIP, nil
+			}
+
 		}
 	}
 	klog.V(4).Infof("No active IP found by looking at default routes")


### PR DESCRIPTION
**What this PR does / why we need it**:
In the network setups where default routes are present, but network
interfaces use only link-local addresses (e.g. as described in RFC5549),
ChooseBindAddress will fail as chooseHostInterfaceFromRoute will not
be able to find any matching unicast IP addresses for that route.
It is likely that matching global unicast IP address for this family of
default route can be found on loopback interface.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#1156

**Special notes for your reviewer**:

**Release note**:
```release-note
netutil.ChooseBindAddress is able to detect global unicast IP addresses attached to loopback interfaces, if default route is using link-local addresses
```
