### PR TITLE
Add the existence check of /proc/net/nf_conntrack

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3393,8 +3393,8 @@ func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*SSHResult,
 	LogSSHResult(result)
 
 	if result.Code != 0 || err != nil {
-		return nil, fmt.Errorf("failed running %q: %v (exit code %d)",
-			cmd, err, result.Code)
+		return nil, fmt.Errorf("failed running %q: %v (exit code %d, stderr %v)",
+			cmd, err, result.Code, result.Stderr)
 	}
 
 	return &result, nil

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -77,6 +77,16 @@ var _ = SIGDescribe("Network", func() {
 
 		zero := int64(0)
 
+		// Some distributions (Ubuntu 16.04 etc.) don't support the proc file.
+		_, err := framework.IssueSSHCommandWithResult(
+			"ls /proc/net/nf_conntrack",
+			framework.TestContext.Provider,
+			clientNodeInfo.node)
+		if err != nil && strings.Contains(err.Error(), "No such file or directory") {
+			framework.Skipf("The node %s does not support /proc/net/nf_conntrack", clientNodeInfo.name)
+		}
+		framework.ExpectNoError(err)
+
 		clientPodSpec := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "e2e-net-client",


### PR DESCRIPTION
**What this PR does / why we need it**:

The existence of /proc/net/nf_conntrack depends on the Linux kernel
config CONFIG_NF_CONNTRACK_PROCFS, and Ubuntu 16.04's one is disabled.
So the e2e test "should set TCP CLOSE_WAIT timeout" fails on that.
This adds the existence check of /proc/net/nf_conntrack for skipping
the test if not existing.
In addition, this makes IssueSSHCommandWithResult return Stderr in
the error message if err is nil to check "No such file or directory"
as nonexistence of /proc/net/nf_conntrack.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69588

**Release note**:
```None```
