### PR TITLE
fix lint issues in the apis/abac directory (except latest.go)

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -13,10 +13,7 @@ cmd/kubeadm/app/util/system
 cmd/kubelet/app
 cmd/kubelet/app/options
 cmd/kubemark
-pkg/apis/abac
 pkg/apis/abac/latest
-pkg/apis/abac/v0
-pkg/apis/abac/v1beta1
 pkg/apis/admission
 pkg/apis/admission/v1beta1
 pkg/apis/admissionregistration

--- a/pkg/apis/abac/register.go
+++ b/pkg/apis/abac/register.go
@@ -22,9 +22,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
-// Group is the API group for abac
+// GroupName is the API group for abac
 const GroupName = "abac.authorization.kubernetes.io"
 
+// SchemeGroupVersion is the API group version used to register abac internal
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
 
 // Scheme is the default instance of runtime.Scheme to which types in the abac API group are api.Registry.
@@ -40,8 +41,10 @@ func init() {
 }
 
 var (
+	// SchemeBuilder is the scheme builder with scheme init functions to run for this API package
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
+	// AddToScheme is a common registration function for mapping packaged scoped group & version keys to a scheme
+	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/pkg/apis/abac/v0/register.go
+++ b/pkg/apis/abac/v0/register.go
@@ -22,9 +22,10 @@ import (
 	"k8s.io/kubernetes/pkg/apis/abac"
 )
 
+// GroupName is the group name use in this package
 const GroupName = "abac.authorization.kubernetes.io"
 
-// GroupVersion is the API group and version for abac v0
+// SchemeGroupVersion is the API group version used to register abac v0
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v0"}
 
 func init() {
@@ -40,11 +41,15 @@ func init() {
 }
 
 var (
+	// SchemeBuilder is the scheme builder with scheme init functions to run for this API package
 	// TODO: move SchemeBuilder with zz_generated.deepcopy.go to k8s.io/api.
+	SchemeBuilder runtime.SchemeBuilder
+	// localSchemeBuilder ïs a pointer to SchemeBuilder instance. Using localSchemeBuilder
+	// defaulting and conversion init funcs are registered as well.
 	// localSchemeBuilder and AddToScheme will stay in k8s.io/kubernetes.
-	SchemeBuilder      runtime.SchemeBuilder
 	localSchemeBuilder = &SchemeBuilder
-	AddToScheme        = localSchemeBuilder.AddToScheme
+	// AddToScheme is a common registration function for mapping packaged scoped group & version keys to a scheme
+	AddToScheme = localSchemeBuilder.AddToScheme
 )
 
 func init() {

--- a/pkg/apis/abac/v0/types.go
+++ b/pkg/apis/abac/v0/types.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // +k8s:openapi-gen=true
+
 package v0
 
 import (

--- a/pkg/apis/abac/v1beta1/register.go
+++ b/pkg/apis/abac/v1beta1/register.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/abac"
 )
 
+// GroupName is the group name use in this package
 const GroupName = "abac.authorization.kubernetes.io"
 
 // SchemeGroupVersion is the API group and version for abac v1beta1
@@ -40,11 +41,15 @@ func init() {
 }
 
 var (
+	// SchemeBuilder is the scheme builder with scheme init functions to run for this API package
 	// TODO: move SchemeBuilder with zz_generated.deepcopy.go to k8s.io/api.
+	SchemeBuilder runtime.SchemeBuilder
+	// localSchemeBuilder ïs a pointer to SchemeBuilder instance. Using localSchemeBuilder
+	// defaulting and conversion init funcs are registered as well.
 	// localSchemeBuilder and AddToScheme will stay in k8s.io/kubernetes.
-	SchemeBuilder      runtime.SchemeBuilder
 	localSchemeBuilder = &SchemeBuilder
-	AddToScheme        = localSchemeBuilder.AddToScheme
+	// AddToScheme is a common registration function for mapping packaged scoped group & version keys to a scheme
+	AddToScheme = localSchemeBuilder.AddToScheme
 )
 
 func init() {

--- a/pkg/apis/abac/v1beta1/types.go
+++ b/pkg/apis/abac/v1beta1/types.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // +k8s:openapi-gen=true
+
 package v1beta1
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the linting errors in pkg/apis/abac/ directory (with the exception of latest.go, which has a interesting todo)

**Release Note**
```release-note
NONE
```
