### PR TITLE
Aligned sched_perf owner.

### DIFF
--- a/test/integration/scheduler_perf/OWNERS
+++ b/test/integration/scheduler_perf/OWNERS
@@ -1,16 +1,4 @@
 approvers:
-- bsalamat
-- davidopp
-- gmarek
-- jayunit100
-- timothysc
-- wojtek-t
+- sig-scheduling-maintainers
 reviewers:
-- bsalamat
-- davidopp
-- jayunit100
-- k82cn
-- ravisantoshgudimetla
-- sjug
-- timothysc
-- wojtek-t
+- sig-scheduling


### PR DESCRIPTION
Also used OWNER_ALIAS in scheduler_perf OWNER

**Release note**:
```release-note
None
```
