### PR TITLE
Update the list of SIG scheduling reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,15 +9,11 @@ aliases:
     - ravisantoshgudimetla
   sig-scheduling:
     - bsalamat
-    - davidopp
-    - jayunit100
     - k82cn
     - resouer
-    - timothysc
-    - wojtek-t
-    - aveshagarwal
     - ravisantoshgudimetla
     - misterikkit
+    - Huang-Wei
   sig-cli-maintainers:
     - adohe
     - brendandburns


### PR DESCRIPTION
Update the list of SIG scheduling reviewers to avoid having PRs assigned to non-active SIG scheduling reviewers.

Welcome @Huang-Wei as a new SIG Scheduling reviewer.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig scheduling
FYI @jayunit100 @davidopp @timothysc @wojtek-t @aveshagarwal

I didn't change the list of approvers, but if you think you won't be able to review and approve SIG Scheduling PRs, please let me know so that we can update the approvers list as well.