### PR TITLE
Fix format arguments in error in cli-runtime builder

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -95,6 +95,9 @@ kube::test::find_dirs() {
 
     find ./staging/src/k8s.io/sample-apiserver -name '*_test.go' \
       -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
+
+    find ./staging/src/k8s.io/cli-runtime -name '*_test.go' \
+      -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
   )
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
@@ -1056,7 +1056,7 @@ func (b *Builder) visitByPaths() *Result {
 	if b.labelSelector != nil {
 		selector, err := labels.Parse(*b.labelSelector)
 		if err != nil {
-			return result.withError(fmt.Errorf("the provided selector %q is not valid: %v", b.labelSelector, err))
+			return result.withError(fmt.Errorf("the provided selector %q is not valid: %v", *b.labelSelector, err))
 		}
 		visitors = NewFilteredVisitor(visitors, FilterByLabelSelector(selector))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
I found this when updating test coverage, apparently we didn't run these tests as part of regular `make test` so I've went ahead and added these there as well. 

**Special notes for your reviewer**:
/assign @juanvallejo 

/kind cleanup
/sig cli

**Release note**:
```release-note
None
```
