### PR TITLE
Remove redundant nil checks around a range loop

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate/rollingupdate_test.go
+++ b/pkg/kubectl/cmd/rollingupdate/rollingupdate_test.go
@@ -76,10 +76,8 @@ func TestValidateArgs(t *testing.T) {
 	for _, test := range tests {
 		cmd := NewCmdRollingUpdate(f, genericclioptions.NewTestIOStreamsDiscard())
 
-		if test.flags != nil {
-			for key, val := range test.flags {
-				cmd.Flags().Set(key, val)
-			}
+		for key, val := range test.flags {
+			cmd.Flags().Set(key, val)
 		}
 		err := validateArguments(cmd, test.filenames, test.args)
 		if err != nil && !test.expectErr {

--- a/pkg/kubectl/util/i18n/i18n.go
+++ b/pkg/kubectl/util/i18n/i18n.go
@@ -67,11 +67,9 @@ func findLanguage(root string, getLanguageFn func() string) string {
 	langStr := getLanguageFn()
 
 	translations := knownTranslations[root]
-	if translations != nil {
-		for ix := range translations {
-			if translations[ix] == langStr {
-				return langStr
-			}
+	for ix := range translations {
+		if translations[ix] == langStr {
+			return langStr
 		}
 	}
 	glog.V(3).Infof("Couldn't find translations for %s, using default", langStr)

--- a/pkg/kubelet/custommetrics/custom_metrics.go
+++ b/pkg/kubelet/custommetrics/custom_metrics.go
@@ -34,13 +34,11 @@ const (
 func GetCAdvisorCustomMetricsDefinitionPath(container *v1.Container) (*string, error) {
 	// Assumes that the container has Custom Metrics enabled if it has "/etc/custom-metrics" directory
 	// mounted as a volume. Custom Metrics definition is expected to be in "definition.json".
-	if container.VolumeMounts != nil {
-		for _, volumeMount := range container.VolumeMounts {
-			if path.Clean(volumeMount.MountPath) == path.Clean(CustomMetricsDefinitionDir) {
-				// TODO: add definition file validation.
-				definitionPath := path.Clean(path.Join(volumeMount.MountPath, CustomMetricsDefinitionContainerFile))
-				return &definitionPath, nil
-			}
+	for _, volumeMount := range container.VolumeMounts {
+		if path.Clean(volumeMount.MountPath) == path.Clean(CustomMetricsDefinitionDir) {
+			// TODO: add definition file validation.
+			definitionPath := path.Clean(path.Join(volumeMount.MountPath, CustomMetricsDefinitionContainerFile))
+			return &definitionPath, nil
 		}
 	}
 	// No Custom Metrics definition available.

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -954,12 +954,10 @@ func getKillMap(pod *v1.Pod, status *kubecontainer.PodStatus, cIndexes []int) ma
 }
 
 func verifyActions(t *testing.T, expected, actual *podActions, desc string) {
-	if actual.ContainersToKill != nil {
-		// Clear the message field since we don't need to verify the message.
-		for k, info := range actual.ContainersToKill {
-			info.message = ""
-			actual.ContainersToKill[k] = info
-		}
+	// Clear the message field since we don't need to verify the message.
+	for k, info := range actual.ContainersToKill {
+		info.message = ""
+		actual.ContainersToKill[k] = info
 	}
 	assert.Equal(t, expected, actual, desc)
 }

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -633,10 +633,8 @@ func (dswp *desiredStateOfWorldPopulator) makeVolumeMap(containers []v1.Containe
 	volumeMountsMap := make(map[string]bool)
 
 	for _, container := range containers {
-		if container.VolumeMounts != nil {
-			for _, mount := range container.VolumeMounts {
-				volumeMountsMap[mount.Name] = true
-			}
+		for _, mount := range container.VolumeMounts {
+			volumeMountsMap[mount.Name] = true
 		}
 		// TODO: remove feature gate check after no longer needed
 		if utilfeature.DefaultFeatureGate.Enabled(features.BlockVolume) &&

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -320,10 +320,8 @@ func lockAndCheckSubPathWithoutSymlink(volumePath, subPath string) ([]uintptr, e
 
 // unlockPath unlock directories
 func unlockPath(fileHandles []uintptr) {
-	if fileHandles != nil {
-		for _, handle := range fileHandles {
-			syscall.CloseHandle(syscall.Handle(handle))
-		}
+	for _, handle := range fileHandles {
+		syscall.CloseHandle(syscall.Handle(handle))
 	}
 }
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -827,11 +827,9 @@ func DeleteNamespaces(c clientset.Interface, deleteFilter, skipFilter []string) 
 	var wg sync.WaitGroup
 OUTER:
 	for _, item := range nsList.Items {
-		if skipFilter != nil {
-			for _, pattern := range skipFilter {
-				if strings.Contains(item.Name, pattern) {
-					continue OUTER
-				}
+		for _, pattern := range skipFilter {
+			if strings.Contains(item.Name, pattern) {
+				continue OUTER
 			}
 		}
 		if deleteFilter != nil {

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -592,16 +592,12 @@ func (config *RCConfig) create() error {
 }
 
 func (config *RCConfig) applyTo(template *v1.PodTemplateSpec) {
-	if config.Env != nil {
-		for k, v := range config.Env {
-			c := &template.Spec.Containers[0]
-			c.Env = append(c.Env, v1.EnvVar{Name: k, Value: v})
-		}
+	for k, v := range config.Env {
+		c := &template.Spec.Containers[0]
+		c.Env = append(c.Env, v1.EnvVar{Name: k, Value: v})
 	}
-	if config.Labels != nil {
-		for k, v := range config.Labels {
-			template.ObjectMeta.Labels[k] = v
-		}
+	for k, v := range config.Labels {
+		template.ObjectMeta.Labels[k] = v
 	}
 	if config.NodeSelector != nil {
 		template.Spec.NodeSelector = make(map[string]string)
@@ -618,11 +614,9 @@ func (config *RCConfig) applyTo(template *v1.PodTemplateSpec) {
 			c.Ports = append(c.Ports, v1.ContainerPort{Name: k, ContainerPort: int32(v)})
 		}
 	}
-	if config.HostPorts != nil {
-		for k, v := range config.HostPorts {
-			c := &template.Spec.Containers[0]
-			c.Ports = append(c.Ports, v1.ContainerPort{Name: k, ContainerPort: int32(v), HostPort: int32(v)})
-		}
+	for k, v := range config.HostPorts {
+		c := &template.Spec.Containers[0]
+		c.Ports = append(c.Ports, v1.ContainerPort{Name: k, ContainerPort: int32(v), HostPort: int32(v)})
 	}
 	if config.CpuLimit > 0 || config.MemLimit > 0 || config.GpuLimit > 0 {
 		template.Spec.Containers[0].Resources.Limits = v1.ResourceList{}


### PR DESCRIPTION
**What this PR does / why we need it**:

Simplifies code by removing redundant nil checks for loops over slices or maps.

**Release note**:
```release-note
NONE
```
