### PR TITLE
e2e: remove workarounds for etcd2 test jobs

### DIFF
--- a/test/e2e/apimachinery/chunking.go
+++ b/test/e2e/apimachinery/chunking.go
@@ -82,10 +82,6 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 				list, err := client.List(opts)
 				Expect(err).ToNot(HaveOccurred())
 				framework.Logf("Retrieved %d/%d results with rv %s and continue %s", len(list.Items), opts.Limit, list.ResourceVersion, list.Continue)
-				// TODO: kops PR job is still using etcd2, which prevents this feature from working. Remove this check when kops is upgraded to etcd3
-				if len(list.Items) > int(opts.Limit) {
-					framework.Skipf("ERROR: This cluster does not support chunking, which means it is running etcd2 and not supported.")
-				}
 				Expect(len(list.Items)).To(BeNumerically("<=", opts.Limit))
 
 				if len(lastRV) == 0 {
@@ -120,10 +116,6 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 		opts := metav1.ListOptions{}
 		opts.Limit = oneTenth
 		list, err := client.List(opts)
-		// TODO: kops PR job is still using etcd2, which prevents this feature from working. Remove this check when kops is upgraded to etcd3
-		if len(list.Items) > int(opts.Limit) {
-			framework.Skipf("ERROR: This cluster does not support chunking, which means it is running etcd2 and not supported.")
-		}
 		Expect(err).ToNot(HaveOccurred())
 		firstToken := list.Continue
 		firstRV := list.ResourceVersion

--- a/test/e2e/apimachinery/table_conversion.go
+++ b/test/e2e/apimachinery/table_conversion.go
@@ -108,10 +108,6 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 			SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").
 			Do().Into(pagedTable)
 		Expect(err).NotTo(HaveOccurred())
-		// TODO: kops PR job is still using etcd2, which prevents this feature from working. Remove this check when kops is upgraded to etcd3
-		if len(pagedTable.Rows) > 2 {
-			framework.Skipf("ERROR: This cluster does not support chunking, which means it is running etcd2 and not supported.")
-		}
 		Expect(len(pagedTable.Rows)).To(Equal(2))
 		Expect(pagedTable.ResourceVersion).ToNot(Equal(""))
 		Expect(pagedTable.SelfLink).ToNot(Equal(""))


### PR DESCRIPTION
Now we've removed support for etcd2, we should make sure we're testing
chunking fully.


```release-note
NONE
```