### PR TITLE
always set lastTransitionTime when crd condition changes

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/helpers.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/helpers.go
@@ -27,18 +27,19 @@ var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
 
 // SetCRDCondition sets the status condition. It either overwrites the existing one or creates a new one.
 func SetCRDCondition(crd *CustomResourceDefinition, newCondition CustomResourceDefinitionCondition) {
+	newCondition.LastTransitionTime = metav1.NewTime(time.Now())
+
 	existingCondition := FindCRDCondition(crd, newCondition.Type)
 	if existingCondition == nil {
-		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
 		crd.Status.Conditions = append(crd.Status.Conditions, newCondition)
 		return
 	}
 
-	if existingCondition.Status != newCondition.Status {
-		existingCondition.Status = newCondition.Status
+	if existingCondition.Status != newCondition.Status || existingCondition.LastTransitionTime.IsZero() {
 		existingCondition.LastTransitionTime = newCondition.LastTransitionTime
 	}
 
+	existingCondition.Status = newCondition.Status
 	existingCondition.Reason = newCondition.Reason
 	existingCondition.Message = newCondition.Message
 }


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/69654
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
When the status of a CRD Condition changes, it's corresponding `LastTransitionTime` is now updated.
```
