### PR TITLE
Fixes lint errors in kubeapiserver packages

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -504,7 +504,7 @@ func buildGenericConfig(
 		genericConfig.DisabledPostStartHooks.Insert(rbacrest.PostStartHookName)
 	}
 
-	admissionConfig := &kubeapiserveradmission.AdmissionConfig{
+	admissionConfig := &kubeapiserveradmission.Config{
 		ExternalInformers:    versionedInformers,
 		LoopbackClientConfig: genericConfig.LoopbackClientConfig,
 		CloudConfigFile:      s.CloudProvider.CloudConfigFile,

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -134,10 +134,6 @@ pkg/credentialprovider/gcp
 pkg/credentialprovider/rancher
 pkg/features
 pkg/kubeapiserver
-pkg/kubeapiserver/admission
-pkg/kubeapiserver/authenticator
-pkg/kubeapiserver/authorizer
-pkg/kubeapiserver/authorizer/modes
 pkg/kubeapiserver/options
 pkg/kubectl
 pkg/kubectl/apps

--- a/pkg/kubeapiserver/admission/config.go
+++ b/pkg/kubeapiserver/admission/config.go
@@ -37,14 +37,15 @@ import (
 	quotainstall "k8s.io/kubernetes/pkg/quota/v1/install"
 )
 
-// AdmissionConfig holds the configuration for initializing the admission plugins
-type AdmissionConfig struct {
+// Config holds the configuration needed to for initialize the admission plugins
+type Config struct {
 	CloudConfigFile      string
 	LoopbackClientConfig *rest.Config
 	ExternalInformers    externalinformers.SharedInformerFactory
 }
 
-func (c *AdmissionConfig) New(proxyTransport *http.Transport, serviceResolver webhook.ServiceResolver) ([]admission.PluginInitializer, server.PostStartHookFunc, error) {
+// New sets up the plugins and admission start hooks needed for admission
+func (c *Config) New(proxyTransport *http.Transport, serviceResolver webhook.ServiceResolver) ([]admission.PluginInitializer, server.PostStartHookFunc, error) {
 	webhookAuthResolverWrapper := webhook.NewDefaultAuthenticationInfoResolverWrapper(proxyTransport, c.LoopbackClientConfig)
 	webhookPluginInitializer := webhookinit.NewPluginInitializer(webhookAuthResolverWrapper, serviceResolver)
 

--- a/pkg/kubeapiserver/admission/initializer_test.go
+++ b/pkg/kubeapiserver/admission/initializer_test.go
@@ -33,8 +33,8 @@ type WantsCloudConfigAdmissionPlugin struct {
 	cloudConfig []byte
 }
 
-func (self *WantsCloudConfigAdmissionPlugin) SetCloudConfig(cloudConfig []byte) {
-	self.cloudConfig = cloudConfig
+func (p *WantsCloudConfigAdmissionPlugin) SetCloudConfig(cloudConfig []byte) {
+	p.cloudConfig = cloudConfig
 }
 
 func TestCloudConfigAdmissionPlugin(t *testing.T) {

--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -38,13 +38,15 @@ import (
 	"k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth"
 	"k8s.io/apiserver/plugin/pkg/authenticator/token/oidc"
 	"k8s.io/apiserver/plugin/pkg/authenticator/token/webhook"
+	// Initialize all known client auth plugins.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 )
 
-type AuthenticatorConfig struct {
+// Config contains the data on how to authenticate a request to the Kube API Server
+type Config struct {
 	Anonymous                   bool
 	BasicAuthFile               string
 	BootstrapToken              bool
@@ -78,7 +80,7 @@ type AuthenticatorConfig struct {
 
 // New returns an authenticator.Request or an error that supports the standard
 // Kubernetes authentication mechanisms.
-func (config AuthenticatorConfig) New() (authenticator.Request, *spec.SecurityDefinitions, error) {
+func (config Config) New() (authenticator.Request, *spec.SecurityDefinitions, error) {
 	var authenticators []authenticator.Request
 	var tokenAuthenticators []authenticator.Token
 	securityDefinitions := spec.SecurityDefinitions{}

--- a/pkg/kubeapiserver/authorizer/config.go
+++ b/pkg/kubeapiserver/authorizer/config.go
@@ -33,7 +33,8 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
 )
 
-type AuthorizationConfig struct {
+// Config contains the data on how to authorize a request to the Kube API Server
+type Config struct {
 	AuthorizationModes []string
 
 	// Options for ModeABAC
@@ -55,7 +56,7 @@ type AuthorizationConfig struct {
 
 // New returns the right sort of union of multiple authorizer.Authorizer objects
 // based on the authorizationMode or an error.
-func (config AuthorizationConfig) New() (authorizer.Authorizer, authorizer.RuleResolver, error) {
+func (config Config) New() (authorizer.Authorizer, authorizer.RuleResolver, error) {
 	if len(config.AuthorizationModes) == 0 {
 		return nil, nil, fmt.Errorf("at least one authorization mode must be passed")
 	}

--- a/pkg/kubeapiserver/authorizer/modes/modes.go
+++ b/pkg/kubeapiserver/authorizer/modes/modes.go
@@ -19,14 +19,21 @@ package modes
 import "k8s.io/apimachinery/pkg/util/sets"
 
 const (
+	// ModeAlwaysAllow is the mode to set all requests as authorized
 	ModeAlwaysAllow string = "AlwaysAllow"
-	ModeAlwaysDeny  string = "AlwaysDeny"
-	ModeABAC        string = "ABAC"
-	ModeWebhook     string = "Webhook"
-	ModeRBAC        string = "RBAC"
-	ModeNode        string = "Node"
+	// ModeAlwaysDeny is the mode to set no requests as authorized
+	ModeAlwaysDeny string = "AlwaysDeny"
+	// ModeABAC is the mode to use Attribute Based Access Control to authorize
+	ModeABAC string = "ABAC"
+	// ModeWebhook is the mode to make an external webhook call to authorize
+	ModeWebhook string = "Webhook"
+	// ModeRBAC is the mode to use Role Based Access Control to authorize
+	ModeRBAC string = "RBAC"
+	// ModeNode is an authorization mode that authorizes API requests made by kubelets.
+	ModeNode string = "Node"
 )
 
+// AuthorizationModeChoices is the list of supported authorization modes
 var AuthorizationModeChoices = []string{ModeAlwaysAllow, ModeAlwaysDeny, ModeABAC, ModeWebhook, ModeRBAC, ModeNode}
 
 // IsValidAuthorizationMode returns true if the given authorization mode is a valid one for the apiserver

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -292,8 +292,8 @@ func (s *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 }
 
-func (s *BuiltInAuthenticationOptions) ToAuthenticationConfig() kubeauthenticator.AuthenticatorConfig {
-	ret := kubeauthenticator.AuthenticatorConfig{
+func (s *BuiltInAuthenticationOptions) ToAuthenticationConfig() kubeauthenticator.Config {
+	ret := kubeauthenticator.Config{
 		TokenSuccessCacheTTL: s.TokenSuccessCacheTTL,
 		TokenFailureCacheTTL: s.TokenFailureCacheTTL,
 	}

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -138,7 +138,7 @@ func TestToAuthenticationConfig(t *testing.T) {
 		TokenFailureCacheTTL: 0,
 	}
 
-	expectConfig := kubeauthenticator.AuthenticatorConfig{
+	expectConfig := kubeauthenticator.Config{
 		APIAudiences:                authenticator.Audiences{"http://foo.bar.com"},
 		Anonymous:                   false,
 		BasicAuthFile:               "/testBasicAuthFile",

--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -109,8 +109,8 @@ func (s *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 		"The duration to cache 'unauthorized' responses from the webhook authorizer.")
 }
 
-func (s *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFactory versionedinformers.SharedInformerFactory) authorizer.AuthorizationConfig {
-	return authorizer.AuthorizationConfig{
+func (s *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFactory versionedinformers.SharedInformerFactory) authorizer.Config {
+	return authorizer.Config{
 		AuthorizationModes:          s.Modes,
 		PolicyFile:                  s.PolicyFile,
 		WebhookConfigFile:           s.WebhookConfigFile,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes lint errors in kubeapiserver/admission, kubeapiserver/authorizer,
kubeapiserver/authenticator. Also enables lint testing of these
directories.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes part of issues/68026
/kind bug

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
