### PR TITLE
Update two doc.go files under staging/src/k8s.io/apiserver

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/user/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/user/doc.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 // Package user contains utilities for dealing with simple user exchange in the auth
 // packages. The user.Info interface defines an interface for exchanging that info.
-package user
+package user // import "k8s.io/apiserver/pkg/authentication/user"

--- a/staging/src/k8s.io/apiserver/pkg/authorization/path/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/path/doc.go
@@ -15,4 +15,4 @@ limitations under the License.
 */
 
 // Package path contains an authorizer that allows certain paths and path prefixes.
-package path
+package path // import "k8s.io/apiserver/pkg/authorization/path"


### PR DESCRIPTION
Signed-off-by: Zhang-hoon Dennis Oh <zhanghoondennisoh@gmail.com>

**What this PR does / why we need it**:
update doc.go in: 
staging/src/k8s.io/apiserver/pkg/authentication/user
and 
staging/src/k8s.io/apiserver/pkg/authorization/path

This is necessary so that if someone wants to import only this package, the import path is not referred to as github.com, but as the k8s.io vanity url.
Ref: https://golang.org/doc/go1.4#canonicalimports

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Only a partial fix for #68231

**Special notes for your reviewer**:

**Release note**:

NONE