### PR TITLE
Rename AWS cloud provider TestParseInstance

### DIFF
--- a/pkg/cloudprovider/providers/aws/instances_test.go
+++ b/pkg/cloudprovider/providers/aws/instances_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 )
 
-func TestParseInstance(t *testing.T) {
+func TestMapToAWSInstanceIDs(t *testing.T) {
 	tests := []struct {
 		Kubernetes  kubernetesInstanceID
 		Aws         awsInstanceID


### PR DESCRIPTION
**What this PR does / why we need it**:
Renames AWS cloud provider TestParseInstance to a more meaningful name.

**Which issue(s) this PR fixes**:
Fixes #69705

**Release note**:
```release-note
NONE
```
/kind cleanup
/sig cloud-provider
/assign @andrewsykim 