### PR TITLE
AWS: unexport unnecessarily exported methods and variables about reco…

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -260,7 +260,7 @@ const MaxReadThenCreateRetries = 30
 // need hardcoded defaults.
 const DefaultVolumeType = "gp2"
 
-// Used to call RecognizeWellKnownRegions just once
+// Used to call recognizeWellKnownRegions just once
 var once sync.Once
 
 // AWS implements PVLabeler.
@@ -1063,7 +1063,7 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 
 	// Trust that if we get a region from configuration or AWS metadata that it is valid,
 	// and register ECR providers
-	RecognizeRegion(regionName)
+	recognizeRegion(regionName)
 
 	if !cfg.Global.DisableStrictZoneCheck {
 		valid := isRegionValid(regionName)
@@ -1152,7 +1152,7 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 
 	// Register regions, in particular for ECR credentials
 	once.Do(func() {
-		RecognizeWellKnownRegions()
+		recognizeWellKnownRegions()
 	})
 
 	return awsCloud, nil

--- a/pkg/cloudprovider/providers/aws/regions.go
+++ b/pkg/cloudprovider/providers/aws/regions.go
@@ -23,9 +23,9 @@ import (
 	"sync"
 )
 
-// WellKnownRegions is the complete list of regions known to the AWS cloudprovider
+// wellKnownRegions is the complete list of regions known to the AWS cloudprovider
 // and credentialprovider.
-var WellKnownRegions = [...]string{
+var wellKnownRegions = [...]string{
 	// from `aws ec2 describe-regions --region us-east-1 --query Regions[].RegionName | sort`
 	"ap-northeast-1",
 	"ap-northeast-2",
@@ -53,12 +53,12 @@ var awsRegionsMutex sync.Mutex
 // awsRegions is a set of recognized regions
 var awsRegions sets.String
 
-// RecognizeRegion is called for each AWS region we know about.
+// recognizeRegion is called for each AWS region we know about.
 // It currently registers a credential provider for that region.
 // There are two paths to discovering a region:
 //  * we hard-code some well-known regions
 //  * if a region is discovered from instance metadata, we add that
-func RecognizeRegion(region string) {
+func recognizeRegion(region string) {
 	awsRegionsMutex.Lock()
 	defer awsRegionsMutex.Unlock()
 
@@ -78,10 +78,10 @@ func RecognizeRegion(region string) {
 	awsRegions.Insert(region)
 }
 
-// RecognizeWellKnownRegions calls RecognizeRegion on each WellKnownRegion
-func RecognizeWellKnownRegions() {
-	for _, region := range WellKnownRegions {
-		RecognizeRegion(region)
+// recognizeWellKnownRegions calls RecognizeRegion on each WellKnownRegion
+func recognizeWellKnownRegions() {
+	for _, region := range wellKnownRegions {
+		recognizeRegion(region)
 	}
 }
 

--- a/pkg/cloudprovider/providers/aws/regions_test.go
+++ b/pkg/cloudprovider/providers/aws/regions_test.go
@@ -22,7 +22,7 @@ import (
 
 // TestRegions does basic checking of region verification / addition
 func TestRegions(t *testing.T) {
-	RecognizeWellKnownRegions()
+	recognizeWellKnownRegions()
 
 	tests := []struct {
 		Add            string
@@ -55,7 +55,7 @@ func TestRegions(t *testing.T) {
 
 	for _, test := range tests {
 		if test.Add != "" {
-			RecognizeRegion(test.Add)
+			recognizeRegion(test.Add)
 		}
 
 		if test.Lookup != "" {


### PR DESCRIPTION
…gnize region

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

unexport unnecessarily exported methods

[RecognizeRegion](https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/regions.go#L61)
[RecognizeWellKnownRegions](https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/regions.go#L82)
[WellKnownRegions](https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/regions.go#L28)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69710 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
