### PR TITLE
Reuse LabelNodeRoleMaster constant for loadbalancers in a common pack…

### DIFF
--- a/cmd/kubeadm/app/constants/BUILD
+++ b/cmd/kubeadm/app/constants/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = ["constants.go"],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/constants",
     deps = [
+        "//pkg/apis/core:go_default_library",
         "//pkg/registry/core/service/ipallocator:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
+	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 )
 
@@ -180,10 +181,6 @@ const (
 	// Default behaviour is 24 hours
 	DefaultTokenDuration = 24 * time.Hour
 
-	// LabelNodeRoleMaster specifies that a node is a master
-	// This is a duplicate definition of the constant in pkg/controller/service/service_controller.go
-	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
-
 	// AnnotationKubeadmCRISocket specifies the annotation kubeadm uses to preserve the crisocket information given to kubeadm at
 	// init/join time for use later. kubeadm annotates the node object with this information
 	AnnotationKubeadmCRISocket = "kubeadm.alpha.kubernetes.io/cri-socket"
@@ -322,13 +319,13 @@ const (
 var (
 	// MasterTaint is the taint to apply on the PodSpec for being able to run that Pod on the master
 	MasterTaint = v1.Taint{
-		Key:    LabelNodeRoleMaster,
+		Key:    core.LabelNodeRoleMaster,
 		Effect: v1.TaintEffectNoSchedule,
 	}
 
 	// MasterToleration is the toleration to apply on the PodSpec for being able to run that Pod on the master
 	MasterToleration = v1.Toleration{
-		Key:    LabelNodeRoleMaster,
+		Key:    core.LabelNodeRoleMaster,
 		Effect: v1.TaintEffectNoSchedule,
 	}
 

--- a/cmd/kubeadm/app/phases/addons/dns/BUILD
+++ b/cmd/kubeadm/app/phases/addons/dns/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//cmd/kubeadm/app/features:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
+        "//pkg/apis/core:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+	"k8s.io/kubernetes/pkg/apis/core"
 )
 
 const (
@@ -102,7 +103,7 @@ func kubeDNSAddon(cfg *kubeadmapi.InitConfiguration, client clientset.Interface)
 			DNSBindAddr:     dnsBindAddr,
 			DNSProbeAddr:    dnsProbeAddr,
 			DNSDomain:       cfg.Networking.DNSDomain,
-			MasterTaintKey:  kubeadmconstants.LabelNodeRoleMaster,
+			MasterTaintKey:  core.LabelNodeRoleMaster,
 		})
 	if err != nil {
 		return fmt.Errorf("error when parsing kube-dns deployment template: %v", err)
@@ -152,7 +153,7 @@ func coreDNSAddon(cfg *kubeadmapi.InitConfiguration, client clientset.Interface)
 	// Get the YAML manifest
 	coreDNSDeploymentBytes, err := kubeadmutil.ParseTemplate(CoreDNSDeployment, struct{ ImageRepository, MasterTaintKey, Version string }{
 		ImageRepository: cfg.ImageRepository,
-		MasterTaintKey:  kubeadmconstants.LabelNodeRoleMaster,
+		MasterTaintKey:  core.LabelNodeRoleMaster,
 		Version:         kubeadmconstants.CoreDNSVersion,
 	})
 	if err != nil {

--- a/cmd/kubeadm/app/phases/markmaster/BUILD
+++ b/cmd/kubeadm/app/phases/markmaster/BUILD
@@ -12,6 +12,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/constants:go_default_library",
+        "//pkg/apis/core:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
@@ -26,8 +27,8 @@ go_library(
     srcs = ["markmaster.go"],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/phases/markmaster",
     deps = [
-        "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
+        "//pkg/apis/core:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
     ],

--- a/cmd/kubeadm/app/phases/markmaster/markmaster.go
+++ b/cmd/kubeadm/app/phases/markmaster/markmaster.go
@@ -21,14 +21,14 @@ import (
 
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+	"k8s.io/kubernetes/pkg/apis/core"
 )
 
 // MarkMaster taints the master and sets the master label
 func MarkMaster(client clientset.Interface, masterName string, taints []v1.Taint) error {
 
-	fmt.Printf("[markmaster] Marking the node %s as master by adding the label \"%s=''\"\n", masterName, constants.LabelNodeRoleMaster)
+	fmt.Printf("[markmaster] Marking the node %s as master by adding the label \"%s=''\"\n", masterName, core.LabelNodeRoleMaster)
 
 	if taints != nil && len(taints) > 0 {
 		taintStrs := []string{}
@@ -54,7 +54,7 @@ func taintExists(taint v1.Taint, taints []v1.Taint) bool {
 }
 
 func markMasterNode(n *v1.Node, taints []v1.Taint) {
-	n.ObjectMeta.Labels[constants.LabelNodeRoleMaster] = ""
+	n.ObjectMeta.Labels[core.LabelNodeRoleMaster] = ""
 
 	for _, nt := range n.Spec.Taints {
 		if !taintExists(nt, taints) {

--- a/cmd/kubeadm/app/phases/markmaster/markmaster_test.go
+++ b/cmd/kubeadm/app/phases/markmaster/markmaster_test.go
@@ -29,6 +29,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/pkg/apis/core"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/util/node"
 )
@@ -69,21 +70,21 @@ func TestMarkMaster(t *testing.T) {
 		},
 		{
 			"master taint missing",
-			kubeadmconstants.LabelNodeRoleMaster,
+			core.LabelNodeRoleMaster,
 			nil,
 			[]v1.Taint{kubeadmconstants.MasterTaint},
 			"{\"spec\":{\"taints\":[{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\"}]}}",
 		},
 		{
 			"nothing missing",
-			kubeadmconstants.LabelNodeRoleMaster,
+			core.LabelNodeRoleMaster,
 			[]v1.Taint{kubeadmconstants.MasterTaint},
 			[]v1.Taint{kubeadmconstants.MasterTaint},
 			"{}",
 		},
 		{
 			"has taint and no new taints wanted",
-			kubeadmconstants.LabelNodeRoleMaster,
+			core.LabelNodeRoleMaster,
 			[]v1.Taint{
 				{
 					Key:    "node.cloudprovider.kubernetes.io/uninitialized",
@@ -95,7 +96,7 @@ func TestMarkMaster(t *testing.T) {
 		},
 		{
 			"has taint and should merge with wanted taint",
-			kubeadmconstants.LabelNodeRoleMaster,
+			core.LabelNodeRoleMaster,
 			[]v1.Taint{
 				{
 					Key:    "node.cloudprovider.kubernetes.io/uninitialized",

--- a/cmd/kubeadm/app/phases/selfhosting/BUILD
+++ b/cmd/kubeadm/app/phases/selfhosting/BUILD
@@ -17,6 +17,7 @@ go_test(
     deps = [
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
+        "//pkg/apis/core:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
     ],
@@ -36,6 +37,7 @@ go_library(
         "//cmd/kubeadm/app/features:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
+        "//pkg/apis/core:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
@@ -24,6 +24,7 @@ import (
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	"k8s.io/kubernetes/pkg/apis/core"
 )
 
 const (
@@ -86,11 +87,11 @@ func mutatePodSpec(mutators map[string][]PodSpecMutatorFunc, name string, podSpe
 // addNodeSelectorToPodSpec makes Pod require to be scheduled on a node marked with the master label
 func addNodeSelectorToPodSpec(podSpec *v1.PodSpec) {
 	if podSpec.NodeSelector == nil {
-		podSpec.NodeSelector = map[string]string{kubeadmconstants.LabelNodeRoleMaster: ""}
+		podSpec.NodeSelector = map[string]string{core.LabelNodeRoleMaster: ""}
 		return
 	}
 
-	podSpec.NodeSelector[kubeadmconstants.LabelNodeRoleMaster] = ""
+	podSpec.NodeSelector[core.LabelNodeRoleMaster] = ""
 }
 
 // setMasterTolerationOnPodSpec makes the Pod tolerate the master taint

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/pkg/apis/core"
 )
 
 func TestMutatePodSpec(t *testing.T) {
@@ -64,7 +65,7 @@ func TestMutatePodSpec(t *testing.T) {
 				},
 
 				NodeSelector: map[string]string{
-					kubeadmconstants.LabelNodeRoleMaster: "",
+					core.LabelNodeRoleMaster: "",
 				},
 				Tolerations: []v1.Toleration{
 					kubeadmconstants.MasterToleration,
@@ -77,7 +78,7 @@ func TestMutatePodSpec(t *testing.T) {
 			podSpec:   &v1.PodSpec{},
 			expected: v1.PodSpec{
 				NodeSelector: map[string]string{
-					kubeadmconstants.LabelNodeRoleMaster: "",
+					core.LabelNodeRoleMaster: "",
 				},
 				Tolerations: []v1.Toleration{
 					kubeadmconstants.MasterToleration,
@@ -90,7 +91,7 @@ func TestMutatePodSpec(t *testing.T) {
 			podSpec:   &v1.PodSpec{},
 			expected: v1.PodSpec{
 				NodeSelector: map[string]string{
-					kubeadmconstants.LabelNodeRoleMaster: "",
+					core.LabelNodeRoleMaster: "",
 				},
 				Tolerations: []v1.Toleration{
 					kubeadmconstants.MasterToleration,
@@ -118,7 +119,7 @@ func TestAddNodeSelectorToPodSpec(t *testing.T) {
 			podSpec: &v1.PodSpec{},
 			expected: v1.PodSpec{
 				NodeSelector: map[string]string{
-					kubeadmconstants.LabelNodeRoleMaster: "",
+					core.LabelNodeRoleMaster: "",
 				},
 			},
 		},
@@ -130,8 +131,8 @@ func TestAddNodeSelectorToPodSpec(t *testing.T) {
 			},
 			expected: v1.PodSpec{
 				NodeSelector: map[string]string{
-					"foo":                                "bar",
-					kubeadmconstants.LabelNodeRoleMaster: "",
+					"foo":                    "bar",
+					core.LabelNodeRoleMaster: "",
 				},
 			},
 		},

--- a/cmd/kubeadm/app/phases/upgrade/BUILD
+++ b/cmd/kubeadm/app/phases/upgrade/BUILD
@@ -37,6 +37,7 @@ go_library(
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//cmd/kubeadm/app/util/dryrun:go_default_library",
         "//cmd/kubeadm/app/util/etcd:go_default_library",
+        "//pkg/apis/core:go_default_library",
         "//pkg/version:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/upgrade/health.go
+++ b/cmd/kubeadm/app/phases/upgrade/health.go
@@ -29,6 +29,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
+	"k8s.io/kubernetes/pkg/apis/core"
 )
 
 // healthCheck is a helper struct for easily performing healthchecks against the cluster and printing the output
@@ -110,7 +111,7 @@ func apiServerHealthy(client clientset.Interface) error {
 // masterNodesReady checks whether all master Nodes in the cluster are in the Running state
 func masterNodesReady(client clientset.Interface) error {
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{
-		constants.LabelNodeRoleMaster: "",
+		core.LabelNodeRoleMaster: "",
 	}))
 	masters, err := client.CoreV1().Nodes().List(metav1.ListOptions{
 		LabelSelector: selector.String(),

--- a/cmd/kubeadm/app/phases/upgrade/prepull.go
+++ b/cmd/kubeadm/app/phases/upgrade/prepull.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+	"k8s.io/kubernetes/pkg/apis/core"
 )
 
 const (
@@ -179,7 +180,7 @@ func buildPrePullDaemonSet(component, image string) *apps.DaemonSet {
 						},
 					},
 					NodeSelector: map[string]string{
-						constants.LabelNodeRoleMaster: "",
+						core.LabelNodeRoleMaster: "",
 					},
 					Tolerations:                   []v1.Toleration{constants.MasterToleration},
 					TerminationGracePeriodSeconds: &gracePeriodSecs,

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3718,6 +3718,20 @@ type Node struct {
 	Status NodeStatus
 }
 
+// We define LabelNodeRoleMaster and LabelNodeRoleNode, which are the preferred
+// form, but we will also recognize other forms that are known to be in
+// widespread use (NodeLabelKubeadmAlphaRole, NodeLabelRole, etc) .
+const (
+	// LabelNodeMasterRole is set to the value "true" indicating a master node.
+	// A master node typically runs kubernetes system components and will not typically run user workloads.
+	// When set to any value other than "true" it is ignored.
+	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
+
+	// LabelNodeRoleNode is set to the value "true" indicating a "normal" node.
+	// When set to any value other than "true" it is ignored.
+	LabelNodeRoleNode = "node-role.kubernetes.io/node"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // NodeList is a list of nodes.

--- a/pkg/controller/service/BUILD
+++ b/pkg/controller/service/BUILD
@@ -14,6 +14,7 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/controller/service",
     deps = [
+        "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/features:go_default_library",

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/kubernetes/pkg/apis/core"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/controller"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
@@ -60,10 +61,6 @@ const (
 
 	clientRetryCount    = 5
 	clientRetryInterval = 5 * time.Second
-
-	// LabelNodeRoleMaster specifies that a node is a master
-	// It's copied over to kubeadm until it's merged in core: https://github.com/kubernetes/kubernetes/pull/39112
-	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
 
 	// LabelNodeRoleExcludeBalancer specifies that the node should be
 	// exclude from load balancers created by a cloud provider.
@@ -595,7 +592,7 @@ func getNodeConditionPredicate() corelisters.NodeConditionPredicate {
 
 		// As of 1.6, we will taint the master, but not necessarily mark it unschedulable.
 		// Recognize nodes labeled as master, and filter them also, as we were doing previously.
-		if _, hasMasterRoleLabel := node.Labels[LabelNodeRoleMaster]; hasMasterRoleLabel {
+		if _, hasMasterRoleLabel := node.Labels[core.LabelNodeRoleMaster]; hasMasterRoleLabel {
 			return false
 		}
 

--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -60,7 +60,6 @@ go_library(
         "//pkg/controller/deployment/util:go_default_library",
         "//pkg/controller/job:go_default_library",
         "//pkg/controller/nodelifecycle:go_default_library",
-        "//pkg/controller/service:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/kubelet/apis/config:go_default_library",

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -80,6 +80,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	appsinternal "k8s.io/kubernetes/pkg/apis/apps"
 	batchinternal "k8s.io/kubernetes/pkg/apis/batch"
+	"k8s.io/kubernetes/pkg/apis/core"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	extensionsinternal "k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -88,7 +89,6 @@ import (
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/controller"
 	nodectlr "k8s.io/kubernetes/pkg/controller/nodelifecycle"
-	"k8s.io/kubernetes/pkg/controller/service"
 	"k8s.io/kubernetes/pkg/features"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
@@ -2696,7 +2696,7 @@ func WaitForAllNodesSchedulable(c clientset.Interface, timeout time.Duration) er
 		}
 		for i := range nodes.Items {
 			node := &nodes.Items[i]
-			if _, hasMasterRoleLabel := node.ObjectMeta.Labels[service.LabelNodeRoleMaster]; hasMasterRoleLabel {
+			if _, hasMasterRoleLabel := node.ObjectMeta.Labels[core.LabelNodeRoleMaster]; hasMasterRoleLabel {
 				// Kops clusters have masters with spec.unscheduable = false and
 				// node-role.kubernetes.io/master NoSchedule taint.
 				// Don't wait for them.


### PR DESCRIPTION
…ageinstead of hard coding it

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Reuse LabelNodeRoleMaster constant for loadbalancers in a common package(kubernetes/pkg/apis/core and next to type Node) instead of hard coding it. Might be good to follow up on https://github.com/kubernetes/kubernetes/pull/39112 before working on this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69715

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reuse LabelNodeRoleMaster constant for loadbalancers in a common packageinstead of hard coding it.
```
