### PR TITLE
refactor kubelet/cpumanager

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -262,8 +262,8 @@ func TestCPUAccumulatorTake(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		acc := newCPUAccumulator(tc.topo, tc.availableCPUs, tc.numCPUs)
-		totalTaken := 0
+		acc := newCPUAccumulator(tc.topo, tc.availableCPUs, uint32(tc.numCPUs))
+		totalTaken := uint32(0)
 		for _, cpus := range tc.takeCPUs {
 			acc.take(cpus)
 			totalTaken += cpus.Size()
@@ -283,7 +283,7 @@ func TestCPUAccumulatorTake(t *testing.T) {
 				t.Errorf("[%s] expected [%s] to be a subset of acc.result [%s]", tc.description, cpus, acc.result)
 			}
 		}
-		expNumCPUsNeeded := tc.numCPUs - totalTaken
+		expNumCPUsNeeded := uint32(tc.numCPUs) - uint32(totalTaken)
 		if acc.numCPUsNeeded != expNumCPUsNeeded {
 			t.Errorf("[%s] expected acc.numCPUsNeeded to be %d (got %d)", tc.description, expNumCPUsNeeded, acc.numCPUsNeeded)
 		}
@@ -374,7 +374,7 @@ func TestTakeByTopology(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		result, err := takeByTopology(tc.topo, tc.availableCPUs, tc.numCPUs)
+		result, err := takeByTopology(tc.topo, tc.availableCPUs, uint32(tc.numCPUs))
 		if tc.expErr != "" && err.Error() != tc.expErr {
 			t.Errorf("expected error to be [%v] but it was [%v] in test \"%s\"", tc.expErr, err, tc.description)
 		}

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -128,7 +128,7 @@ func NewManager(cpuPolicyName string, reconcilePeriod time.Duration, machineInfo
 		// Take the ceiling of the reservation, since fractional CPUs cannot be
 		// exclusively allocated.
 		reservedCPUsFloat := float64(reservedCPUs.MilliValue()) / 1000
-		numReservedCPUs := int(math.Ceil(reservedCPUsFloat))
+		numReservedCPUs := uint32(math.Ceil(reservedCPUsFloat))
 		policy = NewStaticPolicy(topo, numReservedCPUs)
 
 	default:

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -146,7 +146,7 @@ func TestCPUManagerAdd(t *testing.T) {
 			NumCPUs:    4,
 			NumSockets: 1,
 			NumCores:   4,
-			CPUDetails: map[int]topology.CPUInfo{
+			CPUDetails: map[uint32]topology.CPUInfo{
 				0: {CoreID: 0, SocketID: 0},
 				1: {CoreID: 1, SocketID: 0},
 				2: {CoreID: 2, SocketID: 0},

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -81,7 +81,7 @@ var _ Policy = &staticPolicy{}
 // NewStaticPolicy returns a CPU manager policy that does not change CPU
 // assignments for exclusively pinned guaranteed containers after the main
 // container process starts.
-func NewStaticPolicy(topology *topology.CPUTopology, numReservedCPUs int) Policy {
+func NewStaticPolicy(topology *topology.CPUTopology, numReservedCPUs uint32) Policy {
 	allCPUs := topology.CPUDetails.CPUs()
 	// takeByTopology allocates CPUs associated with low-numbered cores from
 	// allCPUs.
@@ -201,7 +201,7 @@ func (p *staticPolicy) RemoveContainer(s state.State, containerID string) error 
 	return nil
 }
 
-func (p *staticPolicy) allocateCPUs(s state.State, numCPUs int) (cpuset.CPUSet, error) {
+func (p *staticPolicy) allocateCPUs(s state.State, numCPUs uint32) (cpuset.CPUSet, error) {
 	glog.Infof("[cpumanager] allocateCpus: (numCPUs: %d)", numCPUs)
 	result, err := takeByTopology(p.topology, p.assignableCPUs(s), numCPUs)
 	if err != nil {
@@ -214,7 +214,7 @@ func (p *staticPolicy) allocateCPUs(s state.State, numCPUs int) (cpuset.CPUSet, 
 	return result, nil
 }
 
-func guaranteedCPUs(pod *v1.Pod, container *v1.Container) int {
+func guaranteedCPUs(pod *v1.Pod, container *v1.Container) uint32 {
 	if v1qos.GetPodQOS(pod) != v1.PodQOSGuaranteed {
 		return 0
 	}
@@ -225,5 +225,5 @@ func guaranteedCPUs(pod *v1.Pod, container *v1.Container) int {
 	// Safe downcast to do for all systems with < 2.1 billion CPUs.
 	// Per the language spec, `int` is guaranteed to be at least 32 bits wide.
 	// https://golang.org/ref/spec#Numeric_types
-	return int(cpuQuantity.Value())
+	return uint32(cpuQuantity.Value())
 }

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -30,7 +30,7 @@ import (
 type staticPolicyTest struct {
 	description     string
 	topo            *topology.CPUTopology
-	numReservedCPUs int
+	numReservedCPUs uint32
 	containerID     string
 	stAssignments   state.ContainerCPUAssignments
 	stDefaultCPUSet cpuset.CPUSet
@@ -127,7 +127,7 @@ func TestStaticPolicyStart(t *testing.T) {
 			policy.Start(st)
 
 			if !testCase.stDefaultCPUSet.IsEmpty() {
-				for cpuid := 1; cpuid < policy.topology.NumCPUs; cpuid++ {
+				for cpuid := uint32(1); cpuid < policy.topology.NumCPUs; cpuid++ {
 					if !st.defaultCPUSet.Contains(cpuid) {
 						t.Errorf("StaticPolicy Start() error. expected cpuid %d to be present in defaultCPUSet", cpuid)
 					}

--- a/pkg/kubelet/cm/cpumanager/policy_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_test.go
@@ -25,7 +25,7 @@ var (
 		NumCPUs:    8,
 		NumSockets: 1,
 		NumCores:   4,
-		CPUDetails: map[int]topology.CPUInfo{
+		CPUDetails: map[uint32]topology.CPUInfo{
 			0: {CoreID: 0, SocketID: 0},
 			1: {CoreID: 1, SocketID: 0},
 			2: {CoreID: 2, SocketID: 0},
@@ -41,7 +41,7 @@ var (
 		NumCPUs:    12,
 		NumSockets: 2,
 		NumCores:   6,
-		CPUDetails: map[int]topology.CPUInfo{
+		CPUDetails: map[uint32]topology.CPUInfo{
 			0:  {CoreID: 0, SocketID: 0},
 			1:  {CoreID: 1, SocketID: 1},
 			2:  {CoreID: 2, SocketID: 0},
@@ -61,7 +61,7 @@ var (
 		NumCPUs:    8,
 		NumSockets: 2,
 		NumCores:   8,
-		CPUDetails: map[int]topology.CPUInfo{
+		CPUDetails: map[uint32]topology.CPUInfo{
 			0: {CoreID: 0, SocketID: 0},
 			1: {CoreID: 1, SocketID: 0},
 			2: {CoreID: 2, SocketID: 0},
@@ -96,7 +96,7 @@ var (
 		NumCPUs:    288,
 		NumSockets: 4,
 		NumCores:   72,
-		CPUDetails: map[int]topology.CPUInfo{
+		CPUDetails: map[uint32]topology.CPUInfo{
 			0:   {CoreID: 0, SocketID: 0},
 			169: {CoreID: 0, SocketID: 0},
 			109: {CoreID: 0, SocketID: 0},

--- a/pkg/kubelet/cm/cpumanager/topology/topology_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology_test.go
@@ -46,10 +46,10 @@ func Test_Discover(t *testing.T) {
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
-							{Id: 0, Threads: []int{0, 4}},
-							{Id: 1, Threads: []int{1, 5}},
-							{Id: 2, Threads: []int{2, 6}},
-							{Id: 3, Threads: []int{3, 7}},
+							{Id: 0, Threads: []uint32{0, 4}},
+							{Id: 1, Threads: []uint32{1, 5}},
+							{Id: 2, Threads: []uint32{2, 6}},
+							{Id: 3, Threads: []uint32{3, 7}},
 						},
 					},
 				},
@@ -58,7 +58,7 @@ func Test_Discover(t *testing.T) {
 				NumCPUs:    8,
 				NumSockets: 1,
 				NumCores:   4,
-				CPUDetails: map[int]CPUInfo{
+				CPUDetails: map[uint32]CPUInfo{
 					0: {CoreID: 0, SocketID: 0},
 					1: {CoreID: 1, SocketID: 0},
 					2: {CoreID: 2, SocketID: 0},
@@ -78,14 +78,14 @@ func Test_Discover(t *testing.T) {
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
-							{Id: 0, Threads: []int{0}},
-							{Id: 2, Threads: []int{2}},
+							{Id: 0, Threads: []uint32{0}},
+							{Id: 2, Threads: []uint32{2}},
 						},
 					},
 					{Id: 1,
 						Cores: []cadvisorapi.Core{
-							{Id: 1, Threads: []int{1}},
-							{Id: 3, Threads: []int{3}},
+							{Id: 1, Threads: []uint32{1}},
+							{Id: 3, Threads: []uint32{3}},
 						},
 					},
 				},
@@ -94,7 +94,7 @@ func Test_Discover(t *testing.T) {
 				NumCPUs:    4,
 				NumSockets: 2,
 				NumCores:   4,
-				CPUDetails: map[int]CPUInfo{
+				CPUDetails: map[uint32]CPUInfo{
 					0: {CoreID: 0, SocketID: 0},
 					1: {CoreID: 1, SocketID: 1},
 					2: {CoreID: 2, SocketID: 0},
@@ -110,16 +110,16 @@ func Test_Discover(t *testing.T) {
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
-							{Id: 0, Threads: []int{0, 6}},
-							{Id: 1, Threads: []int{1, 7}},
-							{Id: 2, Threads: []int{2, 8}},
+							{Id: 0, Threads: []uint32{0, 6}},
+							{Id: 1, Threads: []uint32{1, 7}},
+							{Id: 2, Threads: []uint32{2, 8}},
 						},
 					},
 					{Id: 1,
 						Cores: []cadvisorapi.Core{
-							{Id: 0, Threads: []int{3, 9}},
-							{Id: 1, Threads: []int{4, 10}},
-							{Id: 2, Threads: []int{5, 11}},
+							{Id: 0, Threads: []uint32{3, 9}},
+							{Id: 1, Threads: []uint32{4, 10}},
+							{Id: 2, Threads: []uint32{5, 11}},
 						},
 					},
 				},
@@ -128,7 +128,7 @@ func Test_Discover(t *testing.T) {
 				NumCPUs:    12,
 				NumSockets: 2,
 				NumCores:   6,
-				CPUDetails: map[int]CPUInfo{
+				CPUDetails: map[uint32]CPUInfo{
 					0:  {CoreID: 0, SocketID: 0},
 					1:  {CoreID: 1, SocketID: 0},
 					2:  {CoreID: 2, SocketID: 0},
@@ -152,10 +152,10 @@ func Test_Discover(t *testing.T) {
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
-							{Id: 0, Threads: []int{0, 4}},
-							{Id: 1, Threads: []int{1, 5}},
-							{Id: 2, Threads: []int{2, 2}}, // Wrong case - should fail here
-							{Id: 3, Threads: []int{3, 7}},
+							{Id: 0, Threads: []uint32{0, 4}},
+							{Id: 1, Threads: []uint32{1, 5}},
+							{Id: 2, Threads: []uint32{2, 2}}, // Wrong case - should fail here
+							{Id: 3, Threads: []uint32{3, 7}},
 						},
 					},
 				},
@@ -170,10 +170,10 @@ func Test_Discover(t *testing.T) {
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
-							{Id: 0, Threads: []int{0, 4}},
-							{Id: 1, Threads: []int{1, 5}},
-							{Id: 2, Threads: []int{2, 6}},
-							{Id: 3, Threads: []int{}}, // Wrong case - should fail here
+							{Id: 0, Threads: []uint32{0, 4}},
+							{Id: 1, Threads: []uint32{1, 5}},
+							{Id: 2, Threads: []uint32{2, 6}},
+							{Id: 3, Threads: []uint32{}}, // Wrong case - should fail here
 						},
 					},
 				},

--- a/pkg/kubelet/cm/cpuset/cpuset_test.go
+++ b/pkg/kubelet/cm/cpuset/cpuset_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestCPUSetBuilder(t *testing.T) {
 	b := NewBuilder()
-	elems := []int{1, 2, 3, 4, 5}
+	elems := []uint32{1, 2, 3, 4, 5}
 	for _, elem := range elems {
 		b.Add(elem)
 	}
@@ -33,7 +33,7 @@ func TestCPUSetBuilder(t *testing.T) {
 			t.Fatalf("expected cpuset to contain element %d: [%v]", elem, result)
 		}
 	}
-	if len(elems) != result.Size() {
+	if uint32(len(elems)) != result.Size() {
 		t.Fatalf("expected cpuset %s to have the same size as %v", result, elems)
 	}
 }
@@ -41,7 +41,7 @@ func TestCPUSetBuilder(t *testing.T) {
 func TestCPUSetSize(t *testing.T) {
 	testCases := []struct {
 		cpuset   CPUSet
-		expected int
+		expected uint32
 	}{
 		{NewCPUSet(), 0},
 		{NewCPUSet(5), 1},
@@ -77,12 +77,12 @@ func TestCPUSetIsEmpty(t *testing.T) {
 func TestCPUSetContains(t *testing.T) {
 	testCases := []struct {
 		cpuset         CPUSet
-		mustContain    []int
-		mustNotContain []int
+		mustContain    []uint32
+		mustNotContain []uint32
 	}{
-		{NewCPUSet(), []int{}, []int{1, 2, 3, 4, 5}},
-		{NewCPUSet(5), []int{5}, []int{1, 2, 3, 4}},
-		{NewCPUSet(1, 2, 4, 5), []int{1, 2, 4, 5}, []int{0, 3, 6}},
+		{NewCPUSet(), []uint32{}, []uint32{1, 2, 3, 4, 5}},
+		{NewCPUSet(5), []uint32{5}, []uint32{1, 2, 3, 4}},
+		{NewCPUSet(1, 2, 4, 5), []uint32{1, 2, 4, 5}, []uint32{0, 3, 6}},
 	}
 
 	for _, c := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:
since cpu core and socket must be larger than 0, so use uint32 replace int 
