### PR TITLE
Clarify definition of activeDeadlineSeconds

### DIFF
--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -77,7 +77,7 @@ type JobSpec struct {
 	// +optional
 	Completions *int32 `json:"completions,omitempty" protobuf:"varint,2,opt,name=completions"`
 
-	// Specifies the duration in seconds relative to the startTime that the job may be active
+	// Specifies the duration in seconds relative to the startTime that the job must be active
 	// before the system tries to terminate it; value must be positive integer
 	// +optional
 	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty" protobuf:"varint,3,opt,name=activeDeadlineSeconds"`


### PR DESCRIPTION
/sig docs

**What this PR does / why we need it**: Clarifies that activeDeadlineSeconds is the minimum time required before a job will be considered for termination rather than the maximum time after which a job may be terminated.
As discussed in #sig-docs with @Bradamant3 


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
