### PR TITLE
Rename KUBERNETES_EXTERNAL_DIFF to KUBECTL_EXTERNAL_DIFF

### DIFF
--- a/pkg/kubectl/cmd/diff/diff.go
+++ b/pkg/kubectl/cmd/diff/diff.go
@@ -122,8 +122,7 @@ func (d *DiffProgram) getCommand(args ...string) exec.Cmd {
 
 // Run runs the detected diff program. `from` and `to` are the directory to diff.
 func (d *DiffProgram) Run(from, to string) error {
-	d.getCommand(from, to).Run() // Ignore diff return code
-	return nil
+	return d.getCommand(from, to).Run()
 }
 
 // Printer is used to print an object.
@@ -396,8 +395,5 @@ func RunDiff(f cmdutil.Factory, diff *DiffProgram, options *DiffOptions) error {
 		return err
 	}
 
-	// Error ignore on purpose. diff(1) for example, returns an error if there is any diff.
-	_ = differ.Run(diff)
-
-	return nil
+	return differ.Run(diff)
 }

--- a/pkg/kubectl/cmd/diff/diff.go
+++ b/pkg/kubectl/cmd/diff/diff.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -50,7 +49,7 @@ var (
 
 		Output is always YAML.
 
-		KUBERNETES_EXTERNAL_DIFF environment variable can be used to select your own
+		KUBECTL_EXTERNAL_DIFF environment variable can be used to select your own
 		diff command. By default, the "diff" command available in your path will be
 		run with "-u" (unicode) and "-N" (treat new files as empty) options.`))
 	diffExample = templates.Examples(i18n.T(`
@@ -98,7 +97,7 @@ func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 }
 
 // DiffProgram finds and run the diff program. The value of
-// KUBERNETES_EXTERNAL_DIFF environment variable will be used a diff
+// KUBECTL_EXTERNAL_DIFF environment variable will be used a diff
 // program. By default, `diff(1)` will be used.
 type DiffProgram struct {
 	Exec exec.Interface
@@ -107,7 +106,7 @@ type DiffProgram struct {
 
 func (d *DiffProgram) getCommand(args ...string) exec.Cmd {
 	diff := ""
-	if envDiff := os.Getenv("KUBERNETES_EXTERNAL_DIFF"); envDiff != "" {
+	if envDiff := os.Getenv("KUBECTL_EXTERNAL_DIFF"); envDiff != "" {
 		diff = envDiff
 	} else {
 		diff = "diff"

--- a/pkg/kubectl/cmd/diff/diff_test.go
+++ b/pkg/kubectl/cmd/diff/diff_test.go
@@ -52,7 +52,7 @@ func (f *FakeObject) Live() runtime.Object {
 }
 
 func TestDiffProgram(t *testing.T) {
-	os.Setenv("KUBERNETES_EXTERNAL_DIFF", "echo")
+	os.Setenv("KUBECTL_EXTERNAL_DIFF", "echo")
 	streams, _, stdout, _ := genericclioptions.NewTestIOStreams()
 	diff := DiffProgram{
 		IOStreams: streams,

--- a/test/cmd/diff.sh
+++ b/test/cmd/diff.sh
@@ -27,12 +27,12 @@ run_kubectl_diff_tests() {
     kube::log::status "Testing kubectl diff"
 
     # Test that it works when the live object doesn't exist
-    output_message=$(kubectl diff -f hack/testdata/pod.yaml)
+    output_message=$(! kubectl diff -f hack/testdata/pod.yaml)
     kube::test::if_has_string "${output_message}" 'test-pod'
 
     kubectl apply -f hack/testdata/pod.yaml
 
-    output_message=$(kubectl diff -f hack/testdata/pod-changed.yaml)
+    output_message=$(! kubectl diff -f hack/testdata/pod-changed.yaml)
     kube::test::if_has_string "${output_message}" 'k8s.gcr.io/pause:3.0'
 
     kubectl delete -f  hack/testdata/pod.yaml


### PR DESCRIPTION
And print an error when the diff invocation fails. It is a problem today, because if you specify an alternate binary that can't even be found, kubectl will leave with a success, even though nothing happened.
One of the drawback of doing that is that any non-empty diff will also print "exit status 1", which I think is mostly fine. It also helps whatever script is using kubectl diff to see if something needs to be applied or not.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
