### PR TITLE
Bazel: stop using deprecated docker_ rules and turn on stamping

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build", "docker_bundle")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_bundle", "container_image")
 load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
 
 filegroup(
@@ -56,13 +55,14 @@ DOCKERIZED_BINARIES = {
     },
 }
 
-[docker_build(
+[container_image(
     name = binary + "-internal",
     base = meta["base"],
     cmd = ["/usr/bin/" + binary],
     debs = [
         "//build/debs:%s.deb" % binary,
     ],
+    stamp = True,
     symlinks = {
         # Some cluster startup scripts expect to find the binaries in /usr/local/bin,
         # but the debs install the binaries into /usr/bin.
@@ -70,12 +70,11 @@ DOCKERIZED_BINARIES = {
     },
 ) for binary, meta in DOCKERIZED_BINARIES.items()]
 
-[docker_bundle(
+[container_bundle(
     name = binary,
     # TODO(thockin): remove the google_containers name after release 1.11.
     images = {
         "k8s.gcr.io/%s:{STABLE_DOCKER_TAG}" % binary: binary + "-internal",
-        "gcr.io/google_containers/%s:{STABLE_DOCKER_TAG}" % binary: binary + "-internal",
     },
     stamp = True,
 ) for binary in DOCKERIZED_BINARIES.keys()]

--- a/cluster/images/hyperkube/BUILD
+++ b/cluster/images/hyperkube/BUILD
@@ -1,11 +1,12 @@
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build", "docker_bundle")
+load("@io_bazel_rules_docker//container:container.bzl", "container_bundle", "container_image")
 
-docker_build(
+container_image(
     name = "hyperkube-internal",
     base = "@debian-hyperkube-base-amd64//image",
     files = [
         "//cmd/hyperkube",
     ],
+    stamp = True,
     symlinks = {
         "/%s" % path: "/hyperkube"
         for path in [
@@ -25,7 +26,7 @@ docker_build(
     },
 )
 
-docker_bundle(
+container_bundle(
     name = "hyperkube",
     images = {"k8s.gcr.io/hyperkube-amd64:{STABLE_DOCKER_TAG}": "hyperkube-internal"},
     stamp = True,

--- a/cluster/images/kubemark/BUILD
+++ b/cluster/images/kubemark/BUILD
@@ -1,16 +1,18 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build", "docker_push")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
 
-docker_build(
+container_image(
     name = "image",
     base = "@official_busybox//image",
     entrypoint = ["/kubemark"],
     files = ["//cmd/kubemark"],
+    stamp = True,
 )
 
-docker_push(
+container_push(
     name = "push",
+    format = "Docker",
     image = ":image",
     registry = "$(REGISTRY)",
     repository = "kubemark",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: the `docker_` rules have long been deprecated in favor of the `container_` rules, so we should use them. (There should be no functionality difference though.)

Additionally, enable stamping on all of our images. The main effect is that they'll set a real creation time, rather than epoch (https://github.com/bazelbuild/rules_docker/issues/155).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @BenTheElder @fejta 