### PR TITLE
Expose kms-plugin timeout in EncrypitonConfig.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/BUILD
@@ -15,6 +15,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/options/encryptionconfig",
     importpath = "k8s.io/apiserver/pkg/server/options/encryptionconfig",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/value:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -41,7 +41,7 @@ const (
 	aesGCMTransformerPrefixV1    = "k8s:enc:aesgcm:v1:"
 	secretboxTransformerPrefixV1 = "k8s:enc:secretbox:v1:"
 	kmsTransformerPrefixV1       = "k8s:enc:kms:v1:"
-	kmsPluginConnectionTimeout   = 3 * time.Second
+	kmsPluginConnectionTimeout   = 5 * time.Second
 )
 
 // GetTransformerOverrides returns the transformer overrides by reading and parsing the encryption provider configuration file
@@ -162,7 +162,11 @@ func GetPrefixTransformers(config *ResourceConfig) ([]value.PrefixTransformer, e
 			}
 
 			// Get gRPC client service with endpoint.
-			envelopeService, err := envelopeServiceFactory(provider.KMS.Endpoint, kmsPluginConnectionTimeout)
+			timeout := kmsPluginConnectionTimeout
+			if provider.KMS.Timeout.Duration != 0 {
+				timeout = provider.KMS.Timeout.Duration
+			}
+			envelopeService, err := envelopeServiceFactory(provider.KMS.Endpoint, timeout)
 			if err != nil {
 				return nil, fmt.Errorf("could not configure KMS plugin %q, error: %v", provider.KMS.Name, err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -163,7 +163,7 @@ func GetPrefixTransformers(config *ResourceConfig) ([]value.PrefixTransformer, e
 
 			// Get gRPC client service with endpoint.
 			timeout := kmsPluginConnectionTimeout
-			if provider.KMS.Timeout.Duration != 0 {
+			if provider.KMS != nil && provider.KMS.Timeout.Duration != 0 {
 				timeout = provider.KMS.Timeout.Duration
 			}
 			envelopeService, err := envelopeServiceFactory(provider.KMS.Endpoint, timeout)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -163,7 +163,7 @@ func GetPrefixTransformers(config *ResourceConfig) ([]value.PrefixTransformer, e
 
 			// Get gRPC client service with endpoint.
 			timeout := kmsPluginConnectionTimeout
-			if provider.KMS != nil && provider.KMS.Timeout.Duration != 0 {
+			if provider.KMS.Timeout.Duration != 0 {
 				timeout = provider.KMS.Timeout.Duration
 			}
 			envelopeService, err := envelopeServiceFactory(provider.KMS.Endpoint, timeout)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/types.go
@@ -86,5 +86,15 @@ type KMSConfig struct {
 	// the gRPC server listening address, for example "unix:///var/run/kms-provider.sock".
 	Endpoint string `json:"endpoint"`
 	// Timeout for gRPC calls to kms-plugin (ex. 5s).
-	Timeout metav1.Duration `json:"timeout"`
+	// Default (5s) is defined in a const (kmsPluginConnectionTimeout) in config.go.
+	// How to select a good timeout value:
+	// 1. Check kube-apiserver.log. If you see errors originating from grpc_service.go  (in the format of
+	// "failed to create connection to unix socket"), this may imply that kms-plugin is being started after the
+	// kube-apiserver - this typically leads to crash-looping of kube-apiserver, which is eventually resolved when
+	// kms-plugin is finally loaded.
+	// Based on the time of the first reported error and the successful startup-up of kube-apiserver,
+	// you should arrive at the appropriate timeout value for your environment.
+	// 2. Interactions between the envelope service and kms-plugin (both latencies and failures) are instrumented via
+	// prometheus metrics. See k8s.io/apiserver/pkg/storage/value/metrics.go for details.
+	Timeout metav1.Duration `json:"timeout,omitempty"`
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/types.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package encryptionconfig
 
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 // EncryptionConfig stores the complete configuration for encryption providers.
 type EncryptionConfig struct {
 	// kind is the type of configuration file.
@@ -83,4 +85,6 @@ type KMSConfig struct {
 	CacheSize int `json:"cachesize,omitempty"`
 	// the gRPC server listening address, for example "unix:///var/run/kms-provider.sock".
 	Endpoint string `json:"endpoint"`
+	// Timeout for gRPC calls to kms-plugin (ex. 5s).
+	Timeout metav1.Duration `json:"timeout"`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Expose, via EncryptionConfig,  the timeout value that kube-apiserver will use when awaiting responses from kms-plugin.

This is a followup to 68585, were a timeout was added to calls from kube-apiserver to kms-plugin. This PR exposes the value of the timeout via EncryptionConfig. Providing the appropriate value of the timeout should be left to cluster managers who are familiar with the environment in which the cluster and the plugin operate.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
