### PR TITLE
kubectl: copy printer tabwriter into kubectl

### DIFF
--- a/pkg/kubectl/cmd/apiresources/BUILD
+++ b/pkg/kubectl/cmd/apiresources/BUILD
@@ -11,8 +11,8 @@ go_library(
     deps = [
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/util/i18n:go_default_library",
+        "//pkg/kubectl/util/printers:go_default_library",
         "//pkg/kubectl/util/templates:go_default_library",
-        "//pkg/printers:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/pkg/kubectl/cmd/apiresources/apiresources.go
+++ b/pkg/kubectl/cmd/apiresources/apiresources.go
@@ -29,8 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/util/printers"
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
-	"k8s.io/kubernetes/pkg/printers"
 )
 
 var (

--- a/pkg/kubectl/cmd/config/BUILD
+++ b/pkg/kubectl/cmd/config/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/scheme:go_default_library",
         "//pkg/kubectl/util/i18n:go_default_library",
+        "//pkg/kubectl/util/printers:go_default_library",
         "//pkg/kubectl/util/templates:go_default_library",
         "//pkg/printers:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",

--- a/pkg/kubectl/cmd/config/get_contexts.go
+++ b/pkg/kubectl/cmd/config/get_contexts.go
@@ -32,8 +32,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
+	"k8s.io/kubernetes/pkg/kubectl/util/printers"
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
-	"k8s.io/kubernetes/pkg/printers"
 )
 
 // GetContextsOptions contains the assignable options from the args.

--- a/pkg/kubectl/metricsutil/BUILD
+++ b/pkg/kubectl/metricsutil/BUILD
@@ -14,7 +14,7 @@ go_library(
         "//build/visible_to:pkg_kubectl_metricsutil_CONSUMERS",
     ],
     deps = [
-        "//pkg/printers:go_default_library",
+        "//pkg/kubectl/util/printers:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/validation:go_default_library",

--- a/pkg/kubectl/metricsutil/metrics_printer.go
+++ b/pkg/kubectl/metricsutil/metrics_printer.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/kubernetes/pkg/printers"
+	"k8s.io/kubernetes/pkg/kubectl/util/printers"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
 )
 

--- a/pkg/kubectl/util/BUILD
+++ b/pkg/kubectl/util/BUILD
@@ -70,6 +70,7 @@ filegroup(
         "//pkg/kubectl/util/i18n:all-srcs",
         "//pkg/kubectl/util/logs:all-srcs",
         "//pkg/kubectl/util/podutils:all-srcs",
+        "//pkg/kubectl/util/printers:all-srcs",
         "//pkg/kubectl/util/slice:all-srcs",
         "//pkg/kubectl/util/templates:all-srcs",
         "//pkg/kubectl/util/term:all-srcs",

--- a/pkg/kubectl/util/printers/BUILD
+++ b/pkg/kubectl/util/printers/BUILD
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["tabwriter.go"],
+    importpath = "k8s.io/kubernetes/pkg/kubectl/util/printers",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/kubectl/util/printers/tabwriter.go
+++ b/pkg/kubectl/util/printers/tabwriter.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"io"
+	"text/tabwriter"
+)
+
+const (
+	tabwriterMinWidth = 6
+	tabwriterWidth    = 4
+	tabwriterPadding  = 3
+	tabwriterPadChar  = ' '
+	tabwriterFlags    = 0
+)
+
+// GetNewTabWriter returns a tabwriter that translates tabbed columns in input into properly aligned text.
+func GetNewTabWriter(output io.Writer) *tabwriter.Writer {
+	return tabwriter.NewWriter(output, tabwriterMinWidth, tabwriterWidth, tabwriterPadding, tabwriterPadChar, tabwriterFlags)
+}


### PR DESCRIPTION
* Copies printer tabwriter into `pkg/kubectl/util/printers`
* Very small amount of code is copied
* Removes internal printer dependency for several kubectl files

Helps address:
https://github.com/kubernetes/kubectl/issues/80

```release-note
NONE
```
