### PR TITLE
fix issue that e2e script exits due to unbound variables

### DIFF
--- a/cluster/skeleton/util.sh
+++ b/cluster/skeleton/util.sh
@@ -19,8 +19,8 @@
 
 # Must ensure that the following ENV vars are set
 function detect-master {
-	echo "KUBE_MASTER_IP: $KUBE_MASTER_IP" 1>&2
-	echo "KUBE_MASTER: $KUBE_MASTER" 1>&2
+	echo "KUBE_MASTER_IP: ${KUBE_MASTER_IP:-}" 1>&2
+	echo "KUBE_MASTER: ${KUBE_MASTER:-}" 1>&2
 }
 
 # Get node names if they are not static.


### PR DESCRIPTION
**What this PR does / why we need it**:

In a kubeadm env, when running `go run hack/e2e.go -- --provider=skeleton --test --test_args="--ginkgo.focus=TaintBasedEvictions"`, it outputs:

```console
2018/10/12 19:18:42 e2e.go:79: Calling kubetest --verbose-commands=true --provider=skeleton --test --test_args=--ginkgo.focus=TaintBasedEvictions...
2018/10/12 19:18:42 process.go:153: Running: ./hack/e2e-internal/e2e-status.sh
Skeleton Provider: prepare-e2e not implemented
......
/root/go/src/k8s.io/kubernetes/cluster/../cluster/skeleton/util.sh: line 22: KUBE_MASTER_IP: unbound variable
2018/10/12 19:23:08 process.go:155: Step './hack/ginkgo-e2e.sh --ginkgo.focus=TaintBasedEvictions' finished in 30.036621ms
2018/10/12 19:23:08 main.go:311: Something went wrong: encountered 1 errors: [error during ./hack/ginkgo-e2e.sh --ginkgo.focus=TaintBasedEvictions: exit status 1]
2018/10/12 19:23:08 e2e.go:81: err: exit status 1
exit status 1
```

**Special notes for your reviewer**:

I'm using latest `master` branch in k/k.

**Release note**:
```release-note
NONE
```

/sig testing