### PR TITLE
validate args for kubectl api-versions/api-resources command

### DIFF
--- a/pkg/kubectl/cmd/apiresources/apiresources.go
+++ b/pkg/kubectl/cmd/apiresources/apiresources.go
@@ -86,7 +86,8 @@ func NewCmdApiResources(f cmdutil.Factory, ioStreams genericclioptions.IOStreams
 		Long:    "Print the supported API resources on the server",
 		Example: apiresourcesExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(o.Validate(cmd))
+			cmdutil.CheckErr(o.Complete(cmd, args))
+			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.RunApiResources(cmd, f))
 		},
 	}
@@ -101,10 +102,17 @@ func NewCmdApiResources(f cmdutil.Factory, ioStreams genericclioptions.IOStreams
 	return cmd
 }
 
-func (o *ApiResourcesOptions) Validate(cmd *cobra.Command) error {
+func (o *ApiResourcesOptions) Validate() error {
 	supportedOutputTypes := sets.NewString("", "wide", "name")
 	if !supportedOutputTypes.Has(o.Output) {
 		return fmt.Errorf("--output %v is not available", o.Output)
+	}
+	return nil
+}
+
+func (o *ApiResourcesOptions) Complete(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmdutil.UsageErrorf(cmd, "unexpected args: %v", args)
 	}
 	return nil
 }

--- a/pkg/kubectl/cmd/apiresources/apiversions.go
+++ b/pkg/kubectl/cmd/apiresources/apiversions.go
@@ -56,14 +56,17 @@ func NewCmdApiVersions(f cmdutil.Factory, ioStreams genericclioptions.IOStreams)
 		Long:    "Print the supported API versions on the server, in the form of \"group/version\"",
 		Example: apiversionsExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(o.Complete(f))
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.RunApiVersions())
 		},
 	}
 	return cmd
 }
 
-func (o *ApiVersionsOptions) Complete(f cmdutil.Factory) error {
+func (o *ApiVersionsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmdutil.UsageErrorf(cmd, "unexpected args: %v", args)
+	}
 	var err error
 	o.discoveryClient, err = f.ToDiscoveryClient()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
validate args for `kubectl api-versions/apiresources` , no args needed
before this , command like `kubectl api-resources ooo` work fine. 
after this pr, this command with args will throw error
```
[root@hpa-vm:/opt/kubernetes/1.4.5]$ kubectl api-resources ooo
error: Unexpected args: [ooo]
See 'kubectl api-resources -h' for help and examples.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/kind bug
