### PR TITLE
[WIP] MatchVersionFlags: replace legacyscheme with kubectl scheme

### DIFF
--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//pkg/kubectl:go_default_library",
         "//pkg/kubectl/cmd/util/openapi:go_default_library",
         "//pkg/kubectl/cmd/util/openapi/validation:go_default_library",
+        "//pkg/kubectl/scheme:go_default_library",
         "//pkg/kubectl/util/templates:go_default_library",
         "//pkg/kubectl/validation:go_default_library",
         "//pkg/printers:go_default_library",

--- a/pkg/kubectl/cmd/util/kubectl_match_version.go
+++ b/pkg/kubectl/cmd/util/kubectl_match_version.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/version"
 )
 
@@ -120,7 +120,7 @@ func setKubernetesDefaults(config *rest.Config) error {
 		config.APIPath = "/api"
 	}
 	if config.NegotiatedSerializer == nil {
-		config.NegotiatedSerializer = legacyscheme.Codecs
+		config.NegotiatedSerializer = scheme.Codecs
 	}
 	return rest.SetKubernetesDefaults(config)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces dependency on legacyscheme with kubectl scheme.

Helps address: https://github.com/kubernetes/kubectl/issues/83

**Release note**:

```release-note
NONE
```

---

/kind cleanup
/sig cli
