### PR TITLE
Wrap remaining admission controller plain error into apimachinery error

### DIFF
--- a/plugin/pkg/admission/podnodeselector/admission.go
+++ b/plugin/pkg/admission/podnodeselector/admission.go
@@ -102,7 +102,7 @@ func (p *podNodeSelector) Admit(a admission.Attributes) error {
 	}
 	updateInitialized, err := util.IsUpdatingInitializedObject(a)
 	if err != nil {
-		return err
+		return admission.NewForbidden(a, err)
 	}
 	if updateInitialized {
 		// node selector of an initialized pod is immutable

--- a/plugin/pkg/admission/podpreset/admission.go
+++ b/plugin/pkg/admission/podpreset/admission.go
@@ -116,12 +116,12 @@ func (c *podPresetPlugin) Admit(a admission.Attributes) error {
 
 	list, err := c.lister.PodPresets(a.GetNamespace()).List(labels.Everything())
 	if err != nil {
-		return fmt.Errorf("listing pod presets failed: %v", err)
+		return err
 	}
 
 	matchingPPs, err := filterPodPresets(list, pod)
 	if err != nil {
-		return fmt.Errorf("filtering pod presets failed: %v", err)
+		return errors.NewBadRequest(fmt.Sprintf("filtering pod presets failed: %v", err))
 	}
 
 	if len(matchingPPs) == 0 {

--- a/plugin/pkg/admission/podtolerationrestriction/admission.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission.go
@@ -98,7 +98,7 @@ func (p *podTolerationsPlugin) Admit(a admission.Attributes) error {
 	if a.GetOperation() == admission.Create || updateUninitialized {
 		ts, err := p.getNamespaceDefaultTolerations(a.GetNamespace())
 		if err != nil {
-			return err
+			return admission.NewForbidden(a, err)
 		}
 
 		// If the namespace has not specified its default tolerations,
@@ -110,7 +110,7 @@ func (p *podTolerationsPlugin) Admit(a admission.Attributes) error {
 		if len(ts) > 0 {
 			if len(pod.Spec.Tolerations) > 0 {
 				if tolerations.IsConflict(ts, pod.Spec.Tolerations) {
-					return fmt.Errorf("namespace tolerations and pod tolerations conflict")
+					return admission.NewForbidden(a, fmt.Errorf("namespace tolerations and pod tolerations conflict"))
 				}
 
 				// modified pod tolerations = namespace tolerations + current pod tolerations


### PR DESCRIPTION
all admission controllers should return "apierror" or the client cannot correctly deserialize them.

/assign @deads2k 
/sig api-machinery
/kind cleanup


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
