### PR TITLE
Add OpenAPI scheme methods for metav1.Duration

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/duration.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/duration.go
@@ -48,3 +48,13 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 func (d Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.Duration.String())
 }
+
+// OpenAPISchemaType is used by the kube-openapi generator when constructing
+// the OpenAPI spec of this type.
+//
+// See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
+func (_ Duration) OpenAPISchemaType() []string { return []string{"string"} }
+
+// OpenAPISchemaFormat is used by the kube-openapi generator when constructing
+// the OpenAPI spec of this type.
+func (_ Duration) OpenAPISchemaFormat() string { return "" }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: The `metav1.Duration` type does not have the OpenAPI methods. Using it in any resource type will fail the validation kubectl performs against the openapi specification:

```
# * : Invalid value: "The edited file failed validation": [ValidationError(Foo.spec.duration): invalid type for io.k8s.apimachinery    .pkg.apis.meta.v1.Duration: got "string", expected "map",
```

Similar to the [`metav1.Time` methods](https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/time.go#L154-L162) this PR will add the same functionality to the `metav1.Duration` type.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
