### PR TITLE
Adding volume.beta.kubernetes.io/mount-efs annotation

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -250,6 +250,10 @@ const (
 
 	// MountOptionAnnotation defines mount option annotation used in PVs
 	MountOptionAnnotation = "volume.beta.kubernetes.io/mount-options"
+
+	// MountEFSAnnotation use mount.efs for NFS mounts annotation used in PVs
+	// The AWS EFS Helper needs to be installed to provide mount.efs
+	MountEFSAnnotation = "volume.beta.kubernetes.io/mount-efs"
 )
 
 // +genclient

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -734,6 +734,21 @@ func UnmountViaEmptyDir(dir string, host volume.VolumeHost, volName string, volS
 	return wrapped.TearDownAt(dir)
 }
 
+// MountEFSFromSpec return true if mount-efs=true annoation is set
+func MountEFSFromSpec(spec *volume.Spec, options ...string) bool {
+    pv := spec.PersistentVolume
+
+    if pv != nil {
+        // Use beta annotation first
+        if efs, ok := pv.Annotations[v1.MountEFSAnnotation]; ok {
+            if (efs == "true") {
+               return true
+            }
+        }
+    }
+    return false
+}
+
 // MountOptionFromSpec extracts and joins mount options from volume spec with supplied options
 func MountOptionFromSpec(spec *volume.Spec, options ...string) []string {
 	pv := spec.PersistentVolume

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -260,6 +260,10 @@ const (
 
 	// MountOptionAnnotation defines mount option annotation used in PVs
 	MountOptionAnnotation = "volume.beta.kubernetes.io/mount-options"
+
+	// MountEFSAnnotation use mount.efs for NFS mounts annotation used in PVs
+	// The AWS EFS Helper needs to be installed to provide mount.efs
+	MountEFSAnnotation = "volume.beta.kubernetes.io/mount-efs"
 )
 
 // +genclient


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add support for AWS's mount.efs helper program.  This will allow EFS over TLS by adding tls to the mountOptions when the annotation `volume.beta.kubernetes.io/mount-efs` is set to `"true"` on the PersistentVolume.  The AWS EFS helper will take care of setting up the stunnels and then calling mount.nfs with the right options.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69678

**Special notes for your reviewer**:
The AWS EFS mount helper needs to be installed on the ec2 server.  https://docs.aws.amazon.com/efs/latest/ug/using-amazon-efs-utils.html

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


