### PR TITLE
Automated cherry pick of #68435: Glusterfs: Remove unwanted `log-file` mount argument.

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -319,10 +319,11 @@ func (b *glusterfsMounter) setUpAtInternal(dir string) error {
 		// its own log based on PV + Pod
 		log = path.Join(p, b.pod.Name+"-glusterfs.log")
 
+		// Use derived log file in gluster fuse mount
+		options = append(options, "log-file="+log)
+
 	}
 
-	// Use derived/provided log file in gluster fuse mount
-	options = append(options, "log-file="+log)
 	options = append(options, "log-level=ERROR")
 
 	var addrlist []string


### PR DESCRIPTION
Cherry pick of #68435 on release-1.12.

#68435: Glusterfs: Remove unwanted `log-file` mount argument.