### PR TITLE
Fix error messages suggesting invalid flag

### DIFF
--- a/pkg/kubectl/cmd/config/create_context.go
+++ b/pkg/kubectl/cmd/config/create_context.go
@@ -142,10 +142,10 @@ func (o *createContextOptions) complete(cmd *cobra.Command) error {
 
 func (o createContextOptions) validate() error {
 	if len(o.name) == 0 && !o.currContext {
-		return errors.New("you must specify a non-empty context name or --current-context")
+		return errors.New("you must specify a non-empty context name or --current")
 	}
 	if len(o.name) > 0 && o.currContext {
-		return errors.New("you cannot specify a context name and --current-context")
+		return errors.New("you cannot specify both a context name and --current")
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix incorrect error message returned when modifying a context. Message prompts user to pass "--current-context" flag, which is not valid.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
