### PR TITLE
Use ip address from CNI output

### DIFF
--- a/pkg/kubelet/dockershim/network/BUILD
+++ b/pkg/kubelet/dockershim/network/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/github.com/containernetworking/cni/pkg/types/current:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],

--- a/pkg/kubelet/dockershim/network/cni/BUILD
+++ b/pkg/kubelet/dockershim/network/cni/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2:go_default_library",
         "//vendor/github.com/containernetworking/cni/libcni:go_default_library",
         "//vendor/github.com/containernetworking/cni/pkg/types:go_default_library",
+        "//vendor/github.com/containernetworking/cni/pkg/types/current:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ] + select({
@@ -53,8 +54,6 @@ go_test(
             "//vendor/github.com/containernetworking/cni/pkg/types/020:go_default_library",
             "//vendor/github.com/stretchr/testify/mock:go_default_library",
             "//vendor/github.com/stretchr/testify/require:go_default_library",
-            "//vendor/k8s.io/utils/exec:go_default_library",
-            "//vendor/k8s.io/utils/exec/testing:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/kubelet/apis/config:go_default_library",
@@ -70,8 +69,6 @@ go_test(
             "//vendor/github.com/containernetworking/cni/pkg/types/020:go_default_library",
             "//vendor/github.com/stretchr/testify/mock:go_default_library",
             "//vendor/github.com/stretchr/testify/require:go_default_library",
-            "//vendor/k8s.io/utils/exec:go_default_library",
-            "//vendor/k8s.io/utils/exec/testing:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/kubelet/dockershim/network/cni/cni.go
+++ b/pkg/kubelet/dockershim/network/cni/cni.go
@@ -69,7 +69,6 @@ type cniNetworkPlugin struct {
 
 	host         network.Host
 	execer       utilexec.Interface
-	nsenterPath  string
 	confDir      string
 	binDirs      []string
 	cacheDir     string
@@ -222,11 +221,6 @@ func getDefaultCNINetwork(confDir string, binDirs []string) (*cniNetwork, error)
 }
 
 func (plugin *cniNetworkPlugin) Init(host network.Host, hairpinMode kubeletconfig.HairpinMode, nonMasqueradeCIDR string, mtu int) error {
-	err := plugin.platformInit()
-	if err != nil {
-		return err
-	}
-
 	plugin.host = host
 
 	plugin.syncNetworkConfig()

--- a/pkg/kubelet/dockershim/network/cni/cni_others.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_others.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/containernetworking/cni/libcni"
+	cnicurrent "github.com/containernetworking/cni/pkg/types/current"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -50,23 +51,16 @@ func getLoNetwork(binDirs []string) *cniNetwork {
 	return loNetwork
 }
 
-func (plugin *cniNetworkPlugin) platformInit() error {
-	var err error
-	plugin.nsenterPath, err = plugin.execer.LookPath("nsenter")
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// TODO: Use the addToNetwork function to obtain the IP of the Pod. That will assume idempotent ADD call to the plugin.
-// Also fix the runtime's call to Status function to be done only in the case that the IP is lost, no need to do periodic calls
+//GetPodNetworkStatus get PodNetworkStatus from CNI plugin output
 func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name string, id kubecontainer.ContainerID) (*network.PodNetworkStatus, error) {
 	podIPs := plugin.getPodIPs(id)
 	if podIPs != nil && len(podIPs) > 0 {
 		klog.V(3).Infof("get pod ip %v from plugin", podIPs)
 		return &network.PodNetworkStatus{IP: podIPs[0], IPs: podIPs}, nil
 	}
+	cninetwork := plugin.getDefaultNetwork()
+	cniNet := cninetwork.CNIConfig
+	netConfList := cninetwork.NetworkConfig
 	netnsPath, err := plugin.host.GetNetNS(id.ID)
 	if err != nil {
 		return nil, fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
@@ -74,16 +68,33 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 	if netnsPath == "" {
 		return nil, fmt.Errorf("cannot find the network namespace, skipping pod network status for container %q", id)
 	}
-
-	ips, err := network.GetPodIPs(plugin.execer, plugin.nsenterPath, netnsPath, network.DefaultInterfaceName)
+	rt, err := plugin.buildCNIRuntimeConf(name, namespace, id, netnsPath, nil, nil)
 	if err != nil {
+		klog.Errorf("Error get pod network status when building cni runtime conf: %v", err)
+		return nil, err
+	}
+	res, err := cniNet.GetNetworkListCachedResult(netConfList, rt)
+
+	pdesc := podDesc(name, namespace, id)
+	if res == nil || err != nil {
+		klog.V(3).Infof("Can't get cached result %s for network %s", pdesc, netConfList.Name)
 		return nil, err
 	}
 
-	if len(ips) == 0 {
-		return nil, fmt.Errorf("cannot find pod IPs in the network namespace, skipping pod network status for container %q", id)
+	klog.V(4).Infof("Get cached result for %s in the network %s: %v", pdesc, netConfList.Name, res)
+
+	curRes, err := cnicurrent.NewResultFromResult(res)
+	if curRes == nil || len(curRes.IPs) == 0 {
+		klog.Errorf("CNI result conversion failed: %v", err)
+		return nil, err
 	}
 
+	ips := network.GetIpsFromResult(curRes, rt.IfName)
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("cannot find pod IPs in the CNI output, skipping pod network status for container %q", id)
+	}
+	klog.V(3).Infof("get pod ip %v from cached result", ips)
+	plugin.setPodCNIResult(id, curRes)
 	return &network.PodNetworkStatus{
 		IP:  ips[0],
 		IPs: ips,

--- a/pkg/kubelet/dockershim/network/plugins.go
+++ b/pkg/kubelet/dockershim/network/plugins.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	cnicurrent "github.com/containernetworking/cni/pkg/types/current"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilsets "k8s.io/apimachinery/pkg/util/sets"
@@ -290,6 +291,32 @@ func GetPodIPs(execer utilexec.Interface, nsenterPath, netnsPath, interfaceName 
 	}
 	return list, nil
 
+}
+
+func GetIpsFromResult(res *cnicurrent.Result, ifaceName string) []net.IP {
+	if res == nil || len(res.IPs) == 0 {
+		return nil
+	}
+	outlist := make([]net.IP, 0)
+	for _, ip := range res.IPs {
+		if ip.Interface == nil || *ip.Interface > len(res.Interfaces) {
+			continue
+		}
+		intf := res.Interfaces[*ip.Interface]
+		if intf.Sandbox != "" && intf.Name == ifaceName {
+			// Found our sandbox interface, use the IP
+			outlist = append(outlist, ip.Address.IP)
+		}
+	}
+	if len(outlist) > 0 {
+		return outlist
+	}
+	// Fall back to first un-associated address for compatibility
+	// with older CNI plugins
+	if len(res.Interfaces) > 0 {
+		klog.Warningf("There is no ip address associated with network interface : %s", ifaceName)
+	}
+	return []net.IP{res.IPs[0].Address.IP}
 }
 
 type NoopPortMappingGetter struct{}

--- a/pkg/kubelet/dockershim/network/testing/BUILD
+++ b/pkg/kubelet/dockershim/network/testing/BUILD
@@ -35,6 +35,8 @@ go_test(
         "//pkg/kubelet/dockershim/network:go_default_library",
         "//pkg/util/sysctl/testing:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/github.com/containernetworking/cni/pkg/types:go_default_library",
+        "//vendor/github.com/containernetworking/cni/pkg/types/current:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],

--- a/pkg/kubelet/dockershim/network/testing/plugins_test.go
+++ b/pkg/kubelet/dockershim/network/testing/plugins_test.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"testing"
 
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	cnicurrent "github.com/containernetworking/cni/pkg/types/current"
 	utilsets "k8s.io/apimachinery/pkg/util/sets"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -247,5 +249,58 @@ func TestMultiPodParallelNetworkOps(t *testing.T) {
 
 	if !didWait {
 		t.Errorf("waiter pod didn't wait for runner pod!")
+	}
+}
+
+func getCNIResult(ifaceName string, sandbox string, ipConfigs []*cnicurrent.IPConfig) *cnicurrent.Result {
+	return &cnicurrent.Result{
+		CNIVersion: "0.3.1",
+		Interfaces: []*cnicurrent.Interface{
+			{
+				Name:    ifaceName,
+				Mac:     "00:11:22:33:44:55",
+				Sandbox: sandbox,
+			},
+		},
+		IPs: ipConfigs,
+	}
+
+}
+
+func TestGetIpsFromResult(t *testing.T) {
+	ifaceName := "eth0"
+	sandbox := "/proc/3553/ns/net"
+	ipv4, _ := cnitypes.ParseCIDR("1.2.3.30/24")
+	ipv6, _ := cnitypes.ParseCIDR("abcd:1234:ffff::cdde/64")
+
+	ipv4conf := &cnicurrent.IPConfig{
+		Version:   "4",
+		Interface: cnicurrent.Int(0),
+		Address:   *ipv4,
+		Gateway:   net.ParseIP("1.2.3.1"),
+	}
+	ipv6conf := &cnicurrent.IPConfig{
+		Version:   "6",
+		Interface: cnicurrent.Int(0),
+		Address:   *ipv6,
+		Gateway:   net.ParseIP("abcd:1234:ffff::1"),
+	}
+
+	res := getCNIResult(ifaceName, sandbox, []*cnicurrent.IPConfig{ipv4conf, ipv6conf})
+	ips := network.GetIpsFromResult(res, ifaceName)
+	if len(ips) != 2 || !ipv4.IP.Equal(ips[0]) || !ipv6.IP.Equal(ips[1]) {
+		t.Fatalf("Error getting ipv4 and ipv6 from result")
+	}
+
+	res = getCNIResult(ifaceName, "", []*cnicurrent.IPConfig{ipv4conf, ipv6conf})
+	ips = network.GetIpsFromResult(res, ifaceName)
+	if len(ips) != 1 || !ipv4.IP.Equal(ips[0]) {
+		t.Fatalf("Error getting first ip from result(empty sandbox)")
+	}
+
+	res = getCNIResult("eth1", sandbox, []*cnicurrent.IPConfig{ipv4conf, ipv6conf})
+	ips = network.GetIpsFromResult(res, ifaceName)
+	if len(ips) != 1 || !ipv4.IP.Equal(ips[0]) {
+		t.Fatalf("Error getting first ip from result(another iface)")
 	}
 }


### PR DESCRIPTION
Before this patch Kubernetes obtained ip address from container's eth
device. But in case when containers work only with loopback device and
with vhostuser (it's not device it's UNIX domain socket file) Kubernetes
can't rely on this approach, it should rely on CNI output. Most of plugins
provide IP address of created port.

This patch also touches unit test, CNI spec declares ip field as mandatory
field of ADD/GET command output. But some users may relay on current behaviour
so code where ip is empty and obtained from container's eth is preserved,
but it's not covered in unit test.

Signed-off-by: Alexey Perevalov <a.perevalov@samsung.com>
Fixes #65756

This is a third version of https://github.com/kubernetes/kubernetes/pull/65759 and https://github.com/kubernetes/kubernetes/pull/68876
I wasn't able to update my current PR.

Current implementation has functional drawback: if we restart kubelet when pod already started,
pod's IP becames none, after that pod will be restarted, and its IP obtained by CNI ADD method
is correct. But restarting of the pod is not desirable behaviour.

Update: after moving to libcni 0.7.0 we don't have drawback described above!

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

