### PR TITLE
Make CreatePrivilegedPSPBinding reentrant

### DIFF
--- a/test/e2e/framework/psp_util.go
+++ b/test/e2e/framework/psp_util.go
@@ -113,7 +113,9 @@ func CreatePrivilegedPSPBinding(f *Framework, namespace string) {
 
 		psp := PrivilegedPSP(podSecurityPolicyPrivileged)
 		psp, err = f.ClientSet.ExtensionsV1beta1().PodSecurityPolicies().Create(psp)
-		ExpectNoError(err, "Failed to create PSP %s", podSecurityPolicyPrivileged)
+		if !apierrs.IsAlreadyExists(err) {
+			ExpectNoError(err, "Failed to create PSP %s", podSecurityPolicyPrivileged)
+		}
 
 		if IsRBACEnabled(f) {
 			// Create the Role to bind it to the namespace.
@@ -126,7 +128,9 @@ func CreatePrivilegedPSPBinding(f *Framework, namespace string) {
 					Verbs:         []string{"use"},
 				}},
 			})
-			ExpectNoError(err, "Failed to create PSP role")
+			if !apierrs.IsAlreadyExists(err) {
+				ExpectNoError(err, "Failed to create PSP role")
+			}
 		}
 	})
 


### PR DESCRIPTION
Make CreatePrivilegedPSPBinding reentrant so tests using it (e.g. DNS) can be
executed more than once against a cluster. Without this change, such tests will
fail because the PSP already exists, short circuiting test setup.

**Special notes for your reviewer**:

Problem can be observed with the following e2e test:

```
[sig-network] DNS
  should provide DNS for pods for Hostname and Subdomain
```

**Release note**:
```release-note
NONE
```

/cc @smarterclayton 