### PR TITLE
Automated cherry pick of #68862 #69388 (GCE GetClusters) upstream release 1.12

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -663,6 +663,15 @@ EOF
 multizone = ${MULTIZONE}
 EOF
   fi
+# Multimaster indicates that the cluster is HA.
+# Currently the only HA clusters are regional.
+# If we introduce zonal multimaster this will need to be revisited.
+  if [[ -n "${MULTIMASTER:-}" ]]; then
+    use_cloud_config="true"
+    cat <<EOF >>/etc/gce.conf
+regional = ${MULTIMASTER}
+EOF
+  fi
   if [[ -n "${GCE_ALPHA_FEATURES:-}" ]]; then
     use_cloud_config="true"
     # split GCE_ALPHA_FEATURES into an array by comma.

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -114,6 +114,7 @@ type GCECloud struct {
 	eventRecorder    record.EventRecorder
 	projectID        string
 	region           string
+	regional         bool
 	localZone        string // The zone in which we are running
 	// managedZones will be set to the 1 zone if running a single zone cluster
 	// it will be set to ALL zones in region for any multi-zone cluster
@@ -174,6 +175,7 @@ type ConfigGlobal struct {
 	SecondaryRangeName string   `gcfg:"secondary-range-name"`
 	NodeTags           []string `gcfg:"node-tags"`
 	NodeInstancePrefix string   `gcfg:"node-instance-prefix"`
+	Regional           bool     `gcfg:"regional"`
 	Multizone          bool     `gcfg:"multizone"`
 	// ApiEndpoint is the GCE compute API endpoint to use. If this is blank,
 	// then the default endpoint is used.
@@ -202,6 +204,7 @@ type CloudConfig struct {
 	ProjectID            string
 	NetworkProjectID     string
 	Region               string
+	Regional             bool
 	Zone                 string
 	ManagedZones         []string
 	NetworkName          string
@@ -332,9 +335,14 @@ func generateCloudConfig(configFile *ConfigFile) (cloudConfig *CloudConfig, err 
 		return nil, err
 	}
 
+	// Determine if its a regional cluster
+	if configFile != nil && configFile.Global.Regional {
+		cloudConfig.Regional = true
+	}
+
 	// generate managedZones
 	cloudConfig.ManagedZones = []string{cloudConfig.Zone}
-	if configFile != nil && configFile.Global.Multizone {
+	if configFile != nil && (configFile.Global.Multizone || configFile.Global.Regional) {
 		cloudConfig.ManagedZones = nil // Use all zones in region
 	}
 
@@ -512,6 +520,7 @@ func CreateGCECloud(config *CloudConfig) (*GCECloud, error) {
 		networkProjectID:         netProjID,
 		onXPN:                    onXPN,
 		region:                   config.Region,
+		regional:                 config.Regional,
 		localZone:                config.Zone,
 		managedZones:             config.ManagedZones,
 		networkURL:               networkURL,

--- a/pkg/cloudprovider/providers/gce/gce_clusters.go
+++ b/pkg/cloudprovider/providers/gce/gce_clusters.go
@@ -18,6 +18,10 @@ package gce
 
 import (
 	"context"
+	"errors"
+	"fmt"
+
+	"github.com/golang/glog"
 	container "google.golang.org/api/container/v1"
 )
 
@@ -41,16 +45,22 @@ func (gce *GCECloud) ListClusters(ctx context.Context) ([]string, error) {
 }
 
 func (gce *GCECloud) GetManagedClusters(ctx context.Context) ([]*container.Cluster, error) {
-	managedClusters := []*container.Cluster{}
-	for _, zone := range gce.managedZones {
-		clusters, err := gce.getClustersInZone(zone)
-		if err != nil {
-			return nil, err
-		}
-		managedClusters = append(managedClusters, clusters...)
+	var location string
+	if len(gce.managedZones) > 1 {
+		// Multiple managed zones means this is a regional cluster
+		// so use the regional location and not the zone.
+		location = gce.region
+	} else if len(gce.managedZones) == 1 {
+		location = gce.managedZones[0]
+	} else {
+		return nil, errors.New(fmt.Sprintf("no zones associated with this cluster(%s)", gce.ProjectID()))
+	}
+	clusters, err := gce.getClustersInLocation(location)
+	if err != nil {
+		return nil, err
 	}
 
-	return managedClusters, nil
+	return clusters, nil
 }
 
 func (gce *GCECloud) Master(ctx context.Context, clusterName string) (string, error) {
@@ -58,7 +68,7 @@ func (gce *GCECloud) Master(ctx context.Context, clusterName string) (string, er
 }
 
 func (gce *GCECloud) listClustersInZone(zone string) ([]string, error) {
-	clusters, err := gce.getClustersInZone(zone)
+	clusters, err := gce.getClustersInLocation(zone)
 	if err != nil {
 		return nil, err
 	}
@@ -70,12 +80,17 @@ func (gce *GCECloud) listClustersInZone(zone string) ([]string, error) {
 	return result, nil
 }
 
-func (gce *GCECloud) getClustersInZone(zone string) ([]*container.Cluster, error) {
-	mc := newClustersMetricContext("list_zone", zone)
+func (gce *GCECloud) getClustersInLocation(zoneOrRegion string) ([]*container.Cluster, error) {
+	// TODO: Issue/68913 migrate metric to list_location instead of list_zone.
+	mc := newClustersMetricContext("list_zone", zoneOrRegion)
 	// TODO: use PageToken to list all not just the first 500
-	list, err := gce.containerService.Projects.Zones.Clusters.List(gce.projectID, zone).Do()
+	location := getLocationName(gce.projectID, zoneOrRegion)
+	list, err := gce.containerService.Projects.Locations.Clusters.List(location).Do()
 	if err != nil {
 		return nil, mc.Observe(err)
+	}
+	if list.Header.Get("nextPageToken") != "" {
+		glog.Errorf("Failed to get all clusters for request, received next page token %s", list.Header.Get("nextPageToken"))
 	}
 
 	return list.Clusters, mc.Observe(nil)

--- a/pkg/cloudprovider/providers/gce/gce_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_test.go
@@ -39,6 +39,7 @@ secondary-range-name = my-secondary-range
 node-tags = my-node-tag1
 node-instance-prefix = my-prefix
 multizone = true
+regional = true
    `
 	reader := strings.NewReader(s)
 	config, err := readConfig(reader)
@@ -57,6 +58,7 @@ multizone = true
 		NodeTags:           []string{"my-node-tag1"},
 		NodeInstancePrefix: "my-prefix",
 		Multizone:          true,
+		Regional:           true,
 	}}
 
 	if !reflect.DeepEqual(expected, config) {
@@ -328,6 +330,7 @@ func TestGenerateCloudConfigs(t *testing.T) {
 		NodeTags:           []string{"node-tag"},
 		NodeInstancePrefix: "node-prefix",
 		Multizone:          false,
+		Regional:           false,
 		ApiEndpoint:        "",
 		LocalZone:          "us-central1-a",
 		AlphaFeatures:      []string{},
@@ -442,6 +445,20 @@ func TestGenerateCloudConfigs(t *testing.T) {
 			},
 			cloud: func() CloudConfig {
 				v := cloudBoilerplate
+				v.ManagedZones = nil
+				return v
+			},
+		},
+		{
+			name: "Regional",
+			config: func() ConfigGlobal {
+				v := configBoilerplate
+				v.Regional = true
+				return v
+			},
+			cloud: func() CloudConfig {
+				v := cloudBoilerplate
+				v.Regional = true
 				v.ManagedZones = nil
 				return v
 			},

--- a/pkg/cloudprovider/providers/gce/gce_util.go
+++ b/pkg/cloudprovider/providers/gce/gce_util.go
@@ -281,3 +281,7 @@ func typeOfNetwork(network *compute.Network) netType {
 
 	return netTypeCustom
 }
+
+func getLocationName(project, zoneOrRegion string) string {
+	return fmt.Sprintf("projects/%s/locations/%s", project, zoneOrRegion)
+}


### PR DESCRIPTION
Cherry pick of #68862 on release-1.11.

#68862: Added support for regional calls to GetClusters
#69388: Differentiate multizone zonal from Regional Cluster.

```release-note
NONE
```