### PR TITLE
Adds label prompt and explanation to pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--  Thanks for sending a pull request!  Here are some tips for you:
 1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
-2. Please label this pull request according to what type of issue you are fixing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
-https://github.com/kubernetes/community/blob/master/contributors/devel/release.md#issue-kind-label
+2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
+https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
 3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
 4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
 5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
@@ -10,8 +10,14 @@ https://github.com/kubernetes/community/blob/master/contributors/devel/release.m
 **What type of PR is this?**
 > Uncomment only one, leave it on its own line:
 >
+> /kind api-change
 > /kind bug
+> /kind cleanup
+> /kind design
+> /kind documentation
+> /kind failing-test
 > /kind feature
+> /kind flake
 
 **What this PR does / why we need it**:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,10 +26,12 @@ Fixes #
 
 **Special notes for your reviewer**:
 
-**Release note**:
-<!--  Write your release note:
-1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
-2. If no release note is required, just write "NONE".
+**Does this PR introduce a user-facing change?**:
+<!--  
+If no, just write "NONE".
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+2. 
 -->
 ```release-note
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,17 @@
 <!--  Thanks for sending a pull request!  Here are some tips for you:
 1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
-2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
+2. Please label this pull request according to what type of issue you are fixing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
+https://github.com/kubernetes/community/blob/master/contributors/devel/release.md#issue-kind-label
+3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
+4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
+5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
 -->
+
+**What type of PR is this?**
+> Uncomment only one, leave it on its own line:
+>
+> /kind bug
+> /kind feature
 
 **What this PR does / why we need it**:
 


### PR DESCRIPTION
As the release process no longer requires an issue to be filed with each pull request, we should be treating pull requests as issues for the purposes of triage. This means it is helpful if PR authors add labels right as they open a PR.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We should treat PRs as Issues.

**Which issue(s) this PR fixes**
Partial solutions for concerns here: https://github.com/kubernetes/sig-release/issues/309

**Special notes for your reviewer**:
This is a contributor and release process focused PR.

/sig release
/sig contributor-experience
/cc @AishSundar 
/kind documentation