### PR TITLE
fix register wrong configz for *-controller-manager

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -50,6 +50,8 @@ import (
 const (
 	// ControllerStartJitter is the jitter value used when starting controller managers.
 	ControllerStartJitter = 1.0
+	// ConfigzName is the name used for register cloud-controller manager /configz, same with GroupName.
+	ConfigzName = "cloudcontrollermanager.config.k8s.io"
 )
 
 // NewCloudControllerManagerCommand creates a *cobra.Command object with default parameters
@@ -123,7 +125,7 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, stopCh <-chan struct{}) error
 	}
 
 	// setup /configz endpoint
-	if cz, err := configz.New("componentconfig"); err == nil {
+	if cz, err := configz.New(ConfigzName); err == nil {
 		cz.Set(c.ComponentConfig)
 	} else {
 		glog.Errorf("unable to register configz: %c", err)

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -64,6 +64,8 @@ import (
 const (
 	// Jitter used when starting controller managers
 	ControllerStartJitter = 1.0
+	// ConfigzName is the name used for register kube-controller manager /configz, same with GroupName.
+	ConfigzName = "kubecontrollermanager.config.k8s.io"
 )
 
 type ControllerLoopMode int
@@ -142,7 +144,7 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 	// To help debugging, immediately log version
 	glog.Infof("Version: %+v", version.Get())
 
-	if cfgz, err := configz.New("componentconfig"); err == nil {
+	if cfgz, err := configz.New(ConfigzName); err == nil {
 		cfgz.Set(c.ComponentConfig)
 	} else {
 		glog.Errorf("unable to register configz: %c", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix register wrong configz for `*-controller-manager`, using groupname defined in API

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
