### PR TITLE
persistentvolume support namespaces filter

### DIFF
--- a/pkg/controller/volume/persistentvolume/index.go
+++ b/pkg/controller/volume/persistentvolume/index.go
@@ -19,6 +19,7 @@ package persistentvolume
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -171,6 +172,20 @@ func findMatchingVolume(
 		// check if PV's DeletionTimeStamp is set, if so, skip this volume.
 		if utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection) {
 			if volume.ObjectMeta.DeletionTimestamp != nil {
+				continue
+			}
+		}
+
+		// Check volume limit for namespaces
+		if len(volume.Spec.NamespaceSelector) != 0 {
+			nsMatched := false
+			for _, ns := range volume.Spec.NamespaceSelector {
+				if strings.TrimSpace(ns) == claim.Namespace {
+					nsMatched = true
+					break
+				}
+			}
+			if !nsMatched {
 				continue
 			}
 		}

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -333,6 +333,11 @@ type PersistentVolumeSpec struct {
 	// This field influences the scheduling of pods that use this volume.
 	// +optional
 	NodeAffinity *VolumeNodeAffinity `json:"nodeAffinity,omitempty" protobuf:"bytes,9,opt,name=nodeAffinity"`
+	// NamespaceSelector defines namespaces that can use the persistentvolume,
+	// If empty, all pvc can use the pv;
+	// If not empty, only pvc belongs to these namespaces can use the pv;
+	// +optional
+	NamespaceSelector []string `json:"namespaceSelector,omitempty" protobuf:"bytes,7,opt,name=namespaceSelector"`
 }
 
 // VolumeNodeAffinity defines constraints that limit what nodes this volume can be accessed from.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The PersistentVolume provides an API for users and administrators that abstracts details of how storage is provided from how it is consumed. It is not belongs to any namespace, it is managed by cluster administrators.

In some situations, the administrator wants to selector the users(namespaces) which have authority to use the pv.

Example:

K8S administrator creates 15 pvs for the company teams, and expect: 

```
5 of them can be used by dev team only;
5 of them can be used by test team only;
5 of them can be used by dev/test teams;
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

None

**Special notes for your reviewer**:

Add a label to PV, named "namespaceSelector";

```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: pv1
spec:
  capacity:
    storage: 5Gi
  accessModes:
    - ReadWriteMany
  namespaceSelector:
    - dev
    - test
  nfs:
    path: /abc
    server: 1.1.1.1
```

namespaceSelector not set or empty: all pvc can use it;

namespaceSelector set one namespace: only pvcs belong to that namespace can use it.

namespaceSelector set multi namespaces: pvcs belong to one of these namespaces can use it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
