### PR TITLE
Label node even if CSINodeInfo feature is disabled

### DIFF
--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
@@ -91,9 +91,7 @@ func (nim *nodeInfoManager) AddNodeInfo(driverName string, driverNodeID string, 
 		updateNodeIDInNode(driverName, driverNodeID),
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.CSINodeInfo) {
-		nodeUpdateFuncs = append(nodeUpdateFuncs, updateTopologyLabels(topology))
-	}
+	nodeUpdateFuncs = append(nodeUpdateFuncs, updateTopologyLabels(topology))
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.AttachVolumeLimit) {
 		nodeUpdateFuncs = append(nodeUpdateFuncs, updateMaxAttachLimit(driverName, maxAttachLimit))


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes sure that Kubelet updates the node labels with the topology information even if the `CSINodeInfo` feature is disabled.

**Which issue(s) this PR fixes**:

Fixes #69869.

**Release note**:
```release-note

```

/kind bug
/sig storage