### PR TITLE
Skips Windows unrelated tests

### DIFF
--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -557,6 +557,16 @@ func newConfigMap(f *framework.Framework, name string) *v1.ConfigMap {
 }
 
 func doConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64, defaultMode *int32) {
+	if uid != 0 || fsGroup != 0 {
+		// Windows does not support running as an UID / GID.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
+	if defaultMode != nil {
+		// Windows does not support setting specific file permissions.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
 	userID := int64(uid)
 	groupID := int64(fsGroup)
 
@@ -636,6 +646,16 @@ func doConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64, d
 }
 
 func doConfigMapE2EWithMappings(f *framework.Framework, uid, fsGroup int64, itemMode *int32) {
+	if uid != 0 || fsGroup != 0 {
+		// Windows does not support running as an UID / GID.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
+	if itemMode != nil {
+		// Windows does not support setting specific file permissions.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
 	userID := int64(uid)
 	groupID := int64(fsGroup)
 

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -262,6 +262,11 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 })
 
 func downwardAPIVolumePodForModeTest(name, filePath string, itemMode, defaultMode *int32) *v1.Pod {
+	if itemMode != nil || defaultMode != nil {
+		// Windows does not support setting specific file permissions.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
 	pod := downwardAPIVolumeBasePod(name, nil, nil)
 
 	pod.Spec.Containers = []v1.Container{

--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -199,6 +199,9 @@ const (
 )
 
 func doTestSetgidFSGroup(f *framework.Framework, image string, medium v1.StorageMedium) {
+	// Windows does not support setting specific file permissions.
+	framework.SkipIfNodeOSDistroIs("windows")
+
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
@@ -228,6 +231,9 @@ func doTestSetgidFSGroup(f *framework.Framework, image string, medium v1.Storage
 }
 
 func doTestSubPathFSGroup(f *framework.Framework, image string, medium v1.StorageMedium) {
+	// Windows does not support setting specific file permissions.
+	framework.SkipIfNodeOSDistroIs("windows")
+
 	var (
 		subPath = "test-sub"
 		source  = &v1.EmptyDirVolumeSource{Medium: medium}
@@ -260,6 +266,9 @@ func doTestSubPathFSGroup(f *framework.Framework, image string, medium v1.Storag
 }
 
 func doTestVolumeModeFSGroup(f *framework.Framework, image string, medium v1.StorageMedium) {
+	// Windows does not support setting specific file permissions.
+	framework.SkipIfNodeOSDistroIs("windows")
+
 	var (
 		source = &v1.EmptyDirVolumeSource{Medium: medium}
 		pod    = testPodWithVolume(testImageRootUid, volumePath, source)
@@ -284,6 +293,9 @@ func doTestVolumeModeFSGroup(f *framework.Framework, image string, medium v1.Sto
 }
 
 func doTest0644FSGroup(f *framework.Framework, image string, medium v1.StorageMedium) {
+	// Windows does not support setting specific file permissions.
+	framework.SkipIfNodeOSDistroIs("windows")
+
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
@@ -311,6 +323,8 @@ func doTest0644FSGroup(f *framework.Framework, image string, medium v1.StorageMe
 }
 
 func doTestVolumeMode(f *framework.Framework, image string, medium v1.StorageMedium) {
+	// Windows does not support setting seLinuxOptions.
+	framework.SkipIfNodeOSDistroIs("windows")
 	var (
 		source = &v1.EmptyDirVolumeSource{Medium: medium}
 		pod    = testPodWithVolume(testImageRootUid, volumePath, source)
@@ -332,6 +346,8 @@ func doTestVolumeMode(f *framework.Framework, image string, medium v1.StorageMed
 }
 
 func doTest0644(f *framework.Framework, image string, medium v1.StorageMedium) {
+	// Windows does not support setting specific file permissions.
+	framework.SkipIfNodeOSDistroIs("windows")
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
@@ -356,6 +372,8 @@ func doTest0644(f *framework.Framework, image string, medium v1.StorageMedium) {
 }
 
 func doTest0666(f *framework.Framework, image string, medium v1.StorageMedium) {
+	// Windows does not support setting specific file permissions.
+	framework.SkipIfNodeOSDistroIs("windows")
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
@@ -380,6 +398,8 @@ func doTest0666(f *framework.Framework, image string, medium v1.StorageMedium) {
 }
 
 func doTest0777(f *framework.Framework, image string, medium v1.StorageMedium) {
+	// Windows does not support setting specific file permissions.
+	framework.SkipIfNodeOSDistroIs("windows")
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}

--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -46,6 +46,8 @@ var _ = Describe("[sig-storage] HostPath", func() {
 	   Description: Create a Pod with host volume mounted. The volume mounted MUST be a directory with permissions mode -rwxrwxrwx and that is has the sticky bit (mode flag t) set.
 	*/
 	framework.ConformanceIt("should give a volume the correct mode [NodeConformance]", func() {
+		// Windows does not support the sticky bit (mode flag t), which this test expects.
+		framework.SkipIfNodeOSDistroIs("windows")
 		source := &v1.HostPathVolumeSource{
 			Path: "/tmp",
 		}

--- a/test/e2e/common/kubelet.go
+++ b/test/e2e/common/kubelet.go
@@ -142,6 +142,9 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 			Description: Create a Pod with hostAliases and a container with command to output /etc/hosts entries. Pod's logs MUST have matching entries of specified hostAliases to the output of /etc/hosts entries.
 		*/
 		framework.ConformanceIt("should write entries to /etc/hosts [NodeConformance]", func() {
+			// Cannot mount files in Windows Containers at the moment.
+			// TODO(claudiub): Remove this check when it will be supported.
+			framework.SkipIfNodeOSDistroIs("windows")
 			podClient.CreateSync(&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: podName,
@@ -192,6 +195,8 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 			Description: Create a Pod with security context set with ReadOnlyRootFileSystem set to true. The Pod then tries to write to the /file on the root, write operation to the root filesystem MUST fail as expected.
 		*/
 		framework.ConformanceIt("should not write to root filesystem [NodeConformance]", func() {
+			// Windows Docker does not support creating containers with read-only access.
+			framework.SkipIfNodeOSDistroIs("windows")
 			isReadOnly := true
 			podClient.CreateSync(&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/common/kubelet_etc_hosts.go
+++ b/test/e2e/common/kubelet_etc_hosts.go
@@ -59,6 +59,9 @@ var _ = framework.KubeDescribe("KubeletManagedEtcHosts", func() {
 			3. The Pod with hostNetwork=true , /etc/hosts file MUST not be managed by the Kubelet.
 	*/
 	framework.ConformanceIt("should test kubelet managed /etc/hosts file [NodeConformance]", func() {
+		// Cannot mount files in Windows Containers at the moment.
+		// TODO(claudiub): Remove this check when it will be supported.
+		framework.SkipIfNodeOSDistroIs("windows")
 		By("Setting up the test")
 		config.setup()
 

--- a/test/e2e/common/privileged.go
+++ b/test/e2e/common/privileged.go
@@ -46,6 +46,8 @@ var _ = framework.KubeDescribe("PrivilegedPod [NodeConformance]", func() {
 	}
 
 	It("should enable privileged commands", func() {
+		// Windows does not support privileged containers.
+		framework.SkipIfNodeOSDistroIs("windows")
 		By("Creating a pod with a privileged container")
 		config.createPods()
 

--- a/test/e2e/common/projected_configmap.go
+++ b/test/e2e/common/projected_configmap.go
@@ -484,6 +484,16 @@ var _ = Describe("[sig-storage] Projected configMap", func() {
 })
 
 func doProjectedConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64, defaultMode *int32) {
+	if uid != 0 || fsGroup != 0 {
+		// Windows does not support running as an UID / GID.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
+	if defaultMode != nil {
+		// Windows does not support setting specific file permissions.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
 	userID := int64(uid)
 	groupID := int64(fsGroup)
 
@@ -568,6 +578,16 @@ func doProjectedConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup
 }
 
 func doProjectedConfigMapE2EWithMappings(f *framework.Framework, uid, fsGroup int64, itemMode *int32) {
+	if uid != 0 || fsGroup != 0 {
+		// Windows does not support running as an UID / GID.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
+	if itemMode != nil {
+		// Windows does not support setting specific file permissions.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
 	userID := int64(uid)
 	groupID := int64(fsGroup)
 

--- a/test/e2e/common/projected_downwardapi.go
+++ b/test/e2e/common/projected_downwardapi.go
@@ -261,6 +261,11 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 })
 
 func projectedDownwardAPIVolumePodForModeTest(name, filePath string, itemMode, defaultMode *int32) *v1.Pod {
+	if itemMode != nil || defaultMode != nil {
+		// Windows does not support setting specific file permissions.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
 	pod := projectedDownwardAPIVolumeBasePod(name, nil, nil)
 
 	pod.Spec.Containers = []v1.Container{

--- a/test/e2e/common/projected_secret.go
+++ b/test/e2e/common/projected_secret.go
@@ -403,6 +403,16 @@ var _ = Describe("[sig-storage] Projected secret", func() {
 
 func doProjectedSecretE2EWithoutMapping(f *framework.Framework, defaultMode *int32,
 	secretName string, fsGroup *int64, uid *int64) {
+	if uid != nil || fsGroup != nil {
+		// Windows does not support running as an UID / GID.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
+	if defaultMode != nil {
+		// Windows does not support setting specific file permissions.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
 	var (
 		volumeName      = "projected-secret-volume"
 		volumeMountPath = "/etc/projected-secret-volume"
@@ -483,6 +493,11 @@ func doProjectedSecretE2EWithoutMapping(f *framework.Framework, defaultMode *int
 }
 
 func doProjectedSecretE2EWithMapping(f *framework.Framework, mode *int32) {
+	if mode != nil {
+		// Windows does not support setting specific file permissions.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
 	var (
 		name            = "projected-secret-test-map-" + string(uuid.NewUUID())
 		volumeName      = "projected-secret-volume"

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -207,6 +207,9 @@ while true; do sleep 1; done
 				},
 			} {
 				It(fmt.Sprintf("should report termination message %s", testCase.name), func() {
+					// Cannot mount files in Windows Containers at the moment.
+					// TODO(claudiub): Remove this check when it will be supported.
+					framework.SkipIfNodeOSDistroIs("windows")
 					testCase.container.Name = "termination-message-container"
 					c := ConformanceContainer{
 						PodClient:     f.PodClient(),

--- a/test/e2e/common/secrets_volume.go
+++ b/test/e2e/common/secrets_volume.go
@@ -382,6 +382,16 @@ func secretForTest(namespace, name string) *v1.Secret {
 
 func doSecretE2EWithoutMapping(f *framework.Framework, defaultMode *int32, secretName string,
 	fsGroup *int64, uid *int64) {
+	if uid != nil || fsGroup != nil {
+		// Windows does not support running as an UID / GID.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
+	if defaultMode != nil {
+		// Windows does not support setting specific file permissions.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
 	var (
 		volumeName      = "secret-volume"
 		volumeMountPath = "/etc/secret-volume"
@@ -453,6 +463,11 @@ func doSecretE2EWithoutMapping(f *framework.Framework, defaultMode *int32, secre
 }
 
 func doSecretE2EWithMapping(f *framework.Framework, mode *int32) {
+	if mode != nil {
+		// Windows does not support setting specific file permissions.
+		framework.SkipIfNodeOSDistroIs("windows")
+	}
+
 	var (
 		name            = "secret-test-map-" + string(uuid.NewUUID())
 		volumeName      = "secret-volume"

--- a/test/e2e/common/security_context.go
+++ b/test/e2e/common/security_context.go
@@ -58,6 +58,8 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			}
 		}
 		createAndWaitUserPod := func(userid int64) {
+			// Windows does not support running as an UID / GID.
+			framework.SkipIfNodeOSDistroIs("windows")
 			podName := fmt.Sprintf("busybox-user-%d-%s", userid, uuid.NewUUID())
 			podClient.Create(makeUserPod(podName,
 				framework.BusyBoxImage,
@@ -133,6 +135,8 @@ var _ = framework.KubeDescribe("Security Context", func() {
 		  Description: when a container has configured readOnlyRootFilesystem to true, write operations are not allowed.
 		*/
 		It("should run the container with readonly rootfs when readOnlyRootFilesystem=true [NodeConformance]", func() {
+			// Windows Docker does not support creating containers with read-only access.
+			framework.SkipIfNodeOSDistroIs("windows")
 			createAndWaitUserPod(true)
 		})
 
@@ -214,6 +218,8 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			}
 		}
 		createAndMatchOutput := func(podName, output string, allowPrivilegeEscalation *bool, uid int64) error {
+			// Windows does not support running as an UID / GID.
+			framework.SkipIfNodeOSDistroIs("windows")
 			podClient.Create(makeAllowPrivilegeEscalationPod(podName,
 				allowPrivilegeEscalation,
 				uid,

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -378,6 +378,12 @@ func SkipUnlessNodeOSDistroIs(supportedNodeOsDistros ...string) {
 	}
 }
 
+func SkipIfNodeOSDistroIs(unsupportedNodeOsDistros ...string) {
+	if NodeOSDistroIs(unsupportedNodeOsDistros...) {
+		Skipf("Not supported for node OS distro %v (is %s)", unsupportedNodeOsDistros, TestContext.NodeOSDistro)
+	}
+}
+
 func SkipUnlessSecretExistsAfterWait(c clientset.Interface, name, namespace string, timeout time.Duration) {
 	Logf("Waiting for secret %v in namespace %v to exist in duration %v", name, namespace, timeout)
 	start := time.Now()

--- a/test/e2e/storage/subpath.go
+++ b/test/e2e/storage/subpath.go
@@ -36,6 +36,9 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		var privilegedSecurityContext bool = false
 
 		BeforeEach(func() {
+			// Cannot mount files in Windows Containers at the moment.
+			// TODO(claudiub): Remove this check when it will be supported.
+			framework.SkipIfNodeOSDistroIs("windows")
 			By("Setting up data")
 			secret := &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "my-secret"}, Data: map[string][]byte{"secret-key": []byte("secret-value")}}
 			secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(secret)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Some of the tests cannot pass using Windows nodes due to various reasons:

- seLinuxOptions are not supported on Windows.
- Running as an UID / GID is not supported on Windows.
- file permissions work differently on Windows, and they cannot be set in
  the same manner as on Linux.
- individual files cannot be mounted in Windows Containers.
- Cannot create container using Linux image (alpine) on Windows.

These kinds of tests should be skippable by passing the --node-os-distro=windows ginkgo argument.

/kind bug
/sig testing
/sig windows

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69871

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
