### PR TITLE
Fix local copy path for `kubectl cp'.

### DIFF
--- a/pkg/kubectl/cmd/cp/cp.go
+++ b/pkg/kubectl/cmd/cp/cp.go
@@ -310,8 +310,8 @@ func stripPathShortcuts(p string) string {
 		trimmed = strings.TrimPrefix(newPath, "../")
 	}
 
-	// trim leftover ".."
-	if newPath == ".." {
+	// trim leftover {".", ".."}
+	if (newPath == "." || newPath == "..") {
 		newPath = ""
 	}
 

--- a/pkg/kubectl/cmd/cp/cp.go
+++ b/pkg/kubectl/cmd/cp/cp.go
@@ -311,7 +311,7 @@ func stripPathShortcuts(p string) string {
 	}
 
 	// trim leftover {".", ".."}
-	if (newPath == "." || newPath == "..") {
+	if newPath == "." || newPath == ".." {
 		newPath = ""
 	}
 

--- a/pkg/kubectl/cmd/cp/cp_test.go
+++ b/pkg/kubectl/cmd/cp/cp_test.go
@@ -173,6 +173,11 @@ func TestStripPathShortcuts(t *testing.T) {
 			input:    "...foo",
 			expected: "...foo",
 		},
+		{
+			name:     "test root directory",
+			input:    "/",
+			expected: "",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
```
Fix for `kubectl cp': Currently, in `copyFromPod' if the path specified when
copying files from a pod to local is "/" (e.g.: "kubectl cp pod:/ /local/path"),
the first letter of the generated local file paths when being copied goes missing.

This is caused because getPrefix("/") returns an empty string, and subsequently
when that is passed to path.Clean, it returns: ".".

In `stripPathShortcuts`, there's no check for ".", so the string is
returned as is. When this string (".") is passed as the `prefix' argument in
`untarAll', this expression would end up skipping the first character:
    outFileName := path.Join(destFile, clean(header.Name[len(prefix):]))

If an extra check for "." is added to `stripPathShortcuts', it would return
an empty string and the first letter stays.
```

**Which issue(s) this PR fixes**: #69804.

**Special notes for your reviewer**: None.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes incorrect paths (missing first letter) when copying files from pods to
local in `kubectl cp'.
```
