### PR TITLE
kubeadm: skip upgrade if manifest is not changed

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/BUILD
+++ b/cmd/kubeadm/app/phases/upgrade/BUILD
@@ -37,6 +37,7 @@ go_library(
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//cmd/kubeadm/app/util/dryrun:go_default_library",
         "//cmd/kubeadm/app/util/etcd:go_default_library",
+        "//cmd/kubeadm/app/util/staticpod:go_default_library",
         "//pkg/version:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package staticpod
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -287,4 +288,18 @@ func GetProbeAddress(cfg *kubeadmapi.InitConfiguration, componentName string) st
 		}
 	}
 	return "127.0.0.1"
+}
+
+// ManifestFilesAreEqual compares 2 files. It returns true if their contents are equal, false otherwise
+func ManifestFilesAreEqual(path1, path2 string) (bool, error) {
+	content1, err := ioutil.ReadFile(path1)
+	if err != nil {
+		return false, err
+	}
+	content2, err := ioutil.ReadFile(path2)
+	if err != nil {
+		return false, err
+	}
+
+	return bytes.Equal(content1, content2), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When doing upgrades kubeadm generates new manifests and
waites for kubelet to restarts correspondent pods.

However, kubelet won't restart pods if there are no changes
in the manifests. That makes kubeadm stuck waiting for
restarted pod.

Skipping upgrades if new component manifest is the same as
current manifest should solve this.

**Which issue(s) this PR fixes**
Fixes: kubernetes/kubeadm#1054

**Release note**:
```release-note
fix 'kubeadm upgrade' infinite loop waiting for pod restart
```