### PR TITLE
Reduce cardinality of admission webhook metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -112,17 +112,17 @@ func newAdmissionMetrics() *AdmissionMetrics {
 	// Admission metrics for a step of the admission flow. The entire admission flow is broken down into a series of steps
 	// Each step is identified by a distinct type label value.
 	step := newMetricSet("step",
-		[]string{"type", "operation", "group", "version", "resource", "subresource", "rejected"},
+		[]string{"type", "operation", "rejected"},
 		"Admission sub-step %s, broken out for each operation and API resource and step type (validate or admit).", true)
 
 	// Built-in admission controller metrics. Each admission controller is identified by name.
 	controller := newMetricSet("controller",
-		[]string{"name", "type", "operation", "group", "version", "resource", "subresource", "rejected"},
+		[]string{"name", "type", "operation", "rejected"},
 		"Admission controller %s, identified by name and broken out for each operation and API resource and type (validate or admit).", false)
 
 	// Admission webhook metrics. Each webhook is identified by name.
 	webhook := newMetricSet("webhook",
-		[]string{"name", "type", "operation", "group", "version", "resource", "subresource", "rejected"},
+		[]string{"name", "type", "operation", "rejected"},
 		"Admission webhook %s, identified by name and broken out for each operation and API resource and type (validate or admit).", false)
 
 	step.mustRegister()
@@ -139,20 +139,17 @@ func (m *AdmissionMetrics) reset() {
 
 // ObserveAdmissionStep records admission related metrics for a admission step, identified by step type.
 func (m *AdmissionMetrics) ObserveAdmissionStep(elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
-	gvr := attr.GetResource()
-	m.step.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected))...)
+	m.step.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), strconv.FormatBool(rejected))...)
 }
 
 // ObserveAdmissionController records admission related metrics for a built-in admission controller, identified by it's plugin handler name.
 func (m *AdmissionMetrics) ObserveAdmissionController(elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
-	gvr := attr.GetResource()
-	m.controller.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected))...)
+	m.controller.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), strconv.FormatBool(rejected))...)
 }
 
 // ObserveWebhook records admission related metrics for a admission webhook.
 func (m *AdmissionMetrics) ObserveWebhook(elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
-	gvr := attr.GetResource()
-	m.webhook.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected))...)
+	m.webhook.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), strconv.FormatBool(rejected))...)
 }
 
 type metricSet struct {

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -37,13 +37,9 @@ func TestObserveAdmissionStep(t *testing.T) {
 	handler.(admission.MutationInterface).Admit(attr)
 	handler.(admission.ValidationInterface).Validate(attr)
 	wantLabels := map[string]string{
-		"operation":   string(admission.Create),
-		"group":       resource.Group,
-		"version":     resource.Version,
-		"resource":    resource.Resource,
-		"subresource": "subresource",
-		"type":        "admit",
-		"rejected":    "false",
+		"operation": string(admission.Create),
+		"type":      "admit",
+		"rejected":  "false",
 	}
 	expectHistogramCountTotal(t, "apiserver_admission_step_admission_latencies_seconds", wantLabels, 1)
 	expectFindMetric(t, "apiserver_admission_step_admission_latencies_seconds_summary", wantLabels)
@@ -59,14 +55,10 @@ func TestObserveAdmissionController(t *testing.T) {
 	handler.(admission.MutationInterface).Admit(attr)
 	handler.(admission.ValidationInterface).Validate(attr)
 	wantLabels := map[string]string{
-		"name":        "a",
-		"operation":   string(admission.Create),
-		"group":       resource.Group,
-		"version":     resource.Version,
-		"resource":    resource.Resource,
-		"subresource": "subresource",
-		"type":        "admit",
-		"rejected":    "false",
+		"name":      "a",
+		"operation": string(admission.Create),
+		"type":      "admit",
+		"rejected":  "false",
 	}
 	expectHistogramCountTotal(t, "apiserver_admission_controller_admission_latencies_seconds", wantLabels, 1)
 
@@ -78,14 +70,10 @@ func TestObserveWebhook(t *testing.T) {
 	Metrics.reset()
 	Metrics.ObserveWebhook(2*time.Second, false, attr, stepAdmit, "x")
 	wantLabels := map[string]string{
-		"name":        "x",
-		"operation":   string(admission.Create),
-		"group":       resource.Group,
-		"version":     resource.Version,
-		"resource":    resource.Resource,
-		"subresource": "subresource",
-		"type":        "admit",
-		"rejected":    "false",
+		"name":      "x",
+		"operation": string(admission.Create),
+		"type":      "admit",
+		"rejected":  "false",
 	}
 	expectHistogramCountTotal(t, "apiserver_admission_webhook_admission_latencies_seconds", wantLabels, 1)
 }


### PR DESCRIPTION
Per https://github.com/kubernetes/kubernetes/issues/69540, including resource related labels on admission webhook labels on large cluster with lots of CRDs incurs unacceptable amounts of memory use and churn.

This PR removes the resource related labels: `group`, `version`, `resource` and `subresource`.

```release-note
Reduce memory utilization of admission webhook metrics by removing resource related labels.
```

/sig api-machinery
/kind cleanup
/cc @smarterclayton 