### PR TITLE
Fix Machinery to always call converters for Unstructured Types

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/nop_converter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/nop_converter.go
@@ -61,6 +61,15 @@ func (c *nopConverter) Convert(in, out, context interface{}) error {
 	if err != nil {
 		return err
 	}
+	// If the context is a groupVersener passed from [this](https://bit.ly/2CCByRM), we should convert to that
+	// version.
+	if context != nil {
+		if groupVersioner, ok := context.(runtime.GroupVersioner); ok {
+			if targetGVK, ok := groupVersioner.KindForGroupVersionKinds([]schema.GroupVersionKind{unstructOut.GroupVersionKind()}); ok {
+				unstructOut.SetGroupVersionKind(targetGVK)
+			}
+		}
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -52,6 +52,18 @@ func NewNoxuSubresourcesCRD(scope apiextensionsv1beta1.ResourceScope) *apiextens
 				ListKind:   "NoxuItemList",
 			},
 			Scope: scope,
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1beta1",
+					Served:  true,
+					Storage: false,
+				},
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+				},
+			},
 			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
 				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 				Scale: &apiextensionsv1beta1.CustomResourceSubresourceScale{

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -103,7 +103,8 @@ func (c *codec) Decode(data []byte, defaultGVK *schema.GroupVersionKind, into ru
 
 	// if we specify a target, use generic conversion.
 	if into != nil {
-		if into == obj {
+		_, isUnstructured := obj.(runtime.Unstructured)
+		if into == obj && !isUnstructured {
 			if isVersioned {
 				return versioned, gvk, nil
 			}


### PR DESCRIPTION
There are assumptions in the code for standard type versioning converter that are not true for Unstructured types. This change make sure the unstructured converter will be always called by the versioning decoder so it give it a chance to convert its data after decoding.

fixes #68035

@sttts @roycaihw @yue9944882