### PR TITLE
add some helpers to Audiences to find intersecting audiences

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/BUILD
@@ -1,9 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_library",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -27,4 +24,10 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["helpers_test.go"],
+    embed = [":go_default_library"],
 )

--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/helpers.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/helpers.go
@@ -18,3 +18,25 @@ package authenticator
 
 // Audiences is a container for the Audiences of a token.
 type Audiences []string
+
+// Has checks if Audiences contains a specific audiences.
+func (a Audiences) Has(taud string) bool {
+	for _, aud := range a {
+		if aud == taud {
+			return true
+		}
+	}
+	return false
+}
+
+// Intersect intersects Audiences with a target Audiences and returns all
+// elements in both.
+func (a Audiences) Intersect(tauds Audiences) Audiences {
+	selected := Audiences{}
+	for _, taud := range tauds {
+		if a.Has(taud) {
+			selected = append(selected, taud)
+		}
+	}
+	return selected
+}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/helpers_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authenticator
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIntersect(t *testing.T) {
+	cs := []struct {
+		auds, tauds Audiences
+		expected    Audiences
+	}{
+		{
+			auds:     nil,
+			tauds:    nil,
+			expected: Audiences{},
+		},
+		{
+			auds:     nil,
+			tauds:    Audiences{"foo"},
+			expected: Audiences{},
+		},
+		{
+			auds:     Audiences{},
+			tauds:    Audiences{},
+			expected: Audiences{},
+		},
+		{
+			auds:     Audiences{"foo"},
+			tauds:    Audiences{},
+			expected: Audiences{},
+		},
+		{
+			auds:     Audiences{"foo"},
+			tauds:    Audiences{"foo"},
+			expected: Audiences{"foo"},
+		},
+		{
+			auds:     Audiences{"foo", "bar"},
+			tauds:    Audiences{"foo", "bar"},
+			expected: Audiences{"foo", "bar"},
+		},
+		{
+			auds:     Audiences{"foo", "bar"},
+			tauds:    Audiences{"foo", "wat"},
+			expected: Audiences{"foo"},
+		},
+		{
+			auds:     Audiences{"foo", "bar"},
+			tauds:    Audiences{"pls", "wat"},
+			expected: Audiences{},
+		},
+	}
+	for _, c := range cs {
+		t.Run("auds", func(t *testing.T) {
+			if got, want := c.auds.Intersect(c.tauds), c.expected; !reflect.DeepEqual(got, want) {
+				t.Errorf("unexpected intersection.\ngot:\t%v\nwant:\t%v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
@kubernetes/sig-auth-pr-reviews 

```release-note
NONE
```
