### PR TITLE
Delete invalid assignment in proxy's fuzzer.

### DIFF
--- a/pkg/proxy/apis/config/fuzzer/fuzzer.go
+++ b/pkg/proxy/apis/config/fuzzer/fuzzer.go
@@ -34,7 +34,6 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 		func(obj *kubeproxyconfig.KubeProxyConfiguration, c fuzz.Continue) {
 			c.FuzzNoCustom(obj)
 			obj.BindAddress = fmt.Sprintf("%d.%d.%d.%d", c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(256))
-			obj.ClientConnection.ContentType = c.RandString()
 			obj.Conntrack.MaxPerCore = utilpointer.Int32Ptr(c.Int31())
 			obj.Conntrack.Min = utilpointer.Int32Ptr(c.Int31())
 			obj.Conntrack.TCPCloseWaitTimeout = &metav1.Duration{Duration: time.Duration(c.Int63()) * time.Hour}


### PR DESCRIPTION
**What this PR does / why we need it**:
The "obj.ClientConnection.ContentType" has been set to "bar", so delete
this invalid assignment.

**Which issue(s) this PR fixes** *(optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
```
NONE
```