### PR TITLE
remove duplicate root check for kubeadm

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -991,7 +991,6 @@ func addCommonChecks(execer utilsexec.Interface, cfg kubeadmapi.CommonConfigurat
 	}
 	checks = append(checks,
 		SystemVerificationCheck{IsDocker: isDocker},
-		IsPrivilegedUserCheck{},
 		HostnameCheck{nodeName: cfg.GetNodeName()},
 		KubeletVersionCheck{KubernetesVersion: cfg.GetKubernetesVersion(), exec: execer},
 		ServiceCheck{Service: "kubelet", CheckIfActive: false},


### PR DESCRIPTION
**What this PR does / why we need it**:
The `addCommonChecks` function is only used by `RunJoinNodeChecks` and `RunInitMasterChecks` function.  And both of the two functions  do `RootCheck` at the beginning. So I think it maybe redundant to add `RootCheck` into the `addCommonChecks` function.

/kind cleanup

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
