### PR TITLE
Manually cherry pick part of #58712: Add better event handling for deleted Pods

### DIFF
--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -162,6 +162,13 @@ func NewConfigFactory(
 				switch t := obj.(type) {
 				case *v1.Pod:
 					return assignedNonTerminatedPod(t)
+				case cache.DeletedFinalStateUnknown:
+					if pod, ok := t.Obj.(*v1.Pod); ok {
+						return assignedNonTerminatedPod(pod)
+					} else {
+						runtime.HandleError(fmt.Errorf("unable to convert object %T to *v1.Pod in %T", obj, c))
+						return false
+					}
 				default:
 					runtime.HandleError(fmt.Errorf("unable to handle object in %T: %T", c, obj))
 					return false


### PR DESCRIPTION
**What this PR does / why we need it**:
Manually cherry pick part of #58712 on release-1.8.

#58712: This PR makes the event handling logic more robust by adding logic to check for cache.DeletedFinalStateUnknown in our event handler filters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69926

**Special notes for your reviewer**:
See #69926 for more details.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Stability: Make Pod delete event handling of scheduler more robust.
```
/sig scheduling