### PR TITLE
kubectl: remove internalclientset dependency

### DIFF
--- a/pkg/kubectl/describe/versioned/BUILD
+++ b/pkg/kubectl/describe/versioned/BUILD
@@ -6,13 +6,11 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubectl/describe/versioned",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/kubectl/describe:go_default_library",
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
-        "//staging/src/k8s.io/client-go/dynamic:go_default_library",
     ],
 )
 

--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -195,8 +195,21 @@ func DescriberFor(kind schema.GroupKind, clientConfig *rest.Config) (printers.De
 
 // GenericDescriberFor returns a generic describer for the specified mapping
 // that uses only information available from runtime.Unstructured
-func GenericDescriberFor(mapping *meta.RESTMapping, dynamic dynamic.Interface, events coreclient.EventsGetter) printers.Describer {
-	return &genericDescriber{mapping, dynamic, events}
+func GenericDescriberFor(mapping *meta.RESTMapping, clientConfig *rest.Config) (printers.Describer, bool) {
+	// used to fetch the resource
+	dynamicClient, err := dynamic.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, false
+	}
+
+	// used to get events for the resource
+	clientSet, err := clientset.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, false
+	}
+	eventsClient := clientSet.Core()
+
+	return &genericDescriber{mapping, dynamicClient, eventsClient}, true
 }
 
 type genericDescriber struct {


### PR DESCRIPTION
* Removes kubectl dependency on `internalclientset` (moves to `pkg/printers`, which already depends on `internalclientset`).
* Makes `GenericDescriberFor` more consistent with `DescriberFor`.

Helps address:
https://github.com/kubernetes/kubectl/issues/80

```release-note
NONE
```
