### PR TITLE
Add flag for setting number of service account workers

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -151,6 +151,8 @@ API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,R
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,ReplicationControllerConfiguration,ConcurrentRCSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,ResourceQuotaControllerConfiguration,ConcurrentResourceQuotaSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,ResourceQuotaControllerConfiguration,ResourceQuotaSyncPeriod
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,SAControllerConfiguration,ServiceAccountKeyFile
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,SAControllerConfiguration,ConcurrentServiceAccountSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,SAControllerConfiguration,ConcurrentSATokenSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,SAControllerConfiguration,RootCAFile
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,SAControllerConfiguration,ServiceAccountKeyFile

--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -151,9 +151,8 @@ API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,R
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,ReplicationControllerConfiguration,ConcurrentRCSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,ResourceQuotaControllerConfiguration,ConcurrentResourceQuotaSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,ResourceQuotaControllerConfiguration,ResourceQuotaSyncPeriod
-API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,SAControllerConfiguration,ServiceAccountKeyFile
-API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,SAControllerConfiguration,ConcurrentServiceAccountSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,SAControllerConfiguration,ConcurrentSATokenSyncs
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,SAControllerConfiguration,ConcurrentServiceAccountSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,SAControllerConfiguration,RootCAFile
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,SAControllerConfiguration,ServiceAccountKeyFile
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,ServiceControllerConfiguration,ConcurrentServiceSyncs

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -342,7 +342,7 @@ func startServiceAccountController(ctx ControllerContext) (http.Handler, bool, e
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating ServiceAccount controller: %v", err)
 	}
-	go sac.Run(1, ctx.Stop)
+	go sac.Run(int(ctx.ComponentConfig.SAController.ConcurrentServiceAccountSyncs), ctx.Stop)
 	return nil, true, nil
 }
 

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -168,7 +168,7 @@ func NewKubeControllerManagerOptions() (*KubeControllerManagerOptions, error) {
 			ConcurrentResourceQuotaSyncs: componentConfig.ResourceQuotaController.ConcurrentResourceQuotaSyncs,
 		},
 		SAController: &SAControllerOptions{
-			ConcurrentServiceAccountSyncs: componentConfig.SAController.ConcurrentSASyncs,
+			ConcurrentServiceAccountSyncs: componentConfig.SAController.ConcurrentServiceAccountSyncs,
 			ConcurrentSATokenSyncs:        componentConfig.SAController.ConcurrentSATokenSyncs,
 		},
 		ServiceController: &cmoptions.ServiceControllerOptions{

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -168,7 +168,8 @@ func NewKubeControllerManagerOptions() (*KubeControllerManagerOptions, error) {
 			ConcurrentResourceQuotaSyncs: componentConfig.ResourceQuotaController.ConcurrentResourceQuotaSyncs,
 		},
 		SAController: &SAControllerOptions{
-			ConcurrentSATokenSyncs: componentConfig.SAController.ConcurrentSATokenSyncs,
+			ConcurrentServiceAccountSyncs: componentConfig.SAController.ConcurrentSASyncs,
+			ConcurrentSATokenSyncs:        componentConfig.SAController.ConcurrentSATokenSyncs,
 		},
 		ServiceController: &cmoptions.ServiceControllerOptions{
 			ConcurrentServiceSyncs: componentConfig.ServiceController.ConcurrentServiceSyncs,

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -59,6 +59,7 @@ func TestAddFlags(t *testing.T) {
 		"--concurrent-replicaset-syncs=10",
 		"--concurrent-resource-quota-syncs=10",
 		"--concurrent-service-syncs=2",
+		"--concurrent-serviceaccount-syncs=5",
 		"--concurrent-serviceaccount-token-syncs=10",
 		"--concurrent_rc_syncs=10",
 		"--configure-cloud-routes=false",
@@ -250,8 +251,9 @@ func TestAddFlags(t *testing.T) {
 			ConcurrentResourceQuotaSyncs: 10,
 		},
 		SAController: &SAControllerOptions{
-			ServiceAccountKeyFile:  "/service-account-private-key",
-			ConcurrentSATokenSyncs: 10,
+			ServiceAccountKeyFile:         "/service-account-private-key",
+			ConcurrentSATokenSyncs:        10,
+			ConcurrentServiceAccountSyncs: 5,
 		},
 		ServiceController: &cmoptions.ServiceControllerOptions{
 			ConcurrentServiceSyncs: 2,

--- a/cmd/kube-controller-manager/app/options/serviceaccountcontroller.go
+++ b/cmd/kube-controller-manager/app/options/serviceaccountcontroller.go
@@ -24,9 +24,10 @@ import (
 
 // SAControllerOptions holds the ServiceAccountController options.
 type SAControllerOptions struct {
-	ServiceAccountKeyFile  string
-	ConcurrentSATokenSyncs int32
-	RootCAFile             string
+	ServiceAccountKeyFile         string
+	ConcurrentServiceAccountSyncs int32
+	ConcurrentSATokenSyncs        int32
+	RootCAFile                    string
 }
 
 // AddFlags adds flags related to ServiceAccountController for controller manager to the specified FlagSet
@@ -36,6 +37,7 @@ func (o *SAControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 
 	fs.StringVar(&o.ServiceAccountKeyFile, "service-account-private-key-file", o.ServiceAccountKeyFile, "Filename containing a PEM-encoded private RSA or ECDSA key used to sign service account tokens.")
+	fs.Int32Var(&o.ConcurrentServiceAccountSyncs, "concurrent-serviceaccount-syncs", o.ConcurrentServiceAccountSyncs, "The number of service account objects that are allowed to sync concurrently. Larger number = more responsive service account generation, but more CPU (and network) load")
 	fs.Int32Var(&o.ConcurrentSATokenSyncs, "concurrent-serviceaccount-token-syncs", o.ConcurrentSATokenSyncs, "The number of service account token objects that are allowed to sync concurrently. Larger number = more responsive token generation, but more CPU (and network) load")
 	fs.StringVar(&o.RootCAFile, "root-ca-file", o.RootCAFile, "If set, this root certificate authority will be included in service account's token secret. This must be a valid PEM-encoded CA bundle.")
 }
@@ -47,6 +49,7 @@ func (o *SAControllerOptions) ApplyTo(cfg *kubectrlmgrconfig.SAControllerConfigu
 	}
 
 	cfg.ServiceAccountKeyFile = o.ServiceAccountKeyFile
+	cfg.ConcurrentServiceAccountSyncs = o.ConcurrentServiceAccountSyncs
 	cfg.ConcurrentSATokenSyncs = o.ConcurrentSATokenSyncs
 	cfg.RootCAFile = o.RootCAFile
 

--- a/pkg/controller/apis/config/types.go
+++ b/pkg/controller/apis/config/types.go
@@ -377,6 +377,9 @@ type SAControllerConfiguration struct {
 	// serviceAccountKeyFile is the filename containing a PEM-encoded private RSA key
 	// used to sign service account tokens.
 	ServiceAccountKeyFile string
+	// concurrentServiceAccountSyncs is the number of service account syncing operations
+	// that will be done concurrently.
+	ConcurrentServiceAccountSyncs int32
 	// concurrentSATokenSyncs is the number of service account token syncing operations
 	// that will be done concurrently.
 	ConcurrentSATokenSyncs int32

--- a/pkg/controller/apis/config/v1alpha1/defaults.go
+++ b/pkg/controller/apis/config/v1alpha1/defaults.go
@@ -239,6 +239,15 @@ func SetDefaults_ResourceQuotaControllerConfiguration(obj *kubectrlmgrconfigv1al
 	}
 }
 
+func SetDefaults_SAControllerConfiguration(obj *kubectrlmgrconfigv1alpha1.SAControllerConfiguration) {
+	if obj.ConcurrentSATokenSyncs == 0 {
+		obj.ConcurrentSATokenSyncs = 5
+	}
+	if obj.ConcurrentServiceAccountSyncs == 0 {
+		obj.ConcurrentServiceAccountSyncs = 1
+	}
+}
+
 func SetDefaults_PersistentVolumeRecyclerConfiguration(obj *kubectrlmgrconfigv1alpha1.PersistentVolumeRecyclerConfiguration) {
 	if obj.MaximumRetry == 0 {
 		obj.MaximumRetry = 3

--- a/pkg/controller/apis/config/v1alpha1/defaults.go
+++ b/pkg/controller/apis/config/v1alpha1/defaults.go
@@ -45,9 +45,6 @@ func SetDefaults_KubeControllerManagerConfiguration(obj *kubectrlmgrconfigv1alph
 	if obj.PersistentVolumeBinderController.PVClaimBinderSyncPeriod == zero {
 		obj.PersistentVolumeBinderController.PVClaimBinderSyncPeriod = metav1.Duration{Duration: 15 * time.Second}
 	}
-	if obj.SAController.ConcurrentSATokenSyncs == 0 {
-		obj.SAController.ConcurrentSATokenSyncs = 5
-	}
 	if obj.TTLAfterFinishedController.ConcurrentTTLSyncs <= 0 {
 		obj.TTLAfterFinishedController.ConcurrentTTLSyncs = 5
 	}

--- a/pkg/controller/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/apis/config/v1alpha1/zz_generated.conversion.go
@@ -1054,6 +1054,7 @@ func Convert_config_ResourceQuotaControllerConfiguration_To_v1alpha1_ResourceQuo
 
 func autoConvert_v1alpha1_SAControllerConfiguration_To_config_SAControllerConfiguration(in *v1alpha1.SAControllerConfiguration, out *config.SAControllerConfiguration, s conversion.Scope) error {
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
+	out.ConcurrentServiceAccountSyncs = in.ConcurrentServiceAccountSyncs
 	out.ConcurrentSATokenSyncs = in.ConcurrentSATokenSyncs
 	out.RootCAFile = in.RootCAFile
 	return nil
@@ -1066,6 +1067,7 @@ func Convert_v1alpha1_SAControllerConfiguration_To_config_SAControllerConfigurat
 
 func autoConvert_config_SAControllerConfiguration_To_v1alpha1_SAControllerConfiguration(in *config.SAControllerConfiguration, out *v1alpha1.SAControllerConfiguration, s conversion.Scope) error {
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
+	out.ConcurrentServiceAccountSyncs = in.ConcurrentServiceAccountSyncs
 	out.ConcurrentSATokenSyncs = in.ConcurrentSATokenSyncs
 	out.RootCAFile = in.RootCAFile
 	return nil

--- a/pkg/controller/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/controller/apis/config/v1alpha1/zz_generated.defaults.go
@@ -53,5 +53,6 @@ func SetObjectDefaults_KubeControllerManagerConfiguration(in *v1alpha1.KubeContr
 	SetDefaults_ReplicaSetControllerConfiguration(&in.ReplicaSetController)
 	SetDefaults_ReplicationControllerConfiguration(&in.ReplicationController)
 	SetDefaults_ResourceQuotaControllerConfiguration(&in.ResourceQuotaController)
+	SetDefaults_SAControllerConfiguration(&in.SAController)
 	SetDefaults_ServiceControllerConfiguration(&in.ServiceController)
 }

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -426,6 +426,9 @@ type SAControllerConfiguration struct {
 	// serviceAccountKeyFile is the filename containing a PEM-encoded private RSA key
 	// used to sign service account tokens.
 	ServiceAccountKeyFile string
+	// concurrentServiceAccountSyncs is the number of service account syncing operations
+	// that will be done concurrently.
+	ConcurrentServiceAccountSyncs int32
 	// concurrentSATokenSyncs is the number of service account token syncing operations
 	// that will be done concurrently.
 	ConcurrentSATokenSyncs int32


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This PR makes the number of workers for the Service Account controller configurable. We are running into some issues with this controller keeping up, and needed a way of updating the currently hard-coded worker value of 1.

**Special notes for your reviewer**: The documentation for the `--concurrent-serviceaccount-token-syncs` flag seems to indicate that it defaults to 5, but was unable to find anything that handled the default values for the SAControllerConfiguration struct. Please let me know if defaults for that struct are handled in a different way.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added a configuration flag to controller-manager for number of service account sync workers.
```
