### PR TITLE
Automated cherry-pick of #66516 to v1.11

### DIFF
--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -50,6 +50,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 	statsapi "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+
 	// Do some initialization to decode the query parameters correctly.
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -1165,7 +1166,7 @@ func TestServeExecInContainerIdleTimeout(t *testing.T) {
 
 	url := fw.testHTTPServer.URL + "/exec/" + podNamespace + "/" + podName + "/" + expectedContainerName + "?c=ls&c=-a&" + api.ExecStdinParam + "=1"
 
-	upgradeRoundTripper := spdy.NewSpdyRoundTripper(nil, true)
+	upgradeRoundTripper := spdy.NewSpdyRoundTripper(nil, true, true)
 	c := &http.Client{Transport: upgradeRoundTripper}
 
 	resp, err := c.Post(url, "", nil)
@@ -1331,7 +1332,7 @@ func testExecAttach(t *testing.T, verb string) {
 					return http.ErrUseLastResponse
 				}
 			} else {
-				upgradeRoundTripper = spdy.NewRoundTripper(nil, true)
+				upgradeRoundTripper = spdy.NewRoundTripper(nil, true, true)
 				c = &http.Client{Transport: upgradeRoundTripper}
 			}
 
@@ -1428,7 +1429,7 @@ func TestServePortForwardIdleTimeout(t *testing.T) {
 
 	url := fw.testHTTPServer.URL + "/portForward/" + podNamespace + "/" + podName
 
-	upgradeRoundTripper := spdy.NewRoundTripper(nil, true)
+	upgradeRoundTripper := spdy.NewRoundTripper(nil, true, true)
 	c := &http.Client{Transport: upgradeRoundTripper}
 
 	resp, err := c.Post(url, "", nil)
@@ -1535,7 +1536,7 @@ func TestServePortForward(t *testing.T) {
 					return http.ErrUseLastResponse
 				}
 			} else {
-				upgradeRoundTripper = spdy.NewRoundTripper(nil, true)
+				upgradeRoundTripper = spdy.NewRoundTripper(nil, true, true)
 				c = &http.Client{Transport: upgradeRoundTripper}
 			}
 

--- a/pkg/registry/core/pod/rest/log.go
+++ b/pkg/registry/core/pod/rest/log.go
@@ -80,6 +80,7 @@ func (r *LogREST) Get(ctx context.Context, name string, opts runtime.Object) (ru
 		ContentType:     "text/plain",
 		Flush:           logOpts.Follow,
 		ResponseChecker: genericrest.NewGenericHttpResponseChecker(api.Resource("pods/log"), name),
+		RedirectChecker: genericrest.PreventRedirects,
 	}, nil
 }
 

--- a/pkg/registry/core/pod/rest/subresources.go
+++ b/pkg/registry/core/pod/rest/subresources.go
@@ -194,6 +194,7 @@ func (r *PortForwardREST) Connect(ctx context.Context, name string, opts runtime
 func newThrottledUpgradeAwareProxyHandler(location *url.URL, transport http.RoundTripper, wrapTransport, upgradeRequired, interceptRedirects bool, responder rest.Responder) *proxy.UpgradeAwareHandler {
 	handler := proxy.NewUpgradeAwareHandler(location, transport, wrapTransport, upgradeRequired, proxy.NewErrorResponder(responder))
 	handler.InterceptRedirects = interceptRedirects && utilfeature.DefaultFeatureGate.Enabled(genericfeatures.StreamingProxyRedirects)
+	handler.RequireSameHostRedirects = utilfeature.DefaultFeatureGate.Enabled(genericfeatures.ValidateProxyRedirects)
 	handler.MaxBytesPerSec = capabilities.Get().PerConnectionBandwidthLimitBytesPerSec
 	return handler
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -67,6 +67,9 @@ type SpdyRoundTripper struct {
 	// followRedirects indicates if the round tripper should examine responses for redirects and
 	// follow them.
 	followRedirects bool
+	// requireSameHostRedirects restricts redirect following to only follow redirects to the same host
+	// as the original request.
+	requireSameHostRedirects bool
 }
 
 var _ utilnet.TLSClientConfigHolder = &SpdyRoundTripper{}
@@ -75,14 +78,18 @@ var _ utilnet.Dialer = &SpdyRoundTripper{}
 
 // NewRoundTripper creates a new SpdyRoundTripper that will use
 // the specified tlsConfig.
-func NewRoundTripper(tlsConfig *tls.Config, followRedirects bool) httpstream.UpgradeRoundTripper {
-	return NewSpdyRoundTripper(tlsConfig, followRedirects)
+func NewRoundTripper(tlsConfig *tls.Config, followRedirects, requireSameHostRedirects bool) httpstream.UpgradeRoundTripper {
+	return NewSpdyRoundTripper(tlsConfig, followRedirects, requireSameHostRedirects)
 }
 
 // NewSpdyRoundTripper creates a new SpdyRoundTripper that will use
 // the specified tlsConfig. This function is mostly meant for unit tests.
-func NewSpdyRoundTripper(tlsConfig *tls.Config, followRedirects bool) *SpdyRoundTripper {
-	return &SpdyRoundTripper{tlsConfig: tlsConfig, followRedirects: followRedirects}
+func NewSpdyRoundTripper(tlsConfig *tls.Config, followRedirects, requireSameHostRedirects bool) *SpdyRoundTripper {
+	return &SpdyRoundTripper{
+		tlsConfig:                tlsConfig,
+		followRedirects:          followRedirects,
+		requireSameHostRedirects: requireSameHostRedirects,
+	}
 }
 
 // TLSClientConfig implements pkg/util/net.TLSClientConfigHolder for proper TLS checking during
@@ -257,7 +264,7 @@ func (s *SpdyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	)
 
 	if s.followRedirects {
-		conn, rawResponse, err = utilnet.ConnectWithRedirects(req.Method, req.URL, header, req.Body, s)
+		conn, rawResponse, err = utilnet.ConnectWithRedirects(req.Method, req.URL, header, req.Body, s, s.requireSameHostRedirects)
 	} else {
 		clone := utilnet.CloneRequest(req)
 		clone.Header = header

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
@@ -282,7 +282,7 @@ func TestRoundTripAndNewConnection(t *testing.T) {
 					t.Fatalf("%s: Error creating request: %s", k, err)
 				}
 
-				spdyTransport := NewSpdyRoundTripper(testCase.clientTLS, redirect)
+				spdyTransport := NewSpdyRoundTripper(testCase.clientTLS, redirect, redirect)
 
 				var proxierCalled bool
 				var proxyCalledWithHost string
@@ -391,8 +391,8 @@ func TestRoundTripRedirects(t *testing.T) {
 	}{
 		{0, true},
 		{1, true},
-		{10, true},
-		{11, false},
+		{9, true},
+		{10, false},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("with %d redirects", test.redirects), func(t *testing.T) {
@@ -425,7 +425,7 @@ func TestRoundTripRedirects(t *testing.T) {
 				t.Fatalf("Error creating request: %s", err)
 			}
 
-			spdyTransport := NewSpdyRoundTripper(nil, true)
+			spdyTransport := NewSpdyRoundTripper(nil, true, true)
 			client := &http.Client{Transport: spdyTransport}
 
 			resp, err := client.Do(req)

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/BUILD
@@ -16,7 +16,12 @@ go_test(
         "util_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
+    deps = [
+        "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+    ],
 )
 
 go_library(

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -311,9 +311,10 @@ type Dialer interface {
 
 // ConnectWithRedirects uses dialer to send req, following up to 10 redirects (relative to
 // originalLocation). It returns the opened net.Conn and the raw response bytes.
-func ConnectWithRedirects(originalMethod string, originalLocation *url.URL, header http.Header, originalBody io.Reader, dialer Dialer) (net.Conn, []byte, error) {
+// If requireSameHostRedirects is true, only redirects to the same host are permitted.
+func ConnectWithRedirects(originalMethod string, originalLocation *url.URL, header http.Header, originalBody io.Reader, dialer Dialer, requireSameHostRedirects bool) (net.Conn, []byte, error) {
 	const (
-		maxRedirects    = 10
+		maxRedirects    = 9     // Fail on the 10th redirect
 		maxResponseSize = 16384 // play it safe to allow the potential for lots of / large headers
 	)
 
@@ -377,10 +378,6 @@ redirectLoop:
 
 		resp.Body.Close() // not used
 
-		// Reset the connection.
-		intermediateConn.Close()
-		intermediateConn = nil
-
 		// Prepare to follow the redirect.
 		redirectStr := resp.Header.Get("Location")
 		if redirectStr == "" {
@@ -394,6 +391,15 @@ redirectLoop:
 		if err != nil {
 			return nil, nil, fmt.Errorf("malformed Location header: %v", err)
 		}
+
+		// Only follow redirects to the same host. Otherwise, propagate the redirect response back.
+		if requireSameHostRedirects && location.Hostname() != originalLocation.Hostname() {
+			break redirectLoop
+		}
+
+		// Reset the connection.
+		intermediateConn.Close()
+		intermediateConn = nil
 	}
 
 	connToReturn := intermediateConn

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -69,6 +69,8 @@ type UpgradeAwareHandler struct {
 	// InterceptRedirects determines whether the proxy should sniff backend responses for redirects,
 	// following them as necessary.
 	InterceptRedirects bool
+	// RequireSameHostRedirects only allows redirects to the same host. It is only used if InterceptRedirects=true.
+	RequireSameHostRedirects bool
 	// UseRequestLocation will use the incoming request URL when talking to the backend server.
 	UseRequestLocation bool
 	// FlushInterval controls how often the standard HTTP proxy will flush content from the upstream.
@@ -257,7 +259,7 @@ func (h *UpgradeAwareHandler) tryUpgrade(w http.ResponseWriter, req *http.Reques
 	utilnet.AppendForwardedForHeader(clone)
 	if h.InterceptRedirects {
 		glog.V(6).Infof("Connecting to backend proxy (intercepting redirects) %s\n  Headers: %v", &location, clone.Header)
-		backendConn, rawResponse, err = utilnet.ConnectWithRedirects(req.Method, &location, clone.Header, req.Body, utilnet.DialerFunc(h.DialForUpgrade))
+		backendConn, rawResponse, err = utilnet.ConnectWithRedirects(req.Method, &location, clone.Header, req.Body, utilnet.DialerFunc(h.DialForUpgrade), h.RequireSameHostRedirects)
 	} else {
 		glog.V(6).Infof("Connecting to backend proxy (direct dial) %s\n  Headers: %v", &location, clone.Header)
 		clone.URL = &location

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -29,10 +29,18 @@ const (
 
 	// owner: @tallclair
 	// alpha: v1.5
+	// beta: v1.6
 	//
 	// StreamingProxyRedirects controls whether the apiserver should intercept (and follow)
 	// redirects from the backend (Kubelet) for streaming requests (exec/attach/port-forward).
 	StreamingProxyRedirects utilfeature.Feature = "StreamingProxyRedirects"
+
+	// owner: @tallclair
+	// alpha: v1.10
+	//
+	// ValidateProxyRedirects controls whether the apiserver should validate that redirects are only
+	// followed to the same host. Only used if StreamingProxyRedirects is enabled.
+	ValidateProxyRedirects utilfeature.Feature = "ValidateProxyRedirects"
 
 	// owner: @tallclair
 	// alpha: v1.7
@@ -74,6 +82,7 @@ func init() {
 // available throughout Kubernetes binaries.
 var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
 	StreamingProxyRedirects: {Default: true, PreRelease: utilfeature.Beta},
+	ValidateProxyRedirects:  {Default: false, PreRelease: utilfeature.Alpha},
 	AdvancedAuditing:        {Default: true, PreRelease: utilfeature.Beta},
 	APIResponseCompression:  {Default: false, PreRelease: utilfeature.Alpha},
 	Initializers:            {Default: false, PreRelease: utilfeature.Alpha},

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/BUILD
@@ -14,6 +14,8 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rest
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -28,13 +29,14 @@ import (
 )
 
 // LocationStreamer is a resource that streams the contents of a particular
-// location URL
+// location URL.
 type LocationStreamer struct {
 	Location        *url.URL
 	Transport       http.RoundTripper
 	ContentType     string
 	Flush           bool
 	ResponseChecker HttpResponseChecker
+	RedirectChecker func(req *http.Request, via []*http.Request) error
 }
 
 // a LocationStreamer must implement a rest.ResourceStreamer
@@ -58,7 +60,10 @@ func (s *LocationStreamer) InputStream(apiVersion, acceptHeader string) (stream 
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
-	client := &http.Client{Transport: transport}
+	client := &http.Client{
+		Transport:     transport,
+		CheckRedirect: s.RedirectChecker,
+	}
 	resp, err := client.Get(s.Location.String())
 	if err != nil {
 		return nil, false, "", err
@@ -80,4 +85,9 @@ func (s *LocationStreamer) InputStream(apiVersion, acceptHeader string) (stream 
 	flush = s.Flush
 	stream = resp.Body
 	return
+}
+
+// PreventRedirects is a redirect checker that prevents the client from following a redirect.
+func PreventRedirects(_ *http.Request, _ []*http.Request) error {
+	return errors.New("redirects forbidden")
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer_test.go
@@ -27,6 +27,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -145,4 +147,24 @@ func TestInputStreamInternalServerErrorTransport(t *testing.T) {
 	if !reflect.DeepEqual(err, expectedError) {
 		t.Errorf("StreamInternalServerError does not match. Got: %s. Expected: %s.", err, expectedError)
 	}
+}
+
+func TestInputStreamRedirects(t *testing.T) {
+	const redirectPath = "/redirect"
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == redirectPath {
+			t.Fatal("Redirects should not be followed")
+		} else {
+			http.Redirect(w, req, redirectPath, http.StatusFound)
+		}
+	}))
+	loc, err := url.Parse(s.URL)
+	require.NoError(t, err, "Error parsing server URL")
+
+	streamer := &LocationStreamer{
+		Location:        loc,
+		RedirectChecker: PreventRedirects,
+	}
+	_, _, _, err = streamer.InputStream("", "")
+	assert.Error(t, err, "Redirect should trigger an error")
 }

--- a/staging/src/k8s.io/client-go/transport/spdy/spdy.go
+++ b/staging/src/k8s.io/client-go/transport/spdy/spdy.go
@@ -38,7 +38,7 @@ func RoundTripperFor(config *restclient.Config) (http.RoundTripper, Upgrader, er
 	if err != nil {
 		return nil, nil, err
 	}
-	upgradeRoundTripper := spdy.NewRoundTripper(tlsConfig, true)
+	upgradeRoundTripper := spdy.NewRoundTripper(tlsConfig, true, false)
 	wrapper, err := restclient.HTTPWrappersForConfig(config, upgradeRoundTripper)
 	if err != nil {
 		return nil, nil, err

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -162,7 +162,8 @@ func maybeWrapForConnectionUpgrades(restConfig *restclient.Config, rt http.Round
 		return nil, true, err
 	}
 	followRedirects := utilfeature.DefaultFeatureGate.Enabled(genericfeatures.StreamingProxyRedirects)
-	upgradeRoundTripper := spdy.NewRoundTripper(tlsConfig, followRedirects)
+	requireSameHostRedirects := utilfeature.DefaultFeatureGate.Enabled(genericfeatures.ValidateProxyRedirects)
+	upgradeRoundTripper := spdy.NewRoundTripper(tlsConfig, followRedirects, requireSameHostRedirects)
 	wrappedRT, err := restclient.HTTPWrappersForConfig(restConfig, upgradeRoundTripper)
 	if err != nil {
 		return nil, true, err


### PR DESCRIPTION
Only allow the apiserver to follow redirects to the same host.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Restrict redirect following from the apiserver to same-host redirects, and ignore redirects in some cases. Set alpha feature gate "ValidateProxyRedirects=true" to enable.
```

/milestone v1.11
/cc @liggitt 
/kind bug