### PR TITLE
Include vendor/k8s.io in coverage instrumentation

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -555,7 +555,7 @@ kube::golang::build_some_binaries() {
 
         go test -c -o "$(kube::golang::outfile_for_binary "${package}" "${platform}")" \
           -covermode count \
-          -coverpkg k8s.io/... \
+          -coverpkg k8s.io/...,k8s.io/kubernetes/vendor/k8s.io/... \
           "${build_args[@]}" \
           -tags coverage \
           "${package}"


### PR DESCRIPTION
**What this PR does / why we need it**: Some important Kubernetes packages (in particular, anything in `staging`) are vendored in, and so were being implicitly omitted from coverage instrumentation. While we do want to omit non-k8s vendoring, we want to include Kubernetes' own vendored code.

The practical upshot of this on master is that `k8s.io/{api,apiextensions-apiserver,apimachinery,apiserver,cli-runtime,client-go,cloud-provider,cluster-bootstrap,csi-api,kube-aggregator,kube-openapi,metrics,utils}` are all now instrumented when (and only when) building coverage-instrumented binaries.

/kind bug
/area conformance
/sig testing
/cc @spiffxp
```release-note
NONE
```
