### PR TITLE
kubeadm: fix config fetch via 'config view'

### DIFF
--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -380,7 +380,11 @@ func RunConfigView(out io.Writer, client clientset.Interface) error {
 		return err
 	}
 	// No need to append \n as that already exists in the ConfigMap
-	fmt.Fprintf(out, "%s", cfgConfigMap.Data[constants.InitConfigurationConfigMapKey])
+	if value, ok := cfgConfigMap.Data[constants.InitConfigurationConfigMapKey]; ok {
+		fmt.Fprintf(out, "%s", value)
+	} else {
+		fmt.Fprintf(out, "%s", cfgConfigMap.Data[constants.ClusterConfigurationConfigMapKey])
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/priority critical-urgent

**What this PR does / why we need it**:
fix a small issue in 1.12 where we need to use a new key to fetch the kubeadm config from the config map in case of a 1.12 cluster, but still handle the old config from 1.11.

**not a cherry pick** as our PRs that implement changes are huge.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#1174

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
kubeadm: fix an issue where 'config view' did not return a config in case of a 1.12 cluster
```

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/assign @fabriziopandini @feiskyer 
/cc @rdodev 
