### PR TITLE
add ControllerRevision.Name to Compare function

### DIFF
--- a/pkg/controller/history/controller_history.go
+++ b/pkg/controller/history/controller_history.go
@@ -163,6 +163,9 @@ func (br byRevision) Len() int {
 }
 
 func (br byRevision) Less(i, j int) bool {
+	if br[i].Revision == br[j].Revision {
+		return br[i].Name < br[j].Name
+	}
 	return br[i].Revision < br[j].Revision
 }
 

--- a/pkg/controller/history/controller_history_test.go
+++ b/pkg/controller/history/controller_history_test.go
@@ -1571,21 +1571,28 @@ func TestSortControllerRevisions(t *testing.T) {
 	}
 	ss1Rev3.Namespace = ss1.Namespace
 
+	*ss1.Status.CollisionCount = int32(2)
+	ss1Rev4, err := NewControllerRevision(ss1, parentKind, ss1.Spec.Template.Labels, rawTemplate(&ss1.Spec.Template), 3, ss1.Status.CollisionCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss1Rev4.Namespace = ss1.Namespace
+
 	tests := []testcase{
 		{
 			name:      "out of order",
-			revisions: []*apps.ControllerRevision{ss1Rev2, ss1Rev1, ss1Rev3},
-			want:      []string{ss1Rev1.Name, ss1Rev2.Name, ss1Rev3.Name},
+			revisions: []*apps.ControllerRevision{ss1Rev2, ss1Rev1, ss1Rev4, ss1Rev3},
+			want:      []string{ss1Rev1.Name, ss1Rev2.Name, ss1Rev3.Name, ss1Rev4.Name},
 		},
 		{
 			name:      "sorted",
-			revisions: []*apps.ControllerRevision{ss1Rev1, ss1Rev2, ss1Rev3},
-			want:      []string{ss1Rev1.Name, ss1Rev2.Name, ss1Rev3.Name},
+			revisions: []*apps.ControllerRevision{ss1Rev1, ss1Rev2, ss1Rev3, ss1Rev4},
+			want:      []string{ss1Rev1.Name, ss1Rev2.Name, ss1Rev3.Name, ss1Rev4.Name},
 		},
 		{
 			name:      "reversed",
-			revisions: []*apps.ControllerRevision{ss1Rev3, ss1Rev2, ss1Rev1},
-			want:      []string{ss1Rev1.Name, ss1Rev2.Name, ss1Rev3.Name},
+			revisions: []*apps.ControllerRevision{ss1Rev4, ss1Rev3, ss1Rev2, ss1Rev1},
+			want:      []string{ss1Rev1.Name, ss1Rev2.Name, ss1Rev3.Name, ss1Rev4.Name},
 		},
 		{
 			name:      "empty",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
If statefulset‘s updateRevision has collisionCount > 0, we need to use ControllerRevision.Name to break the tie. Otherwise these updateRevisions with same Revision will have an unstable order. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubernetes/issues/69967

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
add ControllerRevision.Name to Compare function in case of having unstable Revisions
```
