### PR TITLE
Support multiple CNI configuration directories

### DIFF
--- a/cmd/kubelet/app/BUILD
+++ b/cmd/kubelet/app/BUILD
@@ -47,6 +47,7 @@ go_library(
         "//pkg/kubelet/config:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/dockershim:go_default_library",
+        "//pkg/kubelet/dockershim/network/cni:go_default_library",
         "//pkg/kubelet/dockershim/remote:go_default_library",
         "//pkg/kubelet/eviction:go_default_library",
         "//pkg/kubelet/eviction/api:go_default_library",

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -76,6 +76,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/network/cni"
 	dockerremote "k8s.io/kubernetes/pkg/kubelet/dockershim/remote"
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
@@ -1159,7 +1160,7 @@ func RunDockershim(f *options.KubeletFlags, c *kubeletconfiginternal.KubeletConf
 		HairpinMode:        kubeletconfiginternal.HairpinMode(c.HairpinMode),
 		NonMasqueradeCIDR:  f.NonMasqueradeCIDR,
 		PluginName:         r.NetworkPluginName,
-		PluginConfDir:      r.CNIConfDir,
+		PluginConfDirs:     cni.SplitDirs(r.CNIConfDir),
 		PluginBinDirString: r.CNIBinDir,
 		MTU:                int(r.NetworkPluginMTU),
 	}

--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -56,6 +56,7 @@ go_library(
         "//pkg/kubelet/configmap:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/dockershim:go_default_library",
+        "//pkg/kubelet/dockershim/network/cni:go_default_library",
         "//pkg/kubelet/dockershim/remote:go_default_library",
         "//pkg/kubelet/envvars:go_default_library",
         "//pkg/kubelet/events:go_default_library",

--- a/pkg/kubelet/config/flags.go
+++ b/pkg/kubelet/config/flags.go
@@ -94,7 +94,7 @@ func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 
 	// Network plugin settings for Docker.
 	fs.StringVar(&s.NetworkPluginName, "network-plugin", s.NetworkPluginName, fmt.Sprintf("<Warning: Alpha feature> The name of the network plugin to be invoked for various events in kubelet/pod lifecycle. %s", dockerOnlyWarning))
-	fs.StringVar(&s.CNIConfDir, "cni-conf-dir", s.CNIConfDir, fmt.Sprintf("<Warning: Alpha feature> The full path of the directory in which to search for CNI config files. %s", dockerOnlyWarning))
+	fs.StringVar(&s.CNIConfDir, "cni-conf-dir", s.CNIConfDir, fmt.Sprintf("<Warning: Alpha feature> A comma-separated list of full paths of directories in which to search for CNI config files. %s", dockerOnlyWarning))
 	fs.StringVar(&s.CNIBinDir, "cni-bin-dir", s.CNIBinDir, fmt.Sprintf("<Warning: Alpha feature> A comma-separated list of full paths of directories in which to search for CNI plugin binaries. %s", dockerOnlyWarning))
 	fs.Int32Var(&s.NetworkPluginMTU, "network-plugin-mtu", s.NetworkPluginMTU, fmt.Sprintf("<Warning: Alpha feature> The MTU to be passed to the network plugin, to override the default. Set to 0 to use the default 1460 MTU. %s", dockerOnlyWarning))
 }

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -119,10 +119,10 @@ type NetworkPluginSettings struct {
 	// the plugin with PluginName may be found. The admin is responsible for
 	// provisioning these binaries before-hand.
 	PluginBinDirs []string
-	// PluginConfDir is the directory in which the admin places a CNI conf.
-	// Depending on the plugin, this may be an optional field, eg: kubenet
-	// generates its own plugin conf.
-	PluginConfDir string
+	// PluginConfDirs is an array of directories in which the admin places
+	// a CNI conf. Depending on the plugin, this may be an optional field,
+	// eg: kubenet generates its own plugin conf.
+	PluginConfDirs []string
 	// MTU is the desired MTU for network devices created by the plugin.
 	MTU int
 }
@@ -237,7 +237,7 @@ func NewDockerService(config *ClientConfig, podSandboxImage string, streamingCon
 
 	// dockershim currently only supports CNI plugins.
 	pluginSettings.PluginBinDirs = cni.SplitDirs(pluginSettings.PluginBinDirString)
-	cniPlugins := cni.ProbeNetworkPlugins(pluginSettings.PluginConfDir, pluginSettings.PluginBinDirs)
+	cniPlugins := cni.ProbeNetworkPlugins(pluginSettings.PluginConfDirs, pluginSettings.PluginBinDirs)
 	cniPlugins = append(cniPlugins, kubenet.NewPlugin(pluginSettings.PluginBinDirs))
 	netHost := &dockerNetworkHost{
 		&namespaceGetter{ds},

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -69,6 +69,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/configmap"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/network/cni"
 	dockerremote "k8s.io/kubernetes/pkg/kubelet/dockershim/remote"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
@@ -598,7 +599,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		HairpinMode:        kubeletconfiginternal.HairpinMode(kubeCfg.HairpinMode),
 		NonMasqueradeCIDR:  nonMasqueradeCIDR,
 		PluginName:         crOptions.NetworkPluginName,
-		PluginConfDir:      crOptions.CNIConfDir,
+		PluginConfDirs:     cni.SplitDirs(crOptions.CNIConfDir),
 		PluginBinDirString: crOptions.CNIBinDir,
 		MTU:                int(crOptions.NetworkPluginMTU),
 	}


### PR DESCRIPTION
Signed-off-by: Thomas Graf <thomas@cilium.io>
Signed-off-by: André Martins <andre@cilium.io>

**What type of PR is this?**
/kind feature
/sig network

**What this PR does / why we need it**:

This PR introduces the capability of specifying multiple directories that contain CNI configuration files.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Yep

```release-note
Support multiple CNI configuration directories in kubelet.
```
