### PR TITLE
kubeadm: remove TODO about moving token utils to client-go

### DIFF
--- a/cmd/kubeadm/app/phases/bootstraptoken/node/token.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/node/token.go
@@ -26,8 +26,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 )
 
-// TODO(mattmoyer): Move CreateNewTokens, UpdateOrCreateTokens out of this package to client-go for a generic abstraction and client for a Bootstrap Token
-
 // CreateNewTokens tries to create a token and fails if one with the same ID already exists
 func CreateNewTokens(client clientset.Interface, tokens []kubeadmapi.BootstrapToken) error {
 	return UpdateOrCreateTokens(client, true, tokens)


### PR DESCRIPTION
**What this PR does / why we need it**:

the kubeadm token utils were first moved to client-go which sparked a bit of a discussion (complains). then the utils were moved to a new home:
https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/cluster-bootstrap

the utils in the `cmd/kubeadm/app/phases/bootstraptoken/node/token.go` file require client-go for the client set, yet `cluster-bootstrap` does not vendor client-go. vendoring client-go in `cluster-bootstrap` might **not be desired** which leaves the utils in `node/token.go` without a home.

remove the TODO note about the move.

this PR is open for discussion. if it's OK to vendor client-go in cluster-bootstrap then we can perform the move.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
refs https://github.com/kubernetes/kubeadm/issues/1163

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/assign @timothysc @fabriziopandini 
/cc @mattmoyer 
/kind cleanup
