### PR TITLE
WIP - Fix watch event handling for CRDs

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -196,8 +196,6 @@ func startAttachDetachController(ctx ControllerContext) (http.Handler, bool, err
 		return nil, true, fmt.Errorf("Duration time must be greater than one second as set via command line option reconcile-sync-loop-period.")
 	}
 	csiClientConfig := ctx.ClientBuilder.ConfigOrDie("attachdetach-controller")
-	// csiClient works with CRDs that support json only
-	csiClientConfig.ContentType = "application/json"
 
 	attachDetachController, attachDetachControllerErr :=
 		attachdetach.NewAttachDetachController(

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -616,7 +616,6 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 		}
 
 		// csiClient works with CRDs that support json only
-		clientConfig.ContentType = "application/json"
 		csiClient, err := csiclientset.NewForConfig(clientConfig)
 		if err != nil {
 			glog.Warningf("Failed to create CSI API client: %v", err)


### PR DESCRIPTION
Test to see if CI catches errors when these are removed. If not, will just fold into https://github.com/kubernetes/kubernetes/pull/62175

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes handling of watch events for CRD clients

**Special notes for your reviewer**:
xref https://github.com/kubernetes/kubernetes/pull/62175
xref https://github.com/kubernetes/kubernetes/pull/67803#discussion_r225610529

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```