### PR TITLE
Set the default for EnableServiceLinks only in Pod

### DIFF
--- a/pkg/api/testing/pod_specs.go
+++ b/pkg/api/testing/pod_specs.go
@@ -24,26 +24,22 @@ import (
 // DeepEqualSafePodSpec returns a PodSpec which is ready to be used with apiequality.Semantic.DeepEqual
 func DeepEqualSafePodSpec() api.PodSpec {
 	grace := int64(30)
-	enableServiceLinks := v1.DefaultEnableServiceLinks
 	return api.PodSpec{
 		RestartPolicy:                 api.RestartPolicyAlways,
 		DNSPolicy:                     api.DNSClusterFirst,
 		TerminationGracePeriodSeconds: &grace,
 		SecurityContext:               &api.PodSecurityContext{},
 		SchedulerName:                 api.DefaultSchedulerName,
-		EnableServiceLinks:            &enableServiceLinks,
 	}
 }
 
 // V1DeepEqualSafePodSpec returns a PodSpec which is ready to be used with apiequality.Semantic.DeepEqual
 func V1DeepEqualSafePodSpec() v1.PodSpec {
 	grace := int64(30)
-	enableServiceLinks := v1.DefaultEnableServiceLinks
 	return v1.PodSpec{
 		RestartPolicy:                 v1.RestartPolicyAlways,
 		DNSPolicy:                     v1.DNSClusterFirst,
 		TerminationGracePeriodSeconds: &grace,
 		SecurityContext:               &v1.PodSecurityContext{},
-		EnableServiceLinks:            &enableServiceLinks,
 	}
 }

--- a/pkg/apis/apps/v1/defaults_test.go
+++ b/pkg/apis/apps/v1/defaults_test.go
@@ -39,7 +39,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 	defaultLabels := map[string]string{"foo": "bar"}
 	maxUnavailable := intstr.FromInt(1)
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
-	enableServiceLinks := v1.DefaultEnableServiceLinks
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
 			DNSPolicy:                     v1.DNSClusterFirst,
@@ -47,7 +46,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
 			SchedulerName:                 api.DefaultSchedulerName,
-			EnableServiceLinks:            &enableServiceLinks,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: defaultLabels,
@@ -60,7 +58,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
 			SchedulerName:                 api.DefaultSchedulerName,
-			EnableServiceLinks:            &enableServiceLinks,
 		},
 	}
 	tests := []struct {
@@ -178,7 +175,6 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 	var defaultReplicas int32 = 1
 
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
-	enableServiceLinks := v1.DefaultEnableServiceLinks
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
 			DNSPolicy:                     v1.DNSClusterFirst,
@@ -186,7 +182,6 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
 			SchedulerName:                 api.DefaultSchedulerName,
-			EnableServiceLinks:            &enableServiceLinks,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: defaultLabels,
@@ -291,7 +286,6 @@ func TestSetDefaultDeployment(t *testing.T) {
 	defaultIntOrString := intstr.FromString("25%")
 	differentIntOrString := intstr.FromInt(5)
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
-	enableServiceLinks := v1.DefaultEnableServiceLinks
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
 			DNSPolicy:                     v1.DNSClusterFirst,
@@ -299,7 +293,6 @@ func TestSetDefaultDeployment(t *testing.T) {
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
 			SchedulerName:                 api.DefaultSchedulerName,
-			EnableServiceLinks:            &enableServiceLinks,
 		},
 	}
 	tests := []struct {

--- a/pkg/apis/apps/v1beta1/defaults_test.go
+++ b/pkg/apis/apps/v1beta1/defaults_test.go
@@ -38,7 +38,6 @@ func TestSetDefaultDeployment(t *testing.T) {
 	defaultIntOrString := intstr.FromString("25%")
 	differentIntOrString := intstr.FromInt(5)
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
-	enableServiceLinks := v1.DefaultEnableServiceLinks
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
 			DNSPolicy:                     v1.DNSClusterFirst,
@@ -46,7 +45,6 @@ func TestSetDefaultDeployment(t *testing.T) {
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
 			SchedulerName:                 api.DefaultSchedulerName,
-			EnableServiceLinks:            &enableServiceLinks,
 		},
 	}
 	tests := []struct {

--- a/pkg/apis/apps/v1beta2/defaults_test.go
+++ b/pkg/apis/apps/v1beta2/defaults_test.go
@@ -39,7 +39,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 	defaultLabels := map[string]string{"foo": "bar"}
 	maxUnavailable := intstr.FromInt(1)
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
-	enableServiceLinks := v1.DefaultEnableServiceLinks
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
 			DNSPolicy:                     v1.DNSClusterFirst,
@@ -47,7 +46,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
 			SchedulerName:                 api.DefaultSchedulerName,
-			EnableServiceLinks:            &enableServiceLinks,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: defaultLabels,
@@ -60,7 +58,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
 			SchedulerName:                 api.DefaultSchedulerName,
-			EnableServiceLinks:            &enableServiceLinks,
 		},
 	}
 	tests := []struct {
@@ -178,7 +175,6 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 	var defaultReplicas int32 = 1
 
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
-	enableServiceLinks := v1.DefaultEnableServiceLinks
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
 			DNSPolicy:                     v1.DNSClusterFirst,
@@ -186,7 +182,6 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
 			SchedulerName:                 api.DefaultSchedulerName,
-			EnableServiceLinks:            &enableServiceLinks,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: defaultLabels,
@@ -291,7 +286,6 @@ func TestSetDefaultDeployment(t *testing.T) {
 	defaultIntOrString := intstr.FromString("25%")
 	differentIntOrString := intstr.FromInt(5)
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
-	enableServiceLinks := v1.DefaultEnableServiceLinks
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
 			DNSPolicy:                     v1.DNSClusterFirst,
@@ -299,7 +293,6 @@ func TestSetDefaultDeployment(t *testing.T) {
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
 			SchedulerName:                 api.DefaultSchedulerName,
-			EnableServiceLinks:            &enableServiceLinks,
 		},
 	}
 	tests := []struct {

--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -160,8 +160,16 @@ func SetDefaults_Pod(obj *v1.Pod) {
 			}
 		}
 	}
+	if obj.Spec.EnableServiceLinks == nil {
+		enableServiceLinks := v1.DefaultEnableServiceLinks
+		obj.Spec.EnableServiceLinks = &enableServiceLinks
+	}
 }
 func SetDefaults_PodSpec(obj *v1.PodSpec) {
+	// New fields added here will break upgrade tests:
+	// https://github.com/kubernetes/kubernetes/issues/69445
+	// In most cases the new defaulted field can added to SetDefaults_Pod instead of here, so
+	// that it only materializes in the Pod object and not all objects with a PodSpec field.
 	if obj.DNSPolicy == "" {
 		obj.DNSPolicy = v1.DNSClusterFirst
 	}
@@ -181,10 +189,6 @@ func SetDefaults_PodSpec(obj *v1.PodSpec) {
 	}
 	if obj.SchedulerName == "" {
 		obj.SchedulerName = v1.DefaultSchedulerName
-	}
-	if obj.EnableServiceLinks == nil {
-		enableServiceLinks := v1.DefaultEnableServiceLinks
-		obj.EnableServiceLinks = &enableServiceLinks
 	}
 }
 func SetDefaults_Probe(obj *v1.Probe) {

--- a/pkg/apis/extensions/v1beta1/defaults_test.go
+++ b/pkg/apis/extensions/v1beta1/defaults_test.go
@@ -40,7 +40,6 @@ import (
 func TestSetDefaultDaemonSetSpec(t *testing.T) {
 	defaultLabels := map[string]string{"foo": "bar"}
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
-	enableServiceLinks := v1.DefaultEnableServiceLinks
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
 			DNSPolicy:                     v1.DNSClusterFirst,
@@ -48,7 +47,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
 			SchedulerName:                 api.DefaultSchedulerName,
-			EnableServiceLinks:            &enableServiceLinks,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: defaultLabels,
@@ -61,7 +59,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
 			SchedulerName:                 api.DefaultSchedulerName,
-			EnableServiceLinks:            &enableServiceLinks,
 		},
 	}
 	tests := []struct {
@@ -167,7 +164,6 @@ func TestSetDefaultDeployment(t *testing.T) {
 	defaultIntOrString := intstr.FromInt(1)
 	differentIntOrString := intstr.FromInt(5)
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
-	enableServiceLinks := v1.DefaultEnableServiceLinks
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
 			DNSPolicy:                     v1.DNSClusterFirst,
@@ -175,7 +171,6 @@ func TestSetDefaultDeployment(t *testing.T) {
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
 			SchedulerName:                 api.DefaultSchedulerName,
-			EnableServiceLinks:            &enableServiceLinks,
 		},
 	}
 	tests := []struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Change how we default the PodSpec.EnableServiceLinks variable. To avoid having the default value materialize in higher level object (DaemonSet, Deployment) and have controllers react to that as an object change only default this value in the actual Pod object.

**Which issue(s) this PR fixes**
Fixes #69445

**Special notes for your reviewer**:
Also related: #69356, #67903

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
