### PR TITLE
Add log2file base image

### DIFF
--- a/cluster/BUILD
+++ b/cluster/BUILD
@@ -20,6 +20,7 @@ filegroup(
         "//cluster/images/etcd/migrate:all-srcs",
         "//cluster/images/hyperkube:all-srcs",
         "//cluster/images/kubemark:all-srcs",
+        "//cluster/images/log2file:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/cluster/images/log2file/BUILD
+++ b/cluster/images/log2file/BUILD
@@ -1,0 +1,43 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+container_image(
+    name = "log2file-internal",
+    cmd = ["/log2file"],
+    files = [
+        ":log2file",
+    ],
+    stamp = True,
+)
+
+container_bundle(
+    name = "log2file",
+    images = {"staging-k8s.gcr.io/log2file-amd64:{STABLE_DOCKER_TAG}": "log2file-internal"},
+    stamp = True,
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["log2file.go"],
+    importpath = "k8s.io/kubernetes/cluster/images/log2file",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "log2file",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cluster/images/log2file/Dockerfile
+++ b/cluster/images/log2file/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG ARCH=amd64
+FROM k8s.gcr.io/kube-cross:v1.11.1-2 as build
+
+COPY log2file.go .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags="-s -w" log2file.go
+
+FROM scratch
+
+COPY --from=build /go/log2file /log2file
+
+ENTRYPOINT ["/log2file"]

--- a/cluster/images/log2file/Makefile
+++ b/cluster/images/log2file/Makefile
@@ -1,0 +1,48 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# build Kubemark image from currently built binaries containing both 'real' master and Hollow Node.
+# This makefile assumes that the kubemark binary is present in this directory.
+
+# Allow the caller to override this.  Beware make's precedence. This:
+#   REGISTRY=$VAR make
+# .. is not the same as:
+#   make REGISTRY=$VAR
+REGISTRY ?= staging-k8s.gcr.io
+IMAGE = $(REGISTRY)/log2file
+TAG ?= latest
+ARCH ?= amd64
+ALL_ARCH = amd64 arm arm64 ppc64le s390x
+
+# This option is for running docker manifest command
+export DOCKER_CLI_EXPERIMENTAL := enabled
+
+build:
+	docker build --build-arg ARCH=$(ARCH) -t $(IMAGE)-$(ARCH):$(TAG) .
+
+push:
+	docker push $(IMAGE)-$(ARCH):$(TAG)
+
+sub-build-%:
+	$(MAKE) ARCH=$* build
+
+all-build: $(addprefix sub-build-,$(ALL_ARCH))
+
+sub-push-image-%:
+	$(MAKE) ARCH=$* push
+
+push-manifest: $(addprefix sub-push-image-,$(ALL_ARCH))
+	docker manifest create --amend $(IMAGE):$(TAG) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(TAG)~g")
+	@for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${IMAGE}:${TAG} ${IMAGE}-$${arch}:${TAG}; done
+	docker manifest push ${IMAGE}:${TAG}

--- a/cluster/images/log2file/README.md
+++ b/cluster/images/log2file/README.md
@@ -1,0 +1,55 @@
+# log2file
+
+## Usage
+
+Log to file executes the given command, and appends its stdout & stderr to the
+specified file.
+
+```
+Usage: ./log2file [options] -- [command] [args...]
+  -out string
+    	The file to redirect stdout & stderr to (append).
+```
+
+### Example
+
+The previous pattern of using shell redirection to log kube-apiserver output:
+
+```
+/bin/sh -c "exec /usr/local/bin/kube-apiserver {{params}} --allow-privileged={{pillar['allow_privileged']}} 1>>/var/log/kube-apiserver.log 2>&1"
+```
+
+Becomes:
+
+```
+log2file --out=/var/log/kube-apiserver.log -- /usr/local/bin/kube-apiserver {{params}} --allow-privileged={{pillar['allow_privileged']}}
+```
+
+## But why?
+
+Kubernetes makes extensive usage of the glog logging library, which ([amoung
+other problems][glog-issue]) cannot send the log output to a specific file.
+
+To work around this, kubernetes containers would run a shell wrapper around the
+binary, and use redirection to send the output to a log file. Problems with this
+approach include:
+
+1. Including a functional shell (& helper binaries) increases the tools
+   available to attackers, making certain types of exploits much easier.
+2. Vulnerabilities in the included dependencies must be managaged, creating toil
+   for Kubernetes devs.
+
+`log2file` replaces the fully functional shell with a minimal binary that does
+exactly 1 thing: run a command, and redirect it's output (both stdout & stderr)
+to a file (append mode).
+
+### OK, but why not just fix glog?
+
+Great question! We [want to move to a different log library][glog-issue], but
+such changes take a long time in Kubernetes. This utility is a short-term
+solution to the immediate problems causing toil for us.
+
+Once our chosen log library supports specifying an output file directly, this
+utility should be deleted, and images using it should be rebased on scratch.
+
+[glog-issue]: https://github.com/kubernetes/kubernetes/issues/61006

--- a/cluster/images/log2file/log2file.go
+++ b/cluster/images/log2file/log2file.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+var (
+	dst     = flag.String("out", "", "The file to redirect stdout & stderr to (append).")
+	command = flag.String("cmd", "", "The command string to run, with args split on spaces."+
+		" Either cmd or positional args must be specified, but not both.")
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] -- <command> [args...]\n", os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "       %s [options] --cmd=\"[command] [args...]\"\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if *dst == "" {
+		flag.Usage()
+		log.Fatal("--out is required")
+	}
+
+	var args []string
+	if *command != "" {
+		if len(flag.Args()) > 0 {
+			flag.Usage()
+			log.Fatal("Cannot specify both --cmd and positional arguments.")
+		}
+		args = strings.Fields(*command)
+	} else {
+		args = flag.Args()
+	}
+
+	if len(args) == 0 {
+		flag.Usage()
+		log.Fatal("No command to execute")
+	}
+
+	dstFile, err := os.OpenFile(*dst, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatalf("Failed to open %s for writing: %v", *dst, err)
+	}
+	defer dstFile.Close()
+
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = dstFile
+	cmd.Stderr = dstFile
+
+	if err := cmd.Start(); err != nil {
+		log.Fatalf("Failed to start command %s: %v", strings.Join(args, " "), err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+				os.Exit(status.ExitStatus())
+			}
+		} else {
+			log.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

To quote the readme:

> Kubernetes makes extensive usage of the glog logging library, which ([amoung
> other problems][glog-issue]) cannot send the log output to a specific file.
> 
> To work around this, kubernetes containers would run a shell wrapper around the
> binary, and use redirection to send the output to a log file. Problems with this
> approach include:
> 
> 1. Including a functional shell (& helper binaries) increases the tools
>    available to attackers, making certain types of exploits much easier.
> 2. Vulnerabilities in the included dependencies must be managaged, creating toil
>    for Kubernetes devs.
> 
> `log2file` replaces the fully functional shell with a minimal binary that does
> exactly 1 thing: run a command, and redirect it's output (both stdout & stderr)
> to a file (append mode).
> 
> **OK, but why not just fix glog?**
> 
> Great question! We [want to move to a different log library][glog-issue], but
> such changes take a long time in Kubernetes. This utility is a short-term
> solution to the immediate problems causing toil for us.
> 
> Once our chosen log library supports specifying an output file directly, this
> utility should be deleted, and images using it should be rebased on scratch.

[glog-issue]: https://github.com/kubernetes/kubernetes/issues/61006


**Which issue(s) this PR fixes**:
Related: https://github.com/kubernetes/kubernetes/issues/40248, https://github.com/kubernetes/kubernetes/issues/38541, https://github.com/kubernetes/kubernetes/issues/61006

**Special notes for your reviewer**:

- I'm not particularly fond of the `log2file` name. LMK if you have other suggestions.
- Should this live under `build/` instead of `cluster/images/`?
- I have a strong preference for the positional-args command format (e.g. `log2file -out=foo -- command arg1 arg2`), but because of the way `{{params}}` are injected into the system manifests, I added the alternative `--cmd` option. See https://github.com/tallclair/kubernetes/commit/dab5f07ba1992212c25b429cbf2a8994a89c5d94 for an example integration.

Tested by bringing up a test cluster & varifying log files were populated (using https://github.com/tallclair/kubernetes/commit/dab5f07ba1992212c25b429cbf2a8994a89c5d94).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cluster-lifecycle
/area logging
/assign @ixdy 
/cc @dims 