### PR TITLE
fix azure disk attachment error on Linux

### DIFF
--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -152,8 +152,6 @@ func (a *azureDiskAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName ty
 }
 
 func (a *azureDiskAttacher) WaitForAttach(spec *volume.Spec, devicePath string, _ *v1.Pod, timeout time.Duration) (string, error) {
-	var err error
-
 	volumeSource, _, err := getVolumeSource(spec)
 	if err != nil {
 		return "", err
@@ -167,13 +165,22 @@ func (a *azureDiskAttacher) WaitForAttach(spec *volume.Spec, devicePath string, 
 	nodeName := types.NodeName(a.plugin.host.GetHostName())
 	diskName := volumeSource.DiskName
 
-	glog.V(2).Infof("azureDisk - WaitForAttach: begin to GetDiskLun by diskName(%s), DataDiskURI(%s), nodeName(%s), devicePath(%s)",
-		diskName, volumeSource.DataDiskURI, nodeName, devicePath)
-	lun, err := diskController.GetDiskLun(diskName, volumeSource.DataDiskURI, nodeName)
-	if err != nil {
-		return "", err
+	var lun int32
+	if runtime.GOOS == "windows" {
+		glog.V(2).Infof("azureDisk - WaitForAttach: begin to GetDiskLun by diskName(%s), DataDiskURI(%s), nodeName(%s), devicePath(%s)",
+			diskName, volumeSource.DataDiskURI, nodeName, devicePath)
+		lun, err = diskController.GetDiskLun(diskName, volumeSource.DataDiskURI, nodeName)
+		if err != nil {
+			return "", err
+		}
+		glog.V(2).Infof("azureDisk - WaitForAttach: GetDiskLun succeeded, got lun(%v)", lun)
+	} else {
+		lun, err = getDiskLUN(devicePath)
+		if err != nil {
+			return "", err
+		}
 	}
-	glog.V(2).Infof("azureDisk - WaitForAttach: GetDiskLun succeeded, got lun(%v)", lun)
+
 	exec := a.plugin.host.GetExec(a.plugin.GetPluginName())
 
 	io := &osIOHandler{}

--- a/pkg/volume/azure_dd/azure_common.go
+++ b/pkg/volume/azure_dd/azure_common.go
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	libstrings "strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-07-01/storage"
@@ -59,6 +61,8 @@ var (
 		string(api.AzureSharedBlobDisk),
 		string(api.AzureDedicatedBlobDisk),
 		string(api.AzureManagedDisk))
+
+	lunPathRE = regexp.MustCompile(`/dev/disk/azure/scsi(?:.*)/lun(.+)`)
 )
 
 func getPath(uid types.UID, volName string, host volume.VolumeHost) string {
@@ -200,4 +204,26 @@ func strFirstLetterToUpper(str string) string {
 		return str
 	}
 	return libstrings.ToUpper(string(str[0])) + str[1:]
+}
+
+// getDiskLUN : deviceInfo could be a LUN number or a device path, e.g. /dev/disk/azure/scsi1/lun2
+func getDiskLUN(deviceInfo string) (int32, error) {
+	var diskLUN string
+	if len(deviceInfo) <= 2 {
+		diskLUN = deviceInfo
+	} else {
+		// extract the LUN num from a device path
+		matches := lunPathRE.FindStringSubmatch(deviceInfo)
+		if len(matches) == 2 {
+			diskLUN = matches[1]
+		} else {
+			return -1, fmt.Errorf("cannot parse deviceInfo: %s", deviceInfo)
+		}
+	}
+
+	lun, err := strconv.Atoi(diskLUN)
+	if err != nil {
+		return -1, err
+	}
+	return int32(lun), nil
 }

--- a/pkg/volume/azure_dd/azure_common_test.go
+++ b/pkg/volume/azure_dd/azure_common_test.go
@@ -187,3 +187,58 @@ func TestNormalizeStorageAccountType(t *testing.T) {
 		assert.Equal(t, err != nil, test.expectError, fmt.Sprintf("error msg: %v", err))
 	}
 }
+
+func TestGetDiskLUN(t *testing.T) {
+	tests := []struct {
+		deviceInfo  string
+		expectedLUN int32
+		expectError bool
+	}{
+		{
+			deviceInfo:  "0",
+			expectedLUN: 0,
+			expectError: false,
+		},
+		{
+			deviceInfo:  "10",
+			expectedLUN: 10,
+			expectError: false,
+		},
+		{
+			deviceInfo:  "11d",
+			expectedLUN: -1,
+			expectError: true,
+		},
+		{
+			deviceInfo:  "999",
+			expectedLUN: -1,
+			expectError: true,
+		},
+		{
+			deviceInfo:  "",
+			expectedLUN: -1,
+			expectError: true,
+		},
+		{
+			deviceInfo:  "/dev/disk/azure/scsi1/lun2",
+			expectedLUN: 2,
+			expectError: false,
+		},
+		{
+			deviceInfo:  "/dev/disk/azure/scsi0/lun12",
+			expectedLUN: 12,
+			expectError: false,
+		},
+		{
+			deviceInfo:  "/dev/disk/by-id/scsi1/lun2",
+			expectedLUN: -1,
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		result, err := getDiskLUN(test.deviceInfo)
+		assert.Equal(t, result, test.expectedLUN)
+		assert.Equal(t, err != nil, test.expectError, fmt.Sprintf("error msg: %v", err))
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
There PR is going to fix drawback after PR: https://github.com/kubernetes/kubernetes/pull/62612
following `getDiskController` code will fetch vmCache may lead to below error and the vmCache refresh time period would be 1 min, and `MountVolume.WaitForAttach` may cost 1 min which is too long time
https://github.com/kubernetes/kubernetes/blob/ba66014fec87274322fc08190ec405cfb704a7d5/pkg/volume/azure_dd/attacher.go#L162

```
MountVolume.WaitForAttach failed for volume "pvc-12b458f4-c23f-11e8-8d27-46799c22b7c6" : Cannot find Lun for disk kubernetes-dynamic-pvc-12b458f4-c23f-11e8-8d27-46799c22b7c6
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69262

**Special notes for your reviewer**:
This PR add a new func `getDiskLUN` to get disk LUN num from a deviceInfo, deviceInfo could be a LUN number or a device path, e.g. /dev/disk/azure/scsi1/lun2.
While on Windows, since the deviceInfo could be a LUN num or a disk num(on windows), cannot tell whether it's a LUN num since both conditions are a number, we just keep the original code logic.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```
NONE
```

**Release note**:
```
fix azure disk attachment error on Linux
```
/sig azure
/assign @feiskyer @khenidak 
cc @brendandburns 