### PR TITLE
Do not allow cpu and memory limits to set 0 when max limitrange was defined

### DIFF
--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -341,6 +341,9 @@ func maxConstraint(limitType string, resourceName string, enforced resource.Quan
 	if !limExists {
 		return fmt.Errorf("maximum %s usage per %s is %s.  No limit is specified.", resourceName, limitType, enforced.String())
 	}
+	if observedLimValue == 0 {
+		return fmt.Errorf("maximum %s usage per %s is %s, but limit is 0 (unbounded).", resourceName, limitType, enforced.String())
+	}
 	if observedLimValue > enforcedValue {
 		return fmt.Errorf("maximum %s usage per %s is %s, but limit is %s.", resourceName, limitType, enforced.String(), lim.String())
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

As a cluster admin, when we set max cpu/memory by limitrange, we
expect pods/containers have the limit. However, pods/containers can
use all host resources by setting `0` for limits, because when
pod/container has limits `0` for cpu/memory, it means unlimited.

This patch introduces a validation not to allow 0 for cpu/memory when
max values were set in limitrange.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # https://github.com/kubernetes/kubernetes/issues/70017

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
Do not allow cpu and memory limits to set 0 when max limitrange was defined 
```
