### PR TITLE
nodeController should send events to api server and print to the logging

### DIFF
--- a/pkg/controller/nodelifecycle/BUILD
+++ b/pkg/controller/nodelifecycle/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//staging/src/k8s.io/client-go/informers/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/listers/coordination/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/listers/extensions/v1beta1:go_default_library",


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>

 /kind bug
/sig node

**What this PR does / why we need it**:
After node is notReady, nodeController will evict pods and delete all pods on that node ,but nodeController does not print  pod deletion events to the logging  and send events to api server.
after this pr, nodeController sends events to api server, and using " kubectl get events"look like 

[root@node-29:/paasdata/op-log/k8s]$ kubectl get events --all-namespaces |grep pod-22-pod-0-1-wh4ml
k8s-test    3m          3m           1         test-2-pod-0-1-wf9mv.155eaee00f864418   Pod                                              Normal    NodeControllerEviction    node-controller           Marking for deleion Pod test-2-pod-0-1-wf9mv from Node 10.200.138.226

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
