### PR TITLE
Fixed lint errors for pkg/cloudprovider/providers/gce.

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -88,7 +88,6 @@ pkg/apis/storage/v1beta1/util
 pkg/auth/authorizer/abac
 pkg/capabilities
 pkg/cloudprovider/providers/fake
-pkg/cloudprovider/providers/gce
 pkg/cloudprovider/providers/gce/cloud
 pkg/cloudprovider/providers/ovirt
 pkg/cloudprovider/providers/photon

--- a/pkg/cloudprovider/providers/gce/gce_addresses.go
+++ b/pkg/cloudprovider/providers/gce/gce_addresses.go
@@ -42,106 +42,106 @@ func newAddressMetricContextWithVersion(request, region, version string) *metric
 // Caller is allocated a random IP if they do not specify an ipAddress. If an
 // ipAddress is specified, it must belong to the current project, eg: an
 // ephemeral IP associated with a global forwarding rule.
-func (gce *GCECloud) ReserveGlobalAddress(addr *compute.Address) error {
+func (g *Cloud) ReserveGlobalAddress(addr *compute.Address) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newAddressMetricContext("reserve", "")
-	return mc.Observe(gce.c.GlobalAddresses().Insert(ctx, meta.GlobalKey(addr.Name), addr))
+	return mc.Observe(g.c.GlobalAddresses().Insert(ctx, meta.GlobalKey(addr.Name), addr))
 }
 
 // DeleteGlobalAddress deletes a global address by name.
-func (gce *GCECloud) DeleteGlobalAddress(name string) error {
+func (g *Cloud) DeleteGlobalAddress(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newAddressMetricContext("delete", "")
-	return mc.Observe(gce.c.GlobalAddresses().Delete(ctx, meta.GlobalKey(name)))
+	return mc.Observe(g.c.GlobalAddresses().Delete(ctx, meta.GlobalKey(name)))
 }
 
 // GetGlobalAddress returns the global address by name.
-func (gce *GCECloud) GetGlobalAddress(name string) (*compute.Address, error) {
+func (g *Cloud) GetGlobalAddress(name string) (*compute.Address, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newAddressMetricContext("get", "")
-	v, err := gce.c.GlobalAddresses().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.GlobalAddresses().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
 // ReserveRegionAddress creates a region address
-func (gce *GCECloud) ReserveRegionAddress(addr *compute.Address, region string) error {
+func (g *Cloud) ReserveRegionAddress(addr *compute.Address, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newAddressMetricContext("reserve", region)
-	return mc.Observe(gce.c.Addresses().Insert(ctx, meta.RegionalKey(addr.Name, region), addr))
+	return mc.Observe(g.c.Addresses().Insert(ctx, meta.RegionalKey(addr.Name, region), addr))
 }
 
 // ReserveAlphaRegionAddress creates an Alpha, regional address.
-func (gce *GCECloud) ReserveAlphaRegionAddress(addr *computealpha.Address, region string) error {
+func (g *Cloud) ReserveAlphaRegionAddress(addr *computealpha.Address, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newAddressMetricContext("reserve", region)
-	return mc.Observe(gce.c.AlphaAddresses().Insert(ctx, meta.RegionalKey(addr.Name, region), addr))
+	return mc.Observe(g.c.AlphaAddresses().Insert(ctx, meta.RegionalKey(addr.Name, region), addr))
 }
 
 // ReserveBetaRegionAddress creates a beta region address
-func (gce *GCECloud) ReserveBetaRegionAddress(addr *computebeta.Address, region string) error {
+func (g *Cloud) ReserveBetaRegionAddress(addr *computebeta.Address, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newAddressMetricContext("reserve", region)
-	return mc.Observe(gce.c.BetaAddresses().Insert(ctx, meta.RegionalKey(addr.Name, region), addr))
+	return mc.Observe(g.c.BetaAddresses().Insert(ctx, meta.RegionalKey(addr.Name, region), addr))
 }
 
 // DeleteRegionAddress deletes a region address by name.
-func (gce *GCECloud) DeleteRegionAddress(name, region string) error {
+func (g *Cloud) DeleteRegionAddress(name, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newAddressMetricContext("delete", region)
-	return mc.Observe(gce.c.Addresses().Delete(ctx, meta.RegionalKey(name, region)))
+	return mc.Observe(g.c.Addresses().Delete(ctx, meta.RegionalKey(name, region)))
 }
 
 // GetRegionAddress returns the region address by name
-func (gce *GCECloud) GetRegionAddress(name, region string) (*compute.Address, error) {
+func (g *Cloud) GetRegionAddress(name, region string) (*compute.Address, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newAddressMetricContext("get", region)
-	v, err := gce.c.Addresses().Get(ctx, meta.RegionalKey(name, region))
+	v, err := g.c.Addresses().Get(ctx, meta.RegionalKey(name, region))
 	return v, mc.Observe(err)
 }
 
 // GetAlphaRegionAddress returns the Alpha, regional address by name.
-func (gce *GCECloud) GetAlphaRegionAddress(name, region string) (*computealpha.Address, error) {
+func (g *Cloud) GetAlphaRegionAddress(name, region string) (*computealpha.Address, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newAddressMetricContext("get", region)
-	v, err := gce.c.AlphaAddresses().Get(ctx, meta.RegionalKey(name, region))
+	v, err := g.c.AlphaAddresses().Get(ctx, meta.RegionalKey(name, region))
 	return v, mc.Observe(err)
 }
 
 // GetBetaRegionAddress returns the beta region address by name
-func (gce *GCECloud) GetBetaRegionAddress(name, region string) (*computebeta.Address, error) {
+func (g *Cloud) GetBetaRegionAddress(name, region string) (*computebeta.Address, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newAddressMetricContext("get", region)
-	v, err := gce.c.BetaAddresses().Get(ctx, meta.RegionalKey(name, region))
+	v, err := g.c.BetaAddresses().Get(ctx, meta.RegionalKey(name, region))
 	return v, mc.Observe(err)
 }
 
 // GetRegionAddressByIP returns the regional address matching the given IP address.
-func (gce *GCECloud) GetRegionAddressByIP(region, ipAddress string) (*compute.Address, error) {
+func (g *Cloud) GetRegionAddressByIP(region, ipAddress string) (*compute.Address, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newAddressMetricContext("list", region)
-	addrs, err := gce.c.Addresses().List(ctx, region, filter.Regexp("address", ipAddress))
+	addrs, err := g.c.Addresses().List(ctx, region, filter.Regexp("address", ipAddress))
 
 	mc.Observe(err)
 	if err != nil {
@@ -160,12 +160,12 @@ func (gce *GCECloud) GetRegionAddressByIP(region, ipAddress string) (*compute.Ad
 }
 
 // GetBetaRegionAddressByIP returns the beta regional address matching the given IP address.
-func (gce *GCECloud) GetBetaRegionAddressByIP(region, ipAddress string) (*computebeta.Address, error) {
+func (g *Cloud) GetBetaRegionAddressByIP(region, ipAddress string) (*computebeta.Address, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newAddressMetricContext("list", region)
-	addrs, err := gce.c.BetaAddresses().List(ctx, region, filter.Regexp("address", ipAddress))
+	addrs, err := g.c.BetaAddresses().List(ctx, region, filter.Regexp("address", ipAddress))
 
 	mc.Observe(err)
 	if err != nil {
@@ -184,11 +184,11 @@ func (gce *GCECloud) GetBetaRegionAddressByIP(region, ipAddress string) (*comput
 }
 
 // TODO(#51665): retire this function once Network Tiers becomes Beta in GCP.
-func (gce *GCECloud) getNetworkTierFromAddress(name, region string) (string, error) {
-	if !gce.AlphaFeatureGate.Enabled(AlphaFeatureNetworkTiers) {
+func (g *Cloud) getNetworkTierFromAddress(name, region string) (string, error) {
+	if !g.AlphaFeatureGate.Enabled(AlphaFeatureNetworkTiers) {
 		return cloud.NetworkTierDefault.ToGCEValue(), nil
 	}
-	addr, err := gce.GetAlphaRegionAddress(name, region)
+	addr, err := g.GetAlphaRegionAddress(name, region)
 	if err != nil {
 		return handleAlphaNetworkTierGetError(err)
 	}

--- a/pkg/cloudprovider/providers/gce/gce_alpha.go
+++ b/pkg/cloudprovider/providers/gce/gce_alpha.go
@@ -21,21 +21,24 @@ import (
 )
 
 const (
-	// alpha: v1.8 (for Services)
+	// AlphaFeatureNetworkTiers allows Services backed by a GCP load balancer to choose
+	// what network tier to use. Currently supports "Standard" and "Premium" (default).
 	//
-	// Allows Services backed by a GCP load balancer to choose what network
-	// tier to use. Currently supports "Standard" and "Premium" (default).
+	// alpha: v1.8 (for Services)
 	AlphaFeatureNetworkTiers = "NetworkTiers"
 )
 
+// AlphaFeatureGate contains a mapping of alpha features to whether they are enabled
 type AlphaFeatureGate struct {
 	features map[string]bool
 }
 
+// Enabled returns true if the provided alpha feature is enabled
 func (af *AlphaFeatureGate) Enabled(key string) bool {
 	return af.features[key]
 }
 
+// NewAlphaFeatureGate marks the provided alpha features as enabled
 func NewAlphaFeatureGate(features []string) *AlphaFeatureGate {
 	featureMap := make(map[string]bool)
 	for _, name := range features {
@@ -44,9 +47,9 @@ func NewAlphaFeatureGate(features []string) *AlphaFeatureGate {
 	return &AlphaFeatureGate{featureMap}
 }
 
-func (gce *GCECloud) alphaFeatureEnabled(feature string) error {
-	if !gce.AlphaFeatureGate.Enabled(feature) {
-		return fmt.Errorf("alpha feature %q is not enabled.", feature)
+func (g *Cloud) alphaFeatureEnabled(feature string) error {
+	if !g.AlphaFeatureGate.Enabled(feature) {
+		return fmt.Errorf("alpha feature %q is not enabled", feature)
 	}
 	return nil
 }

--- a/pkg/cloudprovider/providers/gce/gce_annotations.go
+++ b/pkg/cloudprovider/providers/gce/gce_annotations.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
 )
 
+// LoadBalancerType defines a specific type for holding load balancer types (eg. Internal)
 type LoadBalancerType string
 
 const (
@@ -33,23 +34,30 @@ const (
 	// Currently, only "internal" is supported.
 	ServiceAnnotationLoadBalancerType = "cloud.google.com/load-balancer-type"
 
+	// LBTypeInternal is the constant for the official internal type.
 	LBTypeInternal LoadBalancerType = "Internal"
+
 	// Deprecating the lowercase spelling of Internal.
 	deprecatedTypeInternalLowerCase LoadBalancerType = "internal"
 
-	// ServiceAnnotationInternalBackendShare is annotated on a service with "true" when users
+	// ServiceAnnotationILBBackendShare is annotated on a service with "true" when users
 	// want to share GCP Backend Services for a set of internal load balancers.
 	// ALPHA feature - this may be removed in a future release.
 	ServiceAnnotationILBBackendShare = "alpha.cloud.google.com/load-balancer-backend-share"
+
 	// This annotation did not correctly specify "alpha", so both annotations will be checked.
 	deprecatedServiceAnnotationILBBackendShare = "cloud.google.com/load-balancer-backend-share"
 
 	// NetworkTierAnnotationKey is annotated on a Service object to indicate which
 	// network tier a GCP LB should use. The valid values are "Standard" and
 	// "Premium" (default).
-	NetworkTierAnnotationKey      = "cloud.google.com/network-tier"
+	NetworkTierAnnotationKey = "cloud.google.com/network-tier"
+
+	// NetworkTierAnnotationStandard is an annotation to indicate the Service is on the Standard network tier
 	NetworkTierAnnotationStandard = cloud.NetworkTierStandard
-	NetworkTierAnnotationPremium  = cloud.NetworkTierPremium
+
+	// NetworkTierAnnotationPremium is an annotation to indicate the Service is on the Premium network tier
+	NetworkTierAnnotationPremium = cloud.NetworkTierPremium
 )
 
 // GetLoadBalancerAnnotationType returns the type of GCP load balancer which should be assembled.

--- a/pkg/cloudprovider/providers/gce/gce_backendservice.go
+++ b/pkg/cloudprovider/providers/gce/gce_backendservice.go
@@ -35,201 +35,201 @@ func newBackendServiceMetricContextWithVersion(request, region, version string) 
 }
 
 // GetGlobalBackendService retrieves a backend by name.
-func (gce *GCECloud) GetGlobalBackendService(name string) (*compute.BackendService, error) {
+func (g *Cloud) GetGlobalBackendService(name string) (*compute.BackendService, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContext("get", "")
-	v, err := gce.c.BackendServices().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.BackendServices().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
 // GetBetaGlobalBackendService retrieves beta backend by name.
-func (gce *GCECloud) GetBetaGlobalBackendService(name string) (*computebeta.BackendService, error) {
+func (g *Cloud) GetBetaGlobalBackendService(name string) (*computebeta.BackendService, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContextWithVersion("get", "", computeBetaVersion)
-	v, err := gce.c.BetaBackendServices().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.BetaBackendServices().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
 // GetAlphaGlobalBackendService retrieves alpha backend by name.
-func (gce *GCECloud) GetAlphaGlobalBackendService(name string) (*computealpha.BackendService, error) {
+func (g *Cloud) GetAlphaGlobalBackendService(name string) (*computealpha.BackendService, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContextWithVersion("get", "", computeAlphaVersion)
-	v, err := gce.c.AlphaBackendServices().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.AlphaBackendServices().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
 // UpdateGlobalBackendService applies the given BackendService as an update to
 // an existing service.
-func (gce *GCECloud) UpdateGlobalBackendService(bg *compute.BackendService) error {
+func (g *Cloud) UpdateGlobalBackendService(bg *compute.BackendService) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContext("update", "")
-	return mc.Observe(gce.c.BackendServices().Update(ctx, meta.GlobalKey(bg.Name), bg))
+	return mc.Observe(g.c.BackendServices().Update(ctx, meta.GlobalKey(bg.Name), bg))
 }
 
 // UpdateBetaGlobalBackendService applies the given beta BackendService as an
 // update to an existing service.
-func (gce *GCECloud) UpdateBetaGlobalBackendService(bg *computebeta.BackendService) error {
+func (g *Cloud) UpdateBetaGlobalBackendService(bg *computebeta.BackendService) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContextWithVersion("update", "", computeBetaVersion)
-	return mc.Observe(gce.c.BetaBackendServices().Update(ctx, meta.GlobalKey(bg.Name), bg))
+	return mc.Observe(g.c.BetaBackendServices().Update(ctx, meta.GlobalKey(bg.Name), bg))
 }
 
 // UpdateAlphaGlobalBackendService applies the given alpha BackendService as an
 // update to an existing service.
-func (gce *GCECloud) UpdateAlphaGlobalBackendService(bg *computealpha.BackendService) error {
+func (g *Cloud) UpdateAlphaGlobalBackendService(bg *computealpha.BackendService) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContextWithVersion("update", "", computeAlphaVersion)
-	return mc.Observe(gce.c.AlphaBackendServices().Update(ctx, meta.GlobalKey(bg.Name), bg))
+	return mc.Observe(g.c.AlphaBackendServices().Update(ctx, meta.GlobalKey(bg.Name), bg))
 }
 
 // DeleteGlobalBackendService deletes the given BackendService by name.
-func (gce *GCECloud) DeleteGlobalBackendService(name string) error {
+func (g *Cloud) DeleteGlobalBackendService(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContext("delete", "")
-	return mc.Observe(gce.c.BackendServices().Delete(ctx, meta.GlobalKey(name)))
+	return mc.Observe(g.c.BackendServices().Delete(ctx, meta.GlobalKey(name)))
 }
 
 // CreateGlobalBackendService creates the given BackendService.
-func (gce *GCECloud) CreateGlobalBackendService(bg *compute.BackendService) error {
+func (g *Cloud) CreateGlobalBackendService(bg *compute.BackendService) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContext("create", "")
-	return mc.Observe(gce.c.BackendServices().Insert(ctx, meta.GlobalKey(bg.Name), bg))
+	return mc.Observe(g.c.BackendServices().Insert(ctx, meta.GlobalKey(bg.Name), bg))
 }
 
 // CreateBetaGlobalBackendService creates the given beta BackendService.
-func (gce *GCECloud) CreateBetaGlobalBackendService(bg *computebeta.BackendService) error {
+func (g *Cloud) CreateBetaGlobalBackendService(bg *computebeta.BackendService) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContextWithVersion("create", "", computeBetaVersion)
-	return mc.Observe(gce.c.BetaBackendServices().Insert(ctx, meta.GlobalKey(bg.Name), bg))
+	return mc.Observe(g.c.BetaBackendServices().Insert(ctx, meta.GlobalKey(bg.Name), bg))
 }
 
 // CreateAlphaGlobalBackendService creates the given alpha BackendService.
-func (gce *GCECloud) CreateAlphaGlobalBackendService(bg *computealpha.BackendService) error {
+func (g *Cloud) CreateAlphaGlobalBackendService(bg *computealpha.BackendService) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContextWithVersion("create", "", computeAlphaVersion)
-	return mc.Observe(gce.c.AlphaBackendServices().Insert(ctx, meta.GlobalKey(bg.Name), bg))
+	return mc.Observe(g.c.AlphaBackendServices().Insert(ctx, meta.GlobalKey(bg.Name), bg))
 }
 
 // ListGlobalBackendServices lists all backend services in the project.
-func (gce *GCECloud) ListGlobalBackendServices() ([]*compute.BackendService, error) {
+func (g *Cloud) ListGlobalBackendServices() ([]*compute.BackendService, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContext("list", "")
-	v, err := gce.c.BackendServices().List(ctx, filter.None)
+	v, err := g.c.BackendServices().List(ctx, filter.None)
 	return v, mc.Observe(err)
 }
 
 // GetGlobalBackendServiceHealth returns the health of the BackendService
 // identified by the given name, in the given instanceGroup. The
 // instanceGroupLink is the fully qualified self link of an instance group.
-func (gce *GCECloud) GetGlobalBackendServiceHealth(name string, instanceGroupLink string) (*compute.BackendServiceGroupHealth, error) {
+func (g *Cloud) GetGlobalBackendServiceHealth(name string, instanceGroupLink string) (*compute.BackendServiceGroupHealth, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContext("get_health", "")
 	groupRef := &compute.ResourceGroupReference{Group: instanceGroupLink}
-	v, err := gce.c.BackendServices().GetHealth(ctx, meta.GlobalKey(name), groupRef)
+	v, err := g.c.BackendServices().GetHealth(ctx, meta.GlobalKey(name), groupRef)
 	return v, mc.Observe(err)
 }
 
 // GetRegionBackendService retrieves a backend by name.
-func (gce *GCECloud) GetRegionBackendService(name, region string) (*compute.BackendService, error) {
+func (g *Cloud) GetRegionBackendService(name, region string) (*compute.BackendService, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContext("get", region)
-	v, err := gce.c.RegionBackendServices().Get(ctx, meta.RegionalKey(name, region))
+	v, err := g.c.RegionBackendServices().Get(ctx, meta.RegionalKey(name, region))
 	return v, mc.Observe(err)
 }
 
 // UpdateRegionBackendService applies the given BackendService as an update to
 // an existing service.
-func (gce *GCECloud) UpdateRegionBackendService(bg *compute.BackendService, region string) error {
+func (g *Cloud) UpdateRegionBackendService(bg *compute.BackendService, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContext("update", region)
-	return mc.Observe(gce.c.RegionBackendServices().Update(ctx, meta.RegionalKey(bg.Name, region), bg))
+	return mc.Observe(g.c.RegionBackendServices().Update(ctx, meta.RegionalKey(bg.Name, region), bg))
 }
 
 // DeleteRegionBackendService deletes the given BackendService by name.
-func (gce *GCECloud) DeleteRegionBackendService(name, region string) error {
+func (g *Cloud) DeleteRegionBackendService(name, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContext("delete", region)
-	return mc.Observe(gce.c.RegionBackendServices().Delete(ctx, meta.RegionalKey(name, region)))
+	return mc.Observe(g.c.RegionBackendServices().Delete(ctx, meta.RegionalKey(name, region)))
 }
 
 // CreateRegionBackendService creates the given BackendService.
-func (gce *GCECloud) CreateRegionBackendService(bg *compute.BackendService, region string) error {
+func (g *Cloud) CreateRegionBackendService(bg *compute.BackendService, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContext("create", region)
-	return mc.Observe(gce.c.RegionBackendServices().Insert(ctx, meta.RegionalKey(bg.Name, region), bg))
+	return mc.Observe(g.c.RegionBackendServices().Insert(ctx, meta.RegionalKey(bg.Name, region), bg))
 }
 
 // ListRegionBackendServices lists all backend services in the project.
-func (gce *GCECloud) ListRegionBackendServices(region string) ([]*compute.BackendService, error) {
+func (g *Cloud) ListRegionBackendServices(region string) ([]*compute.BackendService, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContext("list", region)
-	v, err := gce.c.RegionBackendServices().List(ctx, region, filter.None)
+	v, err := g.c.RegionBackendServices().List(ctx, region, filter.None)
 	return v, mc.Observe(err)
 }
 
 // GetRegionalBackendServiceHealth returns the health of the BackendService
 // identified by the given name, in the given instanceGroup. The
 // instanceGroupLink is the fully qualified self link of an instance group.
-func (gce *GCECloud) GetRegionalBackendServiceHealth(name, region string, instanceGroupLink string) (*compute.BackendServiceGroupHealth, error) {
+func (g *Cloud) GetRegionalBackendServiceHealth(name, region string, instanceGroupLink string) (*compute.BackendServiceGroupHealth, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContext("get_health", region)
 	ref := &compute.ResourceGroupReference{Group: instanceGroupLink}
-	v, err := gce.c.RegionBackendServices().GetHealth(ctx, meta.RegionalKey(name, region), ref)
+	v, err := g.c.RegionBackendServices().GetHealth(ctx, meta.RegionalKey(name, region), ref)
 	return v, mc.Observe(err)
 }
 
 // SetSecurityPolicyForBetaGlobalBackendService sets the given
 // SecurityPolicyReference for the BackendService identified by the given name.
-func (gce *GCECloud) SetSecurityPolicyForBetaGlobalBackendService(backendServiceName string, securityPolicyReference *computebeta.SecurityPolicyReference) error {
+func (g *Cloud) SetSecurityPolicyForBetaGlobalBackendService(backendServiceName string, securityPolicyReference *computebeta.SecurityPolicyReference) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContextWithVersion("set_security_policy", "", computeBetaVersion)
-	return mc.Observe(gce.c.BetaBackendServices().SetSecurityPolicy(ctx, meta.GlobalKey(backendServiceName), securityPolicyReference))
+	return mc.Observe(g.c.BetaBackendServices().SetSecurityPolicy(ctx, meta.GlobalKey(backendServiceName), securityPolicyReference))
 }
 
 // SetSecurityPolicyForAlphaGlobalBackendService sets the given
 // SecurityPolicyReference for the BackendService identified by the given name.
-func (gce *GCECloud) SetSecurityPolicyForAlphaGlobalBackendService(backendServiceName string, securityPolicyReference *computealpha.SecurityPolicyReference) error {
+func (g *Cloud) SetSecurityPolicyForAlphaGlobalBackendService(backendServiceName string, securityPolicyReference *computealpha.SecurityPolicyReference) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newBackendServiceMetricContextWithVersion("set_security_policy", "", computeAlphaVersion)
-	return mc.Observe(gce.c.AlphaBackendServices().SetSecurityPolicy(ctx, meta.GlobalKey(backendServiceName), securityPolicyReference))
+	return mc.Observe(g.c.AlphaBackendServices().SetSecurityPolicy(ctx, meta.GlobalKey(backendServiceName), securityPolicyReference))
 }

--- a/pkg/cloudprovider/providers/gce/gce_cert.go
+++ b/pkg/cloudprovider/providers/gce/gce_cert.go
@@ -29,43 +29,43 @@ func newCertMetricContext(request string) *metricContext {
 }
 
 // GetSslCertificate returns the SslCertificate by name.
-func (gce *GCECloud) GetSslCertificate(name string) (*compute.SslCertificate, error) {
+func (g *Cloud) GetSslCertificate(name string) (*compute.SslCertificate, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newCertMetricContext("get")
-	v, err := gce.c.SslCertificates().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.SslCertificates().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
 // CreateSslCertificate creates and returns a SslCertificate.
-func (gce *GCECloud) CreateSslCertificate(sslCerts *compute.SslCertificate) (*compute.SslCertificate, error) {
+func (g *Cloud) CreateSslCertificate(sslCerts *compute.SslCertificate) (*compute.SslCertificate, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newCertMetricContext("create")
-	err := gce.c.SslCertificates().Insert(ctx, meta.GlobalKey(sslCerts.Name), sslCerts)
+	err := g.c.SslCertificates().Insert(ctx, meta.GlobalKey(sslCerts.Name), sslCerts)
 	if err != nil {
 		return nil, mc.Observe(err)
 	}
-	return gce.GetSslCertificate(sslCerts.Name)
+	return g.GetSslCertificate(sslCerts.Name)
 }
 
 // DeleteSslCertificate deletes the SslCertificate by name.
-func (gce *GCECloud) DeleteSslCertificate(name string) error {
+func (g *Cloud) DeleteSslCertificate(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newCertMetricContext("delete")
-	return mc.Observe(gce.c.SslCertificates().Delete(ctx, meta.GlobalKey(name)))
+	return mc.Observe(g.c.SslCertificates().Delete(ctx, meta.GlobalKey(name)))
 }
 
 // ListSslCertificates lists all SslCertificates in the project.
-func (gce *GCECloud) ListSslCertificates() ([]*compute.SslCertificate, error) {
+func (g *Cloud) ListSslCertificates() ([]*compute.SslCertificate, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newCertMetricContext("list")
-	v, err := gce.c.SslCertificates().List(ctx, filter.None)
+	v, err := g.c.SslCertificates().List(ctx, filter.None)
 	return v, mc.Observe(err)
 }

--- a/pkg/cloudprovider/providers/gce/gce_disks_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_disks_test.go
@@ -35,15 +35,15 @@ import (
 
 func TestCreateDisk_Basic(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{"zone1"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       []string{"zone1"},
-		projectID:          gceProjectId,
+		projectID:          gceProjectID,
 		AlphaFeatureGate:   alphaFeatureGate,
 		nodeZones:          createNodeZones(zonesWithNodes),
 		nodeInformerSynced: func() bool { return true },
@@ -57,7 +57,7 @@ func TestCreateDisk_Basic(t *testing.T) {
 	tags["test-tag"] = "test-value"
 
 	expectedDiskTypeURI := gceComputeAPIEndpoint + "projects/" + fmt.Sprintf(
-		diskTypeURITemplateSingleZone, gceProjectId, zone, diskType)
+		diskTypeURITemplateSingleZone, gceProjectID, zone, diskType)
 	expectedDescription := "{\"test-tag\":\"test-value\"}"
 
 	/* Act */
@@ -90,15 +90,15 @@ func TestCreateDisk_Basic(t *testing.T) {
 
 func TestCreateRegionalDisk_Basic(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{"zone1", "zone3", "zone2"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
-		projectID:          gceProjectId,
+		projectID:          gceProjectID,
 		nodeZones:          createNodeZones(zonesWithNodes),
 		nodeInformerSynced: func() bool { return true },
 	}
@@ -111,7 +111,7 @@ func TestCreateRegionalDisk_Basic(t *testing.T) {
 	tags["test-tag"] = "test-value"
 
 	expectedDiskTypeURI := gceComputeAPIEndpointBeta + "projects/" + fmt.Sprintf(
-		diskTypeURITemplateRegional, gceProjectId, gceRegion, diskType)
+		diskTypeURITemplateRegional, gceProjectID, gceRegion, diskType)
 	expectedDescription := "{\"test-tag\":\"test-value\"}"
 
 	/* Act */
@@ -144,12 +144,12 @@ func TestCreateRegionalDisk_Basic(t *testing.T) {
 
 func TestCreateDisk_DiskAlreadyExists(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{"zone1"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		AlphaFeatureGate:   alphaFeatureGate,
@@ -175,11 +175,11 @@ func TestCreateDisk_DiskAlreadyExists(t *testing.T) {
 
 func TestCreateDisk_WrongZone(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{"zone1"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
-	gce := GCECloud{
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		nodeZones:          createNodeZones(zonesWithNodes),
@@ -200,11 +200,11 @@ func TestCreateDisk_WrongZone(t *testing.T) {
 
 func TestCreateDisk_NoManagedZone(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
-	gce := GCECloud{
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		nodeZones:          createNodeZones(zonesWithNodes),
@@ -225,11 +225,11 @@ func TestCreateDisk_NoManagedZone(t *testing.T) {
 
 func TestCreateDisk_BadDiskType(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{"zone1"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
-	gce := GCECloud{manager: fakeManager,
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
+	gce := Cloud{manager: fakeManager,
 		managedZones:       zonesWithNodes,
 		nodeZones:          createNodeZones(zonesWithNodes),
 		nodeInformerSynced: func() bool { return true }}
@@ -250,12 +250,12 @@ func TestCreateDisk_BadDiskType(t *testing.T) {
 
 func TestCreateDisk_MultiZone(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{"zone1", "zone2", "zone3"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		AlphaFeatureGate:   alphaFeatureGate,
@@ -279,12 +279,12 @@ func TestCreateDisk_MultiZone(t *testing.T) {
 
 func TestDeleteDisk_Basic(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{"zone1"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		AlphaFeatureGate:   alphaFeatureGate,
@@ -313,12 +313,12 @@ func TestDeleteDisk_Basic(t *testing.T) {
 
 func TestDeleteDisk_NotFound(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{"zone1"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		AlphaFeatureGate:   alphaFeatureGate,
@@ -338,12 +338,12 @@ func TestDeleteDisk_NotFound(t *testing.T) {
 
 func TestDeleteDisk_ResourceBeingUsed(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{"zone1"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		AlphaFeatureGate:   alphaFeatureGate,
@@ -369,12 +369,12 @@ func TestDeleteDisk_ResourceBeingUsed(t *testing.T) {
 
 func TestDeleteDisk_SameDiskMultiZone(t *testing.T) {
 	/* Assert */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{"zone1", "zone2", "zone3"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		AlphaFeatureGate:   alphaFeatureGate,
@@ -403,12 +403,12 @@ func TestDeleteDisk_SameDiskMultiZone(t *testing.T) {
 
 func TestDeleteDisk_DiffDiskMultiZone(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{"zone1"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		AlphaFeatureGate:   alphaFeatureGate,
@@ -437,16 +437,16 @@ func TestDeleteDisk_DiffDiskMultiZone(t *testing.T) {
 
 func TestGetAutoLabelsForPD_Basic(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "us-central1"
 	zone := "us-central1-c"
 	zonesWithNodes := []string{zone}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	diskName := "disk"
 	diskType := DiskTypeSSD
 	const sizeGb int64 = 128
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		AlphaFeatureGate:   alphaFeatureGate,
@@ -474,16 +474,16 @@ func TestGetAutoLabelsForPD_Basic(t *testing.T) {
 
 func TestGetAutoLabelsForPD_NoZone(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "europe-west1"
 	zone := "europe-west1-d"
 	zonesWithNodes := []string{zone}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	diskName := "disk"
 	diskType := DiskTypeStandard
 	const sizeGb int64 = 128
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		AlphaFeatureGate:   alphaFeatureGate,
@@ -510,13 +510,13 @@ func TestGetAutoLabelsForPD_NoZone(t *testing.T) {
 
 func TestGetAutoLabelsForPD_DiskNotFound(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zone := "asia-northeast1-a"
 	zonesWithNodes := []string{zone}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	diskName := "disk"
-	gce := GCECloud{manager: fakeManager,
+	gce := Cloud{manager: fakeManager,
 		managedZones:       zonesWithNodes,
 		nodeZones:          createNodeZones(zonesWithNodes),
 		nodeInformerSynced: func() bool { return true }}
@@ -532,13 +532,13 @@ func TestGetAutoLabelsForPD_DiskNotFound(t *testing.T) {
 
 func TestGetAutoLabelsForPD_DiskNotFoundAndNoZone(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	diskName := "disk"
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		AlphaFeatureGate:   alphaFeatureGate,
@@ -557,17 +557,17 @@ func TestGetAutoLabelsForPD_DiskNotFoundAndNoZone(t *testing.T) {
 
 func TestGetAutoLabelsForPD_DupDisk(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "us-west1"
 	zonesWithNodes := []string{"us-west1-b", "asia-southeast1-a"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	diskName := "disk"
 	diskType := DiskTypeStandard
 	zone := "us-west1-b"
 	const sizeGb int64 = 128
 
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		AlphaFeatureGate:   alphaFeatureGate,
@@ -596,16 +596,16 @@ func TestGetAutoLabelsForPD_DupDisk(t *testing.T) {
 
 func TestGetAutoLabelsForPD_DupDiskNoZone(t *testing.T) {
 	/* Arrange */
-	gceProjectId := "test-project"
+	gceProjectID := "test-project"
 	gceRegion := "fake-region"
 	zonesWithNodes := []string{"us-west1-b", "asia-southeast1-a"}
-	fakeManager := newFakeManager(gceProjectId, gceRegion)
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
 	diskName := "disk"
 	diskType := DiskTypeStandard
 	const sizeGb int64 = 128
 
 	alphaFeatureGate := NewAlphaFeatureGate([]string{})
-	gce := GCECloud{
+	gce := Cloud{
 		manager:            fakeManager,
 		managedZones:       zonesWithNodes,
 		AlphaFeatureGate:   alphaFeatureGate,
@@ -738,16 +738,16 @@ func (manager *FakeServiceManager) CreateRegionalDiskOnCloudProvider(
 		manager.regionalDisks[diskToCreateV1.Name] = zones
 		return nil
 	case targetBeta:
-		return fmt.Errorf("RegionalDisk CreateDisk op not supported in beta.")
+		return fmt.Errorf("regionalDisk CreateDisk op not supported in beta")
 	case targetAlpha:
-		return fmt.Errorf("RegionalDisk CreateDisk op not supported in alpha.")
+		return fmt.Errorf("regionalDisk CreateDisk op not supported in alpha")
 	default:
 		return fmt.Errorf("unexpected type: %T", t)
 	}
 }
 
 func (manager *FakeServiceManager) AttachDiskOnCloudProvider(
-	disk *GCEDisk,
+	disk *Disk,
 	readWrite string,
 	instanceZone string,
 	instanceName string) error {
@@ -784,7 +784,7 @@ func (manager *FakeServiceManager) DetachDiskOnCloudProvider(
  * Gets disk info stored in the FakeServiceManager.
  */
 func (manager *FakeServiceManager) GetDiskFromCloudProvider(
-	zone string, diskName string) (*GCEDisk, error) {
+	zone string, diskName string) (*Disk, error) {
 
 	if manager.zonalDisks[zone] == "" {
 		return nil, cloudprovider.DiskNotFound
@@ -796,7 +796,7 @@ func (manager *FakeServiceManager) GetDiskFromCloudProvider(
 		return nil, err
 	}
 
-	return &GCEDisk{
+	return &Disk{
 		Region:   manager.gceRegion,
 		ZoneInfo: singleZone{lastComponent(zone)},
 		Name:     diskName,
@@ -809,7 +809,7 @@ func (manager *FakeServiceManager) GetDiskFromCloudProvider(
  * Gets disk info stored in the FakeServiceManager.
  */
 func (manager *FakeServiceManager) GetRegionalDiskFromCloudProvider(
-	diskName string) (*GCEDisk, error) {
+	diskName string) (*Disk, error) {
 
 	if _, ok := manager.regionalDisks[diskName]; !ok {
 		return nil, cloudprovider.DiskNotFound
@@ -821,7 +821,7 @@ func (manager *FakeServiceManager) GetRegionalDiskFromCloudProvider(
 		return nil, err
 	}
 
-	return &GCEDisk{
+	return &Disk{
 		Region:   manager.gceRegion,
 		ZoneInfo: multiZone{manager.regionalDisks[diskName]},
 		Name:     diskName,
@@ -831,14 +831,14 @@ func (manager *FakeServiceManager) GetRegionalDiskFromCloudProvider(
 }
 
 func (manager *FakeServiceManager) ResizeDiskOnCloudProvider(
-	disk *GCEDisk,
+	disk *Disk,
 	size int64,
 	zone string) error {
 	panic("Not implmented")
 }
 
 func (manager *FakeServiceManager) RegionalResizeDiskOnCloudProvider(
-	disk *GCEDisk,
+	disk *Disk,
 	size int64) error {
 	panic("Not implemented")
 }

--- a/pkg/cloudprovider/providers/gce/gce_fake.go
+++ b/pkg/cloudprovider/providers/gce/gce_fake.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
 )
 
+// TestClusterValues holds the config values for the fake/test gce cloud object.
 type TestClusterValues struct {
 	ProjectID         string
 	Region            string
@@ -34,6 +35,8 @@ type TestClusterValues struct {
 	ClusterName       string
 }
 
+// DefaultTestClusterValues Creates a reasonable set of default cluster values
+// for generating a new test fake GCE cloud instance.
 func DefaultTestClusterValues() TestClusterValues {
 	return TestClusterValues{
 		ProjectID:         "test-project",
@@ -43,10 +46,6 @@ func DefaultTestClusterValues() TestClusterValues {
 		ClusterID:         "test-cluster-id",
 		ClusterName:       "Test Cluster Name",
 	}
-}
-
-func FakeGCECloud(vals TestClusterValues) *GCECloud {
-	return simpleFakeGCECloud(vals)
 }
 
 type fakeRoundTripper struct{}
@@ -66,10 +65,11 @@ func fakeClusterID(clusterID string) ClusterID {
 	}
 }
 
-func simpleFakeGCECloud(vals TestClusterValues) *GCECloud {
+// NewFakeGCECloud constructs a fake GCE Cloud from the cluster values.
+func NewFakeGCECloud(vals TestClusterValues) *Cloud {
 	client := &http.Client{Transport: &fakeRoundTripper{}}
 	service, _ := compute.New(client)
-	gce := &GCECloud{
+	gce := &Cloud{
 		region:           vals.Region,
 		service:          service,
 		managedZones:     []string{vals.ZoneName},

--- a/pkg/cloudprovider/providers/gce/gce_firewall.go
+++ b/pkg/cloudprovider/providers/gce/gce_firewall.go
@@ -28,38 +28,38 @@ func newFirewallMetricContext(request string) *metricContext {
 }
 
 // GetFirewall returns the Firewall by name.
-func (gce *GCECloud) GetFirewall(name string) (*compute.Firewall, error) {
+func (g *Cloud) GetFirewall(name string) (*compute.Firewall, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newFirewallMetricContext("get")
-	v, err := gce.c.Firewalls().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.Firewalls().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
 // CreateFirewall creates the passed firewall
-func (gce *GCECloud) CreateFirewall(f *compute.Firewall) error {
+func (g *Cloud) CreateFirewall(f *compute.Firewall) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newFirewallMetricContext("create")
-	return mc.Observe(gce.c.Firewalls().Insert(ctx, meta.GlobalKey(f.Name), f))
+	return mc.Observe(g.c.Firewalls().Insert(ctx, meta.GlobalKey(f.Name), f))
 }
 
 // DeleteFirewall deletes the given firewall rule.
-func (gce *GCECloud) DeleteFirewall(name string) error {
+func (g *Cloud) DeleteFirewall(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newFirewallMetricContext("delete")
-	return mc.Observe(gce.c.Firewalls().Delete(ctx, meta.GlobalKey(name)))
+	return mc.Observe(g.c.Firewalls().Delete(ctx, meta.GlobalKey(name)))
 }
 
 // UpdateFirewall applies the given firewall as an update to an existing service.
-func (gce *GCECloud) UpdateFirewall(f *compute.Firewall) error {
+func (g *Cloud) UpdateFirewall(f *compute.Firewall) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newFirewallMetricContext("update")
-	return mc.Observe(gce.c.Firewalls().Update(ctx, meta.GlobalKey(f.Name), f))
+	return mc.Observe(g.c.Firewalls().Update(ctx, meta.GlobalKey(f.Name), f))
 }

--- a/pkg/cloudprovider/providers/gce/gce_forwardingrule.go
+++ b/pkg/cloudprovider/providers/gce/gce_forwardingrule.go
@@ -32,129 +32,129 @@ func newForwardingRuleMetricContextWithVersion(request, region, version string) 
 }
 
 // CreateGlobalForwardingRule creates the passed GlobalForwardingRule
-func (gce *GCECloud) CreateGlobalForwardingRule(rule *compute.ForwardingRule) error {
+func (g *Cloud) CreateGlobalForwardingRule(rule *compute.ForwardingRule) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newForwardingRuleMetricContext("create", "")
-	return mc.Observe(gce.c.GlobalForwardingRules().Insert(ctx, meta.GlobalKey(rule.Name), rule))
+	return mc.Observe(g.c.GlobalForwardingRules().Insert(ctx, meta.GlobalKey(rule.Name), rule))
 }
 
 // SetProxyForGlobalForwardingRule links the given TargetHttp(s)Proxy with the given GlobalForwardingRule.
 // targetProxyLink is the SelfLink of a TargetHttp(s)Proxy.
-func (gce *GCECloud) SetProxyForGlobalForwardingRule(forwardingRuleName, targetProxyLink string) error {
+func (g *Cloud) SetProxyForGlobalForwardingRule(forwardingRuleName, targetProxyLink string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newForwardingRuleMetricContext("set_proxy", "")
 	target := &compute.TargetReference{Target: targetProxyLink}
-	return mc.Observe(gce.c.GlobalForwardingRules().SetTarget(ctx, meta.GlobalKey(forwardingRuleName), target))
+	return mc.Observe(g.c.GlobalForwardingRules().SetTarget(ctx, meta.GlobalKey(forwardingRuleName), target))
 }
 
 // DeleteGlobalForwardingRule deletes the GlobalForwardingRule by name.
-func (gce *GCECloud) DeleteGlobalForwardingRule(name string) error {
+func (g *Cloud) DeleteGlobalForwardingRule(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newForwardingRuleMetricContext("delete", "")
-	return mc.Observe(gce.c.GlobalForwardingRules().Delete(ctx, meta.GlobalKey(name)))
+	return mc.Observe(g.c.GlobalForwardingRules().Delete(ctx, meta.GlobalKey(name)))
 }
 
 // GetGlobalForwardingRule returns the GlobalForwardingRule by name.
-func (gce *GCECloud) GetGlobalForwardingRule(name string) (*compute.ForwardingRule, error) {
+func (g *Cloud) GetGlobalForwardingRule(name string) (*compute.ForwardingRule, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newForwardingRuleMetricContext("get", "")
-	v, err := gce.c.GlobalForwardingRules().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.GlobalForwardingRules().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
 // ListGlobalForwardingRules lists all GlobalForwardingRules in the project.
-func (gce *GCECloud) ListGlobalForwardingRules() ([]*compute.ForwardingRule, error) {
+func (g *Cloud) ListGlobalForwardingRules() ([]*compute.ForwardingRule, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newForwardingRuleMetricContext("list", "")
-	v, err := gce.c.GlobalForwardingRules().List(ctx, filter.None)
+	v, err := g.c.GlobalForwardingRules().List(ctx, filter.None)
 	return v, mc.Observe(err)
 }
 
 // GetRegionForwardingRule returns the RegionalForwardingRule by name & region.
-func (gce *GCECloud) GetRegionForwardingRule(name, region string) (*compute.ForwardingRule, error) {
+func (g *Cloud) GetRegionForwardingRule(name, region string) (*compute.ForwardingRule, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newForwardingRuleMetricContext("get", region)
-	v, err := gce.c.ForwardingRules().Get(ctx, meta.RegionalKey(name, region))
+	v, err := g.c.ForwardingRules().Get(ctx, meta.RegionalKey(name, region))
 	return v, mc.Observe(err)
 }
 
 // GetAlphaRegionForwardingRule returns the Alpha forwarding rule by name & region.
-func (gce *GCECloud) GetAlphaRegionForwardingRule(name, region string) (*computealpha.ForwardingRule, error) {
+func (g *Cloud) GetAlphaRegionForwardingRule(name, region string) (*computealpha.ForwardingRule, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newForwardingRuleMetricContextWithVersion("get", region, computeAlphaVersion)
-	v, err := gce.c.AlphaForwardingRules().Get(ctx, meta.RegionalKey(name, region))
+	v, err := g.c.AlphaForwardingRules().Get(ctx, meta.RegionalKey(name, region))
 	return v, mc.Observe(err)
 }
 
 // ListRegionForwardingRules lists all RegionalForwardingRules in the project & region.
-func (gce *GCECloud) ListRegionForwardingRules(region string) ([]*compute.ForwardingRule, error) {
+func (g *Cloud) ListRegionForwardingRules(region string) ([]*compute.ForwardingRule, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newForwardingRuleMetricContext("list", region)
-	v, err := gce.c.ForwardingRules().List(ctx, region, filter.None)
+	v, err := g.c.ForwardingRules().List(ctx, region, filter.None)
 	return v, mc.Observe(err)
 }
 
 // ListAlphaRegionForwardingRules lists all RegionalForwardingRules in the project & region.
-func (gce *GCECloud) ListAlphaRegionForwardingRules(region string) ([]*computealpha.ForwardingRule, error) {
+func (g *Cloud) ListAlphaRegionForwardingRules(region string) ([]*computealpha.ForwardingRule, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newForwardingRuleMetricContextWithVersion("list", region, computeAlphaVersion)
-	v, err := gce.c.AlphaForwardingRules().List(ctx, region, filter.None)
+	v, err := g.c.AlphaForwardingRules().List(ctx, region, filter.None)
 	return v, mc.Observe(err)
 }
 
 // CreateRegionForwardingRule creates and returns a
 // RegionalForwardingRule that points to the given BackendService
-func (gce *GCECloud) CreateRegionForwardingRule(rule *compute.ForwardingRule, region string) error {
+func (g *Cloud) CreateRegionForwardingRule(rule *compute.ForwardingRule, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newForwardingRuleMetricContext("create", region)
-	return mc.Observe(gce.c.ForwardingRules().Insert(ctx, meta.RegionalKey(rule.Name, region), rule))
+	return mc.Observe(g.c.ForwardingRules().Insert(ctx, meta.RegionalKey(rule.Name, region), rule))
 }
 
 // CreateAlphaRegionForwardingRule creates and returns an Alpha
 // forwarding fule in the given region.
-func (gce *GCECloud) CreateAlphaRegionForwardingRule(rule *computealpha.ForwardingRule, region string) error {
+func (g *Cloud) CreateAlphaRegionForwardingRule(rule *computealpha.ForwardingRule, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newForwardingRuleMetricContextWithVersion("create", region, computeAlphaVersion)
-	return mc.Observe(gce.c.AlphaForwardingRules().Insert(ctx, meta.RegionalKey(rule.Name, region), rule))
+	return mc.Observe(g.c.AlphaForwardingRules().Insert(ctx, meta.RegionalKey(rule.Name, region), rule))
 }
 
 // DeleteRegionForwardingRule deletes the RegionalForwardingRule by name & region.
-func (gce *GCECloud) DeleteRegionForwardingRule(name, region string) error {
+func (g *Cloud) DeleteRegionForwardingRule(name, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newForwardingRuleMetricContext("delete", region)
-	return mc.Observe(gce.c.ForwardingRules().Delete(ctx, meta.RegionalKey(name, region)))
+	return mc.Observe(g.c.ForwardingRules().Delete(ctx, meta.RegionalKey(name, region)))
 }
 
 // TODO(#51665): retire this function once Network Tiers becomes Beta in GCP.
-func (gce *GCECloud) getNetworkTierFromForwardingRule(name, region string) (string, error) {
-	if !gce.AlphaFeatureGate.Enabled(AlphaFeatureNetworkTiers) {
+func (g *Cloud) getNetworkTierFromForwardingRule(name, region string) (string, error) {
+	if !g.AlphaFeatureGate.Enabled(AlphaFeatureNetworkTiers) {
 		return cloud.NetworkTierDefault.ToGCEValue(), nil
 	}
-	fwdRule, err := gce.GetAlphaRegionForwardingRule(name, region)
+	fwdRule, err := g.GetAlphaRegionForwardingRule(name, region)
 	if err != nil {
 		return handleAlphaNetworkTierGetError(err)
 	}

--- a/pkg/cloudprovider/providers/gce/gce_healthchecks.go
+++ b/pkg/cloudprovider/providers/gce/gce_healthchecks.go
@@ -56,204 +56,204 @@ func newHealthcheckMetricContextWithVersion(request, version string) *metricCont
 	return newGenericMetricContext("healthcheck", request, unusedMetricLabel, unusedMetricLabel, version)
 }
 
-// GetHttpHealthCheck returns the given HttpHealthCheck by name.
-func (gce *GCECloud) GetHttpHealthCheck(name string) (*compute.HttpHealthCheck, error) {
+// GetHTTPHealthCheck returns the given HttpHealthCheck by name.
+func (g *Cloud) GetHTTPHealthCheck(name string) (*compute.HttpHealthCheck, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("get_legacy")
-	v, err := gce.c.HttpHealthChecks().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.HttpHealthChecks().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
-// UpdateHttpHealthCheck applies the given HttpHealthCheck as an update.
-func (gce *GCECloud) UpdateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
+// UpdateHTTPHealthCheck applies the given HttpHealthCheck as an update.
+func (g *Cloud) UpdateHTTPHealthCheck(hc *compute.HttpHealthCheck) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("update_legacy")
-	return mc.Observe(gce.c.HttpHealthChecks().Update(ctx, meta.GlobalKey(hc.Name), hc))
+	return mc.Observe(g.c.HttpHealthChecks().Update(ctx, meta.GlobalKey(hc.Name), hc))
 }
 
-// DeleteHttpHealthCheck deletes the given HttpHealthCheck by name.
-func (gce *GCECloud) DeleteHttpHealthCheck(name string) error {
+// DeleteHTTPHealthCheck deletes the given HttpHealthCheck by name.
+func (g *Cloud) DeleteHTTPHealthCheck(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("delete_legacy")
-	return mc.Observe(gce.c.HttpHealthChecks().Delete(ctx, meta.GlobalKey(name)))
+	return mc.Observe(g.c.HttpHealthChecks().Delete(ctx, meta.GlobalKey(name)))
 }
 
-// CreateHttpHealthCheck creates the given HttpHealthCheck.
-func (gce *GCECloud) CreateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
+// CreateHTTPHealthCheck creates the given HttpHealthCheck.
+func (g *Cloud) CreateHTTPHealthCheck(hc *compute.HttpHealthCheck) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("create_legacy")
-	return mc.Observe(gce.c.HttpHealthChecks().Insert(ctx, meta.GlobalKey(hc.Name), hc))
+	return mc.Observe(g.c.HttpHealthChecks().Insert(ctx, meta.GlobalKey(hc.Name), hc))
 }
 
-// ListHttpHealthChecks lists all HttpHealthChecks in the project.
-func (gce *GCECloud) ListHttpHealthChecks() ([]*compute.HttpHealthCheck, error) {
+// ListHTTPHealthChecks lists all HttpHealthChecks in the project.
+func (g *Cloud) ListHTTPHealthChecks() ([]*compute.HttpHealthCheck, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("list_legacy")
-	v, err := gce.c.HttpHealthChecks().List(ctx, filter.None)
+	v, err := g.c.HttpHealthChecks().List(ctx, filter.None)
 	return v, mc.Observe(err)
 }
 
 // Legacy HTTPS Health Checks
 
-// GetHttpsHealthCheck returns the given HttpsHealthCheck by name.
-func (gce *GCECloud) GetHttpsHealthCheck(name string) (*compute.HttpsHealthCheck, error) {
+// GetHTTPSHealthCheck returns the given HttpsHealthCheck by name.
+func (g *Cloud) GetHTTPSHealthCheck(name string) (*compute.HttpsHealthCheck, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("get_legacy")
-	v, err := gce.c.HttpsHealthChecks().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.HttpsHealthChecks().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
-// UpdateHttpsHealthCheck applies the given HttpsHealthCheck as an update.
-func (gce *GCECloud) UpdateHttpsHealthCheck(hc *compute.HttpsHealthCheck) error {
+// UpdateHTTPSHealthCheck applies the given HttpsHealthCheck as an update.
+func (g *Cloud) UpdateHTTPSHealthCheck(hc *compute.HttpsHealthCheck) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("update_legacy")
-	return mc.Observe(gce.c.HttpsHealthChecks().Update(ctx, meta.GlobalKey(hc.Name), hc))
+	return mc.Observe(g.c.HttpsHealthChecks().Update(ctx, meta.GlobalKey(hc.Name), hc))
 }
 
-// DeleteHttpsHealthCheck deletes the given HttpsHealthCheck by name.
-func (gce *GCECloud) DeleteHttpsHealthCheck(name string) error {
+// DeleteHTTPSHealthCheck deletes the given HttpsHealthCheck by name.
+func (g *Cloud) DeleteHTTPSHealthCheck(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("delete_legacy")
-	return mc.Observe(gce.c.HttpsHealthChecks().Delete(ctx, meta.GlobalKey(name)))
+	return mc.Observe(g.c.HttpsHealthChecks().Delete(ctx, meta.GlobalKey(name)))
 }
 
-// CreateHttpsHealthCheck creates the given HttpsHealthCheck.
-func (gce *GCECloud) CreateHttpsHealthCheck(hc *compute.HttpsHealthCheck) error {
+// CreateHTTPSHealthCheck creates the given HttpsHealthCheck.
+func (g *Cloud) CreateHTTPSHealthCheck(hc *compute.HttpsHealthCheck) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("create_legacy")
-	return mc.Observe(gce.c.HttpsHealthChecks().Insert(ctx, meta.GlobalKey(hc.Name), hc))
+	return mc.Observe(g.c.HttpsHealthChecks().Insert(ctx, meta.GlobalKey(hc.Name), hc))
 }
 
-// ListHttpsHealthChecks lists all HttpsHealthChecks in the project.
-func (gce *GCECloud) ListHttpsHealthChecks() ([]*compute.HttpsHealthCheck, error) {
+// ListHTTPSHealthChecks lists all HttpsHealthChecks in the project.
+func (g *Cloud) ListHTTPSHealthChecks() ([]*compute.HttpsHealthCheck, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("list_legacy")
-	v, err := gce.c.HttpsHealthChecks().List(ctx, filter.None)
+	v, err := g.c.HttpsHealthChecks().List(ctx, filter.None)
 	return v, mc.Observe(err)
 }
 
 // Generic HealthCheck
 
 // GetHealthCheck returns the given HealthCheck by name.
-func (gce *GCECloud) GetHealthCheck(name string) (*compute.HealthCheck, error) {
+func (g *Cloud) GetHealthCheck(name string) (*compute.HealthCheck, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("get")
-	v, err := gce.c.HealthChecks().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.HealthChecks().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
 // GetAlphaHealthCheck returns the given alpha HealthCheck by name.
-func (gce *GCECloud) GetAlphaHealthCheck(name string) (*computealpha.HealthCheck, error) {
+func (g *Cloud) GetAlphaHealthCheck(name string) (*computealpha.HealthCheck, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContextWithVersion("get", computeAlphaVersion)
-	v, err := gce.c.AlphaHealthChecks().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.AlphaHealthChecks().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
 // GetBetaHealthCheck returns the given beta HealthCheck by name.
-func (gce *GCECloud) GetBetaHealthCheck(name string) (*computebeta.HealthCheck, error) {
+func (g *Cloud) GetBetaHealthCheck(name string) (*computebeta.HealthCheck, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContextWithVersion("get", computeBetaVersion)
-	v, err := gce.c.BetaHealthChecks().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.BetaHealthChecks().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
 // UpdateHealthCheck applies the given HealthCheck as an update.
-func (gce *GCECloud) UpdateHealthCheck(hc *compute.HealthCheck) error {
+func (g *Cloud) UpdateHealthCheck(hc *compute.HealthCheck) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("update")
-	return mc.Observe(gce.c.HealthChecks().Update(ctx, meta.GlobalKey(hc.Name), hc))
+	return mc.Observe(g.c.HealthChecks().Update(ctx, meta.GlobalKey(hc.Name), hc))
 }
 
 // UpdateAlphaHealthCheck applies the given alpha HealthCheck as an update.
-func (gce *GCECloud) UpdateAlphaHealthCheck(hc *computealpha.HealthCheck) error {
+func (g *Cloud) UpdateAlphaHealthCheck(hc *computealpha.HealthCheck) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContextWithVersion("update", computeAlphaVersion)
-	return mc.Observe(gce.c.AlphaHealthChecks().Update(ctx, meta.GlobalKey(hc.Name), hc))
+	return mc.Observe(g.c.AlphaHealthChecks().Update(ctx, meta.GlobalKey(hc.Name), hc))
 }
 
 // UpdateBetaHealthCheck applies the given beta HealthCheck as an update.
-func (gce *GCECloud) UpdateBetaHealthCheck(hc *computebeta.HealthCheck) error {
+func (g *Cloud) UpdateBetaHealthCheck(hc *computebeta.HealthCheck) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContextWithVersion("update", computeBetaVersion)
-	return mc.Observe(gce.c.BetaHealthChecks().Update(ctx, meta.GlobalKey(hc.Name), hc))
+	return mc.Observe(g.c.BetaHealthChecks().Update(ctx, meta.GlobalKey(hc.Name), hc))
 }
 
 // DeleteHealthCheck deletes the given HealthCheck by name.
-func (gce *GCECloud) DeleteHealthCheck(name string) error {
+func (g *Cloud) DeleteHealthCheck(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("delete")
-	return mc.Observe(gce.c.HealthChecks().Delete(ctx, meta.GlobalKey(name)))
+	return mc.Observe(g.c.HealthChecks().Delete(ctx, meta.GlobalKey(name)))
 }
 
 // CreateHealthCheck creates the given HealthCheck.
-func (gce *GCECloud) CreateHealthCheck(hc *compute.HealthCheck) error {
+func (g *Cloud) CreateHealthCheck(hc *compute.HealthCheck) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("create")
-	return mc.Observe(gce.c.HealthChecks().Insert(ctx, meta.GlobalKey(hc.Name), hc))
+	return mc.Observe(g.c.HealthChecks().Insert(ctx, meta.GlobalKey(hc.Name), hc))
 }
 
 // CreateAlphaHealthCheck creates the given alpha HealthCheck.
-func (gce *GCECloud) CreateAlphaHealthCheck(hc *computealpha.HealthCheck) error {
+func (g *Cloud) CreateAlphaHealthCheck(hc *computealpha.HealthCheck) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContextWithVersion("create", computeAlphaVersion)
-	return mc.Observe(gce.c.AlphaHealthChecks().Insert(ctx, meta.GlobalKey(hc.Name), hc))
+	return mc.Observe(g.c.AlphaHealthChecks().Insert(ctx, meta.GlobalKey(hc.Name), hc))
 }
 
 // CreateBetaHealthCheck creates the given beta HealthCheck.
-func (gce *GCECloud) CreateBetaHealthCheck(hc *computebeta.HealthCheck) error {
+func (g *Cloud) CreateBetaHealthCheck(hc *computebeta.HealthCheck) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContextWithVersion("create", computeBetaVersion)
-	return mc.Observe(gce.c.BetaHealthChecks().Insert(ctx, meta.GlobalKey(hc.Name), hc))
+	return mc.Observe(g.c.BetaHealthChecks().Insert(ctx, meta.GlobalKey(hc.Name), hc))
 }
 
 // ListHealthChecks lists all HealthCheck in the project.
-func (gce *GCECloud) ListHealthChecks() ([]*compute.HealthCheck, error) {
+func (g *Cloud) ListHealthChecks() ([]*compute.HealthCheck, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newHealthcheckMetricContext("list")
-	v, err := gce.c.HealthChecks().List(ctx, filter.None)
+	v, err := g.c.HealthChecks().List(ctx, filter.None)
 	return v, mc.Observe(err)
 }
 

--- a/pkg/cloudprovider/providers/gce/gce_instancegroup.go
+++ b/pkg/cloudprovider/providers/gce/gce_instancegroup.go
@@ -30,49 +30,49 @@ func newInstanceGroupMetricContext(request string, zone string) *metricContext {
 
 // CreateInstanceGroup creates an instance group with the given
 // instances. It is the callers responsibility to add named ports.
-func (gce *GCECloud) CreateInstanceGroup(ig *compute.InstanceGroup, zone string) error {
+func (g *Cloud) CreateInstanceGroup(ig *compute.InstanceGroup, zone string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newInstanceGroupMetricContext("create", zone)
-	return mc.Observe(gce.c.InstanceGroups().Insert(ctx, meta.ZonalKey(ig.Name, zone), ig))
+	return mc.Observe(g.c.InstanceGroups().Insert(ctx, meta.ZonalKey(ig.Name, zone), ig))
 }
 
 // DeleteInstanceGroup deletes an instance group.
-func (gce *GCECloud) DeleteInstanceGroup(name string, zone string) error {
+func (g *Cloud) DeleteInstanceGroup(name string, zone string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newInstanceGroupMetricContext("delete", zone)
-	return mc.Observe(gce.c.InstanceGroups().Delete(ctx, meta.ZonalKey(name, zone)))
+	return mc.Observe(g.c.InstanceGroups().Delete(ctx, meta.ZonalKey(name, zone)))
 }
 
 // ListInstanceGroups lists all InstanceGroups in the project and
 // zone.
-func (gce *GCECloud) ListInstanceGroups(zone string) ([]*compute.InstanceGroup, error) {
+func (g *Cloud) ListInstanceGroups(zone string) ([]*compute.InstanceGroup, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newInstanceGroupMetricContext("list", zone)
-	v, err := gce.c.InstanceGroups().List(ctx, zone, filter.None)
+	v, err := g.c.InstanceGroups().List(ctx, zone, filter.None)
 	return v, mc.Observe(err)
 }
 
 // ListInstancesInInstanceGroup lists all the instances in a given
 // instance group and state.
-func (gce *GCECloud) ListInstancesInInstanceGroup(name string, zone string, state string) ([]*compute.InstanceWithNamedPorts, error) {
+func (g *Cloud) ListInstancesInInstanceGroup(name string, zone string, state string) ([]*compute.InstanceWithNamedPorts, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newInstanceGroupMetricContext("list_instances", zone)
 	req := &compute.InstanceGroupsListInstancesRequest{InstanceState: state}
-	v, err := gce.c.InstanceGroups().ListInstances(ctx, meta.ZonalKey(name, zone), req, filter.None)
+	v, err := g.c.InstanceGroups().ListInstances(ctx, meta.ZonalKey(name, zone), req, filter.None)
 	return v, mc.Observe(err)
 }
 
 // AddInstancesToInstanceGroup adds the given instances to the given
 // instance group.
-func (gce *GCECloud) AddInstancesToInstanceGroup(name string, zone string, instanceRefs []*compute.InstanceReference) error {
+func (g *Cloud) AddInstancesToInstanceGroup(name string, zone string, instanceRefs []*compute.InstanceReference) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
@@ -84,12 +84,12 @@ func (gce *GCECloud) AddInstancesToInstanceGroup(name string, zone string, insta
 	req := &compute.InstanceGroupsAddInstancesRequest{
 		Instances: instanceRefs,
 	}
-	return mc.Observe(gce.c.InstanceGroups().AddInstances(ctx, meta.ZonalKey(name, zone), req))
+	return mc.Observe(g.c.InstanceGroups().AddInstances(ctx, meta.ZonalKey(name, zone), req))
 }
 
 // RemoveInstancesFromInstanceGroup removes the given instances from
 // the instance group.
-func (gce *GCECloud) RemoveInstancesFromInstanceGroup(name string, zone string, instanceRefs []*compute.InstanceReference) error {
+func (g *Cloud) RemoveInstancesFromInstanceGroup(name string, zone string, instanceRefs []*compute.InstanceReference) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
@@ -101,25 +101,25 @@ func (gce *GCECloud) RemoveInstancesFromInstanceGroup(name string, zone string, 
 	req := &compute.InstanceGroupsRemoveInstancesRequest{
 		Instances: instanceRefs,
 	}
-	return mc.Observe(gce.c.InstanceGroups().RemoveInstances(ctx, meta.ZonalKey(name, zone), req))
+	return mc.Observe(g.c.InstanceGroups().RemoveInstances(ctx, meta.ZonalKey(name, zone), req))
 }
 
 // SetNamedPortsOfInstanceGroup sets the list of named ports on a given instance group
-func (gce *GCECloud) SetNamedPortsOfInstanceGroup(igName, zone string, namedPorts []*compute.NamedPort) error {
+func (g *Cloud) SetNamedPortsOfInstanceGroup(igName, zone string, namedPorts []*compute.NamedPort) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newInstanceGroupMetricContext("set_namedports", zone)
 	req := &compute.InstanceGroupsSetNamedPortsRequest{NamedPorts: namedPorts}
-	return mc.Observe(gce.c.InstanceGroups().SetNamedPorts(ctx, meta.ZonalKey(igName, zone), req))
+	return mc.Observe(g.c.InstanceGroups().SetNamedPorts(ctx, meta.ZonalKey(igName, zone), req))
 }
 
 // GetInstanceGroup returns an instance group by name.
-func (gce *GCECloud) GetInstanceGroup(name string, zone string) (*compute.InstanceGroup, error) {
+func (g *Cloud) GetInstanceGroup(name string, zone string) (*compute.InstanceGroup, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newInstanceGroupMetricContext("get", zone)
-	v, err := gce.c.InstanceGroups().Get(ctx, meta.ZonalKey(name, zone))
+	v, err := g.c.InstanceGroups().Get(ctx, meta.ZonalKey(name, zone))
 	return v, mc.Observe(err)
 }

--- a/pkg/cloudprovider/providers/gce/gce_instances.go
+++ b/pkg/cloudprovider/providers/gce/gce_instances.go
@@ -67,22 +67,22 @@ func getZone(n *v1.Node) string {
 	return zone
 }
 
-func makeHostURL(projectsApiEndpoint, projectID, zone, host string) string {
+func makeHostURL(projectsAPIEndpoint, projectID, zone, host string) string {
 	host = canonicalizeInstanceName(host)
-	return projectsApiEndpoint + strings.Join([]string{projectID, "zones", zone, "instances", host}, "/")
+	return projectsAPIEndpoint + strings.Join([]string{projectID, "zones", zone, "instances", host}, "/")
 }
 
 // ToInstanceReferences returns instance references by links
-func (gce *GCECloud) ToInstanceReferences(zone string, instanceNames []string) (refs []*compute.InstanceReference) {
+func (g *Cloud) ToInstanceReferences(zone string, instanceNames []string) (refs []*compute.InstanceReference) {
 	for _, ins := range instanceNames {
-		instanceLink := makeHostURL(gce.service.BasePath, gce.projectID, zone, ins)
+		instanceLink := makeHostURL(g.service.BasePath, g.projectID, zone, ins)
 		refs = append(refs, &compute.InstanceReference{Instance: instanceLink})
 	}
 	return refs
 }
 
 // NodeAddresses is an implementation of Instances.NodeAddresses.
-func (gce *GCECloud) NodeAddresses(_ context.Context, _ types.NodeName) ([]v1.NodeAddress, error) {
+func (g *Cloud) NodeAddresses(_ context.Context, _ types.NodeName) ([]v1.NodeAddress, error) {
 	internalIP, err := metadata.Get("instance/network-interfaces/0/ip")
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get internal IP: %v", err)
@@ -109,7 +109,7 @@ func (gce *GCECloud) NodeAddresses(_ context.Context, _ types.NodeName) ([]v1.No
 
 // NodeAddressesByProviderID will not be called from the node that is requesting this ID.
 // i.e. metadata service and other local methods cannot be used here
-func (gce *GCECloud) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
+func (g *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
@@ -118,7 +118,7 @@ func (gce *GCECloud) NodeAddressesByProviderID(ctx context.Context, providerID s
 		return []v1.NodeAddress{}, err
 	}
 
-	instance, err := gce.c.Instances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
+	instance, err := g.c.Instances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
 	if err != nil {
 		return []v1.NodeAddress{}, fmt.Errorf("error while querying for providerID %q: %v", providerID, err)
 	}
@@ -138,13 +138,13 @@ func (gce *GCECloud) NodeAddressesByProviderID(ctx context.Context, providerID s
 
 // instanceByProviderID returns the cloudprovider instance of the node
 // with the specified unique providerID
-func (gce *GCECloud) instanceByProviderID(providerID string) (*gceInstance, error) {
+func (g *Cloud) instanceByProviderID(providerID string) (*gceInstance, error) {
 	project, zone, name, err := splitProviderID(providerID)
 	if err != nil {
 		return nil, err
 	}
 
-	instance, err := gce.getInstanceFromProjectInZoneByName(project, zone, name)
+	instance, err := g.getInstanceFromProjectInZoneByName(project, zone, name)
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
 			return nil, cloudprovider.InstanceNotFound
@@ -156,7 +156,7 @@ func (gce *GCECloud) instanceByProviderID(providerID string) (*gceInstance, erro
 }
 
 // InstanceShutdownByProviderID returns true if the instance is in safe state to detach volumes
-func (gce *GCECloud) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
+func (g *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
 	return false, cloudprovider.NotImplemented
 }
 
@@ -164,8 +164,8 @@ func (gce *GCECloud) InstanceShutdownByProviderID(ctx context.Context, providerI
 // with the specified unique providerID This method will not be called from the
 // node that is requesting this ID. i.e. metadata service and other local
 // methods cannot be used here
-func (gce *GCECloud) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
-	instance, err := gce.instanceByProviderID(providerID)
+func (g *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
+	instance, err := g.instanceByProviderID(providerID)
 	if err != nil {
 		return "", err
 	}
@@ -175,8 +175,8 @@ func (gce *GCECloud) InstanceTypeByProviderID(ctx context.Context, providerID st
 
 // InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
 // If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
-func (gce *GCECloud) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
-	_, err := gce.instanceByProviderID(providerID)
+func (g *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
+	_, err := g.instanceByProviderID(providerID)
 	if err != nil {
 		if err == cloudprovider.InstanceNotFound {
 			return false, nil
@@ -188,49 +188,51 @@ func (gce *GCECloud) InstanceExistsByProviderID(ctx context.Context, providerID 
 }
 
 // InstanceID returns the cloud provider ID of the node with the specified NodeName.
-func (gce *GCECloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
+func (g *Cloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	instanceName := mapNodeNameToInstanceName(nodeName)
-	if gce.useMetadataServer {
+	if g.useMetadataServer {
 		// Use metadata, if possible, to fetch ID. See issue #12000
-		if gce.isCurrentInstance(instanceName) {
+		if g.isCurrentInstance(instanceName) {
 			projectID, zone, err := getProjectAndZone()
 			if err == nil {
 				return projectID + "/" + zone + "/" + canonicalizeInstanceName(instanceName), nil
 			}
 		}
 	}
-	instance, err := gce.getInstanceByName(instanceName)
+	instance, err := g.getInstanceByName(instanceName)
 	if err != nil {
 		return "", err
 	}
-	return gce.projectID + "/" + instance.Zone + "/" + instance.Name, nil
+	return g.projectID + "/" + instance.Zone + "/" + instance.Name, nil
 }
 
 // InstanceType returns the type of the specified node with the specified NodeName.
-func (gce *GCECloud) InstanceType(ctx context.Context, nodeName types.NodeName) (string, error) {
+func (g *Cloud) InstanceType(ctx context.Context, nodeName types.NodeName) (string, error) {
 	instanceName := mapNodeNameToInstanceName(nodeName)
-	if gce.useMetadataServer {
+	if g.useMetadataServer {
 		// Use metadata, if possible, to fetch ID. See issue #12000
-		if gce.isCurrentInstance(instanceName) {
+		if g.isCurrentInstance(instanceName) {
 			mType, err := getCurrentMachineTypeViaMetadata()
 			if err == nil {
 				return mType, nil
 			}
 		}
 	}
-	instance, err := gce.getInstanceByName(instanceName)
+	instance, err := g.getInstanceByName(instanceName)
 	if err != nil {
 		return "", err
 	}
 	return instance.Type, nil
 }
 
-func (gce *GCECloud) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
+// AddSSHKeyToAllInstances adds an SSH public key as a legal identity for all instances
+// expected format for the key is standard ssh-keygen format: <protocol> <blob>
+func (g *Cloud) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	return wait.Poll(2*time.Second, 30*time.Second, func() (bool, error) {
-		project, err := gce.c.Projects().Get(ctx, gce.projectID)
+		project, err := g.c.Projects().Get(ctx, g.projectID)
 		if err != nil {
 			glog.Errorf("Could not get project: %v", err)
 			return false, nil
@@ -261,7 +263,7 @@ func (gce *GCECloud) AddSSHKeyToAllInstances(ctx context.Context, user string, k
 		}
 
 		mc := newInstancesMetricContext("add_ssh_key", "")
-		err = gce.c.Projects().SetCommonInstanceMetadata(ctx, gce.projectID, project.CommonInstanceMetadata)
+		err = g.c.Projects().SetCommonInstanceMetadata(ctx, g.projectID, project.CommonInstanceMetadata)
 		mc.Observe(err)
 
 		if err != nil {
@@ -274,18 +276,18 @@ func (gce *GCECloud) AddSSHKeyToAllInstances(ctx context.Context, user string, k
 }
 
 // GetAllCurrentZones returns all the zones in which k8s nodes are currently running
-func (gce *GCECloud) GetAllCurrentZones() (sets.String, error) {
-	if gce.nodeInformerSynced == nil {
-		glog.Warningf("GCECloud object does not have informers set, should only happen in E2E binary.")
-		return gce.GetAllZonesFromCloudProvider()
+func (g *Cloud) GetAllCurrentZones() (sets.String, error) {
+	if g.nodeInformerSynced == nil {
+		glog.Warningf("Cloud object does not have informers set, should only happen in E2E binary.")
+		return g.GetAllZonesFromCloudProvider()
 	}
-	gce.nodeZonesLock.Lock()
-	defer gce.nodeZonesLock.Unlock()
-	if !gce.nodeInformerSynced() {
+	g.nodeZonesLock.Lock()
+	defer g.nodeZonesLock.Unlock()
+	if !g.nodeInformerSynced() {
 		return nil, fmt.Errorf("node informer is not synced when trying to GetAllCurrentZones")
 	}
 	zones := sets.NewString()
-	for zone, nodes := range gce.nodeZones {
+	for zone, nodes := range g.nodeZones {
 		if len(nodes) > 0 {
 			zones.Insert(zone)
 		}
@@ -300,13 +302,13 @@ func (gce *GCECloud) GetAllCurrentZones() (sets.String, error) {
 // a non-k8s compute in us-central1-a. This func will return a,b, and c.
 //
 // TODO: this should be removed from the cloud provider.
-func (gce *GCECloud) GetAllZonesFromCloudProvider() (sets.String, error) {
+func (g *Cloud) GetAllZonesFromCloudProvider() (sets.String, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	zones := sets.NewString()
-	for _, zone := range gce.managedZones {
-		instances, err := gce.c.Instances().List(ctx, zone, filter.None)
+	for _, zone := range g.managedZones {
+		instances, err := g.c.Instances().List(ctx, zone, filter.None)
 		if err != nil {
 			return sets.NewString(), err
 		}
@@ -318,22 +320,22 @@ func (gce *GCECloud) GetAllZonesFromCloudProvider() (sets.String, error) {
 }
 
 // InsertInstance creates a new instance on GCP
-func (gce *GCECloud) InsertInstance(project string, zone string, i *compute.Instance) error {
+func (g *Cloud) InsertInstance(project string, zone string, i *compute.Instance) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newInstancesMetricContext("create", zone)
-	return mc.Observe(gce.c.Instances().Insert(ctx, meta.ZonalKey(i.Name, zone), i))
+	return mc.Observe(g.c.Instances().Insert(ctx, meta.ZonalKey(i.Name, zone), i))
 }
 
 // ListInstanceNames returns a string of instance names separated by spaces.
 // This method should only be used for e2e testing.
 // TODO: remove this method.
-func (gce *GCECloud) ListInstanceNames(project, zone string) (string, error) {
+func (g *Cloud) ListInstanceNames(project, zone string) (string, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
-	l, err := gce.c.Instances().List(ctx, zone, filter.None)
+	l, err := g.c.Instances().List(ctx, zone, filter.None)
 	if err != nil {
 		return "", err
 	}
@@ -345,33 +347,34 @@ func (gce *GCECloud) ListInstanceNames(project, zone string) (string, error) {
 }
 
 // DeleteInstance deletes an instance specified by project, zone, and name
-func (gce *GCECloud) DeleteInstance(project, zone, name string) error {
+func (g *Cloud) DeleteInstance(project, zone, name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
-	return gce.c.Instances().Delete(ctx, meta.ZonalKey(name, zone))
+	return g.c.Instances().Delete(ctx, meta.ZonalKey(name, zone))
 }
 
-// Implementation of Instances.CurrentNodeName
-func (gce *GCECloud) CurrentNodeName(ctx context.Context, hostname string) (types.NodeName, error) {
+// CurrentNodeName returns the name of the node we are currently running on
+// On most clouds (e.g. GCE) this is the hostname, so we provide the hostname
+func (g *Cloud) CurrentNodeName(ctx context.Context, hostname string) (types.NodeName, error) {
 	return types.NodeName(hostname), nil
 }
 
 // AliasRanges returns a list of CIDR ranges that are assigned to the
 // `node` for allocation to pods. Returns a list of the form
 // "<ip>/<netmask>".
-func (gce *GCECloud) AliasRanges(nodeName types.NodeName) (cidrs []string, err error) {
+func (g *Cloud) AliasRanges(nodeName types.NodeName) (cidrs []string, err error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	var instance *gceInstance
-	instance, err = gce.getInstanceByName(mapNodeNameToInstanceName(nodeName))
+	instance, err = g.getInstanceByName(mapNodeNameToInstanceName(nodeName))
 	if err != nil {
 		return
 	}
 
 	var res *computebeta.Instance
-	res, err = gce.c.BetaInstances().Get(ctx, meta.ZonalKey(instance.Name, lastComponent(instance.Zone)))
+	res, err = g.c.BetaInstances().Get(ctx, meta.ZonalKey(instance.Name, lastComponent(instance.Zone)))
 	if err != nil {
 		return
 	}
@@ -386,15 +389,15 @@ func (gce *GCECloud) AliasRanges(nodeName types.NodeName) (cidrs []string, err e
 
 // AddAliasToInstance adds an alias to the given instance from the named
 // secondary range.
-func (gce *GCECloud) AddAliasToInstance(nodeName types.NodeName, alias *net.IPNet) error {
+func (g *Cloud) AddAliasToInstance(nodeName types.NodeName, alias *net.IPNet) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
-	v1instance, err := gce.getInstanceByName(mapNodeNameToInstanceName(nodeName))
+	v1instance, err := g.getInstanceByName(mapNodeNameToInstanceName(nodeName))
 	if err != nil {
 		return err
 	}
-	instance, err := gce.c.BetaInstances().Get(ctx, meta.ZonalKey(v1instance.Name, lastComponent(v1instance.Zone)))
+	instance, err := g.c.BetaInstances().Get(ctx, meta.ZonalKey(v1instance.Name, lastComponent(v1instance.Zone)))
 	if err != nil {
 		return err
 	}
@@ -413,38 +416,38 @@ func (gce *GCECloud) AddAliasToInstance(nodeName types.NodeName, alias *net.IPNe
 	iface.Fingerprint = instance.NetworkInterfaces[0].Fingerprint
 	iface.AliasIpRanges = append(iface.AliasIpRanges, &computebeta.AliasIpRange{
 		IpCidrRange:         alias.String(),
-		SubnetworkRangeName: gce.secondaryRangeName,
+		SubnetworkRangeName: g.secondaryRangeName,
 	})
 
 	mc := newInstancesMetricContext("add_alias", v1instance.Zone)
-	err = gce.c.BetaInstances().UpdateNetworkInterface(ctx, meta.ZonalKey(instance.Name, lastComponent(instance.Zone)), iface.Name, iface)
+	err = g.c.BetaInstances().UpdateNetworkInterface(ctx, meta.ZonalKey(instance.Name, lastComponent(instance.Zone)), iface.Name, iface)
 	return mc.Observe(err)
 }
 
 // Gets the named instances, returning cloudprovider.InstanceNotFound if any
 // instance is not found
-func (gce *GCECloud) getInstancesByNames(names []string) ([]*gceInstance, error) {
+func (g *Cloud) getInstancesByNames(names []string) ([]*gceInstance, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	found := map[string]*gceInstance{}
 	remaining := len(names)
 
-	nodeInstancePrefix := gce.nodeInstancePrefix
+	nodeInstancePrefix := g.nodeInstancePrefix
 	for _, name := range names {
 		name = canonicalizeInstanceName(name)
-		if !strings.HasPrefix(name, gce.nodeInstancePrefix) {
-			glog.Warningf("Instance %q does not conform to prefix %q, removing filter", name, gce.nodeInstancePrefix)
+		if !strings.HasPrefix(name, g.nodeInstancePrefix) {
+			glog.Warningf("Instance %q does not conform to prefix %q, removing filter", name, g.nodeInstancePrefix)
 			nodeInstancePrefix = ""
 		}
 		found[name] = nil
 	}
 
-	for _, zone := range gce.managedZones {
+	for _, zone := range g.managedZones {
 		if remaining == 0 {
 			break
 		}
-		instances, err := gce.c.Instances().List(ctx, zone, filter.Regexp("name", nodeInstancePrefix+".*"))
+		instances, err := g.c.Instances().List(ctx, zone, filter.Regexp("name", nodeInstancePrefix+".*"))
 		if err != nil {
 			return nil, err
 		}
@@ -490,10 +493,10 @@ func (gce *GCECloud) getInstancesByNames(names []string) ([]*gceInstance, error)
 }
 
 // Gets the named instance, returning cloudprovider.InstanceNotFound if the instance is not found
-func (gce *GCECloud) getInstanceByName(name string) (*gceInstance, error) {
+func (g *Cloud) getInstanceByName(name string) (*gceInstance, error) {
 	// Avoid changing behaviour when not managing multiple zones
-	for _, zone := range gce.managedZones {
-		instance, err := gce.getInstanceFromProjectInZoneByName(gce.projectID, zone, name)
+	for _, zone := range g.managedZones {
+		instance, err := g.getInstanceFromProjectInZoneByName(g.projectID, zone, name)
 		if err != nil {
 			if isHTTPErrorCode(err, http.StatusNotFound) {
 				continue
@@ -507,13 +510,13 @@ func (gce *GCECloud) getInstanceByName(name string) (*gceInstance, error) {
 	return nil, cloudprovider.InstanceNotFound
 }
 
-func (gce *GCECloud) getInstanceFromProjectInZoneByName(project, zone, name string) (*gceInstance, error) {
+func (g *Cloud) getInstanceFromProjectInZoneByName(project, zone, name string) (*gceInstance, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	name = canonicalizeInstanceName(name)
 	mc := newInstancesMetricContext("get", zone)
-	res, err := gce.c.Instances().Get(ctx, meta.ZonalKey(name, zone))
+	res, err := g.c.Instances().Get(ctx, meta.ZonalKey(name, zone))
 	mc.Observe(err)
 	if err != nil {
 		return nil, err
@@ -554,7 +557,7 @@ func getCurrentMachineTypeViaMetadata() (string, error) {
 
 // isCurrentInstance uses metadata server to check if specified
 // instanceID matches current machine's instanceID
-func (gce *GCECloud) isCurrentInstance(instanceID string) bool {
+func (g *Cloud) isCurrentInstance(instanceID string) bool {
 	currentInstanceID, err := getInstanceIDViaMetadata()
 	if err != nil {
 		// Log and swallow error
@@ -571,16 +574,16 @@ func (gce *GCECloud) isCurrentInstance(instanceID string) bool {
 // Invoking this method to get host tags is risky since it depends on the
 // format of the host names in the cluster. Only use it as a fallback if
 // gce.nodeTags is unspecified
-func (gce *GCECloud) computeHostTags(hosts []*gceInstance) ([]string, error) {
+func (g *Cloud) computeHostTags(hosts []*gceInstance) ([]string, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	// TODO: We could store the tags in gceInstance, so we could have already fetched it
 	hostNamesByZone := make(map[string]map[string]bool) // map of zones -> map of names -> bool (for easy lookup)
-	nodeInstancePrefix := gce.nodeInstancePrefix
+	nodeInstancePrefix := g.nodeInstancePrefix
 	for _, host := range hosts {
-		if !strings.HasPrefix(host.Name, gce.nodeInstancePrefix) {
-			glog.Warningf("instance %v does not conform to prefix '%s', ignoring filter", host, gce.nodeInstancePrefix)
+		if !strings.HasPrefix(host.Name, g.nodeInstancePrefix) {
+			glog.Warningf("instance %v does not conform to prefix '%s', ignoring filter", host, g.nodeInstancePrefix)
 			nodeInstancePrefix = ""
 		}
 
@@ -599,7 +602,7 @@ func (gce *GCECloud) computeHostTags(hosts []*gceInstance) ([]string, error) {
 		filt = filter.Regexp("name", nodeInstancePrefix+".*")
 	}
 	for zone, hostNames := range hostNamesByZone {
-		instances, err := gce.c.Instances().List(ctx, zone, filt)
+		instances, err := g.c.Instances().List(ctx, zone, filt)
 		if err != nil {
 			return nil, err
 		}
@@ -607,14 +610,14 @@ func (gce *GCECloud) computeHostTags(hosts []*gceInstance) ([]string, error) {
 			if !hostNames[instance.Name] {
 				continue
 			}
-			longest_tag := ""
+			longestTag := ""
 			for _, tag := range instance.Tags.Items {
-				if strings.HasPrefix(instance.Name, tag) && len(tag) > len(longest_tag) {
-					longest_tag = tag
+				if strings.HasPrefix(instance.Name, tag) && len(tag) > len(longestTag) {
+					longestTag = tag
 				}
 			}
-			if len(longest_tag) > 0 {
-				tags.Insert(longest_tag)
+			if len(longestTag) > 0 {
+				tags.Insert(longestTag)
 			} else {
 				return nil, fmt.Errorf("could not find any tag that is a prefix of instance name for instance %s", instance.Name)
 			}
@@ -629,35 +632,35 @@ func (gce *GCECloud) computeHostTags(hosts []*gceInstance) ([]string, error) {
 // GetNodeTags will first try returning the list of tags specified in GCE cloud Configuration.
 // If they weren't provided, it'll compute the host tags with the given hostnames. If the list
 // of hostnames has not changed, a cached set of nodetags are returned.
-func (gce *GCECloud) GetNodeTags(nodeNames []string) ([]string, error) {
+func (g *Cloud) GetNodeTags(nodeNames []string) ([]string, error) {
 	// If nodeTags were specified through configuration, use them
-	if len(gce.nodeTags) > 0 {
-		return gce.nodeTags, nil
+	if len(g.nodeTags) > 0 {
+		return g.nodeTags, nil
 	}
 
-	gce.computeNodeTagLock.Lock()
-	defer gce.computeNodeTagLock.Unlock()
+	g.computeNodeTagLock.Lock()
+	defer g.computeNodeTagLock.Unlock()
 
 	// Early return if hosts have not changed
 	hosts := sets.NewString(nodeNames...)
-	if hosts.Equal(gce.lastKnownNodeNames) {
-		return gce.lastComputedNodeTags, nil
+	if hosts.Equal(g.lastKnownNodeNames) {
+		return g.lastComputedNodeTags, nil
 	}
 
 	// Get GCE instance data by hostname
-	instances, err := gce.getInstancesByNames(nodeNames)
+	instances, err := g.getInstancesByNames(nodeNames)
 	if err != nil {
 		return nil, err
 	}
 
 	// Determine list of host tags
-	tags, err := gce.computeHostTags(instances)
+	tags, err := g.computeHostTags(instances)
 	if err != nil {
 		return nil, err
 	}
 
 	// Save the list of tags
-	gce.lastKnownNodeNames = hosts
-	gce.lastComputedNodeTags = tags
+	g.lastKnownNodeNames = hosts
+	g.lastComputedNodeTags = tags
 	return tags, nil
 }

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer.go
@@ -87,9 +87,9 @@ func LoadBalancerSrcRanges() []string {
 }
 
 // GetLoadBalancer is an implementation of LoadBalancer.GetLoadBalancer
-func (gce *GCECloud) GetLoadBalancer(ctx context.Context, clusterName string, svc *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
-	loadBalancerName := gce.GetLoadBalancerName(ctx, clusterName, svc)
-	fwd, err := gce.GetRegionForwardingRule(loadBalancerName, gce.region)
+func (g *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, svc *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
+	loadBalancerName := g.GetLoadBalancerName(ctx, clusterName, svc)
+	fwd, err := g.GetRegionForwardingRule(loadBalancerName, g.region)
 	if err == nil {
 		status := &v1.LoadBalancerStatus{}
 		status.Ingress = []v1.LoadBalancerIngress{{IP: fwd.IPAddress}}
@@ -100,23 +100,23 @@ func (gce *GCECloud) GetLoadBalancer(ctx context.Context, clusterName string, sv
 }
 
 // GetLoadBalancerName is an implementation of LoadBalancer.GetLoadBalancerName.
-func (gce *GCECloud) GetLoadBalancerName(ctx context.Context, clusterName string, svc *v1.Service) string {
+func (g *Cloud) GetLoadBalancerName(ctx context.Context, clusterName string, svc *v1.Service) string {
 	// TODO: replace DefaultLoadBalancerName to generate more meaningful loadbalancer names.
 	return cloudprovider.DefaultLoadBalancerName(svc)
 }
 
 // EnsureLoadBalancer is an implementation of LoadBalancer.EnsureLoadBalancer.
-func (gce *GCECloud) EnsureLoadBalancer(ctx context.Context, clusterName string, svc *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
-	loadBalancerName := gce.GetLoadBalancerName(ctx, clusterName, svc)
+func (g *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, svc *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
+	loadBalancerName := g.GetLoadBalancerName(ctx, clusterName, svc)
 	desiredScheme := getSvcScheme(svc)
-	clusterID, err := gce.ClusterID.GetID()
+	clusterID, err := g.ClusterID.GetID()
 	if err != nil {
 		return nil, err
 	}
 
-	glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v): ensure %v loadbalancer", clusterName, svc.Namespace, svc.Name, loadBalancerName, gce.region, desiredScheme)
+	glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v): ensure %v loadbalancer", clusterName, svc.Namespace, svc.Name, loadBalancerName, g.region, desiredScheme)
 
-	existingFwdRule, err := gce.GetRegionForwardingRule(loadBalancerName, gce.region)
+	existingFwdRule, err := g.GetRegionForwardingRule(loadBalancerName, g.region)
 	if err != nil && !isNotFound(err) {
 		return nil, err
 	}
@@ -126,14 +126,14 @@ func (gce *GCECloud) EnsureLoadBalancer(ctx context.Context, clusterName string,
 
 		// If the loadbalancer type changes between INTERNAL and EXTERNAL, the old load balancer should be deleted.
 		if existingScheme != desiredScheme {
-			glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v): deleting existing %v loadbalancer", clusterName, svc.Namespace, svc.Name, loadBalancerName, gce.region, existingScheme)
+			glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v): deleting existing %v loadbalancer", clusterName, svc.Namespace, svc.Name, loadBalancerName, g.region, existingScheme)
 			switch existingScheme {
 			case cloud.SchemeInternal:
-				err = gce.ensureInternalLoadBalancerDeleted(clusterName, clusterID, svc)
+				err = g.ensureInternalLoadBalancerDeleted(clusterName, clusterID, svc)
 			default:
-				err = gce.ensureExternalLoadBalancerDeleted(clusterName, clusterID, svc)
+				err = g.ensureExternalLoadBalancerDeleted(clusterName, clusterID, svc)
 			}
-			glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v): done deleting existing %v loadbalancer. err: %v", clusterName, svc.Namespace, svc.Name, loadBalancerName, gce.region, existingScheme, err)
+			glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v): done deleting existing %v loadbalancer. err: %v", clusterName, svc.Namespace, svc.Name, loadBalancerName, g.region, existingScheme, err)
 			if err != nil {
 				return nil, err
 			}
@@ -146,53 +146,53 @@ func (gce *GCECloud) EnsureLoadBalancer(ctx context.Context, clusterName string,
 	var status *v1.LoadBalancerStatus
 	switch desiredScheme {
 	case cloud.SchemeInternal:
-		status, err = gce.ensureInternalLoadBalancer(clusterName, clusterID, svc, existingFwdRule, nodes)
+		status, err = g.ensureInternalLoadBalancer(clusterName, clusterID, svc, existingFwdRule, nodes)
 	default:
-		status, err = gce.ensureExternalLoadBalancer(clusterName, clusterID, svc, existingFwdRule, nodes)
+		status, err = g.ensureExternalLoadBalancer(clusterName, clusterID, svc, existingFwdRule, nodes)
 	}
-	glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v): done ensuring loadbalancer. err: %v", clusterName, svc.Namespace, svc.Name, loadBalancerName, gce.region, err)
+	glog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v): done ensuring loadbalancer. err: %v", clusterName, svc.Namespace, svc.Name, loadBalancerName, g.region, err)
 	return status, err
 }
 
 // UpdateLoadBalancer is an implementation of LoadBalancer.UpdateLoadBalancer.
-func (gce *GCECloud) UpdateLoadBalancer(ctx context.Context, clusterName string, svc *v1.Service, nodes []*v1.Node) error {
-	loadBalancerName := gce.GetLoadBalancerName(ctx, clusterName, svc)
+func (g *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, svc *v1.Service, nodes []*v1.Node) error {
+	loadBalancerName := g.GetLoadBalancerName(ctx, clusterName, svc)
 	scheme := getSvcScheme(svc)
-	clusterID, err := gce.ClusterID.GetID()
+	clusterID, err := g.ClusterID.GetID()
 	if err != nil {
 		return err
 	}
 
-	glog.V(4).Infof("UpdateLoadBalancer(%v, %v, %v, %v, %v): updating with %d nodes", clusterName, svc.Namespace, svc.Name, loadBalancerName, gce.region, len(nodes))
+	glog.V(4).Infof("UpdateLoadBalancer(%v, %v, %v, %v, %v): updating with %d nodes", clusterName, svc.Namespace, svc.Name, loadBalancerName, g.region, len(nodes))
 
 	switch scheme {
 	case cloud.SchemeInternal:
-		err = gce.updateInternalLoadBalancer(clusterName, clusterID, svc, nodes)
+		err = g.updateInternalLoadBalancer(clusterName, clusterID, svc, nodes)
 	default:
-		err = gce.updateExternalLoadBalancer(clusterName, svc, nodes)
+		err = g.updateExternalLoadBalancer(clusterName, svc, nodes)
 	}
-	glog.V(4).Infof("UpdateLoadBalancer(%v, %v, %v, %v, %v): done updating. err: %v", clusterName, svc.Namespace, svc.Name, loadBalancerName, gce.region, err)
+	glog.V(4).Infof("UpdateLoadBalancer(%v, %v, %v, %v, %v): done updating. err: %v", clusterName, svc.Namespace, svc.Name, loadBalancerName, g.region, err)
 	return err
 }
 
 // EnsureLoadBalancerDeleted is an implementation of LoadBalancer.EnsureLoadBalancerDeleted.
-func (gce *GCECloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, svc *v1.Service) error {
-	loadBalancerName := gce.GetLoadBalancerName(ctx, clusterName, svc)
+func (g *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, svc *v1.Service) error {
+	loadBalancerName := g.GetLoadBalancerName(ctx, clusterName, svc)
 	scheme := getSvcScheme(svc)
-	clusterID, err := gce.ClusterID.GetID()
+	clusterID, err := g.ClusterID.GetID()
 	if err != nil {
 		return err
 	}
 
-	glog.V(4).Infof("EnsureLoadBalancerDeleted(%v, %v, %v, %v, %v): deleting loadbalancer", clusterName, svc.Namespace, svc.Name, loadBalancerName, gce.region)
+	glog.V(4).Infof("EnsureLoadBalancerDeleted(%v, %v, %v, %v, %v): deleting loadbalancer", clusterName, svc.Namespace, svc.Name, loadBalancerName, g.region)
 
 	switch scheme {
 	case cloud.SchemeInternal:
-		err = gce.ensureInternalLoadBalancerDeleted(clusterName, clusterID, svc)
+		err = g.ensureInternalLoadBalancerDeleted(clusterName, clusterID, svc)
 	default:
-		err = gce.ensureExternalLoadBalancerDeleted(clusterName, clusterID, svc)
+		err = g.ensureExternalLoadBalancerDeleted(clusterName, clusterID, svc)
 	}
-	glog.V(4).Infof("EnsureLoadBalancerDeleted(%v, %v, %v, %v, %v): done deleting loadbalancer. err: %v", clusterName, svc.Namespace, svc.Name, loadBalancerName, gce.region, err)
+	glog.V(4).Infof("EnsureLoadBalancerDeleted(%v, %v, %v, %v, %v): done deleting loadbalancer. err: %v", clusterName, svc.Namespace, svc.Name, loadBalancerName, g.region, err)
 	return err
 }
 

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
@@ -44,19 +44,19 @@ import (
 // Due to an interesting series of design decisions, this handles both creating
 // new load balancers and updating existing load balancers, recognizing when
 // each is needed.
-func (gce *GCECloud) ensureExternalLoadBalancer(clusterName string, clusterID string, apiService *v1.Service, existingFwdRule *compute.ForwardingRule, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
+func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string, apiService *v1.Service, existingFwdRule *compute.ForwardingRule, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
 	if len(nodes) == 0 {
 		return nil, fmt.Errorf("Cannot EnsureLoadBalancer() with no hosts")
 	}
 
 	hostNames := nodeNames(nodes)
 	supportsNodesHealthCheck := supportsNodesHealthCheck(nodes)
-	hosts, err := gce.getInstancesByNames(hostNames)
+	hosts, err := g.getInstancesByNames(hostNames)
 	if err != nil {
 		return nil, err
 	}
 
-	loadBalancerName := gce.GetLoadBalancerName(context.TODO(), clusterName, apiService)
+	loadBalancerName := g.GetLoadBalancerName(context.TODO(), clusterName, apiService)
 	requestedIP := apiService.Spec.LoadBalancerIP
 	ports := apiService.Spec.Ports
 	portStr := []string{}
@@ -66,22 +66,22 @@ func (gce *GCECloud) ensureExternalLoadBalancer(clusterName string, clusterID st
 
 	serviceName := types.NamespacedName{Namespace: apiService.Namespace, Name: apiService.Name}
 	lbRefStr := fmt.Sprintf("%v(%v)", loadBalancerName, serviceName)
-	glog.V(2).Infof("ensureExternalLoadBalancer(%s, %v, %v, %v, %v, %v)", lbRefStr, gce.region, requestedIP, portStr, hostNames, apiService.Annotations)
+	glog.V(2).Infof("ensureExternalLoadBalancer(%s, %v, %v, %v, %v, %v)", lbRefStr, g.region, requestedIP, portStr, hostNames, apiService.Annotations)
 
 	// Check the current and the desired network tiers. If they do not match,
 	// tear down the existing resources with the wrong tier.
-	netTier, err := gce.getServiceNetworkTier(apiService)
+	netTier, err := g.getServiceNetworkTier(apiService)
 	if err != nil {
 		glog.Errorf("ensureExternalLoadBalancer(%s): Failed to get the desired network tier: %v.", lbRefStr, err)
 		return nil, err
 	}
 	glog.V(4).Infof("ensureExternalLoadBalancer(%s): Desired network tier %q.", lbRefStr, netTier)
-	if gce.AlphaFeatureGate.Enabled(AlphaFeatureNetworkTiers) {
-		gce.deleteWrongNetworkTieredResources(loadBalancerName, lbRefStr, netTier)
+	if g.AlphaFeatureGate.Enabled(AlphaFeatureNetworkTiers) {
+		g.deleteWrongNetworkTieredResources(loadBalancerName, lbRefStr, netTier)
 	}
 
 	// Check if the forwarding rule exists, and if so, what its IP is.
-	fwdRuleExists, fwdRuleNeedsUpdate, fwdRuleIP, err := gce.forwardingRuleNeedsUpdate(loadBalancerName, gce.region, requestedIP, ports)
+	fwdRuleExists, fwdRuleNeedsUpdate, fwdRuleIP, err := g.forwardingRuleNeedsUpdate(loadBalancerName, g.region, requestedIP, ports)
 	if err != nil {
 		return nil, err
 	}
@@ -120,22 +120,22 @@ func (gce *GCECloud) ensureExternalLoadBalancer(clusterName string, clusterID st
 			return
 		}
 		if isSafeToReleaseIP {
-			if err := gce.DeleteRegionAddress(loadBalancerName, gce.region); err != nil && !isNotFound(err) {
-				glog.Errorf("ensureExternalLoadBalancer(%s): Failed to release static IP %s in region %v: %v.", lbRefStr, ipAddressToUse, gce.region, err)
+			if err := g.DeleteRegionAddress(loadBalancerName, g.region); err != nil && !isNotFound(err) {
+				glog.Errorf("ensureExternalLoadBalancer(%s): Failed to release static IP %s in region %v: %v.", lbRefStr, ipAddressToUse, g.region, err)
 			} else if isNotFound(err) {
 				glog.V(2).Infof("ensureExternalLoadBalancer(%s): IP address %s is not reserved.", lbRefStr, ipAddressToUse)
 			} else {
 				glog.Infof("ensureExternalLoadBalancer(%s): Released static IP %s.", lbRefStr, ipAddressToUse)
 			}
 		} else {
-			glog.Warningf("ensureExternalLoadBalancer(%s): Orphaning static IP %s in region %v: %v.", lbRefStr, ipAddressToUse, gce.region, err)
+			glog.Warningf("ensureExternalLoadBalancer(%s): Orphaning static IP %s in region %v: %v.", lbRefStr, ipAddressToUse, g.region, err)
 		}
 	}()
 
 	if requestedIP != "" {
 		// If user requests a specific IP address, verify first. No mutation to
 		// the GCE resources will be performed in the verification process.
-		isUserOwnedIP, err = verifyUserRequestedIP(gce, gce.region, requestedIP, fwdRuleIP, lbRefStr, netTier)
+		isUserOwnedIP, err = verifyUserRequestedIP(g, g.region, requestedIP, fwdRuleIP, lbRefStr, netTier)
 		if err != nil {
 			return nil, err
 		}
@@ -145,7 +145,7 @@ func (gce *GCECloud) ensureExternalLoadBalancer(clusterName string, clusterID st
 	if !isUserOwnedIP {
 		// If we are not using the user-owned IP, either promote the
 		// emphemeral IP used by the fwd rule, or create a new static IP.
-		ipAddr, existed, err := ensureStaticIP(gce, loadBalancerName, serviceName.String(), gce.region, fwdRuleIP, netTier)
+		ipAddr, existed, err := ensureStaticIP(g, loadBalancerName, serviceName.String(), g.region, fwdRuleIP, netTier)
 		if err != nil {
 			return nil, fmt.Errorf("failed to ensure a static IP for load balancer (%s): %v", lbRefStr, err)
 		}
@@ -167,7 +167,7 @@ func (gce *GCECloud) ensureExternalLoadBalancer(clusterName string, clusterID st
 		return nil, err
 	}
 
-	firewallExists, firewallNeedsUpdate, err := gce.firewallNeedsUpdate(loadBalancerName, serviceName.String(), gce.region, ipAddressToUse, ports, sourceRanges)
+	firewallExists, firewallNeedsUpdate, err := g.firewallNeedsUpdate(loadBalancerName, serviceName.String(), g.region, ipAddressToUse, ports, sourceRanges)
 	if err != nil {
 		return nil, err
 	}
@@ -178,20 +178,20 @@ func (gce *GCECloud) ensureExternalLoadBalancer(clusterName string, clusterID st
 		// without needing to be deleted and recreated.
 		if firewallExists {
 			glog.Infof("ensureExternalLoadBalancer(%s): Updating firewall.", lbRefStr)
-			if err := gce.updateFirewall(apiService, MakeFirewallName(loadBalancerName), gce.region, desc, sourceRanges, ports, hosts); err != nil {
+			if err := g.updateFirewall(apiService, MakeFirewallName(loadBalancerName), g.region, desc, sourceRanges, ports, hosts); err != nil {
 				return nil, err
 			}
 			glog.Infof("ensureExternalLoadBalancer(%s): Updated firewall.", lbRefStr)
 		} else {
 			glog.Infof("ensureExternalLoadBalancer(%s): Creating firewall.", lbRefStr)
-			if err := gce.createFirewall(apiService, MakeFirewallName(loadBalancerName), gce.region, desc, sourceRanges, ports, hosts); err != nil {
+			if err := g.createFirewall(apiService, MakeFirewallName(loadBalancerName), g.region, desc, sourceRanges, ports, hosts); err != nil {
 				return nil, err
 			}
 			glog.Infof("ensureExternalLoadBalancer(%s): Created firewall.", lbRefStr)
 		}
 	}
 
-	tpExists, tpNeedsRecreation, err := gce.targetPoolNeedsRecreation(loadBalancerName, gce.region, apiService.Spec.SessionAffinity)
+	tpExists, tpNeedsRecreation, err := g.targetPoolNeedsRecreation(loadBalancerName, g.region, apiService.Spec.SessionAffinity)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (gce *GCECloud) ensureExternalLoadBalancer(clusterName string, clusterID st
 	// Check which health check needs to create and which health check needs to delete.
 	// Health check management is coupled with target pool operation to prevent leaking.
 	var hcToCreate, hcToDelete *compute.HttpHealthCheck
-	hcLocalTrafficExisting, err := gce.GetHttpHealthCheck(loadBalancerName)
+	hcLocalTrafficExisting, err := g.GetHTTPHealthCheck(loadBalancerName)
 	if err != nil && !isHTTPErrorCode(err, http.StatusNotFound) {
 		return nil, fmt.Errorf("error checking HTTP health check for load balancer (%s): %v", lbRefStr, err)
 	}
@@ -214,11 +214,11 @@ func (gce *GCECloud) ensureExternalLoadBalancer(clusterName string, clusterID st
 			// target pool to use local traffic health check.
 			glog.V(2).Infof("ensureExternalLoadBalancer(%s): Updating from nodes health checks to local traffic health checks.", lbRefStr)
 			if supportsNodesHealthCheck {
-				hcToDelete = makeHttpHealthCheck(MakeNodesHealthCheckName(clusterID), GetNodesHealthCheckPath(), GetNodesHealthCheckPort())
+				hcToDelete = makeHTTPHealthCheck(MakeNodesHealthCheckName(clusterID), GetNodesHealthCheckPath(), GetNodesHealthCheckPort())
 			}
 			tpNeedsRecreation = true
 		}
-		hcToCreate = makeHttpHealthCheck(loadBalancerName, path, healthCheckNodePort)
+		hcToCreate = makeHTTPHealthCheck(loadBalancerName, path, healthCheckNodePort)
 	} else {
 		glog.V(4).Infof("ensureExternalLoadBalancer(%s): Service needs nodes health checks.", lbRefStr)
 		if hcLocalTrafficExisting != nil {
@@ -230,7 +230,7 @@ func (gce *GCECloud) ensureExternalLoadBalancer(clusterName string, clusterID st
 			tpNeedsRecreation = true
 		}
 		if supportsNodesHealthCheck {
-			hcToCreate = makeHttpHealthCheck(MakeNodesHealthCheckName(clusterID), GetNodesHealthCheckPath(), GetNodesHealthCheckPort())
+			hcToCreate = makeHTTPHealthCheck(MakeNodesHealthCheckName(clusterID), GetNodesHealthCheckPath(), GetNodesHealthCheckPort())
 		}
 	}
 	// Now we get to some slightly more interesting logic.
@@ -245,19 +245,19 @@ func (gce *GCECloud) ensureExternalLoadBalancer(clusterName string, clusterID st
 		// and something should fail before we recreate it, don't release the
 		// IP.  That way we can come back to it later.
 		isSafeToReleaseIP = false
-		if err := gce.DeleteRegionForwardingRule(loadBalancerName, gce.region); err != nil && !isNotFound(err) {
+		if err := g.DeleteRegionForwardingRule(loadBalancerName, g.region); err != nil && !isNotFound(err) {
 			return nil, fmt.Errorf("failed to delete existing forwarding rule for load balancer (%s) update: %v", lbRefStr, err)
 		}
 		glog.Infof("ensureExternalLoadBalancer(%s): Deleted forwarding rule.", lbRefStr)
 	}
 
-	if err := gce.ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation, apiService, loadBalancerName, clusterID, ipAddressToUse, hosts, hcToCreate, hcToDelete); err != nil {
+	if err := g.ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation, apiService, loadBalancerName, clusterID, ipAddressToUse, hosts, hcToCreate, hcToDelete); err != nil {
 		return nil, err
 	}
 
 	if tpNeedsRecreation || fwdRuleNeedsUpdate {
 		glog.Infof("ensureExternalLoadBalancer(%s): Creating forwarding rule, IP %s (tier: %s).", lbRefStr, ipAddressToUse, netTier)
-		if err := createForwardingRule(gce, loadBalancerName, serviceName.String(), gce.region, ipAddressToUse, gce.targetPoolURL(loadBalancerName), ports, netTier); err != nil {
+		if err := createForwardingRule(g, loadBalancerName, serviceName.String(), g.region, ipAddressToUse, g.targetPoolURL(loadBalancerName), ports, netTier); err != nil {
 			return nil, fmt.Errorf("failed to create forwarding rule for load balancer (%s): %v", lbRefStr, err)
 		}
 		// End critical section.  It is safe to release the static IP (which
@@ -275,25 +275,25 @@ func (gce *GCECloud) ensureExternalLoadBalancer(clusterName string, clusterID st
 }
 
 // updateExternalLoadBalancer is the external implementation of LoadBalancer.UpdateLoadBalancer.
-func (gce *GCECloud) updateExternalLoadBalancer(clusterName string, service *v1.Service, nodes []*v1.Node) error {
-	hosts, err := gce.getInstancesByNames(nodeNames(nodes))
+func (g *Cloud) updateExternalLoadBalancer(clusterName string, service *v1.Service, nodes []*v1.Node) error {
+	hosts, err := g.getInstancesByNames(nodeNames(nodes))
 	if err != nil {
 		return err
 	}
 
-	loadBalancerName := gce.GetLoadBalancerName(context.TODO(), clusterName, service)
-	return gce.updateTargetPool(loadBalancerName, hosts)
+	loadBalancerName := g.GetLoadBalancerName(context.TODO(), clusterName, service)
+	return g.updateTargetPool(loadBalancerName, hosts)
 }
 
 // ensureExternalLoadBalancerDeleted is the external implementation of LoadBalancer.EnsureLoadBalancerDeleted
-func (gce *GCECloud) ensureExternalLoadBalancerDeleted(clusterName, clusterID string, service *v1.Service) error {
-	loadBalancerName := gce.GetLoadBalancerName(context.TODO(), clusterName, service)
+func (g *Cloud) ensureExternalLoadBalancerDeleted(clusterName, clusterID string, service *v1.Service) error {
+	loadBalancerName := g.GetLoadBalancerName(context.TODO(), clusterName, service)
 	serviceName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
 	lbRefStr := fmt.Sprintf("%v(%v)", loadBalancerName, serviceName)
 
 	var hcNames []string
 	if path, _ := apiservice.GetServiceHealthCheckPathPort(service); path != "" {
-		hcToDelete, err := gce.GetHttpHealthCheck(loadBalancerName)
+		hcToDelete, err := g.GetHTTPHealthCheck(loadBalancerName)
 		if err != nil && !isHTTPErrorCode(err, http.StatusNotFound) {
 			glog.Infof("ensureExternalLoadBalancerDeleted(%s): Failed to retrieve health check:%v.", lbRefStr, err)
 			return err
@@ -315,10 +315,10 @@ func (gce *GCECloud) ensureExternalLoadBalancerDeleted(clusterName, clusterID st
 		func() error {
 			glog.Infof("ensureExternalLoadBalancerDeleted(%s): Deleting firewall rule.", lbRefStr)
 			fwName := MakeFirewallName(loadBalancerName)
-			err := ignoreNotFound(gce.DeleteFirewall(fwName))
-			if isForbidden(err) && gce.OnXPN() {
+			err := ignoreNotFound(g.DeleteFirewall(fwName))
+			if isForbidden(err) && g.OnXPN() {
 				glog.V(4).Infof("ensureExternalLoadBalancerDeleted(%s): Do not have permission to delete firewall rule %v (on XPN). Raising event.", lbRefStr, fwName)
-				gce.raiseFirewallChangeNeededEvent(service, FirewallToGCloudDeleteCmd(fwName, gce.NetworkProjectID()))
+				g.raiseFirewallChangeNeededEvent(service, FirewallToGCloudDeleteCmd(fwName, g.NetworkProjectID()))
 				return nil
 			}
 			return err
@@ -328,17 +328,17 @@ func (gce *GCECloud) ensureExternalLoadBalancerDeleted(clusterName, clusterID st
 		// creation/update attempt, so make sure we clean it up here just in case.
 		func() error {
 			glog.Infof("ensureExternalLoadBalancerDeleted(%s): Deleting IP address.", lbRefStr)
-			return ignoreNotFound(gce.DeleteRegionAddress(loadBalancerName, gce.region))
+			return ignoreNotFound(g.DeleteRegionAddress(loadBalancerName, g.region))
 		},
 		func() error {
 			glog.Infof("ensureExternalLoadBalancerDeleted(%s): Deleting forwarding rule.", lbRefStr)
 			// The forwarding rule must be deleted before either the target pool can,
 			// unfortunately, so we have to do these two serially.
-			if err := ignoreNotFound(gce.DeleteRegionForwardingRule(loadBalancerName, gce.region)); err != nil {
+			if err := ignoreNotFound(g.DeleteRegionForwardingRule(loadBalancerName, g.region)); err != nil {
 				return err
 			}
 			glog.Infof("ensureExternalLoadBalancerDeleted(%s): Deleting target pool.", lbRefStr)
-			if err := gce.DeleteExternalTargetPoolAndChecks(service, loadBalancerName, gce.region, clusterID, hcNames...); err != nil {
+			if err := g.DeleteExternalTargetPoolAndChecks(service, loadBalancerName, g.region, clusterID, hcNames...); err != nil {
 				return err
 			}
 			return nil
@@ -350,11 +350,12 @@ func (gce *GCECloud) ensureExternalLoadBalancerDeleted(clusterName, clusterID st
 	return nil
 }
 
-func (gce *GCECloud) DeleteExternalTargetPoolAndChecks(service *v1.Service, name, region, clusterID string, hcNames ...string) error {
+// DeleteExternalTargetPoolAndChecks Deletes an external load balancer pool and verifies the operation
+func (g *Cloud) DeleteExternalTargetPoolAndChecks(service *v1.Service, name, region, clusterID string, hcNames ...string) error {
 	serviceName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
 	lbRefStr := fmt.Sprintf("%v(%v)", name, serviceName)
 
-	if err := gce.DeleteTargetPool(name, region); err != nil && isHTTPErrorCode(err, http.StatusNotFound) {
+	if err := g.DeleteTargetPool(name, region); err != nil && isHTTPErrorCode(err, http.StatusNotFound) {
 		glog.Infof("DeleteExternalTargetPoolAndChecks(%v): Target pool already deleted. Continuing to delete other resources.", lbRefStr)
 	} else if err != nil {
 		glog.Warningf("DeleteExternalTargetPoolAndChecks(%v): Failed to delete target pool, got error %s.", lbRefStr, err.Error())
@@ -369,11 +370,11 @@ func (gce *GCECloud) DeleteExternalTargetPoolAndChecks(service *v1.Service, name
 			if isNodesHealthCheck {
 				// Lock to prevent deleting necessary nodes health check before it gets attached
 				// to target pool.
-				gce.sharedResourceLock.Lock()
-				defer gce.sharedResourceLock.Unlock()
+				g.sharedResourceLock.Lock()
+				defer g.sharedResourceLock.Unlock()
 			}
 			glog.Infof("DeleteExternalTargetPoolAndChecks(%v): Deleting health check %v.", lbRefStr, hcName)
-			if err := gce.DeleteHttpHealthCheck(hcName); err != nil {
+			if err := g.DeleteHTTPHealthCheck(hcName); err != nil {
 				// Delete nodes health checks will fail if any other target pool is using it.
 				if isInUsedByError(err) {
 					glog.V(4).Infof("DeleteExternalTargetPoolAndChecks(%v): Health check %v is in used: %v.", lbRefStr, hcName, err)
@@ -395,10 +396,10 @@ func (gce *GCECloud) DeleteExternalTargetPoolAndChecks(service *v1.Service, name
 			// So we should delete the health check firewall as well.
 			fwName := MakeHealthCheckFirewallName(clusterID, hcName, isNodesHealthCheck)
 			glog.Infof("DeleteExternalTargetPoolAndChecks(%v): Deleting health check firewall %v.", lbRefStr, fwName)
-			if err := ignoreNotFound(gce.DeleteFirewall(fwName)); err != nil {
-				if isForbidden(err) && gce.OnXPN() {
+			if err := ignoreNotFound(g.DeleteFirewall(fwName)); err != nil {
+				if isForbidden(err) && g.OnXPN() {
 					glog.V(4).Infof("DeleteExternalTargetPoolAndChecks(%v): Do not have permission to delete firewall rule %v (on XPN). Raising event.", lbRefStr, fwName)
-					gce.raiseFirewallChangeNeededEvent(service, FirewallToGCloudDeleteCmd(fwName, gce.NetworkProjectID()))
+					g.raiseFirewallChangeNeededEvent(service, FirewallToGCloudDeleteCmd(fwName, g.NetworkProjectID()))
 					return nil
 				}
 				return err
@@ -462,7 +463,7 @@ func verifyUserRequestedIP(s CloudAddressService, region, requestedIP, fwdRuleIP
 	return false, fmt.Errorf("requested ip %q is neither static nor assigned to the LB", requestedIP)
 }
 
-func (gce *GCECloud) ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation bool, svc *v1.Service, loadBalancerName, clusterID, ipAddressToUse string, hosts []*gceInstance, hcToCreate, hcToDelete *compute.HttpHealthCheck) error {
+func (g *Cloud) ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation bool, svc *v1.Service, loadBalancerName, clusterID, ipAddressToUse string, hosts []*gceInstance, hcToCreate, hcToDelete *compute.HttpHealthCheck) error {
 	serviceName := types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
 	lbRefStr := fmt.Sprintf("%v(%v)", loadBalancerName, serviceName)
 
@@ -472,7 +473,7 @@ func (gce *GCECloud) ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation 
 		if hcToDelete != nil {
 			hcNames = append(hcNames, hcToDelete.Name)
 		}
-		if err := gce.DeleteExternalTargetPoolAndChecks(svc, loadBalancerName, gce.region, clusterID, hcNames...); err != nil {
+		if err := g.DeleteExternalTargetPoolAndChecks(svc, loadBalancerName, g.region, clusterID, hcNames...); err != nil {
 			return fmt.Errorf("failed to delete existing target pool for load balancer (%s) update: %v", lbRefStr, err)
 		}
 		glog.Infof("ensureTargetPoolAndHealthCheck(%s): Deleted target pool.", lbRefStr)
@@ -484,7 +485,7 @@ func (gce *GCECloud) ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation 
 		if len(hosts) > maxTargetPoolCreateInstances {
 			createInstances = createInstances[:maxTargetPoolCreateInstances]
 		}
-		if err := gce.createTargetPoolAndHealthCheck(svc, loadBalancerName, serviceName.String(), ipAddressToUse, gce.region, clusterID, createInstances, hcToCreate); err != nil {
+		if err := g.createTargetPoolAndHealthCheck(svc, loadBalancerName, serviceName.String(), ipAddressToUse, g.region, clusterID, createInstances, hcToCreate); err != nil {
 			return fmt.Errorf("failed to create target pool for load balancer (%s): %v", lbRefStr, err)
 		}
 		if hcToCreate != nil {
@@ -494,19 +495,19 @@ func (gce *GCECloud) ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation 
 			glog.Infof("ensureTargetPoolAndHealthCheck(%s): Created target pool.", lbRefStr)
 		} else {
 			glog.Infof("ensureTargetPoolAndHealthCheck(%s): Created initial target pool (now updating the remaining %d hosts).", lbRefStr, len(hosts)-maxTargetPoolCreateInstances)
-			if err := gce.updateTargetPool(loadBalancerName, hosts); err != nil {
+			if err := g.updateTargetPool(loadBalancerName, hosts); err != nil {
 				return fmt.Errorf("failed to update target pool for load balancer (%s): %v", lbRefStr, err)
 			}
 			glog.Infof("ensureTargetPoolAndHealthCheck(%s): Updated target pool (with %d hosts).", lbRefStr, len(hosts)-maxTargetPoolCreateInstances)
 		}
 	} else if tpExists {
 		// Ensure hosts are updated even if there is no other changes required on target pool.
-		if err := gce.updateTargetPool(loadBalancerName, hosts); err != nil {
+		if err := g.updateTargetPool(loadBalancerName, hosts); err != nil {
 			return fmt.Errorf("failed to update target pool for load balancer (%s): %v", lbRefStr, err)
 		}
 		glog.Infof("ensureTargetPoolAndHealthCheck(%s): Updated target pool (with %d hosts).", lbRefStr, len(hosts))
 		if hcToCreate != nil {
-			if hc, err := gce.ensureHttpHealthCheck(hcToCreate.Name, hcToCreate.RequestPath, int32(hcToCreate.Port)); err != nil || hc == nil {
+			if hc, err := g.ensureHTTPHealthCheck(hcToCreate.Name, hcToCreate.RequestPath, int32(hcToCreate.Port)); err != nil || hc == nil {
 				return fmt.Errorf("Failed to ensure health check for %v port %d path %v: %v", loadBalancerName, hcToCreate.Port, hcToCreate.RequestPath, err)
 			}
 		}
@@ -517,7 +518,7 @@ func (gce *GCECloud) ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation 
 	return nil
 }
 
-func (gce *GCECloud) createTargetPoolAndHealthCheck(svc *v1.Service, name, serviceName, ipAddress, region, clusterID string, hosts []*gceInstance, hc *compute.HttpHealthCheck) error {
+func (g *Cloud) createTargetPoolAndHealthCheck(svc *v1.Service, name, serviceName, ipAddress, region, clusterID string, hosts []*gceInstance, hc *compute.HttpHealthCheck) error {
 	// health check management is coupled with targetPools to prevent leaks. A
 	// target pool is the only thing that requires a health check, so we delete
 	// associated checks on teardown, and ensure checks on setup.
@@ -527,16 +528,16 @@ func (gce *GCECloud) createTargetPoolAndHealthCheck(svc *v1.Service, name, servi
 		isNodesHealthCheck := hc.Name != name
 		if isNodesHealthCheck {
 			// Lock to prevent necessary nodes health check / firewall gets deleted.
-			gce.sharedResourceLock.Lock()
-			defer gce.sharedResourceLock.Unlock()
+			g.sharedResourceLock.Lock()
+			defer g.sharedResourceLock.Unlock()
 		}
 
-		if err := gce.ensureHttpHealthCheckFirewall(svc, serviceName, ipAddress, region, clusterID, hosts, hc.Name, int32(hc.Port), isNodesHealthCheck); err != nil {
+		if err := g.ensureHTTPHealthCheckFirewall(svc, serviceName, ipAddress, region, clusterID, hosts, hc.Name, int32(hc.Port), isNodesHealthCheck); err != nil {
 			return err
 		}
 		var err error
 		hcRequestPath, hcPort := hc.RequestPath, hc.Port
-		if hc, err = gce.ensureHttpHealthCheck(hc.Name, hc.RequestPath, int32(hc.Port)); err != nil || hc == nil {
+		if hc, err = g.ensureHTTPHealthCheck(hc.Name, hc.RequestPath, int32(hc.Port)); err != nil || hc == nil {
 			return fmt.Errorf("Failed to ensure health check for %v port %d path %v: %v", name, hcPort, hcRequestPath, err)
 		}
 		hcLinks = append(hcLinks, hc.SelfLink)
@@ -555,14 +556,14 @@ func (gce *GCECloud) createTargetPoolAndHealthCheck(svc *v1.Service, name, servi
 		HealthChecks:    hcLinks,
 	}
 
-	if err := gce.CreateTargetPool(pool, region); err != nil && !isHTTPErrorCode(err, http.StatusConflict) {
+	if err := g.CreateTargetPool(pool, region); err != nil && !isHTTPErrorCode(err, http.StatusConflict) {
 		return err
 	}
 	return nil
 }
 
-func (gce *GCECloud) updateTargetPool(loadBalancerName string, hosts []*gceInstance) error {
-	pool, err := gce.GetTargetPool(loadBalancerName, gce.region)
+func (g *Cloud) updateTargetPool(loadBalancerName string, hosts []*gceInstance) error {
+	pool, err := g.GetTargetPool(loadBalancerName, g.region)
 	if err != nil {
 		return err
 	}
@@ -585,13 +586,13 @@ func (gce *GCECloud) updateTargetPool(loadBalancerName string, hosts []*gceInsta
 	}
 
 	if len(toAdd) > 0 {
-		if err := gce.AddInstancesToTargetPool(loadBalancerName, gce.region, toAdd); err != nil {
+		if err := g.AddInstancesToTargetPool(loadBalancerName, g.region, toAdd); err != nil {
 			return err
 		}
 	}
 
 	if len(toRemove) > 0 {
-		if err := gce.RemoveInstancesFromTargetPool(loadBalancerName, gce.region, toRemove); err != nil {
+		if err := g.RemoveInstancesFromTargetPool(loadBalancerName, g.region, toRemove); err != nil {
 			return err
 		}
 	}
@@ -599,7 +600,7 @@ func (gce *GCECloud) updateTargetPool(loadBalancerName string, hosts []*gceInsta
 	// Try to verify that the correct number of nodes are now in the target pool.
 	// We've been bitten by a bug here before (#11327) where all nodes were
 	// accidentally removed and want to make similar problems easier to notice.
-	updatedPool, err := gce.GetTargetPool(loadBalancerName, gce.region)
+	updatedPool, err := g.GetTargetPool(loadBalancerName, g.region)
 	if err != nil {
 		return err
 	}
@@ -611,11 +612,11 @@ func (gce *GCECloud) updateTargetPool(loadBalancerName string, hosts []*gceInsta
 	return nil
 }
 
-func (gce *GCECloud) targetPoolURL(name string) string {
-	return gce.service.BasePath + strings.Join([]string{gce.projectID, "regions", gce.region, "targetPools", name}, "/")
+func (g *Cloud) targetPoolURL(name string) string {
+	return g.service.BasePath + strings.Join([]string{g.projectID, "regions", g.region, "targetPools", name}, "/")
 }
 
-func makeHttpHealthCheck(name, path string, port int32) *compute.HttpHealthCheck {
+func makeHTTPHealthCheck(name, path string, port int32) *compute.HttpHealthCheck {
 	return &compute.HttpHealthCheck{
 		Name:               name,
 		Port:               int64(port),
@@ -629,13 +630,13 @@ func makeHttpHealthCheck(name, path string, port int32) *compute.HttpHealthCheck
 	}
 }
 
-// mergeHttpHealthChecks reconciles HttpHealthCheck configures to be no smaller
+// mergeHTTPHealthChecks reconciles HttpHealthCheck configures to be no smaller
 // than the default values.
 // E.g. old health check interval is 2s, new default is 8.
 // The HC interval will be reconciled to 8 seconds.
 // If the existing health check is larger than the default interval,
 // the configuration will be kept.
-func mergeHttpHealthChecks(hc, newHC *compute.HttpHealthCheck) *compute.HttpHealthCheck {
+func mergeHTTPHealthChecks(hc, newHC *compute.HttpHealthCheck) *compute.HttpHealthCheck {
 	if hc.CheckIntervalSec > newHC.CheckIntervalSec {
 		newHC.CheckIntervalSec = hc.CheckIntervalSec
 	}
@@ -651,24 +652,24 @@ func mergeHttpHealthChecks(hc, newHC *compute.HttpHealthCheck) *compute.HttpHeal
 	return newHC
 }
 
-// needToUpdateHttpHealthChecks checks whether the http healthcheck needs to be
+// needToUpdateHTTPHealthChecks checks whether the http healthcheck needs to be
 // updated.
-func needToUpdateHttpHealthChecks(hc, newHC *compute.HttpHealthCheck) bool {
+func needToUpdateHTTPHealthChecks(hc, newHC *compute.HttpHealthCheck) bool {
 	changed := hc.Port != newHC.Port || hc.RequestPath != newHC.RequestPath || hc.Description != newHC.Description
 	changed = changed || hc.CheckIntervalSec < newHC.CheckIntervalSec || hc.TimeoutSec < newHC.TimeoutSec
 	changed = changed || hc.UnhealthyThreshold < newHC.UnhealthyThreshold || hc.HealthyThreshold < newHC.HealthyThreshold
 	return changed
 }
 
-func (gce *GCECloud) ensureHttpHealthCheck(name, path string, port int32) (hc *compute.HttpHealthCheck, err error) {
-	newHC := makeHttpHealthCheck(name, path, port)
-	hc, err = gce.GetHttpHealthCheck(name)
+func (g *Cloud) ensureHTTPHealthCheck(name, path string, port int32) (hc *compute.HttpHealthCheck, err error) {
+	newHC := makeHTTPHealthCheck(name, path, port)
+	hc, err = g.GetHTTPHealthCheck(name)
 	if hc == nil || err != nil && isHTTPErrorCode(err, http.StatusNotFound) {
 		glog.Infof("Did not find health check %v, creating port %v path %v", name, port, path)
-		if err = gce.CreateHttpHealthCheck(newHC); err != nil {
+		if err = g.CreateHTTPHealthCheck(newHC); err != nil {
 			return nil, err
 		}
-		hc, err = gce.GetHttpHealthCheck(name)
+		hc, err = g.GetHTTPHealthCheck(name)
 		if err != nil {
 			glog.Errorf("Failed to get http health check %v", err)
 			return nil, err
@@ -678,15 +679,15 @@ func (gce *GCECloud) ensureHttpHealthCheck(name, path string, port int32) (hc *c
 	}
 	// Validate health check fields
 	glog.V(4).Infof("Checking http health check params %s", name)
-	if needToUpdateHttpHealthChecks(hc, newHC) {
+	if needToUpdateHTTPHealthChecks(hc, newHC) {
 		glog.Warningf("Health check %v exists but parameters have drifted - updating...", name)
-		newHC = mergeHttpHealthChecks(hc, newHC)
-		if err := gce.UpdateHttpHealthCheck(newHC); err != nil {
+		newHC = mergeHTTPHealthChecks(hc, newHC)
+		if err := g.UpdateHTTPHealthCheck(newHC); err != nil {
 			glog.Warningf("Failed to reconcile http health check %v parameters", name)
 			return nil, err
 		}
 		glog.V(4).Infof("Corrected health check %v parameters successful", name)
-		hc, err = gce.GetHttpHealthCheck(name)
+		hc, err = g.GetHTTPHealthCheck(name)
 		if err != nil {
 			return nil, err
 		}
@@ -698,14 +699,14 @@ func (gce *GCECloud) ensureHttpHealthCheck(name, path string, port int32) (hc *c
 // IP is being requested.
 // Returns whether the forwarding rule exists, whether it needs to be updated,
 // what its IP address is (if it exists), and any error we encountered.
-func (gce *GCECloud) forwardingRuleNeedsUpdate(name, region string, loadBalancerIP string, ports []v1.ServicePort) (exists bool, needsUpdate bool, ipAddress string, err error) {
-	fwd, err := gce.GetRegionForwardingRule(name, region)
+func (g *Cloud) forwardingRuleNeedsUpdate(name, region string, loadBalancerIP string, ports []v1.ServicePort) (exists bool, needsUpdate bool, ipAddress string, err error) {
+	fwd, err := g.GetRegionForwardingRule(name, region)
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
 			return false, true, "", nil
 		}
 		// Err on the side of caution in case of errors. Caller should notice the error and retry.
-		// We never want to end up recreating resources because gce api flaked.
+		// We never want to end up recreating resources because g api flaked.
 		return true, false, "", fmt.Errorf("error getting load balancer's forwarding rule: %v", err)
 	}
 	// If the user asks for a specific static ip through the Service spec,
@@ -719,7 +720,7 @@ func (gce *GCECloud) forwardingRuleNeedsUpdate(name, region string, loadBalancer
 	portRange, err := loadBalancerPortRange(ports)
 	if err != nil {
 		// Err on the side of caution in case of errors. Caller should notice the error and retry.
-		// We never want to end up recreating resources because gce api flaked.
+		// We never want to end up recreating resources because g api flaked.
 		return true, false, "", err
 	}
 	if portRange != fwd.PortRange {
@@ -737,14 +738,14 @@ func (gce *GCECloud) forwardingRuleNeedsUpdate(name, region string, loadBalancer
 
 // Doesn't check whether the hosts have changed, since host updating is handled
 // separately.
-func (gce *GCECloud) targetPoolNeedsRecreation(name, region string, affinityType v1.ServiceAffinity) (exists bool, needsRecreation bool, err error) {
-	tp, err := gce.GetTargetPool(name, region)
+func (g *Cloud) targetPoolNeedsRecreation(name, region string, affinityType v1.ServiceAffinity) (exists bool, needsRecreation bool, err error) {
+	tp, err := g.GetTargetPool(name, region)
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
 			return false, true, nil
 		}
 		// Err on the side of caution in case of errors. Caller should notice the error and retry.
-		// We never want to end up recreating resources because gce api flaked.
+		// We never want to end up recreating resources because g api flaked.
 		return true, false, fmt.Errorf("error getting load balancer's target pool: %v", err)
 	}
 	// TODO: If the user modifies their Service's session affinity, it *should*
@@ -818,8 +819,8 @@ func translateAffinityType(affinityType v1.ServiceAffinity) string {
 	}
 }
 
-func (gce *GCECloud) firewallNeedsUpdate(name, serviceName, region, ipAddress string, ports []v1.ServicePort, sourceRanges netsets.IPNet) (exists bool, needsUpdate bool, err error) {
-	fw, err := gce.GetFirewall(MakeFirewallName(name))
+func (g *Cloud) firewallNeedsUpdate(name, serviceName, region, ipAddress string, ports []v1.ServicePort, sourceRanges netsets.IPNet) (exists bool, needsUpdate bool, err error) {
+	fw, err := g.GetFirewall(MakeFirewallName(name))
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
 			return false, true, nil
@@ -856,7 +857,7 @@ func (gce *GCECloud) firewallNeedsUpdate(name, serviceName, region, ipAddress st
 	return true, false, nil
 }
 
-func (gce *GCECloud) ensureHttpHealthCheckFirewall(svc *v1.Service, serviceName, ipAddress, region, clusterID string, hosts []*gceInstance, hcName string, hcPort int32, isNodesHealthCheck bool) error {
+func (g *Cloud) ensureHTTPHealthCheckFirewall(svc *v1.Service, serviceName, ipAddress, region, clusterID string, hosts []*gceInstance, hcName string, hcPort int32, isNodesHealthCheck bool) error {
 	// Prepare the firewall params for creating / checking.
 	desc := fmt.Sprintf(`{"kubernetes.io/cluster-id":"%s"}`, clusterID)
 	if !isNodesHealthCheck {
@@ -866,13 +867,13 @@ func (gce *GCECloud) ensureHttpHealthCheckFirewall(svc *v1.Service, serviceName,
 	ports := []v1.ServicePort{{Protocol: "tcp", Port: hcPort}}
 
 	fwName := MakeHealthCheckFirewallName(clusterID, hcName, isNodesHealthCheck)
-	fw, err := gce.GetFirewall(fwName)
+	fw, err := g.GetFirewall(fwName)
 	if err != nil {
 		if !isHTTPErrorCode(err, http.StatusNotFound) {
 			return fmt.Errorf("error getting firewall for health checks: %v", err)
 		}
 		glog.Infof("Creating firewall %v for health checks.", fwName)
-		if err := gce.createFirewall(svc, fwName, region, desc, sourceRanges, ports, hosts); err != nil {
+		if err := g.createFirewall(svc, fwName, region, desc, sourceRanges, ports, hosts); err != nil {
 			return err
 		}
 		glog.Infof("Created firewall %v for health checks.", fwName)
@@ -885,7 +886,7 @@ func (gce *GCECloud) ensureHttpHealthCheckFirewall(svc *v1.Service, serviceName,
 		!equalStringSets(fw.Allowed[0].Ports, []string{strconv.Itoa(int(ports[0].Port))}) ||
 		!equalStringSets(fw.SourceRanges, sourceRanges.StringSlice()) {
 		glog.Warningf("Firewall %v exists but parameters have drifted - updating...", fwName)
-		if err := gce.updateFirewall(svc, fwName, region, desc, sourceRanges, ports, hosts); err != nil {
+		if err := g.updateFirewall(svc, fwName, region, desc, sourceRanges, ports, hosts); err != nil {
 			glog.Warningf("Failed to reconcile firewall %v parameters.", fwName)
 			return err
 		}
@@ -933,17 +934,17 @@ func createForwardingRule(s CloudForwardingRuleService, name, serviceName, regio
 	return nil
 }
 
-func (gce *GCECloud) createFirewall(svc *v1.Service, name, region, desc string, sourceRanges netsets.IPNet, ports []v1.ServicePort, hosts []*gceInstance) error {
-	firewall, err := gce.firewallObject(name, region, desc, sourceRanges, ports, hosts)
+func (g *Cloud) createFirewall(svc *v1.Service, name, region, desc string, sourceRanges netsets.IPNet, ports []v1.ServicePort, hosts []*gceInstance) error {
+	firewall, err := g.firewallObject(name, region, desc, sourceRanges, ports, hosts)
 	if err != nil {
 		return err
 	}
-	if err = gce.CreateFirewall(firewall); err != nil {
+	if err = g.CreateFirewall(firewall); err != nil {
 		if isHTTPErrorCode(err, http.StatusConflict) {
 			return nil
-		} else if isForbidden(err) && gce.OnXPN() {
+		} else if isForbidden(err) && g.OnXPN() {
 			glog.V(4).Infof("createFirewall(%v): do not have permission to create firewall rule (on XPN). Raising event.", firewall.Name)
-			gce.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudCreateCmd(firewall, gce.NetworkProjectID()))
+			g.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudCreateCmd(firewall, g.NetworkProjectID()))
 			return nil
 		}
 		return err
@@ -951,18 +952,18 @@ func (gce *GCECloud) createFirewall(svc *v1.Service, name, region, desc string, 
 	return nil
 }
 
-func (gce *GCECloud) updateFirewall(svc *v1.Service, name, region, desc string, sourceRanges netsets.IPNet, ports []v1.ServicePort, hosts []*gceInstance) error {
-	firewall, err := gce.firewallObject(name, region, desc, sourceRanges, ports, hosts)
+func (g *Cloud) updateFirewall(svc *v1.Service, name, region, desc string, sourceRanges netsets.IPNet, ports []v1.ServicePort, hosts []*gceInstance) error {
+	firewall, err := g.firewallObject(name, region, desc, sourceRanges, ports, hosts)
 	if err != nil {
 		return err
 	}
 
-	if err = gce.UpdateFirewall(firewall); err != nil {
+	if err = g.UpdateFirewall(firewall); err != nil {
 		if isHTTPErrorCode(err, http.StatusConflict) {
 			return nil
-		} else if isForbidden(err) && gce.OnXPN() {
+		} else if isForbidden(err) && g.OnXPN() {
 			glog.V(4).Infof("updateFirewall(%v): do not have permission to update firewall rule (on XPN). Raising event.", firewall.Name)
-			gce.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudUpdateCmd(firewall, gce.NetworkProjectID()))
+			g.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudUpdateCmd(firewall, g.NetworkProjectID()))
 			return nil
 		}
 		return err
@@ -970,25 +971,25 @@ func (gce *GCECloud) updateFirewall(svc *v1.Service, name, region, desc string, 
 	return nil
 }
 
-func (gce *GCECloud) firewallObject(name, region, desc string, sourceRanges netsets.IPNet, ports []v1.ServicePort, hosts []*gceInstance) (*compute.Firewall, error) {
+func (g *Cloud) firewallObject(name, region, desc string, sourceRanges netsets.IPNet, ports []v1.ServicePort, hosts []*gceInstance) (*compute.Firewall, error) {
 	allowedPorts := make([]string, len(ports))
 	for ix := range ports {
 		allowedPorts[ix] = strconv.Itoa(int(ports[ix].Port))
 	}
 	// If the node tags to be used for this cluster have been predefined in the
 	// provider config, just use them. Otherwise, invoke computeHostTags method to get the tags.
-	hostTags := gce.nodeTags
+	hostTags := g.nodeTags
 	if len(hostTags) == 0 {
 		var err error
-		if hostTags, err = gce.computeHostTags(hosts); err != nil {
-			return nil, fmt.Errorf("No node tags supplied and also failed to parse the given lists of hosts for tags. Abort creating firewall rule.")
+		if hostTags, err = g.computeHostTags(hosts); err != nil {
+			return nil, fmt.Errorf("no node tags supplied and also failed to parse the given lists of hosts for tags. Abort creating firewall rule")
 		}
 	}
 
 	firewall := &compute.Firewall{
 		Name:         name,
 		Description:  desc,
-		Network:      gce.networkURL,
+		Network:      g.networkURL,
 		SourceRanges: sourceRanges.StringSlice(),
 		TargetTags:   hostTags,
 		Allowed: []*compute.FirewallAllowed{
@@ -1054,8 +1055,8 @@ func ensureStaticIP(s CloudAddressService, name, serviceName, region, existingIP
 	return addr.Address, existed, nil
 }
 
-func (gce *GCECloud) getServiceNetworkTier(svc *v1.Service) (cloud.NetworkTier, error) {
-	if !gce.AlphaFeatureGate.Enabled(AlphaFeatureNetworkTiers) {
+func (g *Cloud) getServiceNetworkTier(svc *v1.Service) (cloud.NetworkTier, error) {
+	if !g.AlphaFeatureGate.Enabled(AlphaFeatureNetworkTiers) {
 		return cloud.NetworkTierDefault, nil
 	}
 	tier, err := GetServiceNetworkTier(svc)
@@ -1066,12 +1067,12 @@ func (gce *GCECloud) getServiceNetworkTier(svc *v1.Service) (cloud.NetworkTier, 
 	return tier, nil
 }
 
-func (gce *GCECloud) deleteWrongNetworkTieredResources(lbName, lbRef string, desiredNetTier cloud.NetworkTier) error {
+func (g *Cloud) deleteWrongNetworkTieredResources(lbName, lbRef string, desiredNetTier cloud.NetworkTier) error {
 	logPrefix := fmt.Sprintf("deleteWrongNetworkTieredResources:(%s)", lbRef)
-	if err := deleteFWDRuleWithWrongTier(gce, gce.region, lbName, logPrefix, desiredNetTier); err != nil {
+	if err := deleteFWDRuleWithWrongTier(g, g.region, lbName, logPrefix, desiredNetTier); err != nil {
 		return err
 	}
-	if err := deleteAddressWithWrongTier(gce, gce.region, lbName, logPrefix, desiredNetTier); err != nil {
+	if err := deleteAddressWithWrongTier(g, g.region, lbName, logPrefix, desiredNetTier); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external_test.go
@@ -164,7 +164,7 @@ func TestCreateForwardingRuleWithTier(t *testing.T) {
 	vals := DefaultTestClusterValues()
 	serviceName := "foo-svc"
 
-	baseLinkUrl := "https://www.googleapis.com/compute/%v/projects/%v/regions/%v/forwardingRules/%v"
+	baseLinkURL := "https://www.googleapis.com/compute/%v/projects/%v/regions/%v/forwardingRules/%v"
 
 	for desc, tc := range map[string]struct {
 		netTier      cloud.NetworkTier
@@ -180,7 +180,7 @@ func TestCreateForwardingRuleWithTier(t *testing.T) {
 				PortRange:   "123-123",
 				Target:      target,
 				NetworkTier: "PREMIUM",
-				SelfLink:    fmt.Sprintf(baseLinkUrl, "v1", vals.ProjectID, vals.Region, "lb-1"),
+				SelfLink:    fmt.Sprintf(baseLinkURL, "v1", vals.ProjectID, vals.Region, "lb-1"),
 			},
 		},
 		"Standard tier": {
@@ -193,7 +193,7 @@ func TestCreateForwardingRuleWithTier(t *testing.T) {
 				PortRange:   "123-123",
 				Target:      target,
 				NetworkTier: "STANDARD",
-				SelfLink:    fmt.Sprintf(baseLinkUrl, "alpha", vals.ProjectID, vals.Region, "lb-2"),
+				SelfLink:    fmt.Sprintf(baseLinkURL, "alpha", vals.ProjectID, vals.Region, "lb-2"),
 			},
 		},
 	} {
@@ -276,7 +276,7 @@ func TestDeleteAddressWithWrongTier(t *testing.T) {
 	}
 }
 
-func createExternalLoadBalancer(gce *GCECloud, svc *v1.Service, nodeNames []string, clusterName, clusterID, zoneName string) (*v1.LoadBalancerStatus, error) {
+func createExternalLoadBalancer(gce *Cloud, svc *v1.Service, nodeNames []string, clusterName, clusterID, zoneName string) (*v1.LoadBalancerStatus, error) {
 	nodes, err := createAndInsertNodes(gce, nodeNames, zoneName)
 	if err != nil {
 		return nil, err
@@ -498,7 +498,7 @@ func TestForwardingRuleNeedsUpdate(t *testing.T) {
 		ports        []v1.ServicePort
 		exists       bool
 		needsUpdate  bool
-		expectIpAddr string
+		expectIPAddr string
 		expectError  bool
 	}{
 		"When the loadBalancerIP does not equal the FwdRule IP address.": {
@@ -506,7 +506,7 @@ func TestForwardingRuleNeedsUpdate(t *testing.T) {
 			ports:        svc.Spec.Ports,
 			exists:       true,
 			needsUpdate:  true,
-			expectIpAddr: ipAddr,
+			expectIPAddr: ipAddr,
 			expectError:  false,
 		},
 		"When loadBalancerPortRange returns an error.": {
@@ -514,7 +514,7 @@ func TestForwardingRuleNeedsUpdate(t *testing.T) {
 			ports:        []v1.ServicePort{},
 			exists:       true,
 			needsUpdate:  false,
-			expectIpAddr: "",
+			expectIPAddr: "",
 			expectError:  true,
 		},
 		"When portRange not equals to the forwardingRule port range.": {
@@ -522,7 +522,7 @@ func TestForwardingRuleNeedsUpdate(t *testing.T) {
 			ports:        wrongPorts,
 			exists:       true,
 			needsUpdate:  true,
-			expectIpAddr: ipAddr,
+			expectIPAddr: ipAddr,
 			expectError:  false,
 		},
 		"When the ports protocol does not equal the ForwardingRuel IP Protocol.": {
@@ -530,7 +530,7 @@ func TestForwardingRuleNeedsUpdate(t *testing.T) {
 			ports:        wrongProtocolPorts,
 			exists:       true,
 			needsUpdate:  true,
-			expectIpAddr: ipAddr,
+			expectIPAddr: ipAddr,
 			expectError:  false,
 		},
 		"When basic workflow.": {
@@ -538,7 +538,7 @@ func TestForwardingRuleNeedsUpdate(t *testing.T) {
 			ports:        svc.Spec.Ports,
 			exists:       true,
 			needsUpdate:  false,
-			expectIpAddr: ipAddr,
+			expectIPAddr: ipAddr,
 			expectError:  false,
 		},
 	} {
@@ -546,7 +546,7 @@ func TestForwardingRuleNeedsUpdate(t *testing.T) {
 			exists, needsUpdate, ipAddress, err := gce.forwardingRuleNeedsUpdate(lbName, vals.Region, tc.lbIP, tc.ports)
 			assert.Equal(t, tc.exists, exists, "'exists' didn't return as expected "+desc)
 			assert.Equal(t, tc.needsUpdate, needsUpdate, "'needsUpdate' didn't return as expected "+desc)
-			assert.Equal(t, tc.expectIpAddr, ipAddress, "'ipAddress' didn't return as expected "+desc)
+			assert.Equal(t, tc.expectIPAddr, ipAddress, "'ipAddress' didn't return as expected "+desc)
 			if tc.expectError {
 				assert.Error(t, err, "Should returns an error "+desc)
 			} else {
@@ -806,8 +806,8 @@ func TestEnsureTargetPoolAndHealthCheck(t *testing.T) {
 	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
 	region := vals.Region
 
-	hcToCreate := makeHttpHealthCheck(MakeNodesHealthCheckName(clusterID), GetNodesHealthCheckPath(), GetNodesHealthCheckPort())
-	hcToDelete := makeHttpHealthCheck(MakeNodesHealthCheckName(clusterID), GetNodesHealthCheckPath(), GetNodesHealthCheckPort())
+	hcToCreate := makeHTTPHealthCheck(MakeNodesHealthCheckName(clusterID), GetNodesHealthCheckPath(), GetNodesHealthCheckPort())
+	hcToDelete := makeHTTPHealthCheck(MakeNodesHealthCheckName(clusterID), GetNodesHealthCheckPath(), GetNodesHealthCheckPort())
 
 	// Apply a tag on the target pool. By verifying the change of the tag, target pool update can be ensured.
 	tag := "A Tag"
@@ -823,7 +823,7 @@ func TestEnsureTargetPoolAndHealthCheck(t *testing.T) {
 	pool, err = gce.GetTargetPool(lbName, region)
 	assert.Equal(t, 1, len(pool.Instances))
 	var manyNodeName [maxTargetPoolCreateInstances + 1]string
-	for i := 0; i < maxTargetPoolCreateInstances+1; i += 1 {
+	for i := 0; i < maxTargetPoolCreateInstances+1; i++ {
 		manyNodeName[i] = fmt.Sprintf("testnode_%d", i)
 	}
 	manyNodes, err := createAndInsertNodes(gce, manyNodeName[:], vals.ZoneName)
@@ -1079,17 +1079,17 @@ func TestExternalLoadBalancerEnsureHttpHealthCheck(t *testing.T) {
 			}
 
 			hcName, hcPath, hcPort := "test-hc", "/healthz", int32(12345)
-			existingHC := makeHttpHealthCheck(hcName, hcPath, hcPort)
+			existingHC := makeHTTPHealthCheck(hcName, hcPath, hcPort)
 			existingHC = tc.modifier(existingHC)
 			if existingHC != nil {
-				if err := gce.CreateHttpHealthCheck(existingHC); err != nil {
+				if err := gce.CreateHTTPHealthCheck(existingHC); err != nil {
 					t.Fatalf("gce.CreateHttpHealthCheck(%#v) = %v; want err = nil", existingHC, err)
 				}
 			}
-			if _, err := gce.ensureHttpHealthCheck(hcName, hcPath, hcPort); err != nil {
+			if _, err := gce.ensureHTTPHealthCheck(hcName, hcPath, hcPort); err != nil {
 				t.Fatalf("gce.ensureHttpHealthCheck(%q, %q, %v) = _, %d; want err = nil", hcName, hcPath, hcPort, err)
 			}
-			if hc, err := gce.GetHttpHealthCheck(hcName); err != nil {
+			if hc, err := gce.GetHTTPHealthCheck(hcName); err != nil {
 				t.Fatalf("gce.GetHttpHealthCheck(%q) = _, %d; want err = nil", hcName, err)
 			} else {
 				if tc.wantEqual {
@@ -1127,14 +1127,14 @@ func TestMergeHttpHealthChecks(t *testing.T) {
 		{"unhealthy threshold - user configured - should keep", gceHcCheckIntervalSeconds, gceHcTimeoutSeconds, gceHcHealthyThreshold, gceHcUnhealthyThreshold + 1, gceHcCheckIntervalSeconds, gceHcTimeoutSeconds, gceHcHealthyThreshold, gceHcUnhealthyThreshold + 1},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			wantHC := makeHttpHealthCheck("hc", "/", 12345)
+			wantHC := makeHTTPHealthCheck("hc", "/", 12345)
 			hc := &compute.HttpHealthCheck{
 				CheckIntervalSec:   tc.checkIntervalSec,
 				TimeoutSec:         tc.timeoutSec,
 				HealthyThreshold:   tc.healthyThreshold,
 				UnhealthyThreshold: tc.unhealthyThreshold,
 			}
-			mergeHttpHealthChecks(hc, wantHC)
+			mergeHTTPHealthChecks(hc, wantHC)
 			if wantHC.CheckIntervalSec != tc.wantCheckIntervalSec {
 				t.Errorf("wantHC.CheckIntervalSec = %d; want %d", wantHC.CheckIntervalSec, tc.checkIntervalSec)
 			}
@@ -1172,13 +1172,13 @@ func TestNeedToUpdateHttpHealthChecks(t *testing.T) {
 		{"unhealthy threshold does not need update", func(hc *compute.HttpHealthCheck) { hc.UnhealthyThreshold = gceHcUnhealthyThreshold + 1 }, false},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			hc := makeHttpHealthCheck("hc", "/", 12345)
-			wantHC := makeHttpHealthCheck("hc", "/", 12345)
+			hc := makeHTTPHealthCheck("hc", "/", 12345)
+			wantHC := makeHTTPHealthCheck("hc", "/", 12345)
 			if tc.modifier != nil {
 				tc.modifier(hc)
 			}
-			if gotChanged := needToUpdateHttpHealthChecks(hc, wantHC); gotChanged != tc.wantChanged {
-				t.Errorf("needToUpdateHttpHealthChecks(%#v, %#v) = %t; want changed = %t", hc, wantHC, gotChanged, tc.wantChanged)
+			if gotChanged := needToUpdateHTTPHealthChecks(hc, wantHC); gotChanged != tc.wantChanged {
+				t.Errorf("needToUpdateHTTPHealthChecks(%#v, %#v) = %t; want changed = %t", hc, wantHC, gotChanged, tc.wantChanged)
 			}
 		})
 	}

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
@@ -35,21 +35,21 @@ const (
 	allInstances = "ALL"
 )
 
-func (gce *GCECloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v1.Service, existingFwdRule *compute.ForwardingRule, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
+func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v1.Service, existingFwdRule *compute.ForwardingRule, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
 	nm := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
 	ports, protocol := getPortsAndProtocol(svc.Spec.Ports)
 	if protocol != v1.ProtocolTCP && protocol != v1.ProtocolUDP {
 		return nil, fmt.Errorf("Invalid protocol %s, only TCP and UDP are supported", string(protocol))
 	}
 	scheme := cloud.SchemeInternal
-	loadBalancerName := gce.GetLoadBalancerName(context.TODO(), clusterName, svc)
+	loadBalancerName := g.GetLoadBalancerName(context.TODO(), clusterName, svc)
 	sharedBackend := shareBackendService(svc)
 	backendServiceName := makeBackendServiceName(loadBalancerName, clusterID, sharedBackend, scheme, protocol, svc.Spec.SessionAffinity)
-	backendServiceLink := gce.getBackendServiceLink(backendServiceName)
+	backendServiceLink := g.getBackendServiceLink(backendServiceName)
 
 	// Ensure instance groups exist and nodes are assigned to groups
 	igName := makeInstanceGroupName(clusterID)
-	igLinks, err := gce.ensureInternalInstanceGroups(igName, nodes)
+	igLinks, err := g.ensureInternalInstanceGroups(igName, nodes)
 	if err != nil {
 		return nil, err
 	}
@@ -58,14 +58,14 @@ func (gce *GCECloud) ensureInternalLoadBalancer(clusterName, clusterID string, s
 	var existingBackendService *compute.BackendService
 	if existingFwdRule != nil && existingFwdRule.BackendService != "" {
 		existingBSName := getNameFromLink(existingFwdRule.BackendService)
-		if existingBackendService, err = gce.GetRegionBackendService(existingBSName, gce.region); err != nil && !isNotFound(err) {
+		if existingBackendService, err = g.GetRegionBackendService(existingBSName, g.region); err != nil && !isNotFound(err) {
 			return nil, err
 		}
 	}
 
 	// Lock the sharedResourceLock to prevent any deletions of shared resources while assembling shared resources here
-	gce.sharedResourceLock.Lock()
-	defer gce.sharedResourceLock.Unlock()
+	g.sharedResourceLock.Lock()
+	defer g.sharedResourceLock.Unlock()
 
 	// Ensure health check exists before creating the backend service. The health check is shared
 	// if externalTrafficPolicy=Cluster.
@@ -76,7 +76,7 @@ func (gce *GCECloud) ensureInternalLoadBalancer(clusterName, clusterID string, s
 		// Service requires a special health check, retrieve the OnlyLocal port & path
 		hcPath, hcPort = v1_service.GetServiceHealthCheckPathPort(svc)
 	}
-	hc, err := gce.ensureInternalHealthCheck(hcName, nm, sharedHealthCheck, hcPath, hcPort)
+	hc, err := g.ensureInternalHealthCheck(hcName, nm, sharedHealthCheck, hcPath, hcPort)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (gce *GCECloud) ensureInternalLoadBalancer(clusterName, clusterID string, s
 
 	// If the ILB already exists, continue using the subnet that it's already using.
 	// This is to support existing ILBs that were setup using the wrong subnet.
-	subnetworkURL := gce.SubnetworkURL()
+	subnetworkURL := g.SubnetworkURL()
 	if existingFwdRule != nil && existingFwdRule.Subnetwork != "" {
 		// external LBs have an empty Subnetwork field.
 		subnetworkURL = existingFwdRule.Subnetwork
@@ -96,8 +96,8 @@ func (gce *GCECloud) ensureInternalLoadBalancer(clusterName, clusterID string, s
 
 	var addrMgr *addressManager
 	// If the network is not a legacy network, use the address manager
-	if !gce.IsLegacyNetwork() {
-		addrMgr = newAddressManager(gce, nm.String(), gce.Region(), subnetworkURL, loadBalancerName, requestedIP, cloud.SchemeInternal)
+	if !g.IsLegacyNetwork() {
+		addrMgr = newAddressManager(g, nm.String(), g.Region(), subnetworkURL, loadBalancerName, requestedIP, cloud.SchemeInternal)
 		ipToUse, err = addrMgr.HoldAddress()
 		if err != nil {
 			return nil, err
@@ -106,7 +106,7 @@ func (gce *GCECloud) ensureInternalLoadBalancer(clusterName, clusterID string, s
 	}
 
 	// Ensure firewall rules if necessary
-	if err = gce.ensureInternalFirewalls(loadBalancerName, ipToUse, clusterID, nm, svc, strconv.Itoa(int(hcPort)), sharedHealthCheck, nodes); err != nil {
+	if err = g.ensureInternalFirewalls(loadBalancerName, ipToUse, clusterID, nm, svc, strconv.Itoa(int(hcPort)), sharedHealthCheck, nodes); err != nil {
 		return nil, err
 	}
 
@@ -125,20 +125,20 @@ func (gce *GCECloud) ensureInternalLoadBalancer(clusterName, clusterID string, s
 	if subnetworkURL != "" {
 		expectedFwdRule.Subnetwork = subnetworkURL
 	} else {
-		expectedFwdRule.Network = gce.networkURL
+		expectedFwdRule.Network = g.networkURL
 	}
 
 	fwdRuleDeleted := false
 	if existingFwdRule != nil && !fwdRuleEqual(existingFwdRule, expectedFwdRule) {
 		glog.V(2).Infof("ensureInternalLoadBalancer(%v): deleting existing forwarding rule with IP address %v", loadBalancerName, existingFwdRule.IPAddress)
-		if err = ignoreNotFound(gce.DeleteRegionForwardingRule(loadBalancerName, gce.region)); err != nil {
+		if err = ignoreNotFound(g.DeleteRegionForwardingRule(loadBalancerName, g.region)); err != nil {
 			return nil, err
 		}
 		fwdRuleDeleted = true
 	}
 
 	bsDescription := makeBackendServiceDescription(nm, sharedBackend)
-	err = gce.ensureInternalBackendService(backendServiceName, bsDescription, svc.Spec.SessionAffinity, scheme, protocol, igLinks, hc.SelfLink)
+	err = g.ensureInternalBackendService(backendServiceName, bsDescription, svc.Spec.SessionAffinity, scheme, protocol, igLinks, hc.SelfLink)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (gce *GCECloud) ensureInternalLoadBalancer(clusterName, clusterID string, s
 	// If we previously deleted the forwarding rule or it never existed, finally create it.
 	if fwdRuleDeleted || existingFwdRule == nil {
 		glog.V(2).Infof("ensureInternalLoadBalancer(%v): creating forwarding rule", loadBalancerName)
-		if err = gce.CreateRegionForwardingRule(expectedFwdRule, gce.region); err != nil {
+		if err = g.CreateRegionForwardingRule(expectedFwdRule, g.region); err != nil {
 			return nil, err
 		}
 		glog.V(2).Infof("ensureInternalLoadBalancer(%v): created forwarding rule", loadBalancerName)
@@ -154,7 +154,7 @@ func (gce *GCECloud) ensureInternalLoadBalancer(clusterName, clusterID string, s
 
 	// Delete the previous internal load balancer resources if necessary
 	if existingBackendService != nil {
-		gce.clearPreviousInternalResources(svc, loadBalancerName, existingBackendService, backendServiceName, hcName)
+		g.clearPreviousInternalResources(svc, loadBalancerName, existingBackendService, backendServiceName, hcName)
 	}
 
 	if addrMgr != nil {
@@ -165,7 +165,7 @@ func (gce *GCECloud) ensureInternalLoadBalancer(clusterName, clusterID string, s
 	}
 
 	// Get the most recent forwarding rule for the address.
-	updatedFwdRule, err := gce.GetRegionForwardingRule(loadBalancerName, gce.region)
+	updatedFwdRule, err := g.GetRegionForwardingRule(loadBalancerName, g.region)
 	if err != nil {
 		return nil, err
 	}
@@ -175,11 +175,11 @@ func (gce *GCECloud) ensureInternalLoadBalancer(clusterName, clusterID string, s
 	return status, nil
 }
 
-func (gce *GCECloud) clearPreviousInternalResources(svc *v1.Service, loadBalancerName string, existingBackendService *compute.BackendService, expectedBSName, expectedHCName string) {
+func (g *Cloud) clearPreviousInternalResources(svc *v1.Service, loadBalancerName string, existingBackendService *compute.BackendService, expectedBSName, expectedHCName string) {
 	// If a new backend service was created, delete the old one.
 	if existingBackendService.Name != expectedBSName {
 		glog.V(2).Infof("clearPreviousInternalResources(%v): expected backend service %q does not match previous %q - deleting backend service", loadBalancerName, expectedBSName, existingBackendService.Name)
-		if err := gce.teardownInternalBackendService(existingBackendService.Name); err != nil && !isNotFound(err) {
+		if err := g.teardownInternalBackendService(existingBackendService.Name); err != nil && !isNotFound(err) {
 			glog.Warningf("clearPreviousInternalResources: could not delete old backend service: %v, err: %v", existingBackendService.Name, err)
 		}
 	}
@@ -189,7 +189,7 @@ func (gce *GCECloud) clearPreviousInternalResources(svc *v1.Service, loadBalance
 		existingHCName := getNameFromLink(existingBackendService.HealthChecks[0])
 		if existingHCName != expectedHCName {
 			glog.V(2).Infof("clearPreviousInternalResources(%v): expected health check %q does not match previous %q - deleting health check", loadBalancerName, expectedHCName, existingHCName)
-			if err := gce.teardownInternalHealthCheckAndFirewall(svc, existingHCName); err != nil {
+			if err := g.teardownInternalHealthCheckAndFirewall(svc, existingHCName); err != nil {
 				glog.Warningf("clearPreviousInternalResources: could not delete existing healthcheck: %v, err: %v", existingHCName, err)
 			}
 		}
@@ -200,12 +200,12 @@ func (gce *GCECloud) clearPreviousInternalResources(svc *v1.Service, loadBalance
 
 // updateInternalLoadBalancer is called when the list of nodes has changed. Therefore, only the instance groups
 // and possibly the backend service need to be updated.
-func (gce *GCECloud) updateInternalLoadBalancer(clusterName, clusterID string, svc *v1.Service, nodes []*v1.Node) error {
-	gce.sharedResourceLock.Lock()
-	defer gce.sharedResourceLock.Unlock()
+func (g *Cloud) updateInternalLoadBalancer(clusterName, clusterID string, svc *v1.Service, nodes []*v1.Node) error {
+	g.sharedResourceLock.Lock()
+	defer g.sharedResourceLock.Unlock()
 
 	igName := makeInstanceGroupName(clusterID)
-	igLinks, err := gce.ensureInternalInstanceGroups(igName, nodes)
+	igLinks, err := g.ensureInternalInstanceGroups(igName, nodes)
 	if err != nil {
 		return err
 	}
@@ -213,41 +213,41 @@ func (gce *GCECloud) updateInternalLoadBalancer(clusterName, clusterID string, s
 	// Generate the backend service name
 	_, protocol := getPortsAndProtocol(svc.Spec.Ports)
 	scheme := cloud.SchemeInternal
-	loadBalancerName := gce.GetLoadBalancerName(context.TODO(), clusterName, svc)
+	loadBalancerName := g.GetLoadBalancerName(context.TODO(), clusterName, svc)
 	backendServiceName := makeBackendServiceName(loadBalancerName, clusterID, shareBackendService(svc), scheme, protocol, svc.Spec.SessionAffinity)
 	// Ensure the backend service has the proper backend/instance-group links
-	return gce.ensureInternalBackendServiceGroups(backendServiceName, igLinks)
+	return g.ensureInternalBackendServiceGroups(backendServiceName, igLinks)
 }
 
-func (gce *GCECloud) ensureInternalLoadBalancerDeleted(clusterName, clusterID string, svc *v1.Service) error {
-	loadBalancerName := gce.GetLoadBalancerName(context.TODO(), clusterName, svc)
+func (g *Cloud) ensureInternalLoadBalancerDeleted(clusterName, clusterID string, svc *v1.Service) error {
+	loadBalancerName := g.GetLoadBalancerName(context.TODO(), clusterName, svc)
 	_, protocol := getPortsAndProtocol(svc.Spec.Ports)
 	scheme := cloud.SchemeInternal
 	sharedBackend := shareBackendService(svc)
 	sharedHealthCheck := !v1_service.RequestsOnlyLocalTraffic(svc)
 
-	gce.sharedResourceLock.Lock()
-	defer gce.sharedResourceLock.Unlock()
+	g.sharedResourceLock.Lock()
+	defer g.sharedResourceLock.Unlock()
 
 	glog.V(2).Infof("ensureInternalLoadBalancerDeleted(%v): attempting delete of region internal address", loadBalancerName)
-	ensureAddressDeleted(gce, loadBalancerName, gce.region)
+	ensureAddressDeleted(g, loadBalancerName, g.region)
 
 	glog.V(2).Infof("ensureInternalLoadBalancerDeleted(%v): deleting region internal forwarding rule", loadBalancerName)
-	if err := ignoreNotFound(gce.DeleteRegionForwardingRule(loadBalancerName, gce.region)); err != nil {
+	if err := ignoreNotFound(g.DeleteRegionForwardingRule(loadBalancerName, g.region)); err != nil {
 		return err
 	}
 
 	backendServiceName := makeBackendServiceName(loadBalancerName, clusterID, sharedBackend, scheme, protocol, svc.Spec.SessionAffinity)
 	glog.V(2).Infof("ensureInternalLoadBalancerDeleted(%v): deleting region backend service %v", loadBalancerName, backendServiceName)
-	if err := gce.teardownInternalBackendService(backendServiceName); err != nil {
+	if err := g.teardownInternalBackendService(backendServiceName); err != nil {
 		return err
 	}
 
 	glog.V(2).Infof("ensureInternalLoadBalancerDeleted(%v): deleting firewall for traffic", loadBalancerName)
-	if err := ignoreNotFound(gce.DeleteFirewall(loadBalancerName)); err != nil {
-		if isForbidden(err) && gce.OnXPN() {
+	if err := ignoreNotFound(g.DeleteFirewall(loadBalancerName)); err != nil {
+		if isForbidden(err) && g.OnXPN() {
 			glog.V(2).Infof("ensureInternalLoadBalancerDeleted(%v): could not delete traffic firewall on XPN cluster. Raising event.", loadBalancerName)
-			gce.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudDeleteCmd(loadBalancerName, gce.NetworkProjectID()))
+			g.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudDeleteCmd(loadBalancerName, g.NetworkProjectID()))
 		} else {
 			return err
 		}
@@ -255,21 +255,21 @@ func (gce *GCECloud) ensureInternalLoadBalancerDeleted(clusterName, clusterID st
 
 	hcName := makeHealthCheckName(loadBalancerName, clusterID, sharedHealthCheck)
 	glog.V(2).Infof("ensureInternalLoadBalancerDeleted(%v): deleting health check %v and its firewall", loadBalancerName, hcName)
-	if err := gce.teardownInternalHealthCheckAndFirewall(svc, hcName); err != nil {
+	if err := g.teardownInternalHealthCheckAndFirewall(svc, hcName); err != nil {
 		return err
 	}
 
 	// Try deleting instance groups - expect ResourceInuse error if needed by other LBs
 	igName := makeInstanceGroupName(clusterID)
-	if err := gce.ensureInternalInstanceGroupsDeleted(igName); err != nil && !isInUsedByError(err) {
+	if err := g.ensureInternalInstanceGroupsDeleted(igName); err != nil && !isInUsedByError(err) {
 		return err
 	}
 
 	return nil
 }
 
-func (gce *GCECloud) teardownInternalBackendService(bsName string) error {
-	if err := gce.DeleteRegionBackendService(bsName, gce.region); err != nil {
+func (g *Cloud) teardownInternalBackendService(bsName string) error {
+	if err := g.DeleteRegionBackendService(bsName, g.region); err != nil {
 		if isNotFound(err) {
 			glog.V(2).Infof("teardownInternalBackendService(%v): backend service already deleted. err: %v", bsName, err)
 			return nil
@@ -284,8 +284,8 @@ func (gce *GCECloud) teardownInternalBackendService(bsName string) error {
 	return nil
 }
 
-func (gce *GCECloud) teardownInternalHealthCheckAndFirewall(svc *v1.Service, hcName string) error {
-	if err := gce.DeleteHealthCheck(hcName); err != nil {
+func (g *Cloud) teardownInternalHealthCheckAndFirewall(svc *v1.Service, hcName string) error {
+	if err := g.DeleteHealthCheck(hcName); err != nil {
 		if isNotFound(err) {
 			glog.V(2).Infof("teardownInternalHealthCheckAndFirewall(%v): health check does not exist.", hcName)
 			// Purposely do not early return - double check the firewall does not exist
@@ -299,10 +299,10 @@ func (gce *GCECloud) teardownInternalHealthCheckAndFirewall(svc *v1.Service, hcN
 	glog.V(2).Infof("teardownInternalHealthCheckAndFirewall(%v): health check deleted", hcName)
 
 	hcFirewallName := makeHealthCheckFirewallNameFromHC(hcName)
-	if err := ignoreNotFound(gce.DeleteFirewall(hcFirewallName)); err != nil {
-		if isForbidden(err) && gce.OnXPN() {
+	if err := ignoreNotFound(g.DeleteFirewall(hcFirewallName)); err != nil {
+		if isForbidden(err) && g.OnXPN() {
 			glog.V(2).Infof("teardownInternalHealthCheckAndFirewall(%v): could not delete health check traffic firewall on XPN cluster. Raising Event.", hcName)
-			gce.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudDeleteCmd(hcFirewallName, gce.NetworkProjectID()))
+			g.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudDeleteCmd(hcFirewallName, g.NetworkProjectID()))
 			return nil
 		}
 
@@ -312,14 +312,14 @@ func (gce *GCECloud) teardownInternalHealthCheckAndFirewall(svc *v1.Service, hcN
 	return nil
 }
 
-func (gce *GCECloud) ensureInternalFirewall(svc *v1.Service, fwName, fwDesc string, sourceRanges []string, ports []string, protocol v1.Protocol, nodes []*v1.Node) error {
+func (g *Cloud) ensureInternalFirewall(svc *v1.Service, fwName, fwDesc string, sourceRanges []string, ports []string, protocol v1.Protocol, nodes []*v1.Node) error {
 	glog.V(2).Infof("ensureInternalFirewall(%v): checking existing firewall", fwName)
-	targetTags, err := gce.GetNodeTags(nodeNames(nodes))
+	targetTags, err := g.GetNodeTags(nodeNames(nodes))
 	if err != nil {
 		return err
 	}
 
-	existingFirewall, err := gce.GetFirewall(fwName)
+	existingFirewall, err := g.GetFirewall(fwName)
 	if err != nil && !isNotFound(err) {
 		return err
 	}
@@ -327,7 +327,7 @@ func (gce *GCECloud) ensureInternalFirewall(svc *v1.Service, fwName, fwDesc stri
 	expectedFirewall := &compute.Firewall{
 		Name:         fwName,
 		Description:  fwDesc,
-		Network:      gce.networkURL,
+		Network:      g.networkURL,
 		SourceRanges: sourceRanges,
 		TargetTags:   targetTags,
 		Allowed: []*compute.FirewallAllowed{
@@ -340,10 +340,10 @@ func (gce *GCECloud) ensureInternalFirewall(svc *v1.Service, fwName, fwDesc stri
 
 	if existingFirewall == nil {
 		glog.V(2).Infof("ensureInternalFirewall(%v): creating firewall", fwName)
-		err = gce.CreateFirewall(expectedFirewall)
-		if err != nil && isForbidden(err) && gce.OnXPN() {
+		err = g.CreateFirewall(expectedFirewall)
+		if err != nil && isForbidden(err) && g.OnXPN() {
 			glog.V(2).Infof("ensureInternalFirewall(%v): do not have permission to create firewall rule (on XPN). Raising event.", fwName)
-			gce.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudCreateCmd(expectedFirewall, gce.NetworkProjectID()))
+			g.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudCreateCmd(expectedFirewall, g.NetworkProjectID()))
 			return nil
 		}
 		return err
@@ -354,16 +354,16 @@ func (gce *GCECloud) ensureInternalFirewall(svc *v1.Service, fwName, fwDesc stri
 	}
 
 	glog.V(2).Infof("ensureInternalFirewall(%v): updating firewall", fwName)
-	err = gce.UpdateFirewall(expectedFirewall)
-	if err != nil && isForbidden(err) && gce.OnXPN() {
+	err = g.UpdateFirewall(expectedFirewall)
+	if err != nil && isForbidden(err) && g.OnXPN() {
 		glog.V(2).Infof("ensureInternalFirewall(%v): do not have permission to update firewall rule (on XPN). Raising event.", fwName)
-		gce.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudUpdateCmd(expectedFirewall, gce.NetworkProjectID()))
+		g.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudUpdateCmd(expectedFirewall, g.NetworkProjectID()))
 		return nil
 	}
 	return err
 }
 
-func (gce *GCECloud) ensureInternalFirewalls(loadBalancerName, ipAddress, clusterID string, nm types.NamespacedName, svc *v1.Service, healthCheckPort string, sharedHealthCheck bool, nodes []*v1.Node) error {
+func (g *Cloud) ensureInternalFirewalls(loadBalancerName, ipAddress, clusterID string, nm types.NamespacedName, svc *v1.Service, healthCheckPort string, sharedHealthCheck bool, nodes []*v1.Node) error {
 	// First firewall is for ingress traffic
 	fwDesc := makeFirewallDescription(nm.String(), ipAddress)
 	ports, protocol := getPortsAndProtocol(svc.Spec.Ports)
@@ -371,7 +371,7 @@ func (gce *GCECloud) ensureInternalFirewalls(loadBalancerName, ipAddress, cluste
 	if err != nil {
 		return err
 	}
-	err = gce.ensureInternalFirewall(svc, loadBalancerName, fwDesc, sourceRanges.StringSlice(), ports, protocol, nodes)
+	err = g.ensureInternalFirewall(svc, loadBalancerName, fwDesc, sourceRanges.StringSlice(), ports, protocol, nodes)
 	if err != nil {
 		return err
 	}
@@ -379,24 +379,24 @@ func (gce *GCECloud) ensureInternalFirewalls(loadBalancerName, ipAddress, cluste
 	// Second firewall is for health checking nodes / services
 	fwHCName := makeHealthCheckFirewallName(loadBalancerName, clusterID, sharedHealthCheck)
 	hcSrcRanges := LoadBalancerSrcRanges()
-	return gce.ensureInternalFirewall(svc, fwHCName, "", hcSrcRanges, []string{healthCheckPort}, v1.ProtocolTCP, nodes)
+	return g.ensureInternalFirewall(svc, fwHCName, "", hcSrcRanges, []string{healthCheckPort}, v1.ProtocolTCP, nodes)
 }
 
-func (gce *GCECloud) ensureInternalHealthCheck(name string, svcName types.NamespacedName, shared bool, path string, port int32) (*compute.HealthCheck, error) {
+func (g *Cloud) ensureInternalHealthCheck(name string, svcName types.NamespacedName, shared bool, path string, port int32) (*compute.HealthCheck, error) {
 	glog.V(2).Infof("ensureInternalHealthCheck(%v, %v, %v): checking existing health check", name, path, port)
 	expectedHC := newInternalLBHealthCheck(name, svcName, shared, path, port)
 
-	hc, err := gce.GetHealthCheck(name)
+	hc, err := g.GetHealthCheck(name)
 	if err != nil && !isNotFound(err) {
 		return nil, err
 	}
 
 	if hc == nil {
 		glog.V(2).Infof("ensureInternalHealthCheck: did not find health check %v, creating one with port %v path %v", name, port, path)
-		if err = gce.CreateHealthCheck(expectedHC); err != nil {
+		if err = g.CreateHealthCheck(expectedHC); err != nil {
 			return nil, err
 		}
-		hc, err = gce.GetHealthCheck(name)
+		hc, err = g.GetHealthCheck(name)
 		if err != nil {
 			glog.Errorf("Failed to get http health check %v", err)
 			return nil, err
@@ -408,12 +408,12 @@ func (gce *GCECloud) ensureInternalHealthCheck(name string, svcName types.Namesp
 	if needToUpdateHealthChecks(hc, expectedHC) {
 		glog.V(2).Infof("ensureInternalHealthCheck: health check %v exists but parameters have drifted - updating...", name)
 		expectedHC = mergeHealthChecks(hc, expectedHC)
-		if err := gce.UpdateHealthCheck(expectedHC); err != nil {
+		if err := g.UpdateHealthCheck(expectedHC); err != nil {
 			glog.Warningf("Failed to reconcile http health check %v parameters", name)
 			return nil, err
 		}
 		glog.V(2).Infof("ensureInternalHealthCheck: corrected health check %v parameters successful", name)
-		hc, err = gce.GetHealthCheck(name)
+		hc, err = g.GetHealthCheck(name)
 		if err != nil {
 			return nil, err
 		}
@@ -421,9 +421,9 @@ func (gce *GCECloud) ensureInternalHealthCheck(name string, svcName types.Namesp
 	return hc, nil
 }
 
-func (gce *GCECloud) ensureInternalInstanceGroup(name, zone string, nodes []*v1.Node) (string, error) {
+func (g *Cloud) ensureInternalInstanceGroup(name, zone string, nodes []*v1.Node) (string, error) {
 	glog.V(2).Infof("ensureInternalInstanceGroup(%v, %v): checking group that it contains %v nodes", name, zone, len(nodes))
-	ig, err := gce.GetInstanceGroup(name, zone)
+	ig, err := g.GetInstanceGroup(name, zone)
 	if err != nil && !isNotFound(err) {
 		return "", err
 	}
@@ -437,16 +437,16 @@ func (gce *GCECloud) ensureInternalInstanceGroup(name, zone string, nodes []*v1.
 	if ig == nil {
 		glog.V(2).Infof("ensureInternalInstanceGroup(%v, %v): creating instance group", name, zone)
 		newIG := &compute.InstanceGroup{Name: name}
-		if err = gce.CreateInstanceGroup(newIG, zone); err != nil {
+		if err = g.CreateInstanceGroup(newIG, zone); err != nil {
 			return "", err
 		}
 
-		ig, err = gce.GetInstanceGroup(name, zone)
+		ig, err = g.GetInstanceGroup(name, zone)
 		if err != nil {
 			return "", err
 		}
 	} else {
-		instances, err := gce.ListInstancesInInstanceGroup(name, zone, allInstances)
+		instances, err := g.ListInstancesInInstanceGroup(name, zone, allInstances)
 		if err != nil {
 			return "", err
 		}
@@ -462,17 +462,17 @@ func (gce *GCECloud) ensureInternalInstanceGroup(name, zone string, nodes []*v1.
 
 	if len(removeNodes) != 0 {
 		glog.V(2).Infof("ensureInternalInstanceGroup(%v, %v): removing nodes: %v", name, zone, removeNodes)
-		instanceRefs := gce.ToInstanceReferences(zone, removeNodes)
+		instanceRefs := g.ToInstanceReferences(zone, removeNodes)
 		// Possible we'll receive 404's here if the instance was deleted before getting to this point.
-		if err = gce.RemoveInstancesFromInstanceGroup(name, zone, instanceRefs); err != nil && !isNotFound(err) {
+		if err = g.RemoveInstancesFromInstanceGroup(name, zone, instanceRefs); err != nil && !isNotFound(err) {
 			return "", err
 		}
 	}
 
 	if len(addNodes) != 0 {
 		glog.V(2).Infof("ensureInternalInstanceGroup(%v, %v): adding nodes: %v", name, zone, addNodes)
-		instanceRefs := gce.ToInstanceReferences(zone, addNodes)
-		if err = gce.AddInstancesToInstanceGroup(name, zone, instanceRefs); err != nil {
+		instanceRefs := g.ToInstanceReferences(zone, addNodes)
+		if err = g.AddInstancesToInstanceGroup(name, zone, instanceRefs); err != nil {
 			return "", err
 		}
 	}
@@ -482,12 +482,12 @@ func (gce *GCECloud) ensureInternalInstanceGroup(name, zone string, nodes []*v1.
 
 // ensureInternalInstanceGroups generates an unmanaged instance group for every zone
 // where a K8s node exists. It also ensures that each node belongs to an instance group
-func (gce *GCECloud) ensureInternalInstanceGroups(name string, nodes []*v1.Node) ([]string, error) {
+func (g *Cloud) ensureInternalInstanceGroups(name string, nodes []*v1.Node) ([]string, error) {
 	zonedNodes := splitNodesByZone(nodes)
-	glog.V(2).Infof("ensureInternalInstanceGroups(%v): %d nodes over %d zones in region %v", name, len(nodes), len(zonedNodes), gce.region)
+	glog.V(2).Infof("ensureInternalInstanceGroups(%v): %d nodes over %d zones in region %v", name, len(nodes), len(zonedNodes), g.region)
 	var igLinks []string
 	for zone, nodes := range zonedNodes {
-		igLink, err := gce.ensureInternalInstanceGroup(name, zone, nodes)
+		igLink, err := g.ensureInternalInstanceGroup(name, zone, nodes)
 		if err != nil {
 			return []string{}, err
 		}
@@ -497,25 +497,25 @@ func (gce *GCECloud) ensureInternalInstanceGroups(name string, nodes []*v1.Node)
 	return igLinks, nil
 }
 
-func (gce *GCECloud) ensureInternalInstanceGroupsDeleted(name string) error {
+func (g *Cloud) ensureInternalInstanceGroupsDeleted(name string) error {
 	// List of nodes isn't available here - fetch all zones in region and try deleting this cluster's ig
-	zones, err := gce.ListZonesInRegion(gce.region)
+	zones, err := g.ListZonesInRegion(g.region)
 	if err != nil {
 		return err
 	}
 
 	glog.V(2).Infof("ensureInternalInstanceGroupsDeleted(%v): attempting delete instance group in all %d zones", name, len(zones))
 	for _, z := range zones {
-		if err := gce.DeleteInstanceGroup(name, z.Name); err != nil && !isNotFoundOrInUse(err) {
+		if err := g.DeleteInstanceGroup(name, z.Name); err != nil && !isNotFoundOrInUse(err) {
 			return err
 		}
 	}
 	return nil
 }
 
-func (gce *GCECloud) ensureInternalBackendService(name, description string, affinityType v1.ServiceAffinity, scheme cloud.LbScheme, protocol v1.Protocol, igLinks []string, hcLink string) error {
+func (g *Cloud) ensureInternalBackendService(name, description string, affinityType v1.ServiceAffinity, scheme cloud.LbScheme, protocol v1.Protocol, igLinks []string, hcLink string) error {
 	glog.V(2).Infof("ensureInternalBackendService(%v, %v, %v): checking existing backend service with %d groups", name, scheme, protocol, len(igLinks))
-	bs, err := gce.GetRegionBackendService(name, gce.region)
+	bs, err := g.GetRegionBackendService(name, g.region)
 	if err != nil && !isNotFound(err) {
 		return err
 	}
@@ -534,7 +534,7 @@ func (gce *GCECloud) ensureInternalBackendService(name, description string, affi
 	// Create backend service if none was found
 	if bs == nil {
 		glog.V(2).Infof("ensureInternalBackendService: creating backend service %v", name)
-		err := gce.CreateRegionBackendService(expectedBS, gce.region)
+		err := g.CreateRegionBackendService(expectedBS, g.region)
 		if err != nil {
 			return err
 		}
@@ -549,7 +549,7 @@ func (gce *GCECloud) ensureInternalBackendService(name, description string, affi
 	glog.V(2).Infof("ensureInternalBackendService: updating backend service %v", name)
 	// Set fingerprint for optimistic locking
 	expectedBS.Fingerprint = bs.Fingerprint
-	if err := gce.UpdateRegionBackendService(expectedBS, gce.region); err != nil {
+	if err := g.UpdateRegionBackendService(expectedBS, g.region); err != nil {
 		return err
 	}
 	glog.V(2).Infof("ensureInternalBackendService: updated backend service %v successfully", name)
@@ -557,9 +557,9 @@ func (gce *GCECloud) ensureInternalBackendService(name, description string, affi
 }
 
 // ensureInternalBackendServiceGroups updates backend services if their list of backend instance groups is incorrect.
-func (gce *GCECloud) ensureInternalBackendServiceGroups(name string, igLinks []string) error {
+func (g *Cloud) ensureInternalBackendServiceGroups(name string, igLinks []string) error {
 	glog.V(2).Infof("ensureInternalBackendServiceGroups(%v): checking existing backend service's groups", name)
-	bs, err := gce.GetRegionBackendService(name, gce.region)
+	bs, err := g.GetRegionBackendService(name, g.region)
 	if err != nil {
 		return err
 	}
@@ -573,7 +573,7 @@ func (gce *GCECloud) ensureInternalBackendServiceGroups(name string, igLinks []s
 	bs.Backends = backends
 
 	glog.V(2).Infof("ensureInternalBackendServiceGroups: updating backend service %v", name)
-	if err := gce.UpdateRegionBackendService(bs, gce.region); err != nil {
+	if err := g.UpdateRegionBackendService(bs, g.region); err != nil {
 		return err
 	}
 	glog.V(2).Infof("ensureInternalBackendServiceGroups: updated backend service %v successfully", name)
@@ -707,8 +707,8 @@ func getPortsAndProtocol(svcPorts []v1.ServicePort) (ports []string, protocol v1
 	return ports, protocol
 }
 
-func (gce *GCECloud) getBackendServiceLink(name string) string {
-	return gce.service.BasePath + strings.Join([]string{gce.projectID, "regions", gce.region, "backendServices", name}, "/")
+func (g *Cloud) getBackendServiceLink(name string) string {
+	return g.service.BasePath + strings.Join([]string{g.projectID, "regions", g.region, "backendServices", name}, "/")
 }
 
 func getNameFromLink(link string) string {

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_utils_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_utils_test.go
@@ -67,7 +67,7 @@ var (
 	FilewallChangeMsg = fmt.Sprintf("%s %s %s", v1.EventTypeNormal, eventReasonManualChange, eventMsgFirewallChange)
 )
 
-func createAndInsertNodes(gce *GCECloud, nodeNames []string, zoneName string) ([]*v1.Node, error) {
+func createAndInsertNodes(gce *Cloud, nodeNames []string, zoneName string) ([]*v1.Node, error) {
 	nodes := []*v1.Node{}
 
 	for _, name := range nodeNames {
@@ -116,7 +116,7 @@ func createAndInsertNodes(gce *GCECloud, nodeNames []string, zoneName string) ([
 	return nodes, nil
 }
 
-func assertExternalLbResources(t *testing.T, gce *GCECloud, apiService *v1.Service, vals TestClusterValues, nodeNames []string) {
+func assertExternalLbResources(t *testing.T, gce *Cloud, apiService *v1.Service, vals TestClusterValues, nodeNames []string) {
 	lbName := gce.GetLoadBalancerName(context.TODO(), "", apiService)
 	hcName := MakeNodesHealthCheckName(vals.ClusterID)
 
@@ -141,7 +141,7 @@ func assertExternalLbResources(t *testing.T, gce *GCECloud, apiService *v1.Servi
 	assert.Equal(t, 1, len(pool.Instances))
 
 	// Check that HealthCheck is created
-	healthcheck, err := gce.GetHttpHealthCheck(hcName)
+	healthcheck, err := gce.GetHTTPHealthCheck(hcName)
 	require.NoError(t, err)
 	assert.Equal(t, hcName, healthcheck.Name)
 
@@ -153,7 +153,7 @@ func assertExternalLbResources(t *testing.T, gce *GCECloud, apiService *v1.Servi
 	assert.Equal(t, "123-123", fwdRule.PortRange)
 }
 
-func assertExternalLbResourcesDeleted(t *testing.T, gce *GCECloud, apiService *v1.Service, vals TestClusterValues, firewallsDeleted bool) {
+func assertExternalLbResourcesDeleted(t *testing.T, gce *Cloud, apiService *v1.Service, vals TestClusterValues, firewallsDeleted bool) {
 	lbName := gce.GetLoadBalancerName(context.TODO(), "", apiService)
 	hcName := MakeNodesHealthCheckName(vals.ClusterID)
 
@@ -182,13 +182,13 @@ func assertExternalLbResourcesDeleted(t *testing.T, gce *GCECloud, apiService *v
 	assert.Nil(t, pool)
 
 	// Check that HealthCheck is deleted
-	healthcheck, err := gce.GetHttpHealthCheck(hcName)
+	healthcheck, err := gce.GetHTTPHealthCheck(hcName)
 	require.Error(t, err)
 	assert.Nil(t, healthcheck)
 
 }
 
-func assertInternalLbResources(t *testing.T, gce *GCECloud, apiService *v1.Service, vals TestClusterValues, nodeNames []string) {
+func assertInternalLbResources(t *testing.T, gce *Cloud, apiService *v1.Service, vals TestClusterValues, nodeNames []string) {
 	lbName := gce.GetLoadBalancerName(context.TODO(), "", apiService)
 
 	// Check that Instance Group is created
@@ -241,7 +241,7 @@ func assertInternalLbResources(t *testing.T, gce *GCECloud, apiService *v1.Servi
 	assert.Equal(t, gce.NetworkURL(), fwdRule.Subnetwork)
 }
 
-func assertInternalLbResourcesDeleted(t *testing.T, gce *GCECloud, apiService *v1.Service, vals TestClusterValues, firewallsDeleted bool) {
+func assertInternalLbResourcesDeleted(t *testing.T, gce *Cloud, apiService *v1.Service, vals TestClusterValues, firewallsDeleted bool) {
 	lbName := gce.GetLoadBalancerName(context.TODO(), "", apiService)
 	sharedHealthCheck := !v1_service.RequestsOnlyLocalTraffic(apiService)
 	hcName := makeHealthCheckName(lbName, vals.ClusterID, sharedHealthCheck)

--- a/pkg/cloudprovider/providers/gce/gce_securitypolicy.go
+++ b/pkg/cloudprovider/providers/gce/gce_securitypolicy.go
@@ -29,88 +29,88 @@ func newSecurityPolicyMetricContextWithVersion(request, version string) *metricC
 }
 
 // GetBetaSecurityPolicy retrieves a security policy.
-func (gce *GCECloud) GetBetaSecurityPolicy(name string) (*computebeta.SecurityPolicy, error) {
+func (g *Cloud) GetBetaSecurityPolicy(name string) (*computebeta.SecurityPolicy, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newSecurityPolicyMetricContextWithVersion("get", computeBetaVersion)
-	v, err := gce.c.BetaSecurityPolicies().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.BetaSecurityPolicies().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
 // ListBetaSecurityPolicy lists all security policies in the project.
-func (gce *GCECloud) ListBetaSecurityPolicy() ([]*computebeta.SecurityPolicy, error) {
+func (g *Cloud) ListBetaSecurityPolicy() ([]*computebeta.SecurityPolicy, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newSecurityPolicyMetricContextWithVersion("list", computeBetaVersion)
-	v, err := gce.c.BetaSecurityPolicies().List(ctx, filter.None)
+	v, err := g.c.BetaSecurityPolicies().List(ctx, filter.None)
 	return v, mc.Observe(err)
 }
 
 // CreateBetaSecurityPolicy creates the given security policy.
-func (gce *GCECloud) CreateBetaSecurityPolicy(sp *computebeta.SecurityPolicy) error {
+func (g *Cloud) CreateBetaSecurityPolicy(sp *computebeta.SecurityPolicy) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newSecurityPolicyMetricContextWithVersion("create", computeBetaVersion)
-	return mc.Observe(gce.c.BetaSecurityPolicies().Insert(ctx, meta.GlobalKey(sp.Name), sp))
+	return mc.Observe(g.c.BetaSecurityPolicies().Insert(ctx, meta.GlobalKey(sp.Name), sp))
 }
 
 // DeleteBetaSecurityPolicy deletes the given security policy.
-func (gce *GCECloud) DeleteBetaSecurityPolicy(name string) error {
+func (g *Cloud) DeleteBetaSecurityPolicy(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newSecurityPolicyMetricContextWithVersion("delete", computeBetaVersion)
-	return mc.Observe(gce.c.BetaSecurityPolicies().Delete(ctx, meta.GlobalKey(name)))
+	return mc.Observe(g.c.BetaSecurityPolicies().Delete(ctx, meta.GlobalKey(name)))
 }
 
 // PatchBetaSecurityPolicy applies the given security policy as a
 // patch to an existing security policy.
-func (gce *GCECloud) PatchBetaSecurityPolicy(sp *computebeta.SecurityPolicy) error {
+func (g *Cloud) PatchBetaSecurityPolicy(sp *computebeta.SecurityPolicy) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newSecurityPolicyMetricContextWithVersion("patch", computeBetaVersion)
-	return mc.Observe(gce.c.BetaSecurityPolicies().Patch(ctx, meta.GlobalKey(sp.Name), sp))
+	return mc.Observe(g.c.BetaSecurityPolicies().Patch(ctx, meta.GlobalKey(sp.Name), sp))
 }
 
 // GetRuleForBetaSecurityPolicy gets rule from a security policy.
-func (gce *GCECloud) GetRuleForBetaSecurityPolicy(name string) (*computebeta.SecurityPolicyRule, error) {
+func (g *Cloud) GetRuleForBetaSecurityPolicy(name string) (*computebeta.SecurityPolicyRule, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newSecurityPolicyMetricContextWithVersion("get_rule", computeBetaVersion)
-	v, err := gce.c.BetaSecurityPolicies().GetRule(ctx, meta.GlobalKey(name))
+	v, err := g.c.BetaSecurityPolicies().GetRule(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
 // AddRuletoBetaSecurityPolicy adds the given security policy rule to
 // a security policy.
-func (gce *GCECloud) AddRuletoBetaSecurityPolicy(name string, spr *computebeta.SecurityPolicyRule) error {
+func (g *Cloud) AddRuletoBetaSecurityPolicy(name string, spr *computebeta.SecurityPolicyRule) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newSecurityPolicyMetricContextWithVersion("add_rule", computeBetaVersion)
-	return mc.Observe(gce.c.BetaSecurityPolicies().AddRule(ctx, meta.GlobalKey(name), spr))
+	return mc.Observe(g.c.BetaSecurityPolicies().AddRule(ctx, meta.GlobalKey(name), spr))
 }
 
 // PatchRuleForBetaSecurityPolicy patches the given security policy
 // rule to a security policy.
-func (gce *GCECloud) PatchRuleForBetaSecurityPolicy(name string, spr *computebeta.SecurityPolicyRule) error {
+func (g *Cloud) PatchRuleForBetaSecurityPolicy(name string, spr *computebeta.SecurityPolicyRule) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newSecurityPolicyMetricContextWithVersion("patch_rule", computeBetaVersion)
-	return mc.Observe(gce.c.BetaSecurityPolicies().PatchRule(ctx, meta.GlobalKey(name), spr))
+	return mc.Observe(g.c.BetaSecurityPolicies().PatchRule(ctx, meta.GlobalKey(name), spr))
 }
 
 // RemoveRuleFromBetaSecurityPolicy removes rule from a security policy.
-func (gce *GCECloud) RemoveRuleFromBetaSecurityPolicy(name string) error {
+func (g *Cloud) RemoveRuleFromBetaSecurityPolicy(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newSecurityPolicyMetricContextWithVersion("remove_rule", computeBetaVersion)
-	return mc.Observe(gce.c.BetaSecurityPolicies().RemoveRule(ctx, meta.GlobalKey(name)))
+	return mc.Observe(g.c.BetaSecurityPolicies().RemoveRule(ctx, meta.GlobalKey(name)))
 }

--- a/pkg/cloudprovider/providers/gce/gce_targetpool.go
+++ b/pkg/cloudprovider/providers/gce/gce_targetpool.go
@@ -28,35 +28,35 @@ func newTargetPoolMetricContext(request, region string) *metricContext {
 }
 
 // GetTargetPool returns the TargetPool by name.
-func (gce *GCECloud) GetTargetPool(name, region string) (*compute.TargetPool, error) {
+func (g *Cloud) GetTargetPool(name, region string) (*compute.TargetPool, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newTargetPoolMetricContext("get", region)
-	v, err := gce.c.TargetPools().Get(ctx, meta.RegionalKey(name, region))
+	v, err := g.c.TargetPools().Get(ctx, meta.RegionalKey(name, region))
 	return v, mc.Observe(err)
 }
 
 // CreateTargetPool creates the passed TargetPool
-func (gce *GCECloud) CreateTargetPool(tp *compute.TargetPool, region string) error {
+func (g *Cloud) CreateTargetPool(tp *compute.TargetPool, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newTargetPoolMetricContext("create", region)
-	return mc.Observe(gce.c.TargetPools().Insert(ctx, meta.RegionalKey(tp.Name, region), tp))
+	return mc.Observe(g.c.TargetPools().Insert(ctx, meta.RegionalKey(tp.Name, region), tp))
 }
 
 // DeleteTargetPool deletes TargetPool by name.
-func (gce *GCECloud) DeleteTargetPool(name, region string) error {
+func (g *Cloud) DeleteTargetPool(name, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newTargetPoolMetricContext("delete", region)
-	return mc.Observe(gce.c.TargetPools().Delete(ctx, meta.RegionalKey(name, region)))
+	return mc.Observe(g.c.TargetPools().Delete(ctx, meta.RegionalKey(name, region)))
 }
 
 // AddInstancesToTargetPool adds instances by link to the TargetPool
-func (gce *GCECloud) AddInstancesToTargetPool(name, region string, instanceRefs []*compute.InstanceReference) error {
+func (g *Cloud) AddInstancesToTargetPool(name, region string, instanceRefs []*compute.InstanceReference) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
@@ -64,11 +64,11 @@ func (gce *GCECloud) AddInstancesToTargetPool(name, region string, instanceRefs 
 		Instances: instanceRefs,
 	}
 	mc := newTargetPoolMetricContext("add_instances", region)
-	return mc.Observe(gce.c.TargetPools().AddInstance(ctx, meta.RegionalKey(name, region), req))
+	return mc.Observe(g.c.TargetPools().AddInstance(ctx, meta.RegionalKey(name, region), req))
 }
 
 // RemoveInstancesFromTargetPool removes instances by link to the TargetPool
-func (gce *GCECloud) RemoveInstancesFromTargetPool(name, region string, instanceRefs []*compute.InstanceReference) error {
+func (g *Cloud) RemoveInstancesFromTargetPool(name, region string, instanceRefs []*compute.InstanceReference) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
@@ -76,5 +76,5 @@ func (gce *GCECloud) RemoveInstancesFromTargetPool(name, region string, instance
 		Instances: instanceRefs,
 	}
 	mc := newTargetPoolMetricContext("remove_instances", region)
-	return mc.Observe(gce.c.TargetPools().RemoveInstance(ctx, meta.RegionalKey(name, region), req))
+	return mc.Observe(g.c.TargetPools().RemoveInstance(ctx, meta.RegionalKey(name, region), req))
 }

--- a/pkg/cloudprovider/providers/gce/gce_targetproxy.go
+++ b/pkg/cloudprovider/providers/gce/gce_targetproxy.go
@@ -28,87 +28,87 @@ func newTargetProxyMetricContext(request string) *metricContext {
 	return newGenericMetricContext("targetproxy", request, unusedMetricLabel, unusedMetricLabel, computeV1Version)
 }
 
-// GetTargetHttpProxy returns the UrlMap by name.
-func (gce *GCECloud) GetTargetHttpProxy(name string) (*compute.TargetHttpProxy, error) {
+// GetTargetHTTPProxy returns the UrlMap by name.
+func (g *Cloud) GetTargetHTTPProxy(name string) (*compute.TargetHttpProxy, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newTargetProxyMetricContext("get")
-	v, err := gce.c.TargetHttpProxies().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.TargetHttpProxies().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
-// CreateTargetHttpProxy creates a TargetHttpProxy
-func (gce *GCECloud) CreateTargetHttpProxy(proxy *compute.TargetHttpProxy) error {
+// CreateTargetHTTPProxy creates a TargetHttpProxy
+func (g *Cloud) CreateTargetHTTPProxy(proxy *compute.TargetHttpProxy) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newTargetProxyMetricContext("create")
-	return mc.Observe(gce.c.TargetHttpProxies().Insert(ctx, meta.GlobalKey(proxy.Name), proxy))
+	return mc.Observe(g.c.TargetHttpProxies().Insert(ctx, meta.GlobalKey(proxy.Name), proxy))
 }
 
-// SetUrlMapForTargetHttpProxy sets the given UrlMap for the given TargetHttpProxy.
-func (gce *GCECloud) SetUrlMapForTargetHttpProxy(proxy *compute.TargetHttpProxy, urlMapLink string) error {
+// SetURLMapForTargetHTTPProxy sets the given UrlMap for the given TargetHttpProxy.
+func (g *Cloud) SetURLMapForTargetHTTPProxy(proxy *compute.TargetHttpProxy, urlMapLink string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	ref := &compute.UrlMapReference{UrlMap: urlMapLink}
 	mc := newTargetProxyMetricContext("set_url_map")
-	return mc.Observe(gce.c.TargetHttpProxies().SetUrlMap(ctx, meta.GlobalKey(proxy.Name), ref))
+	return mc.Observe(g.c.TargetHttpProxies().SetUrlMap(ctx, meta.GlobalKey(proxy.Name), ref))
 }
 
-// DeleteTargetHttpProxy deletes the TargetHttpProxy by name.
-func (gce *GCECloud) DeleteTargetHttpProxy(name string) error {
+// DeleteTargetHTTPProxy deletes the TargetHttpProxy by name.
+func (g *Cloud) DeleteTargetHTTPProxy(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newTargetProxyMetricContext("delete")
-	return mc.Observe(gce.c.TargetHttpProxies().Delete(ctx, meta.GlobalKey(name)))
+	return mc.Observe(g.c.TargetHttpProxies().Delete(ctx, meta.GlobalKey(name)))
 }
 
-// ListTargetHttpProxies lists all TargetHttpProxies in the project.
-func (gce *GCECloud) ListTargetHttpProxies() ([]*compute.TargetHttpProxy, error) {
+// ListTargetHTTPProxies lists all TargetHttpProxies in the project.
+func (g *Cloud) ListTargetHTTPProxies() ([]*compute.TargetHttpProxy, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newTargetProxyMetricContext("list")
-	v, err := gce.c.TargetHttpProxies().List(ctx, filter.None)
+	v, err := g.c.TargetHttpProxies().List(ctx, filter.None)
 	return v, mc.Observe(err)
 }
 
 // TargetHttpsProxy management
 
-// GetTargetHttpsProxy returns the UrlMap by name.
-func (gce *GCECloud) GetTargetHttpsProxy(name string) (*compute.TargetHttpsProxy, error) {
+// GetTargetHTTPSProxy returns the UrlMap by name.
+func (g *Cloud) GetTargetHTTPSProxy(name string) (*compute.TargetHttpsProxy, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newTargetProxyMetricContext("get")
-	v, err := gce.c.TargetHttpsProxies().Get(ctx, meta.GlobalKey(name))
+	v, err := g.c.TargetHttpsProxies().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
-// CreateTargetHttpsProxy creates a TargetHttpsProxy
-func (gce *GCECloud) CreateTargetHttpsProxy(proxy *compute.TargetHttpsProxy) error {
+// CreateTargetHTTPSProxy creates a TargetHttpsProxy
+func (g *Cloud) CreateTargetHTTPSProxy(proxy *compute.TargetHttpsProxy) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newTargetProxyMetricContext("create")
-	return mc.Observe(gce.c.TargetHttpsProxies().Insert(ctx, meta.GlobalKey(proxy.Name), proxy))
+	return mc.Observe(g.c.TargetHttpsProxies().Insert(ctx, meta.GlobalKey(proxy.Name), proxy))
 }
 
-// SetUrlMapForTargetHttpsProxy sets the given UrlMap for the given TargetHttpsProxy.
-func (gce *GCECloud) SetUrlMapForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, urlMapLink string) error {
+// SetURLMapForTargetHTTPSProxy sets the given UrlMap for the given TargetHttpsProxy.
+func (g *Cloud) SetURLMapForTargetHTTPSProxy(proxy *compute.TargetHttpsProxy, urlMapLink string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newTargetProxyMetricContext("set_url_map")
 	ref := &compute.UrlMapReference{UrlMap: urlMapLink}
-	return mc.Observe(gce.c.TargetHttpsProxies().SetUrlMap(ctx, meta.GlobalKey(proxy.Name), ref))
+	return mc.Observe(g.c.TargetHttpsProxies().SetUrlMap(ctx, meta.GlobalKey(proxy.Name), ref))
 }
 
-// SetSslCertificateForTargetHttpsProxy sets the given SslCertificate for the given TargetHttpsProxy.
-func (gce *GCECloud) SetSslCertificateForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, sslCertURLs []string) error {
+// SetSslCertificateForTargetHTTPSProxy sets the given SslCertificate for the given TargetHttpsProxy.
+func (g *Cloud) SetSslCertificateForTargetHTTPSProxy(proxy *compute.TargetHttpsProxy, sslCertURLs []string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
@@ -116,24 +116,24 @@ func (gce *GCECloud) SetSslCertificateForTargetHttpsProxy(proxy *compute.TargetH
 	req := &compute.TargetHttpsProxiesSetSslCertificatesRequest{
 		SslCertificates: sslCertURLs,
 	}
-	return mc.Observe(gce.c.TargetHttpsProxies().SetSslCertificates(ctx, meta.GlobalKey(proxy.Name), req))
+	return mc.Observe(g.c.TargetHttpsProxies().SetSslCertificates(ctx, meta.GlobalKey(proxy.Name), req))
 }
 
-// DeleteTargetHttpsProxy deletes the TargetHttpsProxy by name.
-func (gce *GCECloud) DeleteTargetHttpsProxy(name string) error {
+// DeleteTargetHTTPSProxy deletes the TargetHttpsProxy by name.
+func (g *Cloud) DeleteTargetHTTPSProxy(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newTargetProxyMetricContext("delete")
-	return mc.Observe(gce.c.TargetHttpsProxies().Delete(ctx, meta.GlobalKey(name)))
+	return mc.Observe(g.c.TargetHttpsProxies().Delete(ctx, meta.GlobalKey(name)))
 }
 
-// ListTargetHttpsProxies lists all TargetHttpsProxies in the project.
-func (gce *GCECloud) ListTargetHttpsProxies() ([]*compute.TargetHttpsProxy, error) {
+// ListTargetHTTPSProxies lists all TargetHttpsProxies in the project.
+func (g *Cloud) ListTargetHTTPSProxies() ([]*compute.TargetHttpsProxy, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newTargetProxyMetricContext("list")
-	v, err := gce.c.TargetHttpsProxies().List(ctx, filter.None)
+	v, err := g.c.TargetHttpsProxies().List(ctx, filter.None)
 	return v, mc.Observe(err)
 }

--- a/pkg/cloudprovider/providers/gce/gce_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_test.go
@@ -91,7 +91,7 @@ func TestGetRegion(t *testing.T) {
 	if regionName != "us-central1" {
 		t.Errorf("Unexpected region from GetGCERegion: %s", regionName)
 	}
-	gce := &GCECloud{
+	gce := &Cloud{
 		localZone: zoneName,
 		region:    regionName,
 	}
@@ -299,7 +299,7 @@ func TestGetZoneByProviderID(t *testing.T) {
 		},
 	}
 
-	gce := &GCECloud{
+	gce := &Cloud{
 		localZone: "us-central1-f",
 		region:    "us-central1",
 	}
@@ -331,13 +331,13 @@ func TestGenerateCloudConfigs(t *testing.T) {
 		NodeInstancePrefix: "node-prefix",
 		Multizone:          false,
 		Regional:           false,
-		ApiEndpoint:        "",
+		APIEndpoint:        "",
 		LocalZone:          "us-central1-a",
 		AlphaFeatures:      []string{},
 	}
 
 	cloudBoilerplate := CloudConfig{
-		ApiEndpoint:        "",
+		APIEndpoint:        "",
 		ProjectID:          "project-id",
 		NetworkProjectID:   "",
 		Region:             "us-central1",
@@ -395,12 +395,12 @@ func TestGenerateCloudConfigs(t *testing.T) {
 			name: "Specified API Endpint",
 			config: func() ConfigGlobal {
 				v := configBoilerplate
-				v.ApiEndpoint = "https://www.googleapis.com/compute/staging_v1/"
+				v.APIEndpoint = "https://www.googleapis.com/compute/staging_v1/"
 				return v
 			},
 			cloud: func() CloudConfig {
 				v := cloudBoilerplate
-				v.ApiEndpoint = "https://www.googleapis.com/compute/staging_v1/"
+				v.APIEndpoint = "https://www.googleapis.com/compute/staging_v1/"
 				return v
 			},
 		},

--- a/pkg/cloudprovider/providers/gce/gce_urlmap.go
+++ b/pkg/cloudprovider/providers/gce/gce_urlmap.go
@@ -24,53 +24,53 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
 )
 
-func newUrlMapMetricContext(request string) *metricContext {
+func newURLMapMetricContext(request string) *metricContext {
 	return newGenericMetricContext("urlmap", request, unusedMetricLabel, unusedMetricLabel, computeV1Version)
 }
 
-// GetUrlMap returns the UrlMap by name.
-func (gce *GCECloud) GetUrlMap(name string) (*compute.UrlMap, error) {
+// GetURLMap returns the UrlMap by name.
+func (g *Cloud) GetURLMap(name string) (*compute.UrlMap, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
-	mc := newUrlMapMetricContext("get")
-	v, err := gce.c.UrlMaps().Get(ctx, meta.GlobalKey(name))
+	mc := newURLMapMetricContext("get")
+	v, err := g.c.UrlMaps().Get(ctx, meta.GlobalKey(name))
 	return v, mc.Observe(err)
 }
 
-// CreateUrlMap creates a url map
-func (gce *GCECloud) CreateUrlMap(urlMap *compute.UrlMap) error {
+// CreateURLMap creates a url map
+func (g *Cloud) CreateURLMap(urlMap *compute.UrlMap) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
-	mc := newUrlMapMetricContext("create")
-	return mc.Observe(gce.c.UrlMaps().Insert(ctx, meta.GlobalKey(urlMap.Name), urlMap))
+	mc := newURLMapMetricContext("create")
+	return mc.Observe(g.c.UrlMaps().Insert(ctx, meta.GlobalKey(urlMap.Name), urlMap))
 }
 
-// UpdateUrlMap applies the given UrlMap as an update
-func (gce *GCECloud) UpdateUrlMap(urlMap *compute.UrlMap) error {
+// UpdateURLMap applies the given UrlMap as an update
+func (g *Cloud) UpdateURLMap(urlMap *compute.UrlMap) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
-	mc := newUrlMapMetricContext("update")
-	return mc.Observe(gce.c.UrlMaps().Update(ctx, meta.GlobalKey(urlMap.Name), urlMap))
+	mc := newURLMapMetricContext("update")
+	return mc.Observe(g.c.UrlMaps().Update(ctx, meta.GlobalKey(urlMap.Name), urlMap))
 }
 
-// DeleteUrlMap deletes a url map by name.
-func (gce *GCECloud) DeleteUrlMap(name string) error {
+// DeleteURLMap deletes a url map by name.
+func (g *Cloud) DeleteURLMap(name string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
-	mc := newUrlMapMetricContext("delete")
-	return mc.Observe(gce.c.UrlMaps().Delete(ctx, meta.GlobalKey(name)))
+	mc := newURLMapMetricContext("delete")
+	return mc.Observe(g.c.UrlMaps().Delete(ctx, meta.GlobalKey(name)))
 }
 
-// ListUrlMaps lists all UrlMaps in the project.
-func (gce *GCECloud) ListUrlMaps() ([]*compute.UrlMap, error) {
+// ListURLMaps lists all UrlMaps in the project.
+func (g *Cloud) ListURLMaps() ([]*compute.UrlMap, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
-	mc := newUrlMapMetricContext("list")
-	v, err := gce.c.UrlMaps().List(ctx, filter.None)
+	mc := newURLMapMetricContext("list")
+	v, err := g.c.UrlMaps().List(ctx, filter.None)
 	return v, mc.Observe(err)
 }

--- a/pkg/cloudprovider/providers/gce/gce_zones.go
+++ b/pkg/cloudprovider/providers/gce/gce_zones.go
@@ -33,17 +33,17 @@ func newZonesMetricContext(request, region string) *metricContext {
 }
 
 // GetZone creates a cloudprovider.Zone of the current zone and region
-func (gce *GCECloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
+func (g *Cloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 	return cloudprovider.Zone{
-		FailureDomain: gce.localZone,
-		Region:        gce.region,
+		FailureDomain: g.localZone,
+		Region:        g.region,
 	}, nil
 }
 
 // GetZoneByProviderID implements Zones.GetZoneByProviderID
 // This is particularly useful in external cloud providers where the kubelet
 // does not initialize node data.
-func (gce *GCECloud) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
+func (g *Cloud) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
 	_, zone, _, err := splitProviderID(providerID)
 	if err != nil {
 		return cloudprovider.Zone{}, err
@@ -58,9 +58,9 @@ func (gce *GCECloud) GetZoneByProviderID(ctx context.Context, providerID string)
 // GetZoneByNodeName implements Zones.GetZoneByNodeName
 // This is particularly useful in external cloud providers where the kubelet
 // does not initialize node data.
-func (gce *GCECloud) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
+func (g *Cloud) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
 	instanceName := mapNodeNameToInstanceName(nodeName)
-	instance, err := gce.getInstanceByName(instanceName)
+	instance, err := g.getInstanceByName(instanceName)
 	if err != nil {
 		return cloudprovider.Zone{}, err
 	}
@@ -72,18 +72,18 @@ func (gce *GCECloud) GetZoneByNodeName(ctx context.Context, nodeName types.NodeN
 }
 
 // ListZonesInRegion returns all zones in a GCP region
-func (gce *GCECloud) ListZonesInRegion(region string) ([]*compute.Zone, error) {
+func (g *Cloud) ListZonesInRegion(region string) ([]*compute.Zone, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
 	mc := newZonesMetricContext("list", region)
-	list, err := gce.c.Zones().List(ctx, filter.Regexp("region", gce.getRegionLink(region)))
+	list, err := g.c.Zones().List(ctx, filter.Regexp("region", g.getRegionLink(region)))
 	if err != nil {
 		return nil, mc.Observe(err)
 	}
 	return list, mc.Observe(err)
 }
 
-func (gce *GCECloud) getRegionLink(region string) string {
-	return gce.service.BasePath + strings.Join([]string{gce.projectID, "regions", region}, "/")
+func (g *Cloud) getRegionLink(region string) string {
+	return g.service.BasePath + strings.Join([]string{g.projectID, "regions", region}, "/")
 }

--- a/pkg/cloudprovider/providers/gce/support.go
+++ b/pkg/cloudprovider/providers/gce/support.go
@@ -25,7 +25,7 @@ import (
 
 // gceProjectRouter sends requests to the appropriate project ID.
 type gceProjectRouter struct {
-	gce *GCECloud
+	gce *Cloud
 }
 
 // ProjectID returns the project ID to be used for the given operation.
@@ -40,7 +40,7 @@ func (r *gceProjectRouter) ProjectID(ctx context.Context, version meta.Version, 
 
 // gceRateLimiter implements cloud.RateLimiter.
 type gceRateLimiter struct {
-	gce *GCECloud
+	gce *Cloud
 }
 
 // Accept blocks until the operation can be performed.
@@ -63,10 +63,10 @@ func (l *gceRateLimiter) Accept(ctx context.Context, key *cloud.RateLimitKey) er
 	return nil
 }
 
-// CreateGCECloudWithCloud is a helper function to create an instance of GCECloud with the
+// CreateGCECloudWithCloud is a helper function to create an instance of Cloud with the
 // given Cloud interface implementation. Typical usage is to use cloud.NewMockGCE to get a
 // handle to a mock Cloud instance and then use that for testing.
-func CreateGCECloudWithCloud(config *CloudConfig, c cloud.Cloud) (*GCECloud, error) {
+func CreateGCECloudWithCloud(config *CloudConfig, c cloud.Cloud) (*Cloud, error) {
 	gceCloud, err := CreateGCECloud(config)
 	if err == nil {
 		gceCloud.c = c

--- a/pkg/cloudprovider/providers/gce/token_source.go
+++ b/pkg/cloudprovider/providers/gce/token_source.go
@@ -57,6 +57,7 @@ func init() {
 	prometheus.MustRegister(getTokenFailCounter)
 }
 
+// AltTokenSource is the structure holding the data for the functionality needed to generates tokens
 type AltTokenSource struct {
 	oauthClient *http.Client
 	tokenURL    string
@@ -64,6 +65,7 @@ type AltTokenSource struct {
 	throttle    flowcontrol.RateLimiter
 }
 
+// Token returns a token which may be used for authentication
 func (a *AltTokenSource) Token() (*oauth2.Token, error) {
 	a.throttle.Accept()
 	getTokenCounter.Inc()
@@ -100,6 +102,7 @@ func (a *AltTokenSource) token() (*oauth2.Token, error) {
 	}, nil
 }
 
+// NewAltTokenSource constructs a new alternate token source for generating tokens.
 func NewAltTokenSource(tokenURL, tokenBody string) oauth2.TokenSource {
 	client := oauth2.NewClient(oauth2.NoContext, google.ComputeTokenSource(""))
 	a := &AltTokenSource{

--- a/pkg/controller/nodeipam/ipam/adapter.go
+++ b/pkg/controller/nodeipam/ipam/adapter.go
@@ -36,12 +36,12 @@ import (
 
 type adapter struct {
 	k8s   clientset.Interface
-	cloud *gce.GCECloud
+	cloud *gce.Cloud
 
 	recorder record.EventRecorder
 }
 
-func newAdapter(k8s clientset.Interface, cloud *gce.GCECloud) *adapter {
+func newAdapter(k8s clientset.Interface, cloud *gce.Cloud) *adapter {
 	ret := &adapter{
 		k8s:   k8s,
 		cloud: cloud,

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -59,7 +59,7 @@ type nodeProcessingInfo struct {
 // merely takes the assignment and updates the node spec.
 type cloudCIDRAllocator struct {
 	client clientset.Interface
-	cloud  *gce.GCECloud
+	cloud  *gce.Cloud
 
 	// nodeLister is able to list/get nodes and is populated by the shared informer passed to
 	// NewCloudCIDRAllocator.
@@ -93,7 +93,7 @@ func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Inter
 	glog.V(0).Infof("Sending events to api server.")
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: client.CoreV1().Events("")})
 
-	gceCloud, ok := cloud.(*gce.GCECloud)
+	gceCloud, ok := cloud.(*gce.Cloud)
 	if !ok {
 		err := fmt.Errorf("cloudCIDRAllocator does not support %v provider", cloud.ProviderName())
 		return nil, err

--- a/pkg/controller/nodeipam/ipam/controller.go
+++ b/pkg/controller/nodeipam/ipam/controller.go
@@ -71,7 +71,7 @@ func NewController(
 		return nil, fmt.Errorf("invalid IPAM controller mode %q", config.Mode)
 	}
 
-	gceCloud, ok := cloud.(*gce.GCECloud)
+	gceCloud, ok := cloud.(*gce.Cloud)
 	if !ok {
 		return nil, fmt.Errorf("cloud IPAM controller does not support %q provider", cloud.ProviderName())
 	}

--- a/pkg/controller/nodeipam/node_ipam_controller_test.go
+++ b/pkg/controller/nodeipam/node_ipam_controller_test.go
@@ -48,7 +48,7 @@ func newTestNodeIpamController(clusterCIDR, serviceCIDR *net.IPNet, nodeCIDRMask
 		fakeNodeInformer.Informer().GetStore().Add(node)
 	}
 
-	fakeGCE := gce.FakeGCECloud(gce.DefaultTestClusterValues())
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	return NewNodeIpamController(
 		fakeNodeInformer, fakeGCE, clientSet,
 		clusterCIDR, serviceCIDR, nodeCIDRMaskSize, allocatorType,

--- a/pkg/volume/gcepd/gce_util.go
+++ b/pkg/volume/gcepd/gce_util.go
@@ -284,10 +284,10 @@ func getDiskByIDPaths(pdName string, partition string) []string {
 }
 
 // Return cloud provider
-func getCloudProvider(cloudProvider cloudprovider.Interface) (*gcecloud.GCECloud, error) {
+func getCloudProvider(cloudProvider cloudprovider.Interface) (*gcecloud.Cloud, error) {
 	var err error
 	for numRetries := 0; numRetries < maxRetries; numRetries++ {
-		gceCloudProvider, ok := cloudProvider.(*gcecloud.GCECloud)
+		gceCloudProvider, ok := cloudProvider.(*gcecloud.Cloud)
 		if !ok || gceCloudProvider == nil {
 			// Retry on error. See issue #11321
 			glog.Errorf("Failed to get GCE Cloud Provider. plugin.host.GetCloudProvider returned %v instead", cloudProvider)

--- a/plugin/pkg/admission/storage/persistentvolume/label/admission.go
+++ b/plugin/pkg/admission/storage/persistentvolume/label/admission.go
@@ -58,7 +58,7 @@ type persistentVolumeLabel struct {
 	mutex            sync.Mutex
 	ebsVolumes       aws.Volumes
 	cloudConfig      []byte
-	gceCloudProvider *gce.GCECloud
+	gceCloudProvider *gce.Cloud
 	azureProvider    *azure.Cloud
 }
 
@@ -259,7 +259,7 @@ func (l *persistentVolumeLabel) findGCEPDLabels(volume *api.PersistentVolume) (m
 }
 
 // getGCECloudProvider returns the GCE cloud provider, for use for querying volume labels
-func (l *persistentVolumeLabel) getGCECloudProvider() (*gce.GCECloud, error) {
+func (l *persistentVolumeLabel) getGCECloudProvider() (*gce.Cloud, error) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
@@ -272,7 +272,7 @@ func (l *persistentVolumeLabel) getGCECloudProvider() (*gce.GCECloud, error) {
 		if err != nil || cloudProvider == nil {
 			return nil, err
 		}
-		gceCloudProvider, ok := cloudProvider.(*gce.GCECloud)
+		gceCloudProvider, ok := cloudProvider.(*gce.Cloud)
 		if !ok {
 			// GetCloudProvider has gone very wrong
 			return nil, fmt.Errorf("error retrieving GCE cloud provider")

--- a/test/e2e/framework/providers/gce/firewall.go
+++ b/test/e2e/framework/providers/gce/firewall.go
@@ -401,7 +401,7 @@ func VerifyFirewallRule(res, exp *compute.Firewall, network string, portsSubset 
 	return nil
 }
 
-func WaitForFirewallRule(gceCloud *gcecloud.GCECloud, fwName string, exist bool, timeout time.Duration) (*compute.Firewall, error) {
+func WaitForFirewallRule(gceCloud *gcecloud.Cloud, fwName string, exist bool, timeout time.Duration) (*compute.Firewall, error) {
 	framework.Logf("Waiting up to %v for firewall %v exist=%v", timeout, fwName, exist)
 	var fw *compute.Firewall
 	var err error

--- a/test/e2e/framework/providers/gce/gce.go
+++ b/test/e2e/framework/providers/gce/gce.go
@@ -58,7 +58,7 @@ func factory() (framework.ProviderInterface, error) {
 	}
 
 	gceCloud, err := gcecloud.CreateGCECloud(&gcecloud.CloudConfig{
-		ApiEndpoint:        framework.TestContext.CloudConfig.ApiEndpoint,
+		APIEndpoint:        framework.TestContext.CloudConfig.ApiEndpoint,
 		ProjectID:          framework.TestContext.CloudConfig.ProjectID,
 		Region:             region,
 		Zone:               zone,
@@ -89,7 +89,7 @@ func factory() (framework.ProviderInterface, error) {
 	return NewProvider(gceCloud), nil
 }
 
-func NewProvider(gceCloud *gcecloud.GCECloud) framework.ProviderInterface {
+func NewProvider(gceCloud *gcecloud.Cloud) framework.ProviderInterface {
 	return &Provider{
 		gceCloud: gceCloud,
 	}
@@ -97,7 +97,7 @@ func NewProvider(gceCloud *gcecloud.GCECloud) framework.ProviderInterface {
 
 type Provider struct {
 	framework.NullProvider
-	gceCloud *gcecloud.GCECloud
+	gceCloud *gcecloud.Cloud
 }
 
 func (p *Provider) ResizeGroup(group string, size int32) error {
@@ -279,7 +279,7 @@ func (p *Provider) cleanupGCEResources(c clientset.Interface, loadBalancerName, 
 		return
 	}
 	hcNames := []string{gcecloud.MakeNodesHealthCheckName(clusterID)}
-	hc, getErr := p.gceCloud.GetHttpHealthCheck(loadBalancerName)
+	hc, getErr := p.gceCloud.GetHTTPHealthCheck(loadBalancerName)
 	if getErr != nil && !IsGoogleAPIHTTPErrorCode(getErr, http.StatusNotFound) {
 		retErr = fmt.Errorf("%v\n%v", retErr, getErr)
 		return
@@ -351,7 +351,7 @@ func IsGoogleAPIHTTPErrorCode(err error, code int) bool {
 	return ok && apiErr.Code == code
 }
 
-func GetGCECloud() (*gcecloud.GCECloud, error) {
+func GetGCECloud() (*gcecloud.Cloud, error) {
 	p, ok := framework.TestContext.CloudConfig.Provider.(*Provider)
 	if !ok {
 		return nil, fmt.Errorf("failed to convert CloudConfig.Provider to GCE provider: %#v", framework.TestContext.CloudConfig.Provider)

--- a/test/e2e/framework/providers/gce/ingress.go
+++ b/test/e2e/framework/providers/gce/ingress.go
@@ -198,7 +198,7 @@ func (cont *GCEIngressController) deleteAddresses(del bool) string {
 func (cont *GCEIngressController) ListTargetHttpProxies() []*compute.TargetHttpProxy {
 	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
 	tpList := []*compute.TargetHttpProxy{}
-	l, err := gceCloud.ListTargetHttpProxies()
+	l, err := gceCloud.ListTargetHTTPProxies()
 	Expect(err).NotTo(HaveOccurred())
 	for _, tp := range l {
 		if cont.isOwned(tp.Name) {
@@ -211,7 +211,7 @@ func (cont *GCEIngressController) ListTargetHttpProxies() []*compute.TargetHttpP
 func (cont *GCEIngressController) ListTargetHttpsProxies() []*compute.TargetHttpsProxy {
 	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
 	tpsList := []*compute.TargetHttpsProxy{}
-	l, err := gceCloud.ListTargetHttpsProxies()
+	l, err := gceCloud.ListTargetHTTPSProxies()
 	Expect(err).NotTo(HaveOccurred())
 	for _, tps := range l {
 		if cont.isOwned(tps.Name) {
@@ -259,7 +259,7 @@ func (cont *GCEIngressController) deleteTargetProxy(del bool) string {
 func (cont *GCEIngressController) ListUrlMaps() []*compute.UrlMap {
 	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
 	umList := []*compute.UrlMap{}
-	l, err := gceCloud.ListUrlMaps()
+	l, err := gceCloud.ListURLMaps()
 	Expect(err).NotTo(HaveOccurred())
 	for _, um := range l {
 		if cont.isOwned(um.Name) {
@@ -271,7 +271,7 @@ func (cont *GCEIngressController) ListUrlMaps() []*compute.UrlMap {
 
 func (cont *GCEIngressController) deleteURLMap(del bool) (msg string) {
 	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
-	umList, err := gceCloud.ListUrlMaps()
+	umList, err := gceCloud.ListURLMaps()
 	if err != nil {
 		if cont.isHTTPErrorCode(err, http.StatusNotFound) {
 			return msg
@@ -287,7 +287,7 @@ func (cont *GCEIngressController) deleteURLMap(del bool) (msg string) {
 		}
 		if del {
 			framework.Logf("Deleting url-map: %s", um.Name)
-			if err := gceCloud.DeleteUrlMap(um.Name); err != nil &&
+			if err := gceCloud.DeleteURLMap(um.Name); err != nil &&
 				!cont.isHTTPErrorCode(err, http.StatusNotFound) {
 				msg += fmt.Sprintf("Failed to delete url map %v\n", um.Name)
 			}
@@ -343,7 +343,7 @@ func (cont *GCEIngressController) deleteBackendService(del bool) (msg string) {
 
 func (cont *GCEIngressController) deleteHTTPHealthCheck(del bool) (msg string) {
 	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
-	hcList, err := gceCloud.ListHttpHealthChecks()
+	hcList, err := gceCloud.ListHTTPHealthChecks()
 	if err != nil {
 		if cont.isHTTPErrorCode(err, http.StatusNotFound) {
 			return msg
@@ -359,7 +359,7 @@ func (cont *GCEIngressController) deleteHTTPHealthCheck(del bool) (msg string) {
 		}
 		if del {
 			framework.Logf("Deleting http-health-check: %s", hc.Name)
-			if err := gceCloud.DeleteHttpHealthCheck(hc.Name); err != nil &&
+			if err := gceCloud.DeleteHTTPHealthCheck(hc.Name); err != nil &&
 				!cont.isHTTPErrorCode(err, http.StatusNotFound) {
 				msg += fmt.Sprintf("Failed to delete HTTP health check %v\n", hc.Name)
 			}

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -252,7 +252,7 @@ func RegisterClusterFlags() {
 	// TODO: Flags per provider?  Rename gce-project/gce-zone?
 	cloudConfig := &TestContext.CloudConfig
 	flag.StringVar(&cloudConfig.MasterName, "kube-master", "", "Name of the kubernetes master. Only required if provider is gce or gke")
-	flag.StringVar(&cloudConfig.ApiEndpoint, "gce-api-endpoint", "", "The GCE ApiEndpoint being used, if applicable")
+	flag.StringVar(&cloudConfig.ApiEndpoint, "gce-api-endpoint", "", "The GCE APIEndpoint being used, if applicable")
 	flag.StringVar(&cloudConfig.ProjectID, "gce-project", "", "The GCE project being used, if applicable")
 	flag.StringVar(&cloudConfig.Zone, "gce-zone", "", "GCE zone being used, if applicable")
 	flag.StringVar(&cloudConfig.Region, "gce-region", "", "GCE region being used, if applicable")

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -39,7 +39,7 @@ var _ = SIGDescribe("Firewall rule", func() {
 
 	var cs clientset.Interface
 	var cloudConfig framework.CloudConfig
-	var gceCloud *gcecloud.GCECloud
+	var gceCloud *gcecloud.Cloud
 
 	BeforeEach(func() {
 		framework.SkipUnlessProviderIs("gce")

--- a/test/e2e/network/network_tiers.go
+++ b/test/e2e/network/network_tiers.go
@@ -222,7 +222,7 @@ func clearNetworkTier(svc *v1.Service) {
 
 // TODO: add retries if this turns out to be flaky.
 // TODO(#51665): remove this helper function once Network Tiers becomes beta.
-func reserveAlphaRegionalAddress(cloud *gcecloud.GCECloud, name string, netTier cloud.NetworkTier) (string, error) {
+func reserveAlphaRegionalAddress(cloud *gcecloud.Cloud, name string, netTier cloud.NetworkTier) (string, error) {
 	alphaAddr := &computealpha.Address{
 		Name:        name,
 		NetworkTier: netTier.ToGCEValue(),

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1585,7 +1585,7 @@ var _ = SIGDescribe("Services", func() {
 		svc = jig.WaitForLoadBalancerOrFail(namespace, serviceName, framework.LoadBalancerCreateTimeoutDefault)
 
 		hcName := gcecloud.MakeNodesHealthCheckName(clusterID)
-		hc, err := gceCloud.GetHttpHealthCheck(hcName)
+		hc, err := gceCloud.GetHTTPHealthCheck(hcName)
 		if err != nil {
 			framework.Failf("gceCloud.GetHttpHealthCheck(%q) = _, %v; want nil", hcName, err)
 		}
@@ -1593,7 +1593,7 @@ var _ = SIGDescribe("Services", func() {
 
 		By("modify the health check interval")
 		hc.CheckIntervalSec = gceHcCheckIntervalSeconds - 1
-		if err = gceCloud.UpdateHttpHealthCheck(hc); err != nil {
+		if err = gceCloud.UpdateHTTPHealthCheck(hc); err != nil {
 			framework.Failf("gcecloud.UpdateHttpHealthCheck(%#v) = %v; want nil", hc, err)
 		}
 
@@ -1608,7 +1608,7 @@ var _ = SIGDescribe("Services", func() {
 		By("health check should be reconciled")
 		pollInterval := framework.Poll * 10
 		if pollErr := wait.PollImmediate(pollInterval, framework.LoadBalancerCreateTimeoutDefault, func() (bool, error) {
-			hc, err := gceCloud.GetHttpHealthCheck(hcName)
+			hc, err := gceCloud.GetHTTPHealthCheck(hcName)
 			if err != nil {
 				framework.Logf("Failed to get HttpHealthCheck(%q): %v", hcName, err)
 				return false, err

--- a/test/integration/util/cloud.go
+++ b/test/integration/util/cloud.go
@@ -52,9 +52,9 @@ func (*mockTokenSource) Token() (*oauth2.Token, error) {
 	}, nil
 }
 
-// NewMockGCECloud returns a handle to a GCECloud instance that is
+// NewMockGCECloud returns a handle to a Cloud instance that is
 // served by a mock http server
-func NewMockGCECloud(cloud cloud.Cloud) (*gce.GCECloud, error) {
+func NewMockGCECloud(cloud cloud.Cloud) (*gce.Cloud, error) {
 	config := &gce.CloudConfig{
 		ProjectID:          TestProjectID,
 		NetworkProjectID:   TestNetworkProjectID,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes lint errors in kubeapiserver/admission, kubeapiserver/authorizer,
kubeapiserver/authenticator. Also enables lint testing of these
directories.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes part of issues/68026
/kind cleanup
/sig cloud-provider

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```