### PR TITLE
e2e/framework: include kubernetes-anywhere to new provider registry

### DIFF
--- a/test/e2e/framework/provider.go
+++ b/test/e2e/framework/provider.go
@@ -43,11 +43,14 @@ func RegisterProvider(name string, factory Factory) {
 }
 
 func init() {
-	// "local" or "skeleton" can always be used.
+	// register some known null providers
 	RegisterProvider("local", func() (ProviderInterface, error) {
 		return NullProvider{}, nil
 	})
 	RegisterProvider("skeleton", func() (ProviderInterface, error) {
+		return NullProvider{}, nil
+	})
+	RegisterProvider("kubernetes-anywhere", func() (ProviderInterface, error) {
 		return NullProvider{}, nil
 	})
 	// The empty string also works, but triggers a warning.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix an issue where e2e_test.go does not know
about kubernetes-anywhere as it's unregistered as a --provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Refs https://github.com/kubernetes/kubernetes/issues/70058

**Special notes for your reviewer**:
similar to @BenTheElder 's PR here:
https://github.com/kubernetes/kubernetes/pull/70042

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

/area test
/kind failing-test
/priority critical-urgent
/assign @pohly @timothysc @MrHohn 
cc @jberkus 
