### PR TITLE
updates shared apiserver webhook client

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/client.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/client.go
@@ -66,14 +66,14 @@ func NewClientManager(gv schema.GroupVersion, addToSchemaFunc func(s *runtime.Sc
 	if err != nil {
 		return ClientManager{}, err
 	}
-	admissionScheme := runtime.NewScheme()
-	if err := addToSchemaFunc(admissionScheme); err != nil {
+	hookScheme := runtime.NewScheme()
+	if err := addToSchemaFunc(hookScheme); err != nil {
 		return ClientManager{}, err
 	}
 	return ClientManager{
 		cache: cache,
 		negotiatedSerializer: serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{
-			Serializer: serializer.NewCodecFactory(admissionScheme).LegacyCodec(gv),
+			Serializer: serializer.NewCodecFactory(hookScheme).LegacyCodec(gv),
 		}),
 	}, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/error.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/error.go
@@ -28,7 +28,7 @@ type ErrCallingWebhook struct {
 
 func (e *ErrCallingWebhook) Error() string {
 	if e.Reason != nil {
-		return fmt.Sprintf("failed calling admission webhook %q: %v", e.WebhookName, e.Reason)
+		return fmt.Sprintf("failed calling webhook %q: %v", e.WebhookName, e.Reason)
 	}
-	return fmt.Sprintf("failed calling admission webhook %q; no further details available", e.WebhookName)
+	return fmt.Sprintf("failed calling webhook %q; no further details available", e.WebhookName)
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook.go
@@ -37,7 +37,7 @@ const defaultRequestTimeout = 30 * time.Second
 
 type GenericWebhook struct {
 	RestClient     *rest.RESTClient
-	initialBackoff time.Duration
+	InitialBackoff time.Duration
 }
 
 // NewGenericWebhook creates a new GenericWebhook from the provided kubeconfig file.
@@ -83,7 +83,7 @@ func newGenericWebhook(scheme *runtime.Scheme, codecFactory serializer.CodecFact
 // it returns an error for which apierrors.SuggestsClientDelay() or apierrors.IsInternalError() returns true.
 func (g *GenericWebhook) WithExponentialBackoff(webhookFn func() rest.Result) rest.Result {
 	var result rest.Result
-	WithExponentialBackoff(g.initialBackoff, func() error {
+	WithExponentialBackoff(g.InitialBackoff, func() error {
 		result = webhookFn()
 		return result.Error()
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Makes the shared apiserver webhook more generic

**Special notes for your reviewer**:
The shared webhook is being used in https://github.com/kubernetes/kubernetes/pull/70021. We need a way of creating a generic webhook without using a kubeconfig which is why the `InitialBackoff` is now exported. If preferred a separate `set` method could be used. Thanks!

**Does this PR introduce a user-facing change?**:
NONE
