### PR TITLE
kubeadm: run tests in parallel

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/addons_test.go
+++ b/cmd/kubeadm/app/cmd/phases/addons_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestAddonsSubCommandsHasFlags(t *testing.T) {
-
+	t.Parallel()
 	subCmds := getAddonsSubCommands()
 
 	commonFlags := []string{

--- a/cmd/kubeadm/app/cmd/phases/certs_test.go
+++ b/cmd/kubeadm/app/cmd/phases/certs_test.go
@@ -35,7 +35,7 @@ import (
 const phaseTestK8sVersion = "v1.11.0"
 
 func TestCertsSubCommandsHasFlags(t *testing.T) {
-
+	t.Parallel()
 	subCmds := getCertsSubCommands(phaseTestK8sVersion)
 
 	commonFlags := []string{
@@ -104,7 +104,6 @@ func TestCertsSubCommandsHasFlags(t *testing.T) {
 }
 
 func TestSubCmdCertsCreateFilesWithFlags(t *testing.T) {
-
 	subCmds := getCertsSubCommands(phaseTestK8sVersion)
 
 	var tests = []struct {
@@ -211,7 +210,7 @@ func TestSubCmdCertsApiServerForwardsFlags(t *testing.T) {
 }
 
 func TestSubCmdCertsCreateFilesWithConfigFile(t *testing.T) {
-
+	t.Parallel()
 	subCmds := getCertsSubCommands(phaseTestK8sVersion)
 
 	var tests = []struct {

--- a/cmd/kubeadm/app/cmd/phases/controlplane_test.go
+++ b/cmd/kubeadm/app/cmd/phases/controlplane_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestControlPlaneSubCommandsHasFlags(t *testing.T) {
-
+	t.Parallel()
 	subCmds := getControlPlaneSubCommands("", phaseTestK8sVersion)
 
 	commonFlags := []string{
@@ -81,7 +81,7 @@ func TestControlPlaneSubCommandsHasFlags(t *testing.T) {
 }
 
 func TestControlPlaneCreateFilesWithFlags(t *testing.T) {
-
+	t.Parallel()
 	var tests = []struct {
 		command         string
 		additionalFlags []string

--- a/cmd/kubeadm/app/cmd/phases/etcd_test.go
+++ b/cmd/kubeadm/app/cmd/phases/etcd_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestEtcdSubCommandsHasFlags(t *testing.T) {
-
+	t.Parallel()
 	subCmds := getEtcdSubCommands("", phaseTestK8sVersion)
 
 	commonFlags := []string{
@@ -50,7 +50,7 @@ func TestEtcdSubCommandsHasFlags(t *testing.T) {
 }
 
 func TestEtcdCreateFilesWithFlags(t *testing.T) {
-
+	t.Parallel()
 	var tests = []struct {
 		command         string
 		additionalFlags []string

--- a/cmd/kubeadm/app/cmd/phases/kubeconfig_test.go
+++ b/cmd/kubeadm/app/cmd/phases/kubeconfig_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestKubeConfigCSubCommandsHasFlags(t *testing.T) {
-
+	t.Parallel()
 	subCmds := getKubeConfigSubCommands(nil, "", phaseTestK8sVersion)
 
 	commonFlags := []string{
@@ -96,7 +96,7 @@ func TestKubeConfigCSubCommandsHasFlags(t *testing.T) {
 }
 
 func TestKubeConfigSubCommandsThatCreateFilesWithFlags(t *testing.T) {
-
+	t.Parallel()
 	commonFlags := []string{
 		"--apiserver-advertise-address=1.2.3.4",
 		"--apiserver-bind-port=1234",
@@ -208,7 +208,7 @@ func TestKubeConfigSubCommandsThatCreateFilesWithFlags(t *testing.T) {
 }
 
 func TestKubeConfigSubCommandsThatCreateFilesWithConfigFile(t *testing.T) {
-
+	t.Parallel()
 	var tests = []struct {
 		command       string
 		expectedFiles []string
@@ -316,7 +316,7 @@ func TestKubeConfigSubCommandsThatCreateFilesWithConfigFile(t *testing.T) {
 }
 
 func TestKubeConfigSubCommandsThatWritesToOut(t *testing.T) {
-
+	t.Parallel()
 	// Temporary folders for the test case
 	tmpdir := testutil.SetupTempDir(t)
 	defer os.RemoveAll(tmpdir)

--- a/cmd/kubeadm/app/cmd/phases/kubelet_test.go
+++ b/cmd/kubeadm/app/cmd/phases/kubelet_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestKubeletSubCommandsHasFlags(t *testing.T) {
+
 	subCmds := []*cobra.Command{
 		NewCmdKubeletWriteEnvFile(),
 		NewCmdKubeletConfigUpload(),

--- a/cmd/kubeadm/app/cmd/phases/util_test.go
+++ b/cmd/kubeadm/app/cmd/phases/util_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestSetKubernetesVersion(t *testing.T) {
-
+	t.Parallel()
 	ver := version.Get().String()
 
 	tests := []struct {

--- a/cmd/kubeadm/app/phases/certs/certlist_test.go
+++ b/cmd/kubeadm/app/phases/certs/certlist_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestCAPointersValid(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		certs Certificates
 		name  string
@@ -59,6 +60,7 @@ func TestCAPointersValid(t *testing.T) {
 }
 
 func TestMakeCertTree(t *testing.T) {
+	t.Parallel()
 	rootCert := &KubeadmCert{
 		Name: "root",
 	}
@@ -109,6 +111,7 @@ func TestMakeCertTree(t *testing.T) {
 }
 
 func TestCreateCertificateChain(t *testing.T) {
+	t.Parallel()
 	dir, err := ioutil.TempDir("", t.Name())
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -55,6 +55,7 @@ func createTestCert(t *testing.T, caCert *x509.Certificate, caKey *rsa.PrivateKe
 }
 
 func TestWriteCertificateAuthorithyFilesIfNotExist(t *testing.T) {
+	t.Parallel()
 	setupCert, setupKey := createCACert(t)
 	caCert, caKey := createCACert(t)
 
@@ -130,7 +131,7 @@ func TestWriteCertificateAuthorithyFilesIfNotExist(t *testing.T) {
 }
 
 func TestWriteCertificateFilesIfNotExist(t *testing.T) {
-
+	t.Parallel()
 	caCert, caKey := createCACert(t)
 	setupCert, setupKey := createTestCert(t, caCert, caKey)
 	cert, key := createTestCert(t, caCert, caKey)
@@ -209,7 +210,7 @@ func TestWriteCertificateFilesIfNotExist(t *testing.T) {
 }
 
 func TestWriteKeyFilesIfNotExist(t *testing.T) {
-
+	t.Parallel()
 	setupKey, _ := NewServiceAccountSigningKey()
 	key, _ := NewServiceAccountSigningKey()
 
@@ -280,6 +281,7 @@ func TestWriteKeyFilesIfNotExist(t *testing.T) {
 }
 
 func TestNewCACertAndKey(t *testing.T) {
+	t.Parallel()
 	certCfg := &certutil.Config{CommonName: "kubernetes"}
 	caCert, _, err := NewCACertAndKey(certCfg)
 	if err != nil {
@@ -290,6 +292,7 @@ func TestNewCACertAndKey(t *testing.T) {
 }
 
 func TestSharedCertificateExists(t *testing.T) {
+	t.Parallel()
 	caCert, caKey := createCACert(t)
 	_, key := createTestCert(t, caCert, caKey)
 	publicKey := &key.PublicKey
@@ -375,6 +378,7 @@ func TestSharedCertificateExists(t *testing.T) {
 }
 
 func TestCreatePKIAssetsWithSparseCerts(t *testing.T) {
+	t.Parallel()
 	caCert, caKey := createCACert(t)
 	fpCACert, fpCAKey := createCACert(t)
 	etcdCACert, etcdCAKey := createCACert(t)
@@ -458,6 +462,7 @@ func TestCreatePKIAssetsWithSparseCerts(t *testing.T) {
 }
 
 func TestUsingExternalCA(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		setupFuncs []func(cfg *kubeadmapi.InitConfiguration) error
 		expected   bool
@@ -504,7 +509,7 @@ func TestUsingExternalCA(t *testing.T) {
 }
 
 func TestValidateMethods(t *testing.T) {
-
+	t.Parallel()
 	caCert, caKey := createCACert(t)
 	cert, key := createTestCert(t, caCert, caKey)
 
@@ -609,7 +614,7 @@ func writePKIFiles(t *testing.T, dir string, files pkiFiles) {
 }
 
 func TestCreateCertificateFilesMethods(t *testing.T) {
-
+	t.Parallel()
 	var tests = []struct {
 		setupFunc     func(cfg *kubeadmapi.InitConfiguration) error
 		createFunc    func(cfg *kubeadmapi.InitConfiguration) error


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Issue kubernetes/kubeadm#952 mentions phases tests as slowest among
kubeadm tests.

Running tests in parallel shows substantional speedup:

- Running sequentially:
$ time go test
real	0m38.199s
user	0m17.326s
sys	0m0.456s

- Running in parallel:
$ time go test
...
real	0m27.769s
user	0m17.924s
sys	0m0.431s

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```