### PR TITLE
[WIP] hack: add verify-canonical-import-path.sh

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -40,6 +40,7 @@ QUICK_PATTERNS+=(
   "verify-api-groups.sh"
   "verify-bazel.sh"
   "verify-boilerplate.sh"
+  "verify-canonical-import-path.sh"
   "verify-godep-licenses.sh"
   "verify-gofmt.sh"
   "verify-imports.sh"

--- a/hack/verify-canonical-import-path.sh
+++ b/hack/verify-canonical-import-path.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+staging_repos="${KUBE_ROOT}/staging/src/k8s.io"
+
+# verify-canonical-import-path checks that directories in staging
+# having doc.go contain canonical import paths.
+# See https://golang.org/doc/go1.4#canonicalimports for more details.
+
+failed=false
+while read i; do
+    # don't consider generated files
+    if grep -q "DO NOT EDIT" $i; then
+        continue
+    fi
+
+    # extract import path and package name from the file name
+    # If i="hack/../staging/src/k8s.io/client-go/scale/doc.go", then
+    # import_path=k8s.io/client-go/scale and package_name=scale
+    import_path=$(echo ${i:20} | rev | cut -c8- | rev)
+    package_name=${import_path##*/}
+    
+    if ! grep -q "package ${package_name} // import \"${import_path}\"" $i; then
+        echo "staging/src/${import_path}/doc.go does not use canonical import paths."
+        failed=true
+    fi
+done < <(find $staging_repos -name 'doc.go')
+
+if [[ "${failed}" == "true" ]]; then
+  echo "See https://golang.org/doc/go1.4#canonicalimports for more details on canonical import paths."
+  exit 1
+fi


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/68266#issuecomment-419373586, https://github.com/kubernetes/kubernetes/pull/69667#issuecomment-431769679, https://github.com/kubernetes/kubernetes/issues/68231

This script looks into the directories under staging and checks that all directories having `doc.go` files
use canonical import paths.

See https://golang.org/doc/go1.4#canonicalimports for more details.


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
