### PR TITLE
kubeadm: remove temporary directories after upgrade

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -288,7 +288,7 @@ func PerformControlPlaneUpgrade(flags *applyFlags, client clientset.Interface, w
 // GetPathManagerForUpgrade returns a path manager properly configured for the given InitConfiguration.
 func GetPathManagerForUpgrade(internalcfg *kubeadmapi.InitConfiguration, etcdUpgrade bool) (upgrade.StaticPodPathManager, error) {
 	isHAEtcd := etcdutil.CheckConfigurationIsHA(&internalcfg.Etcd)
-	return upgrade.NewKubeStaticPodPathManagerUsingTempDirs(constants.GetStaticPodDirectory(), true, etcdUpgrade && !isHAEtcd)
+	return upgrade.NewKubeStaticPodPathManagerUsingTempDirs(constants.GetStaticPodDirectory(), false, !etcdUpgrade && !isHAEtcd)
 }
 
 // PerformStaticPodUpgrade performs the upgrade of the control plane components for a static pod hosted cluster


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

kubeadm doesn't remove manifest and etcd temporary backup directories
due to incorrectly set NewKubeStaticPodPathManagerUsingTempDirs
parameters saveManifestsDir and saveEtcdDir.

**Does this PR introduce a user-facing change?**:

```release-note
kubeadm: remove temporary backup directories after upgrade
```