### PR TITLE
API Schema fix: container port keys

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -83373,6 +83373,11 @@
       "items": {
        "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
       },
+      "x-kubernetes-list-map-keys": [
+       "containerPort",
+       "protocol"
+      ],
+      "x-kubernetes-list-type": "map",
       "x-kubernetes-patch-merge-key": "containerPort",
       "x-kubernetes-patch-strategy": "merge"
      },

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -606,6 +606,9 @@ message Container {
   // +optional
   // +patchMergeKey=containerPort
   // +patchStrategy=merge
+  // +listType=map
+  // +listMapKey=containerPort
+  // +listMapKey=protocol
   repeated ContainerPort ports = 6;
 
   // List of sources to populate environment variables in the container.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2060,6 +2060,9 @@ type Container struct {
 	// +optional
 	// +patchMergeKey=containerPort
 	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=containerPort
+	// +listMapKey=protocol
 	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort" protobuf:"bytes,6,rep,name=ports"`
 	// List of sources to populate environment variables in the container.
 	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys


### PR DESCRIPTION
The first of (likely) many such fixes.

As part of Apply, we're allowing more specificity into the schema, in particular, the ability for associative lists to have more than one key field.

This should be 100% backwards compatible (nothing pays attention to the new openapi schema annotations yet). As such, I'm sending it to master rather than the feature branch.

We will not remove the existing merge key annotations, even though they are largely redundant, so as not to change any existing behavior.

```release-note
NONE
```
