### PR TITLE
RFC: Add logs option to send stdout & stderr to a file

### DIFF
--- a/cmd/cloud-controller-manager/controller-manager.go
+++ b/cmd/cloud-controller-manager/controller-manager.go
@@ -50,7 +50,7 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	// utilflag.InitFlags()
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/hyperkube/main.go
+++ b/cmd/hyperkube/main.go
@@ -58,7 +58,7 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	// utilflag.InitFlags()
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	basename := filepath.Base(os.Args[0])
 	if err := commandFor(basename, hyperkubeCommand, allCommandFns).Execute(); err != nil {

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -47,7 +47,7 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	// utilflag.InitFlags()
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -50,7 +50,7 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	// utilflag.InitFlags()
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -44,7 +44,7 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	// utilflag.InitFlags()
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/kube-scheduler/scheduler.go
+++ b/cmd/kube-scheduler/scheduler.go
@@ -43,7 +43,7 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	// utilflag.InitFlags()
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -38,7 +38,7 @@ func main() {
 
 	command := app.NewKubeletCommand(server.SetupSignalHandler())
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -111,7 +111,7 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	// utilflag.InitFlags()
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/staging/src/k8s.io/apiextensions-apiserver/main.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/main.go
@@ -29,7 +29,7 @@ import (
 
 func main() {
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	stopCh := genericapiserver.SetupSignalHandler()
 	cmd := server.NewServerCommand(os.Stdout, os.Stderr, stopCh)

--- a/staging/src/k8s.io/kube-aggregator/main.go
+++ b/staging/src/k8s.io/kube-aggregator/main.go
@@ -36,7 +36,7 @@ import (
 
 func main() {
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	stopCh := genericapiserver.SetupSignalHandler()
 	options := server.NewDefaultOptions(os.Stdout, os.Stderr)

--- a/staging/src/k8s.io/sample-apiserver/main.go
+++ b/staging/src/k8s.io/sample-apiserver/main.go
@@ -29,7 +29,7 @@ import (
 
 func main() {
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	stopCh := genericapiserver.SetupSignalHandler()
 	options := server.NewWardleServerOptions(os.Stdout, os.Stderr)

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -282,7 +282,7 @@ func gatherTestSuiteMetrics() error {
 func RunE2ETests(t *testing.T) {
 	runtimeutils.ReallyCrash = true
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	gomega.RegisterFailHandler(ginkgowrapper.Fail)
 	// Disable skipped tests unless they are explicitly requested.

--- a/test/images/no-snat-test-proxy/main.go
+++ b/test/images/no-snat-test-proxy/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	flag.InitFlags()
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	if err := m.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/test/images/no-snat-test/main.go
+++ b/test/images/no-snat-test/main.go
@@ -54,7 +54,7 @@ func main() {
 
 	flag.InitFlags()
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer logs.ShutDownLogs()
 
 	if err := m.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

_This PR is offered as an alternative to https://github.com/kubernetes/kubernetes/pull/69333, in case we decided to prioritize the interface changes over the logs implementation changes. I don't have a strong stance on which path we should take, but wanted to put this option out there._

Kubernetes makes extensive usage of the glog logging library, which ([amoung
other problems][glog-issue]) cannot send the log output to a specific file.

To work around this, kubernetes containers commonly run a shell wrapper around the
binary, and use redirection to send the output to a log file. Problems with this
approach include:

1. Including a functional shell (& helper binaries) increases the tools
   available to attackers, making certain types of exploits much easier.
2. Vulnerabilities in the included dependencies must be managaged, creating toil
   for Kubernetes devs.

This PR attempts to hack around this glog limitation by hijacking tho os.Stdout and os.Stderr files. This is a temporary solution until we are able to do a larger overhaul of kubernetes debug logging.

**Which issue(s) this PR fixes**:
Related: https://github.com/kubernetes/kubernetes/issues/40248, https://github.com/kubernetes/kubernetes/issues/38541, https://github.com/kubernetes/kubernetes/issues/61006

**Special notes for your reviewer**:

Still TODO:
- Add the log flags where needed
- Extensive testing

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Add 2 new flags for redirecting log output: `--log-file` specifies a file to redirect stdout & stderr to, and `--tee-logs` adds the option of continuing to output to stdout.
```

/assign @dims @thockin 

/area logging