### PR TITLE
promote --service-account-api-audiences to top level kube-apiserver config

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -333,14 +333,14 @@ func CreateKubeAPIServerConfig(
 
 	if s.ServiceAccountSigningKeyFile != "" ||
 		s.Authentication.ServiceAccounts.Issuer != "" ||
-		len(s.Authentication.ServiceAccounts.APIAudiences) > 0 {
+		len(s.Authentication.APIAudiences) > 0 {
 		if !utilfeature.DefaultFeatureGate.Enabled(features.TokenRequest) {
 			lastErr = fmt.Errorf("the TokenRequest feature is not enabled but --service-account-signing-key-file, --service-account-issuer and/or --service-account-api-audiences flags were passed")
 			return
 		}
 		if s.ServiceAccountSigningKeyFile == "" ||
 			s.Authentication.ServiceAccounts.Issuer == "" ||
-			len(s.Authentication.ServiceAccounts.APIAudiences) == 0 ||
+			len(s.Authentication.APIAudiences) == 0 ||
 			len(s.Authentication.ServiceAccounts.KeyFiles) == 0 {
 			lastErr = fmt.Errorf("service-account-signing-key-file, service-account-issuer, service-account-api-audiences and service-account-key-file should be specified together")
 			return
@@ -365,7 +365,7 @@ func CreateKubeAPIServerConfig(
 			lastErr = fmt.Errorf("failed to build token generator: %v", err)
 			return
 		}
-		apiAudiences = s.Authentication.ServiceAccounts.APIAudiences
+		apiAudiences = s.Authentication.APIAudiences
 		maxExpiration = s.Authentication.ServiceAccounts.MaxExpiration
 	}
 
@@ -401,7 +401,7 @@ func CreateKubeAPIServerConfig(
 			MasterCount:            s.MasterCount,
 
 			ServiceAccountIssuer:        issuer,
-			ServiceAccountAPIAudiences:  apiAudiences,
+			APIAudiences:                apiAudiences,
 			ServiceAccountMaxExpiration: maxExpiration,
 
 			InternalInformers:  sharedInformers,

--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -63,7 +63,7 @@ type AuthenticatorConfig struct {
 	ServiceAccountKeyFiles      []string
 	ServiceAccountLookup        bool
 	ServiceAccountIssuer        string
-	ServiceAccountAPIAudiences  []string
+	APIAudiences                []string
 	WebhookTokenAuthnConfigFile string
 	WebhookTokenAuthnCacheTTL   time.Duration
 
@@ -141,7 +141,7 @@ func (config AuthenticatorConfig) New() (authenticator.Request, *spec.SecurityDe
 		tokenAuthenticators = append(tokenAuthenticators, serviceAccountAuth)
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.TokenRequest) && config.ServiceAccountIssuer != "" {
-		serviceAccountAuth, err := newServiceAccountAuthenticator(config.ServiceAccountIssuer, config.ServiceAccountAPIAudiences, config.ServiceAccountKeyFiles, config.ServiceAccountTokenGetter)
+		serviceAccountAuth, err := newServiceAccountAuthenticator(config.ServiceAccountIssuer, config.APIAudiences, config.ServiceAccountKeyFiles, config.ServiceAccountTokenGetter)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -169,8 +169,9 @@ type ExtraConfig struct {
 	EndpointReconcilerType reconcilers.Type
 
 	ServiceAccountIssuer        serviceaccount.TokenGenerator
-	ServiceAccountAPIAudiences  []string
 	ServiceAccountMaxExpiration time.Duration
+
+	APIAudiences []string
 
 	VersionedInformers informers.SharedInformerFactory
 	InternalInformers  internalinformers.SharedInformerFactory
@@ -334,8 +335,8 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 			ServiceNodePortRange:        c.ExtraConfig.ServiceNodePortRange,
 			LoopbackClientConfig:        c.GenericConfig.LoopbackClientConfig,
 			ServiceAccountIssuer:        c.ExtraConfig.ServiceAccountIssuer,
-			ServiceAccountAPIAudiences:  c.ExtraConfig.ServiceAccountAPIAudiences,
 			ServiceAccountMaxExpiration: c.ExtraConfig.ServiceAccountMaxExpiration,
+			APIAudiences:                c.ExtraConfig.APIAudiences,
 		}
 		m.InstallLegacyAPI(&c, c.GenericConfig.RESTOptionsGetter, legacyRESTStorageProvider)
 	}

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -80,8 +80,9 @@ type LegacyRESTStorageProvider struct {
 	ServiceNodePortRange utilnet.PortRange
 
 	ServiceAccountIssuer        serviceaccount.TokenGenerator
-	ServiceAccountAPIAudiences  []string
 	ServiceAccountMaxExpiration time.Duration
+
+	APIAudiences []string
 
 	LoopbackClientConfig *restclient.Config
 }
@@ -142,7 +143,7 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(restOptionsGetter generi
 
 	var serviceAccountStorage *serviceaccountstore.REST
 	if c.ServiceAccountIssuer != nil && utilfeature.DefaultFeatureGate.Enabled(features.TokenRequest) {
-		serviceAccountStorage = serviceaccountstore.NewREST(restOptionsGetter, c.ServiceAccountIssuer, c.ServiceAccountAPIAudiences, c.ServiceAccountMaxExpiration, podStorage.Pod.Store, secretStorage.Store)
+		serviceAccountStorage = serviceaccountstore.NewREST(restOptionsGetter, c.ServiceAccountIssuer, c.APIAudiences, c.ServiceAccountMaxExpiration, podStorage.Pod.Store, secretStorage.Store)
 	} else {
 		serviceAccountStorage = serviceaccountstore.NewREST(restOptionsGetter, nil, nil, 0, nil, nil)
 	}

--- a/test/integration/auth/svcaccttoken_test.go
+++ b/test/integration/auth/svcaccttoken_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"gopkg.in/square/go-jose.v2/jwt"
+
 	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,8 +88,8 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	masterConfig.ExtraConfig.ServiceAccountIssuer = tokenGenerator
-	masterConfig.ExtraConfig.ServiceAccountAPIAudiences = aud
 	masterConfig.ExtraConfig.ServiceAccountMaxExpiration = maxExpirationDuration
+	masterConfig.ExtraConfig.APIAudiences = aud
 
 	master, _, closeFn := framework.RunAMaster(masterConfig)
 	defer closeFn()


### PR DESCRIPTION
The service account authenticator isn't the only authenticator that
should respect API audience. The authentication config structure should
reflect that.

/kind cleanup
/sig auth

```release-note
The --service-account-api-audiences on kube-apiserver is deprecated in favor of --api-audiences.
```

@kubernetes/sig-auth-pr-reviews 