### PR TITLE
Add support to inject projected volume when TokenRequest feature was enabled and token projected volume was bounded to pod.

### DIFF
--- a/plugin/pkg/admission/serviceaccount/BUILD
+++ b/plugin/pkg/admission/serviceaccount/BUILD
@@ -16,10 +16,12 @@ go_library(
     deps = [
         "//pkg/api/pod:go_default_library",
         "//pkg/apis/core:go_default_library",
+        "//pkg/controller/certificates/rootcacertpublisher:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/kubeapiserver/admission/util:go_default_library",
         "//pkg/serviceaccount:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",


### PR DESCRIPTION

> /kind feature


**What this PR does / why we need it**:
Add support to inject projected volume when TokenRequest feature was enabled and token projected volume was bounded to pod.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68811 


-->
```release-note
Add support to inject projected volume when TokenRequest feature was enabled and token projected volume was bounded to pod.
```
