### PR TITLE
Fix SubPath printing

### DIFF
--- a/pkg/kubectl/describe/versioned/describe.go
+++ b/pkg/kubectl/describe/versioned/describe.go
@@ -1647,12 +1647,12 @@ func describeContainerVolumes(container corev1.Container, w PrefixWriter) {
 	sort.Sort(SortableVolumeMounts(container.VolumeMounts))
 	for _, mount := range container.VolumeMounts {
 		flags := []string{}
-		switch {
-		case mount.ReadOnly:
+		if mount.ReadOnly {
 			flags = append(flags, "ro")
-		case !mount.ReadOnly:
+		} else {
 			flags = append(flags, "rw")
-		case len(mount.SubPath) > 0:
+		}
+		if len(mount.SubPath) > 0 {
 			flags = append(flags, fmt.Sprintf("path=%q", mount.SubPath))
 		}
 		w.Write(LEVEL_3, "%s from %s (%s)\n", mount.MountPath, mount.Name, strings.Join(flags, ","))

--- a/pkg/kubectl/describe/versioned/describe_test.go
+++ b/pkg/kubectl/describe/versioned/describe_test.go
@@ -718,6 +718,22 @@ func TestDescribeContainers(t *testing.T) {
 			expectedElements: []string{"Mounts", "mounted-volume", "/opt/", "(ro)"},
 		},
 
+		// volumeMounts subPath
+		{
+			container: corev1.Container{
+				Name:  "test",
+				Image: "image",
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "mounted-volume",
+						MountPath: "/opt/",
+						SubPath:   "foo",
+					},
+				},
+			},
+			expectedElements: []string{"Mounts", "mounted-volume", "/opt/", "(rw,path=\"foo\")"},
+		},
+
 		// volumeDevices
 		{
 			container: corev1.Container{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`VolumeMounts` section didn't print `SubPath` correctly because `switch/case` always take a flag of `ReadOnly`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
Fix `SubPath` printing of `VolumeMounts`.
```