### PR TITLE
match stdlib http.Request context API in the restclient

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -99,7 +99,7 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *v1beta
 		return &webhook.ErrCallingWebhook{WebhookName: h.Name, Reason: err}
 	}
 	response := &admissionv1beta1.AdmissionReview{}
-	if err := client.Post().Context(ctx).Body(&request).Do().Into(response); err != nil {
+	if err := client.Post().WithContext(ctx).Body(&request).Do().Into(response); err != nil {
 		return &webhook.ErrCallingWebhook{WebhookName: h.Name, Reason: err}
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -114,7 +114,7 @@ func (d *validatingDispatcher) callHook(ctx context.Context, h *v1beta1.Webhook,
 		return &webhook.ErrCallingWebhook{WebhookName: h.Name, Reason: err}
 	}
 	response := &admissionv1beta1.AdmissionReview{}
-	if err := client.Post().Context(ctx).Body(&request).Do().Into(response); err != nil {
+	if err := client.Post().WithContext(ctx).Body(&request).Do().Into(response); err != nil {
 		return &webhook.ErrCallingWebhook{WebhookName: h.Name, Reason: err}
 	}
 

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -411,9 +411,15 @@ func (r *Request) Body(obj interface{}) *Request {
 	return r
 }
 
-// Context adds a context to the request. Contexts are only used for
+// Context returns the context currently associated with the request. To change
+// the context, use WithContext.
+func (r *Request) Context() context.Context {
+	return r.ctx
+}
+
+// WithContext adds a context to the request. Contexts are only used for
 // timeouts, deadlines, and cancellations.
-func (r *Request) Context(ctx context.Context) *Request {
+func (r *Request) WithContext(ctx context.Context) *Request {
 	r.ctx = ctx
 	return r
 }

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -1839,7 +1839,7 @@ func TestDoContext(t *testing.T) {
 
 	c := testRESTClient(t, testServer)
 	_, err := c.Verb("GET").
-		Context(ctx).
+		WithContext(ctx).
 		Prefix("foo").
 		DoRaw()
 	if err == nil {

--- a/test/e2e/common/autoscaling_utils.go
+++ b/test/e2e/common/autoscaling_utils.go
@@ -258,7 +258,7 @@ func (rc *ResourceConsumer) sendConsumeCPURequest(millicores int) {
 		proxyRequest, err := framework.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
-			Context(ctx).
+			WithContext(ctx).
 			Name(rc.controllerName).
 			Suffix("ConsumeCPU").
 			Param("millicores", strconv.Itoa(millicores)).
@@ -285,7 +285,7 @@ func (rc *ResourceConsumer) sendConsumeMemRequest(megabytes int) {
 		proxyRequest, err := framework.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
-			Context(ctx).
+			WithContext(ctx).
 			Name(rc.controllerName).
 			Suffix("ConsumeMem").
 			Param("megabytes", strconv.Itoa(megabytes)).
@@ -312,7 +312,7 @@ func (rc *ResourceConsumer) sendConsumeCustomMetric(delta int) {
 		proxyRequest, err := framework.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
-			Context(ctx).
+			WithContext(ctx).
 			Name(rc.controllerName).
 			Suffix("BumpMetric").
 			Param("metric", customMetricName).

--- a/test/e2e/framework/kubelet_stats.go
+++ b/test/e2e/framework/kubelet_stats.go
@@ -287,7 +287,7 @@ func getStatsSummary(c clientset.Interface, nodeName string) (*stats.Summary, er
 	defer cancel()
 
 	data, err := c.CoreV1().RESTClient().Get().
-		Context(ctx).
+		WithContext(ctx).
 		Resource("nodes").
 		SubResource("proxy").
 		Name(fmt.Sprintf("%v:%v", nodeName, ports.KubeletPort)).

--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -608,7 +608,7 @@ func sendRestRequestToScheduler(c clientset.Interface, op string) (string, error
 		defer cancel()
 
 		body, err := c.CoreV1().RESTClient().Verb(opUpper).
-			Context(ctx).
+			WithContext(ctx).
 			Namespace(metav1.NamespaceSystem).
 			Resource("pods").
 			Name(fmt.Sprintf("kube-scheduler-%v:%v", TestContext.CloudConfig.MasterName, ports.SchedulerPort)).

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1820,7 +1820,7 @@ func (r podProxyResponseChecker) CheckAllResponses() (done bool, err error) {
 		defer cancel()
 
 		body, err := r.c.CoreV1().RESTClient().Get().
-			Context(ctx).
+			WithContext(ctx).
 			Namespace(r.ns).
 			Resource("pods").
 			SubResource("proxy").
@@ -2019,7 +2019,7 @@ func ServiceResponding(c clientset.Interface, ns, name string) error {
 		defer cancel()
 
 		body, err := proxyRequest.Namespace(ns).
-			Context(ctx).
+			WithContext(ctx).
 			Name(name).
 			Do().
 			Raw()

--- a/test/e2e/instrumentation/logging/elasticsearch/kibana.go
+++ b/test/e2e/instrumentation/logging/elasticsearch/kibana.go
@@ -92,7 +92,7 @@ func ClusterLevelLoggingWithKibana(f *framework.Framework) {
 		defer cancel()
 
 		_, err = req.Namespace(metav1.NamespaceSystem).
-			Context(ctx).
+			WithContext(ctx).
 			Name("kibana-logging").
 			DoRaw()
 		if err != nil {

--- a/test/e2e/instrumentation/monitoring/prometheus.go
+++ b/test/e2e/instrumentation/monitoring/prometheus.go
@@ -228,7 +228,7 @@ func fetchPrometheusTargetDiscovery(c clientset.Interface) (TargetDiscovery, err
 	defer cancel()
 
 	response, err := c.CoreV1().RESTClient().Get().
-		Context(ctx).
+		WithContext(ctx).
 		Namespace("kube-system").
 		Resource("services").
 		Name(prometheusService+":9090").
@@ -284,7 +284,7 @@ func queryPrometheus(c clientset.Interface, query string, start, end time.Time, 
 	defer cancel()
 
 	response, err := c.CoreV1().RESTClient().Get().
-		Context(ctx).
+		WithContext(ctx).
 		Namespace("kube-system").
 		Resource("services").
 		Name(prometheusService+":9090").

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -2029,7 +2029,7 @@ func makeRequestToGuestbook(c clientset.Interface, cmd, value string, ns string)
 	defer cancel()
 
 	result, err := proxyRequest.Namespace(ns).
-		Context(ctx).
+		WithContext(ctx).
 		Name("frontend").
 		Suffix("/guestbook.php").
 		Param("cmd", cmd).

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -503,7 +503,7 @@ func assertFilesContain(fileNames []string, fileDir string, pod *v1.Pod, client 
 
 		for _, fileName := range fileNames {
 			contents, err := client.CoreV1().RESTClient().Get().
-				Context(ctx).
+				WithContext(ctx).
 				Namespace(pod.Namespace).
 				Resource("pods").
 				SubResource("proxy").

--- a/test/e2e/node/pre_stop.go
+++ b/test/e2e/node/pre_stop.go
@@ -127,7 +127,7 @@ func testPreStop(c clientset.Interface, ns string) {
 
 		var body []byte
 		body, err = c.CoreV1().RESTClient().Get().
-			Context(ctx).
+			WithContext(ctx).
 			Namespace(ns).
 			Resource("pods").
 			SubResource("proxy").

--- a/test/e2e/ui/dashboard.go
+++ b/test/e2e/ui/dashboard.go
@@ -72,7 +72,7 @@ var _ = SIGDescribe("Kubernetes Dashboard", func() {
 
 			// Query against the proxy URL for the kubernetes-dashboard service.
 			err := proxyRequest.Namespace(uiNamespace).
-				Context(ctx).
+				WithContext(ctx).
 				Name(utilnet.JoinSchemeNamePort("https", uiServiceName, "")).
 				Timeout(framework.SingleCallTimeout).
 				Do().


### PR DESCRIPTION
https://godoc.org/net/http#Request.WithContext

RFC. Switching between this library and `net/http` is pretty frustrating. If this is amenable, anything extra I need to do to satisfy the client-go compatibility objective?

/kind cleanup
/sig api-machinery

@kubernetes/sig-api-machinery-api-reviews 

```release-note
NONE
```
