### PR TITLE
Fix missing glog flags for some commands which output flags in logical sections

### DIFF
--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	goflag "flag"
 	"fmt"
 	"math/rand"
 	"net"
@@ -140,6 +141,7 @@ func (o *CloudControllerManagerOptions) Flags() apiserverflag.NamedFlagSets {
 	fs.StringVar(&o.Master, "master", o.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig).")
 	fs.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	fs.DurationVar(&o.NodeStatusUpdateFrequency.Duration, "node-status-update-frequency", o.NodeStatusUpdateFrequency.Duration, "Specifies how often the controller updates nodes' status.")
+	fs.AddGoFlagSet(goflag.CommandLine)
 
 	utilfeature.DefaultFeatureGate.AddFlag(fss.FlagSet("generic"))
 

--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -18,6 +18,7 @@ limitations under the License.
 package options
 
 import (
+	goflag "flag"
 	"net"
 	"strings"
 	"time"
@@ -234,6 +235,8 @@ func (s *ServerRunOptions) Flags() (fss apiserverflag.NamedFlagSets) {
 
 	fs.StringVar(&s.ServiceAccountSigningKeyFile, "service-account-signing-key-file", s.ServiceAccountSigningKeyFile, ""+
 		"Path to the file that contains the current private key of the service account token issuer. The issuer will sign issued ID tokens with this private key. (Requires the 'TokenRequest' feature gate.)")
+
+	fs.AddGoFlagSet(goflag.CommandLine)
 
 	return fss
 }

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -19,6 +19,7 @@ limitations under the License.
 package options
 
 import (
+	goflag "flag"
 	"fmt"
 	"net"
 
@@ -263,6 +264,7 @@ func (s *KubeControllerManagerOptions) Flags(allControllers []string, disabledBy
 	var dummy string
 	fs.MarkDeprecated("insecure-experimental-approve-all-kubelet-csrs-for-group", "This flag does nothing.")
 	fs.StringVar(&dummy, "insecure-experimental-approve-all-kubelet-csrs-for-group", "", "This flag does nothing.")
+	fs.AddGoFlagSet(goflag.CommandLine)
 	utilfeature.DefaultFeatureGate.AddFlag(fss.FlagSet("generic"))
 
 	return fss


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Some binaries (e.g. `kube-apiserver`, `kube-controller-manager`, `cloud-controller-manager`) tend to output flags in logical sections. This feature was introduced in #64517 and #67362. It seems like it does not consider glog-related flags. This PR includes these glog flags in the named section "misc".

The glog related flags are initialized in the `init` function (when we include the `glog` package).
https://github.com/kubernetes/kubernetes/blob/0d17976413e3220e739247e1626d4800d1d2b2d4/vendor/github.com/golang/glog/glog.go#L399-L404

**Which issue(s) this PR fixes**:
See #70145.

**Special notes for your reviewer**: I am not quite sure if we're planning to switch everything to logical sections. If yes, we might be able to abstract this so that we don't need to manually add glog commands in the misc section.

**Does this PR introduce a user-facing change?**:
```release-note
Fix missing glog flags in kube-apiserver --help and *-controller-manager --help.
```

/sig cli 
cc @sttts @stewart-yu