### PR TITLE
Automated cherry pick of #69454: delete node from aws if it is terminated

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1385,7 +1385,9 @@ func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID str
 	}
 	if len(instances) == 0 {
 		glog.Warningf("the instance %s does not exist anymore", providerID)
-		return true, nil
+		// returns false, because otherwise node is not deleted from cluster
+		// false means that it will continue to check InstanceExistsByProviderID
+		return false, nil
 	}
 	if len(instances) > 1 {
 		return false, fmt.Errorf("multiple instances found for instance: %s", instanceID)
@@ -1395,7 +1397,7 @@ func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID str
 	if instance.State != nil {
 		state := aws.StringValue(instance.State.Name)
 		// valid state for detaching volumes
-		if state == ec2.InstanceStateNameStopped || state == ec2.InstanceStateNameTerminated {
+		if state == ec2.InstanceStateNameStopped {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Cherry pick of #69454 on release-1.12.

#69454: delete node from aws if it is terminated

```release-note
node is deleted again from the cluster if it is terminated in AWS. This bug existed in 1.12 releases
```