### PR TITLE
Switch bootstrap token authenticator informer to external types

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -524,7 +524,7 @@ func buildGenericConfig(
 	}
 	serviceResolver = aggregatorapiserver.NewLoopbackServiceResolver(serviceResolver, localHost)
 
-	genericConfig.Authentication.Authenticator, genericConfig.OpenAPIConfig.SecurityDefinitions, err = BuildAuthenticator(s, clientgoExternalClient, sharedInformers)
+	genericConfig.Authentication.Authenticator, genericConfig.OpenAPIConfig.SecurityDefinitions, err = BuildAuthenticator(s, clientgoExternalClient, versionedInformers)
 	if err != nil {
 		lastErr = fmt.Errorf("invalid authentication config: %v", err)
 		return
@@ -625,13 +625,13 @@ func BuildAdmissionPluginInitializers(
 }
 
 // BuildAuthenticator constructs the authenticator
-func BuildAuthenticator(s *options.ServerRunOptions, extclient clientgoclientset.Interface, sharedInformers informers.SharedInformerFactory) (authenticator.Request, *spec.SecurityDefinitions, error) {
+func BuildAuthenticator(s *options.ServerRunOptions, extclient clientgoclientset.Interface, versionedInformer clientgoinformers.SharedInformerFactory) (authenticator.Request, *spec.SecurityDefinitions, error) {
 	authenticatorConfig := s.Authentication.ToAuthenticationConfig()
 	if s.Authentication.ServiceAccounts.Lookup {
 		authenticatorConfig.ServiceAccountTokenGetter = serviceaccountcontroller.NewGetterFromClient(extclient)
 	}
 	authenticatorConfig.BootstrapTokenAuthenticator = bootstrap.NewTokenAuthenticator(
-		sharedInformers.Core().InternalVersion().Secrets().Lister().Secrets(v1.NamespaceSystem),
+		versionedInformer.Core().V1().Secrets().Lister().Secrets(v1.NamespaceSystem),
 	)
 
 	return authenticatorConfig.New()

--- a/plugin/pkg/auth/authenticator/token/bootstrap/BUILD
+++ b/plugin/pkg/auth/authenticator/token/bootstrap/BUILD
@@ -11,7 +11,7 @@ go_test(
     srcs = ["bootstrap_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/apis/core:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
@@ -26,12 +26,12 @@ go_library(
     srcs = ["bootstrap.go"],
     importpath = "k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap",
     deps = [
-        "//pkg/apis/core:go_default_library",
-        "//pkg/client/listers/core/internalversion:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
         "//staging/src/k8s.io/cluster-bootstrap/token/api:go_default_library",
         "//staging/src/k8s.io/cluster-bootstrap/token/util:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap_test.go
+++ b/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap_test.go
@@ -21,24 +21,24 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/user"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
-	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
 type lister struct {
-	secrets []*api.Secret
+	secrets []*corev1.Secret
 }
 
-func (l *lister) List(selector labels.Selector) (ret []*api.Secret, err error) {
+func (l *lister) List(selector labels.Selector) (ret []*corev1.Secret, err error) {
 	return l.secrets, nil
 }
 
-func (l *lister) Get(name string) (*api.Secret, error) {
+func (l *lister) Get(name string) (*corev1.Secret, error) {
 	for _, s := range l.secrets {
 		if s.Name == name {
 			return s, nil
@@ -58,7 +58,7 @@ func TestTokenAuthenticator(t *testing.T) {
 	tests := []struct {
 		name string
 
-		secrets []*api.Secret
+		secrets []*corev1.Secret
 		token   string
 
 		wantNotFound bool
@@ -66,7 +66,7 @@ func TestTokenAuthenticator(t *testing.T) {
 	}{
 		{
 			name: "valid token",
-			secrets: []*api.Secret{
+			secrets: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: bootstrapapi.BootstrapTokenSecretPrefix + tokenID,
@@ -87,7 +87,7 @@ func TestTokenAuthenticator(t *testing.T) {
 		},
 		{
 			name: "valid token with extra group",
-			secrets: []*api.Secret{
+			secrets: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: bootstrapapi.BootstrapTokenSecretPrefix + tokenID,
@@ -109,7 +109,7 @@ func TestTokenAuthenticator(t *testing.T) {
 		},
 		{
 			name: "invalid group",
-			secrets: []*api.Secret{
+			secrets: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: bootstrapapi.BootstrapTokenSecretPrefix + tokenID,
@@ -128,7 +128,7 @@ func TestTokenAuthenticator(t *testing.T) {
 		},
 		{
 			name: "invalid secret name",
-			secrets: []*api.Secret{
+			secrets: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "bad-name",
@@ -146,7 +146,7 @@ func TestTokenAuthenticator(t *testing.T) {
 		},
 		{
 			name: "no usage",
-			secrets: []*api.Secret{
+			secrets: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: bootstrapapi.BootstrapTokenSecretPrefix + tokenID,
@@ -163,7 +163,7 @@ func TestTokenAuthenticator(t *testing.T) {
 		},
 		{
 			name: "wrong token",
-			secrets: []*api.Secret{
+			secrets: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: bootstrapapi.BootstrapTokenSecretPrefix + tokenID,
@@ -181,7 +181,7 @@ func TestTokenAuthenticator(t *testing.T) {
 		},
 		{
 			name: "deleted token",
-			secrets: []*api.Secret{
+			secrets: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              bootstrapapi.BootstrapTokenSecretPrefix + tokenID,
@@ -200,7 +200,7 @@ func TestTokenAuthenticator(t *testing.T) {
 		},
 		{
 			name: "expired token",
-			secrets: []*api.Secret{
+			secrets: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: bootstrapapi.BootstrapTokenSecretPrefix + tokenID,
@@ -219,7 +219,7 @@ func TestTokenAuthenticator(t *testing.T) {
 		},
 		{
 			name: "not expired token",
-			secrets: []*api.Secret{
+			secrets: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: bootstrapapi.BootstrapTokenSecretPrefix + tokenID,
@@ -241,7 +241,7 @@ func TestTokenAuthenticator(t *testing.T) {
 		},
 		{
 			name: "token id wrong length",
-			secrets: []*api.Secret{
+			secrets: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: bootstrapapi.BootstrapTokenSecretPrefix + "foo",
@@ -292,13 +292,13 @@ func TestTokenAuthenticator(t *testing.T) {
 func TestGetGroups(t *testing.T) {
 	tests := []struct {
 		name         string
-		secret       *api.Secret
+		secret       *corev1.Secret
 		expectResult []string
 		expectError  bool
 	}{
 		{
 			name: "not set",
-			secret: &api.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Data:       map[string][]byte{},
 			},
@@ -306,7 +306,7 @@ func TestGetGroups(t *testing.T) {
 		},
 		{
 			name: "set to empty value",
-			secret: &api.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Data: map[string][]byte{
 					bootstrapapi.BootstrapTokenExtraGroupsKey: []byte(""),
@@ -316,7 +316,7 @@ func TestGetGroups(t *testing.T) {
 		},
 		{
 			name: "invalid prefix",
-			secret: &api.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Data: map[string][]byte{
 					bootstrapapi.BootstrapTokenExtraGroupsKey: []byte("foo"),
@@ -326,7 +326,7 @@ func TestGetGroups(t *testing.T) {
 		},
 		{
 			name: "valid",
-			secret: &api.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Data: map[string][]byte{
 					bootstrapapi.BootstrapTokenExtraGroupsKey: []byte("system:bootstrappers:foo,system:bootstrappers:bar,system:bootstrappers:bar"),

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4996,6 +4996,10 @@ const (
 	TLSCertKey = "tls.crt"
 	// TLSPrivateKeyKey is the key for the private key field in a TLS secret.
 	TLSPrivateKeyKey = "tls.key"
+	// SecretTypeBootstrapToken is used during the automated bootstrap process (first
+	// implemented by kubeadm). It stores tokens that are used to sign well known
+	// ConfigMaps. They are used for authn.
+	SecretTypeBootstrapToken SecretType = "bootstrap.kubernetes.io/token"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/test/integration/auth/bootstraptoken_test.go
+++ b/test/integration/auth/bootstraptoken_test.go
@@ -24,24 +24,24 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap"
 	bootstraputil "k8s.io/kubernetes/test/e2e/lifecycle/bootstrap"
 	"k8s.io/kubernetes/test/integration"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
-type bootstrapSecrets []*api.Secret
+type bootstrapSecrets []*corev1.Secret
 
-func (b bootstrapSecrets) List(selector labels.Selector) (ret []*api.Secret, err error) {
+func (b bootstrapSecrets) List(selector labels.Selector) (ret []*corev1.Secret, err error) {
 	return b, nil
 }
 
-func (b bootstrapSecrets) Get(name string) (*api.Secret, error) {
+func (b bootstrapSecrets) Get(name string) (*corev1.Secret, error) {
 	return b[0], nil
 }
 
@@ -55,36 +55,36 @@ func TestBootstrapTokenAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var bootstrapSecretValid = &api.Secret{
+	var bootstrapSecretValid = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: metav1.NamespaceSystem,
 			Name:      bootstrapapi.BootstrapTokenSecretPrefix,
 		},
-		Type: api.SecretTypeBootstrapToken,
+		Type: corev1.SecretTypeBootstrapToken,
 		Data: map[string][]byte{
 			bootstrapapi.BootstrapTokenIDKey:               []byte(tokenId),
 			bootstrapapi.BootstrapTokenSecretKey:           []byte(secret),
 			bootstrapapi.BootstrapTokenUsageAuthentication: []byte("true"),
 		},
 	}
-	var bootstrapSecretInvalid = &api.Secret{
+	var bootstrapSecretInvalid = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: metav1.NamespaceSystem,
 			Name:      bootstrapapi.BootstrapTokenSecretPrefix,
 		},
-		Type: api.SecretTypeBootstrapToken,
+		Type: corev1.SecretTypeBootstrapToken,
 		Data: map[string][]byte{
 			bootstrapapi.BootstrapTokenIDKey:               []byte(tokenId),
 			bootstrapapi.BootstrapTokenSecretKey:           []byte("invalid"),
 			bootstrapapi.BootstrapTokenUsageAuthentication: []byte("true"),
 		},
 	}
-	var expiredBootstrapToken = &api.Secret{
+	var expiredBootstrapToken = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: metav1.NamespaceSystem,
 			Name:      bootstrapapi.BootstrapTokenSecretPrefix,
 		},
-		Type: api.SecretTypeBootstrapToken,
+		Type: corev1.SecretTypeBootstrapToken,
 		Data: map[string][]byte{
 			bootstrapapi.BootstrapTokenIDKey:               []byte(tokenId),
 			bootstrapapi.BootstrapTokenSecretKey:           []byte("invalid"),
@@ -101,7 +101,7 @@ func TestBootstrapTokenAuth(t *testing.T) {
 	tests := []struct {
 		name    string
 		request request
-		secret  *api.Secret
+		secret  *corev1.Secret
 	}{
 		{
 			name:    "valid token",


### PR DESCRIPTION
this pull switches the informer in bootstrap token authenticator to versioned types. once the admission controller's dependency on internal clientset/informer is gone, the authenticator will be the last type needs internal informers.

/sig auth
/sig api-machinery
/kind cleanup


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
