### PR TITLE
Fix incorrect return value of kubeadm pre-flight checks

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/preflight.go
@@ -83,7 +83,7 @@ func runPreflightMaster(c workflow.RunData) error {
 
 	fmt.Println("[preflight] running pre-flight checks")
 	if err := preflight.RunInitMasterChecks(utilsexec.New(), data.Cfg(), data.IgnorePreflightErrors()); err != nil {
-		return nil
+		return err
 	}
 
 	if !data.DryRun() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
Fix incorrect return value for kubeadm pre-flight checks.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
