### PR TITLE
Automated cherry pick of #70135: Correct regexp check in IsNodeUnmanagedByProvider

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_wrap.go
+++ b/pkg/cloudprovider/providers/azure/azure_wrap.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/golang/glog"
-
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )
@@ -302,5 +301,5 @@ func (az *Cloud) IsNodeUnmanaged(nodeName string) (bool, error) {
 // IsNodeUnmanagedByProviderID returns true if the node is not managed by Azure cloud provider.
 // All managed node's providerIDs are in format 'azure:///subscriptions/<id>/resourceGroups/<rg>/providers/Microsoft.Compute/.*'
 func (az *Cloud) IsNodeUnmanagedByProviderID(providerID string) bool {
-	return azureNodeProviderIDRE.Match([]byte(providerID))
+	return !azureNodeProviderIDRE.Match([]byte(providerID))
 }

--- a/pkg/cloudprovider/providers/azure/azure_wrap_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_wrap_test.go
@@ -107,3 +107,38 @@ func TestIsNodeUnmanaged(t *testing.T) {
 		assert.Equal(t, test.expected, real, test.name)
 	}
 }
+
+func TestIsNodeUnmanagedByProviderID(t *testing.T) {
+	tests := []struct {
+		providerID string
+		expected   bool
+		name       string
+	}{
+		{
+			providerID: CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
+			expected:   false,
+		},
+		{
+			providerID: CloudProviderName + "://",
+			expected:   true,
+		},
+		{
+			providerID: ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
+			expected:   true,
+		},
+		{
+			providerID: "aws:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
+			expected:   true,
+		},
+		{
+			providerID: "k8s-agent-AAAAAAAA-0",
+			expected:   true,
+		},
+	}
+
+	az := getTestCloud()
+	for _, test := range tests {
+		isUnmanagedNode := az.IsNodeUnmanagedByProviderID(test.providerID)
+		assert.Equal(t, test.expected, isUnmanagedNode, test.providerID)
+	}
+}


### PR DESCRIPTION
Cherry pick of #70135 on release-1.12.

#70135: Correct regexp check in IsNodeUnmanagedByProvider