### PR TITLE
Move the provisioning test for retain policy back to volume_provisioning.go

### DIFF
--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -185,19 +185,6 @@ func testProvisioning(input *provisioningTestInput) {
 		TestDynamicProvisioning(input.testCase, input.cs, input.pvc, input.sc)
 	})
 
-	It("should provision storage with non-default reclaim policy Retain", func() {
-		retain := v1.PersistentVolumeReclaimRetain
-		input.sc.ReclaimPolicy = &retain
-		pv := TestDynamicProvisioning(input.testCase, input.cs, input.pvc, input.sc)
-
-		By(fmt.Sprintf("waiting for the provisioned PV %q to enter phase %s", pv.Name, v1.VolumeReleased))
-		framework.ExpectNoError(framework.WaitForPersistentVolumePhase(v1.VolumeReleased, input.cs, pv.Name, 1*time.Second, 30*time.Second))
-
-		By(fmt.Sprintf("deleting the PV %q", pv.Name))
-		framework.ExpectNoError(framework.DeletePersistentVolume(input.cs, pv.Name), "Failed to delete PV ", pv.Name)
-		framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(input.cs, pv.Name, 1*time.Second, 30*time.Second))
-	})
-
 	It("should create and delete block persistent volumes [Feature:BlockVolume]", func() {
 		if !input.dInfo.IsBlockSupported {
 			framework.Skipf("Driver %q does not support BlockVolume - skipping", input.dInfo.Name)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
#69441 introduced a volume leakage issue by not deleting the backend volume for the PV that is provisioned with retain policy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #70191

**Special notes for your reviewer**:
/kind failing-test
/sig storage

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```