### PR TITLE
kube-apiserver: fix missing global flags for --help

### DIFF
--- a/cmd/kube-apiserver/BUILD
+++ b/cmd/kube-apiserver/BUILD
@@ -23,9 +23,7 @@ go_library(
         "//pkg/client/metrics/prometheus:go_default_library",
         "//pkg/version/prometheus:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
     ],
 )
 

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -19,16 +19,12 @@ limitations under the License.
 package main
 
 import (
-	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"time"
 
-	"github.com/spf13/pflag"
-
 	"k8s.io/apiserver/pkg/server"
-	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
@@ -43,8 +39,6 @@ func main() {
 	// TODO: once we switch everything over to Cobra commands, we can go back to calling
 	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
 	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	// utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()

--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -57,6 +57,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage/etcd3/preflight:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/globalflag:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/webhook:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/cmd/kube-apiserver/app/options/BUILD
+++ b/cmd/kube-apiserver/app/options/BUILD
@@ -9,6 +9,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "globalflags.go",
         "options.go",
         "validation.go",
     ],
@@ -16,6 +17,7 @@ go_library(
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
+        "//pkg/cloudprovider/providers:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/kubeapiserver/options:go_default_library",
         "//pkg/kubelet/client:go_default_library",
@@ -24,17 +26,23 @@ go_library(
         "//pkg/serviceaccount:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/globalflag:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/apiserver/scheme:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["options_test.go"],
+    srcs = [
+        "globalflags_test.go",
+        "options_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
@@ -46,6 +54,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/globalflag:go_default_library",
         "//staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered:go_default_library",
         "//staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/cmd/kube-apiserver/app/options/globalflags.go
+++ b/cmd/kube-apiserver/app/options/globalflags.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+
+	"k8s.io/apiserver/pkg/util/globalflag"
+
+	// ensure libs have a chance to globally register their flags
+	_ "k8s.io/apiserver/pkg/admission"
+	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
+)
+
+// AddCustomGlobalFlags explicitly registers flags that internal packages register
+// against the global flagsets from "flag". We do this in order to prevent
+// unwanted flags from leaking into the kube-apiserver's flagset.
+func AddCustomGlobalFlags(fs *pflag.FlagSet) {
+	// Lookup flags in global flag set and re-register the values with our flagset.
+
+	// Adds flags from k8s.io/kubernetes/pkg/cloudprovider/providers.
+	globalflag.Register(fs, "cloud-provider-gce-lb-src-cidrs")
+
+	// Adds flags from k8s.io/apiserver/pkg/admission.
+	globalflag.Register(fs, "default-not-ready-toleration-seconds")
+	globalflag.Register(fs, "default-unreachable-toleration-seconds")
+}

--- a/cmd/kube-apiserver/app/options/globalflags_test.go
+++ b/cmd/kube-apiserver/app/options/globalflags_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"flag"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	apiserverflag "k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/globalflag"
+)
+
+func TestAddCustomGlobalFlags(t *testing.T) {
+	namedFlagSets := &apiserverflag.NamedFlagSets{}
+
+	// Note that we will register all flags (including klog flags) into the same
+	// flag set. This allows us to test against all global flags from
+	// flags.CommandLine.
+	nfs := namedFlagSets.FlagSet("test")
+	globalflag.AddGlobalFlags(nfs, "test-cmd")
+	AddCustomGlobalFlags(nfs)
+
+	actualFlag := []string{}
+	nfs.VisitAll(func(flag *pflag.Flag) {
+		actualFlag = append(actualFlag, flag.Name)
+	})
+
+	// Get all flags from flags.CommandLine, except flag `test.*`.
+	wantedFlag := []string{"help"}
+	pflag.CommandLine.SetNormalizeFunc(apiserverflag.WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.VisitAll(func(flag *pflag.Flag) {
+		if !strings.Contains(flag.Name, "test.") {
+			wantedFlag = append(wantedFlag, flag.Name)
+		}
+	})
+	sort.Strings(wantedFlag)
+
+	if !reflect.DeepEqual(wantedFlag, actualFlag) {
+		t.Errorf("[Default]: expected %+v, got %+v", wantedFlag, actualFlag)
+	}
+}

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -50,6 +50,7 @@ import (
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3/preflight"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/globalflag"
 	"k8s.io/apiserver/pkg/util/webhook"
 	clientgoinformers "k8s.io/client-go/informers"
 	clientgoclientset "k8s.io/client-go/kubernetes"
@@ -117,6 +118,9 @@ cluster's shared state through which all other components interact.`,
 
 	fs := cmd.Flags()
 	namedFlagSets := s.Flags()
+	verflag.AddFlags(namedFlagSets.FlagSet("global"))
+	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
+	options.AddCustomGlobalFlags(namedFlagSets.FlagSet("generic"))
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: In #64517, we introduced logical sections for the `--help` output in the `kube-apiserver` binary. It seems like it does not consider global flags that were registered through the `flag` package. This PR fixes that issue. We will output glog related and version flags in the "global" section and everything else in the "generic" section.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See #70145.

**Special notes for your reviewer**: The original PR is in #70164. The plan to is to break it down into individual PRs.

Here's the simplified result of `kube-apiserver --help`. It now shows the appropriate global flags and generic flags that were missing.

```
Generic flags:

      --advertise-address ip
                The IP address on which to advertise the apiserver to members of the cluster. This address must be reachable by the rest of the cluster. If blank, the --bind-address will be used. If
                --bind-address is unspecified, the host's default interface will be used.
      --cloud-provider-gce-lb-src-cidrs cidrs
                CIDRs opened in GCE firewall for LB traffic proxy & health checks (default 130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16)
      --cors-allowed-origins strings
                List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching. If this list is empty CORS will not be enabled.
      --default-not-ready-toleration-seconds int
                Indicates the tolerationSeconds of the toleration for notReady:NoExecute that is added by default to every pod that does not already have such a toleration. (default 300)
      --default-unreachable-toleration-seconds int
                Indicates the tolerationSeconds of the toleration for unreachable:NoExecute that is added by default to every pod that does not already have such a toleration. (default 300)
      ...

...

Global flags:

      --alsologtostderr
                log to standard error as well as files
  -h, --help
                help for kube-apiserver
      --log-backtrace-at traceLocation
                when logging hits line file:N, emit a stack trace (default :0)
      --log-dir string
                If non-empty, write log files in this directory
      --log-file string
                If non-empty, use this log file
      --log-flush-frequency duration
                Maximum number of seconds between log flushes (default 5s)
      --logtostderr
                log to standard error instead of files (default true)
      --skip-headers
                If true, avoid header prefixes in the log messages
      --stderrthreshold severity
                logs at or above this threshold go to stderr (default 2)
  -v, --v Level
                log level for V logs
      --version version[=true]
                Print version information and quit
      --vmodule moduleSpec
                comma-separated list of pattern=N settings for file-filtered logging

```

**Does this PR introduce a user-facing change?**:
```release-note
Fix missing flags in kube-apiserver --help.
```

/sig cli
/cc @stewart-yu 