### PR TITLE
cloud-controller-manager: fix missing global flags for --help

### DIFF
--- a/cmd/cloud-controller-manager/app/BUILD
+++ b/cmd/cloud-controller-manager/app/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/globalflag:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/tools/leaderelection:go_default_library",
         "//staging/src/k8s.io/client-go/tools/leaderelection/resourcelock:go_default_library",

--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/globalflag"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -85,6 +86,9 @@ the cloud specific control loops shipped with Kubernetes.`,
 
 	fs := cmd.Flags()
 	namedFlagSets := s.Flags()
+	verflag.AddFlags(namedFlagSets.FlagSet("global"))
+	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
+	options.AddGenericFlags(namedFlagSets.FlagSet("generic"))
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)
 	}

--- a/cmd/cloud-controller-manager/app/options/BUILD
+++ b/cmd/cloud-controller-manager/app/options/BUILD
@@ -8,7 +8,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["options.go"],
+    srcs = [
+        "customflags.go",
+        "options.go",
+    ],
     importpath = "k8s.io/kubernetes/cmd/cloud-controller-manager/app/options",
     deps = [
         "//cmd/cloud-controller-manager/app/apis/config:go_default_library",
@@ -17,6 +20,7 @@ go_library(
         "//cmd/cloud-controller-manager/app/config:go_default_library",
         "//cmd/controller-manager/app/options:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
+        "//pkg/cloudprovider/providers:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/master/ports:go_default_library",
@@ -32,6 +36,7 @@ go_library(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )
@@ -51,7 +56,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["options_test.go"],
+    srcs = [
+        "customflags_test.go",
+        "options_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//cmd/controller-manager/app/options:go_default_library",
@@ -60,6 +68,8 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/config:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/globalflag:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
     ],
 )

--- a/cmd/cloud-controller-manager/app/options/customflags.go
+++ b/cmd/cloud-controller-manager/app/options/customflags.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	// ensure libs have a chance to globally register their flags
+	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
+)
+
+// AddGenericFlags explicitly registers flags that internal packages register
+// against the global flagsets from "flag". We do this in order to prevent
+// unwanted flags from leaking into the cloud-controller-manager's flagset.
+func AddGenericFlags(fs *pflag.FlagSet) {
+	addCloudProviderFlags(fs)
+}
+
+// addCloudProviderFlags adds flags from k8s.io/kubernetes/pkg/cloudprovider/providers.
+func addCloudProviderFlags(fs *pflag.FlagSet) {
+	// lookup flags in global flag set and re-register the values with our flagset
+	global := flag.CommandLine
+	local := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+	register(global, local, "cloud-provider-gce-lb-src-cidrs")
+
+	fs.AddFlagSet(local)
+}
+
+// normalize replaces underscores with hyphens. This ensures that all globally
+// registered flags that use underscores will be converted to use hyphens.
+func normalize(s string) string {
+	return strings.Replace(s, "_", "-", -1)
+}
+
+// register adds a flag to local that targets the Value associated with the Flag named globalName in global
+func register(global *flag.FlagSet, local *pflag.FlagSet, globalName string) {
+	if f := global.Lookup(globalName); f != nil {
+		pflagFlag := pflag.PFlagFromGoFlag(f)
+		pflagFlag.Name = normalize(pflagFlag.Name)
+		local.AddFlag(pflagFlag)
+	} else {
+		panic(fmt.Sprintf("failed to find flag in global flagset (flag): %s", globalName))
+	}
+}

--- a/cmd/cloud-controller-manager/app/options/customflags_test.go
+++ b/cmd/cloud-controller-manager/app/options/customflags_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"flag"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	apiserverflag "k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/globalflag"
+)
+
+func TestAddGenericFlags(t *testing.T) {
+	namedFlagSets := &apiserverflag.NamedFlagSets{}
+
+	// Note that we will register all flags (including klog flags) into the same
+	// flag set. This allows us to test against all global flags from
+	// flags.CommandLine.
+	nfs := namedFlagSets.FlagSet("test")
+	globalflag.AddGlobalFlags(nfs, "test-cmd")
+	AddGenericFlags(nfs)
+
+	actualFlag := []string{}
+	nfs.VisitAll(func(flag *pflag.Flag) {
+		actualFlag = append(actualFlag, flag.Name)
+	})
+
+	// Get all flags from flags.CommandLine, except flag `test.*`.
+	wantedFlag := []string{"help"}
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.VisitAll(func(flag *pflag.Flag) {
+		if !strings.Contains(flag.Name, "test.") {
+			wantedFlag = append(wantedFlag, normalize(flag.Name))
+		}
+	})
+	sort.Strings(wantedFlag)
+
+	if !reflect.DeepEqual(wantedFlag, actualFlag) {
+		t.Errorf("[Default]: expected %+v, got %+v", wantedFlag, actualFlag)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: In #67362, we introduced logical sections for the `--help` output in the `cloud-controller-manager` binary. It seems like it does not consider global flags that were registered through the `flag` package. This PR fixes that issue. We will output glog related and version flags in the "global" section, and everything else in the "generic" section.

**Which issue(s) this PR fixes**:
See #70145.

**Special notes for your reviewer**: The original PR is in #70164. The plan to is to break it down into individual PRs.

**Does this PR introduce a user-facing change?**:
```release-note
Fix missing flags in cloud-controller-manager --help.
```

/sig cli
/cc @stewart-yu @andrewsykim @dims 
/assign @deads2k