### PR TITLE
Update images after #69995

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -88,7 +88,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 #
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
-  debian_iptables_version=v10.2
+  debian_iptables_version=v11.0
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets
   case $1 in

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -67,18 +67,18 @@ http_file(
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:0987db7ce42949d20ed2647a65d4bee0b616b4d40c7ea54769cc24b7ad003677",
+    digest = "sha256:d4ff8136b9037694a3165a7fff6a91e7fc828741b8ea1eda226d4d9ea5d23abb",
     registry = "k8s.gcr.io",
     repository = "debian-iptables-amd64",
-    tag = "v10.2",  # ignored, but kept here for documentation
+    tag = "v11.0",  # ignored, but kept here for documentation
 )
 
 docker_pull(
     name = "debian-hyperkube-base-amd64",
-    digest = "sha256:b180af61c8c40a3e011630be135c091e7af6b6c784bedce839d31b9fad63c435",
+    digest = "sha256:4a77bc882f7d629c088a11ff144a2e86660268fddf63b61f52b6a93d16ab83f0",
     registry = "k8s.gcr.io",
     repository = "debian-hyperkube-base-amd64",
-    tag = "0.11.0",  # ignored, but kept here for documentation
+    tag = "0.12.0",  # ignored, but kept here for documentation
 )
 
 docker_pull(

--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -14,7 +14,7 @@ spec:
   - name: kube-addon-manager
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: k8s.gcr.io/kube-addon-manager:v8.8
+    image: k8s.gcr.io/kube-addon-manager:v8.9
     command:
     - /bin/bash
     - -c

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -25,7 +25,7 @@ KUBECTL_BIN?=$(shell pwd)/../../../$(OUT_DIR)/dockerized/bin/linux/$(ARCH)/kubec
 E2E_TEST_BIN?=$(shell pwd)/../../../$(OUT_DIR)/dockerized/bin/linux/$(ARCH)/e2e.test
 CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
-BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.11.0
+BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.12.0
 TEMP_DIR:=$(shell mktemp -d -t conformanceXXXXXX)
 
 all: build

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -22,7 +22,7 @@ ARCH?=amd64
 OUT_DIR?=_output
 HYPERKUBE_BIN?=$(shell pwd)/../../../$(OUT_DIR)/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.11.0
+BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.12.0
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build

--- a/test/e2e/testing-manifests/statefulset/redis/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/redis/statefulset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       initContainers:
       - name: install
-        image: gcr.io/kubernetes-e2e-test-images/pets/redis-installer:1.1
+        image: gcr.io/kubernetes-e2e-test-images/pets/redis-installer:1.2
         imagePullPolicy: Always
         args:
         - "--install-into=/opt"

--- a/test/e2e/testing-manifests/statefulset/zookeeper/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/zookeeper/statefulset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       initContainers:
       - name: install
-        image: gcr.io/kubernetes-e2e-test-images/pets/zookeeper-installer:1.1
+        image: gcr.io/kubernetes-e2e-test-images/pets/zookeeper-installer:1.2
         imagePullPolicy: Always
         args:
         - "--install-into=/opt"

--- a/test/images/resource-consumer/README.md
+++ b/test/images/resource-consumer/README.md
@@ -48,7 +48,7 @@ Custom metrics in Prometheus format are exposed on "/metrics" endpoint.
 
 ### CURL example
 ```console
-$ kubectl run resource-consumer --image=gcr.io/kubernetes-e2e-test-images/resource-consumer:1.3 --expose --service-overrides='{ "spec": { "type": "LoadBalancer" } }' --port 8080 --requests='cpu=500m,memory=256Mi'
+$ kubectl run resource-consumer --image=gcr.io/kubernetes-e2e-test-images/resource-consumer:1.4 --expose --service-overrides='{ "spec": { "type": "LoadBalancer" } }' --port 8080 --requests='cpu=500m,memory=256Mi'
 $ kubectl get services resource-consumer
 ```
 
@@ -62,7 +62,7 @@ $ curl --data "millicores=300&durationSec=600" http://<EXTERNAL-IP>:8080/Consume
 
 ## Image
 
-Docker image of Resource Consumer can be found in Google Container Registry as gcr.io/kubernetes-e2e-test-images/resource-consumer:1.3
+Docker image of Resource Consumer can be found in Google Container Registry as gcr.io/kubernetes-e2e-test-images/resource-consumer:1.4
 
 ## Use cases
 

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v8.8
+    image: {{kube_docker_registry}}/kube-addon-manager:v8.9
     command:
     - /bin/bash
     - -c

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -117,7 +117,7 @@ var (
 	Porter              = ImageConfig{e2eRegistry, "porter", "1.0"}
 	PortForwardTester   = ImageConfig{e2eRegistry, "port-forward-tester", "1.0"}
 	Redis               = ImageConfig{e2eRegistry, "redis", "1.0"}
-	ResourceConsumer    = ImageConfig{e2eRegistry, "resource-consumer", "1.3"}
+	ResourceConsumer    = ImageConfig{e2eRegistry, "resource-consumer", "1.4"}
 	ResourceController  = ImageConfig{e2eRegistry, "resource-consumer/controller", "1.0"}
 	ServeHostname       = ImageConfig{e2eRegistry, "serve-hostname", "1.1"}
 	TestWebserver       = ImageConfig{e2eRegistry, "test-webserver", "1.0"}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**: updates manifests and references to use the new versions of images based on debian-base 0.4.0 that were defined in #69995.

**Special notes for your reviewer**: oddly I can't find anything using gcr.io/kubernetes-e2e-test-images/pets/peer-finder.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Updates to use debian-iptables v11.0, debian-hyperkube-base 0.12.0, and kube-addon-manager:v8.9.
```

/assign @awly 