### PR TITLE
Ignore registration if file is not socket file

### DIFF
--- a/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
@@ -216,7 +216,12 @@ func (w *Watcher) handleCreateEvent(event fsnotify.Event) error {
 	}
 
 	if !fi.IsDir() {
-		return w.handlePluginRegistration(event.Name)
+		if fi.Mode()&os.ModeSocket != 0 {
+			return w.handlePluginRegistration(event.Name)
+		} else {
+			glog.V(5).Infof("Ignoring file: %s with mode %v", fi.Name(), fi.Mode())
+			return nil
+		}
 	}
 
 	return w.traversePluginDir(event.Name)


### PR DESCRIPTION
Signed-off-by: mYmNeo thomassong2012@gmail.com

What type of PR is this?

/kind flake

What this PR does / why we need it:

Pluginwatcher does a file mode validation at `traversePluginDir`, but when handling `handleCreateEvent`, it seems that pluginwatcher doesn't validate the mode of new created file.
This PR tries to report an error message and ignore further execution of `handlePluginRegistration`.