### PR TITLE
kube-controller-manager: fix missing global flags for --help

### DIFF
--- a/cmd/kube-controller-manager/app/BUILD
+++ b/cmd/kube-controller-manager/app/BUILD
@@ -116,6 +116,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/server/mux:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/globalflag:go_default_library",
         "//staging/src/k8s.io/client-go/discovery/cached:go_default_library",
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/mux"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/globalflag"
 	cacheddiscovery "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/informers"
 	restclient "k8s.io/client-go/rest"
@@ -111,6 +112,9 @@ controller, and serviceaccounts controller.`,
 
 	fs := cmd.Flags()
 	namedFlagSets := s.Flags(KnownControllers(), ControllersDisabledByDefault.List())
+	verflag.AddFlags(namedFlagSets.FlagSet("global"))
+	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
+	options.AddGenericFlags(namedFlagSets.FlagSet("generic"))
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)
 	}

--- a/cmd/kube-controller-manager/app/options/BUILD
+++ b/cmd/kube-controller-manager/app/options/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = [
         "attachdetachcontroller.go",
         "csrsigningcontroller.go",
+        "customflags.go",
         "daemonsetcontroller.go",
         "deploymentcontroller.go",
         "deprecatedcontroller.go",
@@ -35,6 +36,7 @@ go_library(
         "//cmd/controller-manager/app/options:go_default_library",
         "//cmd/kube-controller-manager/app/config:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
+        "//pkg/cloudprovider/providers:go_default_library",
         "//pkg/controller/apis/config:go_default_library",
         "//pkg/controller/apis/config/v1alpha1:go_default_library",
         "//pkg/controller/garbagecollector:go_default_library",

--- a/cmd/kube-controller-manager/app/options/customflags.go
+++ b/cmd/kube-controller-manager/app/options/customflags.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+
+	// ensure libs have a chance to globally register their flags
+	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
+)
+
+// AddGenericFlags explicitly registers flags that internal packages register
+// against the global flagsets from "flag". We do this in order to prevent
+// unwanted flags from leaking into the kube-controller-manager's flagset.
+func AddGenericFlags(fs *pflag.FlagSet) {
+	addCloudProviderFlags(fs)
+}
+
+// addCloudProviderFlags adds flags from k8s.io/kubernetes/pkg/cloudprovider/providers.
+func addCloudProviderFlags(fs *pflag.FlagSet) {
+	// lookup flags in global flag set and re-register the values with our flagset
+	global := flag.CommandLine
+	local := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+	register(global, local, "cloud-provider-gce-lb-src-cidrs")
+
+	fs.AddFlagSet(local)
+}
+
+// register adds a flag to local that targets the Value associated with the Flag named globalName in global
+func register(global *flag.FlagSet, local *pflag.FlagSet, globalName string) {
+	if f := global.Lookup(globalName); f != nil {
+		local.AddGoFlag(f)
+	} else {
+		panic(fmt.Sprintf("failed to find flag in global flagset (flag): %s", globalName))
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: In #67362, we introduced logical sections for the `--help` output in the `kube-controller-manager` binary. It seems like it does not consider global flags that were registered through the `flag` package. This PR fixes that issue. We will output glog related and version flags in the "global" section, and everything else in the "generic" section.

**Which issue(s) this PR fixes**:
See #70145.

**Special notes for your reviewer**: The original PR is in #70164. The plan to is to break it down into individual PRs.

**Does this PR introduce a user-facing change?**:
```release-note
Fix missing flags in kube-controller-manager --help.
```

/sig cli
/cc @stewart-yu @andrewsykim @dims 
/assign @deads2k