### PR TITLE
Allow use of client-go credential plugins as a fallback to unauthorized authentication tokens

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
@@ -583,9 +583,7 @@ func TestRoundTripper(t *testing.T) {
 	get(t, http.StatusOK)
 
 	wantToken = "token2"
-	// Token is still cached, hits unauthorized but causes token to rotate.
-	get(t, http.StatusUnauthorized)
-	// Follow up request uses the rotated token.
+	// Cached token hits unauthorized, token is refreshed and retry succeeds
 	get(t, http.StatusOK)
 
 	setOutput(`{
@@ -597,8 +595,8 @@ func TestRoundTripper(t *testing.T) {
 		}
 	}`)
 	wantToken = "token3"
-	// Token is still cached, hit's unauthorized but causes rotation to token with an expiry.
-	get(t, http.StatusUnauthorized)
+	// Cached token hits unauthorized, token is refreshed and retry succeeds. The
+	// new token has an expiry.
 	get(t, http.StatusOK)
 
 	// Move time forward 2 hours, "token3" is now expired.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR allows the use [client-go credential plugins](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins) to prompt a user to reauthenticate if they attempt a request _with a token_ that results in an unauthorized response. Formerly auth credential plugins were only invoked when no token was provided at all.

API requests can include tokens pulled from the kube config file, or from `--token` arguments to `kubectl`. However the given token might be invalid, amongst other reasons if the token is used with a [webhook token authenticator](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication) that enforces its own token expiration.

One example of how this change is helpful is if a user's authorization token expires in the middle of executing a deploy script that invokes `kubectl` then it is a much nicer if the user can reauthenticate and seamlessly continue without having to determine exactly where their script failed and how to re-execute it from that point.

**Does this PR introduce a user-facing change?**:
Yes

```release-note
Allow use of client-go credential plugins as a fallback to unauthorized authentication tokens
```

/sig cli