### PR TITLE
Change back HPA e2e tests to request 500 mCPU

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -137,14 +137,14 @@ func scaleUp(name string, kind schema.GroupVersionKind, checkStability bool, rc 
 	}
 	scaleTest := &HPAScaleTest{
 		initPods:                    1,
-		totalInitialCPUUsage:        500,
-		perPodCPURequest:            1000,
+		totalInitialCPUUsage:        250,
+		perPodCPURequest:            500,
 		targetCPUUtilizationPercent: 20,
 		minPods:                     1,
 		maxPods:                     5,
 		firstScale:                  3,
 		firstScaleStasis:            stasis,
-		cpuBurst:                    1400,
+		cpuBurst:                    700,
 		secondScale:                 5,
 	}
 	scaleTest.run(name, kind, rc, f)
@@ -157,8 +157,8 @@ func scaleDown(name string, kind schema.GroupVersionKind, checkStability bool, r
 	}
 	scaleTest := &HPAScaleTest{
 		initPods:                    5,
-		totalInitialCPUUsage:        650,
-		perPodCPURequest:            1000,
+		totalInitialCPUUsage:        325,
+		perPodCPURequest:            500,
 		targetCPUUtilizationPercent: 30,
 		minPods:                     1,
 		maxPods:                     5,


### PR DESCRIPTION
I increased request from 500mCPU to 1CPU in
https://github.com/kubernetes/kubernetes/pull/70125 but this interacts
poorly with other e2e tests (higher requests mean pods fil to schedule).
So revert that change.

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Trying to deflake e2e HPA tests in increased requests of pods in those tests. Now pods fail to schedule. So revert that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
