### PR TITLE
Map allocation optimization for client-go/tools/cache

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/expiration_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/expiration_cache.go
@@ -179,7 +179,7 @@ func (c *ExpirationCache) Delete(obj interface{}) error {
 func (c *ExpirationCache) Replace(list []interface{}, resourceVersion string) error {
 	c.expirationLock.Lock()
 	defer c.expirationLock.Unlock()
-	items := map[string]interface{}{}
+	items := make(map[string]interface{}, len(list))
 	ts := c.clock.Now()
 	for _, item := range list {
 		key, err := c.keyFunc(item)

--- a/staging/src/k8s.io/client-go/tools/cache/fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/fifo.go
@@ -297,7 +297,7 @@ func (f *FIFO) Pop(process PopProcessFunc) (interface{}, error) {
 // after calling this function. f's queue is reset, too; upon return, it
 // will contain the items in the map, in no particular order.
 func (f *FIFO) Replace(list []interface{}, resourceVersion string) error {
-	items := map[string]interface{}{}
+	items := make(map[string]interface{}, len(list))
 	for _, item := range list {
 		key, err := f.keyFunc(item)
 		if err != nil {

--- a/staging/src/k8s.io/client-go/tools/cache/store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store.go
@@ -210,7 +210,7 @@ func (c *cache) GetByKey(key string) (item interface{}, exists bool, err error) 
 // 'c' takes ownership of the list, you should not reference the list again
 // after calling this function.
 func (c *cache) Replace(list []interface{}, resourceVersion string) error {
-	items := map[string]interface{}{}
+	items := make(map[string]interface{}, len(list))
 	for _, item := range list {
 		key, err := c.keyFunc(item)
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Pre-allocates 3 maps in different `Replace` methods that are being created from a slice, so the size is known beforehand.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
The optimization may be really small but it is good practice to pre-allocate in such cases.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
