### PR TITLE
CoreDNS memory test - pods verified

### DIFF
--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -65,7 +65,7 @@ data:
         errors
         health
         kubernetes __PILLAR__DNS__DOMAIN__ in-addr.arpa ip6.arpa {
-            pods insecure
+            pods verified
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -65,7 +65,7 @@ data:
         errors
         health
         kubernetes {{ pillar['dns_domain'] }} in-addr.arpa ip6.arpa {
-            pods insecure
+            pods verified
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -65,7 +65,7 @@ data:
         errors
         health
         kubernetes $DNS_DOMAIN in-addr.arpa ip6.arpa {
-            pods insecure
+            pods verified
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Testing memory usage of the `pod verified` option in the 500/2000 node pre-submit scale tests.
This is an exploratory PR _only_.  The metrics collected in these tests are needed to complete a set of CoreDNS resource request/limit guidelines I'm creating.

**Special notes for your reviewer**:

_Do not merge this PR_.

/hold

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```