### PR TITLE
Use debian-base instead of busybox as base image for server images

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -21,32 +21,23 @@ filegroup(
     tags = ["automanaged"],
 )
 
-# ensure /etc/nsswitch.conf exists so go's resolver respects /etc/hosts
-container_image(
-    name = "busybox-with-nsswitch",
-    base = "@official_busybox//image",
-    directory = "/etc",
-    files = ["nsswitch.conf"],
-    mode = "0644",
-)
-
 # This list should roughly match kube::build::get_docker_wrapped_binaries()
 # in build/common.sh.
 DOCKERIZED_BINARIES = {
     "cloud-controller-manager": {
-        "base": ":busybox-with-nsswitch",
+        "base": "@debian-base-amd64//image",
         "target": "//cmd/cloud-controller-manager:cloud-controller-manager",
     },
     "kube-apiserver": {
-        "base": ":busybox-with-nsswitch",
+        "base": "@debian-base-amd64//image",
         "target": "//cmd/kube-apiserver:kube-apiserver",
     },
     "kube-controller-manager": {
-        "base": ":busybox-with-nsswitch",
+        "base": "@debian-base-amd64//image",
         "target": "//cmd/kube-controller-manager:kube-controller-manager",
     },
     "kube-scheduler": {
-        "base": ":busybox-with-nsswitch",
+        "base": "@debian-base-amd64//image",
         "target": "//cmd/kube-scheduler:kube-scheduler",
     },
     "kube-proxy": {

--- a/build/common.sh
+++ b/build/common.sh
@@ -88,51 +88,18 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 #
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
-  debian_iptables_version=v11.0
+  local arch=$1
+  local debian_base_version=0.4.0
+  local debian_iptables_version=v11.0
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets
-  case $1 in
-    "amd64")
-        local targets=(
-          cloud-controller-manager,busybox
-          kube-apiserver,busybox
-          kube-controller-manager,busybox
-          kube-scheduler,busybox
-          kube-proxy,k8s.gcr.io/debian-iptables-amd64:${debian_iptables_version}
-        );;
-    "arm")
-        local targets=(
-          cloud-controller-manager,arm32v7/busybox
-          kube-apiserver,arm32v7/busybox
-          kube-controller-manager,arm32v7/busybox
-          kube-scheduler,arm32v7/busybox
-          kube-proxy,k8s.gcr.io/debian-iptables-arm:${debian_iptables_version}
-        );;
-    "arm64")
-        local targets=(
-          cloud-controller-manager,arm64v8/busybox
-          kube-apiserver,arm64v8/busybox
-          kube-controller-manager,arm64v8/busybox
-          kube-scheduler,arm64v8/busybox
-          kube-proxy,k8s.gcr.io/debian-iptables-arm64:${debian_iptables_version}
-        );;
-    "ppc64le")
-        local targets=(
-          cloud-controller-manager,ppc64le/busybox
-          kube-apiserver,ppc64le/busybox
-          kube-controller-manager,ppc64le/busybox
-          kube-scheduler,ppc64le/busybox
-          kube-proxy,k8s.gcr.io/debian-iptables-ppc64le:${debian_iptables_version}
-        );;
-    "s390x")
-        local targets=(
-          cloud-controller-manager,s390x/busybox
-          kube-apiserver,s390x/busybox
-          kube-controller-manager,s390x/busybox
-          kube-scheduler,s390x/busybox
-          kube-proxy,k8s.gcr.io/debian-iptables-s390x:${debian_iptables_version}
-        );;
-  esac
+  local targets=(
+    cloud-controller-manager,"k8s.gcr.io/debian-base-${arch}:${debian_base_version}"
+    kube-apiserver,"k8s.gcr.io/debian-base-${arch}:${debian_base_version}"
+    kube-controller-manager,"k8s.gcr.io/debian-base-${arch}:${debian_base_version}"
+    kube-scheduler,"k8s.gcr.io/debian-base-${arch}:${debian_base_version}"
+    kube-proxy,"k8s.gcr.io/debian-iptables-${arch}:${debian_iptables_version}"
+  )
 
   echo "${targets[@]}"
 }

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -66,6 +66,14 @@ http_file(
 )
 
 docker_pull(
+    name = "debian-base-amd64",
+    digest = "sha256:86176bc8ccdc4d8ea7fbf6ba4b57fcefc2cb61ff7413114630940474ff9bf751",
+    registry = "k8s.gcr.io",
+    repository = "debian-base-amd64",
+    tag = "0.4.0",  # ignored, but kept here for documentation
+)
+
+docker_pull(
     name = "debian-iptables-amd64",
     digest = "sha256:d4ff8136b9037694a3165a7fff6a91e7fc828741b8ea1eda226d4d9ea5d23abb",
     registry = "k8s.gcr.io",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**: standardizes on `debian-base` for the server images instead of busybox, per https://github.com/kubernetes/kubernetes/issues/40248#issuecomment-280781931.

Using `debian-base` also ensures we use a consistent libc (glibc instead of musl libc), allows better security scanning on gcr.io, avoids weird compatibility bugs like #69195, and may even use marginally less space on nodes, since `debian-iptables` is based on it and is already included on all nodes for `kube-proxy`.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Use debian-base instead of busybox as base image for server images
```

/assign @BenTheElder @cblecker @dims 
cc @tallclair @AishSundar @simony-gke @listx 
/sig release