### PR TITLE
kubeadm: Switch to github.com/pkg/errors

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/bootstraptokenhelpers.go
+++ b/cmd/kubeadm/app/apis/kubeadm/bootstraptokenhelpers.go
@@ -17,11 +17,11 @@ limitations under the License.
 package kubeadm
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
@@ -84,24 +84,24 @@ func BootstrapTokenFromSecret(secret *v1.Secret) (*BootstrapToken, error) {
 	// Get the Token ID field from the Secret data
 	tokenID := getSecretString(secret, bootstrapapi.BootstrapTokenIDKey)
 	if len(tokenID) == 0 {
-		return nil, fmt.Errorf("Bootstrap Token Secret has no token-id data: %s", secret.Name)
+		return nil, errors.Errorf("Bootstrap Token Secret has no token-id data: %s", secret.Name)
 	}
 
 	// Enforce the right naming convention
 	if secret.Name != bootstraputil.BootstrapTokenSecretName(tokenID) {
-		return nil, fmt.Errorf("bootstrap token name is not of the form '%s(token-id)'. Actual: %q. Expected: %q",
+		return nil, errors.Errorf("bootstrap token name is not of the form '%s(token-id)'. Actual: %q. Expected: %q",
 			bootstrapapi.BootstrapTokenSecretPrefix, secret.Name, bootstraputil.BootstrapTokenSecretName(tokenID))
 	}
 
 	tokenSecret := getSecretString(secret, bootstrapapi.BootstrapTokenSecretKey)
 	if len(tokenSecret) == 0 {
-		return nil, fmt.Errorf("Bootstrap Token Secret has no token-secret data: %s", secret.Name)
+		return nil, errors.Errorf("Bootstrap Token Secret has no token-secret data: %s", secret.Name)
 	}
 
 	// Create the BootstrapTokenString object based on the ID and Secret
 	bts, err := NewBootstrapTokenStringFromIDAndSecret(tokenID, tokenSecret)
 	if err != nil {
-		return nil, fmt.Errorf("Bootstrap Token Secret is invalid and couldn't be parsed: %v", err)
+		return nil, errors.Wrapf(err, "Bootstrap Token Secret is invalid and couldn't be parsed")
 	}
 
 	// Get the description (if any) from the Secret
@@ -114,7 +114,7 @@ func BootstrapTokenFromSecret(secret *v1.Secret) (*BootstrapToken, error) {
 	if len(secretExpiration) > 0 {
 		expTime, err := time.Parse(time.RFC3339, secretExpiration)
 		if err != nil {
-			return nil, fmt.Errorf("can't parse expiration time of bootstrap token %q: %v", secret.Name, err)
+			return nil, errors.Wrapf(err, "can't parse expiration time of bootstrap token %q", secret.Name)
 		}
 		expires = &metav1.Time{Time: expTime}
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/bootstraptokenstring.go
+++ b/cmd/kubeadm/app/apis/kubeadm/bootstraptokenstring.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
 )
@@ -77,7 +78,7 @@ func NewBootstrapTokenString(token string) (*BootstrapTokenString, error) {
 	substrs := bootstraputil.BootstrapTokenRegexp.FindStringSubmatch(token)
 	// TODO: Add a constant for the 3 value here, and explain better why it's needed (other than because how the regexp parsin works)
 	if len(substrs) != 3 {
-		return nil, fmt.Errorf("the bootstrap token %q was not of the form %q", token, bootstrapapi.BootstrapTokenPattern)
+		return nil, errors.Errorf("the bootstrap token %q was not of the form %q", token, bootstrapapi.BootstrapTokenPattern)
 	}
 
 	return &BootstrapTokenString{ID: substrs[1], Secret: substrs[2]}, nil

--- a/cmd/kubeadm/app/apis/kubeadm/bootstraptokenstring_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/bootstraptokenstring_test.go
@@ -18,9 +18,10 @@ package kubeadm
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestMarshalJSON(t *testing.T) {
@@ -99,13 +100,13 @@ func roundtrip(input string, bts *BootstrapTokenString) error {
 	// If string input was specified, roundtrip like this: string -> (unmarshal) -> object -> (marshal) -> string
 	if len(input) > 0 {
 		if err := json.Unmarshal([]byte(input), newbts); err != nil {
-			return fmt.Errorf("expected no unmarshal error, got error: %v", err)
+			return errors.Wrapf(err, "expected no unmarshal error")
 		}
 		if b, err = json.Marshal(newbts); err != nil {
-			return fmt.Errorf("expected no marshal error, got error: %v", err)
+			return errors.Wrapf(err, "expected no marshal error")
 		}
 		if input != string(b) {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"expected token: %s\n\t  actual: %s",
 				input,
 				string(b),
@@ -113,13 +114,13 @@ func roundtrip(input string, bts *BootstrapTokenString) error {
 		}
 	} else { // Otherwise, roundtrip like this: object -> (marshal) -> string -> (unmarshal) -> object
 		if b, err = json.Marshal(bts); err != nil {
-			return fmt.Errorf("expected no marshal error, got error: %v", err)
+			return errors.Wrapf(err, "expected no marshal error")
 		}
 		if err := json.Unmarshal(b, newbts); err != nil {
-			return fmt.Errorf("expected no unmarshal error, got error: %v", err)
+			return errors.Wrapf(err, "expected no unmarshal error")
 		}
 		if !reflect.DeepEqual(bts, newbts) {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"expected object: %v\n\t  actual: %v",
 				bts,
 				newbts,

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/bootstraptokenstring.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/bootstraptokenstring.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
 )
@@ -73,7 +74,7 @@ func NewBootstrapTokenString(token string) (*BootstrapTokenString, error) {
 	substrs := bootstraputil.BootstrapTokenRegexp.FindStringSubmatch(token)
 	// TODO: Add a constant for the 3 value here, and explain better why it's needed (other than because how the regexp parsin works)
 	if len(substrs) != 3 {
-		return nil, fmt.Errorf("the bootstrap token %q was not of the form %q", token, bootstrapapi.BootstrapTokenPattern)
+		return nil, errors.Errorf("the bootstrap token %q was not of the form %q", token, bootstrapapi.BootstrapTokenPattern)
 	}
 
 	return &BootstrapTokenString{ID: substrs[1], Secret: substrs[2]}, nil

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/bootstraptokenstring_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/bootstraptokenstring_test.go
@@ -18,9 +18,10 @@ package v1alpha3
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestMarshalJSON(t *testing.T) {
@@ -99,13 +100,13 @@ func roundtrip(input string, bts *BootstrapTokenString) error {
 	// If string input was specified, roundtrip like this: string -> (unmarshal) -> object -> (marshal) -> string
 	if len(input) > 0 {
 		if err := json.Unmarshal([]byte(input), newbts); err != nil {
-			return fmt.Errorf("expected no unmarshal error, got error: %v", err)
+			return errors.Wrapf(err, "expected no unmarshal error")
 		}
 		if b, err = json.Marshal(newbts); err != nil {
-			return fmt.Errorf("expected no marshal error, got error: %v", err)
+			return errors.Wrapf(err, "expected no marshal error")
 		}
 		if input != string(b) {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"expected token: %s\n\t  actual: %s",
 				input,
 				string(b),
@@ -113,13 +114,13 @@ func roundtrip(input string, bts *BootstrapTokenString) error {
 		}
 	} else { // Otherwise, roundtrip like this: object -> (marshal) -> string -> (unmarshal) -> object
 		if b, err = json.Marshal(bts); err != nil {
-			return fmt.Errorf("expected no marshal error, got error: %v", err)
+			return errors.Wrapf(err, "expected no marshal error")
 		}
 		if err := json.Unmarshal(b, newbts); err != nil {
-			return fmt.Errorf("expected no unmarshal error, got error: %v", err)
+			return errors.Wrapf(err, "expected no unmarshal error")
 		}
 		if !reflect.DeepEqual(bts, newbts) {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"expected object: %v\n\t  actual: %v",
 				bts,
 				newbts,

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/bootstraptokenstring.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/bootstraptokenstring.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
 )
@@ -73,7 +74,7 @@ func NewBootstrapTokenString(token string) (*BootstrapTokenString, error) {
 	substrs := bootstraputil.BootstrapTokenRegexp.FindStringSubmatch(token)
 	// TODO: Add a constant for the 3 value here, and explain better why it's needed (other than because how the regexp parsin works)
 	if len(substrs) != 3 {
-		return nil, fmt.Errorf("the bootstrap token %q was not of the form %q", token, bootstrapapi.BootstrapTokenPattern)
+		return nil, errors.Errorf("the bootstrap token %q was not of the form %q", token, bootstrapapi.BootstrapTokenPattern)
 	}
 
 	return &BootstrapTokenString{ID: substrs[1], Secret: substrs[2]}, nil

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/bootstraptokenstring_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/bootstraptokenstring_test.go
@@ -18,9 +18,10 @@ package v1beta1
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestMarshalJSON(t *testing.T) {
@@ -99,13 +100,13 @@ func roundtrip(input string, bts *BootstrapTokenString) error {
 	// If string input was specified, roundtrip like this: string -> (unmarshal) -> object -> (marshal) -> string
 	if len(input) > 0 {
 		if err := json.Unmarshal([]byte(input), newbts); err != nil {
-			return fmt.Errorf("expected no unmarshal error, got error: %v", err)
+			return errors.Wrapf(err, "expected no unmarshal error")
 		}
 		if b, err = json.Marshal(newbts); err != nil {
-			return fmt.Errorf("expected no marshal error, got error: %v", err)
+			return errors.Wrapf(err, "expected no marshal error")
 		}
 		if input != string(b) {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"expected token: %s\n\t  actual: %s",
 				input,
 				string(b),
@@ -113,13 +114,13 @@ func roundtrip(input string, bts *BootstrapTokenString) error {
 		}
 	} else { // Otherwise, roundtrip like this: object -> (marshal) -> string -> (unmarshal) -> object
 		if b, err = json.Marshal(bts); err != nil {
-			return fmt.Errorf("expected no marshal error, got error: %v", err)
+			return errors.Wrapf(err, "expected no marshal error")
 		}
 		if err := json.Unmarshal(b, newbts); err != nil {
-			return fmt.Errorf("expected no unmarshal error, got error: %v", err)
+			return errors.Wrapf(err, "expected no unmarshal error")
 		}
 		if !reflect.DeepEqual(bts, newbts) {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"expected object: %v\n\t  actual: %v",
 				bts,
 				newbts,

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -398,7 +399,7 @@ func ValidateMixedArguments(flag *pflag.FlagSet) error {
 	})
 
 	if len(mixedInvalidFlags) != 0 {
-		return fmt.Errorf("can not mix '--config' with arguments %v", mixedInvalidFlags)
+		return errors.Errorf("can not mix '--config' with arguments %v", mixedInvalidFlags)
 	}
 	return nil
 }

--- a/cmd/kubeadm/app/cmd/completion.go
+++ b/cmd/kubeadm/app/cmd/completion.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 
 	"github.com/golang/glog"
@@ -126,7 +125,7 @@ func RunCompletion(out io.Writer, boilerPlate string, cmd *cobra.Command, args [
 	}
 	run, found := completionShells[args[0]]
 	if !found {
-		return fmt.Errorf("unsupported shell type %q", args[0])
+		return errors.Errorf("unsupported shell type %q", args[0])
 	}
 
 	if len(boilerPlate) == 0 {

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -188,7 +188,7 @@ func NewCmdConfigPrintDefault(out io.Writer) *cobra.Command {
 func getDefaultComponentConfigAPIObjectBytes(apiObject string) ([]byte, error) {
 	registration, ok := componentconfigs.Known[componentconfigs.RegistrationKind(apiObject)]
 	if !ok {
-		return []byte{}, fmt.Errorf("--component-configs needs to contain some of %v", getSupportedComponentConfigAPIObjects())
+		return []byte{}, errors.Errorf("--component-configs needs to contain some of %v", getSupportedComponentConfigAPIObjects())
 	}
 	return getDefaultComponentConfigBytes(registration)
 }
@@ -208,7 +208,7 @@ func getDefaultAPIObjectBytes(apiObject string) ([]byte, error) {
 		// Is this a component config?
 		registration, ok := componentconfigs.Known[componentconfigs.RegistrationKind(apiObject)]
 		if !ok {
-			return []byte{}, fmt.Errorf("--api-object needs to be one of %v", getAllAPIObjectNames())
+			return []byte{}, errors.Errorf("--api-object needs to be one of %v", getAllAPIObjectNames())
 		}
 		return getDefaultComponentConfigBytes(registration)
 	}
@@ -339,7 +339,7 @@ func NewCmdConfigMigrate(out io.Writer) *cobra.Command {
 				fmt.Fprint(out, string(outputBytes))
 			} else {
 				if err := ioutil.WriteFile(newCfgPath, outputBytes, 0644); err != nil {
-					kubeadmutil.CheckErr(fmt.Errorf("failed to write the new configuration to the file %q: %v", newCfgPath, err))
+					kubeadmutil.CheckErr(errors.Wrapf(err, "failed to write the new configuration to the file %q", newCfgPath))
 				}
 			}
 		},
@@ -545,7 +545,7 @@ func NewImagesPull(runtime utilruntime.ContainerRuntime, images []string) *Image
 func (ip *ImagesPull) PullAll() error {
 	for _, image := range ip.images {
 		if err := ip.runtime.PullImage(image); err != nil {
-			return fmt.Errorf("failed to pull image %q: %v", image, err)
+			return errors.Wrapf(err, "failed to pull image %q", image)
 		}
 		fmt.Printf("[config/images] Pulled %s\n", image)
 	}

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -448,12 +448,12 @@ func runInit(i *initData, out io.Writer) error {
 		if i.cfg.AuditPolicyConfiguration.Path != "" {
 			// TODO(chuckha) ensure passed in audit policy is valid so users don't have to find the error in the api server log.
 			if _, err := os.Stat(i.cfg.AuditPolicyConfiguration.Path); err != nil {
-				return fmt.Errorf("error getting file info for audit policy file %q [%v]", i.cfg.AuditPolicyConfiguration.Path, err)
+				return errors.Wrapf(err, "error getting file info for audit policy file %q", i.cfg.AuditPolicyConfiguration.Path)
 			}
 		} else {
 			i.cfg.AuditPolicyConfiguration.Path = filepath.Join(kubeConfigDir, kubeadmconstants.AuditPolicyDir, kubeadmconstants.AuditPolicyFile)
 			if err := auditutil.CreateDefaultAuditLogPolicy(i.cfg.AuditPolicyConfiguration.Path); err != nil {
-				return fmt.Errorf("error creating default audit policy %q [%v]", i.cfg.AuditPolicyConfiguration.Path, err)
+				return errors.Wrapf(err, "error creating default audit policy %q", i.cfg.AuditPolicyConfiguration.Path)
 			}
 		}
 	}

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -495,7 +495,7 @@ func (j *Join) BootstrapKubelet(tlsBootstrapCfg *clientcmdapi.Config) error {
 
 	bootstrapClient, err := kubeconfigutil.ClientSetFromFile(bootstrapKubeConfigFile)
 	if err != nil {
-		return fmt.Errorf("couldn't create client from kubeconfig file %q", bootstrapKubeConfigFile)
+		return errors.Errorf("couldn't create client from kubeconfig file %q", bootstrapKubeConfigFile)
 	}
 
 	// Configure the kubelet. In this short timeframe, kubeadm is trying to stop/restart the kubelet

--- a/cmd/kubeadm/app/cmd/phases/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/preflight.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	perrors "github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -78,7 +79,7 @@ func NewPreflightMasterPhase() workflow.Phase {
 func runPreflightMaster(c workflow.RunData) error {
 	data, ok := c.(preflightMasterData)
 	if !ok {
-		return fmt.Errorf("preflight phase invoked with an invalid data struct")
+		return perrors.Errorf("preflight phase invoked with an invalid data struct")
 	}
 
 	fmt.Println("[preflight] running pre-flight checks")

--- a/cmd/kubeadm/app/cmd/phases/workflow/doc_test.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/doc_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package workflow
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 )
 
 var myWorkflowRunner = NewRunner()

--- a/cmd/kubeadm/app/cmd/phases/workflow/runner.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/runner.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -135,7 +136,7 @@ func (e *Runner) computePhaseRunFlags() (map[string]bool, error) {
 		}
 		for _, f := range e.Options.FilterPhases {
 			if _, ok := phaseRunFlags[f]; !ok {
-				return phaseRunFlags, fmt.Errorf("invalid phase name: %s", f)
+				return phaseRunFlags, errors.Errorf("invalid phase name: %s", f)
 			}
 			phaseRunFlags[f] = true
 			for _, c := range phaseHierarchy[f] {
@@ -148,7 +149,7 @@ func (e *Runner) computePhaseRunFlags() (map[string]bool, error) {
 	// to false and apply the same change to the underlying hierarchy
 	for _, f := range e.Options.SkipPhases {
 		if _, ok := phaseRunFlags[f]; !ok {
-			return phaseRunFlags, fmt.Errorf("invalid phase name: %s", f)
+			return phaseRunFlags, errors.Errorf("invalid phase name: %s", f)
 		}
 		phaseRunFlags[f] = false
 		for _, c := range phaseHierarchy[f] {
@@ -206,7 +207,7 @@ func (e *Runner) Run() error {
 			// Check the condition and returns if the condition isn't satisfied (or fails)
 			ok, err := p.RunIf(data)
 			if err != nil {
-				return fmt.Errorf("error execution run condition for phase %s: %v", p.generatedName, err)
+				return errors.Wrapf(err, "error execution run condition for phase %s", p.generatedName)
 			}
 
 			if !ok {
@@ -217,7 +218,7 @@ func (e *Runner) Run() error {
 		// Runs the phase action (if defined)
 		if p.Run != nil {
 			if err := p.Run(data); err != nil {
-				return fmt.Errorf("error execution phase %s: %v", p.generatedName, err)
+				return errors.Wrapf(err, "error execution phase %s", p.generatedName)
 			}
 		}
 

--- a/cmd/kubeadm/app/cmd/phases/workflow/runner_test.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/runner_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package workflow
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func phaseBuilder(name string, phases ...Phase) Phase {

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -170,7 +170,7 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 		`),
 		Run: func(tokenCmd *cobra.Command, args []string) {
 			if len(args) < 1 {
-				kubeadmutil.CheckErr(fmt.Errorf("missing subcommand; 'token delete' is missing token of form %q", bootstrapapi.BootstrapTokenIDPattern))
+				kubeadmutil.CheckErr(errors.Errorf("missing subcommand; 'token delete' is missing token of form %q", bootstrapapi.BootstrapTokenIDPattern))
 			}
 			kubeConfigFile = cmdutil.FindExistingKubeConfig(kubeConfigFile)
 			client, err := getClientset(kubeConfigFile, dryRun)
@@ -303,7 +303,7 @@ func RunDeleteToken(out io.Writer, client clientset.Interface, tokenIDOrToken st
 		// Okay, the full token with both id and secret was probably passed. Parse it and extract the ID only
 		bts, err := kubeadmapiv1beta1.NewBootstrapTokenString(tokenIDOrToken)
 		if err != nil {
-			return fmt.Errorf("given token or token id %q didn't match pattern %q or %q", tokenIDOrToken, bootstrapapi.BootstrapTokenIDPattern, bootstrapapi.BootstrapTokenIDPattern)
+			return errors.Errorf("given token or token id %q didn't match pattern %q or %q", tokenIDOrToken, bootstrapapi.BootstrapTokenIDPattern, bootstrapapi.BootstrapTokenIDPattern)
 		}
 		tokenID = bts.ID
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/util/version"
@@ -169,7 +170,7 @@ func RunApply(flags *applyFlags) error {
 	flags.newK8sVersionStr = upgradeVars.cfg.KubernetesVersion
 	k8sVer, err := version.ParseSemantic(flags.newK8sVersionStr)
 	if err != nil {
-		return fmt.Errorf("unable to parse normalized version %q as a semantic version", flags.newK8sVersionStr)
+		return errors.Errorf("unable to parse normalized version %q as a semantic version", flags.newK8sVersionStr)
 	}
 	flags.newK8sVersion = k8sVer
 
@@ -180,7 +181,7 @@ func RunApply(flags *applyFlags) error {
 	// Enforce the version skew policies
 	glog.V(1).Infof("[upgrade/version] enforcing version skew policies")
 	if err := EnforceVersionPolicies(flags, upgradeVars.versionGetter); err != nil {
-		return fmt.Errorf("[upgrade/version] FATAL: %v", err)
+		return errors.Wrapf(err, "[upgrade/version] FATAL")
 	}
 
 	// If the current session is interactive, ask the user whether they really want to upgrade
@@ -199,19 +200,19 @@ func RunApply(flags *applyFlags) error {
 		componentsToPrepull = append(componentsToPrepull, constants.Etcd)
 	}
 	if err := upgrade.PrepullImagesInParallel(prepuller, flags.imagePullTimeout, componentsToPrepull); err != nil {
-		return fmt.Errorf("[upgrade/prepull] Failed prepulled the images for the control plane components error: %v", err)
+		return errors.Wrap(err, "[upgrade/prepull] Failed prepulled the images for the control plane components error")
 	}
 
 	// Now; perform the upgrade procedure
 	glog.V(1).Infof("[upgrade/apply] performing upgrade")
 	if err := PerformControlPlaneUpgrade(flags, upgradeVars.client, upgradeVars.waiter, upgradeVars.cfg); err != nil {
-		return fmt.Errorf("[upgrade/apply] FATAL: %v", err)
+		return errors.Wrap(err, "[upgrade/apply] FATAL")
 	}
 
 	// Upgrade RBAC rules and addons.
 	glog.V(1).Infof("[upgrade/postupgrade] upgrading RBAC rules and addons")
 	if err := upgrade.PerformPostUpgradeTasks(upgradeVars.client, upgradeVars.cfg, flags.newK8sVersion, flags.dryRun); err != nil {
-		return fmt.Errorf("[upgrade/postupgrade] FATAL post-upgrade error: %v", err)
+		return errors.Wrap(err, "[upgrade/postupgrade] FATAL post-upgrade error")
 	}
 
 	if flags.dryRun {
@@ -235,7 +236,7 @@ func SetImplicitFlags(flags *applyFlags) error {
 	}
 
 	if len(flags.newK8sVersionStr) == 0 {
-		return fmt.Errorf("version string can't be empty")
+		return errors.Errorf("version string can't be empty")
 	}
 
 	return nil
@@ -250,13 +251,13 @@ func EnforceVersionPolicies(flags *applyFlags, versionGetter upgrade.VersionGett
 	if versionSkewErrs != nil {
 
 		if len(versionSkewErrs.Mandatory) > 0 {
-			return fmt.Errorf("The --version argument is invalid due to these fatal errors:\n\n%v\nPlease fix the misalignments highlighted above and try upgrading again", kubeadmutil.FormatErrMsg(versionSkewErrs.Mandatory))
+			return errors.Errorf("The --version argument is invalid due to these fatal errors:\n\n%v\nPlease fix the misalignments highlighted above and try upgrading again", kubeadmutil.FormatErrMsg(versionSkewErrs.Mandatory))
 		}
 
 		if len(versionSkewErrs.Skippable) > 0 {
 			// Return the error if the user hasn't specified the --force flag
 			if !flags.force {
-				return fmt.Errorf("The --version argument is invalid due to these errors:\n\n%v\nCan be bypassed if you pass the --force flag", kubeadmutil.FormatErrMsg(versionSkewErrs.Skippable))
+				return errors.Errorf("The --version argument is invalid due to these errors:\n\n%v\nCan be bypassed if you pass the --force flag", kubeadmutil.FormatErrMsg(versionSkewErrs.Skippable))
 			}
 			// Soft errors found, but --force was specified
 			fmt.Printf("[upgrade/version] Found %d potential version compatibility errors but skipping since the --force flag is set: \n\n%v", len(versionSkewErrs.Skippable), kubeadmutil.FormatErrMsg(versionSkewErrs.Skippable))

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -54,12 +55,12 @@ func enforceRequirements(flags *applyPlanFlags, dryRun bool, newK8sVersion strin
 
 	client, err := getClient(flags.kubeConfigPath, dryRun)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create a Kubernetes client from file %q: %v", flags.kubeConfigPath, err)
+		return nil, errors.Wrapf(err, "couldn't create a Kubernetes client from file %q", flags.kubeConfigPath)
 	}
 
 	// Run healthchecks against the cluster
 	if err := upgrade.CheckClusterHealth(client, flags.ignorePreflightErrorsSet); err != nil {
-		return nil, fmt.Errorf("[upgrade/health] FATAL: %v", err)
+		return nil, errors.Wrapf(err, "[upgrade/health] FATAL")
 	}
 
 	// Fetch the configuration from a file or ConfigMap and validate it
@@ -75,9 +76,9 @@ func enforceRequirements(flags *applyPlanFlags, dryRun bool, newK8sVersion strin
 			fmt.Printf("\t- OPTION 2: Run 'kubeadm config upload from-file' and specify the same config file you passed to 'kubeadm init' when you created your master.\n")
 			fmt.Printf("\t- OPTION 3: Pass a config file to 'kubeadm upgrade' using the --config flag.\n")
 			fmt.Println("")
-			err = fmt.Errorf("the ConfigMap %q in the %s namespace used for getting configuration information was not found", constants.KubeadmConfigConfigMap, metav1.NamespaceSystem)
+			err = errors.Errorf("the ConfigMap %q in the %s namespace used for getting configuration information was not found", constants.KubeadmConfigConfigMap, metav1.NamespaceSystem)
 		}
-		return nil, fmt.Errorf("[upgrade/config] FATAL: %v", err)
+		return nil, errors.Wrapf(err, "[upgrade/config] FATAL")
 	}
 
 	// If a new k8s version should be set, apply the change before printing the config
@@ -89,7 +90,7 @@ func enforceRequirements(flags *applyPlanFlags, dryRun bool, newK8sVersion strin
 	if flags.featureGatesString != "" {
 		cfg.FeatureGates, err = features.NewFeatureGate(&features.InitFeatureGates, flags.featureGatesString)
 		if err != nil {
-			return nil, fmt.Errorf("[upgrade/config] FATAL: %v", err)
+			return nil, errors.Wrapf(err, "[upgrade/config] FATAL")
 		}
 	}
 
@@ -98,7 +99,7 @@ func enforceRequirements(flags *applyPlanFlags, dryRun bool, newK8sVersion strin
 		for _, m := range msg {
 			fmt.Printf("[upgrade/config] %s\n", m)
 		}
-		return nil, fmt.Errorf("[upgrade/config] FATAL. Unable to upgrade a cluster using deprecated feature-gate flags. Please see the release notes")
+		return nil, errors.Errorf("[upgrade/config] FATAL. Unable to upgrade a cluster using deprecated feature-gate flags. Please see the release notes")
 	}
 
 	// If the user told us to print this information out; do it!
@@ -153,7 +154,7 @@ func getClient(file string, dryRun bool) (clientset.Interface, error) {
 		// API Server's version
 		realServerVersion, err := dryRunGetter.Client().Discovery().ServerVersion()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get server version: %v", err)
+			return nil, errors.Wrapf(err, "failed to get server version")
 		}
 
 		// Get the fake clientset
@@ -165,7 +166,7 @@ func getClient(file string, dryRun bool) (clientset.Interface, error) {
 		// we can convert it to that struct.
 		fakeclientDiscovery, ok := fakeclient.Discovery().(*fakediscovery.FakeDiscovery)
 		if !ok {
-			return nil, fmt.Errorf("couldn't set fake discovery's server version")
+			return nil, errors.Errorf("couldn't set fake discovery's server version")
 		}
 		// Lastly, set the right server version to be used
 		fakeclientDiscovery.FakedServerVersion = realServerVersion
@@ -191,12 +192,12 @@ func InteractivelyConfirmUpgrade(question string) error {
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("couldn't read from standard input: %v", err)
+		return errors.Wrapf(err, "couldn't read from standard input")
 	}
 	answer := scanner.Text()
 	if strings.ToLower(answer) == "y" || strings.ToLower(answer) == "yes" {
 		return nil
 	}
 
-	return fmt.Errorf("won't proceed; the user didn't answer (Y|y) in order to continue")
+	return errors.Errorf("won't proceed; the user didn't answer (Y|y) in order to continue")
 }

--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -17,11 +17,11 @@ limitations under the License.
 package upgrade
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -125,7 +125,7 @@ func runDiff(flags *diffFlags, args []string) error {
 			return err
 		}
 		if path == "" {
-			return fmt.Errorf("empty manifest path")
+			return errors.Errorf("empty manifest path")
 		}
 		existingManifest, err := ioutil.ReadFile(path)
 		if err != nil {

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/util/version"
@@ -155,7 +156,7 @@ func NewCmdUpgradeControlPlane() *cobra.Command {
 // RunUpgradeNodeConfig is executed when `kubeadm upgrade node config` runs.
 func RunUpgradeNodeConfig(flags *nodeUpgradeFlags) error {
 	if len(flags.kubeletVersionStr) == 0 {
-		return fmt.Errorf("The --kubelet-version argument is required")
+		return errors.Errorf("The --kubelet-version argument is required")
 	}
 
 	// Set up the kubelet directory to use. If dry-running, use a fake directory
@@ -166,7 +167,7 @@ func RunUpgradeNodeConfig(flags *nodeUpgradeFlags) error {
 
 	client, err := getClient(flags.kubeConfigPath, flags.dryRun)
 	if err != nil {
-		return fmt.Errorf("couldn't create a Kubernetes client from file %q: %v", flags.kubeConfigPath, err)
+		return errors.Wrapf(err, "couldn't create a Kubernetes client from file %q", flags.kubeConfigPath)
 	}
 
 	// Parse the desired kubelet version
@@ -181,7 +182,7 @@ func RunUpgradeNodeConfig(flags *nodeUpgradeFlags) error {
 
 	// If we're dry-running, print the generated manifests, otherwise do nothing
 	if err := printFilesIfDryRunning(flags.dryRun, kubeletDir); err != nil {
-		return fmt.Errorf("error printing files on dryrun: %v", err)
+		return errors.Wrapf(err, "error printing files on dryrun")
 	}
 
 	fmt.Println("[upgrade] The configuration for this node was successfully updated!")
@@ -194,7 +195,7 @@ func getKubeletDir(dryRun bool) (string, error) {
 	if dryRun {
 		dryRunDir, err := ioutil.TempDir("", "kubeadm-init-dryrun")
 		if err != nil {
-			return "", fmt.Errorf("couldn't create a temporary directory: %v", err)
+			return "", errors.Wrapf(err, "couldn't create a temporary directory")
 		}
 		return dryRunDir, nil
 	}
@@ -220,7 +221,7 @@ func RunUpgradeControlPlane(flags *controlplaneUpgradeFlags) error {
 
 	client, err := getClient(flags.kubeConfigPath, flags.dryRun)
 	if err != nil {
-		return fmt.Errorf("Couldn't create a Kubernetes client from file %q: %v", flags.kubeConfigPath, err)
+		return errors.Wrapf(err, "Couldn't create a Kubernetes client from file %q", flags.kubeConfigPath)
 	}
 
 	waiter := apiclient.NewKubeWaiter(client, upgrade.UpgradeManifestTimeout, os.Stdout)
@@ -228,12 +229,12 @@ func RunUpgradeControlPlane(flags *controlplaneUpgradeFlags) error {
 	// Fetches the cluster configuration
 	cfg, err := configutil.FetchConfigFromFileOrCluster(client, os.Stdout, "upgrade", "", false)
 	if err != nil {
-		return fmt.Errorf("Unable to fetch the kubeadm-config ConfigMap: %v", err)
+		return errors.Wrapf(err, "Unable to fetch the kubeadm-config ConfigMap")
 	}
 
 	// Rotate API server certificate if needed
 	if err := upgrade.BackupAPIServerCertIfNeeded(cfg, flags.dryRun); err != nil {
-		return fmt.Errorf("Unable to rotate API server certificate: %v", err)
+		return errors.Wrapf(err, "Unable to rotate API server certificate")
 	}
 
 	// Upgrade the control plane
@@ -243,7 +244,7 @@ func RunUpgradeControlPlane(flags *controlplaneUpgradeFlags) error {
 	}
 
 	if err := PerformStaticPodUpgrade(client, waiter, cfg, false); err != nil {
-		return fmt.Errorf("Couldn't complete the static pod upgrade: %v", err)
+		return errors.Wrapf(err, "Couldn't complete the static pod upgrade")
 	}
 
 	fmt.Println("[upgrade] The control plane instance for this node was successfully updated!")

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -25,6 +25,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/util/version"
@@ -126,7 +127,7 @@ func RunPlan(flags *planFlags) error {
 	glog.V(1).Infof("[upgrade/plan] computing upgrade possibilities")
 	availUpgrades, err := upgrade.GetAvailableUpgrades(upgradeVars.versionGetter, flags.allowExperimentalUpgrades, flags.allowRCUpgrades, etcdClient, upgradeVars.cfg.FeatureGates, upgradeVars.client)
 	if err != nil {
-		return fmt.Errorf("[upgrade/versions] FATAL: %v", err)
+		return errors.Wrapf(err, "[upgrade/versions] FATAL")
 	}
 
 	// Tell the user which upgrades are available

--- a/cmd/kubeadm/app/cmd/util/cmdutil.go
+++ b/cmd/kubeadm/app/cmd/util/cmdutil.go
@@ -17,8 +17,7 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -33,10 +32,10 @@ import (
 func SubCmdRunE(name string) func(*cobra.Command, []string) error {
 	return func(_ *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return fmt.Errorf("missing subcommand; %q is not meant to be run on its own", name)
+			return errors.Errorf("missing subcommand; %q is not meant to be run on its own", name)
 		}
 
-		return fmt.Errorf("invalid subcommand: %q", args[0])
+		return errors.Errorf("invalid subcommand: %q", args[0])
 	}
 }
 
@@ -51,12 +50,12 @@ func ValidateExactArgNumber(args []string, supportedArgs []string) error {
 		}
 		// break early for too many arguments
 		if validArgs > lenSupported {
-			return fmt.Errorf("too many arguments. Required arguments: %v", supportedArgs)
+			return errors.Errorf("too many arguments. Required arguments: %v", supportedArgs)
 		}
 	}
 
 	if validArgs < lenSupported {
-		return fmt.Errorf("missing one or more required arguments. Required arguments: %v", supportedArgs)
+		return errors.Errorf("missing one or more required arguments. Required arguments: %v", supportedArgs)
 	}
 	return nil
 }

--- a/cmd/kubeadm/app/cmd/util/join.go
+++ b/cmd/kubeadm/app/cmd/util/join.go
@@ -19,10 +19,10 @@ package util
 import (
 	"bytes"
 	"crypto/x509"
-	"fmt"
 	"html/template"
 	"strings"
 
+	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcertutil "k8s.io/client-go/util/cert"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
@@ -39,13 +39,13 @@ func GetJoinCommand(kubeConfigFile string, token string, skipTokenPrint bool) (s
 	// load the kubeconfig file to get the CA certificate and endpoint
 	config, err := clientcmd.LoadFromFile(kubeConfigFile)
 	if err != nil {
-		return "", fmt.Errorf("failed to load kubeconfig: %v", err)
+		return "", errors.Wrapf(err, "failed to load kubeconfig")
 	}
 
 	// load the default cluster config
 	clusterConfig := kubeconfigutil.GetClusterFromKubeConfig(config)
 	if clusterConfig == nil {
-		return "", fmt.Errorf("failed to get default cluster config")
+		return "", errors.Errorf("failed to get default cluster config")
 	}
 
 	// load CA certificates from the kubeconfig (either from PEM data or by file path)
@@ -53,15 +53,15 @@ func GetJoinCommand(kubeConfigFile string, token string, skipTokenPrint bool) (s
 	if clusterConfig.CertificateAuthorityData != nil {
 		caCerts, err = clientcertutil.ParseCertsPEM(clusterConfig.CertificateAuthorityData)
 		if err != nil {
-			return "", fmt.Errorf("failed to parse CA certificate from kubeconfig: %v", err)
+			return "", errors.Wrapf(err, "failed to parse CA certificate from kubeconfig")
 		}
 	} else if clusterConfig.CertificateAuthority != "" {
 		caCerts, err = clientcertutil.CertsFromFile(clusterConfig.CertificateAuthority)
 		if err != nil {
-			return "", fmt.Errorf("failed to load CA certificate referenced by kubeconfig: %v", err)
+			return "", errors.Wrapf(err, "failed to load CA certificate referenced by kubeconfig")
 		}
 	} else {
-		return "", fmt.Errorf("no CA certificates found in kubeconfig")
+		return "", errors.Errorf("no CA certificates found in kubeconfig")
 	}
 
 	// hash all the CA certs and include their public key pins as trusted values
@@ -83,7 +83,7 @@ func GetJoinCommand(kubeConfigFile string, token string, skipTokenPrint bool) (s
 	var out bytes.Buffer
 	err = joinCommandTemplate.Execute(&out, ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to render join command template: %v", err)
+		return "", errors.Wrapf(err, "failed to render join command template")
 	}
 	return out.String(), nil
 }

--- a/cmd/kubeadm/app/cmd/version.go
+++ b/cmd/kubeadm/app/cmd/version.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
@@ -82,7 +83,7 @@ func RunVersion(out io.Writer, cmd *cobra.Command) error {
 		}
 		fmt.Fprintln(out, string(y))
 	default:
-		return fmt.Errorf("invalid output format: %s", of)
+		return errors.Errorf("invalid output format: %s", of)
 	}
 
 	return nil

--- a/cmd/kubeadm/app/cmd/version_test.go
+++ b/cmd/kubeadm/app/cmd/version_test.go
@@ -19,9 +19,10 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"github.com/ghodss/yaml"
 	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
 )
 
 func TestNewCmdVersion(t *testing.T) {
@@ -80,7 +81,7 @@ func TestRunVersion(t *testing.T) {
 			goto error
 		}
 		if buf.String() == "" {
-			err = fmt.Errorf("empty output")
+			err = errors.Errorf("empty output")
 			goto error
 		}
 		if tc.shouldBeValidYAML {

--- a/cmd/kubeadm/app/componentconfigs/config.go
+++ b/cmd/kubeadm/app/componentconfigs/config.go
@@ -17,8 +17,7 @@ limitations under the License.
 package componentconfigs
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -41,7 +40,7 @@ func GetFromKubeletConfigMap(client clientset.Interface, version *version.Versio
 
 	kubeletConfigData, ok := kubeletCfg.Data[kubeadmconstants.KubeletBaseConfigurationConfigMapKey]
 	if !ok {
-		return nil, fmt.Errorf("unexpected error when reading %s ConfigMap: %s key value pair missing", configMapName, kubeadmconstants.KubeletBaseConfigurationConfigMapKey)
+		return nil, errors.Errorf("unexpected error when reading %s ConfigMap: %s key value pair missing", configMapName, kubeadmconstants.KubeletBaseConfigurationConfigMapKey)
 	}
 
 	// Decodes the kubeletConfigData into the internal component config
@@ -66,7 +65,7 @@ func GetFromKubeProxyConfigMap(client clientset.Interface, version *version.Vers
 
 	kubeproxyConfigData, ok := kubeproxyCfg.Data[kubeadmconstants.KubeProxyConfigMapKey]
 	if !ok {
-		return nil, fmt.Errorf("unexpected error when reading %s ConfigMap: %s key value pair missing", kubeadmconstants.KubeProxyConfigMap, kubeadmconstants.KubeProxyConfigMapKey)
+		return nil, errors.Errorf("unexpected error when reading %s ConfigMap: %s key value pair missing", kubeadmconstants.KubeProxyConfigMap, kubeadmconstants.KubeProxyConfigMapKey)
 	}
 
 	// Decodes the Config map dat into the internal component config


### PR DESCRIPTION
Updated packages to use `github.com/pkg/errors` instead of `fmt.Error*` or the package `"errors"`:
```
./cmd/kubeadm/app/apis/...
./cmd/kubeadm/app/cmd/...
./cmd/kubeadm/app/componentconfigs/...
```

For kubernetes/kubeadm#1183

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
