### PR TITLE
Move "-s -w" flags to GOLDFLAGS as an overridable default.

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -680,7 +680,7 @@ kube::golang::build_binaries() {
     # Use eval to preserve embedded quoted strings.
     local goflags goldflags goasmflags gogcflags
     eval "goflags=(${GOFLAGS:-})"
-    goldflags="${GOLDFLAGS:-} -s -w $(kube::version::ldflags)"
+    goldflags="${GOLDFLAGS:-"-s -w"} $(kube::version::ldflags)"
     goasmflags="-trimpath=${KUBE_ROOT}"
     gogcflags="${GOGCFLAGS:-} -trimpath=${KUBE_ROOT}"
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
GOLDFLAGS can be specified when compiling, so it is better to set "-s -w" as the overridable default value of GOLDFLAGS.

**Which issue(s) this PR fixes** *(optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
```
NONE
```