### PR TITLE
e2e: Only do LB health check reconciliation test on GCE

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1552,8 +1552,9 @@ var _ = SIGDescribe("Services", func() {
 	// to be something else, see if the interval will be reconciled.
 	It("should reconcile LB health check interval [Slow][Serial]", func() {
 		const gceHcCheckIntervalSeconds = int64(8)
-		// This test is for clusters on GCE/GKE.
-		framework.SkipUnlessProviderIs("gce", "gke")
+		// This test is for clusters on GCE.
+		// (It restarts kube-controller-manager, which we don't support on GKE)
+		framework.SkipUnlessProviderIs("gce")
 		clusterID, err := gce.GetClusterID(cs)
 		if err != nil {
 			framework.Failf("framework.GetClusterID(cs) = _, %v; want nil", err)


### PR DESCRIPTION
The test requires restarting kube-controller-manager, we don't support
that on GKE.

Fix #70280

/kind bug
/kind failing-test

/sig network

```release-note
NONE
```