### PR TITLE
Use pvc uid instead of pvc name in glusterfs endpoint name.

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -824,7 +824,7 @@ func (p *glusterfsVolumeProvisioner) CreateVolume(gid int) (r *v1.GlusterfsVolum
 
 	// The 'endpointname' is created in form of 'glusterfs-dynamic-<PVC UID>'.
 	// createEndpointService() checks for this 'endpoint' existence in PVC's namespace and
-	// If not found, it create an endpoint and service using the IPs we dynamically picked at time
+	// if not found, it create an endpoint and service using the IPs we dynamically picked at time
 	// of volume creation.
 	epServiceName := dynamicEpSvcPrefix + string(p.options.PVC.UID)
 	epNamespace := p.options.PVC.Namespace

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -822,11 +822,11 @@ func (p *glusterfsVolumeProvisioner) CreateVolume(gid int) (r *v1.GlusterfsVolum
 		return nil, 0, "", fmt.Errorf("failed to get cluster nodes for volume %s: %v", volume, err)
 	}
 
-	// The 'endpointname' is created in form of 'glusterfs-dynamic-<claimname>'.
+	// The 'endpointname' is created in form of 'glusterfs-dynamic-<PVC UID>'.
 	// createEndpointService() checks for this 'endpoint' existence in PVC's namespace and
 	// If not found, it create an endpoint and service using the IPs we dynamically picked at time
 	// of volume creation.
-	epServiceName := dynamicEpSvcPrefix + p.options.PVC.Name
+	epServiceName := dynamicEpSvcPrefix + string(p.options.PVC.UID)
 	epNamespace := p.options.PVC.Namespace
 	endpoint, service, err := p.createEndpointService(epNamespace, epServiceName, dynamicHostIps, p.options.PVC.Name)
 	if err != nil {


### PR DESCRIPTION
GlusterFS: At present, endpoints and services are created
for glusterfs pvcs are in form of glusterfs-dynamic-<PVC name>
however this could cause issue if user deletes a PVC and immediately
creates a new one with the same name, PV controller will try to delete
the old PV and its endpoint and at the same the controller will try to create new PV
and the same endpoint. Depending on which event reaches the
controller first, it may create new PV, check that endpoints exists,
then delete the old PVC and delete endpoints already used by the new PV.

This patch changes the endpoint/service name to below format:

`glusterfs-dynamic-<PVC UUID>`.

By the uniqueness of UUID, above mentioned issue will no longer be present.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

