### PR TITLE
Adding Datadog Cluster Agent to the list of Custom Metrics Providers

### DIFF
--- a/staging/src/k8s.io/metrics/IMPLEMENTATIONS.md
+++ b/staging/src/k8s.io/metrics/IMPLEMENTATIONS.md
@@ -24,3 +24,7 @@ They are listed here for convenience.***
 
 - [Google Stackdriver (coming
   soon)](https://github.com/GoogleCloudPlatform/k8s-stackdriver)
+
+- [Datadog Cluster Agent](https://github.com/DataDog/datadog-agent/blob/c4f38af1897bac294d8fed6285098b14aafa6178/docs/cluster-agent/CUSTOM_METRICS_SERVER.md).
+  Implementation of the external metrics provider, using Datadog as a backend for the metrics.
+  Coming soon: Implementation of the custom metrics provider to support in-cluster metrics collected by the Datadog Agents.


### PR DESCRIPTION
**What this PR does / why we need it**:

Hello all, I'd like to add the Datadog Cluster Agent to the list of implementations for the Custom/External Metrics Provider.
We released it [last week](https://www.datadoghq.com/blog/datadog-cluster-agent/), and I think it could benefit the community.

We made a dedicated blogpost about the External Metrics Provider if that is of interest as well:
https://www.datadoghq.com/blog/autoscale-kubernetes-datadog/

Let me know if you have any questions!

/kind documentation

**Does this PR introduce a user-facing change?**:
NONE