### PR TITLE
Add code for including shutdown nodes

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vclib/virtualmachine.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/virtualmachine.go
@@ -202,6 +202,29 @@ func (vm *VirtualMachine) IsActive(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
+// Exists checks if VM exists and is not terminated
+func (vm *VirtualMachine) Exists(ctx context.Context) (bool, error) {
+	vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*VirtualMachine{vm}, []string{"summary.runtime.powerState"})
+	if err != nil {
+		glog.Errorf("Failed to get VM Managed object with property summary. err: +%v", err)
+		return false, err
+	}
+	// We check for VMs which are still available in vcenter and has not been terminated/removed from
+	// disk and hence we consider PoweredOn,PoweredOff and Suspended as alive states.
+	aliveStates := []types.VirtualMachinePowerState{
+		types.VirtualMachinePowerStatePoweredOff,
+		types.VirtualMachinePowerStatePoweredOn,
+		types.VirtualMachinePowerStateSuspended,
+	}
+	currentState := vmMoList[0].Summary.Runtime.PowerState
+	for _, state := range aliveStates {
+		if state == currentState {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // GetAllAccessibleDatastores gets the list of accessible Datastores for the given Virtual Machine
 func (vm *VirtualMachine) GetAllAccessibleDatastores(ctx context.Context) ([]*DatastoreInfo, error) {
 	host, err := vm.HostSystem(ctx)

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -726,12 +726,12 @@ func (vs *VSphere) InstanceID(ctx context.Context, nodeName k8stypes.NodeName) (
 			glog.Errorf("Failed to get VM object for node: %q. err: +%v", convertToString(nodeName), err)
 			return "", err
 		}
-		isActive, err := vm.IsActive(ctx)
+		exists, err := vm.Exists(ctx)
 		if err != nil {
-			glog.Errorf("Failed to check whether node %q is active. err: %+v.", convertToString(nodeName), err)
+			glog.Errorf("Failed to check whether node %q still exists. err: %+v.", convertToString(nodeName), err)
 			return "", err
 		}
-		if isActive {
+		if exists {
 			return vs.vmUUID, nil
 		}
 		glog.Warningf("The VM: %s is not in %s state", convertToString(nodeName), vclib.ActivePowerState)


### PR DESCRIPTION
Fixes Kubernetes not detaching volumes from shutdown nodes even after pods that are using the volume has been deleted. Fixes #67900

Related to https://github.com/kubernetes/kubernetes/pull/69691

/sig storage

```release-note
Do not remove shutdown nodes from api-server for vSphere.
Fixes volume detach from shutdown nodes.
```