### PR TITLE
added non-optional and empty key test cases for secret and configMap

### DIFF
--- a/test/e2e/common/projected_configmap.go
+++ b/test/e2e/common/projected_configmap.go
@@ -481,6 +481,26 @@ var _ = Describe("[sig-storage] Projected configMap", func() {
 		})
 
 	})
+
+	//The pod is in pending during volume creation until the configMap objects are available
+	//or until mount the configMap volume times out. There is no configMap object defined for the pod, so it should return timout exception unless it is marked optional.
+	//Slow (~5 mins)
+	It("Should fail non-optional pod creation due to configMap object does not exist [Slow]", func() {
+		volumeMountPath := "/etc/projected-configmap-volumes"
+		podName := "pod-projected-configmaps-" + string(uuid.NewUUID())
+		err := createNonOptionalConfigMapPod(f, volumeMountPath, podName)
+		Expect(err).To(HaveOccurred(), "created pod %q with non-optional configMap in namespace %q", podName, f.Namespace.Name)
+	})
+
+	//ConfigMap object defined for the pod, If a key is specified which is not present in the ConfigMap,
+	// the volume setup will error unless it is marked optional, during the pod creation.
+	//Slow (~5 mins)
+	It("Should fail non-optional pod creation due to the key in the configMap object does not exist [Slow]", func() {
+		volumeMountPath := "/etc/configmap-volumes"
+		podName := "pod-configmaps-" + string(uuid.NewUUID())
+		err := createNonOptionalConfigMapPodWithConfig(f, volumeMountPath, podName)
+		Expect(err).To(HaveOccurred(), "created pod %q with non-optional configMap in namespace %q", podName, f.Namespace.Name)
+	})
 })
 
 func doProjectedConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64, defaultMode *int32) {

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -26,6 +26,7 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("[sig-api-machinery] Secrets", func() {
@@ -124,6 +125,11 @@ var _ = Describe("[sig-api-machinery] Secrets", func() {
 			"p_data_1=value-1", "p_data_2=value-2", "p_data_3=value-3",
 		})
 	})
+
+	It("should fail to create secret in volume due to empty secret key", func() {
+		secret, err := createEmptyKeySecretForTest(f)
+		Expect(err).To(HaveOccurred(), "created secret %q with empty key in namespace %q", secret.Name, f.Namespace.Name)
+	})
 })
 
 func newEnvFromSecret(namespace, name string) *v1.Secret {
@@ -138,4 +144,19 @@ func newEnvFromSecret(namespace, name string) *v1.Secret {
 			"data_3": []byte("value-3\n"),
 		},
 	}
+}
+
+func createEmptyKeySecretForTest(f *framework.Framework) (*v1.Secret, error) {
+	secretName := "secret-emptyKey-test-" + string(uuid.NewUUID())
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: f.Namespace.Name,
+			Name:      secretName,
+		},
+		Data: map[string][]byte{
+			"": []byte("value-1\n"),
+		},
+	}
+	By(fmt.Sprintf("Creating projection with secret that has name %s", secret.Name))
+	return f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(secret)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
While refactoring the e2e tests as part of [#68910 (comment)](https://github.com/kubernetes/kubernetes/pull/68910#discussion_r223863346) , there were a few more test cases identified that can be added for projected volumes:

- non-optional for secrets
- non-optional should fail for secrets when key doesn't exist
- non-optional should fail for configmaps when key doesn't exist

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: 
Fixes [#69911](https://github.com/kubernetes/kubernetes/issues/69911#issue-370872487)

**Special notes for your reviewer**:
   
-  Non-optional update in volume of secret and configMap, with `optional = false`, failed to initiate and start pod in a namespace. 
- Identified empty key secret creation and configMap creation


**Does this PR introduce a user-facing change?**:
no
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2.  If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/area conformance
cc @spiffxp, @msau42 