### PR TITLE
Glusterfs: improve some comments

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -823,9 +823,6 @@ func (p *glusterfsVolumeProvisioner) CreateVolume(gid int) (r *v1.GlusterfsVolum
 	}
 
 	// The 'endpointname' is created in form of 'glusterfs-dynamic-<PVC UID>'.
-	// createEndpointService() checks for this 'endpoint' existence in PVC's namespace and
-	// if not found, it create an endpoint and service using the IPs we dynamically picked at time
-	// of volume creation.
 	epServiceName := dynamicEpSvcPrefix + string(p.options.PVC.UID)
 	epNamespace := p.options.PVC.Namespace
 	endpoint, service, err := p.createEndpointService(epNamespace, epServiceName, dynamicHostIps, p.options.PVC.Name)
@@ -845,6 +842,10 @@ func (p *glusterfsVolumeProvisioner) CreateVolume(gid int) (r *v1.GlusterfsVolum
 	}, sz, volID, nil
 }
 
+// createEndpointService() makes sure an endpoint and service
+// exist for the given namespace, PVC name, endpoint name, and
+// set of IPs. I.e. the endpoint or service is only created
+// if it does not exist yet.
 func (p *glusterfsVolumeProvisioner) createEndpointService(namespace string, epServiceName string, hostips []string, pvcname string) (endpoint *v1.Endpoints, service *v1.Service, err error) {
 
 	addrlist := make([]v1.EndpointAddress, len(hostips))

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -822,7 +822,6 @@ func (p *glusterfsVolumeProvisioner) CreateVolume(gid int) (r *v1.GlusterfsVolum
 		return nil, 0, "", fmt.Errorf("failed to get cluster nodes for volume %s: %v", volume, err)
 	}
 
-	// The 'endpointname' is created in form of 'glusterfs-dynamic-<PVC UID>'.
 	epServiceName := dynamicEpSvcPrefix + string(p.options.PVC.UID)
 	epNamespace := p.options.PVC.Namespace
 	endpoint, service, err := p.createEndpointService(epNamespace, epServiceName, dynamicHostIps, p.options.PVC.Name)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This cleans up some comments in the glusterfs provisioner, moving a comment block to the function it is explaning, rewording, and removing a redundant comment that just repeats what is obvious in the code directly following.

**Special notes for your reviewer**:

This was originally part of PR #68343 which is currently stalled due to #70286. And the discussion in the latter PR triggered me to revive these comment cleanup commits.

**Does this PR introduce a user-facing change?**:

NONE

```release-note
NONE
```