### PR TITLE
fix ContinueOnError visitor

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
@@ -1089,9 +1089,10 @@ func (b *Builder) Do() *Result {
 	if b.requireObject {
 		helpers = append(helpers, RetrieveLazy)
 	}
-	r.visitor = NewDecoratedVisitor(r.visitor, helpers...)
 	if b.continueOnError {
-		r.visitor = ContinueOnErrorVisitor{r.visitor}
+		r.visitor = NewDecoratedVisitor(ContinueOnErrorVisitor{r.visitor}, helpers...)
+	} else {
+		r.visitor = NewDecoratedVisitor(r.visitor, helpers...)
 	}
 	return r
 }


### PR DESCRIPTION
> /kind bug

**Does this PR introduce a user-facing change?**:
```release-note
"kubectl get" no longer exits before printing all of its results if an error is found
```

Based on the [godoc and desired behavior of the ContinueOnError visitor](https://github.com/kubernetes/cli-runtime/blob/1ee5ba10d7e36fbf3115191ef894ed9b4766eedf/pkg/genericclioptions/resource/visitor.go#L326), encountering an error while visiting results should not short-circuit a visitor chain.

This patch replaces existing behavior, which wraps a decorated visitor in a ContinueOnError visitor, with the originally-intended behavior which prevents a DecoratedVisitor list from short-circuiting upon encountering an error.

cc @soltysh @seans3 