### PR TITLE
Revert "limit forbidden error to details of what was forbidden"

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
@@ -73,7 +73,7 @@ func WithAuthorization(handler http.Handler, a authorizer.Authorizer, s runtime.
 		glog.V(4).Infof("Forbidden: %#v, Reason: %q", req.RequestURI, reason)
 		audit.LogAnnotation(ae, decisionAnnotationKey, decisionForbid)
 		audit.LogAnnotation(ae, reasonAnnotationKey, reason)
-		responsewriters.Forbidden(ctx, attributes, w, req, "", s)
+		responsewriters.Forbidden(ctx, attributes, w, req, reason, s)
 	})
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
@@ -110,7 +110,7 @@ func WithImpersonation(handler http.Handler, a authorizer.Authorizer, s runtime.
 			decision, reason, err := a.Authorize(actingAsAttributes)
 			if err != nil || decision != authorizer.DecisionAllow {
 				glog.V(4).Infof("Forbidden: %#v, Reason: %s, Error: %v", req.RequestURI, reason, err)
-				responsewriters.Forbidden(ctx, actingAsAttributes, w, req, "", s)
+				responsewriters.Forbidden(ctx, actingAsAttributes, w, req, reason, s)
 				return
 			}
 		}

--- a/test/integration/master/synthetic_master_test.go
+++ b/test/integration/master/synthetic_master_test.go
@@ -175,7 +175,7 @@ func TestStatus(t *testing.T) {
 			statusCode:   http.StatusForbidden,
 			reqPath:      "/apis",
 			reason:       "Forbidden",
-			message:      `forbidden: User "" cannot get path "/apis"`,
+			message:      `forbidden: User "" cannot get path "/apis": Everything is forbidden.`,
 		},
 		{
 			name:         "401",


### PR DESCRIPTION
Reverts changes from https://github.com/kubernetes/kubernetes/pull/67617.

The main justification for the original change was the confusing "Unknown user" authorizer response returned by the GKE authorizor when an authorize request is made with a non-Google/GCP service account identity. This was leading to [confusion](https://github.com/kubernetes/kubernetes/pull/65906#discussion_r210048853). However one big down side in removing the the authorizer's _reason_ is users never get constructive feedback on how to fix _403 Forbidden_ issues, e.g. "Required permission `container.pods.get`" for the GKE authorizer.

Recently the "Unknown user" error has been removed which should mitigate user confusion once this PR is submitted. At this point I think returning authorizer _reason_s is valuable and should be re-enabled.

/kind design
/assign liggitt

```release-note
NONE
```
