### PR TITLE
Swap cmd_test to cmd package in kubeadm/app/cmd/config_test.go

### DIFF
--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd_test
+package cmd
 
 import (
 	"bytes"
@@ -31,7 +31,6 @@ import (
 	"github.com/spf13/cobra"
 
 	kubeadmapiv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
-	"k8s.io/kubernetes/cmd/kubeadm/app/cmd"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
@@ -52,7 +51,7 @@ const (
 func TestNewCmdConfigImagesList(t *testing.T) {
 	var output bytes.Buffer
 	mockK8sVersion := dummyKubernetesVersion
-	images := cmd.NewCmdConfigImagesList(&output, &mockK8sVersion)
+	images := NewCmdConfigImagesList(&output, &mockK8sVersion)
 	images.Run(nil, nil)
 	actual := strings.Split(output.String(), "\n")
 	if len(actual) != defaultNumberOfImages {
@@ -109,7 +108,7 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 				t.Fatalf("Failed writing a config file: %v", err)
 			}
 
-			i, err := cmd.NewImagesList(configFilePath, &kubeadmapiv1beta1.InitConfiguration{
+			i, err := NewImagesList(configFilePath, &kubeadmapiv1beta1.InitConfiguration{
 				ClusterConfiguration: kubeadmapiv1beta1.ClusterConfiguration{
 					KubernetesVersion: dummyKubernetesVersion,
 				},
@@ -180,7 +179,7 @@ func TestConfigImagesListRunWithoutPath(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			i, err := cmd.NewImagesList("", &tc.cfg)
+			i, err := NewImagesList("", &tc.cfg)
 			if err != nil {
 				t.Fatalf("did not expect an error while creating the Images command: %v", err)
 			}
@@ -226,7 +225,7 @@ func TestImagesPull(t *testing.T) {
 	}
 
 	images := []string{"a", "b", "c", "d", "a"}
-	ip := cmd.NewImagesPull(containerRuntime, images)
+	ip := NewImagesPull(containerRuntime, images)
 
 	err = ip.PullAll()
 	if err != nil {
@@ -249,7 +248,7 @@ func TestMigrate(t *testing.T) {
 	defer cleanup()
 
 	var output bytes.Buffer
-	command := cmd.NewCmdConfigMigrate(&output)
+	command := NewCmdConfigMigrate(&output)
 	if err := command.Flags().Set("old-config", configFile); err != nil {
 		t.Fatalf("failed to set old-config flag")
 	}
@@ -293,7 +292,7 @@ func TestNewCmdConfigPrintActionDefaults(t *testing.T) {
 				constants.ClusterConfigurationKind,
 				constants.InitConfigurationKind,
 			},
-			cmdProc: cmd.NewCmdConfigPrintInitDefaults,
+			cmdProc: NewCmdConfigPrintInitDefaults,
 		},
 		{
 			name: "InitConfiguration: KubeProxyConfiguration",
@@ -303,7 +302,7 @@ func TestNewCmdConfigPrintActionDefaults(t *testing.T) {
 				string(componentconfigs.KubeProxyConfigurationKind),
 			},
 			componentConfigs: "KubeProxyConfiguration",
-			cmdProc:          cmd.NewCmdConfigPrintInitDefaults,
+			cmdProc:          NewCmdConfigPrintInitDefaults,
 		},
 		{
 			name: "InitConfiguration: KubeProxyConfiguration and KubeletConfiguration",
@@ -314,14 +313,14 @@ func TestNewCmdConfigPrintActionDefaults(t *testing.T) {
 				string(componentconfigs.KubeletConfigurationKind),
 			},
 			componentConfigs: "KubeProxyConfiguration,KubeletConfiguration",
-			cmdProc:          cmd.NewCmdConfigPrintInitDefaults,
+			cmdProc:          NewCmdConfigPrintInitDefaults,
 		},
 		{
 			name: "JoinConfiguration: No component configs",
 			expectedKinds: []string{
 				constants.JoinConfigurationKind,
 			},
-			cmdProc: cmd.NewCmdConfigPrintJoinDefaults,
+			cmdProc: NewCmdConfigPrintJoinDefaults,
 		},
 		{
 			name: "JoinConfiguration: KubeProxyConfiguration",
@@ -330,7 +329,7 @@ func TestNewCmdConfigPrintActionDefaults(t *testing.T) {
 				string(componentconfigs.KubeProxyConfigurationKind),
 			},
 			componentConfigs: "KubeProxyConfiguration",
-			cmdProc:          cmd.NewCmdConfigPrintJoinDefaults,
+			cmdProc:          NewCmdConfigPrintJoinDefaults,
 		},
 		{
 			name: "JoinConfiguration: KubeProxyConfiguration and KubeletConfiguration",
@@ -340,7 +339,7 @@ func TestNewCmdConfigPrintActionDefaults(t *testing.T) {
 				string(componentconfigs.KubeletConfigurationKind),
 			},
 			componentConfigs: "KubeProxyConfiguration,KubeletConfiguration",
-			cmdProc:          cmd.NewCmdConfigPrintJoinDefaults,
+			cmdProc:          NewCmdConfigPrintJoinDefaults,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Changes the package used for `config_test.go` to the same package as the file it's testing. This will allow us to test unexported functions in `config.go` and makes this consistent with the usual pattern with unit tests being in the same package.

**Special notes for your reviewer**:
I wasn't 100% sure if there was a legitimate reason for using the `cmd_test` package here instead of `cmd`, but as I was looking at improving some test coverage, this stood out as it was preventing unit testing functions that weren't exported.

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```