### PR TITLE
bazel: bump repo-infra dependency

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -9,9 +9,9 @@ http_archive(
 
 http_archive(
     name = "io_kubernetes_build",
-    sha256 = "66a44fd5f6357268340d66fbd8a502065445a7c022732fe5f6fd84d9a20f75a3",
-    strip_prefix = "repo-infra-e8f2f7c3decf03e1fde9f30d249e39b8328aa8b0",
-    urls = mirror("https://github.com/kubernetes/repo-infra/archive/e8f2f7c3decf03e1fde9f30d249e39b8328aa8b0.tar.gz"),
+    sha256 = "21160531ea8a9a4001610223ad815622bf60671d308988c7057168a495a7e2e8",
+    strip_prefix = "repo-infra-b4bc4f1552c7fc1d4654753ca9b0e5e13883429f",
+    urls = mirror("https://github.com/kubernetes/repo-infra/archive/b4bc4f1552c7fc1d4654753ca9b0e5e13883429f.tar.gz"),
 )
 
 http_archive(


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: updates the kubernetes/repo-infra dependency to include https://github.com/kubernetes/repo-infra/pull/88 which fixes https://github.com/kubernetes/kubernetes/issues/64018, a bug in the fast tar builder implementation.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
/assign @BenTheElder 
cc @randomvariable 