### PR TITLE
Remove return value of mergeHealthChecks. Simplified HC equivalence check

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external.go
@@ -636,7 +636,7 @@ func makeHTTPHealthCheck(name, path string, port int32) *compute.HttpHealthCheck
 // The HC interval will be reconciled to 8 seconds.
 // If the existing health check is larger than the default interval,
 // the configuration will be kept.
-func mergeHTTPHealthChecks(hc, newHC *compute.HttpHealthCheck) *compute.HttpHealthCheck {
+func mergeHTTPHealthChecks(hc, newHC *compute.HttpHealthCheck) {
 	if hc.CheckIntervalSec > newHC.CheckIntervalSec {
 		newHC.CheckIntervalSec = hc.CheckIntervalSec
 	}
@@ -649,16 +649,23 @@ func mergeHTTPHealthChecks(hc, newHC *compute.HttpHealthCheck) *compute.HttpHeal
 	if hc.HealthyThreshold > newHC.HealthyThreshold {
 		newHC.HealthyThreshold = hc.HealthyThreshold
 	}
-	return newHC
 }
 
 // needToUpdateHTTPHealthChecks checks whether the http healthcheck needs to be
 // updated.
 func needToUpdateHTTPHealthChecks(hc, newHC *compute.HttpHealthCheck) bool {
-	changed := hc.Port != newHC.Port || hc.RequestPath != newHC.RequestPath || hc.Description != newHC.Description
-	changed = changed || hc.CheckIntervalSec < newHC.CheckIntervalSec || hc.TimeoutSec < newHC.TimeoutSec
-	changed = changed || hc.UnhealthyThreshold < newHC.UnhealthyThreshold || hc.HealthyThreshold < newHC.HealthyThreshold
-	return changed
+	switch {
+	case
+		hc.Port != newHC.Port,
+		hc.RequestPath != newHC.RequestPath,
+		hc.Description != newHC.Description,
+		hc.CheckIntervalSec < newHC.CheckIntervalSec,
+		hc.TimeoutSec < newHC.TimeoutSec,
+		hc.UnhealthyThreshold < newHC.UnhealthyThreshold,
+		hc.HealthyThreshold < newHC.HealthyThreshold:
+		return true
+	}
+	return false
 }
 
 func (g *Cloud) ensureHTTPHealthCheck(name, path string, port int32) (hc *compute.HttpHealthCheck, err error) {
@@ -681,7 +688,7 @@ func (g *Cloud) ensureHTTPHealthCheck(name, path string, port int32) (hc *comput
 	klog.V(4).Infof("Checking http health check params %s", name)
 	if needToUpdateHTTPHealthChecks(hc, newHC) {
 		klog.Warningf("Health check %v exists but parameters have drifted - updating...", name)
-		newHC = mergeHTTPHealthChecks(hc, newHC)
+		mergeHTTPHealthChecks(hc, newHC)
 		if err := g.UpdateHTTPHealthCheck(newHC); err != nil {
 			klog.Warningf("Failed to reconcile http health check %v parameters", name)
 			return nil, err

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
@@ -420,7 +420,7 @@ func (g *Cloud) ensureInternalHealthCheck(name string, svcName types.NamespacedN
 
 	if needToUpdateHealthChecks(hc, expectedHC) {
 		klog.V(2).Infof("ensureInternalHealthCheck: health check %v exists but parameters have drifted - updating...", name)
-		expectedHC = mergeHealthChecks(hc, expectedHC)
+		mergeHealthChecks(hc, expectedHC)
 		if err := g.UpdateHealthCheck(expectedHC); err != nil {
 			klog.Warningf("Failed to reconcile http health check %v parameters", name)
 			return nil, err
@@ -642,7 +642,7 @@ func firewallRuleEqual(a, b *compute.Firewall) bool {
 // The HC interval will be reconciled to 8 seconds.
 // If the existing health check is larger than the default interval,
 // the configuration will be kept.
-func mergeHealthChecks(hc, newHC *compute.HealthCheck) *compute.HealthCheck {
+func mergeHealthChecks(hc, newHC *compute.HealthCheck) {
 	if hc.CheckIntervalSec > newHC.CheckIntervalSec {
 		newHC.CheckIntervalSec = hc.CheckIntervalSec
 	}
@@ -655,18 +655,24 @@ func mergeHealthChecks(hc, newHC *compute.HealthCheck) *compute.HealthCheck {
 	if hc.HealthyThreshold > newHC.HealthyThreshold {
 		newHC.HealthyThreshold = hc.HealthyThreshold
 	}
-	return newHC
 }
 
 // needToUpdateHealthChecks checks whether the healthcheck needs to be updated.
 func needToUpdateHealthChecks(hc, newHC *compute.HealthCheck) bool {
-	if hc.HttpHealthCheck == nil || newHC.HttpHealthCheck == nil {
+	switch {
+	case
+		hc.HttpHealthCheck == nil,
+		newHC.HttpHealthCheck == nil,
+		hc.HttpHealthCheck.Port != newHC.HttpHealthCheck.Port,
+		hc.HttpHealthCheck.RequestPath != newHC.HttpHealthCheck.RequestPath,
+		hc.Description != newHC.Description,
+		hc.CheckIntervalSec < newHC.CheckIntervalSec,
+		hc.TimeoutSec < newHC.TimeoutSec,
+		hc.UnhealthyThreshold < newHC.UnhealthyThreshold,
+		hc.HealthyThreshold < newHC.HealthyThreshold:
 		return true
 	}
-	changed := hc.HttpHealthCheck.Port != newHC.HttpHealthCheck.Port || hc.HttpHealthCheck.RequestPath != newHC.HttpHealthCheck.RequestPath || hc.Description != newHC.Description
-	changed = changed || hc.CheckIntervalSec < newHC.CheckIntervalSec || hc.TimeoutSec < newHC.TimeoutSec
-	changed = changed || hc.UnhealthyThreshold < newHC.UnhealthyThreshold || hc.HealthyThreshold < newHC.HealthyThreshold
-	return changed
+	return false
 }
 
 // backendsListEqual asserts that backend lists are equal by instance group link only


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/sig network

**What this PR does / why we need it**:
A function should not change its parameter and return the same object. 
Use switch/case to make healthcheck equivalence check easier to read and maintain.
See comment in https://github.com/kubernetes/kubernetes/pull/70301

**Special notes for your reviewer**:
/assign @bowei 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
