### PR TITLE
Add myself as reviewer to test/conformance/OWNERS

### DIFF
--- a/test/conformance/OWNERS
+++ b/test/conformance/OWNERS
@@ -2,6 +2,7 @@
 reviewers:
   - mml
   - cheftako
+  - spiffxp
 approvers:
   - mml
   - cheftako


### PR DESCRIPTION
I'd like to start fielding more reviews of this code since I'm actively
involved in efforts that are consumers of it

```release-note
NONE
```