### PR TITLE
client-go/tools/watch/until: Drop early 'Until' reference from godocs

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/until.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until.go
@@ -52,8 +52,7 @@ var ErrWatchClosed = errors.New("watch closed before UntilWithoutRetry timeout")
 //
 // Warning: Unless you have a very specific use case (probably a special Watcher) don't use this function!!!
 // Warning: This will fail e.g. on API timeouts and/or 'too old resource version' error.
-// Warning: You are most probably looking for a function *Until* or *UntilWithSync* below,
-// Warning: solving such issues.
+// Warning: You are most probably looking for *UntilWithSync*, solving such issues.
 // TODO: Consider making this function private to prevent misuse when the other occurrences in our codebase are gone.
 func UntilWithoutRetry(ctx context.Context, watcher watch.Interface, conditions ...ConditionFunc) (*watch.Event, error) {
 	ch := watcher.ResultChan()


### PR DESCRIPTION
3d4a02ab (#66906) performed the rename it claimed, after which there was no longer an `Until` function in this package.  3d4a02ab had been spun out of #50102, which is still in flight with [an improved `Until`][2].  But until that lands, don't reference it in the godocs ;).

[edit: updated now that I realize the docs weren't referencing `wait.Util`]

```release-note
NONE
```

CC @tnozicka, @liggitt

[2]: https://github.com/kubernetes/kubernetes/commit/a241de76e9149d67b2566aa973fae3790a63efb2#diff-b7ca7f71d0c92e184f946e29d5734a4eR96