### PR TITLE
s/ORed/ANDed/ nodeSelectorTerms matchExpressions

### DIFF
--- a/pkg/apis/core/v1/helper/helpers_test.go
+++ b/pkg/apis/core/v1/helper/helpers_test.go
@@ -773,6 +773,34 @@ func TestMatchNodeSelectorTerms(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "multi-selector was set, both node fields and labels (mismatched)",
+			args: args{
+				nodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{{
+							Key:      "label_1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"label_1_val"},
+						}},
+					},
+					{
+						MatchFields: []v1.NodeSelectorRequirement{{
+							Key:      "metadata.name",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"host_1"},
+						}},
+					},
+				},
+				nodeLabels: map[string]string{
+					"label_1": "label_1_val",
+				},
+				nodeFields: map[string]string{
+					"metadata.name": "host_1",
+				},
+			},
+			want: true,
+		},
+		{
 			name: "multi-selector was set, both node fields and labels (one mismatched)",
 			args: args{
 				nodeSelectorTerms: []v1.NodeSelectorTerm{
@@ -798,14 +826,14 @@ func TestMatchNodeSelectorTerms(t *testing.T) {
 					"metadata.name": "host_1",
 				},
 			},
-			want: true,
+			want: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := MatchNodeSelectorTerms(tt.args.nodeSelectorTerms, tt.args.nodeLabels, tt.args.nodeFields); got != tt.want {
-				t.Errorf("MatchNodeSelectorTermsORed() = %v, want %v", got, tt.want)
+				t.Errorf("MatchNodeSelectorTermsANDed() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -793,7 +793,7 @@ func PodFitsResources(pod *v1.Pod, meta algorithm.PredicateMetadata, nodeInfo *s
 }
 
 // nodeMatchesNodeSelectorTerms checks if a node's labels satisfy a list of node selector terms,
-// terms are ORed, and an empty list of terms will match nothing.
+// terms are ANDed, and an empty list of terms will match nothing.
 func nodeMatchesNodeSelectorTerms(node *v1.Node, nodeSelectorTerms []v1.NodeSelectorTerm) bool {
 	nodeFields := map[string]string{}
 	for k, f := range algorithm.NodeFieldSelectorKeys {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Documentation for [nodeAffinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) says:
>If you specify multiple `matchExpressions` associated with `nodeSelectorTerms`, then the pod can be scheduled onto a node **only if all** matchExpressions can be satisfied.

But when I tried specify two `nodeSelectorTerms` it actually used `OR` instead of `AND`, so I could not leverage multiple labels to precisely target pods to specific group of hosts:

```
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                - key: node-role.kubernetes.io/role
                  operator: In
                  values:
                   - app
               - matchExpressions:
                 - key: node-role.kubernetes.io/environment
                   operator: In
                   values:
                     - perf
```


**Which issue(s) this PR fixes**:
Fixes #52141 . The issue closed but the problem exists.


**Does this PR introduce a user-facing change?**:
NONE