### PR TITLE
patch webhook authenticator to support token review with audiences

### DIFF
--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -166,7 +166,7 @@ func (config AuthenticatorConfig) New() (authenticator.Request, *spec.SecurityDe
 		tokenAuthenticators = append(tokenAuthenticators, oidcAuth)
 	}
 	if len(config.WebhookTokenAuthnConfigFile) > 0 {
-		webhookTokenAuth, err := newWebhookTokenAuthenticator(config.WebhookTokenAuthnConfigFile, config.WebhookTokenAuthnCacheTTL)
+		webhookTokenAuth, err := newWebhookTokenAuthenticator(config.WebhookTokenAuthnConfigFile, config.WebhookTokenAuthnCacheTTL, config.APIAudiences)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -315,8 +315,8 @@ func newAuthenticatorFromClientCAFile(clientCAFile string) (authenticator.Reques
 	return x509.New(opts, x509.CommonNameUserConversion), nil
 }
 
-func newWebhookTokenAuthenticator(webhookConfigFile string, ttl time.Duration) (authenticator.Token, error) {
-	webhookTokenAuthenticator, err := webhook.New(webhookConfigFile)
+func newWebhookTokenAuthenticator(webhookConfigFile string, ttl time.Duration, implicitAuds authenticator.Audiences) (authenticator.Token, error) {
+	webhookTokenAuthenticator, err := webhook.New(webhookConfigFile, implicitAuds)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/delegating.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/delegating.go
@@ -51,6 +51,8 @@ type DelegatingAuthenticatorConfig struct {
 	// ClientCAFile is the CA bundle file used to authenticate client certificates
 	ClientCAFile string
 
+	APIAudiences authenticator.Audiences
+
 	RequestHeaderConfig *RequestHeaderConfig
 }
 
@@ -86,7 +88,7 @@ func (c DelegatingAuthenticatorConfig) New() (authenticator.Request, *spec.Secur
 	}
 
 	if c.TokenAccessReviewClient != nil {
-		tokenAuth, err := webhooktoken.NewFromInterface(c.TokenAccessReviewClient)
+		tokenAuth, err := webhooktoken.NewFromInterface(c.TokenAccessReviewClient, c.APIAudiences)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -114,6 +114,8 @@ type DelegatingAuthenticationOptions struct {
 	// CacheTTL is the length of time that a token authentication answer will be cached.
 	CacheTTL time.Duration
 
+	APIAudiences []string
+
 	ClientCert    ClientCertAuthenticationOptions
 	RequestHeader RequestHeaderAuthenticationOptions
 
@@ -147,6 +149,10 @@ func (s *DelegatingAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 	if s.RemoteKubeConfigFileOptional {
 		optionalKubeConfigSentence = " This is optional. If empty, all token requests are considered to be anonymous and no client CA is looked up in the cluster."
 	}
+	fs.StringSliceVar(&s.APIAudiences, "api-audiences", s.APIAudiences, ""+
+		"Identifiers of the API. Authenticators will validate that tokens used "+
+		"against the API are bound to at least one of these audiences.")
+
 	fs.StringVar(&s.RemoteKubeConfigFile, "authentication-kubeconfig", s.RemoteKubeConfigFile, ""+
 		"kubeconfig file pointing at the 'core' kubernetes server with enough rights to create "+
 		"tokenaccessreviews.authentication.k8s.io."+optionalKubeConfigSentence)
@@ -169,8 +175,9 @@ func (s *DelegatingAuthenticationOptions) ApplyTo(c *server.AuthenticationInfo, 
 	}
 
 	cfg := authenticatorfactory.DelegatingAuthenticatorConfig{
-		Anonymous: true,
-		CacheTTL:  s.CacheTTL,
+		Anonymous:    true,
+		CacheTTL:     s.CacheTTL,
+		APIAudiences: s.APIAudiences,
 	}
 
 	client, err := s.getClient()

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_test.go
@@ -39,6 +39,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api/v1"
 )
 
+var apiAuds = authenticator.Audiences{"api"}
+
 // Service mocks a remote authentication service.
 type Service interface {
 	// Review looks at the TokenReviewSpec and provides an authentication
@@ -168,7 +170,7 @@ func (m *mockService) HTTPStatusCode() int { return m.statusCode }
 
 // newTokenAuthenticator creates a temporary kubeconfig file from the provided
 // arguments and attempts to load a new WebhookTokenAuthenticator from it.
-func newTokenAuthenticator(serverURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration) (authenticator.Token, error) {
+func newTokenAuthenticator(serverURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, implicitAuds authenticator.Audiences) (authenticator.Token, error) {
 	tempfile, err := ioutil.TempFile("", "")
 	if err != nil {
 		return nil, err
@@ -196,7 +198,7 @@ func newTokenAuthenticator(serverURL string, clientCert, clientKey, ca []byte, c
 		return nil, err
 	}
 
-	authn, err := newWithBackoff(c, 0)
+	authn, err := newWithBackoff(c, 0, implicitAuds)
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +259,7 @@ func TestTLSConfig(t *testing.T) {
 			}
 			defer server.Close()
 
-			wh, err := newTokenAuthenticator(server.URL, tt.clientCert, tt.clientKey, tt.clientCA, 0)
+			wh, err := newTokenAuthenticator(server.URL, tt.clientCert, tt.clientKey, tt.clientCA, 0, nil)
 			if err != nil {
 				t.Errorf("%s: failed to create client: %v", tt.test, err)
 				return
@@ -312,20 +314,17 @@ func TestWebhookTokenAuthenticator(t *testing.T) {
 	}
 	defer s.Close()
 
-	wh, err := newTokenAuthenticator(s.URL, clientCert, clientKey, caCert, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	expTypeMeta := metav1.TypeMeta{
 		APIVersion: "authentication.k8s.io/v1beta1",
 		Kind:       "TokenReview",
 	}
 
 	tests := []struct {
+		implicitAuds, reqAuds authenticator.Audiences
 		serverResponse        v1beta1.TokenReviewStatus
 		expectedAuthenticated bool
 		expectedUser          *user.DefaultInfo
+		expectedAuds          authenticator.Audiences
 	}{
 		// Successful response should pass through all user info.
 		{
@@ -378,31 +377,98 @@ func TestWebhookTokenAuthenticator(t *testing.T) {
 			expectedAuthenticated: false,
 			expectedUser:          nil,
 		},
+		// good audience
+		{
+			implicitAuds: apiAuds,
+			reqAuds:      apiAuds,
+			serverResponse: v1beta1.TokenReviewStatus{
+				Authenticated: true,
+				User: v1beta1.UserInfo{
+					Username: "somebody",
+				},
+			},
+			expectedAuthenticated: true,
+			expectedUser: &user.DefaultInfo{
+				Name: "somebody",
+			},
+			expectedAuds: apiAuds,
+		},
+		{
+			implicitAuds: append(apiAuds, "other"),
+			reqAuds:      apiAuds,
+			serverResponse: v1beta1.TokenReviewStatus{
+				Authenticated: true,
+				User: v1beta1.UserInfo{
+					Username: "somebody",
+				},
+			},
+			expectedAuthenticated: true,
+			expectedUser: &user.DefaultInfo{
+				Name: "somebody",
+			},
+			expectedAuds: apiAuds,
+		},
+		// bad audiences
+		{
+			implicitAuds: apiAuds,
+			reqAuds:      authenticator.Audiences{"other"},
+			serverResponse: v1beta1.TokenReviewStatus{
+				Authenticated: false,
+			},
+			expectedAuthenticated: false,
+		},
+		{
+			implicitAuds: apiAuds,
+			reqAuds:      authenticator.Audiences{"other"},
+			// webhook authenticator hasn't been upgraded to support audience.
+			serverResponse: v1beta1.TokenReviewStatus{
+				Authenticated: true,
+				User: v1beta1.UserInfo{
+					Username: "somebody",
+				},
+			},
+			expectedAuthenticated: false,
+		},
 	}
 	token := "my-s3cr3t-t0ken"
 	for i, tt := range tests {
-		serv.response = tt.serverResponse
-		resp, authenticated, err := wh.AuthenticateToken(context.Background(), token)
-		if err != nil {
-			t.Errorf("case %d: authentication failed: %v", i, err)
-			continue
-		}
-		if serv.lastRequest.Spec.Token != token {
-			t.Errorf("case %d: Server did not see correct token. Got %q, expected %q.",
-				i, serv.lastRequest.Spec.Token, token)
-		}
-		if !reflect.DeepEqual(serv.lastRequest.TypeMeta, expTypeMeta) {
-			t.Errorf("case %d: Server did not see correct TypeMeta. Got %v, expected %v",
-				i, serv.lastRequest.TypeMeta, expTypeMeta)
-		}
-		if authenticated != tt.expectedAuthenticated {
-			t.Errorf("case %d: Plugin returned incorrect authentication response. Got %t, expected %t.",
-				i, authenticated, tt.expectedAuthenticated)
-		}
-		if resp != nil && tt.expectedUser != nil && !reflect.DeepEqual(resp.User, tt.expectedUser) {
-			t.Errorf("case %d: Plugin returned incorrect user. Got %#v, expected %#v",
-				i, resp.User, tt.expectedUser)
-		}
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			wh, err := newTokenAuthenticator(s.URL, clientCert, clientKey, caCert, 0, tt.implicitAuds)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := context.Background()
+			if tt.reqAuds != nil {
+				ctx = authenticator.WithAudiences(ctx, tt.reqAuds)
+			}
+
+			serv.response = tt.serverResponse
+			resp, authenticated, err := wh.AuthenticateToken(ctx, token)
+			if err != nil {
+				t.Fatalf("authentication failed: %v", err)
+			}
+			if serv.lastRequest.Spec.Token != token {
+				t.Errorf("Server did not see correct token. Got %q, expected %q.",
+					serv.lastRequest.Spec.Token, token)
+			}
+			if !reflect.DeepEqual(serv.lastRequest.TypeMeta, expTypeMeta) {
+				t.Errorf("Server did not see correct TypeMeta. Got %v, expected %v",
+					serv.lastRequest.TypeMeta, expTypeMeta)
+			}
+			if authenticated != tt.expectedAuthenticated {
+				t.Errorf("Plugin returned incorrect authentication response. Got %t, expected %t.",
+					authenticated, tt.expectedAuthenticated)
+			}
+			if resp != nil && tt.expectedUser != nil && !reflect.DeepEqual(resp.User, tt.expectedUser) {
+				t.Errorf("Plugin returned incorrect user. Got %#v, expected %#v",
+					resp.User, tt.expectedUser)
+			}
+			if resp != nil && tt.expectedAuds != nil && !reflect.DeepEqual(resp.Audiences, tt.expectedAuds) {
+				t.Errorf("Plugin returned incorrect audiences. Got %#v, expected %#v",
+					resp.Audiences, tt.expectedAuds)
+			}
+		})
 	}
 }
 
@@ -440,7 +506,7 @@ func TestWebhookCacheAndRetry(t *testing.T) {
 	defer s.Close()
 
 	// Create an authenticator that caches successful responses "forever" (100 days).
-	wh, err := newTokenAuthenticator(s.URL, clientCert, clientKey, caCert, 2400*time.Hour)
+	wh, err := newTokenAuthenticator(s.URL, clientCert, clientKey, caCert, 2400*time.Hour, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -85,7 +85,7 @@ func getTestWebhookTokenAuth(serverURL string) (authenticator.Request, error) {
 	if err := json.NewEncoder(kubecfgFile).Encode(config); err != nil {
 		return nil, err
 	}
-	webhookTokenAuth, err := webhook.New(kubecfgFile.Name())
+	webhookTokenAuth, err := webhook.New(kubecfgFile.Name(), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Incomplete changes we need to make as part of https://github.com/kubernetes/kubernetes/issues/69893 . The rest of the changes are blocked on adding Audiences fields to TokenReview.

/kind feature

@kubernetes/sig-auth-pr-reviews 

```release-note
NONE
```
