### PR TITLE
Fix golint error for `pkg/volume/util/resize_util.go`

### DIFF
--- a/pkg/volume/util/resize_util.go
+++ b/pkg/volume/util/resize_util.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	knownResizeConditions map[v1.PersistentVolumeClaimConditionType]bool = map[v1.PersistentVolumeClaimConditionType]bool{
+	knownResizeConditions = map[v1.PersistentVolumeClaimConditionType]bool{
 		v1.PersistentVolumeClaimFileSystemResizePending: true,
 		v1.PersistentVolumeClaimResizing:                true,
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Followup of #68491

```
pkg/volume/util/resize_util.go:30:24: should omit type map[v1.PersistentVolumeClaimConditionType]bool from declaration of var knownResizeConditions; it will be inferred from the right-hand side
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

This actually breaks the golint verify test. I'm not sure why CI passes on the master branch.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```