### PR TITLE
Use versioned loopbacke connection in master endpoint reconciliation

### DIFF
--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -50,7 +50,6 @@ go_library(
         "//pkg/registry/batch/rest:go_default_library",
         "//pkg/registry/certificates/rest:go_default_library",
         "//pkg/registry/coordination/rest:go_default_library",
-        "//pkg/registry/core/endpoint/storage:go_default_library",
         "//pkg/registry/core/rangeallocation:go_default_library",
         "//pkg/registry/core/rest:go_default_library",
         "//pkg/registry/core/service/ipallocator:go_default_library",

--- a/pkg/master/client_ca_hook.go
+++ b/pkg/master/client_ca_hook.go
@@ -69,7 +69,7 @@ func (h ClientCARegistrationHook) PostStartHook(hookContext genericapiserver.Pos
 // tryToWriteClientCAs is here for unit testing with a fake client.  This is a wait.ConditionFunc so the bool
 // indicates if the condition was met.  True when its finished, false when it should retry.
 func (h ClientCARegistrationHook) tryToWriteClientCAs(client coreclient.CoreInterface) (bool, error) {
-	if err := createNamespaceIfNeeded(client, metav1.NamespaceSystem); err != nil {
+	if err := createNamespaceIfNeededWithInternalClient(client, metav1.NamespaceSystem); err != nil {
 		utilruntime.HandleError(err)
 		return false, nil
 	}

--- a/pkg/master/controller_test.go
+++ b/pkg/master/controller_test.go
@@ -21,11 +21,11 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 	"k8s.io/kubernetes/pkg/master/reconcilers"
 )
 
@@ -38,23 +38,23 @@ func TestReconcileEndpoints(t *testing.T) {
 		testName          string
 		serviceName       string
 		ip                string
-		endpointPorts     []api.EndpointPort
+		endpointPorts     []corev1.EndpointPort
 		additionalMasters int
-		endpoints         *api.EndpointsList
-		expectUpdate      *api.Endpoints // nil means none expected
-		expectCreate      *api.Endpoints // nil means none expected
+		endpoints         *corev1.EndpointsList
+		expectUpdate      *corev1.Endpoints // nil means none expected
+		expectCreate      *corev1.Endpoints // nil means none expected
 	}{
 		{
 			testName:      "no existing endpoints",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			endpoints:     nil,
-			expectCreate: &api.Endpoints{
+			expectCreate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -62,13 +62,13 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:      "existing endpoints satisfy",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
@@ -77,21 +77,21 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:      "existing endpoints satisfy but too many",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}, {IP: "4.3.2.1"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}, {IP: "4.3.2.1"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -99,33 +99,33 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:          "existing endpoints satisfy but too many + extra masters",
 			serviceName:       "foo",
 			ip:                "1.2.3.4",
-			endpointPorts:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			additionalMasters: 3,
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{
 							{IP: "1.2.3.4"},
 							{IP: "4.3.2.1"},
 							{IP: "4.3.2.2"},
 							{IP: "4.3.2.3"},
 							{IP: "4.3.2.4"},
 						},
-						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{
 						{IP: "1.2.3.4"},
 						{IP: "4.3.2.2"},
 						{IP: "4.3.2.3"},
 						{IP: "4.3.2.4"},
 					},
-					Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -133,33 +133,33 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:          "existing endpoints satisfy but too many + extra masters + delete first",
 			serviceName:       "foo",
 			ip:                "4.3.2.4",
-			endpointPorts:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			additionalMasters: 3,
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{
 							{IP: "1.2.3.4"},
 							{IP: "4.3.2.1"},
 							{IP: "4.3.2.2"},
 							{IP: "4.3.2.3"},
 							{IP: "4.3.2.4"},
 						},
-						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{
 						{IP: "4.3.2.1"},
 						{IP: "4.3.2.2"},
 						{IP: "4.3.2.3"},
 						{IP: "4.3.2.4"},
 					},
-					Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -167,17 +167,17 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:          "existing endpoints satisfy and endpoint addresses length less than master count",
 			serviceName:       "foo",
 			ip:                "4.3.2.2",
-			endpointPorts:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			additionalMasters: 3,
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{
 							{IP: "4.3.2.1"},
 							{IP: "4.3.2.2"},
 						},
-						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
@@ -187,27 +187,27 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:          "existing endpoints current IP missing and address length less than master count",
 			serviceName:       "foo",
 			ip:                "4.3.2.2",
-			endpointPorts:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			additionalMasters: 3,
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{
 							{IP: "4.3.2.1"},
 						},
-						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{
 						{IP: "4.3.2.1"},
 						{IP: "4.3.2.2"},
 					},
-					Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -215,21 +215,21 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:      "existing endpoints wrong name",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("bar"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectCreate: &api.Endpoints{
+			expectCreate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -237,21 +237,21 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:      "existing endpoints wrong IP",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "4.3.2.1"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "4.3.2.1"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -259,21 +259,21 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:      "existing endpoints wrong port",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 9090, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 9090, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -281,21 +281,21 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:      "existing endpoints wrong protocol",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "UDP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "UDP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -303,21 +303,21 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:      "existing endpoints wrong port name",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -325,17 +325,17 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:    "existing endpoints extra service ports satisfy",
 			serviceName: "foo",
 			ip:          "1.2.3.4",
-			endpointPorts: []api.EndpointPort{
+			endpointPorts: []corev1.EndpointPort{
 				{Name: "foo", Port: 8080, Protocol: "TCP"},
 				{Name: "bar", Port: 1000, Protocol: "TCP"},
 				{Name: "baz", Port: 1010, Protocol: "TCP"},
 			},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports: []api.EndpointPort{
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports: []corev1.EndpointPort{
 							{Name: "foo", Port: 8080, Protocol: "TCP"},
 							{Name: "bar", Port: 1000, Protocol: "TCP"},
 							{Name: "baz", Port: 1010, Protocol: "TCP"},
@@ -348,24 +348,24 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:    "existing endpoints extra service ports missing port",
 			serviceName: "foo",
 			ip:          "1.2.3.4",
-			endpointPorts: []api.EndpointPort{
+			endpointPorts: []corev1.EndpointPort{
 				{Name: "foo", Port: 8080, Protocol: "TCP"},
 				{Name: "bar", Port: 1000, Protocol: "TCP"},
 			},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports: []api.EndpointPort{
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports: []corev1.EndpointPort{
 						{Name: "foo", Port: 8080, Protocol: "TCP"},
 						{Name: "bar", Port: 1000, Protocol: "TCP"},
 					},
@@ -376,13 +376,13 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:      "no existing sctp endpoints",
 			serviceName:   "boo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "boo", Port: 7777, Protocol: "SCTP"}},
+			endpointPorts: []corev1.EndpointPort{{Name: "boo", Port: 7777, Protocol: "SCTP"}},
 			endpoints:     nil,
-			expectCreate: &api.Endpoints{
+			expectCreate: &corev1.Endpoints{
 				ObjectMeta: om("boo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "boo", Port: 7777, Protocol: "SCTP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "boo", Port: 7777, Protocol: "SCTP"}},
 				}},
 			},
 		},
@@ -440,26 +440,26 @@ func TestReconcileEndpoints(t *testing.T) {
 		testName          string
 		serviceName       string
 		ip                string
-		endpointPorts     []api.EndpointPort
+		endpointPorts     []corev1.EndpointPort
 		additionalMasters int
-		endpoints         *api.EndpointsList
-		expectUpdate      *api.Endpoints // nil means none expected
-		expectCreate      *api.Endpoints // nil means none expected
+		endpoints         *corev1.EndpointsList
+		expectUpdate      *corev1.Endpoints // nil means none expected
+		expectCreate      *corev1.Endpoints // nil means none expected
 	}{
 		{
 			testName:    "existing endpoints extra service ports missing port no update",
 			serviceName: "foo",
 			ip:          "1.2.3.4",
-			endpointPorts: []api.EndpointPort{
+			endpointPorts: []corev1.EndpointPort{
 				{Name: "foo", Port: 8080, Protocol: "TCP"},
 				{Name: "bar", Port: 1000, Protocol: "TCP"},
 			},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
@@ -469,24 +469,24 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:    "existing endpoints extra service ports, wrong ports, wrong IP",
 			serviceName: "foo",
 			ip:          "1.2.3.4",
-			endpointPorts: []api.EndpointPort{
+			endpointPorts: []corev1.EndpointPort{
 				{Name: "foo", Port: 8080, Protocol: "TCP"},
 				{Name: "bar", Port: 1000, Protocol: "TCP"},
 			},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "4.3.2.1"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "4.3.2.1"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -494,13 +494,13 @@ func TestReconcileEndpoints(t *testing.T) {
 			testName:      "no existing endpoints",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			endpoints:     nil,
-			expectCreate: &api.Endpoints{
+			expectCreate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -565,27 +565,27 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 	create_tests := []struct {
 		testName     string
 		serviceName  string
-		servicePorts []api.ServicePort
-		serviceType  api.ServiceType
-		expectCreate *api.Service // nil means none expected
+		servicePorts []corev1.ServicePort
+		serviceType  corev1.ServiceType
+		expectCreate *corev1.Service // nil means none expected
 	}{
 		{
 			testName:    "service does not exist",
 			serviceName: "foo",
-			servicePorts: []api.ServicePort{
+			servicePorts: []corev1.ServicePort{
 				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 			},
-			serviceType: api.ServiceTypeClusterIP,
-			expectCreate: &api.Service{
+			serviceType: corev1.ServiceTypeClusterIP,
+			expectCreate: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
 		},
@@ -606,7 +606,7 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 				t.Errorf("case %q: unexpected creations: %v", test.testName, creates)
 			} else {
 				obj := creates[0].GetObject()
-				if e, a := test.expectCreate.Spec, obj.(*api.Service).Spec; !reflect.DeepEqual(e, a) {
+				if e, a := test.expectCreate.Spec, obj.(*corev1.Service).Spec; !reflect.DeepEqual(e, a) {
 					t.Errorf("case %q: expected create:\n%#v\ngot:\n%#v\n", test.testName, e, a)
 				}
 			}
@@ -619,254 +619,254 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 	reconcile_tests := []struct {
 		testName     string
 		serviceName  string
-		servicePorts []api.ServicePort
-		serviceType  api.ServiceType
-		service      *api.Service
-		expectUpdate *api.Service // nil means none expected
+		servicePorts []corev1.ServicePort
+		serviceType  corev1.ServiceType
+		service      *corev1.Service
+		expectUpdate *corev1.Service // nil means none expected
 	}{
 		{
 			testName:    "service definition wrong port",
 			serviceName: "foo",
-			servicePorts: []api.ServicePort{
+			servicePorts: []corev1.ServicePort{
 				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
+			serviceType: corev1.ServiceTypeClusterIP,
+			service: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8000, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
-			expectUpdate: &api.Service{
+			expectUpdate: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
 		},
 		{
 			testName:    "service definition missing port",
 			serviceName: "foo",
-			servicePorts: []api.ServicePort{
+			servicePorts: []corev1.ServicePort{
 				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 				{Name: "baz", Port: 1000, Protocol: "TCP", TargetPort: intstr.FromInt(1000)},
 			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
+			serviceType: corev1.ServiceTypeClusterIP,
+			service: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
-			expectUpdate: &api.Service{
+			expectUpdate: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 						{Name: "baz", Port: 1000, Protocol: "TCP", TargetPort: intstr.FromInt(1000)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
 		},
 		{
 			testName:    "service definition incorrect port",
 			serviceName: "foo",
-			servicePorts: []api.ServicePort{
+			servicePorts: []corev1.ServicePort{
 				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
+			serviceType: corev1.ServiceTypeClusterIP,
+			service: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "bar", Port: 1000, Protocol: "UDP", TargetPort: intstr.FromInt(1000)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
-			expectUpdate: &api.Service{
+			expectUpdate: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
 		},
 		{
 			testName:    "service definition incorrect port name",
 			serviceName: "foo",
-			servicePorts: []api.ServicePort{
+			servicePorts: []corev1.ServicePort{
 				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
+			serviceType: corev1.ServiceTypeClusterIP,
+			service: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 1000, Protocol: "UDP", TargetPort: intstr.FromInt(1000)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
-			expectUpdate: &api.Service{
+			expectUpdate: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
 		},
 		{
 			testName:    "service definition incorrect target port",
 			serviceName: "foo",
-			servicePorts: []api.ServicePort{
+			servicePorts: []corev1.ServicePort{
 				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
+			serviceType: corev1.ServiceTypeClusterIP,
+			service: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(1000)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
-			expectUpdate: &api.Service{
+			expectUpdate: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
 		},
 		{
 			testName:    "service definition incorrect protocol",
 			serviceName: "foo",
-			servicePorts: []api.ServicePort{
+			servicePorts: []corev1.ServicePort{
 				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
+			serviceType: corev1.ServiceTypeClusterIP,
+			service: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "UDP", TargetPort: intstr.FromInt(8080)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
-			expectUpdate: &api.Service{
+			expectUpdate: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
 		},
 		{
 			testName:    "service definition has incorrect type",
 			serviceName: "foo",
-			servicePorts: []api.ServicePort{
+			servicePorts: []corev1.ServicePort{
 				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
+			serviceType: corev1.ServiceTypeClusterIP,
+			service: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeNodePort,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeNodePort,
 				},
 			},
-			expectUpdate: &api.Service{
+			expectUpdate: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
 		},
 		{
 			testName:    "service definition satisfies",
 			serviceName: "foo",
-			servicePorts: []api.ServicePort{
+			servicePorts: []corev1.ServicePort{
 				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
+			serviceType: corev1.ServiceTypeClusterIP,
+			service: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
 			expectUpdate: nil,
@@ -891,7 +891,7 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 				t.Errorf("case %q: unexpected updates: %v", test.testName, updates)
 			} else {
 				obj := updates[0].GetObject()
-				if e, a := test.expectUpdate.Spec, obj.(*api.Service).Spec; !reflect.DeepEqual(e, a) {
+				if e, a := test.expectUpdate.Spec, obj.(*corev1.Service).Spec; !reflect.DeepEqual(e, a) {
 					t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
 				}
 			}
@@ -904,28 +904,28 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 	non_reconcile_tests := []struct {
 		testName     string
 		serviceName  string
-		servicePorts []api.ServicePort
-		serviceType  api.ServiceType
-		service      *api.Service
-		expectUpdate *api.Service // nil means none expected
+		servicePorts []corev1.ServicePort
+		serviceType  corev1.ServiceType
+		service      *corev1.Service
+		expectUpdate *corev1.Service // nil means none expected
 	}{
 		{
 			testName:    "service definition wrong port, no expected update",
 			serviceName: "foo",
-			servicePorts: []api.ServicePort{
+			servicePorts: []corev1.ServicePort{
 				{Name: "foo", Port: 8080, Protocol: "TCP", TargetPort: intstr.FromInt(8080)},
 			},
-			serviceType: api.ServiceTypeClusterIP,
-			service: &api.Service{
+			serviceType: corev1.ServiceTypeClusterIP,
+			service: &corev1.Service{
 				ObjectMeta: om("foo"),
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{Name: "foo", Port: 1000, Protocol: "TCP", TargetPort: intstr.FromInt(1000)},
 					},
 					Selector:        nil,
 					ClusterIP:       "1.2.3.4",
-					SessionAffinity: api.ServiceAffinityNone,
-					Type:            api.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
 			expectUpdate: nil,
@@ -950,7 +950,7 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 				t.Errorf("case %q: unexpected updates: %v", test.testName, updates)
 			} else {
 				obj := updates[0].GetObject()
-				if e, a := test.expectUpdate.Spec, obj.(*api.Service).Spec; !reflect.DeepEqual(e, a) {
+				if e, a := test.expectUpdate.Spec, obj.(*corev1.Service).Spec; !reflect.DeepEqual(e, a) {
 					t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
 				}
 			}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -68,12 +68,10 @@ import (
 	"k8s.io/client-go/informers"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/master/reconcilers"
 	"k8s.io/kubernetes/pkg/master/tunneler"
-	endpointsstorage "k8s.io/kubernetes/pkg/registry/core/endpoint/storage"
 	"k8s.io/kubernetes/pkg/routes"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
@@ -144,10 +142,10 @@ type ExtraConfig struct {
 	// service because this pkg is linked by out-of-tree projects
 	// like openshift which want to use the GenericAPIServer but also do
 	// more stuff.
-	ExtraServicePorts []api.ServicePort
+	ExtraServicePorts []apiv1.ServicePort
 	// Additional ports to be exposed on the GenericAPIServer endpoints
 	// Port names should align with ports defined in ExtraServicePorts
-	ExtraEndpointPorts []api.EndpointPort
+	ExtraEndpointPorts []apiv1.EndpointPort
 	// If non-zero, the "kubernetes" services uses this port as NodePort.
 	KubernetesServiceNodePort int
 
@@ -206,7 +204,7 @@ type Master struct {
 }
 
 func (c *Config) createMasterCountReconciler() reconcilers.EndpointReconciler {
-	endpointClient := coreclient.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
+	endpointClient := corev1client.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
 	return reconcilers.NewMasterCountEndpointReconciler(c.ExtraConfig.MasterCount, endpointClient)
 }
 
@@ -215,6 +213,7 @@ func (c *Config) createNoneReconciler() reconcilers.EndpointReconciler {
 }
 
 func (c *Config) createLeaseReconciler() reconcilers.EndpointReconciler {
+	endpointClient := corev1client.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
 	ttl := c.ExtraConfig.MasterEndpointReconcileTTL
 	config, err := c.ExtraConfig.StorageFactory.NewConfig(api.Resource("apiServerIPInfo"))
 	if err != nil {
@@ -224,18 +223,8 @@ func (c *Config) createLeaseReconciler() reconcilers.EndpointReconciler {
 	if err != nil {
 		glog.Fatalf("Error creating storage factory: %v", err)
 	}
-	endpointConfig, err := c.ExtraConfig.StorageFactory.NewConfig(api.Resource("endpoints"))
-	if err != nil {
-		glog.Fatalf("Error getting storage config: %v", err)
-	}
-	endpointsStorage := endpointsstorage.NewREST(generic.RESTOptions{
-		StorageConfig:           endpointConfig,
-		Decorator:               generic.UndecoratedStorage,
-		DeleteCollectionWorkers: 0,
-		ResourcePrefix:          c.ExtraConfig.StorageFactory.ResourcePrefix(api.Resource("endpoints")),
-	})
 	masterLeases := reconcilers.NewLeases(leaseStorage, "/masterleases/", ttl)
-	return reconcilers.NewLeaseEndpointReconciler(endpointsStorage.Store, masterLeases)
+	return reconcilers.NewLeaseEndpointReconciler(endpointClient, masterLeases)
 }
 
 func (c *Config) createEndpointReconciler() reconcilers.EndpointReconciler {
@@ -386,7 +375,7 @@ func (m *Master) InstallLegacyAPI(c *completedConfig, restOptionsGetter generic.
 	}
 
 	controllerName := "bootstrap-controller"
-	coreClient := coreclient.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
+	coreClient := corev1client.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
 	bootstrapController := c.NewBootstrapController(legacyRESTStorage, coreClient, coreClient, coreClient)
 	m.GenericAPIServer.AddPostStartHookOrDie(controllerName, bootstrapController.PostStartHook)
 	m.GenericAPIServer.AddPreShutdownHookOrDie(controllerName, bootstrapController.PreShutdownHook)

--- a/pkg/master/reconcilers/BUILD
+++ b/pkg/master/reconcilers/BUILD
@@ -12,15 +12,14 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/master/reconcilers",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/api/endpoints:go_default_library",
-        "//pkg/apis/core:go_default_library",
-        "//pkg/client/clientset_generated/internalclientset/typed/core/internalversion:go_default_library",
+        "//pkg/api/v1/endpoints:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],
@@ -31,9 +30,9 @@ go_test(
     srcs = ["lease_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/apis/core:go_default_library",
-        "//pkg/registry/registrytest:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
     ],
 )
 

--- a/pkg/master/reconcilers/lease_test.go
+++ b/pkg/master/reconcilers/lease_test.go
@@ -26,9 +26,9 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/registry/registrytest"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 type fakeLeases struct {
@@ -76,7 +76,7 @@ func (f *fakeLeases) GetUpdatedKeys() []string {
 }
 
 func TestLeaseEndpointReconciler(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := corev1.NamespaceDefault
 	om := func(name string) metav1.ObjectMeta {
 		return metav1.ObjectMeta{Namespace: ns, Name: name}
 	}
@@ -84,22 +84,22 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 		testName      string
 		serviceName   string
 		ip            string
-		endpointPorts []api.EndpointPort
+		endpointPorts []corev1.EndpointPort
 		endpointKeys  []string
-		endpoints     *api.EndpointsList
-		expectUpdate  *api.Endpoints // nil means none expected
+		endpoints     *corev1.EndpointsList
+		expectUpdate  *corev1.Endpoints // nil means none expected
 	}{
 		{
 			testName:      "no existing endpoints",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			endpoints:     nil,
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -107,13 +107,13 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:      "existing endpoints satisfy",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
@@ -122,14 +122,14 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:      "existing endpoints satisfy + refresh existing key",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			endpointKeys:  []string{"1.2.3.4"},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
@@ -138,21 +138,21 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:      "existing endpoints satisfy but too many",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}, {IP: "4.3.2.1"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}, {IP: "4.3.2.1"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -160,33 +160,33 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:      "existing endpoints satisfy but too many + extra masters",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			endpointKeys:  []string{"1.2.3.4", "4.3.2.2", "4.3.2.3", "4.3.2.4"},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{
 							{IP: "1.2.3.4"},
 							{IP: "4.3.2.1"},
 							{IP: "4.3.2.2"},
 							{IP: "4.3.2.3"},
 							{IP: "4.3.2.4"},
 						},
-						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{
 						{IP: "1.2.3.4"},
 						{IP: "4.3.2.2"},
 						{IP: "4.3.2.3"},
 						{IP: "4.3.2.4"},
 					},
-					Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -194,33 +194,33 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:      "existing endpoints satisfy but too many + extra masters + delete first",
 			serviceName:   "foo",
 			ip:            "4.3.2.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			endpointKeys:  []string{"4.3.2.1", "4.3.2.2", "4.3.2.3", "4.3.2.4"},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{
 							{IP: "1.2.3.4"},
 							{IP: "4.3.2.1"},
 							{IP: "4.3.2.2"},
 							{IP: "4.3.2.3"},
 							{IP: "4.3.2.4"},
 						},
-						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{
 						{IP: "4.3.2.1"},
 						{IP: "4.3.2.2"},
 						{IP: "4.3.2.3"},
 						{IP: "4.3.2.4"},
 					},
-					Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -228,27 +228,27 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:      "existing endpoints current IP missing",
 			serviceName:   "foo",
 			ip:            "4.3.2.2",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			endpointKeys:  []string{"4.3.2.1"},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{
 							{IP: "4.3.2.1"},
 						},
-						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{
 						{IP: "4.3.2.1"},
 						{IP: "4.3.2.2"},
 					},
-					Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -256,21 +256,21 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:      "existing endpoints wrong name",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("bar"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -278,21 +278,21 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:      "existing endpoints wrong IP",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "4.3.2.1"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "4.3.2.1"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -300,21 +300,21 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:      "existing endpoints wrong port",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 9090, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 9090, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -322,21 +322,21 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:      "existing endpoints wrong protocol",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "UDP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "UDP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -344,21 +344,21 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:      "existing endpoints wrong port name",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpointPorts: []corev1.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -366,17 +366,17 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:    "existing endpoints extra service ports satisfy",
 			serviceName: "foo",
 			ip:          "1.2.3.4",
-			endpointPorts: []api.EndpointPort{
+			endpointPorts: []corev1.EndpointPort{
 				{Name: "foo", Port: 8080, Protocol: "TCP"},
 				{Name: "bar", Port: 1000, Protocol: "TCP"},
 				{Name: "baz", Port: 1010, Protocol: "TCP"},
 			},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports: []api.EndpointPort{
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports: []corev1.EndpointPort{
 							{Name: "foo", Port: 8080, Protocol: "TCP"},
 							{Name: "bar", Port: 1000, Protocol: "TCP"},
 							{Name: "baz", Port: 1010, Protocol: "TCP"},
@@ -389,24 +389,24 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:    "existing endpoints extra service ports missing port",
 			serviceName: "foo",
 			ip:          "1.2.3.4",
-			endpointPorts: []api.EndpointPort{
+			endpointPorts: []corev1.EndpointPort{
 				{Name: "foo", Port: 8080, Protocol: "TCP"},
 				{Name: "bar", Port: 1000, Protocol: "TCP"},
 			},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports: []api.EndpointPort{
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports: []corev1.EndpointPort{
 						{Name: "foo", Port: 8080, Protocol: "TCP"},
 						{Name: "bar", Port: 1000, Protocol: "TCP"},
 					},
@@ -417,23 +417,28 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 	for _, test := range reconcileTests {
 		fakeLeases := newFakeLeases()
 		fakeLeases.SetKeys(test.endpointKeys)
-		registry := &registrytest.EndpointRegistry{
-			Endpoints: test.endpoints,
+		clientset := fake.NewSimpleClientset()
+		if test.endpoints != nil {
+			for _, ep := range test.endpoints.Items {
+				if _, err := clientset.CoreV1().Endpoints(ep.Namespace).Create(&ep); err != nil {
+					t.Errorf("case %q: unexpected error: %v", test.testName, err)
+					continue
+				}
+			}
 		}
-		r := NewLeaseEndpointReconciler(registry, fakeLeases)
+		r := NewLeaseEndpointReconciler(clientset.CoreV1(), fakeLeases)
 		err := r.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, true)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
 		}
+		actualEndpoints, err := clientset.CoreV1().Endpoints(corev1.NamespaceDefault).Get(test.serviceName, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("case %q: unexpected error: %v", test.testName, err)
+		}
 		if test.expectUpdate != nil {
-			if len(registry.Updates) != 1 {
-				t.Errorf("case %q: unexpected updates: %v", test.testName, registry.Updates)
-			} else if e, a := test.expectUpdate, &registry.Updates[0]; !reflect.DeepEqual(e, a) {
+			if e, a := test.expectUpdate, actualEndpoints; !reflect.DeepEqual(e, a) {
 				t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
 			}
-		}
-		if test.expectUpdate == nil && len(registry.Updates) > 0 {
-			t.Errorf("case %q: no update expected, yet saw: %v", test.testName, registry.Updates)
 		}
 		if updatedKeys := fakeLeases.GetUpdatedKeys(); len(updatedKeys) != 1 || updatedKeys[0] != test.ip {
 			t.Errorf("case %q: expected the master's IP to be refreshed, but the following IPs were refreshed instead: %v", test.testName, updatedKeys)
@@ -444,25 +449,25 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 		testName      string
 		serviceName   string
 		ip            string
-		endpointPorts []api.EndpointPort
+		endpointPorts []corev1.EndpointPort
 		endpointKeys  []string
-		endpoints     *api.EndpointsList
-		expectUpdate  *api.Endpoints // nil means none expected
+		endpoints     *corev1.EndpointsList
+		expectUpdate  *corev1.Endpoints // nil means none expected
 	}{
 		{
 			testName:    "existing endpoints extra service ports missing port no update",
 			serviceName: "foo",
 			ip:          "1.2.3.4",
-			endpointPorts: []api.EndpointPort{
+			endpointPorts: []corev1.EndpointPort{
 				{Name: "foo", Port: 8080, Protocol: "TCP"},
 				{Name: "bar", Port: 1000, Protocol: "TCP"},
 			},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
@@ -472,24 +477,24 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:    "existing endpoints extra service ports, wrong ports, wrong IP",
 			serviceName: "foo",
 			ip:          "1.2.3.4",
-			endpointPorts: []api.EndpointPort{
+			endpointPorts: []corev1.EndpointPort{
 				{Name: "foo", Port: 8080, Protocol: "TCP"},
 				{Name: "bar", Port: 1000, Protocol: "TCP"},
 			},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{{IP: "4.3.2.1"}},
-						Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "4.3.2.1"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -497,13 +502,13 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			testName:      "no existing endpoints",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			endpoints:     nil,
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -512,23 +517,28 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			fakeLeases := newFakeLeases()
 			fakeLeases.SetKeys(test.endpointKeys)
-			registry := &registrytest.EndpointRegistry{
-				Endpoints: test.endpoints,
+			clientset := fake.NewSimpleClientset()
+			if test.endpoints != nil {
+				for _, ep := range test.endpoints.Items {
+					if _, err := clientset.CoreV1().Endpoints(ep.Namespace).Create(&ep); err != nil {
+						t.Errorf("case %q: unexpected error: %v", test.testName, err)
+						continue
+					}
+				}
 			}
-			r := NewLeaseEndpointReconciler(registry, fakeLeases)
+			r := NewLeaseEndpointReconciler(clientset.CoreV1(), fakeLeases)
 			err := r.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, false)
 			if err != nil {
 				t.Errorf("case %q: unexpected error: %v", test.testName, err)
 			}
+			actualEndpoints, err := clientset.CoreV1().Endpoints(corev1.NamespaceDefault).Get(test.serviceName, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("case %q: unexpected error: %v", test.testName, err)
+			}
 			if test.expectUpdate != nil {
-				if len(registry.Updates) != 1 {
-					t.Errorf("case %q: unexpected updates: %v", test.testName, registry.Updates)
-				} else if e, a := test.expectUpdate, &registry.Updates[0]; !reflect.DeepEqual(e, a) {
+				if e, a := test.expectUpdate, actualEndpoints; !reflect.DeepEqual(e, a) {
 					t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
 				}
-			}
-			if test.expectUpdate == nil && len(registry.Updates) > 0 {
-				t.Errorf("case %q: no update expected, yet saw: %v", test.testName, registry.Updates)
 			}
 			if updatedKeys := fakeLeases.GetUpdatedKeys(); len(updatedKeys) != 1 || updatedKeys[0] != test.ip {
 				t.Errorf("case %q: expected the master's IP to be refreshed, but the following IPs were refreshed instead: %v", test.testName, updatedKeys)
@@ -538,7 +548,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 }
 
 func TestLeaseStopReconciling(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := corev1.NamespaceDefault
 	om := func(name string) metav1.ObjectMeta {
 		return metav1.ObjectMeta{Namespace: ns, Name: name}
 	}
@@ -546,40 +556,40 @@ func TestLeaseStopReconciling(t *testing.T) {
 		testName      string
 		serviceName   string
 		ip            string
-		endpointPorts []api.EndpointPort
+		endpointPorts []corev1.EndpointPort
 		endpointKeys  []string
-		endpoints     *api.EndpointsList
-		expectUpdate  *api.Endpoints // nil means none expected
+		endpoints     *corev1.EndpointsList
+		expectUpdate  *corev1.Endpoints // nil means none expected
 	}{
 		{
 			testName:      "successful stop reconciling",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			endpointKeys:  []string{"1.2.3.4", "4.3.2.2", "4.3.2.3", "4.3.2.4"},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{
 							{IP: "1.2.3.4"},
 							{IP: "4.3.2.2"},
 							{IP: "4.3.2.3"},
 							{IP: "4.3.2.4"},
 						},
-						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
-			expectUpdate: &api.Endpoints{
+			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
-				Subsets: []api.EndpointSubset{{
-					Addresses: []api.EndpointAddress{
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{
 						{IP: "4.3.2.2"},
 						{IP: "4.3.2.3"},
 						{IP: "4.3.2.4"},
 					},
-					Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},
@@ -587,19 +597,19 @@ func TestLeaseStopReconciling(t *testing.T) {
 			testName:      "stop reconciling with ip not in endpoint ip list",
 			serviceName:   "foo",
 			ip:            "5.6.7.8",
-			endpointPorts: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			endpointKeys:  []string{"1.2.3.4", "4.3.2.2", "4.3.2.3", "4.3.2.4"},
-			endpoints: &api.EndpointsList{
-				Items: []api.Endpoints{{
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
-					Subsets: []api.EndpointSubset{{
-						Addresses: []api.EndpointAddress{
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{
 							{IP: "1.2.3.4"},
 							{IP: "4.3.2.2"},
 							{IP: "4.3.2.3"},
 							{IP: "4.3.2.4"},
 						},
-						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
@@ -609,23 +619,26 @@ func TestLeaseStopReconciling(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			fakeLeases := newFakeLeases()
 			fakeLeases.SetKeys(test.endpointKeys)
-			registry := &registrytest.EndpointRegistry{
-				Endpoints: test.endpoints,
+			clientset := fake.NewSimpleClientset()
+			for _, ep := range test.endpoints.Items {
+				if _, err := clientset.CoreV1().Endpoints(ep.Namespace).Create(&ep); err != nil {
+					t.Errorf("case %q: unexpected error: %v", test.testName, err)
+					continue
+				}
 			}
-			r := NewLeaseEndpointReconciler(registry, fakeLeases)
+			r := NewLeaseEndpointReconciler(clientset.CoreV1(), fakeLeases)
 			err := r.StopReconciling(test.serviceName, net.ParseIP(test.ip), test.endpointPorts)
 			if err != nil {
 				t.Errorf("case %q: unexpected error: %v", test.testName, err)
 			}
+			actualEndpoints, err := clientset.CoreV1().Endpoints(corev1.NamespaceDefault).Get(test.serviceName, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("case %q: unexpected error: %v", test.testName, err)
+			}
 			if test.expectUpdate != nil {
-				if len(registry.Updates) != 1 {
-					t.Errorf("case %q: unexpected updates: %v", test.testName, registry.Updates)
-				} else if e, a := test.expectUpdate, &registry.Updates[0]; !reflect.DeepEqual(e, a) {
+				if e, a := test.expectUpdate, actualEndpoints; !reflect.DeepEqual(e, a) {
 					t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
 				}
-			}
-			if test.expectUpdate == nil && len(registry.Updates) > 0 {
-				t.Errorf("case %q: no update expected, yet saw: %v", test.testName, registry.Updates)
 			}
 			for _, key := range fakeLeases.GetUpdatedKeys() {
 				if key == test.ip {

--- a/pkg/master/reconcilers/none.go
+++ b/pkg/master/reconcilers/none.go
@@ -18,7 +18,7 @@ limitations under the License.
 package reconcilers
 
 import (
-	api "k8s.io/kubernetes/pkg/apis/core"
+	corev1 "k8s.io/api/core/v1"
 	"net"
 )
 
@@ -32,11 +32,11 @@ func NewNoneEndpointReconciler() EndpointReconciler {
 }
 
 // ReconcileEndpoints noop reconcile
-func (r *noneEndpointReconciler) ReconcileEndpoints(serviceName string, ip net.IP, endpointPorts []api.EndpointPort, reconcilePorts bool) error {
+func (r *noneEndpointReconciler) ReconcileEndpoints(serviceName string, ip net.IP, endpointPorts []corev1.EndpointPort, reconcilePorts bool) error {
 	return nil
 }
 
 // StopReconciling noop reconcile
-func (r *noneEndpointReconciler) StopReconciling(serviceName string, ip net.IP, endpointPorts []api.EndpointPort) error {
+func (r *noneEndpointReconciler) StopReconciling(serviceName string, ip net.IP, endpointPorts []corev1.EndpointPort) error {
 	return nil
 }

--- a/pkg/master/reconcilers/reconcilers.go
+++ b/pkg/master/reconcilers/reconcilers.go
@@ -18,7 +18,7 @@ limitations under the License.
 package reconcilers
 
 import (
-	api "k8s.io/kubernetes/pkg/apis/core"
+	corev1 "k8s.io/api/core/v1"
 	"net"
 )
 
@@ -34,8 +34,8 @@ type EndpointReconciler interface {
 	//  * All apiservers MUST use ReconcileEndpoints and only ReconcileEndpoints to manage the
 	//      endpoints for their {rw, ro} services.
 	//  * ReconcileEndpoints is called periodically from all apiservers.
-	ReconcileEndpoints(serviceName string, ip net.IP, endpointPorts []api.EndpointPort, reconcilePorts bool) error
-	StopReconciling(serviceName string, ip net.IP, endpointPorts []api.EndpointPort) error
+	ReconcileEndpoints(serviceName string, ip net.IP, endpointPorts []corev1.EndpointPort, reconcilePorts bool) error
+	StopReconciling(serviceName string, ip net.IP, endpointPorts []corev1.EndpointPort) error
 }
 
 // Type the reconciler type

--- a/pkg/registry/core/service/ipallocator/controller/BUILD
+++ b/pkg/registry/core/service/ipallocator/controller/BUILD
@@ -13,8 +13,7 @@ go_library(
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
-        "//pkg/apis/core/helper:go_default_library",
-        "//pkg/client/clientset_generated/internalclientset/typed/core/internalversion:go_default_library",
+        "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/registry/core/rangeallocation:go_default_library",
         "//pkg/registry/core/service/ipallocator:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
@@ -22,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/client-go/util/retry:go_default_library",
     ],
@@ -33,9 +33,10 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core:go_default_library",
-        "//pkg/client/clientset_generated/internalclientset/fake:go_default_library",
         "//pkg/registry/core/service/ipallocator:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/service/ipallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair_test.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 )
 
@@ -134,29 +135,29 @@ func TestRepairWithExisting(t *testing.T) {
 	}
 
 	fakeClient := fake.NewSimpleClientset(
-		&api.Service{
+		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "one"},
-			Spec:       api.ServiceSpec{ClusterIP: "192.168.1.1"},
+			Spec:       corev1.ServiceSpec{ClusterIP: "192.168.1.1"},
 		},
-		&api.Service{
+		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "two", Name: "two"},
-			Spec:       api.ServiceSpec{ClusterIP: "192.168.1.100"},
+			Spec:       corev1.ServiceSpec{ClusterIP: "192.168.1.100"},
 		},
-		&api.Service{ // outside CIDR, will be dropped
+		&corev1.Service{ // outside CIDR, will be dropped
 			ObjectMeta: metav1.ObjectMeta{Namespace: "three", Name: "three"},
-			Spec:       api.ServiceSpec{ClusterIP: "192.168.0.1"},
+			Spec:       corev1.ServiceSpec{ClusterIP: "192.168.0.1"},
 		},
-		&api.Service{ // empty, ignored
+		&corev1.Service{ // empty, ignored
 			ObjectMeta: metav1.ObjectMeta{Namespace: "four", Name: "four"},
-			Spec:       api.ServiceSpec{ClusterIP: ""},
+			Spec:       corev1.ServiceSpec{ClusterIP: ""},
 		},
-		&api.Service{ // duplicate, dropped
+		&corev1.Service{ // duplicate, dropped
 			ObjectMeta: metav1.ObjectMeta{Namespace: "five", Name: "five"},
-			Spec:       api.ServiceSpec{ClusterIP: "192.168.1.1"},
+			Spec:       corev1.ServiceSpec{ClusterIP: "192.168.1.1"},
 		},
-		&api.Service{ // headless
+		&corev1.Service{ // headless
 			ObjectMeta: metav1.ObjectMeta{Namespace: "six", Name: "six"},
-			Spec:       api.ServiceSpec{ClusterIP: "None"},
+			Spec:       corev1.ServiceSpec{ClusterIP: "None"},
 		},
 	)
 

--- a/pkg/registry/core/service/portallocator/controller/BUILD
+++ b/pkg/registry/core/service/portallocator/controller/BUILD
@@ -13,7 +13,6 @@ go_library(
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
-        "//pkg/client/clientset_generated/internalclientset/typed/core/internalversion:go_default_library",
         "//pkg/registry/core/rangeallocation:go_default_library",
         "//pkg/registry/core/service/portallocator:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
@@ -22,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/client-go/util/retry:go_default_library",
     ],
@@ -33,10 +33,11 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core:go_default_library",
-        "//pkg/client/clientset_generated/internalclientset/fake:go_default_library",
         "//pkg/registry/core/service/portallocator:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/service/portallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/portallocator/controller/repair_test.go
@@ -21,10 +21,11 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/kubernetes/fake"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 	"k8s.io/kubernetes/pkg/registry/core/service/portallocator"
 )
 
@@ -134,39 +135,39 @@ func TestRepairWithExisting(t *testing.T) {
 	}
 
 	fakeClient := fake.NewSimpleClientset(
-		&api.Service{
+		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "one"},
-			Spec: api.ServiceSpec{
-				Ports: []api.ServicePort{{NodePort: 111}},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{NodePort: 111}},
 			},
 		},
-		&api.Service{
+		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "two", Name: "two"},
-			Spec: api.ServiceSpec{
-				Ports: []api.ServicePort{{NodePort: 122}, {NodePort: 133}},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{NodePort: 122}, {NodePort: 133}},
 			},
 		},
-		&api.Service{ // outside range, will be dropped
+		&corev1.Service{ // outside range, will be dropped
 			ObjectMeta: metav1.ObjectMeta{Namespace: "three", Name: "three"},
-			Spec: api.ServiceSpec{
-				Ports: []api.ServicePort{{NodePort: 201}},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{NodePort: 201}},
 			},
 		},
-		&api.Service{ // empty, ignored
+		&corev1.Service{ // empty, ignored
 			ObjectMeta: metav1.ObjectMeta{Namespace: "four", Name: "four"},
-			Spec: api.ServiceSpec{
-				Ports: []api.ServicePort{{}},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{}},
 			},
 		},
-		&api.Service{ // duplicate, dropped
+		&corev1.Service{ // duplicate, dropped
 			ObjectMeta: metav1.ObjectMeta{Namespace: "five", Name: "five"},
-			Spec: api.ServiceSpec{
-				Ports: []api.ServicePort{{NodePort: 111}},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{NodePort: 111}},
 			},
 		},
-		&api.Service{
+		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "six", Name: "six"},
-			Spec: api.ServiceSpec{
+			Spec: corev1.ServiceSpec{
 				HealthCheckNodePort: 144,
 			},
 		},


### PR DESCRIPTION
/sig api-machinery
/kind cleanup

trying pruning internal clientset from kubeapiserver but the master reconciler is the biggest blocker as fas i can tell. 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
