### PR TITLE
[WIP] kubeadm graduate enable-dynamic-kubelet-config phase

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -182,6 +182,7 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 	initRunner.AppendPhase(phases.NewEtcdPhase())
 	initRunner.AppendPhase(phases.NewWaitControlPlanePhase())
 	initRunner.AppendPhase(phases.NewUploadConfigPhase())
+	initRunner.AppendPhase(phases.NewEnableDynamicKubeletConfigPhase())
 	// TODO: add other phases to the runner.
 
 	// sets the data builder function, that will be used by the runner

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -48,15 +48,12 @@ import (
 	nodebootstraptokenphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	kubeconfigphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubeconfig"
-	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
 	markmasterphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/markmaster"
 	selfhostingphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/selfhosting"
-	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
-	utilsexec "k8s.io/utils/exec"
 )
 
 var (
@@ -491,19 +488,6 @@ func runInit(i *initData, out io.Writer) error {
 	glog.V(1).Infof("[init] marking the master with right label")
 	if err := markmasterphase.MarkMaster(client, i.cfg.NodeRegistration.Name, i.cfg.NodeRegistration.Taints); err != nil {
 		return errors.Wrap(err, "error marking master")
-	}
-
-	// This feature is disabled by default
-	if features.Enabled(i.cfg.FeatureGates, features.DynamicKubeletConfig) {
-		kubeletVersion, err := preflight.GetKubeletVersion(utilsexec.New())
-		if err != nil {
-			return err
-		}
-
-		// Enable dynamic kubelet configuration for the node.
-		if err := kubeletphase.EnableDynamicConfigForNode(client, i.cfg.NodeRegistration.Name, kubeletVersion); err != nil {
-			return errors.Wrap(err, "error enabling dynamic kubelet configuration")
-		}
 	}
 
 	// PHASE 5: Set up the node bootstrap tokens

--- a/cmd/kubeadm/app/cmd/phases/BUILD
+++ b/cmd/kubeadm/app/cmd/phases/BUILD
@@ -7,6 +7,7 @@ go_library(
         "bootstraptoken.go",
         "certs.go",
         "controlplane.go",
+        "dynamickubletconfig.go",
         "etcd.go",
         "kubeconfig.go",
         "kubelet.go",

--- a/cmd/kubeadm/app/cmd/phases/dynamickubletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/dynamickubletconfig.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"errors"
+
+	clientset "k8s.io/client-go/kubernetes"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
+	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
+	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
+	"k8s.io/kubernetes/pkg/util/normalizer"
+	utilsexec "k8s.io/utils/exec"
+)
+
+var (
+	dynamicKubeletConfigLongDesc = normalizer.LongDesc(`
+		Enables or updates dynamic kubelet configuration for a Node, against the kubelet-config-1.X ConfigMap in the cluster,
+		where X is the minor version of the desired kubelet version.
+
+		WARNING: This feature is still experimental, and disabled by default. Enable only if you know what you are doing, as it
+		may have surprising side-effects at this stage.
+		`)
+
+	dynamicKubeletConfigExample = normalizer.Examples(`
+		# Enables dynamic kubelet configuration for a Node.
+		kubeadm init phase enable-dynamic-kubelet-config --node-name node-1
+
+		WARNING: This feature is still experimental, and disabled by default. Enable only if you know what you are doing, as it
+		may have surprising side-effects at this stage.
+		`)
+)
+
+type enableDynamicKubeletConfigData interface {
+	Cfg() *kubeadmapi.InitConfiguration
+	Client() (clientset.Interface, error)
+}
+
+// NewEnableDynamicKubeletConfigPhase returns the phase to EnableDynamicKubeletConfig
+func NewEnableDynamicKubeletConfigPhase() workflow.Phase {
+	return workflow.Phase{
+		Name:    "enable-dynamic-kubelet-config",
+		Short:   "EXPERIMENTAL: Enables or updates dynamic kubelet configuration for a Node",
+		Long:    dynamicKubeletConfigLongDesc,
+		Example: dynamicKubeletConfigExample,
+		Hidden:  true,
+		Run:     EnableDynamicKubeletConfig,
+	}
+}
+
+// EnableDynamicKubeletConfig enables dynamic kubelet configuration on node
+// This feature is still in experimental state
+func EnableDynamicKubeletConfig(c workflow.RunData) error {
+	data, ok := c.(enableDynamicKubeletConfigData)
+	if !ok {
+		return errors.New("enable-dynamic-kubelet-config phase invoked with an invalid data struct")
+	}
+
+	cfg := data.Cfg()
+	client, err := data.Client()
+	if err != nil {
+		return err
+	}
+	nodeName := cfg.NodeRegistration.Name
+	if len(nodeName) == 0 {
+		return errors.New("NodeRegistration.Name is required for the enable-dynamic-kubelet-config phase")
+	}
+
+	kubeletVersion, err := preflight.GetKubeletVersion(utilsexec.New())
+	if err != nil {
+		return err
+	}
+
+	return kubeletphase.EnableDynamicConfigForNode(client, nodeName, kubeletVersion)
+}


### PR DESCRIPTION
**What type of PR is this?**
This PR graduates phase `enable-dynamic-kubelet-config` in the kubeadm init workflow.
/kind feature

**What this PR does / why we need it**:
Ref https://github.com/kubernetes/kubeadm/issues/1163

/sig cluster-lifecycle
@kubernetes/sig-cluster-lifecycle-pr-reviews

```release-note
NONE
```