### PR TITLE
e2e CSI: bump all containers to v0.4.1 in Kubernetes 1.12

### DIFF
--- a/test/e2e/storage/csi_objects.go
+++ b/test/e2e/storage/csi_objects.go
@@ -47,10 +47,10 @@ import (
 )
 
 var csiImageVersions = map[string]string{
-	"hostpathplugin":   "canary", // TODO (verult) update tag once new hostpathplugin release is cut
-	"csi-attacher":     "v0.2.0",
-	"csi-provisioner":  "v0.2.1",
-	"driver-registrar": "v0.3.0",
+	"hostpathplugin":   "v0.4.1",
+	"csi-attacher":     "v0.4.1",
+	"csi-provisioner":  "v0.4.1",
+	"driver-registrar": "v0.4.1",
 }
 
 func csiContainerImage(image string) string {

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: csi-external-provisioner
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-provisioner:v0.2.0
+          image: quay.io/k8scsi/csi-provisioner:v0.4.1
           args:
             - "--v=5"
             - "--provisioner=com.google.csi.gcepd"
@@ -29,7 +29,7 @@ spec:
               mountPath: /csi
         - name: csi-attacher
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-attacher:v0.2.0
+          image: quay.io/k8scsi/csi-attacher:v0.4.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
         - name: csi-driver-registrar
           imagePullPolicy: Always
-          image: quay.io/k8scsi/driver-registrar:v0.3.0
+          image: quay.io/k8scsi/driver-registrar:v0.4.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
Backported from master branch commit a56c518292. Bumping the versions
for the hostpath test had to be done differently because the master
branch deploys it from manifest files while here that is done in code.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

The current set of CSI containers for Kubernetes 1.12.x are the ones with version 0.4.1. We should be testing also with those.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
