### PR TITLE
clean up some codes about the deprecated SelfHosting feature

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -599,17 +599,6 @@ func runInit(i *initData, out io.Writer) error {
 		return errors.Wrap(err, "error ensuring proxy addon")
 	}
 
-	// PHASE 7: Make the control plane self-hosted if feature gate is enabled
-	if features.Enabled(i.cfg.FeatureGates, features.SelfHosting) {
-		glog.V(1).Infof("[init] feature gate is enabled. Making control plane self-hosted")
-		// Temporary control plane is up, now we create our self hosted control
-		// plane components and remove the static manifests:
-		fmt.Println("[self-hosted] creating self-hosted control plane")
-		if err := selfhostingphase.CreateSelfHostedControlPlane(manifestDir, kubeConfigDir, i.cfg, client, waiter, i.dryRun); err != nil {
-			return errors.Wrap(err, "error creating self hosted control plane")
-		}
-	}
-
 	// Exit earlier if we're dryrunning
 	if i.dryRun {
 		fmt.Println("[dryrun] finished dry-running successfully. Above are the resources that would be created")


### PR DESCRIPTION
**What type of PR is this?**

I find that some codes will never be executed because that the `SelfHosting` feature is deprecated from v1.12.
Maybe it is time to remove these codes now.

/kind cleanup


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
