### PR TITLE
testservers: return Run method errors correctly

### DIFF
--- a/cmd/cloud-controller-manager/app/testing/testserver.go
+++ b/cmd/cloud-controller-manager/app/testing/testserver.go
@@ -113,9 +113,10 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		return result, fmt.Errorf("failed to create config from options: %v", err)
 	}
 
+	errCh := make(chan error)
 	go func(stopCh <-chan struct{}) {
 		if err := app.Run(config.Complete(), stopCh); err != nil {
-			t.Errorf("cloud-apiserver failed run: %v", err)
+			errCh <- err
 		}
 	}(stopCh)
 
@@ -125,6 +126,12 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		return result, fmt.Errorf("failed to create a client: %v", err)
 	}
 	err = wait.Poll(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		select {
+		case err := <-errCh:
+			return false, err
+		default:
+		}
+
 		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do()
 		status := 0
 		result.StatusCode(&status)

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -145,9 +145,10 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 	if err != nil {
 		return result, fmt.Errorf("failed to create server chain: %v", err)
 	}
+	errCh := make(chan error)
 	go func(stopCh <-chan struct{}) {
 		if err := server.PrepareRun().Run(stopCh); err != nil {
-			t.Errorf("kube-apiserver failed run: %v", err)
+			errCh <- err
 		}
 	}(stopCh)
 
@@ -158,6 +159,12 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 		return result, fmt.Errorf("failed to create a client: %v", err)
 	}
 	err = wait.Poll(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		select {
+		case err := <-errCh:
+			return false, err
+		default:
+		}
+
 		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do()
 		status := 0
 		result.StatusCode(&status)

--- a/cmd/kube-controller-manager/app/testing/testserver.go
+++ b/cmd/kube-controller-manager/app/testing/testserver.go
@@ -114,9 +114,10 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		return result, fmt.Errorf("failed to create config from options: %v", err)
 	}
 
+	errCh := make(chan error)
 	go func(stopCh <-chan struct{}) {
 		if err := app.Run(config.Complete(), stopCh); err != nil {
-			t.Errorf("kube-apiserver failed run: %v", err)
+			errCh <- err
 		}
 	}(stopCh)
 
@@ -126,6 +127,12 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		return result, fmt.Errorf("failed to create a client: %v", err)
 	}
 	err = wait.Poll(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		select {
+		case err := <-errCh:
+			return false, err
+		default:
+		}
+
 		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do()
 		status := 0
 		result.StatusCode(&status)


### PR DESCRIPTION
In https://github.com/kubernetes/kubernetes/pull/69663 the `Run` method returned an error. This PR aligns the `Run` method error handling in the existing test servers.