### PR TITLE
Fix for the 'kubectl explain crd --recursive' goes into an infinite loop issue

### DIFF
--- a/pkg/kubectl/explain/BUILD
+++ b/pkg/kubectl/explain/BUILD
@@ -46,7 +46,10 @@ go_test(
         "recursive_fields_printer_test.go",
         "typename_test.go",
     ],
-    data = ["test-swagger.json"],
+    data = [
+        "test-recursive-swagger.json",
+        "test-swagger.json",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/kubectl/cmd/util/openapi/testing:go_default_library",

--- a/pkg/kubectl/explain/recursive_fields_printer.go
+++ b/pkg/kubectl/explain/recursive_fields_printer.go
@@ -30,6 +30,7 @@ type recursiveFieldsPrinter struct {
 
 var _ proto.SchemaVisitor = &recursiveFieldsPrinter{}
 var _ fieldsPrinter = &recursiveFieldsPrinter{}
+var visitedReferences = map[string]struct{}{}
 
 // VisitArray is just a passthrough.
 func (f *recursiveFieldsPrinter) VisitArray(a *proto.Array) {
@@ -64,7 +65,12 @@ func (f *recursiveFieldsPrinter) VisitPrimitive(p *proto.Primitive) {
 
 // VisitReference is just a passthrough.
 func (f *recursiveFieldsPrinter) VisitReference(r proto.Reference) {
+	if _, ok := visitedReferences[r.Reference()]; ok {
+		return
+	}
+	visitedReferences[r.Reference()] = struct{}{}
 	r.SubSchema().Accept(f)
+	delete(visitedReferences, r.Reference())
 }
 
 // PrintFields will recursively print all the fields for the given

--- a/pkg/kubectl/explain/test-recursive-swagger.json
+++ b/pkg/kubectl/explain/test-recursive-swagger.json
@@ -1,0 +1,63 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Kubernetes",
+    "version": "v1.9.0"
+  },
+  "paths": {},
+  "definitions": {
+    "OneKind": {
+      "description": "OneKind has a short description",
+      "required": [
+        "field1"
+      ],
+      "properties": {
+        "field1": {
+          "description": "This is first reference field",
+          "$ref": "#/definitions/ReferenceKind"
+        },
+        "field2": {
+          "description": "This is other kind field with string and reference",
+          "$ref": "#/definitions/OtherKind"
+        }
+      },
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "OneKind",
+          "version": "v2"
+        }
+      ]
+    },
+    "ReferenceKind": {
+      "description": "This is reference Kind",
+      "properties": {
+        "referencefield": {
+          "description": "This is reference to itself.",
+          "$ref": "#/definitions/ReferenceKind"
+        },
+        "referencesarray": {
+          "description": "This is an array of references",
+          "type": "array",
+          "items": {
+            "description": "This is reference object",
+            "$ref": "#/definitions/ReferenceKind"
+          }
+        }
+      }
+    },
+    "OtherKind": {
+      "description": "This is other kind with string and reference fields",
+      "properties": {
+        "string": {
+          "description": "This string must be a string",
+          "type": "string"
+        },
+        "reference": {
+          "description": "This is reference field.",
+          "$ref": "#/definitions/ReferenceKind"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
'kubectl explain crd --recursive' goes into infinite loop because visitor at path spec.validation.openAPIV3Schema.allOf reference an object type that references itself. This PR change detects self reference loops while visiting references to avoid infinite loop. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubectl/issues/546

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
```release-note
NONE
```
