### PR TITLE
Node selector to run full e2e Conformance tests on Clusters with Windows

### DIFF
--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -73,6 +73,7 @@ var _ = Describe("[sig-node] ConfigMap", func() {
 			},
 		}
 
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 		f.TestContainerOutput("consume configMaps", pod, 0, []string{
 			"CONFIG_DATA_1=value-1",
 		})
@@ -116,6 +117,7 @@ var _ = Describe("[sig-node] ConfigMap", func() {
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("consume configMaps", pod, 0, []string{
 			"data_1=value-1", "data_2=value-2", "data_3=value-3",

--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -39,7 +39,9 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST default to 0x644.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
-		doConfigMapE2EWithoutMappings(f, 0, 0, nil)
+
+		nodeSelector := framework.GetOSNodeSelectorForPod(true)
+		doConfigMapE2EWithoutMappings(f, 0, 0, nil, nodeSelector)
 	})
 
 	/*
@@ -49,12 +51,18 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
 		defaultMode := int32(0400)
-		doConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode)
+		// Windows doesn't support setting mode. Since tests set permissions Unix style,
+		// there is no dirrect correspondance to Windows permissions.
+		nodeSelector := framework.GetOSNodeSelectorForPod(false)
+		doConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode, nodeSelector)
 	})
 
 	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
-		doConfigMapE2EWithoutMappings(f, 1000, 1001, &defaultMode)
+		// Windows doesn't support setting mode. Since tests set permissions Unix style,
+		// there is no dirrect correspondance to Windows permissions.
+		nodeSelector := framework.GetOSNodeSelectorForPod(false)
+		doConfigMapE2EWithoutMappings(f, 1000, 1001, &defaultMode, nodeSelector)
 	})
 
 	/*
@@ -63,11 +71,13 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Pod is run as a non-root user with uid=1000. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The file on the volume MUST have file mode set to default value of 0x644.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume as non-root [NodeConformance]", func() {
-		doConfigMapE2EWithoutMappings(f, 1000, 0, nil)
+		// Windows doesn't support security context
+		nodeSelector := framework.GetOSNodeSelectorForPod(false)
+		doConfigMapE2EWithoutMappings(f, 1000, 0, nil, nodeSelector)
 	})
 
 	It("should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]", func() {
-		doConfigMapE2EWithoutMappings(f, 1000, 1001, nil)
+		doConfigMapE2EWithoutMappings(f, 1000, 1001, nil, nil)
 	})
 
 	/*
@@ -76,7 +86,8 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Files are mapped to a path in the volume. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST default to 0x644.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
-		doConfigMapE2EWithMappings(f, 0, 0, nil)
+		nodeSelector := framework.GetOSNodeSelectorForPod(true)
+		doConfigMapE2EWithMappings(f, 0, 0, nil, nodeSelector)
 	})
 
 	/*
@@ -86,7 +97,10 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [NodeConformance]", func() {
 		mode := int32(0400)
-		doConfigMapE2EWithMappings(f, 0, 0, &mode)
+		// Windows doesn't support setting mode. Since tests set permissions Unix style,
+		// there is no dirrect correspondance to Windows permissions.
+		nodeSelector := framework.GetOSNodeSelectorForPod(false)
+		doConfigMapE2EWithMappings(f, 0, 0, &mode, nodeSelector)
 	})
 
 	/*
@@ -95,11 +109,13 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Files are mapped to a path in the volume. Pod is run as a non-root user with uid=1000. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The file on the volume MUST have file mode set to default value of 0x644.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [NodeConformance]", func() {
-		doConfigMapE2EWithMappings(f, 1000, 0, nil)
+		// Windows doesn't support security context
+		nodeSelector := framework.GetOSNodeSelectorForPod(false)
+		doConfigMapE2EWithMappings(f, 1000, 0, nil, nodeSelector)
 	})
 
 	It("should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]", func() {
-		doConfigMapE2EWithMappings(f, 1000, 1001, nil)
+		doConfigMapE2EWithMappings(f, 1000, 1001, nil, nil)
 	})
 
 	/*
@@ -166,6 +182,8 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
+
 		By("Creating the pod")
 		f.PodClient().CreateSync(pod)
 
@@ -265,6 +283,8 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
+
 		By("Creating the pod")
 		f.PodClient().CreateSync(pod)
 
@@ -423,6 +443,8 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
+
 		By("Creating the pod")
 		f.PodClient().CreateSync(pod)
 
@@ -534,6 +556,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("consume configMaps", pod, 0, []string{
 			"content of file \"/etc/configmap-volume/data-1\": value-1",
@@ -556,7 +579,7 @@ func newConfigMap(f *framework.Framework, name string) *v1.ConfigMap {
 	}
 }
 
-func doConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64, defaultMode *int32) {
+func doConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64, defaultMode *int32, nodeSelector map[string]string) {
 	userID := int64(uid)
 	groupID := int64(fsGroup)
 
@@ -609,6 +632,7 @@ func doConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64, d
 			},
 			RestartPolicy:                 v1.RestartPolicyNever,
 			TerminationGracePeriodSeconds: &one,
+			NodeSelector:                  nodeSelector,
 		},
 	}
 
@@ -635,7 +659,7 @@ func doConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64, d
 	f.TestContainerOutput("consume configMaps", pod, 0, output)
 }
 
-func doConfigMapE2EWithMappings(f *framework.Framework, uid, fsGroup int64, itemMode *int32) {
+func doConfigMapE2EWithMappings(f *framework.Framework, uid, fsGroup int64, itemMode *int32, nodeSelector map[string]string) {
 	userID := int64(uid)
 	groupID := int64(fsGroup)
 
@@ -695,6 +719,7 @@ func doConfigMapE2EWithMappings(f *framework.Framework, uid, fsGroup int64, item
 			},
 			RestartPolicy:                 v1.RestartPolicyNever,
 			TerminationGracePeriodSeconds: &one,
+			NodeSelector:                  nodeSelector,
 		},
 	}
 

--- a/test/e2e/common/container.go
+++ b/test/e2e/common/container.go
@@ -43,6 +43,7 @@ type ConformanceContainer struct {
 	PodClient          *framework.PodClient
 	podName            string
 	PodSecurityContext *v1.PodSecurityContext
+	NodeSelector       map[string]string
 }
 
 func (cc *ConformanceContainer) Create() {
@@ -63,6 +64,7 @@ func (cc *ConformanceContainer) Create() {
 			SecurityContext:  cc.PodSecurityContext,
 			Volumes:          cc.Volumes,
 			ImagePullSecrets: imagePullSecrets,
+			NodeSelector:     cc.NodeSelector,
 		},
 	}
 	cc.PodClient.Create(pod)

--- a/test/e2e/common/docker_containers.go
+++ b/test/e2e/common/docker_containers.go
@@ -33,7 +33,9 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 		Description: Default command and arguments from the docker image entrypoint MUST be used when Pod does not specify the container command
 	*/
 	framework.ConformanceIt("should use the image defaults if command and args are blank [NodeConformance]", func() {
-		f.TestContainerOutput("use defaults", entrypointTestPod(), 0, []string{
+		pod := entrypointTestPod()
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
+		f.TestContainerOutput("use defaults", pod, 0, []string{
 			"[/ep default arguments]",
 		})
 	})
@@ -46,6 +48,7 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 	framework.ConformanceIt("should be able to override the image's default arguments (docker cmd) [NodeConformance]", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("override arguments", pod, 0, []string{
 			"[/ep override arguments]",
@@ -62,6 +65,7 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 	framework.ConformanceIt("should be able to override the image's default command (docker entrypoint) [NodeConformance]", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("override command", pod, 0, []string{
 			"[/ep-2]",
@@ -77,6 +81,7 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("override all", pod, 0, []string{
 			"[/ep-2 override arguments]",

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -38,6 +38,9 @@ var (
 var _ = Describe("[sig-node] Downward API", func() {
 	f := framework.NewDefaultFramework("downward-api")
 
+	// All downward API Conformance tests work on Windows. Using one "global" nodeSelector var.
+	nodeSelector := framework.GetOSNodeSelectorForPod(true)
+
 	/*
 	   Release : v1.9
 	   Testname: DownwardAPI, environment for name, namespace and ip
@@ -81,7 +84,7 @@ var _ = Describe("[sig-node] Downward API", func() {
 			"POD_IP=(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)",
 		}
 
-		testDownwardAPI(f, podName, env, expectations)
+		testDownwardAPI(f, podName, env, expectations, nodeSelector)
 	})
 
 	/*
@@ -108,7 +111,7 @@ var _ = Describe("[sig-node] Downward API", func() {
 			"HOST_IP=(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)",
 		}
 
-		testDownwardAPI(f, podName, env, expectations)
+		testDownwardAPI(f, podName, env, expectations, nodeSelector)
 	})
 
 	/*
@@ -159,7 +162,7 @@ var _ = Describe("[sig-node] Downward API", func() {
 			"MEMORY_REQUEST=33554432",
 		}
 
-		testDownwardAPI(f, podName, env, expectations)
+		testDownwardAPI(f, podName, env, expectations, nodeSelector)
 	})
 
 	/*
@@ -205,6 +208,7 @@ var _ = Describe("[sig-node] Downward API", func() {
 						Env:     env,
 					},
 				},
+				NodeSelector:  nodeSelector,
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
@@ -236,7 +240,7 @@ var _ = Describe("[sig-node] Downward API", func() {
 			"POD_UID=[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}",
 		}
 
-		testDownwardAPI(f, podName, env, expectations)
+		testDownwardAPI(f, podName, env, expectations, nodeSelector)
 	})
 })
 
@@ -315,7 +319,7 @@ var _ = framework.KubeDescribe("Downward API [Serial] [Disruptive] [NodeFeature:
 
 })
 
-func testDownwardAPI(f *framework.Framework, podName string, env []v1.EnvVar, expectations []string) {
+func testDownwardAPI(f *framework.Framework, podName string, env []v1.EnvVar, expectations []string, nodeSelector map[string]string) {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   podName,
@@ -340,6 +344,7 @@ func testDownwardAPI(f *framework.Framework, podName string, env []v1.EnvVar, ex
 					Env: env,
 				},
 			},
+			NodeSelector:  nodeSelector,
 			RestartPolicy: v1.RestartPolicyNever,
 		},
 	}

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -48,7 +48,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	framework.ConformanceIt("should provide podname only [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
-
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("%s\n", podName),
 		})
@@ -63,6 +63,8 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
+		// Windows does not support mode being set as permissions on Windows don't have Unix style equivalent
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			"mode of file \"/etc/podinfo/podname\": -r--------",
@@ -78,6 +80,8 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
+		// Windows does not support mode being set as permissions on Windows don't have Unix style equivalent
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			"mode of file \"/etc/podinfo/podname\": -r--------",
@@ -125,6 +129,8 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 
 		podName := "labelsupdate" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForUpdateTest(podName, labels, map[string]string{}, "/etc/podinfo/labels")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
+
 		containerName := "client-container"
 		By("Creating the pod")
 		podClient.CreateSync(pod)
@@ -155,6 +161,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		annotations["builder"] = "bar"
 		podName := "annotationupdate" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForUpdateTest(podName, map[string]string{}, annotations, "/etc/podinfo/annotations")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		containerName := "client-container"
 		By("Creating the pod")
@@ -187,6 +194,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	framework.ConformanceIt("should provide container's cpu limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_limit")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("2\n"),
@@ -201,6 +209,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	framework.ConformanceIt("should provide container's memory limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("67108864\n"),
@@ -215,6 +224,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	framework.ConformanceIt("should provide container's cpu request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_request")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("1\n"),
@@ -229,6 +239,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	framework.ConformanceIt("should provide container's memory request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_request")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("33554432\n"),
@@ -243,6 +254,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/cpu_limit")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
@@ -255,6 +267,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/memory_limit")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})

--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -40,6 +40,9 @@ var (
 var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 	f := framework.NewDefaultFramework("emptydir")
 
+	// All these tests should be skipped on Windows. They set podSecurityContext which
+	// is unsupported on Windows.
+
 	Context("when FSGroup is specified [NodeFeature:FSGroup]", func() {
 		It("new files should be created with FSGroup ownership when container is root", func() {
 			doTestSetgidFSGroup(f, testImageRootUid, v1.StorageMediumMemory)
@@ -448,6 +451,7 @@ func testPodWithVolume(image, path string, source *v1.EmptyDirVolumeSource) *v1.
 					},
 				},
 			},
+			NodeSelector: framework.GetOSNodeSelectorForPod(false),
 		},
 	}
 }

--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -33,6 +33,8 @@ import (
 var _ = framework.KubeDescribe("Variable Expansion", func() {
 	f := framework.NewDefaultFramework("var-expansion")
 
+	// All VariableExpansion Conformance test can be run on Windows
+
 	/*
 		Release : v1.9
 		Testname: Environment variables, expansion
@@ -70,6 +72,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("env composition", pod, 0, []string{
 			"FOO=foo-value",
@@ -107,6 +110,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("substitution in container's command", pod, 0, []string{
 			"test-value",
@@ -143,6 +147,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("substitution in container's args", pod, 0, []string{
 			"test-value",

--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -50,6 +50,8 @@ var _ = Describe("[sig-storage] HostPath", func() {
 			Path: "/tmp",
 		}
 		pod := testPodWithHostVol(volumePath, source)
+		// Does not work on Windows as we cannot check for file mode.
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 
 		pod.Spec.Containers[0].Args = []string{
 			fmt.Sprintf("--fs_type=%v", volumePath),
@@ -68,6 +70,7 @@ var _ = Describe("[sig-storage] HostPath", func() {
 			Path: "/tmp",
 		}
 		pod := testPodWithHostVol(volumePath, source)
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		pod.Spec.Containers[0].Args = []string{
 			fmt.Sprintf("--new_file_0644=%v", filePath),
@@ -97,6 +100,7 @@ var _ = Describe("[sig-storage] HostPath", func() {
 			Path: "/tmp",
 		}
 		pod := testPodWithHostVol(volumePath, source)
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 
 		// Write the file in the subPath from container 0
 		container := &pod.Spec.Containers[0]

--- a/test/e2e/common/init_container.go
+++ b/test/e2e/common/init_container.go
@@ -87,6 +87,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 		framework.Logf("PodSpec: initContainers in spec.initContainers")
 		startedPod := podClient.Create(pod)
 		w, err := podClient.Watch(metav1.SingleObject(startedPod.ObjectMeta))
@@ -158,6 +159,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 		framework.Logf("PodSpec: initContainers in spec.initContainers")
 		startedPod := podClient.Create(pod)
 		w, err := podClient.Watch(metav1.SingleObject(startedPod.ObjectMeta))
@@ -230,6 +232,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 		framework.Logf("PodSpec: initContainers in spec.initContainers")
 		startedPod := podClient.Create(pod)
 		w, err := podClient.Watch(metav1.SingleObject(startedPod.ObjectMeta))
@@ -347,6 +350,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 		framework.Logf("PodSpec: initContainers in spec.initContainers")
 		startedPod := podClient.Create(pod)
 

--- a/test/e2e/common/kubelet.go
+++ b/test/e2e/common/kubelet.go
@@ -60,6 +60,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 							Command: []string{"sh", "-c", "echo 'Hello World' ; sleep 240"},
 						},
 					},
+					NodeSelector: framework.GetOSNodeSelectorForPod(true),
 				},
 			})
 			Eventually(func() string {
@@ -94,6 +95,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 							Command: []string{"/bin/false"},
 						},
 					},
+					NodeSelector: framework.GetOSNodeSelectorForPod(true),
 				},
 			})
 		})
@@ -162,6 +164,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 							Hostnames: []string{"foo", "bar"},
 						},
 					},
+					NodeSelector: framework.GetOSNodeSelectorForPod(false),
 				},
 			})
 
@@ -210,6 +213,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 							},
 						},
 					},
+					NodeSelector: framework.GetOSNodeSelectorForPod(false),
 				},
 			})
 			Eventually(func() string {

--- a/test/e2e/common/kubelet_etc_hosts.go
+++ b/test/e2e/common/kubelet_etc_hosts.go
@@ -90,11 +90,13 @@ func (config *KubeletManagedHostConfig) setup() {
 
 func (config *KubeletManagedHostConfig) createPodWithoutHostNetwork() {
 	podSpec := config.createPodSpec(etcHostsPodName)
+	podSpec.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 	config.pod = config.f.PodClient().CreateSync(podSpec)
 }
 
 func (config *KubeletManagedHostConfig) createPodWithHostNetwork() {
 	podSpec := config.createPodSpecWithHostNetwork(etcHostsHostNetworkPodName)
+	podSpec.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 	config.hostNetworkPod = config.f.PodClient().CreateSync(podSpec)
 }
 

--- a/test/e2e/common/lifecycle_hook.go
+++ b/test/e2e/common/lifecycle_hook.go
@@ -58,9 +58,11 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 				},
 			},
 		}
+
 		BeforeEach(func() {
 			podClient = f.PodClient()
 			By("create the container to handle the HTTPGet hook request.")
+			podHandleHookRequest.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 			newPod := podClient.CreateSync(podHandleHookRequest)
 			targetIP = newPod.Status.PodIP
 		})
@@ -98,6 +100,7 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 				},
 			}
 			podWithHook := getPodWithHook("pod-with-poststart-exec-hook", imageutils.GetE2EImage(imageutils.Hostexec), lifecycle)
+			podWithHook.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 			testPodWithHook(podWithHook)
 		})
 		/*
@@ -114,6 +117,7 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 				},
 			}
 			podWithHook := getPodWithHook("pod-with-prestop-exec-hook", imageutils.GetE2EImage(imageutils.Hostexec), lifecycle)
+			podWithHook.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 			testPodWithHook(podWithHook)
 		})
 		/*
@@ -132,6 +136,7 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 				},
 			}
 			podWithHook := getPodWithHook("pod-with-poststart-http-hook", imageutils.GetPauseImageName(), lifecycle)
+			podWithHook.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 			testPodWithHook(podWithHook)
 		})
 		/*
@@ -150,6 +155,7 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 				},
 			}
 			podWithHook := getPodWithHook("pod-with-prestop-http-hook", imageutils.GetPauseImageName(), lifecycle)
+			podWithHook.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 			testPodWithHook(podWithHook)
 		})
 	})

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -140,7 +140,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 	*/
 	framework.ConformanceIt("should get a host IP [NodeConformance]", func() {
 		name := "pod-hostip-" + string(uuid.NewUUID())
-		testHostIP(podClient, &v1.Pod{
+		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
@@ -152,7 +152,9 @@ var _ = framework.KubeDescribe("Pods", func() {
 					},
 				},
 			},
-		})
+		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
+		testHostIP(podClient, pod)
 	})
 
 	/*
@@ -181,6 +183,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		By("setting up watch")
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
@@ -307,6 +310,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		By("submitting the pod to kubernetes")
 		pod = podClient.CreateSync(pod)
@@ -361,6 +365,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		By("submitting the pod to kubernetes")
 		podClient.CreateSync(pod)
@@ -405,6 +410,8 @@ var _ = framework.KubeDescribe("Pods", func() {
 				},
 			},
 		}
+		serverPod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
+
 		podClient.CreateSync(serverPod)
 
 		// This service exposes port 8080 of the test pod as a service on port 8765
@@ -454,6 +461,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		// It's possible for the Pod to be created before the Kubelet is updated with the new
 		// service. In that case, we just retry.
@@ -498,6 +506,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		By("submitting the pod to kubernetes")
 		pod = podClient.CreateSync(pod)
@@ -580,6 +589,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		By("submitting the pod to kubernetes")
 		podClient.CreateSync(pod)
@@ -636,6 +646,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		delay1, delay2 := startPodAndGetBackOffs(podClient, pod, buildBackOffDuration)
 
@@ -677,6 +688,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		podClient.CreateSync(pod)
 		time.Sleep(2 * kubelet.MaxContainerBackOff) // it takes slightly more than 2*x to get to a back-off of x

--- a/test/e2e/common/projected_combined.go
+++ b/test/e2e/common/projected_combined.go
@@ -85,6 +85,7 @@ var _ = Describe("[sig-storage] Projected combined", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 		f.TestContainerOutput("Check all projections for projected volume plugin", pod, 0, []string{
 			fmt.Sprintf("%s", podName),
 			"secret-value-1",

--- a/test/e2e/common/projected_downwardapi.go
+++ b/test/e2e/common/projected_downwardapi.go
@@ -48,6 +48,7 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 	framework.ConformanceIt("should provide podname only [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("%s\n", podName),
@@ -63,6 +64,8 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
+		// Windows does not support mode being set as permissions on Windows don't have Unix style equivalent
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			"mode of file \"/etc/podinfo/podname\": -r--------",
@@ -78,6 +81,8 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
+		// Windows does not support mode being set as permissions on Windows don't have Unix style equivalent
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			"mode of file \"/etc/podinfo/podname\": -r--------",
@@ -125,6 +130,8 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 
 		podName := "labelsupdate" + string(uuid.NewUUID())
 		pod := projectedDownwardAPIVolumePodForUpdateTest(podName, labels, map[string]string{}, "/etc/podinfo/labels")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
+
 		containerName := "client-container"
 		By("Creating the pod")
 		podClient.CreateSync(pod)
@@ -155,6 +162,7 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 		annotations["builder"] = "bar"
 		podName := "annotationupdate" + string(uuid.NewUUID())
 		pod := projectedDownwardAPIVolumePodForUpdateTest(podName, map[string]string{}, annotations, "/etc/podinfo/annotations")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		containerName := "client-container"
 		By("Creating the pod")
@@ -187,6 +195,7 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 	framework.ConformanceIt("should provide container's cpu limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_limit")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("2\n"),
@@ -201,6 +210,7 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 	framework.ConformanceIt("should provide container's memory limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("67108864\n"),
@@ -215,6 +225,7 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 	framework.ConformanceIt("should provide container's cpu request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_request")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("1\n"),
@@ -229,6 +240,7 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 	framework.ConformanceIt("should provide container's memory request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_request")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("33554432\n"),
@@ -243,6 +255,7 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/cpu_limit")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
@@ -255,6 +268,7 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/memory_limit")
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -74,6 +74,7 @@ var _ = Describe("[sig-api-machinery] Secrets", func() {
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("consume secrets", pod, 0, []string{
 			"SECRET_DATA=value-1",
@@ -118,6 +119,7 @@ var _ = Describe("[sig-api-machinery] Secrets", func() {
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		f.TestContainerOutput("consume secrets", pod, 0, []string{
 			"data_1=value-1", "data_2=value-2", "data_3=value-3",

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -108,6 +108,9 @@ type TestContextType struct {
 	DeleteNamespaceOnFailure bool
 	AllowedNotReadyNodes     int
 	CleanStart               bool
+	// If set to 'true' indicates that the tested cluster is to be a hybrid consisting of both Linux and Windows nodes
+	// This means tests that can't be run on Windows ( tmpfs tests , security context tests etc. ) will be run on the Linux nodes
+	HybridCluster bool
 	// If set to 'true' or 'all' framework will start a goroutine monitoring resource usage of system add-ons.
 	// It will read the data every 30 seconds from all Nodes and print summary during afterEach. If set to 'master'
 	// only master Node will be monitored.
@@ -252,6 +255,7 @@ func RegisterClusterFlags() {
 	flag.StringVar(&TestContext.ClusterMonitoringMode, "cluster-monitoring-mode", "standalone", "The monitoring solution that is used in the cluster.")
 	flag.BoolVar(&TestContext.EnablePrometheusMonitoring, "prometheus-monitoring", false, "Separate Prometheus monitoring deployed in cluster.")
 	flag.StringVar(&TestContext.ClusterDNSDomain, "dns-domain", "cluster.local", "The DNS Domain of the cluster.")
+	flag.BoolVar(&TestContext.HybridCluster, "hybrid-cluster", false, "Indicates weather the tested cluster is a hybrid consisting of Linux and Windows nodes")
 
 	// TODO: Flags per provider?  Rename gce-project/gce-zone?
 	cloudConfig := &TestContext.CloudConfig

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -201,6 +201,10 @@ const (
 
 	// ssh port
 	sshPort = "22"
+
+	nodeSelectorKey     = "beta.kubernetes.io/os"
+	nodeSelectorWindows = "windows"
+	nodeSelectorLinux   = "linux"
 )
 
 var (
@@ -460,6 +464,22 @@ func NodeOSDistroIs(supportedNodeOsDistros ...string) bool {
 		}
 	}
 	return false
+}
+
+func isHybridCluster() bool {
+	return TestContext.HybridCluster
+}
+
+func GetOSNodeSelectorForPod(testRunsOnWin bool) map[string]string {
+	nodeOS := nodeSelectorLinux
+	if isHybridCluster() && testRunsOnWin {
+		nodeOS = nodeSelectorWindows
+	}
+
+	return map[string]string{
+		nodeSelectorKey: nodeOS,
+	}
+
 }
 
 func ProxyMode(f *Framework) (string, error) {

--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -65,6 +65,7 @@ var _ = SIGDescribe("Events", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 		By("submitting the pod to kubernetes")
 		defer func() {

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -238,6 +238,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 					},
 				},
 			}
+			pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
 
 			By("submitting the pod to kubernetes")
 			podClient.Create(pod)

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -141,6 +141,8 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 				},
 			},
 		}
+		pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(true)
+
 		pod = f.PodClient().CreateSync(pod)
 
 		defer func() {

--- a/test/e2e/storage/subpath.go
+++ b/test/e2e/storage/subpath.go
@@ -58,6 +58,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		*/
 		framework.ConformanceIt("should support subpaths with secret pod", func() {
 			pod := testsuites.SubpathTestPod(f, "secret-key", "secret", &v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "my-secret"}}, privilegedSecurityContext)
+			pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 			testsuites.TestBasicSubpath(f, "secret-value", pod)
 		})
 
@@ -68,6 +69,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		*/
 		framework.ConformanceIt("should support subpaths with configmap pod", func() {
 			pod := testsuites.SubpathTestPod(f, "configmap-key", "configmap", &v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "my-configmap"}}}, privilegedSecurityContext)
+			pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 			testsuites.TestBasicSubpath(f, "configmap-value", pod)
 		})
 
@@ -80,6 +82,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 			pod := testsuites.SubpathTestPod(f, "configmap-key", "configmap", &v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "my-configmap"}}}, privilegedSecurityContext)
 			file := "/etc/resolv.conf"
 			pod.Spec.Containers[0].VolumeMounts[0].MountPath = file
+			pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 			testsuites.TestBasicSubpathFile(f, "configmap-value", pod, file)
 		})
 
@@ -94,6 +97,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 					Items: []v1.DownwardAPIVolumeFile{{Path: "downward/podname", FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.name"}}},
 				},
 			}, privilegedSecurityContext)
+			pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 			testsuites.TestBasicSubpath(f, pod.Name, pod)
 		})
 
@@ -113,6 +117,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 					},
 				},
 			}, privilegedSecurityContext)
+			pod.Spec.NodeSelector = framework.GetOSNodeSelectorForPod(false)
 			testsuites.TestBasicSubpath(f, "configmap-value", pod)
 		})
 	})


### PR DESCRIPTION
Alternative for: https://github.com/kubernetes/kubernetes/pull/69872 related to discussion / issue: https://github.com/kubernetes/kubernetes/issues/69892

As per the discussion with SIG-Architecture , clusters must pass all conformance tests. In the case of Windows only clusters, this is of course problematic since some features are by default not supported by Windows Nodes. 

A proposed solution for this is to have Hybrid clusters and run tests that can't possibly work on Windows on Linux.

For that, some changes need to be added in the tests, particularly a mechanism for ensuring that tests are ran on the proper node. The aproach here is to use a flag to mark the clusters as hybrid and then use nodeSelectors on the pod spec to ensure the proper node is used for the test.

This PR is marked as WIP as we should agree on the flag and if the approach is acceptable before converting 200+ tests :) . As such I only included some groups of conformance tests .

TO DO: 

- [ ] Have a discussion around what tests should be forced on Windows. i.e: sig-apps conformance tests. These tests don't specifically test anything specific about the nodes, thus is there a point in forcing them on Windows?