### PR TITLE
fix aws provider to handle only EBS volumes

### DIFF
--- a/pkg/cloudprovider/providers/aws/BUILD
+++ b/pkg/cloudprovider/providers/aws/BUILD
@@ -78,6 +78,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/kubelet/apis:go_default_library",
+        "//pkg/volume:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -2323,6 +2323,11 @@ func (c *Cloud) checkIfAvailable(disk *awsDisk, opName string, instance string) 
 
 // GetLabelsForVolume gets the volume labels for a volume
 func (c *Cloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error) {
+	// Ignore if not AWSElasticBlockStore.
+	if pv.Spec.AWSElasticBlockStore == nil {
+		return nil, nil
+	}
+
 	// Ignore any volumes that are being provisioned
 	if pv.Spec.AWSElasticBlockStore.VolumeID == volume.ProvisionedVolumeName {
 		return nil, nil

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
+	"k8s.io/kubernetes/pkg/volume"
 )
 
 const TestClusterID = "clusterid.test"
@@ -905,6 +906,98 @@ func TestGetVolumeLabels(t *testing.T) {
 		kubeletapis.LabelZoneFailureDomain: "us-east-1a",
 		kubeletapis.LabelZoneRegion:        "us-east-1"}, labels)
 	awsServices.ec2.(*MockedFakeEC2).AssertExpectations(t)
+}
+
+func TestGetLabelsForVolume(t *testing.T) {
+	defaultVolume := EBSVolumeID("vol-VolumeId").awsString()
+	tests := []struct {
+		name               string
+		pv                 *v1.PersistentVolume
+		expectedVolumeID   *string
+		expectedEC2Volumes []*ec2.Volume
+		expectedLabels     map[string]string
+		expectedError      error
+	}{
+		{
+			"not an EBS volume",
+			&v1.PersistentVolume{
+				Spec: v1.PersistentVolumeSpec{},
+			},
+			nil,
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"volume which is being provisioned",
+			&v1.PersistentVolume{
+				Spec: v1.PersistentVolumeSpec{
+					PersistentVolumeSource: v1.PersistentVolumeSource{
+						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
+							VolumeID: volume.ProvisionedVolumeName,
+						},
+					},
+				},
+			},
+			nil,
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"no volumes found",
+			&v1.PersistentVolume{
+				Spec: v1.PersistentVolumeSpec{
+					PersistentVolumeSource: v1.PersistentVolumeSource{
+						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
+							VolumeID: "vol-VolumeId",
+						},
+					},
+				},
+			},
+			defaultVolume,
+			nil,
+			nil,
+			fmt.Errorf("no volumes found"),
+		},
+		{
+			"correct labels for volume",
+			&v1.PersistentVolume{
+				Spec: v1.PersistentVolumeSpec{
+					PersistentVolumeSource: v1.PersistentVolumeSource{
+						AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
+							VolumeID: "vol-VolumeId",
+						},
+					},
+				},
+			},
+			defaultVolume,
+			[]*ec2.Volume{{
+				VolumeId:         defaultVolume,
+				AvailabilityZone: aws.String("us-east-1a"),
+			}},
+			map[string]string{
+				kubeletapis.LabelZoneFailureDomain: "us-east-1a",
+				kubeletapis.LabelZoneRegion:        "us-east-1",
+			},
+			nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			awsServices := newMockedFakeAWSServices(TestClusterID)
+			expectedVolumeRequest := &ec2.DescribeVolumesInput{VolumeIds: []*string{test.expectedVolumeID}}
+			awsServices.ec2.(*MockedFakeEC2).On("DescribeVolumes", expectedVolumeRequest).Return(test.expectedEC2Volumes)
+
+			c, err := newAWSCloud(CloudConfig{}, awsServices)
+			assert.Nil(t, err, "Error building aws cloud: %v", err)
+
+			l, err := c.GetLabelsForVolume(context.TODO(), test.pv)
+			assert.Equal(t, test.expectedLabels, l)
+			assert.Equal(t, test.expectedError, err)
+		})
+
+	}
 }
 
 func TestDescribeLoadBalancerOnDelete(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**: 
When the cloud-controller-manager is running with PV label initializing controller and NFS volume is created, it causes nil pointer dereference error.

**Which issue(s) this PR fixes**:
Fixes #68996

**Special notes for your reviewer**: 
I'll fix `OpenStack` and `GCE` in subsequent PR.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Fix cloud-controller-manager crash when using AWS provider and PersistentVolume initializing controller 
```

/sig cloud-provider
/sig aws
