### PR TITLE
prevent sorting of PATH dirs for kubectl plugins

### DIFF
--- a/pkg/kubectl/cmd/plugin/BUILD
+++ b/pkg/kubectl/cmd/plugin/BUILD
@@ -9,7 +9,6 @@ go_library(
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/util/i18n:go_default_library",
         "//pkg/kubectl/util/templates:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],


### PR DESCRIPTION
This patch allows the `kubectl plugin list` command to display discovered
plugin paths in the same order as they appear in a user's PATH.
Prior to this patch, discovered plugin paths were sorted before being
displayed.

Additionally, any errors encountered while reading from any directory in a
user's PATH will now be printed to stderr at the end of the command's
output.

/kind bug

**Does this PR introduce a user-facing change?**:
```release-note
The `kubectl plugin list` command will now display discovered plugin paths in the same order as they are found in a user's PATH variable.
```

/sig cli

cc @soltysh @seans3 