### PR TITLE
Add Aliases to workflow phases

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/workflow/phase.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/phase.go
@@ -24,6 +24,9 @@ type Phase struct {
 	// the same workflow or phases belonging to the same parent phase).
 	Name string
 
+	// Aliases returns the aliases for the pashe.
+	Aliases []string
+
 	// Short description of the phase.
 	Short string
 

--- a/cmd/kubeadm/app/cmd/phases/workflow/runner.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/runner.go
@@ -301,6 +301,7 @@ func (e *Runner) BindToCommand(cmd *cobra.Command) {
 			Short:   p.Short,
 			Long:    p.Long,
 			Example: p.Example,
+			Aliases: p.Aliases,
 			Run: func(cmd *cobra.Command, args []string) {
 				e.Options.FilterPhases = []string{p.generatedName}
 				if err := e.Run(); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Many subphases use aliases, will help on https://github.com/kubernetes/kubeadm/issues/1163

```release-note
NONE
```
