### PR TITLE
kubeadm: remove the unit test TestRunListTokens

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -111,7 +111,6 @@ go_test(
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",
-        "//staging/src/k8s.io/cluster-bootstrap/token/api:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/renstrom/dedent:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:

Remove the test based on these points:

- it's apparently flaky by more than one reports and it's hard to debug.
- it's not a CLI unit test.
- it's testing API objects using a fake API server which is a bad hack...
- existing e2e tests already provide coverage for all
the `expectedError: false` cases.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
refs discussion in: https://github.com/kubernetes/kubeadm/issues/952
fixes https://github.com/kubernetes/kubernetes/issues/64625

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/assign @ncdc @timothysc 
