### PR TITLE
Update API-related owners files

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,4 +1,7 @@
 aliases:
+  sig-storage-reviewers:
+    - saad-ali
+    - childsb
   sig-scheduling-maintainers:
     - bsalamat
     - davidopp

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/OWNERS
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/OWNERS
@@ -6,5 +6,4 @@ approvers:
 reviewers:
 - api-reviewers
 labels:
-- sig/architecture
 - kind/api-change

--- a/staging/src/k8s.io/apimachinery/pkg/apis/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/OWNERS
@@ -6,5 +6,4 @@ approvers:
 reviewers:
 - api-reviewers
 labels:
-- sig/architecture
 - kind/api-change

--- a/staging/src/k8s.io/apiserver/pkg/apis/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/apis/OWNERS
@@ -6,5 +6,4 @@ approvers:
 reviewers:
 - api-reviewers
 labels:
-- sig/architecture
 - kind/api-change

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/OWNERS
@@ -1,7 +1,0 @@
-approvers:
-- api-approvers
-- sttts
-- luxas
-reviewers:
-- api-reviewers
-- hanxiaoshuai

--- a/staging/src/k8s.io/csi-api/pkg/apis/OWNERS
+++ b/staging/src/k8s.io/csi-api/pkg/apis/OWNERS
@@ -5,6 +5,6 @@ approvers:
 - api-approvers
 reviewers:
 - api-reviewers
+- sig-storage-reviewers
 labels:
-- sig/architecture
 - kind/api-change

--- a/staging/src/k8s.io/csi-api/pkg/crd/OWNERS
+++ b/staging/src/k8s.io/csi-api/pkg/crd/OWNERS
@@ -5,6 +5,6 @@ approvers:
 - api-approvers
 reviewers:
 - api-reviewers
+- sig-storage-reviewers
 labels:
-- sig/architecture
 - kind/api-change

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/OWNERS
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/OWNERS
@@ -6,5 +6,4 @@ approvers:
 reviewers:
 - api-reviewers
 labels:
-- sig/architecture
 - kind/api-change

--- a/staging/src/k8s.io/kube-controller-manager/OWNERS
+++ b/staging/src/k8s.io/kube-controller-manager/OWNERS
@@ -1,12 +1,10 @@
 approvers:
-- api-approvers
 - deads2k
 - luxas
 - mtaufen
 - sttts
 - stewart-yu
 reviewers:
-- api-reviewers
 - deads2k
 - luxas
 - mtaufen

--- a/staging/src/k8s.io/kube-controller-manager/config/OWNERS
+++ b/staging/src/k8s.io/kube-controller-manager/config/OWNERS
@@ -5,6 +5,10 @@ approvers:
 - api-approvers
 reviewers:
 - api-reviewers
+- deads2k
+- luxas
+- mtaufen
+- sttts
+- stewart-yu
 labels:
-- sig/architecture
 - kind/api-change

--- a/staging/src/k8s.io/kube-proxy/OWNERS
+++ b/staging/src/k8s.io/kube-proxy/OWNERS
@@ -1,10 +1,8 @@
 approvers:
-- api-approvers
 - sig-network-approvers
 - sttts
 - luxas
 reviewers:
-- api-reviewers
 - sig-network-reviewers
 - luxas
 - sttts

--- a/staging/src/k8s.io/kube-proxy/config/OWNERS
+++ b/staging/src/k8s.io/kube-proxy/config/OWNERS
@@ -5,6 +5,6 @@ approvers:
 - api-approvers
 reviewers:
 - api-reviewers
+- sig-network-reviewers
 labels:
-- sig/architecture
 - kind/api-change

--- a/staging/src/k8s.io/kube-scheduler/OWNERS
+++ b/staging/src/k8s.io/kube-scheduler/OWNERS
@@ -1,11 +1,9 @@
 approvers:
-- api-approvers
 - sig-scheduling-maintainers
 - sttts
 - luxas
 reviewers:
 - sig-scheduling
-- api-reviewers
 - dixudx
 - luxas
 - sttts

--- a/staging/src/k8s.io/kube-scheduler/config/OWNERS
+++ b/staging/src/k8s.io/kube-scheduler/config/OWNERS
@@ -5,6 +5,6 @@ approvers:
 - api-approvers
 reviewers:
 - api-reviewers
+- sig-scheduling
 labels:
-- sig/architecture
 - kind/api-change

--- a/staging/src/k8s.io/kubelet/OWNERS
+++ b/staging/src/k8s.io/kubelet/OWNERS
@@ -1,11 +1,9 @@
 approvers:
-- api-approvers
 - sig-node-approvers
 - sttts
 - luxas
 - mtaufen
 reviewers:
-- api-reviewers
 - sig-node-reviewers
 - luxas
 - sttts

--- a/staging/src/k8s.io/kubelet/config/OWNERS
+++ b/staging/src/k8s.io/kubelet/config/OWNERS
@@ -5,6 +5,6 @@ approvers:
 - api-approvers
 reviewers:
 - api-reviewers
+- sig-node-reviewers
 labels:
-- sig/architecture
 - kind/api-change

--- a/staging/src/k8s.io/metrics/pkg/apis/OWNERS
+++ b/staging/src/k8s.io/metrics/pkg/apis/OWNERS
@@ -5,6 +5,6 @@ approvers:
 - api-approvers
 reviewers:
 - api-reviewers
+- sig-autoscaling-maintainers
 labels:
-- sig/architecture
 - kind/api-change


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Updates owners files to funnel [API changes](https://github.com/kubernetes/community/blob/master/sig-architecture/api-review-process.md#what-apis-need-to-be-reviewed) through API review. Follow up from https://github.com/kubernetes/kubernetes/pull/69772 that includes API directories for config and CRD-related APIs.

```release-note
NONE
```

cc @kubernetes/sig-architecture-pr-reviews 