### PR TITLE
WIP: Get full-object from server before exposing

### DIFF
--- a/pkg/kubectl/cmd/expose/expose.go
+++ b/pkg/kubectl/cmd/expose/expose.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -234,6 +233,10 @@ func (o *ExposeServiceOptions) RunExpose(cmd *cobra.Command, args []string) erro
 
 	err = r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
+			return err
+		}
+
+		if err := info.Get(); err != nil {
 			return err
 		}
 

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -1096,31 +1096,31 @@ run_rc_tests() {
 
   ### Expose deployments by creating a service
   # Uses deployment selectors for created service
+  kubectl apply -f test/fixtures/pkg/kubectl/cmd/expose/appsv1deployment.yaml "${kube_flags[@]}"
   output_message=$(kubectl expose -f test/fixtures/pkg/kubectl/cmd/expose/appsv1deployment.yaml --port 80 2>&1 "${kube_flags[@]}")
   # Post-condition: service created for deployment.
   kube::test::if_has_string "${output_message}" 'service/expose-test-deployment exposed'
   # Clean-up
   kubectl delete service/expose-test-deployment "${kube_flags[@]}"
+  kubectl delete -f test/fixtures/pkg/kubectl/cmd/expose/appsv1deployment.yaml "${kube_flags[@]}"
+
   # Uses deployment selectors for created service
+  kubectl apply -f test/fixtures/pkg/kubectl/cmd/expose/appsv1beta2deployment.yaml "${kube_flags[@]}"
   output_message=$(kubectl expose -f test/fixtures/pkg/kubectl/cmd/expose/appsv1beta2deployment.yaml --port 80 2>&1 "${kube_flags[@]}")
   # Post-condition: service created for deployment.
   kube::test::if_has_string "${output_message}" 'service/expose-test-deployment exposed'
   # Clean-up
   kubectl delete service/expose-test-deployment "${kube_flags[@]}"
+  kubectl delete -f test/fixtures/pkg/kubectl/cmd/expose/appsv1beta2deployment.yaml "${kube_flags[@]}"
+
   # Uses deployment selectors for created service
+  kubectl apply -f test/fixtures/pkg/kubectl/cmd/expose/appsv1beta1deployment.yaml "${kube_flags[@]}"
   output_message=$(kubectl expose -f test/fixtures/pkg/kubectl/cmd/expose/appsv1beta1deployment.yaml --port 80 2>&1 "${kube_flags[@]}")
   # Post-condition: service created for deployment.
   kube::test::if_has_string "${output_message}" 'service/expose-test-deployment exposed'
   # Clean-up
   kubectl delete service/expose-test-deployment "${kube_flags[@]}"
-  # Contains no selectors, should fail.
-  output_message=$(! kubectl expose -f test/fixtures/pkg/kubectl/cmd/expose/appsv1deployment-no-selectors.yaml --port 80 2>&1 "${kube_flags[@]}")
-  # Post-condition: service created for deployment.
-  kube::test::if_has_string "${output_message}" 'invalid deployment: no selectors'
-  # Contains no selectors, should fail.
-  output_message=$(! kubectl expose -f test/fixtures/pkg/kubectl/cmd/expose/appsv1beta2deployment-no-selectors.yaml --port 80 2>&1 "${kube_flags[@]}")
-  # Post-condition: service created for deployment.
-  kube::test::if_has_string "${output_message}" 'invalid deployment: no selectors'
+  kubectl delete -f test/fixtures/pkg/kubectl/cmd/expose/appsv1beta1deployment.yaml "${kube_flags[@]}"
 
   ### Expose a deployment as a service
   kubectl create -f test/fixtures/doc-yaml/user-guide/deployment.yaml "${kube_flags[@]}"
@@ -1170,6 +1170,8 @@ run_rc_tests() {
   kube::test::if_has_string "${output_message}" 'cannot expose'
 
   ### Try to generate a service with invalid name (exceeding maximum valid size)
+  # First we create the pod
+  kubectl apply -f hack/testdata/pod-with-large-name.yaml "${kube_flags[@]}"
   # Pre-condition: use --name flag
   output_message=$(! kubectl expose -f hack/testdata/pod-with-large-name.yaml --name=invalid-large-service-name-that-has-more-than-sixty-three-characters --port=8081 2>&1 "${kube_flags[@]}")
   # Post-condition: should fail due to invalid name
@@ -1180,8 +1182,10 @@ run_rc_tests() {
   kube::test::if_has_string "${output_message}" 'kubernetes-serve-hostname-testing-sixty-three-characters-in-len exposed'
   # Clean-up
   kubectl delete svc kubernetes-serve-hostname-testing-sixty-three-characters-in-len "${kube_flags[@]}"
+  kubectl delete -f hack/testdata/pod-with-large-name.yaml "${kube_flags[@]}"
 
   ### Expose multiport object as a new service
+  kubectl apply -f test/fixtures/doc-yaml/admin/high-availability/etcd.yaml "${kube_flags[@]}"
   # Pre-condition: don't use --port flag
   output_message=$(kubectl expose -f test/fixtures/doc-yaml/admin/high-availability/etcd.yaml --selector=test=etcd 2>&1 "${kube_flags[@]}")
   # Post-condition: expose succeeded
@@ -1191,6 +1195,7 @@ run_rc_tests() {
   kube::test::get_object_assert 'service etcd-server' "{{$second_port_name}} {{$second_port_field}}" 'port-2 2379'
   # Clean-up
   kubectl delete svc etcd-server "${kube_flags[@]}"
+  kubectl delete -f test/fixtures/doc-yaml/admin/high-availability/etcd.yaml "${kube_flags[@]}"
 
   ### Delete replication controller with id
   # Pre-condition: frontend replication controller exists

--- a/test/cmd/template-output.sh
+++ b/test/cmd/template-output.sh
@@ -59,8 +59,10 @@ run_template_output_tests() {
   kube::test::if_has_string "${output_message}" 'scale-1:'
 
   # check that expose command supports --template output
+  kubectl apply -f hack/testdata/redis-slave-replicaset.yaml "${kube_flags[@]}"
   output_message=$(kubectl "${kube_flags[@]}" expose -f hack/testdata/redis-slave-replicaset.yaml --save-config --port=80 --target-port=8000 --dry-run --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'redis-slave:'
+  kubectl delete -f hack/testdata/redis-slave-replicaset.yaml "${kube_flags[@]}"
 
   # check that convert command supports --template output
   output_message=$(kubectl "${kube_flags[@]}" convert -f hack/testdata/deployment-revision1.yaml --output-version=apps/v1beta1 --template="{{ .metadata.name }}:")


### PR DESCRIPTION
Get the object that we want to expose from the server before we actually expose. When using `-f filename`, the file may not contain up-to-date information and hasn't be defaulted. We can't necessarily assume that the default or what is in the file is what needs to be exposed.

One drawback of this pull-request is that you can no longer expose a deployment/... that hasn't been created yet.

WIP Because I think we want to discuss this, and I have no clue if this works.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
