### PR TITLE
fix gce provider to handle only GCEPersistentDisk volumes

### DIFF
--- a/pkg/cloudprovider/providers/gce/BUILD
+++ b/pkg/cloudprovider/providers/gce/BUILD
@@ -117,6 +117,7 @@ go_test(
         "//pkg/cloudprovider/providers/gce/cloud/mock:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/net/sets:go_default_library",
+        "//pkg/volume:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/cloudprovider/providers/gce/gce_disks.go
+++ b/pkg/cloudprovider/providers/gce/gce_disks.go
@@ -511,6 +511,11 @@ func newDiskMetricContextRegional(request, region string) *metricContext {
 }
 
 func (gce *GCECloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error) {
+	// Ignore any volumes which are not GCEPersistentDisk
+	if pv.Spec.GCEPersistentDisk == nil {
+		return nil, nil
+	}
+
 	// Ignore any volumes that are being provisioned
 	if pv.Spec.GCEPersistentDisk.PDName == volume.ProvisionedVolumeName {
 		return nil, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**: 
When the cloud-controller-manager is running with PV label initializing controller and NFS volume is created, it causes nil pointer dereference error.

**Which issue(s) this PR fixes**:
gce variant of #68996

**Special notes for your reviewer**: 
This the `GCE` variant of #70432 .

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Fix cloud-controller-manager crash when using GCE provider and PersistentVolume initializing controller 
```

/sig cloud-provider
/sig gcp
