### PR TITLE
fix auditsink validation output

### DIFF
--- a/pkg/apis/auditregistration/validation/validation.go
+++ b/pkg/apis/auditregistration/validation/validation.go
@@ -38,8 +38,8 @@ func ValidateAuditSink(as *auditregistration.AuditSink) field.ErrorList {
 // ValidateAuditSinkSpec validates the sink spec for audit
 func ValidateAuditSinkSpec(s auditregistration.AuditSinkSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
-	allErrs = append(allErrs, ValidatePolicy(s.Policy, field.NewPath("policy"))...)
-	allErrs = append(allErrs, ValidateWebhook(s.Webhook, field.NewPath("webhook"))...)
+	allErrs = append(allErrs, ValidatePolicy(s.Policy, fldPath.Child("policy"))...)
+	allErrs = append(allErrs, ValidateWebhook(s.Webhook, fldPath.Child("webhook"))...)
 	return allErrs
 }
 


### PR DESCRIPTION

 /kind bug


**What this PR does / why we need it**:
fix auditsink object validation output

-->
```release-note
NONE
```
