### PR TITLE
[*-controller-manager]get rid of copied fields in the options and using componentconfig fields

### DIFF
--- a/cmd/cloud-controller-manager/app/options/BUILD
+++ b/cmd/cloud-controller-manager/app/options/BUILD
@@ -55,6 +55,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/controller-manager/app/options:go_default_library",
+        "//pkg/controller/apis/config:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",

--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -82,10 +82,10 @@ func NewCloudControllerManagerOptions() (*CloudControllerManagerOptions, error) 
 	}
 
 	s := CloudControllerManagerOptions{
-		Generic:         cmoptions.NewGenericControllerManagerConfigurationOptions(componentConfig.Generic),
-		KubeCloudShared: cmoptions.NewKubeCloudSharedOptions(componentConfig.KubeCloudShared),
+		Generic:         cmoptions.NewGenericControllerManagerConfigurationOptions(&componentConfig.Generic),
+		KubeCloudShared: cmoptions.NewKubeCloudSharedOptions(&componentConfig.KubeCloudShared),
 		ServiceController: &cmoptions.ServiceControllerOptions{
-			ConcurrentServiceSyncs: componentConfig.ServiceController.ConcurrentServiceSyncs,
+			ServiceControllerConfiguration: &componentConfig.ServiceController,
 		},
 		SecureServing: apiserveroptions.NewSecureServingOptions().WithLoopback(),
 		InsecureServing: (&apiserveroptions.DeprecatedInsecureServingOptions{

--- a/cmd/cloud-controller-manager/app/options/options_test.go
+++ b/cmd/cloud-controller-manager/app/options/options_test.go
@@ -29,6 +29,7 @@ import (
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	componentbaseconfig "k8s.io/component-base/config"
 	cmoptions "k8s.io/kubernetes/cmd/controller-manager/app/options"
+	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 )
 
 func TestDefaultFlags(t *testing.T) {
@@ -36,42 +37,52 @@ func TestDefaultFlags(t *testing.T) {
 
 	expected := &CloudControllerManagerOptions{
 		Generic: &cmoptions.GenericControllerManagerConfigurationOptions{
-			Port:            DefaultInsecureCloudControllerManagerPort, // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
-			Address:         "0.0.0.0",                                 // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
-			MinResyncPeriod: metav1.Duration{Duration: 12 * time.Hour},
-			ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
-				ContentType: "application/vnd.kubernetes.protobuf",
-				QPS:         20.0,
-				Burst:       30,
-			},
-			ControllerStartInterval: metav1.Duration{Duration: 0},
-			LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-				ResourceLock:  "endpoints",
-				LeaderElect:   true,
-				LeaseDuration: metav1.Duration{Duration: 15 * time.Second},
-				RenewDeadline: metav1.Duration{Duration: 10 * time.Second},
-				RetryPeriod:   metav1.Duration{Duration: 2 * time.Second},
+			GenericControllerManagerConfiguration: &kubectrlmgrconfig.GenericControllerManagerConfiguration{
+				Port:            DefaultInsecureCloudControllerManagerPort, // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
+				Address:         "0.0.0.0",                                 // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
+				MinResyncPeriod: metav1.Duration{Duration: 12 * time.Hour},
+				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
+					ContentType: "application/vnd.kubernetes.protobuf",
+					QPS:         20.0,
+					Burst:       30,
+				},
+				ControllerStartInterval: metav1.Duration{Duration: 0},
+				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+					ResourceLock:  "endpoints",
+					LeaderElect:   true,
+					LeaseDuration: metav1.Duration{Duration: 15 * time.Second},
+					RenewDeadline: metav1.Duration{Duration: 10 * time.Second},
+					RetryPeriod:   metav1.Duration{Duration: 2 * time.Second},
+				},
+				Controllers: []string{"*"},
 			},
 			Debugging: &cmoptions.DebuggingOptions{
-				EnableContentionProfiling: false,
+				DebuggingConfiguration: &componentbaseconfig.DebuggingConfiguration{
+					EnableContentionProfiling: false,
+				},
 			},
-			Controllers: []string{"*"},
 		},
 		KubeCloudShared: &cmoptions.KubeCloudSharedOptions{
-			RouteReconciliationPeriod: metav1.Duration{Duration: 10 * time.Second},
-			NodeMonitorPeriod:         metav1.Duration{Duration: 5 * time.Second},
-			ClusterName:               "kubernetes",
-			ClusterCIDR:               "",
-			AllocateNodeCIDRs:         false,
-			CIDRAllocatorType:         "",
-			ConfigureCloudRoutes:      true,
+			KubeCloudSharedConfiguration: &kubectrlmgrconfig.KubeCloudSharedConfiguration{
+				RouteReconciliationPeriod: metav1.Duration{Duration: 10 * time.Second},
+				NodeMonitorPeriod:         metav1.Duration{Duration: 5 * time.Second},
+				ClusterName:               "kubernetes",
+				ClusterCIDR:               "",
+				AllocateNodeCIDRs:         false,
+				CIDRAllocatorType:         "",
+				ConfigureCloudRoutes:      true,
+			},
 			CloudProvider: &cmoptions.CloudProviderOptions{
-				Name:            "",
-				CloudConfigFile: "",
+				CloudProviderConfiguration: &kubectrlmgrconfig.CloudProviderConfiguration{
+					Name:            "",
+					CloudConfigFile: "",
+				},
 			},
 		},
 		ServiceController: &cmoptions.ServiceControllerOptions{
-			ConcurrentServiceSyncs: 1,
+			ServiceControllerConfiguration: &kubectrlmgrconfig.ServiceControllerConfiguration{
+				ConcurrentServiceSyncs: 1,
+			},
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
 			BindPort:    10258,
@@ -155,42 +166,52 @@ func TestAddFlags(t *testing.T) {
 
 	expected := &CloudControllerManagerOptions{
 		Generic: &cmoptions.GenericControllerManagerConfigurationOptions{
-			Port:            DefaultInsecureCloudControllerManagerPort, // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
-			Address:         "0.0.0.0",                                 // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
-			MinResyncPeriod: metav1.Duration{Duration: 100 * time.Minute},
-			ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
-				ContentType: "application/vnd.kubernetes.protobuf",
-				QPS:         50.0,
-				Burst:       100,
-			},
-			ControllerStartInterval: metav1.Duration{Duration: 2 * time.Minute},
-			LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-				ResourceLock:  "configmap",
-				LeaderElect:   false,
-				LeaseDuration: metav1.Duration{Duration: 30 * time.Second},
-				RenewDeadline: metav1.Duration{Duration: 15 * time.Second},
-				RetryPeriod:   metav1.Duration{Duration: 5 * time.Second},
+			GenericControllerManagerConfiguration: &kubectrlmgrconfig.GenericControllerManagerConfiguration{
+				Port:            DefaultInsecureCloudControllerManagerPort, // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
+				Address:         "0.0.0.0",                                 // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
+				MinResyncPeriod: metav1.Duration{Duration: 100 * time.Minute},
+				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
+					ContentType: "application/vnd.kubernetes.protobuf",
+					QPS:         50.0,
+					Burst:       100,
+				},
+				ControllerStartInterval: metav1.Duration{Duration: 2 * time.Minute},
+				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+					ResourceLock:  "configmap",
+					LeaderElect:   false,
+					LeaseDuration: metav1.Duration{Duration: 30 * time.Second},
+					RenewDeadline: metav1.Duration{Duration: 15 * time.Second},
+					RetryPeriod:   metav1.Duration{Duration: 5 * time.Second},
+				},
+				Controllers: []string{"foo", "bar"},
 			},
 			Debugging: &cmoptions.DebuggingOptions{
-				EnableContentionProfiling: true,
+				DebuggingConfiguration: &componentbaseconfig.DebuggingConfiguration{
+					EnableContentionProfiling: true,
+				},
 			},
-			Controllers: []string{"foo", "bar"},
 		},
 		KubeCloudShared: &cmoptions.KubeCloudSharedOptions{
-			CloudProvider: &cmoptions.CloudProviderOptions{
-				Name:            "gce",
-				CloudConfigFile: "/cloud-config",
+			KubeCloudSharedConfiguration: &kubectrlmgrconfig.KubeCloudSharedConfiguration{
+				RouteReconciliationPeriod: metav1.Duration{Duration: 30 * time.Second},
+				NodeMonitorPeriod:         metav1.Duration{Duration: 5 * time.Second},
+				ClusterName:               "k8s",
+				ClusterCIDR:               "1.2.3.4/24",
+				AllocateNodeCIDRs:         true,
+				CIDRAllocatorType:         "RangeAllocator",
+				ConfigureCloudRoutes:      false,
 			},
-			RouteReconciliationPeriod: metav1.Duration{Duration: 30 * time.Second},
-			NodeMonitorPeriod:         metav1.Duration{Duration: 5 * time.Second},
-			ClusterName:               "k8s",
-			ClusterCIDR:               "1.2.3.4/24",
-			AllocateNodeCIDRs:         true,
-			CIDRAllocatorType:         "RangeAllocator",
-			ConfigureCloudRoutes:      false,
+			CloudProvider: &cmoptions.CloudProviderOptions{
+				CloudProviderConfiguration: &kubectrlmgrconfig.CloudProviderConfiguration{
+					Name:            "gce",
+					CloudConfigFile: "/cloud-config",
+				},
+			},
 		},
 		ServiceController: &cmoptions.ServiceControllerOptions{
-			ConcurrentServiceSyncs: 1,
+			ServiceControllerConfiguration: &kubectrlmgrconfig.ServiceControllerConfiguration{
+				ConcurrentServiceSyncs: 1,
+			},
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
 			BindPort:    10001,

--- a/cmd/controller-manager/app/options/BUILD
+++ b/cmd/controller-manager/app/options/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//pkg/client/leaderelectionconfig:go_default_library",
         "//pkg/cloudprovider/providers:go_default_library",
         "//pkg/controller/apis/config:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/globalflag:go_default_library",

--- a/cmd/controller-manager/app/options/cloudprovider.go
+++ b/cmd/controller-manager/app/options/cloudprovider.go
@@ -24,8 +24,7 @@ import (
 
 // CloudProviderOptions holds the cloudprovider options.
 type CloudProviderOptions struct {
-	CloudConfigFile string
-	Name            string
+	*kubectrlmgrconfig.CloudProviderConfiguration
 }
 
 // Validate checks validation of cloudprovider options.

--- a/cmd/controller-manager/app/options/debugging.go
+++ b/cmd/controller-manager/app/options/debugging.go
@@ -24,8 +24,7 @@ import (
 
 // DebuggingOptions holds the Debugging options.
 type DebuggingOptions struct {
-	EnableProfiling           bool
-	EnableContentionProfiling bool
+	*componentbaseconfig.DebuggingConfiguration
 }
 
 // AddFlags adds flags related to debugging for controller manager to the specified FlagSet.

--- a/cmd/controller-manager/app/options/generic.go
+++ b/cmd/controller-manager/app/options/generic.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
 	componentbaseconfig "k8s.io/component-base/config"
@@ -30,29 +29,19 @@ import (
 
 // GenericControllerManagerConfigurationOptions holds the options which are generic.
 type GenericControllerManagerConfigurationOptions struct {
-	Port                    int32
-	Address                 string
-	MinResyncPeriod         metav1.Duration
-	ClientConnection        componentbaseconfig.ClientConnectionConfiguration
-	ControllerStartInterval metav1.Duration
-	LeaderElection          componentbaseconfig.LeaderElectionConfiguration
-	Debugging               *DebuggingOptions
-	Controllers             []string
+	*kubectrlmgrconfig.GenericControllerManagerConfiguration
+	Debugging *DebuggingOptions
 }
 
 // NewGenericControllerManagerConfigurationOptions returns generic configuration default values for both
 // the kube-controller-manager and the cloud-contoller-manager. Any common changes should
 // be made here. Any individual changes should be made in that controller.
-func NewGenericControllerManagerConfigurationOptions(cfg kubectrlmgrconfig.GenericControllerManagerConfiguration) *GenericControllerManagerConfigurationOptions {
+func NewGenericControllerManagerConfigurationOptions(cfg *kubectrlmgrconfig.GenericControllerManagerConfiguration) *GenericControllerManagerConfigurationOptions {
 	o := &GenericControllerManagerConfigurationOptions{
-		Port:                    cfg.Port,
-		Address:                 cfg.Address,
-		MinResyncPeriod:         cfg.MinResyncPeriod,
-		ClientConnection:        cfg.ClientConnection,
-		ControllerStartInterval: cfg.ControllerStartInterval,
-		LeaderElection:          cfg.LeaderElection,
-		Debugging:               &DebuggingOptions{},
-		Controllers:             cfg.Controllers,
+		GenericControllerManagerConfiguration: cfg,
+		Debugging: &DebuggingOptions{
+			DebuggingConfiguration: &componentbaseconfig.DebuggingConfiguration{},
+		},
 	}
 
 	return o

--- a/cmd/controller-manager/app/options/kubecloudshared.go
+++ b/cmd/controller-manager/app/options/kubecloudshared.go
@@ -19,39 +19,25 @@ package options
 import (
 	"github.com/spf13/pflag"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 )
 
 // KubeCloudSharedOptions holds the options shared between kube-controller-manager
 // and cloud-controller-manager.
 type KubeCloudSharedOptions struct {
-	CloudProvider                *CloudProviderOptions
-	ExternalCloudVolumePlugin    string
-	UseServiceAccountCredentials bool
-	AllowUntaggedCloud           bool
-	RouteReconciliationPeriod    metav1.Duration
-	NodeMonitorPeriod            metav1.Duration
-	ClusterName                  string
-	ClusterCIDR                  string
-	AllocateNodeCIDRs            bool
-	CIDRAllocatorType            string
-	ConfigureCloudRoutes         bool
-	NodeSyncPeriod               metav1.Duration
+	*kubectrlmgrconfig.KubeCloudSharedConfiguration
+	CloudProvider *CloudProviderOptions
 }
 
 // NewKubeCloudSharedOptions returns common/default configuration values for both
 // the kube-controller-manager and the cloud-contoller-manager. Any common changes should
 // be made here. Any individual changes should be made in that controller.
-func NewKubeCloudSharedOptions(cfg kubectrlmgrconfig.KubeCloudSharedConfiguration) *KubeCloudSharedOptions {
+func NewKubeCloudSharedOptions(cfg *kubectrlmgrconfig.KubeCloudSharedConfiguration) *KubeCloudSharedOptions {
 	o := &KubeCloudSharedOptions{
-		CloudProvider:                &CloudProviderOptions{},
-		ExternalCloudVolumePlugin:    cfg.ExternalCloudVolumePlugin,
-		UseServiceAccountCredentials: cfg.UseServiceAccountCredentials,
-		RouteReconciliationPeriod:    cfg.RouteReconciliationPeriod,
-		NodeMonitorPeriod:            cfg.NodeMonitorPeriod,
-		ClusterName:                  cfg.ClusterName,
-		ConfigureCloudRoutes:         cfg.ConfigureCloudRoutes,
+		KubeCloudSharedConfiguration: cfg,
+		CloudProvider: &CloudProviderOptions{
+			CloudProviderConfiguration: &kubectrlmgrconfig.CloudProviderConfiguration{},
+		},
 	}
 
 	return o
@@ -92,6 +78,7 @@ func (o *KubeCloudSharedOptions) ApplyTo(cfg *kubectrlmgrconfig.KubeCloudSharedC
 	if err := o.CloudProvider.ApplyTo(&cfg.CloudProvider); err != nil {
 		return err
 	}
+
 	cfg.ExternalCloudVolumePlugin = o.ExternalCloudVolumePlugin
 	cfg.UseServiceAccountCredentials = o.UseServiceAccountCredentials
 	cfg.AllowUntaggedCloud = o.AllowUntaggedCloud

--- a/cmd/controller-manager/app/options/servicecontroller.go
+++ b/cmd/controller-manager/app/options/servicecontroller.go
@@ -24,7 +24,7 @@ import (
 
 // ServiceControllerOptions holds the ServiceController options.
 type ServiceControllerOptions struct {
-	ConcurrentServiceSyncs int32
+	*kubectrlmgrconfig.ServiceControllerConfiguration
 }
 
 // AddFlags adds flags related to ServiceController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/BUILD
+++ b/cmd/kube-controller-manager/app/options/BUILD
@@ -40,7 +40,6 @@ go_library(
         "//pkg/features:go_default_library",
         "//pkg/master/ports:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",

--- a/cmd/kube-controller-manager/app/options/attachdetachcontroller.go
+++ b/cmd/kube-controller-manager/app/options/attachdetachcontroller.go
@@ -19,14 +19,12 @@ package options
 import (
 	"github.com/spf13/pflag"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 )
 
 // AttachDetachControllerOptions holds the AttachDetachController options.
 type AttachDetachControllerOptions struct {
-	ReconcilerSyncLoopPeriod          metav1.Duration
-	DisableAttachDetachReconcilerSync bool
+	*kubectrlmgrconfig.AttachDetachControllerConfiguration
 }
 
 // AddFlags adds flags related to AttachDetachController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/csrsigningcontroller.go
+++ b/cmd/kube-controller-manager/app/options/csrsigningcontroller.go
@@ -19,7 +19,6 @@ package options
 import (
 	"github.com/spf13/pflag"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 )
 
@@ -35,9 +34,7 @@ const (
 
 // CSRSigningControllerOptions holds the CSRSigningController options.
 type CSRSigningControllerOptions struct {
-	ClusterSigningDuration metav1.Duration
-	ClusterSigningKeyFile  string
-	ClusterSigningCertFile string
+	*kubectrlmgrconfig.CSRSigningControllerConfiguration
 }
 
 // AddFlags adds flags related to CSRSigningController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/daemonsetcontroller.go
+++ b/cmd/kube-controller-manager/app/options/daemonsetcontroller.go
@@ -24,7 +24,7 @@ import (
 
 // DaemonSetControllerOptions holds the DaemonSetController options.
 type DaemonSetControllerOptions struct {
-	ConcurrentDaemonSetSyncs int32
+	*kubectrlmgrconfig.DaemonSetControllerConfiguration
 }
 
 // AddFlags adds flags related to DaemonSetController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/deploymentcontroller.go
+++ b/cmd/kube-controller-manager/app/options/deploymentcontroller.go
@@ -19,14 +19,12 @@ package options
 import (
 	"github.com/spf13/pflag"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 )
 
 // DeploymentControllerOptions holds the DeploymentController options.
 type DeploymentControllerOptions struct {
-	ConcurrentDeploymentSyncs      int32
-	DeploymentControllerSyncPeriod metav1.Duration
+	*kubectrlmgrconfig.DeploymentControllerConfiguration
 }
 
 // AddFlags adds flags related to DeploymentController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/deprecatedcontroller.go
+++ b/cmd/kube-controller-manager/app/options/deprecatedcontroller.go
@@ -25,9 +25,7 @@ import (
 // DeprecatedControllerOptions holds the DeprecatedController options, those option are deprecated.
 // TODO remove these fields once the deprecated flags are removed.
 type DeprecatedControllerOptions struct {
-	DeletingPodsQPS    float32
-	DeletingPodsBurst  int32
-	RegisterRetryCount int32
+	*kubectrlmgrconfig.DeprecatedControllerConfiguration
 }
 
 // AddFlags adds flags related to DeprecatedController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/endpointcontroller.go
+++ b/cmd/kube-controller-manager/app/options/endpointcontroller.go
@@ -24,7 +24,7 @@ import (
 
 // EndpointControllerOptions holds the EndPointController options.
 type EndpointControllerOptions struct {
-	ConcurrentEndpointSyncs int32
+	*kubectrlmgrconfig.EndpointControllerConfiguration
 }
 
 // AddFlags adds flags related to EndPointController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/garbagecollectorcontroller.go
+++ b/cmd/kube-controller-manager/app/options/garbagecollectorcontroller.go
@@ -24,9 +24,7 @@ import (
 
 // GarbageCollectorControllerOptions holds the GarbageCollectorController options.
 type GarbageCollectorControllerOptions struct {
-	ConcurrentGCSyncs      int32
-	GCIgnoredResources     []kubectrlmgrconfig.GroupResource
-	EnableGarbageCollector bool
+	*kubectrlmgrconfig.GarbageCollectorControllerConfiguration
 }
 
 // AddFlags adds flags related to GarbageCollectorController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/hpacontroller.go
+++ b/cmd/kube-controller-manager/app/options/hpacontroller.go
@@ -19,20 +19,12 @@ package options
 import (
 	"github.com/spf13/pflag"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 )
 
 // HPAControllerOptions holds the HPAController options.
 type HPAControllerOptions struct {
-	HorizontalPodAutoscalerUseRESTClients               bool
-	HorizontalPodAutoscalerTolerance                    float64
-	HorizontalPodAutoscalerDownscaleStabilizationWindow metav1.Duration
-	HorizontalPodAutoscalerDownscaleForbiddenWindow     metav1.Duration
-	HorizontalPodAutoscalerUpscaleForbiddenWindow       metav1.Duration
-	HorizontalPodAutoscalerSyncPeriod                   metav1.Duration
-	HorizontalPodAutoscalerCPUInitializationPeriod      metav1.Duration
-	HorizontalPodAutoscalerInitialReadinessDelay        metav1.Duration
+	*kubectrlmgrconfig.HPAControllerConfiguration
 }
 
 // AddFlags adds flags related to HPAController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/jobcontroller.go
+++ b/cmd/kube-controller-manager/app/options/jobcontroller.go
@@ -24,7 +24,7 @@ import (
 
 // JobControllerOptions holds the JobController options.
 type JobControllerOptions struct {
-	ConcurrentJobSyncs int32
+	*kubectrlmgrconfig.JobControllerConfiguration
 }
 
 // AddFlags adds flags related to JobController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/namespacecontroller.go
+++ b/cmd/kube-controller-manager/app/options/namespacecontroller.go
@@ -19,14 +19,12 @@ package options
 import (
 	"github.com/spf13/pflag"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 )
 
 // NamespaceControllerOptions holds the NamespaceController options.
 type NamespaceControllerOptions struct {
-	NamespaceSyncPeriod      metav1.Duration
-	ConcurrentNamespaceSyncs int32
+	*kubectrlmgrconfig.NamespaceControllerConfiguration
 }
 
 // AddFlags adds flags related to NamespaceController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/nodeipamcontroller.go
+++ b/cmd/kube-controller-manager/app/options/nodeipamcontroller.go
@@ -24,8 +24,7 @@ import (
 
 // NodeIPAMControllerOptions holds the NodeIpamController options.
 type NodeIPAMControllerOptions struct {
-	ServiceCIDR      string
-	NodeCIDRMaskSize int32
+	*kubectrlmgrconfig.NodeIPAMControllerConfiguration
 }
 
 // AddFlags adds flags related to NodeIpamController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/nodelifecyclecontroller.go
+++ b/cmd/kube-controller-manager/app/options/nodelifecyclecontroller.go
@@ -19,20 +19,12 @@ package options
 import (
 	"github.com/spf13/pflag"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 )
 
 // NodeLifecycleControllerOptions holds the NodeLifecycleController options.
 type NodeLifecycleControllerOptions struct {
-	EnableTaintManager        bool
-	NodeEvictionRate          float32
-	SecondaryNodeEvictionRate float32
-	NodeStartupGracePeriod    metav1.Duration
-	NodeMonitorGracePeriod    metav1.Duration
-	PodEvictionTimeout        metav1.Duration
-	LargeClusterSizeThreshold int32
-	UnhealthyZoneThreshold    float32
+	*kubectrlmgrconfig.NodeLifecycleControllerConfiguration
 }
 
 // AddFlags adds flags related to NodeLifecycleController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -96,84 +96,67 @@ func NewKubeControllerManagerOptions() (*KubeControllerManagerOptions, error) {
 	}
 
 	s := KubeControllerManagerOptions{
-		Generic:         cmoptions.NewGenericControllerManagerConfigurationOptions(componentConfig.Generic),
-		KubeCloudShared: cmoptions.NewKubeCloudSharedOptions(componentConfig.KubeCloudShared),
+		Generic:         cmoptions.NewGenericControllerManagerConfigurationOptions(&componentConfig.Generic),
+		KubeCloudShared: cmoptions.NewKubeCloudSharedOptions(&componentConfig.KubeCloudShared),
+		ServiceController: &cmoptions.ServiceControllerOptions{
+			ServiceControllerConfiguration: &componentConfig.ServiceController,
+		},
 		AttachDetachController: &AttachDetachControllerOptions{
-			ReconcilerSyncLoopPeriod: componentConfig.AttachDetachController.ReconcilerSyncLoopPeriod,
+			&componentConfig.AttachDetachController,
 		},
 		CSRSigningController: &CSRSigningControllerOptions{
-			ClusterSigningCertFile: componentConfig.CSRSigningController.ClusterSigningCertFile,
-			ClusterSigningKeyFile:  componentConfig.CSRSigningController.ClusterSigningKeyFile,
-			ClusterSigningDuration: componentConfig.CSRSigningController.ClusterSigningDuration,
+			&componentConfig.CSRSigningController,
 		},
 		DaemonSetController: &DaemonSetControllerOptions{
-			ConcurrentDaemonSetSyncs: componentConfig.DaemonSetController.ConcurrentDaemonSetSyncs,
+			&componentConfig.DaemonSetController,
 		},
 		DeploymentController: &DeploymentControllerOptions{
-			ConcurrentDeploymentSyncs:      componentConfig.DeploymentController.ConcurrentDeploymentSyncs,
-			DeploymentControllerSyncPeriod: componentConfig.DeploymentController.DeploymentControllerSyncPeriod,
+			&componentConfig.DeploymentController,
 		},
 		DeprecatedFlags: &DeprecatedControllerOptions{
-			RegisterRetryCount: componentConfig.DeprecatedController.RegisterRetryCount,
+			&componentConfig.DeprecatedController,
 		},
 		EndpointController: &EndpointControllerOptions{
-			ConcurrentEndpointSyncs: componentConfig.EndpointController.ConcurrentEndpointSyncs,
+			&componentConfig.EndpointController,
 		},
 		GarbageCollectorController: &GarbageCollectorControllerOptions{
-			ConcurrentGCSyncs:      componentConfig.GarbageCollectorController.ConcurrentGCSyncs,
-			EnableGarbageCollector: componentConfig.GarbageCollectorController.EnableGarbageCollector,
+			&componentConfig.GarbageCollectorController,
 		},
 		HPAController: &HPAControllerOptions{
-			HorizontalPodAutoscalerSyncPeriod:                   componentConfig.HPAController.HorizontalPodAutoscalerSyncPeriod,
-			HorizontalPodAutoscalerUpscaleForbiddenWindow:       componentConfig.HPAController.HorizontalPodAutoscalerUpscaleForbiddenWindow,
-			HorizontalPodAutoscalerDownscaleForbiddenWindow:     componentConfig.HPAController.HorizontalPodAutoscalerDownscaleForbiddenWindow,
-			HorizontalPodAutoscalerDownscaleStabilizationWindow: componentConfig.HPAController.HorizontalPodAutoscalerDownscaleStabilizationWindow,
-			HorizontalPodAutoscalerCPUInitializationPeriod:      componentConfig.HPAController.HorizontalPodAutoscalerCPUInitializationPeriod,
-			HorizontalPodAutoscalerInitialReadinessDelay:        componentConfig.HPAController.HorizontalPodAutoscalerInitialReadinessDelay,
-			HorizontalPodAutoscalerTolerance:                    componentConfig.HPAController.HorizontalPodAutoscalerTolerance,
-			HorizontalPodAutoscalerUseRESTClients:               componentConfig.HPAController.HorizontalPodAutoscalerUseRESTClients,
+			&componentConfig.HPAController,
 		},
 		JobController: &JobControllerOptions{
-			ConcurrentJobSyncs: componentConfig.JobController.ConcurrentJobSyncs,
+			&componentConfig.JobController,
 		},
 		NamespaceController: &NamespaceControllerOptions{
-			NamespaceSyncPeriod:      componentConfig.NamespaceController.NamespaceSyncPeriod,
-			ConcurrentNamespaceSyncs: componentConfig.NamespaceController.ConcurrentNamespaceSyncs,
+			&componentConfig.NamespaceController,
 		},
 		NodeIPAMController: &NodeIPAMControllerOptions{
-			NodeCIDRMaskSize: componentConfig.NodeIPAMController.NodeCIDRMaskSize,
+			&componentConfig.NodeIPAMController,
 		},
 		NodeLifecycleController: &NodeLifecycleControllerOptions{
-			EnableTaintManager:     componentConfig.NodeLifecycleController.EnableTaintManager,
-			NodeMonitorGracePeriod: componentConfig.NodeLifecycleController.NodeMonitorGracePeriod,
-			NodeStartupGracePeriod: componentConfig.NodeLifecycleController.NodeStartupGracePeriod,
-			PodEvictionTimeout:     componentConfig.NodeLifecycleController.PodEvictionTimeout,
+			&componentConfig.NodeLifecycleController,
 		},
 		PersistentVolumeBinderController: &PersistentVolumeBinderControllerOptions{
-			PVClaimBinderSyncPeriod: componentConfig.PersistentVolumeBinderController.PVClaimBinderSyncPeriod,
-			VolumeConfiguration:     componentConfig.PersistentVolumeBinderController.VolumeConfiguration,
+			&componentConfig.PersistentVolumeBinderController,
 		},
 		PodGCController: &PodGCControllerOptions{
-			TerminatedPodGCThreshold: componentConfig.PodGCController.TerminatedPodGCThreshold,
+			&componentConfig.PodGCController,
 		},
 		ReplicaSetController: &ReplicaSetControllerOptions{
-			ConcurrentRSSyncs: componentConfig.ReplicaSetController.ConcurrentRSSyncs,
+			&componentConfig.ReplicaSetController,
 		},
 		ReplicationController: &ReplicationControllerOptions{
-			ConcurrentRCSyncs: componentConfig.ReplicationController.ConcurrentRCSyncs,
+			&componentConfig.ReplicationController,
 		},
 		ResourceQuotaController: &ResourceQuotaControllerOptions{
-			ResourceQuotaSyncPeriod:      componentConfig.ResourceQuotaController.ResourceQuotaSyncPeriod,
-			ConcurrentResourceQuotaSyncs: componentConfig.ResourceQuotaController.ConcurrentResourceQuotaSyncs,
+			&componentConfig.ResourceQuotaController,
 		},
 		SAController: &SAControllerOptions{
-			ConcurrentSATokenSyncs: componentConfig.SAController.ConcurrentSATokenSyncs,
-		},
-		ServiceController: &cmoptions.ServiceControllerOptions{
-			ConcurrentServiceSyncs: componentConfig.ServiceController.ConcurrentServiceSyncs,
+			&componentConfig.SAController,
 		},
 		TTLAfterFinishedController: &TTLAfterFinishedControllerOptions{
-			ConcurrentTTLSyncs: componentConfig.TTLAfterFinishedController.ConcurrentTTLSyncs,
+			&componentConfig.TTLAfterFinishedController,
 		},
 		SecureServing: apiserveroptions.NewSecureServingOptions().WithLoopback(),
 		InsecureServing: (&apiserveroptions.DeprecatedInsecureServingOptions{

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -124,139 +124,187 @@ func TestAddFlags(t *testing.T) {
 
 	expected := &KubeControllerManagerOptions{
 		Generic: &cmoptions.GenericControllerManagerConfigurationOptions{
-			Port:            10252,     // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
-			Address:         "0.0.0.0", // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
-			MinResyncPeriod: metav1.Duration{Duration: 8 * time.Hour},
-			ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
-				ContentType: "application/json",
-				QPS:         50.0,
-				Burst:       100,
-			},
-			ControllerStartInterval: metav1.Duration{Duration: 2 * time.Minute},
-			LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-				ResourceLock:  "configmap",
-				LeaderElect:   false,
-				LeaseDuration: metav1.Duration{Duration: 30 * time.Second},
-				RenewDeadline: metav1.Duration{Duration: 15 * time.Second},
-				RetryPeriod:   metav1.Duration{Duration: 5 * time.Second},
+			GenericControllerManagerConfiguration: &kubectrlmgrconfig.GenericControllerManagerConfiguration{
+				Port:            10252,     // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
+				Address:         "0.0.0.0", // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
+				MinResyncPeriod: metav1.Duration{Duration: 8 * time.Hour},
+				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
+					ContentType: "application/json",
+					QPS:         50.0,
+					Burst:       100,
+				},
+				ControllerStartInterval: metav1.Duration{Duration: 2 * time.Minute},
+				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+					ResourceLock:  "configmap",
+					LeaderElect:   false,
+					LeaseDuration: metav1.Duration{Duration: 30 * time.Second},
+					RenewDeadline: metav1.Duration{Duration: 15 * time.Second},
+					RetryPeriod:   metav1.Duration{Duration: 5 * time.Second},
+				},
+				Controllers: []string{"foo", "bar"},
 			},
 			Debugging: &cmoptions.DebuggingOptions{
-				EnableProfiling:           false,
-				EnableContentionProfiling: true,
+				DebuggingConfiguration: &componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           false,
+					EnableContentionProfiling: true,
+				},
 			},
-			Controllers: []string{"foo", "bar"},
 		},
 		KubeCloudShared: &cmoptions.KubeCloudSharedOptions{
-			UseServiceAccountCredentials: true,
-			RouteReconciliationPeriod:    metav1.Duration{Duration: 30 * time.Second},
-			NodeMonitorPeriod:            metav1.Duration{Duration: 10 * time.Second},
-			ClusterName:                  "k8s",
-			ClusterCIDR:                  "1.2.3.4/24",
-			AllocateNodeCIDRs:            true,
-			CIDRAllocatorType:            "CloudAllocator",
-			ConfigureCloudRoutes:         false,
+			KubeCloudSharedConfiguration: &kubectrlmgrconfig.KubeCloudSharedConfiguration{
+				UseServiceAccountCredentials: true,
+				RouteReconciliationPeriod:    metav1.Duration{Duration: 30 * time.Second},
+				NodeMonitorPeriod:            metav1.Duration{Duration: 10 * time.Second},
+				ClusterName:                  "k8s",
+				ClusterCIDR:                  "1.2.3.4/24",
+				AllocateNodeCIDRs:            true,
+				CIDRAllocatorType:            "CloudAllocator",
+				ConfigureCloudRoutes:         false,
+			},
 			CloudProvider: &cmoptions.CloudProviderOptions{
-				Name:            "gce",
-				CloudConfigFile: "/cloud-config",
+				CloudProviderConfiguration: &kubectrlmgrconfig.CloudProviderConfiguration{
+					Name:            "gce",
+					CloudConfigFile: "/cloud-config",
+				},
+			},
+		},
+		ServiceController: &cmoptions.ServiceControllerOptions{
+			ServiceControllerConfiguration: &kubectrlmgrconfig.ServiceControllerConfiguration{
+				ConcurrentServiceSyncs: 2,
 			},
 		},
 		AttachDetachController: &AttachDetachControllerOptions{
-			ReconcilerSyncLoopPeriod:          metav1.Duration{Duration: 30 * time.Second},
-			DisableAttachDetachReconcilerSync: true,
+			&kubectrlmgrconfig.AttachDetachControllerConfiguration{
+				ReconcilerSyncLoopPeriod:          metav1.Duration{Duration: 30 * time.Second},
+				DisableAttachDetachReconcilerSync: true,
+			},
 		},
 		CSRSigningController: &CSRSigningControllerOptions{
-			ClusterSigningCertFile: "/cluster-signing-cert",
-			ClusterSigningKeyFile:  "/cluster-signing-key",
-			ClusterSigningDuration: metav1.Duration{Duration: 10 * time.Hour},
+			&kubectrlmgrconfig.CSRSigningControllerConfiguration{
+				ClusterSigningCertFile: "/cluster-signing-cert",
+				ClusterSigningKeyFile:  "/cluster-signing-key",
+				ClusterSigningDuration: metav1.Duration{Duration: 10 * time.Hour},
+			},
 		},
 		DaemonSetController: &DaemonSetControllerOptions{
-			ConcurrentDaemonSetSyncs: 2,
+			&kubectrlmgrconfig.DaemonSetControllerConfiguration{
+				ConcurrentDaemonSetSyncs: 2,
+			},
 		},
 		DeploymentController: &DeploymentControllerOptions{
-			ConcurrentDeploymentSyncs:      10,
-			DeploymentControllerSyncPeriod: metav1.Duration{Duration: 45 * time.Second},
+			&kubectrlmgrconfig.DeploymentControllerConfiguration{
+				ConcurrentDeploymentSyncs:      10,
+				DeploymentControllerSyncPeriod: metav1.Duration{Duration: 45 * time.Second},
+			},
 		},
 		DeprecatedFlags: &DeprecatedControllerOptions{
-			DeletingPodsQPS:    0.1,
-			RegisterRetryCount: 10,
+			&kubectrlmgrconfig.DeprecatedControllerConfiguration{
+				DeletingPodsQPS:    0.1,
+				RegisterRetryCount: 10,
+			},
 		},
 		EndpointController: &EndpointControllerOptions{
-			ConcurrentEndpointSyncs: 10,
+			&kubectrlmgrconfig.EndpointControllerConfiguration{
+				ConcurrentEndpointSyncs: 10,
+			},
 		},
 		GarbageCollectorController: &GarbageCollectorControllerOptions{
-			ConcurrentGCSyncs: 30,
-			GCIgnoredResources: []kubectrlmgrconfig.GroupResource{
-				{Group: "", Resource: "events"},
+			&kubectrlmgrconfig.GarbageCollectorControllerConfiguration{
+				ConcurrentGCSyncs: 30,
+				GCIgnoredResources: []kubectrlmgrconfig.GroupResource{
+					{Group: "", Resource: "events"},
+				},
+				EnableGarbageCollector: false,
 			},
-			EnableGarbageCollector: false,
 		},
 		HPAController: &HPAControllerOptions{
-			HorizontalPodAutoscalerSyncPeriod:                   metav1.Duration{Duration: 45 * time.Second},
-			HorizontalPodAutoscalerUpscaleForbiddenWindow:       metav1.Duration{Duration: 1 * time.Minute},
-			HorizontalPodAutoscalerDownscaleForbiddenWindow:     metav1.Duration{Duration: 2 * time.Minute},
-			HorizontalPodAutoscalerDownscaleStabilizationWindow: metav1.Duration{Duration: 3 * time.Minute},
-			HorizontalPodAutoscalerCPUInitializationPeriod:      metav1.Duration{Duration: 90 * time.Second},
-			HorizontalPodAutoscalerInitialReadinessDelay:        metav1.Duration{Duration: 50 * time.Second},
-			HorizontalPodAutoscalerTolerance:                    0.1,
-			HorizontalPodAutoscalerUseRESTClients:               true,
+			&kubectrlmgrconfig.HPAControllerConfiguration{
+				HorizontalPodAutoscalerSyncPeriod:                   metav1.Duration{Duration: 45 * time.Second},
+				HorizontalPodAutoscalerUpscaleForbiddenWindow:       metav1.Duration{Duration: 1 * time.Minute},
+				HorizontalPodAutoscalerDownscaleForbiddenWindow:     metav1.Duration{Duration: 2 * time.Minute},
+				HorizontalPodAutoscalerDownscaleStabilizationWindow: metav1.Duration{Duration: 3 * time.Minute},
+				HorizontalPodAutoscalerCPUInitializationPeriod:      metav1.Duration{Duration: 90 * time.Second},
+				HorizontalPodAutoscalerInitialReadinessDelay:        metav1.Duration{Duration: 50 * time.Second},
+				HorizontalPodAutoscalerTolerance:                    0.1,
+				HorizontalPodAutoscalerUseRESTClients:               true,
+			},
 		},
 		JobController: &JobControllerOptions{
-			ConcurrentJobSyncs: 5,
+			&kubectrlmgrconfig.JobControllerConfiguration{
+				ConcurrentJobSyncs: 5,
+			},
 		},
 		NamespaceController: &NamespaceControllerOptions{
-			NamespaceSyncPeriod:      metav1.Duration{Duration: 10 * time.Minute},
-			ConcurrentNamespaceSyncs: 20,
+			&kubectrlmgrconfig.NamespaceControllerConfiguration{
+				NamespaceSyncPeriod:      metav1.Duration{Duration: 10 * time.Minute},
+				ConcurrentNamespaceSyncs: 20,
+			},
 		},
 		NodeIPAMController: &NodeIPAMControllerOptions{
-			NodeCIDRMaskSize: 48,
+			&kubectrlmgrconfig.NodeIPAMControllerConfiguration{
+				NodeCIDRMaskSize: 48,
+			},
 		},
 		NodeLifecycleController: &NodeLifecycleControllerOptions{
-			EnableTaintManager:        false,
-			NodeEvictionRate:          0.2,
-			SecondaryNodeEvictionRate: 0.05,
-			NodeMonitorGracePeriod:    metav1.Duration{Duration: 30 * time.Second},
-			NodeStartupGracePeriod:    metav1.Duration{Duration: 30 * time.Second},
-			PodEvictionTimeout:        metav1.Duration{Duration: 2 * time.Minute},
-			LargeClusterSizeThreshold: 100,
-			UnhealthyZoneThreshold:    0.6,
+			&kubectrlmgrconfig.NodeLifecycleControllerConfiguration{
+				EnableTaintManager:        false,
+				NodeEvictionRate:          0.2,
+				SecondaryNodeEvictionRate: 0.05,
+				NodeMonitorGracePeriod:    metav1.Duration{Duration: 30 * time.Second},
+				NodeStartupGracePeriod:    metav1.Duration{Duration: 30 * time.Second},
+				PodEvictionTimeout:        metav1.Duration{Duration: 2 * time.Minute},
+				LargeClusterSizeThreshold: 100,
+				UnhealthyZoneThreshold:    0.6,
+			},
 		},
 		PersistentVolumeBinderController: &PersistentVolumeBinderControllerOptions{
-			PVClaimBinderSyncPeriod: metav1.Duration{Duration: 30 * time.Second},
-			VolumeConfiguration: kubectrlmgrconfig.VolumeConfiguration{
-				EnableDynamicProvisioning:  false,
-				EnableHostPathProvisioning: true,
-				FlexVolumePluginDir:        "/flex-volume-plugin",
-				PersistentVolumeRecyclerConfiguration: kubectrlmgrconfig.PersistentVolumeRecyclerConfiguration{
-					MaximumRetry:             3,
-					MinimumTimeoutNFS:        200,
-					IncrementTimeoutNFS:      45,
-					MinimumTimeoutHostPath:   45,
-					IncrementTimeoutHostPath: 45,
+			&kubectrlmgrconfig.PersistentVolumeBinderControllerConfiguration{
+				PVClaimBinderSyncPeriod: metav1.Duration{Duration: 30 * time.Second},
+				VolumeConfiguration: kubectrlmgrconfig.VolumeConfiguration{
+					EnableDynamicProvisioning:  false,
+					EnableHostPathProvisioning: true,
+					FlexVolumePluginDir:        "/flex-volume-plugin",
+					PersistentVolumeRecyclerConfiguration: kubectrlmgrconfig.PersistentVolumeRecyclerConfiguration{
+						MaximumRetry:             3,
+						MinimumTimeoutNFS:        200,
+						IncrementTimeoutNFS:      45,
+						MinimumTimeoutHostPath:   45,
+						IncrementTimeoutHostPath: 45,
+					},
 				},
 			},
 		},
 		PodGCController: &PodGCControllerOptions{
-			TerminatedPodGCThreshold: 12000,
+			&kubectrlmgrconfig.PodGCControllerConfiguration{
+				TerminatedPodGCThreshold: 12000,
+			},
 		},
 		ReplicaSetController: &ReplicaSetControllerOptions{
-			ConcurrentRSSyncs: 10,
+			&kubectrlmgrconfig.ReplicaSetControllerConfiguration{
+				ConcurrentRSSyncs: 10,
+			},
 		},
 		ReplicationController: &ReplicationControllerOptions{
-			ConcurrentRCSyncs: 10,
+			&kubectrlmgrconfig.ReplicationControllerConfiguration{
+				ConcurrentRCSyncs: 10,
+			},
 		},
 		ResourceQuotaController: &ResourceQuotaControllerOptions{
-			ResourceQuotaSyncPeriod:      metav1.Duration{Duration: 10 * time.Minute},
-			ConcurrentResourceQuotaSyncs: 10,
+			&kubectrlmgrconfig.ResourceQuotaControllerConfiguration{
+				ResourceQuotaSyncPeriod:      metav1.Duration{Duration: 10 * time.Minute},
+				ConcurrentResourceQuotaSyncs: 10,
+			},
 		},
 		SAController: &SAControllerOptions{
-			ServiceAccountKeyFile:  "/service-account-private-key",
-			ConcurrentSATokenSyncs: 10,
-		},
-		ServiceController: &cmoptions.ServiceControllerOptions{
-			ConcurrentServiceSyncs: 2,
+			&kubectrlmgrconfig.SAControllerConfiguration{
+				ServiceAccountKeyFile:  "/service-account-private-key",
+				ConcurrentSATokenSyncs: 10,
+			},
 		},
 		TTLAfterFinishedController: &TTLAfterFinishedControllerOptions{
-			ConcurrentTTLSyncs: 8,
+			&kubectrlmgrconfig.TTLAfterFinishedControllerConfiguration{
+				ConcurrentTTLSyncs: 8,
+			},
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
 			BindPort:    10001,

--- a/cmd/kube-controller-manager/app/options/persistentvolumebindercontroller.go
+++ b/cmd/kube-controller-manager/app/options/persistentvolumebindercontroller.go
@@ -19,14 +19,12 @@ package options
 import (
 	"github.com/spf13/pflag"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 )
 
 // PersistentVolumeBinderControllerOptions holds the PersistentVolumeBinderController options.
 type PersistentVolumeBinderControllerOptions struct {
-	PVClaimBinderSyncPeriod metav1.Duration
-	VolumeConfiguration     kubectrlmgrconfig.VolumeConfiguration
+	*kubectrlmgrconfig.PersistentVolumeBinderControllerConfiguration
 }
 
 // AddFlags adds flags related to PersistentVolumeBinderController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/podgccontroller.go
+++ b/cmd/kube-controller-manager/app/options/podgccontroller.go
@@ -24,7 +24,7 @@ import (
 
 // PodGCControllerOptions holds the PodGCController options.
 type PodGCControllerOptions struct {
-	TerminatedPodGCThreshold int32
+	*kubectrlmgrconfig.PodGCControllerConfiguration
 }
 
 // AddFlags adds flags related to PodGCController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/replicasetcontroller.go
+++ b/cmd/kube-controller-manager/app/options/replicasetcontroller.go
@@ -24,7 +24,7 @@ import (
 
 // ReplicaSetControllerOptions holds the ReplicaSetController options.
 type ReplicaSetControllerOptions struct {
-	ConcurrentRSSyncs int32
+	*kubectrlmgrconfig.ReplicaSetControllerConfiguration
 }
 
 // AddFlags adds flags related to ReplicaSetController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/replicationcontroller.go
+++ b/cmd/kube-controller-manager/app/options/replicationcontroller.go
@@ -24,7 +24,7 @@ import (
 
 // ReplicationControllerOptions holds the ReplicationController options.
 type ReplicationControllerOptions struct {
-	ConcurrentRCSyncs int32
+	*kubectrlmgrconfig.ReplicationControllerConfiguration
 }
 
 // AddFlags adds flags related to ReplicationController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/resourcequotacontroller.go
+++ b/cmd/kube-controller-manager/app/options/resourcequotacontroller.go
@@ -19,14 +19,12 @@ package options
 import (
 	"github.com/spf13/pflag"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 )
 
 // ResourceQuotaControllerOptions holds the ResourceQuotaController options.
 type ResourceQuotaControllerOptions struct {
-	ResourceQuotaSyncPeriod      metav1.Duration
-	ConcurrentResourceQuotaSyncs int32
+	*kubectrlmgrconfig.ResourceQuotaControllerConfiguration
 }
 
 // AddFlags adds flags related to ResourceQuotaController for controller manager to the specified FlagSet.

--- a/cmd/kube-controller-manager/app/options/serviceaccountcontroller.go
+++ b/cmd/kube-controller-manager/app/options/serviceaccountcontroller.go
@@ -24,9 +24,7 @@ import (
 
 // SAControllerOptions holds the ServiceAccountController options.
 type SAControllerOptions struct {
-	ServiceAccountKeyFile  string
-	ConcurrentSATokenSyncs int32
-	RootCAFile             string
+	*kubectrlmgrconfig.SAControllerConfiguration
 }
 
 // AddFlags adds flags related to ServiceAccountController for controller manager to the specified FlagSet

--- a/cmd/kube-controller-manager/app/options/ttlafterfinishedcontroller.go
+++ b/cmd/kube-controller-manager/app/options/ttlafterfinishedcontroller.go
@@ -24,7 +24,7 @@ import (
 
 // TTLAfterFinishedControllerOptions holds the TTLAfterFinishedController options.
 type TTLAfterFinishedControllerOptions struct {
-	ConcurrentTTLSyncs int32
+	*kubectrlmgrconfig.TTLAfterFinishedControllerConfiguration
 }
 
 // AddFlags adds flags related to TTLAfterFinishedController for controller manager to the specified FlagSet.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind feature

**What this PR does / why we need it**:

- There are so many coped fields in `kube-controller manager`( betwwen `config` and `option`), such as
 [`AttachDetachControllerOptions`](https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-controller-manager/app/options/attachdetachcontroller.go#L27-L30) and [`AttachDetachControllerConfiguration`](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/apis/config/types.go#L166-L174), and so on.
- We should not maintain the copied fields. Get rid of copied fields in the options and directly point the flags to the componentconfig fields in this PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
