### PR TITLE
Use `audit.k8s.io/v1` as default value of option --audit-webhook-vers…

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -137,9 +137,8 @@ func NewAuditOptions() *AuditOptions {
 				Mode:        ModeBatch,
 				BatchConfig: defaultWebhookBatchConfig(),
 			},
-			TruncateOptions: NewAuditTruncateOptions(),
-			// TODO(audit): use v1 API in release 1.13
-			GroupVersionString: "audit.k8s.io/v1beta1",
+			TruncateOptions:    NewAuditTruncateOptions(),
+			GroupVersionString: "audit.k8s.io/v1",
 		},
 		LogOptions: AuditLogOptions{
 			Format: pluginlog.FormatJson,
@@ -147,9 +146,8 @@ func NewAuditOptions() *AuditOptions {
 				Mode:        ModeBlocking,
 				BatchConfig: defaultLogBatchConfig(),
 			},
-			TruncateOptions: NewAuditTruncateOptions(),
-			// TODO(audit): use v1 API in release 1.13
-			GroupVersionString: "audit.k8s.io/v1beta1",
+			TruncateOptions:    NewAuditTruncateOptions(),
+			GroupVersionString: "audit.k8s.io/v1",
 		},
 	}
 }


### PR DESCRIPTION
…ion and --audit-log-version in release 1.13

```release-note
kube-apiserver: `--audit-webhook-version` and `--audit-log-version` now default to `audit.k8s.io/v1` if unspecified
```
