### PR TITLE
Align sample controller styling with other k/k controllers

### DIFF
--- a/staging/src/k8s.io/sample-controller/controller.go
+++ b/staging/src/k8s.io/sample-controller/controller.go
@@ -191,49 +191,41 @@ func (c *Controller) processNextWorkItem() bool {
 	if shutdown {
 		return false
 	}
+	defer c.workqueue.Done(obj)
 
-	// We wrap this block in a func so we can defer c.workqueue.Done.
-	err := func(obj interface{}) error {
-		// We call Done here so the workqueue knows we have finished
-		// processing this item. We also must remember to call Forget if we
-		// do not want this work item being re-queued. For example, we do
-		// not call Forget if a transient error occurs, instead the item is
-		// put back on the workqueue and attempted again after a back-off
-		// period.
-		defer c.workqueue.Done(obj)
-		var key string
-		var ok bool
-		// We expect strings to come off the workqueue. These are of the
-		// form namespace/name. We do this as the delayed nature of the
-		// workqueue means the items in the informer cache may actually be
-		// more up to date that when the item was initially put onto the
-		// workqueue.
-		if key, ok = obj.(string); !ok {
-			// As the item in the workqueue is actually invalid, we call
-			// Forget here else we'd go into a loop of attempting to
-			// process a work item that is invalid.
-			c.workqueue.Forget(obj)
-			runtime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
-			return nil
-		}
-		// Run the syncHandler, passing it the namespace/name string of the
-		// Foo resource to be synced.
-		if err := c.syncHandler(key); err != nil {
-			// Put the item back on the workqueue to handle any transient errors.
-			c.workqueue.AddRateLimited(key)
-			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
-		}
-		// Finally, if no error occurs we Forget this item so it does not
-		// get queued again until another change happens.
+	// We call Done here so the workqueue knows we have finished
+	// processing this item. We also must remember to call Forget if we
+	// do not want this work item being re-queued. For example, we do
+	// not call Forget if a transient error occurs, instead the item is
+	// put back on the workqueue and attempted again after a back-off
+	// period.
+	var key string
+	var ok bool
+	// We expect strings to come off the workqueue. These are of the
+	// form namespace/name. We do this as the delayed nature of the
+	// workqueue means the items in the informer cache may actually be
+	// more up to date that when the item was initially put onto the
+	// workqueue.
+	if key, ok = obj.(string); !ok {
+		// As the item in the workqueue is actually invalid, we call
+		// Forget here else we'd go into a loop of attempting to
+		// process a work item that is invalid.
 		c.workqueue.Forget(obj)
-		glog.Infof("Successfully synced '%s'", key)
-		return nil
-	}(obj)
-
-	if err != nil {
-		runtime.HandleError(err)
+		runtime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
 		return true
 	}
+	// Run the syncHandler, passing it the namespace/name string of the
+	// Foo resource to be synced.
+	if err := c.syncHandler(key); err != nil {
+		// Put the item back on the workqueue to handle any transient errors.
+		c.workqueue.AddRateLimited(key)
+		runtime.HandleError(fmt.Errorf("error syncing '%s': %v, requeuing", key, err))
+		return true
+	}
+	// Finally, if no error occurs we Forget this item so it does not
+	// get queued again until another change happens.
+	c.workqueue.Forget(obj)
+	glog.Infof("Successfully synced '%s'", key)
 
 	return true
 }


### PR DESCRIPTION
no need to call sync handler in a closure.

> // We wrap this block in a func so we can defer c.workqueue.Done.

it's not convincing and will make the code even harder to read.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
