### PR TITLE
Try looking up the pod IP via HNS.

### DIFF
--- a/pkg/kubelet/dockershim/network/cni/BUILD
+++ b/pkg/kubelet/dockershim/network/cni/BUILD
@@ -25,7 +25,7 @@ go_library(
         "//vendor/k8s.io/utils/exec:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:windows": [
-            "//vendor/github.com/containernetworking/cni/pkg/types/020:go_default_library",
+            "//vendor/github.com/Microsoft/hcsshim:go_default_library",
         ],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Alternate implementation of `GetPodNetworkStatus()` on Windows.  Look up the HNS interface by name, assuming the name contains the container ID.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #70279

**Special notes for your reviewer**:

It's a bit of a hack that relies on the naming used by the currently-known CNI plugins, but it does make the call idempotent.  Putting it up as an RFC.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note

```
