### PR TITLE
Automated cherry pick of #70459: fix openstack provider to handle only Cinder volumes

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -697,6 +697,11 @@ func (os *OpenStack) ShouldTrustDevicePath() bool {
 
 // GetLabelsForVolume implements PVLabeler.GetLabelsForVolume
 func (os *OpenStack) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error) {
+	// Ignore if not Cinder.
+	if pv.Spec.Cinder == nil {
+		return nil, nil
+	}
+
 	// Ignore any volumes that are being provisioned
 	if pv.Spec.Cinder.VolumeID == k8s_volume.ProvisionedVolumeName {
 		return nil, nil


### PR DESCRIPTION
Cherry pick of #70459 on release-1.12.

#70459: fix openstack provider to handle only Cinder volumes