### PR TITLE
Ignore non socket files in the kubelet plugin watcher

### DIFF
--- a/pkg/kubelet/config/defaults.go
+++ b/pkg/kubelet/config/defaults.go
@@ -17,11 +17,12 @@ limitations under the License.
 package config
 
 const (
-	DefaultKubeletPodsDirName             = "pods"
-	DefaultKubeletVolumesDirName          = "volumes"
-	DefaultKubeletVolumeDevicesDirName    = "volumeDevices"
-	DefaultKubeletPluginsDirName          = "plugins"
-	DefaultKubeletContainersDirName       = "containers"
-	DefaultKubeletPluginContainersDirName = "plugin-containers"
-	DefaultKubeletPodResourcesDirName     = "pod-resources"
+	DefaultKubeletPodsDirName                = "pods"
+	DefaultKubeletVolumesDirName             = "volumes"
+	DefaultKubeletVolumeDevicesDirName       = "volumeDevices"
+	DefaultKubeletPluginsDirName             = "plugins"
+	DefaultKubeletPluginsRegistrationDirName = "plugins_registry"
+	DefaultKubeletContainersDirName          = "containers"
+	DefaultKubeletPluginContainersDirName    = "plugin-containers"
+	DefaultKubeletPodResourcesDirName        = "pod-resources"
 )

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -789,7 +789,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		return nil, err
 	}
 	if klet.enablePluginsWatcher {
-		klet.pluginWatcher = pluginwatcher.NewWatcher(klet.getPluginsDir())
+		klet.pluginWatcher = pluginwatcher.NewWatcher(klet.getPluginsRegistrationDir())
 	}
 
 	// If the experimentalMounterPathFlag is set, we do not want to
@@ -1259,6 +1259,9 @@ func (kl *Kubelet) setupDataDirs() error {
 	}
 	if err := os.MkdirAll(kl.getPluginsDir(), 0750); err != nil {
 		return fmt.Errorf("error creating plugins directory: %v", err)
+	}
+	if err := os.MkdirAll(kl.getPluginsRegistrationDir(), 0750); err != nil {
+		return fmt.Errorf("error creating plugins registry directory: %v", err)
 	}
 	if err := os.MkdirAll(kl.getPodResourcesDir(), 0750); err != nil {
 		return fmt.Errorf("error creating podresources directory: %v", err)

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -57,6 +57,14 @@ func (kl *Kubelet) getPluginsDir() string {
 	return filepath.Join(kl.getRootDir(), config.DefaultKubeletPluginsDirName)
 }
 
+// getPluginsRegistrationDir returns the full path to the directory under which
+// plugins socket should be placed to be registered.
+// More information is available about plugin registration in the pluginwatcher
+// module
+func (kl *Kubelet) getPluginsRegistrationDir() string {
+	return filepath.Join(kl.getRootDir(), config.DefaultKubeletPluginsRegistrationDirName)
+}
+
 // getPluginDir returns a data directory name for a given plugin name.
 // Plugins can use these directories to store data that they need to persist.
 // For per-pod plugin data, see getPodPluginDir.

--- a/pkg/kubelet/util/pluginwatcher/BUILD
+++ b/pkg/kubelet/util/pluginwatcher/BUILD
@@ -29,6 +29,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/kubelet/apis/pluginregistration/v1:go_default_library",
+        "//vendor/github.com/fsnotify/fsnotify:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/kubelet/util/pluginwatcher/BUILD
+++ b/pkg/kubelet/util/pluginwatcher/BUILD
@@ -29,7 +29,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/kubelet/apis/pluginregistration/v1:go_default_library",
-        "//vendor/github.com/fsnotify/fsnotify:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
@@ -60,7 +60,7 @@ spec:
       volumes:
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/
+            path: /var/lib/kubelet/plugins_registry/
             type: Directory
         - name: kubelet-dir
           hostPath:

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpathplugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpathplugin.yaml
@@ -65,6 +65,6 @@ spec:
             type: DirectoryOrCreate
           name: mountpoint-dir
         - hostPath:
-            path: /var/lib/kubelet/plugins
+            path: /var/lib/kubelet/plugins_registry
             type: Directory
           name: registration-dir

--- a/test/e2e_node/device_plugin.go
+++ b/test/e2e_node/device_plugin.go
@@ -53,7 +53,7 @@ var _ = framework.KubeDescribe("Device Plugin [Feature:DevicePlugin][NodeFeature
 
 var _ = framework.KubeDescribe("Device Plugin [Feature:DevicePluginProbe][NodeFeature:DevicePluginProbe][Serial]", func() {
 	f := framework.NewDefaultFramework("device-plugin-errors")
-	testDevicePlugin(f, true, "/var/lib/kubelet/plugins/")
+	testDevicePlugin(f, true, "/var/lib/kubelet/plugins_registry")
 })
 
 func testDevicePlugin(f *framework.Framework, enablePluginWatcher bool, pluginSockDir string) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig node

**What this PR does / why we need it**: Makes sure the pluginwatcher ignores non socket files.

**Which issue(s) this PR fixes** : Fixes https://github.com/kubernetes/kubernetes/issues/69015

**Special notes for your reviewer**:
Will post a list of plugins using the pluginwatcher mechanism and where they place the socket.
cc @vladimirvivien @vikaschoudhary16 @figo 

**Does this PR introduce a user-facing change?**:
```release-note
Kubelet Device Plugin Registration directory changed from from `{kubelet_root_dir}/plugins/` to `{kubelet_root_dir}/plugins_registry/`. Any drivers (CSI or device plugin) that were using the old path must be updated to work with this version.
```
