### PR TITLE
Cherry-pick metadata-agent psp binding

### DIFF
--- a/cluster/addons/metadata-agent/stackdriver/podsecuritypolicies/metadata-agent-psp-binding.yaml
+++ b/cluster/addons/metadata-agent/stackdriver/podsecuritypolicies/metadata-agent-psp-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gce:podsecuritypolicy:metadata-agent
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/cluster-service: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gce:podsecuritypolicy:privileged
+subjects:
+  - kind: ServiceAccount
+    name: metadata-agent
+    namespace: kube-system


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Cherry-pick the PodSecurityPolicy binding for the metadata-agent addon to release-1.11. This is required for the metadata-agent to work with PodSecurityPolicy.

**Special notes for your reviewer**:

The master change was added across a number of commits that moved the file around, so rather than cherrypicking each commit individually, I only grabbed the end-result. See https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/metadata-agent/stackdriver/podsecuritypolicies

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig gcp

/assign @davidebelloni @kawych @foxish 