### PR TITLE
Fix kube-proxy IPVS mode cleanup of IPv6 addrs on kube-ipvs0 iface

### DIFF
--- a/pkg/proxy/ipvs/netlink_linux.go
+++ b/pkg/proxy/ipvs/netlink_linux.go
@@ -63,11 +63,11 @@ func (h *netlinkHandle) UnbindAddress(address, devName string) error {
 	if err != nil {
 		return fmt.Errorf("error get interface: %s, err: %v", devName, err)
 	}
-	addr := net.ParseIP(address)
-	if addr == nil {
-		return fmt.Errorf("error parse ip address: %s", address)
+	ipnet, err := netlink.ParseIPNet(address)
+	if err != nil {
+		return fmt.Errorf("error parse IPNet: %s", address)
 	}
-	if err := h.AddrDel(dev, &netlink.Addr{IPNet: netlink.NewIPNet(addr)}); err != nil {
+	if err := h.AddrDel(dev, &netlink.Addr{IPNet: ipnet}); err != nil {
 		if err != unix.ENXIO {
 			return fmt.Errorf("error unbind address: %s from interface: %s, err: %v", address, devName, err)
 		}
@@ -117,7 +117,7 @@ func (h *netlinkHandle) ListBindAddress(devName string) ([]string, error) {
 	}
 	var ips []string
 	for _, addr := range addrs {
-		ips = append(ips, addr.IP.String())
+		ips = append(ips, addr.IPNet.String())
 	}
 	return ips, nil
 }

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1619,7 +1619,8 @@ func (proxier *Proxier) cleanLegacyService(activeServices map[string]bool, curre
 
 func (proxier *Proxier) cleanLegacyBindAddr(activeBindAddrs map[string]bool, currentBindAddrs []string) {
 	for _, addr := range currentBindAddrs {
-		if _, ok := activeBindAddrs[addr]; !ok {
+		// Strip IP mask from currentBindAddr (e.g. 1.2.3.4/32) to match activeBindAddrs (e.g. 1.2.3.4)
+		if _, ok := activeBindAddrs[strings.Split(addr, "/")[0]]; !ok {
 			// This address was not processed in the latest sync loop
 			glog.V(4).Infof("Unbind addr %s", addr)
 			err := proxier.netlinkHandle.UnbindAddress(addr, DefaultDummyDevice)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

* Change ipvs `ListBindAddress` to return address strings that retain IPNet subnet mask info (e.g. prev `1002:ab8::2:1`, now `1002:ab8::2:1/64`)
* Change ipvs `UnbindAddress` to create a `netlink.IPNet` rather than using the [NewIPNet](https://godoc.org/github.com/vishvananda/netlink#NewIPNet) convenience function that guesses a `/32` mask for IPv4 and a `/128 mask for IPv6
* Fix spurious logs deleting link default IPv6 address #70113

**Which issue(s) this PR fixes**

Fixes #70113

**Special notes for your reviewer**:

This is one approach that tries to touch as little as possible. The issue has a walk-through of the original cause: https://github.com/kubernetes/kubernetes/issues/70113#issuecomment-432088186

**Does this PR introduce a user-facing change?**:

NONE

```release-note
Fix kube-proxy IPVS-mode errors removing IPv6 addresses from kube-ipvs0 iface 
```
