### PR TITLE
cmd/cloud-controller-manager: add myself as approver

### DIFF
--- a/cmd/cloud-controller-manager/OWNERS
+++ b/cmd/cloud-controller-manager/OWNERS
@@ -3,12 +3,14 @@ approvers:
 - luxas
 - wlan0
 - andrewsykim
+- sttts
 reviewers:
 - thockin
 - luxas
 - wlan0
 - andrewsykim
 - stewart-yu
+- sttts
 labels:
 - sig/api-machinery
 - sig/cloud-provider


### PR DESCRIPTION
Having done quite a lot in the command plumbing in the last months here plus the KEP around component config, adding myself as approver:

```
$ git log --pretty=format:"%h%x09%an%x09%ad%x09%s" cmd/cloud-controller-manager/ | grep Schimanski
3aed193718	Dr. Stefan Schimanski	Thu Nov 1 12:22:59 2018 +0100	cmd/cloud-controller-manager: add myself as approver
c609df0ed1	Dr. Stefan Schimanski	Thu Aug 30 19:21:47 2018 +0200	cloud-controller-manager: disable authn/z on insecure port
f6b0c9359b	Dr. Stefan Schimanski	Tue Aug 28 13:22:09 2018 +0200	controller-managers: generalize authn/z test to cloud-controller-manager
c9913269a6	Dr. Stefan Schimanski	Tue Aug 28 12:58:40 2018 +0200	cloud-controller-manager: add test server
88035a4599	Dr. Stefan Schimanski	Tue Aug 28 12:53:48 2018 +0200	cloud-controller-manager: enable secure loopback
b25a551ed8	Dr. Stefan Schimanski	Tue Aug 7 11:11:36 2018 +0200	cloud-controller-manager: enable delegated authz/authn if secure port is enabled
f35c3f1836	Dr. Stefan Schimanski	Tue Aug 7 11:13:18 2018 +0200	cloud-controller-manager: enable secure ports 10258, deprecate insecure port
c2724793e8	Dr. Stefan Schimanski	Tue Aug 7 07:34:13 2018 +0200	Update bazel
1d9a896066	Dr. Stefan Schimanski	Thu Aug 16 20:47:15 2018 +0200	apiserver: move controller-manager's insecure config into apiserver
5483ab7679	Dr. Stefan Schimanski	Thu Feb 8 19:37:08 2018 +0100	Update generated files
f4564ea0b8	Dr. Stefan Schimanski	Thu Feb 8 19:28:31 2018 +0100	controller-manager: add SecureServingOptions
cad0364e73	Dr. Stefan Schimanski	Mon Oct 16 14:04:55 2017 +0200	Update bazel
7773a30f67	Dr. Stefan Schimanski	Mon Oct 16 13:41:50 2017 +0200	pkg/api/legacyscheme: fixup imports
2b8e938128	Dr. Stefan Schimanski	Mon Jan 23 10:02:54 2017 +0100	Update generated files
82826ec273	Dr. Stefan Schimanski	Mon Jan 23 15:46:05 2017 +0100	pkg/util/flag: move to k8s.io/apiserver
a6b2ebb50c	Dr. Stefan Schimanski	Fri Jan 20 14:05:41 2017 +0100	pkg/flag: make feature gate extensible and split between generic and kube
56d60cfae6	Dr. Stefan Schimanski	Thu Jan 19 13:39:13 2017 +0100	pkg/util: move flags from pkg/util/config to pkg/util/flags
3d9449a353	Dr. Stefan Schimanski	Tue Jan 17 11:38:25 2017 +0100	genericapiserver: fix imports
```
