### PR TITLE
Add boolean to GetLabelsForVolume signitature

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -2327,24 +2327,24 @@ func (c *Cloud) checkIfAvailable(disk *awsDisk, opName string, instance string) 
 }
 
 // GetLabelsForVolume gets the volume labels for a volume
-func (c *Cloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error) {
+func (c *Cloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, bool, error) {
 	// Ignore if not AWSElasticBlockStore.
 	if pv.Spec.AWSElasticBlockStore == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	// Ignore any volumes that are being provisioned
 	if pv.Spec.AWSElasticBlockStore.VolumeID == volume.ProvisionedVolumeName {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	spec := KubernetesVolumeID(pv.Spec.AWSElasticBlockStore.VolumeID)
 	labels, err := c.GetVolumeLabels(spec)
 	if err != nil {
-		return nil, err
+		return nil, true, err
 	}
 
-	return labels, nil
+	return labels, true, nil
 }
 
 // GetVolumeLabels implements Volumes.GetVolumeLabels

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -921,6 +921,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 		expectedVolumeID   *string
 		expectedEC2Volumes []*ec2.Volume
 		expectedLabels     map[string]string
+		expectedSupported  bool
 		expectedError      error
 	}{
 		{
@@ -931,6 +932,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 			nil,
 			nil,
 			nil,
+			false,
 			nil,
 		},
 		{
@@ -947,6 +949,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 			nil,
 			nil,
 			nil,
+			false,
 			nil,
 		},
 		{
@@ -963,6 +966,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 			defaultVolume,
 			nil,
 			nil,
+			true,
 			fmt.Errorf("no volumes found"),
 		},
 		{
@@ -985,6 +989,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 				kubeletapis.LabelZoneFailureDomain: "us-east-1a",
 				kubeletapis.LabelZoneRegion:        "us-east-1",
 			},
+			true,
 			nil,
 		},
 	}
@@ -997,8 +1002,9 @@ func TestGetLabelsForVolume(t *testing.T) {
 			c, err := newAWSCloud(CloudConfig{}, awsServices)
 			assert.Nil(t, err, "Error building aws cloud: %v", err)
 
-			l, err := c.GetLabelsForVolume(context.TODO(), test.pv)
+			l, s, err := c.GetLabelsForVolume(context.TODO(), test.pv)
 			assert.Equal(t, test.expectedLabels, l)
+			assert.Equal(t, test.expectedSupported, s)
 			assert.Equal(t, test.expectedError, err)
 		})
 

--- a/pkg/cloudprovider/providers/azure/azure_managedDiskController.go
+++ b/pkg/cloudprovider/providers/azure/azure_managedDiskController.go
@@ -275,18 +275,19 @@ func getResourceGroupFromDiskURI(diskURI string) (string, error) {
 }
 
 // GetLabelsForVolume implements PVLabeler.GetLabelsForVolume
-func (c *Cloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error) {
+func (c *Cloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, bool, error) {
 	// Ignore if not AzureDisk.
 	if pv.Spec.AzureDisk == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	// Ignore any volumes that are being provisioned
 	if pv.Spec.AzureDisk.DiskName == volume.ProvisionedVolumeName {
-		return nil, nil
+		return nil, false, nil
 	}
 
-	return c.GetAzureDiskLabels(pv.Spec.AzureDisk.DataDiskURI)
+	labels, err := c.GetAzureDiskLabels(pv.Spec.AzureDisk.DataDiskURI)
+	return labels, true, err
 }
 
 // GetAzureDiskLabels gets availability zone labels for Azuredisk.

--- a/pkg/cloudprovider/providers/gce/gce_disks.go
+++ b/pkg/cloudprovider/providers/gce/gce_disks.go
@@ -503,10 +503,10 @@ func newDiskMetricContextRegional(request, region string) *metricContext {
 }
 
 // GetLabelsForVolume retrieved the label info for the provided volume
-func (g *Cloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error) {
+func (g *Cloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, bool, error) {
 	// Ignore any volumes that are being provisioned
 	if pv.Spec.GCEPersistentDisk.PDName == volume.ProvisionedVolumeName {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	// If the zone is already labeled, honor the hint
@@ -514,10 +514,10 @@ func (g *Cloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume)
 
 	labels, err := g.GetAutoLabelsForPD(pv.Spec.GCEPersistentDisk.PDName, zone)
 	if err != nil {
-		return nil, err
+		return nil, true, err
 	}
 
-	return labels, nil
+	return labels, true, nil
 }
 
 // AttachDisk attaches given disk to the node with the specified NodeName.

--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -696,21 +696,21 @@ func (os *OpenStack) ShouldTrustDevicePath() bool {
 }
 
 // GetLabelsForVolume implements PVLabeler.GetLabelsForVolume
-func (os *OpenStack) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error) {
+func (os *OpenStack) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, bool, error) {
 	// Ignore if not Cinder.
 	if pv.Spec.Cinder == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	// Ignore any volumes that are being provisioned
 	if pv.Spec.Cinder.VolumeID == k8s_volume.ProvisionedVolumeName {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	// Get Volume
 	volume, err := os.getVolume(pv.Spec.Cinder.VolumeID)
 	if err != nil {
-		return nil, err
+		return nil, true, err
 	}
 
 	// Construct Volume Labels
@@ -719,7 +719,7 @@ func (os *OpenStack) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVo
 	labels[kubeletapis.LabelZoneRegion] = os.region
 	klog.V(4).Infof("The Volume %s has labels %v", pv.Spec.Cinder.VolumeID, labels)
 
-	return labels, nil
+	return labels, true, nil
 }
 
 // recordOpenstackOperationMetric records openstack operation metrics

--- a/pkg/controller/cloud/pvlcontroller.go
+++ b/pkg/controller/cloud/pvlcontroller.go
@@ -188,12 +188,15 @@ func (pvlc *PersistentVolumeLabelController) addLabelsAndAffinity(key string) er
 
 func (pvlc *PersistentVolumeLabelController) addLabelsAndAffinityToVolume(vol *v1.PersistentVolume) error {
 	var volumeLabels map[string]string
-	// Only add labels if the next pending initializer.
+	// Only add labels, if the next pending initializer is pvlabel.kubernetes.io.
 	if needsInitialization(vol.Initializers, initializerName) {
 		if labeler, ok := (pvlc.cloud).(cloudprovider.PVLabeler); ok {
-			labels, err := labeler.GetLabelsForVolume(context.TODO(), vol)
+			labels, update, err := labeler.GetLabelsForVolume(context.TODO(), vol)
 			if err != nil {
 				return fmt.Errorf("error querying volume %v: %v", vol.Spec, err)
+			}
+			if !update {
+				return nil
 			}
 			volumeLabels = labels
 		} else {

--- a/staging/src/k8s.io/cloud-provider/cloud.go
+++ b/staging/src/k8s.io/cloud-provider/cloud.go
@@ -231,5 +231,6 @@ type Zones interface {
 
 // PVLabeler is an abstract, pluggable interface for fetching labels for volumes
 type PVLabeler interface {
-	GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error)
+	// GetLabelsForVolume returns the labels for volume and true if volume is supported and it is not being provisioned.
+	GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, bool, error)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: 
The current implementation does not take into account if the cloud providers can actually handle the PVs send to them in `GetLabelsForVolume` method. 

Initializers are only removed, if the volume is supported by the cloud provider and it's not being provisioned.
 
**Which issue(s) this PR fixes** Related to https://github.com/kubernetes/kubernetes/pull/70462#discussion_r229950139

**Special notes for your reviewer**: 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Fix cloud-controller-manager's `PersistentVolumeLabel` controller to now update `PersistentVolumes` only when volume type is supported by the cloud provider and volume is not being provisioned.
```
