### PR TITLE
Validate kubeconfig files in case of external CA mode

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import (
 	clusterinfophase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo"
 	nodebootstraptokenphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
+	kubeconfigphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubeconfig"
 	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
 	markmasterphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/markmaster"
 	patchnodephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/patchnode"
@@ -316,6 +317,15 @@ func newInitData(cmd *cobra.Command, options *initOptions, out io.Writer) (initD
 
 	// Checks if an external CA is provided by the user.
 	externalCA, _ := certsphase.UsingExternalCA(cfg)
+	if externalCA {
+		kubeconfigDir := kubeadmconstants.KubernetesDir
+		if options.dryRun {
+			kubeconfigDir = dryRunDir
+		}
+		if err := kubeconfigphase.ValidateKubeconfigsForExternalCA(kubeconfigDir, cfg); err != nil {
+			return initData{}, err
+		}
+	}
 
 	return initData{
 		cfg:                   cfg,

--- a/cmd/kubeadm/app/cmd/phases/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/kubeconfig.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -116,7 +116,6 @@ func runKubeConfigFile(kubeConfigFileName string) func(workflow.RunData) error {
 
 		// if external CA mode, skip certificate authority generation
 		if data.ExternalCA() {
-			//TODO: implement validation of existing kubeconfig files
 			fmt.Printf("[kubeconfig] External CA mode: Using user provided %s\n", kubeConfigFileName)
 			return nil
 		}

--- a/cmd/kubeadm/app/phases/kubeconfig/BUILD
+++ b/cmd/kubeadm/app/phases/kubeconfig/BUILD
@@ -54,5 +54,6 @@ go_test(
         "//cmd/kubeadm/test/kubeconfig:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
+        "//vendor/github.com/renstrom/dedent:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -216,22 +216,12 @@ func buildKubeConfigFromSpec(spec *kubeConfigSpec, clustername string) (*clientc
 	), nil
 }
 
-// createKubeConfigFileIfNotExists saves the KubeConfig object into a file if there isn't any file at the given path.
-// If there already is a kubeconfig file at the given path; kubeadm tries to load it and check if the values in the
-// existing and the expected config equals. If they do; kubeadm will just skip writing the file as it's up-to-date,
-// but if a file exists but has old content or isn't a kubeconfig file, this function returns an error.
-func createKubeConfigFileIfNotExists(outDir, filename string, config *clientcmdapi.Config) error {
+// validateKubeConfig check if the kubeconfig file exist and has the expected CA and server URL
+func validateKubeConfig(outDir, filename string, config *clientcmdapi.Config) error {
 	kubeConfigFilePath := filepath.Join(outDir, filename)
 
-	// Check if the file exist, and if it doesn't, just write it to disk
-	if _, err := os.Stat(kubeConfigFilePath); os.IsNotExist(err) {
-		fmt.Printf("[kubeconfig] Writing %q kubeconfig file\n", filename)
-
-		err = kubeconfigutil.WriteToDisk(kubeConfigFilePath, config)
-		if err != nil {
-			return errors.Wrapf(err, "failed to save kubeconfig file %s on disk", kubeConfigFilePath)
-		}
-		return nil
+	if _, err := os.Stat(kubeConfigFilePath); err != nil {
+		return err
 	}
 
 	// The kubeconfig already exists, let's check if it has got the same CA and server URL
@@ -254,6 +244,29 @@ func createKubeConfigFileIfNotExists(outDir, filename string, config *clientcmda
 		return errors.Errorf("a kubeconfig file %q exists already but has got the wrong API Server URL", kubeConfigFilePath)
 	}
 
+	return nil
+}
+
+// createKubeConfigFileIfNotExists saves the KubeConfig object into a file if there isn't any file at the given path.
+// If there already is a kubeconfig file at the given path; kubeadm tries to load it and check if the values in the
+// existing and the expected config equals. If they do; kubeadm will just skip writing the file as it's up-to-date,
+// but if a file exists but has old content or isn't a kubeconfig file, this function returns an error.
+func createKubeConfigFileIfNotExists(outDir, filename string, config *clientcmdapi.Config) error {
+	kubeConfigFilePath := filepath.Join(outDir, filename)
+
+	err := validateKubeConfig(outDir, filename, config)
+	if err != nil {
+		// Check if the file exist, and if it doesn't, just write it to disk
+		if !os.IsNotExist(err) {
+			return err
+		}
+		fmt.Printf("[kubeconfig] Writing %q kubeconfig file\n", filename)
+		err = kubeconfigutil.WriteToDisk(kubeConfigFilePath, config)
+		if err != nil {
+			return errors.Wrapf(err, "failed to save kubeconfig file %q on disk", kubeConfigFilePath)
+		}
+		return nil
+	}
 	// kubeadm doesn't validate the existing kubeconfig file more than this (kubeadm trusts the client certs to be valid)
 	// Basically, if we find a kubeconfig file with the same path; the same CA cert and the same server URL;
 	// kubeadm thinks those files are equal and doesn't bother writing a new file
@@ -331,5 +344,37 @@ func writeKubeConfigFromSpec(out io.Writer, spec *kubeConfigSpec, clustername st
 	}
 
 	fmt.Fprintln(out, string(configBytes))
+	return nil
+}
+
+// ValidateKubeconfigsForExternalCA check if the kubeconfig file exist and has the expected CA and server URL using kubeadmapi.InitConfiguration.
+func ValidateKubeconfigsForExternalCA(outDir string, cfg *kubeadmapi.InitConfiguration) error {
+	kubeConfigFileNames := []string{
+		kubeadmconstants.AdminKubeConfigFileName,
+		kubeadmconstants.KubeletKubeConfigFileName,
+		kubeadmconstants.ControllerManagerKubeConfigFileName,
+		kubeadmconstants.SchedulerKubeConfigFileName,
+	}
+
+	specs, err := getKubeConfigSpecs(cfg)
+	if err != nil {
+		return err
+	}
+
+	for _, kubeConfigFileName := range kubeConfigFileNames {
+		spec, exists := specs[kubeConfigFileName]
+		if !exists {
+			return errors.Errorf("couldn't retrive KubeConfigSpec for %s", kubeConfigFileName)
+		}
+
+		kubeconfig, err := buildKubeConfigFromSpec(spec, cfg.ClusterName)
+		if err != nil {
+			return err
+		}
+
+		if err = validateKubeConfig(outDir, kubeConfigFileName, kubeconfig); err != nil {
+			return err
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/1203

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: validate kubeconfig files in case of external CA mode.
```

/assign @timothysc
/assign @fabriziopandini 
