### PR TITLE
moves audit event copy to handler

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/dynamic.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/dynamic.go
@@ -41,14 +41,15 @@ func ConvertDynamicPolicyToInternal(p *v1alpha1.Policy) *audit.Policy {
 
 // NewDynamicChecker returns a new dynamic policy checker
 func NewDynamicChecker() Checker {
-	return &dynamicPolicyChecker{}
+	return &DynamicPolicyChecker{}
 }
 
-type dynamicPolicyChecker struct{}
+// DynamicPolicyChecker is a policy checker for the dynamic audit backend.
+type DynamicPolicyChecker struct{}
 
 // LevelAndStages returns returns a fixed level of the full event, this is so that the downstream policy
 // can be applied per sink.
 // TODO: this needs benchmarking before the API moves to beta to determine the effect this has on the apiserver
-func (d *dynamicPolicyChecker) LevelAndStages(authorizer.Attributes) (audit.Level, []audit.Stage) {
+func (d *DynamicPolicyChecker) LevelAndStages(authorizer.Attributes) (audit.Level, []audit.Stage) {
 	return audit.LevelRequestResponse, []audit.Stage{}
 }

--- a/staging/src/k8s.io/apiserver/pkg/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/types.go
@@ -25,7 +25,7 @@ type Sink interface {
 	// Errors might be logged by the sink itself. If an error should be fatal, leading to an internal
 	// error, ProcessEvents is supposed to panic. The event must not be mutated and is reused by the caller
 	// after the call returns, i.e. the sink has to make a deepcopy to keep a copy around if necessary.
-	// Returns true on success, may return false on error.
+	// Returns true on success, may return false on error. The event is safe to use from spawned goroutines.
 	ProcessEvents(events ...*auditinternal.Event) bool
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/types.go
@@ -23,8 +23,8 @@ import (
 type Sink interface {
 	// ProcessEvents handles events. Per audit ID it might be that ProcessEvents is called up to three times.
 	// Errors might be logged by the sink itself. If an error should be fatal, leading to an internal
-	// error, ProcessEvents is supposed to panic. The event must not be mutated and is reused by the caller
-	// after the call returns, i.e. the sink has to make a deepcopy to keep a copy around if necessary.
+	// error, ProcessEvents is supposed to panic. The event must not be mutated, i.e. the sink has to make a
+	// deepcopy prior to any modifications.
 	// Returns true on success, may return false on error. The event is safe to use from spawned goroutines.
 	ProcessEvents(events ...*auditinternal.Event) bool
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = [
+        "audit_bench_test.go",
         "audit_test.go",
         "authentication_test.go",
         "authn_audit_test.go",
@@ -34,6 +35,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -157,7 +157,7 @@ func processAuditEvent(sink audit.Sink, ev *auditinternal.Event, omitStages []au
 	// the request passes through its stages
 	e := ev.DeepCopy()
 	audit.ObserveEvent()
-	return sink.ProcessEvents(ev)
+	return sink.ProcessEvents(e)
 }
 
 func decorateResponseWriter(responseWriter http.ResponseWriter, ev *auditinternal.Event, sink audit.Sink, omitStages []auditinternal.Stage) http.ResponseWriter {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -153,6 +153,9 @@ func processAuditEvent(sink audit.Sink, ev *auditinternal.Event, omitStages []au
 	} else {
 		ev.StageTimestamp = metav1.NewMicroTime(time.Now())
 	}
+	// Make deep copy of event before sending to the sink, so that as it can be processed concurrently as
+	// the request passes through its stages
+	e := ev.DeepCopy()
 	audit.ObserveEvent()
 	return sink.ProcessEvents(ev)
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_bench_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_bench_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit/policy"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+type benchAuditSink struct {
+	b *testing.B
+}
+
+func (s *benchAuditSink) ProcessEvents(evs ...*auditinternal.Event) bool {
+	for _, ev := range evs {
+		require.NotNil(s.b, ev)
+	}
+	return true
+}
+
+func BenchmarkAudit(b *testing.B) {
+	shortRunningPath := "/api/v1/namespaces/default/pods/foo"
+
+	for _, test := range []struct {
+		desc           string
+		path           string
+		verb           string
+		dynamicEnabled bool
+	}{
+		{
+			"dynamic disabled",
+			shortRunningPath,
+			"GET",
+			false,
+		},
+		{
+			"dynamic enabled",
+			shortRunningPath,
+			"GET",
+			true,
+		},
+	} {
+		b.Run(test.desc, func(b *testing.B) {
+			sink := &benchAuditSink{b}
+			checker := policy.FakeChecker(auditinternal.LevelRequestResponse, []auditinternal.Stage{})
+			if test.dynamicEnabled {
+				checker = policy.NewDynamicChecker()
+			}
+			h := func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte("foo"))
+			}
+			handler := WithAudit(http.HandlerFunc(h), sink, checker, func(r *http.Request, ri *request.RequestInfo) bool {
+				// simplified long-running check
+				return ri.Verb == "watch"
+			})
+			req, _ := http.NewRequest(test.verb, test.path, nil)
+			req = withTestContext(req, &user.DefaultInfo{Name: "admin"}, nil)
+			req.RemoteAddr = "127.0.0.1"
+
+			func() {
+				defer func() {
+					recover()
+				}()
+				for i := 0; i < b.N; i++ {
+					handler.ServeHTTP(httptest.NewRecorder(), req)
+				}
+			}()
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -92,14 +92,14 @@ func (*fancyResponseWriter) Flush() {}
 func (*fancyResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) { return nil, nil, nil }
 
 func TestConstructResponseWriter(t *testing.T) {
-	actual := decorateResponseWriter(&simpleResponseWriter{}, nil, nil, nil)
+	actual := decorateResponseWriter(&simpleResponseWriter{}, nil, nil, nil, false)
 	switch v := actual.(type) {
 	case *auditResponseWriter:
 	default:
 		t.Errorf("Expected auditResponseWriter, got %v", reflect.TypeOf(v))
 	}
 
-	actual = decorateResponseWriter(&fancyResponseWriter{}, nil, nil, nil)
+	actual = decorateResponseWriter(&fancyResponseWriter{}, nil, nil, nil, false)
 	switch v := actual.(type) {
 	case *fancyResponseWriterDelegator:
 	default:
@@ -109,7 +109,7 @@ func TestConstructResponseWriter(t *testing.T) {
 
 func TestDecorateResponseWriterWithoutChannel(t *testing.T) {
 	ev := &auditinternal.Event{}
-	actual := decorateResponseWriter(&simpleResponseWriter{}, ev, nil, nil)
+	actual := decorateResponseWriter(&simpleResponseWriter{}, ev, nil, nil, false)
 
 	// write status. This will not block because firstEventSentCh is nil
 	actual.WriteHeader(42)
@@ -123,7 +123,7 @@ func TestDecorateResponseWriterWithoutChannel(t *testing.T) {
 
 func TestDecorateResponseWriterWithImplicitWrite(t *testing.T) {
 	ev := &auditinternal.Event{}
-	actual := decorateResponseWriter(&simpleResponseWriter{}, ev, nil, nil)
+	actual := decorateResponseWriter(&simpleResponseWriter{}, ev, nil, nil, false)
 
 	// write status. This will not block because firstEventSentCh is nil
 	actual.Write([]byte("foo"))
@@ -138,7 +138,7 @@ func TestDecorateResponseWriterWithImplicitWrite(t *testing.T) {
 func TestDecorateResponseWriterChannel(t *testing.T) {
 	sink := &fakeAuditSink{}
 	ev := &auditinternal.Event{}
-	actual := decorateResponseWriter(&simpleResponseWriter{}, ev, sink, nil)
+	actual := decorateResponseWriter(&simpleResponseWriter{}, ev, sink, nil, false)
 
 	done := make(chan struct{})
 	go func() {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -672,6 +672,7 @@ func defaultWebhookBatchConfig() pluginbuffered.BatchConfig {
 		ThrottleBurst:  defaultBatchThrottleBurst,
 
 		AsyncDelegate: true,
+		DeepCopy:      true,
 	}
 }
 
@@ -685,5 +686,6 @@ func defaultLogBatchConfig() pluginbuffered.BatchConfig {
 		ThrottleEnable: false,
 		// Asynchronous log threads just create lock contention.
 		AsyncDelegate: false,
+		DeepCopy:      true,
 	}
 }

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered.go
@@ -271,12 +271,9 @@ func (b *bufferedBackend) ProcessEvents(ev ...*auditinternal.Event) bool {
 
 	for i, e := range ev {
 		evIndex = i
-		// Per the audit.Backend interface these events are reused after being
-		// sent to the Sink. Deep copy and send the copy to the queue.
-		event := e.DeepCopy()
 
 		select {
-		case b.buffer <- event:
+		case b.buffer <- e:
 		default:
 			sendErr = fmt.Errorf("audit buffer queue blocked")
 			return true

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/dynamic/defaults.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/dynamic/defaults.go
@@ -42,5 +42,6 @@ func NewDefaultWebhookBatchConfig() *bufferedplugin.BatchConfig {
 		ThrottleQPS:    defaultBatchThrottleQPS,
 		ThrottleBurst:  defaultBatchThrottleBurst,
 		AsyncDelegate:  true,
+		DeepCopy:       false,
 	}
 }

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/truncate.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/truncate.go
@@ -124,6 +124,13 @@ func truncate(e *auditinternal.Event) *auditinternal.Event {
 	newEvent := &auditinternal.Event{}
 	*newEvent = *e
 
+	// copy annotations map before modifying
+	newAnnotations := map[string]string{}
+	for k, v := range e.Annotations {
+		newAnnotations[k] = v
+	}
+	newEvent.Annotations = newAnnotations
+
 	newEvent.RequestObject = nil
 	newEvent.ResponseObject = nil
 	audit.LogAnnotation(newEvent, annotationKey, annotationValue)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As a part of the dynamic audit work kubernetes/enhancements#600, we are moving the event copy from the buffer to the handler. This will allow us to have multiple cheap buffers by sharing the event pointer.

**Does this PR introduce a user-facing change?**:
```
NONE
```
