### PR TITLE
Fix typos

### DIFF
--- a/pkg/proxy/ipvs/README.md
+++ b/pkg/proxy/ipvs/README.md
@@ -38,7 +38,7 @@ Differences between IPVS mode and IPTABLES mode are as follows:
 
 ### When ipvs falls back to iptables
 IPVS proxier will employ iptables in doing packet filtering, SNAT or masquerade.
-Specifically, ipvs proxier will use ipset to store source or destination address of traffics that need DROP or do masquared, to make sure the number of iptables rules be constant, no metter how many services we have.
+Specifically, ipvs proxier will use ipset to store source or destination address of traffics that need DROP or do masquerade, to make sure the number of iptables rules be constant, no metter how many services we have.
 
 
 Here is the table of ipset sets that ipvs proxier used.

--- a/pkg/scheduler/algorithm/priorities/metadata_test.go
+++ b/pkg/scheduler/algorithm/priorities/metadata_test.go
@@ -152,14 +152,14 @@ func TestPriorityMetadata(t *testing.T) {
 			name: "Produce a priorityMetadata with specified requests",
 		},
 	}
-	mataDataProducer := NewPriorityMetadataFactory(
+	metaDataProducer := NewPriorityMetadataFactory(
 		schedulertesting.FakeServiceLister([]*v1.Service{}),
 		schedulertesting.FakeControllerLister([]*v1.ReplicationController{}),
 		schedulertesting.FakeReplicaSetLister([]*apps.ReplicaSet{}),
 		schedulertesting.FakeStatefulSetLister([]*apps.StatefulSet{}))
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ptData := mataDataProducer(test.pod, nil)
+			ptData := metaDataProducer(test.pod, nil)
 			if !reflect.DeepEqual(test.expected, ptData) {
 				t.Errorf("expected %#v, got %#v", test.expected, ptData)
 			}

--- a/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
+++ b/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
@@ -347,14 +347,14 @@ func TestSelectorSpreadPriority(t *testing.T) {
 				statefulSetLister: schedulertesting.FakeStatefulSetLister(test.sss),
 			}
 
-			mataDataProducer := NewPriorityMetadataFactory(
+			metaDataProducer := NewPriorityMetadataFactory(
 				schedulertesting.FakeServiceLister(test.services),
 				schedulertesting.FakeControllerLister(test.rcs),
 				schedulertesting.FakeReplicaSetLister(test.rss),
 				schedulertesting.FakeStatefulSetLister(test.sss))
-			mataData := mataDataProducer(test.pod, nodeNameToInfo)
+			metaData := metaDataProducer(test.pod, nodeNameToInfo)
 
-			ttp := priorityFunction(selectorSpread.CalculateSpreadPriorityMap, selectorSpread.CalculateSpreadPriorityReduce, mataData)
+			ttp := priorityFunction(selectorSpread.CalculateSpreadPriorityMap, selectorSpread.CalculateSpreadPriorityReduce, metaData)
 			list, err := ttp(test.pod, nodeNameToInfo, makeNodeList(test.nodes))
 			if err != nil {
 				t.Errorf("unexpected error: %v \n", err)
@@ -583,13 +583,13 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 				statefulSetLister: schedulertesting.FakeStatefulSetLister(test.sss),
 			}
 
-			mataDataProducer := NewPriorityMetadataFactory(
+			metaDataProducer := NewPriorityMetadataFactory(
 				schedulertesting.FakeServiceLister(test.services),
 				schedulertesting.FakeControllerLister(test.rcs),
 				schedulertesting.FakeReplicaSetLister(test.rss),
 				schedulertesting.FakeStatefulSetLister(test.sss))
-			mataData := mataDataProducer(test.pod, nodeNameToInfo)
-			ttp := priorityFunction(selectorSpread.CalculateSpreadPriorityMap, selectorSpread.CalculateSpreadPriorityReduce, mataData)
+			metaData := metaDataProducer(test.pod, nodeNameToInfo)
+			ttp := priorityFunction(selectorSpread.CalculateSpreadPriorityMap, selectorSpread.CalculateSpreadPriorityReduce, metaData)
 			list, err := ttp(test.pod, nodeNameToInfo, makeLabeledNodeList(labeledNodes))
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
@@ -760,7 +760,7 @@ func TestZoneSpreadPriority(t *testing.T) {
 		},
 	}
 	// these local variables just make sure controllerLister\replicaSetLister\statefulSetLister not nil
-	// when construct mataDataProducer
+	// when construct metaDataProducer
 	sss := []*apps.StatefulSet{{Spec: apps.StatefulSetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}}}}
 	rcs := []*v1.ReplicationController{{Spec: v1.ReplicationControllerSpec{Selector: map[string]string{"foo": "bar"}}}}
 	rss := []*apps.ReplicaSet{{Spec: apps.ReplicaSetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}}}}
@@ -770,13 +770,13 @@ func TestZoneSpreadPriority(t *testing.T) {
 			nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, makeLabeledNodeList(test.nodes))
 			zoneSpread := ServiceAntiAffinity{podLister: schedulertesting.FakePodLister(test.pods), serviceLister: schedulertesting.FakeServiceLister(test.services), label: "zone"}
 
-			mataDataProducer := NewPriorityMetadataFactory(
+			metaDataProducer := NewPriorityMetadataFactory(
 				schedulertesting.FakeServiceLister(test.services),
 				schedulertesting.FakeControllerLister(rcs),
 				schedulertesting.FakeReplicaSetLister(rss),
 				schedulertesting.FakeStatefulSetLister(sss))
-			mataData := mataDataProducer(test.pod, nodeNameToInfo)
-			ttp := priorityFunction(zoneSpread.CalculateAntiAffinityPriorityMap, zoneSpread.CalculateAntiAffinityPriorityReduce, mataData)
+			metaData := metaDataProducer(test.pod, nodeNameToInfo)
+			ttp := priorityFunction(zoneSpread.CalculateAntiAffinityPriorityMap, zoneSpread.CalculateAntiAffinityPriorityReduce, metaData)
 			list, err := ttp(test.pod, nodeNameToInfo, makeLabeledNodeList(test.nodes))
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)

--- a/pkg/scheduler/algorithm/priorities/test_util.go
+++ b/pkg/scheduler/algorithm/priorities/test_util.go
@@ -41,18 +41,18 @@ func makeNode(node string, milliCPU, memory int64) *v1.Node {
 	}
 }
 
-func priorityFunction(mapFn algorithm.PriorityMapFunction, reduceFn algorithm.PriorityReduceFunction, mataData interface{}) algorithm.PriorityFunction {
+func priorityFunction(mapFn algorithm.PriorityMapFunction, reduceFn algorithm.PriorityReduceFunction, metaData interface{}) algorithm.PriorityFunction {
 	return func(pod *v1.Pod, nodeNameToInfo map[string]*schedulercache.NodeInfo, nodes []*v1.Node) (schedulerapi.HostPriorityList, error) {
 		result := make(schedulerapi.HostPriorityList, 0, len(nodes))
 		for i := range nodes {
-			hostResult, err := mapFn(pod, mataData, nodeNameToInfo[nodes[i].Name])
+			hostResult, err := mapFn(pod, metaData, nodeNameToInfo[nodes[i].Name])
 			if err != nil {
 				return nil, err
 			}
 			result = append(result, hostResult)
 		}
 		if reduceFn != nil {
-			if err := reduceFn(pod, mataData, nodeNameToInfo, result); err != nil {
+			if err := reduceFn(pod, metaData, nodeNameToInfo, result); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -706,15 +706,15 @@ func TestZeroRequest(t *testing.T) {
 
 			nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
 
-			mataDataProducer := algorithmpriorities.NewPriorityMetadataFactory(
+			metaDataProducer := algorithmpriorities.NewPriorityMetadataFactory(
 				schedulertesting.FakeServiceLister([]*v1.Service{}),
 				schedulertesting.FakeControllerLister([]*v1.ReplicationController{}),
 				schedulertesting.FakeReplicaSetLister([]*apps.ReplicaSet{}),
 				schedulertesting.FakeStatefulSetLister([]*apps.StatefulSet{}))
-			mataData := mataDataProducer(test.pod, nodeNameToInfo)
+			metaData := metaDataProducer(test.pod, nodeNameToInfo)
 
 			list, err := PrioritizeNodes(
-				test.pod, nodeNameToInfo, mataData, priorityConfigs,
+				test.pod, nodeNameToInfo, metaData, priorityConfigs,
 				schedulertesting.FakeNodeLister(test.nodes), []algorithm.SchedulerExtender{})
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
/kind cleanup

Fix Typo: `masquared` -> `masquerade`
Fix Typo: `mataData` -> `metaData`

```release-note
NONE
```