### PR TITLE
gitattributes: remove the union merge driver since GitHub doesn't support it

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,3 @@
-hack/verify-flags/known-flags.txt merge=union
-test/test_owners.csv merge=union
-
 **/zz_generated.*.go linguist-generated=true
 **/types.generated.go linguist-generated=true
 **/generated.pb.go linguist-generated=true


### PR DESCRIPTION
GitHub doesn't support the union merge driver currently: https://github.com/isaacs/github/issues/487.

Prow doesn't use `git merge` but does a "GitHub merge" through the GH API while automatically merging PRs. GitHub will not allow merging PRs if they have conflicts so a union merge doesn't make much sense here.

/kind cleanup

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
