### PR TITLE
CSI: enhance driver tests to update the drivers.

### DIFF
--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -55,6 +55,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath-v0/csi-hostpathplugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath-v0/csi-hostpathplugin.yaml
@@ -55,6 +55,8 @@ spec:
             - mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
               name: mountpoint-dir
+            - mountPath: /tmp
+              name: tmp
       volumes:
         - hostPath:
             path: /var/lib/kubelet/plugins/csi-hostpath-v0
@@ -68,3 +70,7 @@ spec:
             path: /var/lib/kubelet/plugins
             type: Directory
           name: registration-dir
+        - name: tmp
+          hostPath:
+            path: /tmp
+            type: Directory

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpathplugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpathplugin.yaml
@@ -55,6 +55,8 @@ spec:
             - mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
               name: mountpoint-dir
+            - mountPath: /tmp
+              name: tmp
       volumes:
         - hostPath:
             path: /var/lib/kubelet/plugins/csi-hostpath
@@ -68,3 +70,7 @@ spec:
             path: /var/lib/kubelet/plugins_registry
             type: Directory
           name: registration-dir
+        - name: tmp
+          hostPath:
+            path: /tmp
+            type: Directory


### PR DESCRIPTION
We want to check that kubelet correctly handles driver update on a node and does not screw up sockets.

I extended an existing tests, because testing of update starts exactly the same as simply testing the driver and I want to avoid two tests where one is subset of the other one.

**Which issue(s) this PR fixes**
Fixes #70293

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

/sig storage
cc: @msau42 @pohly @davidz627 