### PR TITLE
Deflake e2e HPA tests

### DIFF
--- a/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
+++ b/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
@@ -86,7 +86,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: Custom Me
 		initialReplicas := 2
 		// metric should cause scale down
 		metricValue := externalMetricValue
-		metricTarget := 2 * metricValue
+		metricTarget := 3 * metricValue
 		metricTargets := map[string]externalMetricTarget{
 			"target": {
 				value:     metricTarget,
@@ -109,7 +109,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: Custom Me
 		initialReplicas := 2
 		// metric should cause scale down
 		metricValue := externalMetricValue
-		metricAverageTarget := (3 * metricValue) / 2
+		metricAverageTarget := 3 * metricValue
 		metricTargets := map[string]externalMetricTarget{
 			"target_average": {
 				value:     metricAverageTarget,


### PR DESCRIPTION
Tests for scaling down based on external metric are flaky. I think this
is because they:
 - Start with 2 replicas,
 - Export metric value == 1/2 target,
 - Expect scale down to 1.

Since the expected recommendation is exactly 1 it might flake (and with
scale down stabilization any recommendations higher than 1 will
persist).

Change expected value of the metric so recommended size will be lower
than 1. This should make those tests less flaky.

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: [Tests are flaky](https://k8s-testgrid.appspot.com/sig-autoscaling-hpa#gci-gce-autoscaling-hpa&width=20)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
