### PR TITLE
e2e: remove "nodes" permission from driver-registrar RBAC

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/driver-registrar/rbac.yaml
+++ b/test/e2e/testing-manifests/storage-csi/driver-registrar/rbac.yaml
@@ -24,9 +24,16 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "update", "patch"]
+  # The following permissions are only needed when running
+  # driver-registrar without the --kubelet-registration-path
+  # parameter, i.e. when using driver-registrar instead of
+  # kubelet to update the csi.volume.kubernetes.io/nodeid
+  # annotation. That mode of operation is going to be deprecated
+  # and should not be used anymore, but is needed on older
+  # Kubernetes versions.
+  # - apiGroups: [""]
+  #   resources: ["nodes"]
+  #   verbs: ["get", "update", "patch"]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

In the review of
https://github.com/kubernetes-csi/driver-registrar/pull/69 it was
pointed out that the "nodes" permissions are not longer needed.

**Special notes for your reviewer**:

The same change will also be merged via https://github.com/kubernetes-csi/driver-registrar/pull/69 into the upstream driver-registrar repo.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
