### PR TITLE
Enable --all flag for kubectl wait

### DIFF
--- a/pkg/kubectl/cmd/wait/wait.go
+++ b/pkg/kubectl/cmd/wait/wait.go
@@ -90,6 +90,7 @@ func NewWaitFlags(restClientGetter genericclioptions.RESTClientGetter, streams g
 		ResourceBuilderFlags: genericclioptions.NewResourceBuilderFlags().
 			WithLabelSelector("").
 			WithAllNamespaces(false).
+			WithAll(false).
 			WithLatest(),
 
 		Timeout: 30 * time.Second,


### PR DESCRIPTION
It's useful to have the --all flag. Another reason to enable the flag is that if I don't provide any flag, the error message is "resource(s) were provided, but no name, label selector, or --all flag specified".

/assign @deads2k 
/kind bug
/sig cli

```release-note
"kubectl wait" command now supports the "--all" flag to select all resources in the namespace of the specified resource types.
```