### PR TITLE
periodically reload tokens read from TokenFile in kubeconfig

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -322,7 +322,7 @@ func InClusterConfig() (*Config, error) {
 		return nil, ErrNotInCluster
 	}
 
-	ts := newCachedPathTokenSource(tokenFile)
+	ts := NewCachedFileTokenSource(tokenFile)
 
 	if _, err := ts.Token(); err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/rest/token_source.go
+++ b/staging/src/k8s.io/client-go/rest/token_source.go
@@ -42,7 +42,9 @@ func TokenSourceWrapTransport(ts oauth2.TokenSource) func(http.RoundTripper) htt
 	}
 }
 
-func newCachedPathTokenSource(path string) oauth2.TokenSource {
+// NewCachedFileTokenSource returns a oauth2.TokenSource reads a token from a
+// file at a specified path and periodically reloads it.
+func NewCachedFileTokenSource(path string) oauth2.TokenSource {
 	return &cachingTokenSource{
 		now:    time.Now,
 		leeway: 1 * time.Minute,

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -229,11 +229,11 @@ func (config *DirectClientConfig) getUserIdentificationPartialConfig(configAuthI
 	if len(configAuthInfo.Token) > 0 {
 		mergedConfig.BearerToken = configAuthInfo.Token
 	} else if len(configAuthInfo.TokenFile) > 0 {
-		tokenBytes, err := ioutil.ReadFile(configAuthInfo.TokenFile)
-		if err != nil {
+		ts := restclient.NewCachedFileTokenSource(configAuthInfo.TokenFile)
+		if _, err := ts.Token(); err != nil {
 			return nil, err
 		}
-		mergedConfig.BearerToken = string(tokenBytes)
+		mergedConfig.WrapTransport = restclient.TokenSourceWrapTransport(ts)
 	}
 	if len(configAuthInfo.Impersonate) > 0 {
 		mergedConfig.Impersonate = restclient.ImpersonationConfig{


### PR DESCRIPTION
Like we do with InClusterConfig.

/kind cleanup
/sig auth

```release-note
Go clients created from a kubeconfig that specifies a TokenFile now periodically reload the token from the specified file.
```
