### PR TITLE
fix local volume getVolumeSourceFSType func by golint

### DIFF
--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -322,10 +322,9 @@ func getVolumeSourceFSType(spec *volume.Spec) (string, error) {
 		spec.PersistentVolume.Spec.Local != nil {
 		if spec.PersistentVolume.Spec.Local.FSType != nil {
 			return *spec.PersistentVolume.Spec.Local.FSType, nil
-		} else {
-			// if the FSType is not set in local PV spec, setting it to default ("ext4")
-			return defaultFSType, nil
 		}
+		// if the FSType is not set in local PV spec, setting it to default ("ext4")
+		return defaultFSType, nil
 	}
 
 	return "", fmt.Errorf("spec does not reference a Local volume type")


### PR DESCRIPTION
/kind cleanup
**What this PR does / why we need it**:
fix golint problem
/media/B/src/k8s.io/kubernetes/pkg/volume/local/local.go:325:10: if block ends with a return statement, so drop this else and outdent its block
Found 1 lint suggestions; failing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
