### PR TITLE
Add new reviewers for conformance

### DIFF
--- a/test/conformance/testdata/OWNERS
+++ b/test/conformance/testdata/OWNERS
@@ -4,6 +4,9 @@ options:
 reviewers:
   - bgrant0607
   - smarterclayton
+  - spiffxp
+  - timothysc
+  - dims
 approvers:
   - bgrant0607
   - smarterclayton


### PR DESCRIPTION
Put into OWNERS files what has effectively been happening
for the past few months, we review and shepherd PR's
through other SIG reviewers before bringing to sig-arch
for a final /approve.

The goal is to eventually grow approvers when it's been
demonstrated that we have sufficient context.

/kind cleanup

/cc @dims @timothysc

```release-note
NONE
```