### PR TITLE
delete some para no need used in local volume

### DIFF
--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -573,7 +573,7 @@ type localVolumeUnmapper struct {
 var _ volume.BlockVolumeUnmapper = &localVolumeUnmapper{}
 
 // TearDownDevice will undo SetUpDevice procedure. In local PV, all of this already handled by operation_generator.
-func (u *localVolumeUnmapper) TearDownDevice(mapPath, devicePath string) error {
+func (u *localVolumeUnmapper) TearDownDevice(mapPath, _ string) error {
 	glog.V(4).Infof("local: TearDownDevice completed for: %s", mapPath)
 	return nil
 }

--- a/pkg/volume/local/local_test.go
+++ b/pkg/volume/local/local_test.go
@@ -41,7 +41,6 @@ const (
 	testMountPath                     = "pods/poduid/volumes/kubernetes.io~local-volume/pvA"
 	testGlobalPath                    = "plugins/kubernetes.io~local-volume/volumeDevices/pvA"
 	testPodPath                       = "pods/poduid/volumeDevices/kubernetes.io~local-volume"
-	testNodeName                      = "fakeNodeName"
 	testBlockFormattingToFSGlobalPath = "plugins/kubernetes.io/local-volume/mounts/pvA"
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup
**What this PR does / why we need it**:
TearDownDevice func there is no need devicePath para because no used and the const   testNodeName also no used so delete it!
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
