### PR TITLE
Fix a wrong judgement in elasticsearch_logging_discovery.go

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go
+++ b/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go
@@ -113,7 +113,7 @@ func main() {
 		}
 		addrs = flattenSubsets(endpoints.Subsets)
 		glog.Infof("Found %s", addrs)
-		if len(addrs) > 0 && len(addrs) == count {
+		if len(addrs) > 0 && len(addrs) >= count {
 			break
 		}
 	}


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:

The previous judgement is wrong. The number of endpoints's addresses can be greater or equal to the
value of "MINIMUM_MASTER_NODES".

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

```release-note
None
```
Signed-off-by: zhihui wu <wu.zhihui1@zte.com.cn>
