### PR TITLE
Remove unnecessary lock in scheduling PriorityQueue

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -457,9 +457,8 @@ func (p *PriorityQueue) movePodsToActiveQueue(pods []*v1.Pod) {
 
 // getUnschedulablePodsWithMatchingAffinityTerm returns unschedulable pods which have
 // any affinity term that matches "pod".
+// NOTE: this function assumes lock has been acquired in caller
 func (p *PriorityQueue) getUnschedulablePodsWithMatchingAffinityTerm(pod *v1.Pod) []*v1.Pod {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
 	var podsToMove []*v1.Pod
 	for _, up := range p.unschedulableQ.pods {
 		affinity := up.Spec.Affinity


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Detailed issue description is in #70622.

**Which issue(s) this PR fixes**:

Fixes #70622.

**Special notes for your reviewer**:

At this moment I just found that this PR can fix #70622. (Tried several times with this fix, everytime works. And without this PR, everytime I can reproduce that issue)

But I can't find a fully convincing reason yet. Will dig more and comment later.

**Does this PR introduce a user-facing change?**:

```release-note
Fix a potential bug that scheduler isn't preempting pods in an exact correct path.
```
