### PR TITLE
Remove pkg/kubeapiserver/* from hack/.golint_failures.

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -461,7 +461,7 @@ func buildGenericConfig(
 	genericConfig.Version = &kubeVersion
 
 	storageFactoryConfig := kubeapiserver.NewStorageFactoryConfig()
-	storageFactoryConfig.ApiResourceConfig = genericConfig.MergedResourceConfig
+	storageFactoryConfig.APIResourceConfig = genericConfig.MergedResourceConfig
 	completedStorageFactoryConfig, err := storageFactoryConfig.Complete(s.Etcd, s.StorageSerialization)
 	if err != nil {
 		lastErr = err
@@ -504,7 +504,7 @@ func buildGenericConfig(
 		genericConfig.DisabledPostStartHooks.Insert(rbacrest.PostStartHookName)
 	}
 
-	admissionConfig := &kubeapiserveradmission.AdmissionConfig{
+	admissionConfig := &kubeapiserveradmission.Config{
 		ExternalInformers:    versionedInformers,
 		LoopbackClientConfig: genericConfig.LoopbackClientConfig,
 		CloudConfigFile:      s.CloudProvider.CloudConfigFile,

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -133,12 +133,6 @@ pkg/credentialprovider
 pkg/credentialprovider/gcp
 pkg/credentialprovider/rancher
 pkg/features
-pkg/kubeapiserver
-pkg/kubeapiserver/admission
-pkg/kubeapiserver/authenticator
-pkg/kubeapiserver/authorizer
-pkg/kubeapiserver/authorizer/modes
-pkg/kubeapiserver/options
 pkg/kubectl
 pkg/kubectl/apps
 pkg/kubectl/cmd

--- a/pkg/kubeapiserver/admission/config.go
+++ b/pkg/kubeapiserver/admission/config.go
@@ -37,14 +37,15 @@ import (
 	quotainstall "k8s.io/kubernetes/pkg/quota/v1/install"
 )
 
-// AdmissionConfig holds the configuration for initializing the admission plugins
-type AdmissionConfig struct {
+// Config holds the configuration for initializing the admission plugins.
+type Config struct {
 	CloudConfigFile      string
 	LoopbackClientConfig *rest.Config
 	ExternalInformers    externalinformers.SharedInformerFactory
 }
 
-func (c *AdmissionConfig) New(proxyTransport *http.Transport, serviceResolver webhook.ServiceResolver) ([]admission.PluginInitializer, server.PostStartHookFunc, error) {
+// New creates a new apiserver.Config.
+func (c *Config) New(proxyTransport *http.Transport, serviceResolver webhook.ServiceResolver) ([]admission.PluginInitializer, server.PostStartHookFunc, error) {
 	webhookAuthResolverWrapper := webhook.NewDefaultAuthenticationInfoResolverWrapper(proxyTransport, c.LoopbackClientConfig)
 	webhookPluginInitializer := webhookinit.NewPluginInitializer(webhookAuthResolverWrapper, serviceResolver)
 

--- a/pkg/kubeapiserver/admission/initializer_test.go
+++ b/pkg/kubeapiserver/admission/initializer_test.go
@@ -33,8 +33,8 @@ type WantsCloudConfigAdmissionPlugin struct {
 	cloudConfig []byte
 }
 
-func (self *WantsCloudConfigAdmissionPlugin) SetCloudConfig(cloudConfig []byte) {
-	self.cloudConfig = cloudConfig
+func (w *WantsCloudConfigAdmissionPlugin) SetCloudConfig(cloudConfig []byte) {
+	w.cloudConfig = cloudConfig
 }
 
 func TestCloudConfigAdmissionPlugin(t *testing.T) {

--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -38,13 +38,15 @@ import (
 	"k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth"
 	"k8s.io/apiserver/plugin/pkg/authenticator/token/oidc"
 	"k8s.io/apiserver/plugin/pkg/authenticator/token/webhook"
+	// Import solely to initialize client auth plugins.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 )
 
-type AuthenticatorConfig struct {
+// Config holds the configuration for authentication.
+type Config struct {
 	Anonymous                   bool
 	BasicAuthFile               string
 	BootstrapToken              bool
@@ -78,7 +80,7 @@ type AuthenticatorConfig struct {
 
 // New returns an authenticator.Request or an error that supports the standard
 // Kubernetes authentication mechanisms.
-func (config AuthenticatorConfig) New() (authenticator.Request, *spec.SecurityDefinitions, error) {
+func (config Config) New() (authenticator.Request, *spec.SecurityDefinitions, error) {
 	var authenticators []authenticator.Request
 	var tokenAuthenticators []authenticator.Token
 	securityDefinitions := spec.SecurityDefinitions{}

--- a/pkg/kubeapiserver/authorizer/config.go
+++ b/pkg/kubeapiserver/authorizer/config.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
 )
 
+// AuthorizationConfig holds options for various modes of authorization.
 type AuthorizationConfig struct {
 	AuthorizationModes []string
 

--- a/pkg/kubeapiserver/authorizer/modes/modes.go
+++ b/pkg/kubeapiserver/authorizer/modes/modes.go
@@ -19,14 +19,21 @@ package modes
 import "k8s.io/apimachinery/pkg/util/sets"
 
 const (
+	// ModeAlwaysAllow results in all requests being allowed.
 	ModeAlwaysAllow string = "AlwaysAllow"
-	ModeAlwaysDeny  string = "AlwaysDeny"
-	ModeABAC        string = "ABAC"
-	ModeWebhook     string = "Webhook"
-	ModeRBAC        string = "RBAC"
-	ModeNode        string = "Node"
+	// ModeAlwaysDeny results in all requests being blocked.
+	ModeAlwaysDeny string = "AlwaysDeny"
+	// ModeABAC enables policies to be configured using local files.
+	ModeABAC string = "ABAC"
+	// ModeWebhook enables authorization to be managed using a remote REST endpoint.
+	ModeWebhook string = "Webhook"
+	// ModeRBAC enables the creation and storage of policies using the Kubernetes API.
+	ModeRBAC string = "RBAC"
+	// ModeNode enables node authorization to authorize requests.
+	ModeNode string = "Node"
 )
 
+// AuthorizationModeChoices is a list of possible authorization options.
 var AuthorizationModeChoices = []string{ModeAlwaysAllow, ModeAlwaysDeny, ModeABAC, ModeWebhook, ModeRBAC, ModeNode}
 
 // IsValidAuthorizationMode returns true if the given authorization mode is a valid one for the apiserver

--- a/pkg/kubeapiserver/doc.go
+++ b/pkg/kubeapiserver/doc.go
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// The kubapiserver package holds code that is common to both the kube-apiserver
+// Package kubeapiserver holds code that is common to both the kube-apiserver
 // and the federation-apiserver, but isn't part of a generic API server.
 // For instance, the non-delegated authorization options are used by those two
 // servers, but no generic API server is likely to use them.
-package kubeapiserver
+package kubeapiserver // import "k8s.io/kubernetes/pkg/kubeapiserver"

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -34,6 +34,8 @@ import (
 	authzmodes "k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
 )
 
+// BuiltInAuthenticationOptions holds configuration options for various athentication modes
+// provided by Kubernetes.
 type BuiltInAuthenticationOptions struct {
 	APIAudiences    []string
 	Anonymous       *AnonymousAuthenticationOptions
@@ -50,14 +52,17 @@ type BuiltInAuthenticationOptions struct {
 	TokenFailureCacheTTL time.Duration
 }
 
+// AnonymousAuthenticationOptions holds settings for anonymous authentication.
 type AnonymousAuthenticationOptions struct {
 	Allow bool
 }
 
+// BootstrapTokenAuthenticationOptions holds settings for authenticating with bootstrap tokens.
 type BootstrapTokenAuthenticationOptions struct {
 	Enable bool
 }
 
+// OIDCAuthenticationOptions holds settings for OIDC authentication.
 type OIDCAuthenticationOptions struct {
 	CAFile         string
 	ClientID       string
@@ -70,10 +75,13 @@ type OIDCAuthenticationOptions struct {
 	RequiredClaims map[string]string
 }
 
+// PasswordFileAuthenticationOptions holds settings for basic auth.
 type PasswordFileAuthenticationOptions struct {
 	BasicAuthFile string
 }
 
+// ServiceAccountAuthenticationOptions holds settings for authenticating service
+// accounts.
 type ServiceAccountAuthenticationOptions struct {
 	KeyFiles      []string
 	Lookup        bool
@@ -81,15 +89,18 @@ type ServiceAccountAuthenticationOptions struct {
 	MaxExpiration time.Duration
 }
 
+// TokenFileAuthenticationOptions holds settings for token file authentication.
 type TokenFileAuthenticationOptions struct {
 	TokenFile string
 }
 
+// WebHookAuthenticationOptions holds settings for authentication using webhooks.
 type WebHookAuthenticationOptions struct {
 	ConfigFile string
 	CacheTTL   time.Duration
 }
 
+// NewBuiltInAuthenticationOptions creates a new BuiltInAuthenticationOptions with a default config.
 func NewBuiltInAuthenticationOptions() *BuiltInAuthenticationOptions {
 	return &BuiltInAuthenticationOptions{
 		TokenSuccessCacheTTL: 10 * time.Second,
@@ -97,8 +108,10 @@ func NewBuiltInAuthenticationOptions() *BuiltInAuthenticationOptions {
 	}
 }
 
-func (s *BuiltInAuthenticationOptions) WithAll() *BuiltInAuthenticationOptions {
-	return s.
+// WithAll initializes BuiltInAuthenticationOptions with defaults for all authentication
+// modes.
+func (o *BuiltInAuthenticationOptions) WithAll() *BuiltInAuthenticationOptions {
+	return o.
 		WithAnonymous().
 		WithBootstrapToken().
 		WithClientCert().
@@ -110,63 +123,72 @@ func (s *BuiltInAuthenticationOptions) WithAll() *BuiltInAuthenticationOptions {
 		WithWebHook()
 }
 
-func (s *BuiltInAuthenticationOptions) WithAnonymous() *BuiltInAuthenticationOptions {
-	s.Anonymous = &AnonymousAuthenticationOptions{Allow: true}
-	return s
+// WithAnonymous initializes an options object for anonymous athentication.
+func (o *BuiltInAuthenticationOptions) WithAnonymous() *BuiltInAuthenticationOptions {
+	o.Anonymous = &AnonymousAuthenticationOptions{Allow: true}
+	return o
 }
 
-func (s *BuiltInAuthenticationOptions) WithBootstrapToken() *BuiltInAuthenticationOptions {
-	s.BootstrapToken = &BootstrapTokenAuthenticationOptions{}
-	return s
+// WithBootstrapToken initializes an options object for bootstrap token authentication.
+func (o *BuiltInAuthenticationOptions) WithBootstrapToken() *BuiltInAuthenticationOptions {
+	o.BootstrapToken = &BootstrapTokenAuthenticationOptions{}
+	return o
 }
 
-func (s *BuiltInAuthenticationOptions) WithClientCert() *BuiltInAuthenticationOptions {
-	s.ClientCert = &genericoptions.ClientCertAuthenticationOptions{}
-	return s
+// WithClientCert initializes an options object for client cert authentication.
+func (o *BuiltInAuthenticationOptions) WithClientCert() *BuiltInAuthenticationOptions {
+	o.ClientCert = &genericoptions.ClientCertAuthenticationOptions{}
+	return o
 }
 
-func (s *BuiltInAuthenticationOptions) WithOIDC() *BuiltInAuthenticationOptions {
-	s.OIDC = &OIDCAuthenticationOptions{}
-	return s
+// WithOIDC initializes an options object for OIDC authentication.
+func (o *BuiltInAuthenticationOptions) WithOIDC() *BuiltInAuthenticationOptions {
+	o.OIDC = &OIDCAuthenticationOptions{}
+	return o
 }
 
-func (s *BuiltInAuthenticationOptions) WithPasswordFile() *BuiltInAuthenticationOptions {
-	s.PasswordFile = &PasswordFileAuthenticationOptions{}
-	return s
+// WithPasswordFile initializes an options object for password file authentication.
+func (o *BuiltInAuthenticationOptions) WithPasswordFile() *BuiltInAuthenticationOptions {
+	o.PasswordFile = &PasswordFileAuthenticationOptions{}
+	return o
 }
 
-func (s *BuiltInAuthenticationOptions) WithRequestHeader() *BuiltInAuthenticationOptions {
-	s.RequestHeader = &genericoptions.RequestHeaderAuthenticationOptions{}
-	return s
+// WithRequestHeader initializes an options object for authentication using request headers.
+func (o *BuiltInAuthenticationOptions) WithRequestHeader() *BuiltInAuthenticationOptions {
+	o.RequestHeader = &genericoptions.RequestHeaderAuthenticationOptions{}
+	return o
 }
 
-func (s *BuiltInAuthenticationOptions) WithServiceAccounts() *BuiltInAuthenticationOptions {
-	s.ServiceAccounts = &ServiceAccountAuthenticationOptions{Lookup: true}
-	return s
+// WithServiceAccounts initializes an options object for service account authentication.
+func (o *BuiltInAuthenticationOptions) WithServiceAccounts() *BuiltInAuthenticationOptions {
+	o.ServiceAccounts = &ServiceAccountAuthenticationOptions{Lookup: true}
+	return o
 }
 
-func (s *BuiltInAuthenticationOptions) WithTokenFile() *BuiltInAuthenticationOptions {
-	s.TokenFile = &TokenFileAuthenticationOptions{}
-	return s
+// WithTokenFile initializes an options object for token file authentication.
+func (o *BuiltInAuthenticationOptions) WithTokenFile() *BuiltInAuthenticationOptions {
+	o.TokenFile = &TokenFileAuthenticationOptions{}
+	return o
 }
 
-func (s *BuiltInAuthenticationOptions) WithWebHook() *BuiltInAuthenticationOptions {
-	s.WebHook = &WebHookAuthenticationOptions{
+// WithWebHook initializes an options object for webhook authentication.
+func (o *BuiltInAuthenticationOptions) WithWebHook() *BuiltInAuthenticationOptions {
+	o.WebHook = &WebHookAuthenticationOptions{
 		CacheTTL: 2 * time.Minute,
 	}
-	return s
+	return o
 }
 
-// Validate checks invalid config combination
-func (s *BuiltInAuthenticationOptions) Validate() []error {
+// Validate checks invalid config combination.
+func (o *BuiltInAuthenticationOptions) Validate() []error {
 	allErrors := []error{}
 
-	if s.OIDC != nil && (len(s.OIDC.IssuerURL) > 0) != (len(s.OIDC.ClientID) > 0) {
+	if o.OIDC != nil && (len(o.OIDC.IssuerURL) > 0) != (len(o.OIDC.ClientID) > 0) {
 		allErrors = append(allErrors, fmt.Errorf("oidc-issuer-url and oidc-client-id should be specified together"))
 	}
 
-	if s.ServiceAccounts != nil && len(s.ServiceAccounts.Issuer) > 0 && strings.Contains(s.ServiceAccounts.Issuer, ":") {
-		if _, err := url.Parse(s.ServiceAccounts.Issuer); err != nil {
+	if o.ServiceAccounts != nil && len(o.ServiceAccounts.Issuer) > 0 && strings.Contains(o.ServiceAccounts.Issuer, ":") {
+		if _, err := url.Parse(o.ServiceAccounts.Issuer); err != nil {
 			allErrors = append(allErrors, fmt.Errorf("service-account-issuer contained a ':' but was not a valid URL: %v", err))
 		}
 	}
@@ -174,186 +196,188 @@ func (s *BuiltInAuthenticationOptions) Validate() []error {
 	return allErrors
 }
 
-func (s *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringSliceVar(&s.APIAudiences, "api-audiences", s.APIAudiences, ""+
+// AddFlags configures a BuiltInAuthenticationOptions from options provided on the command line.
+func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringSliceVar(&o.APIAudiences, "api-audiences", o.APIAudiences, ""+
 		"Identifiers of the API. The service account token authenticator will validate that "+
 		"tokens used against the API are bound to at least one of these audiences. If the "+
 		"--service-account-issuer flag is configured and this flag is not, this field "+
 		"defaults to a single element list containing the issuer URL .")
 
-	if s.Anonymous != nil {
-		fs.BoolVar(&s.Anonymous.Allow, "anonymous-auth", s.Anonymous.Allow, ""+
+	if o.Anonymous != nil {
+		fs.BoolVar(&o.Anonymous.Allow, "anonymous-auth", o.Anonymous.Allow, ""+
 			"Enables anonymous requests to the secure port of the API server. "+
 			"Requests that are not rejected by another authentication method are treated as anonymous requests. "+
 			"Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated.")
 	}
 
-	if s.BootstrapToken != nil {
-		fs.BoolVar(&s.BootstrapToken.Enable, "enable-bootstrap-token-auth", s.BootstrapToken.Enable, ""+
+	if o.BootstrapToken != nil {
+		fs.BoolVar(&o.BootstrapToken.Enable, "enable-bootstrap-token-auth", o.BootstrapToken.Enable, ""+
 			"Enable to allow secrets of type 'bootstrap.kubernetes.io/token' in the 'kube-system' "+
 			"namespace to be used for TLS bootstrapping authentication.")
 	}
 
-	if s.ClientCert != nil {
-		s.ClientCert.AddFlags(fs)
+	if o.ClientCert != nil {
+		o.ClientCert.AddFlags(fs)
 	}
 
-	if s.OIDC != nil {
-		fs.StringVar(&s.OIDC.IssuerURL, "oidc-issuer-url", s.OIDC.IssuerURL, ""+
+	if o.OIDC != nil {
+		fs.StringVar(&o.OIDC.IssuerURL, "oidc-issuer-url", o.OIDC.IssuerURL, ""+
 			"The URL of the OpenID issuer, only HTTPS scheme will be accepted. "+
 			"If set, it will be used to verify the OIDC JSON Web Token (JWT).")
 
-		fs.StringVar(&s.OIDC.ClientID, "oidc-client-id", s.OIDC.ClientID,
+		fs.StringVar(&o.OIDC.ClientID, "oidc-client-id", o.OIDC.ClientID,
 			"The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.")
 
-		fs.StringVar(&s.OIDC.CAFile, "oidc-ca-file", s.OIDC.CAFile, ""+
+		fs.StringVar(&o.OIDC.CAFile, "oidc-ca-file", o.OIDC.CAFile, ""+
 			"If set, the OpenID server's certificate will be verified by one of the authorities "+
 			"in the oidc-ca-file, otherwise the host's root CA set will be used.")
 
-		fs.StringVar(&s.OIDC.UsernameClaim, "oidc-username-claim", "sub", ""+
+		fs.StringVar(&o.OIDC.UsernameClaim, "oidc-username-claim", "sub", ""+
 			"The OpenID claim to use as the user name. Note that claims other than the default ('sub') "+
 			"is not guaranteed to be unique and immutable. This flag is experimental, please see "+
 			"the authentication documentation for further details.")
 
-		fs.StringVar(&s.OIDC.UsernamePrefix, "oidc-username-prefix", "", ""+
+		fs.StringVar(&o.OIDC.UsernamePrefix, "oidc-username-prefix", "", ""+
 			"If provided, all usernames will be prefixed with this value. If not provided, "+
 			"username claims other than 'email' are prefixed by the issuer URL to avoid "+
 			"clashes. To skip any prefixing, provide the value '-'.")
 
-		fs.StringVar(&s.OIDC.GroupsClaim, "oidc-groups-claim", "", ""+
+		fs.StringVar(&o.OIDC.GroupsClaim, "oidc-groups-claim", "", ""+
 			"If provided, the name of a custom OpenID Connect claim for specifying user groups. "+
 			"The claim value is expected to be a string or array of strings. This flag is experimental, "+
 			"please see the authentication documentation for further details.")
 
-		fs.StringVar(&s.OIDC.GroupsPrefix, "oidc-groups-prefix", "", ""+
+		fs.StringVar(&o.OIDC.GroupsPrefix, "oidc-groups-prefix", "", ""+
 			"If provided, all groups will be prefixed with this value to prevent conflicts with "+
 			"other authentication strategies.")
 
-		fs.StringSliceVar(&s.OIDC.SigningAlgs, "oidc-signing-algs", []string{"RS256"}, ""+
+		fs.StringSliceVar(&o.OIDC.SigningAlgs, "oidc-signing-algs", []string{"RS256"}, ""+
 			"Comma-separated list of allowed JOSE asymmetric signing algorithms. JWTs with a "+
 			"'alg' header value not in this list will be rejected. "+
 			"Values are defined by RFC 7518 https://tools.ietf.org/html/rfc7518#section-3.1.")
 
-		fs.Var(flag.NewMapStringStringNoSplit(&s.OIDC.RequiredClaims), "oidc-required-claim", ""+
+		fs.Var(flag.NewMapStringStringNoSplit(&o.OIDC.RequiredClaims), "oidc-required-claim", ""+
 			"A key=value pair that describes a required claim in the ID Token. "+
 			"If set, the claim is verified to be present in the ID Token with a matching value. "+
 			"Repeat this flag to specify multiple claims.")
 	}
 
-	if s.PasswordFile != nil {
-		fs.StringVar(&s.PasswordFile.BasicAuthFile, "basic-auth-file", s.PasswordFile.BasicAuthFile, ""+
+	if o.PasswordFile != nil {
+		fs.StringVar(&o.PasswordFile.BasicAuthFile, "basic-auth-file", o.PasswordFile.BasicAuthFile, ""+
 			"If set, the file that will be used to admit requests to the secure port of the API server "+
 			"via http basic authentication.")
 	}
 
-	if s.RequestHeader != nil {
-		s.RequestHeader.AddFlags(fs)
+	if o.RequestHeader != nil {
+		o.RequestHeader.AddFlags(fs)
 	}
 
-	if s.ServiceAccounts != nil {
-		fs.StringArrayVar(&s.ServiceAccounts.KeyFiles, "service-account-key-file", s.ServiceAccounts.KeyFiles, ""+
+	if o.ServiceAccounts != nil {
+		fs.StringArrayVar(&o.ServiceAccounts.KeyFiles, "service-account-key-file", o.ServiceAccounts.KeyFiles, ""+
 			"File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify "+
 			"ServiceAccount tokens. The specified file can contain multiple keys, and the flag can "+
 			"be specified multiple times with different files. If unspecified, "+
 			"--tls-private-key-file is used. Must be specified when "+
 			"--service-account-signing-key is provided")
 
-		fs.BoolVar(&s.ServiceAccounts.Lookup, "service-account-lookup", s.ServiceAccounts.Lookup,
+		fs.BoolVar(&o.ServiceAccounts.Lookup, "service-account-lookup", o.ServiceAccounts.Lookup,
 			"If true, validate ServiceAccount tokens exist in etcd as part of authentication.")
 
-		fs.StringVar(&s.ServiceAccounts.Issuer, "service-account-issuer", s.ServiceAccounts.Issuer, ""+
+		fs.StringVar(&o.ServiceAccounts.Issuer, "service-account-issuer", o.ServiceAccounts.Issuer, ""+
 			"Identifier of the service account token issuer. The issuer will assert this identifier "+
 			"in \"iss\" claim of issued tokens. This value is a string or URI.")
 
 		// Deprecated in 1.13
-		fs.StringSliceVar(&s.APIAudiences, "service-account-api-audiences", s.APIAudiences, ""+
+		fs.StringSliceVar(&o.APIAudiences, "service-account-api-audiences", o.APIAudiences, ""+
 			"Identifiers of the API. The service account token authenticator will validate that "+
 			"tokens used against the API are bound to at least one of these audiences.")
 		fs.MarkDeprecated("service-account-api-audiences", "Use --api-audiences")
 
-		fs.DurationVar(&s.ServiceAccounts.MaxExpiration, "service-account-max-token-expiration", s.ServiceAccounts.MaxExpiration, ""+
+		fs.DurationVar(&o.ServiceAccounts.MaxExpiration, "service-account-max-token-expiration", o.ServiceAccounts.MaxExpiration, ""+
 			"The maximum validity duration of a token created by the service account token issuer. If an otherwise valid "+
 			"TokenRequest with a validity duration larger than this value is requested, a token will be issued with a validity duration of this value.")
 	}
 
-	if s.TokenFile != nil {
-		fs.StringVar(&s.TokenFile.TokenFile, "token-auth-file", s.TokenFile.TokenFile, ""+
+	if o.TokenFile != nil {
+		fs.StringVar(&o.TokenFile.TokenFile, "token-auth-file", o.TokenFile.TokenFile, ""+
 			"If set, the file that will be used to secure the secure port of the API server "+
 			"via token authentication.")
 	}
 
-	if s.WebHook != nil {
-		fs.StringVar(&s.WebHook.ConfigFile, "authentication-token-webhook-config-file", s.WebHook.ConfigFile, ""+
+	if o.WebHook != nil {
+		fs.StringVar(&o.WebHook.ConfigFile, "authentication-token-webhook-config-file", o.WebHook.ConfigFile, ""+
 			"File with webhook configuration for token authentication in kubeconfig format. "+
 			"The API server will query the remote service to determine authentication for bearer tokens.")
 
-		fs.DurationVar(&s.WebHook.CacheTTL, "authentication-token-webhook-cache-ttl", s.WebHook.CacheTTL,
+		fs.DurationVar(&o.WebHook.CacheTTL, "authentication-token-webhook-cache-ttl", o.WebHook.CacheTTL,
 			"The duration to cache responses from the webhook token authenticator.")
 	}
 }
 
-func (s *BuiltInAuthenticationOptions) ToAuthenticationConfig() kubeauthenticator.AuthenticatorConfig {
-	ret := kubeauthenticator.AuthenticatorConfig{
-		TokenSuccessCacheTTL: s.TokenSuccessCacheTTL,
-		TokenFailureCacheTTL: s.TokenFailureCacheTTL,
+// ToAuthenticationConfig creates a new Config from settings in BuiltInAuthenticationOptions.
+func (o *BuiltInAuthenticationOptions) ToAuthenticationConfig() kubeauthenticator.Config {
+	ret := kubeauthenticator.Config{
+		TokenSuccessCacheTTL: o.TokenSuccessCacheTTL,
+		TokenFailureCacheTTL: o.TokenFailureCacheTTL,
 	}
 
-	if s.Anonymous != nil {
-		ret.Anonymous = s.Anonymous.Allow
+	if o.Anonymous != nil {
+		ret.Anonymous = o.Anonymous.Allow
 	}
 
-	if s.BootstrapToken != nil {
-		ret.BootstrapToken = s.BootstrapToken.Enable
+	if o.BootstrapToken != nil {
+		ret.BootstrapToken = o.BootstrapToken.Enable
 	}
 
-	if s.ClientCert != nil {
-		ret.ClientCAFile = s.ClientCert.ClientCA
+	if o.ClientCert != nil {
+		ret.ClientCAFile = o.ClientCert.ClientCA
 	}
 
-	if s.OIDC != nil {
-		ret.OIDCCAFile = s.OIDC.CAFile
-		ret.OIDCClientID = s.OIDC.ClientID
-		ret.OIDCGroupsClaim = s.OIDC.GroupsClaim
-		ret.OIDCGroupsPrefix = s.OIDC.GroupsPrefix
-		ret.OIDCIssuerURL = s.OIDC.IssuerURL
-		ret.OIDCUsernameClaim = s.OIDC.UsernameClaim
-		ret.OIDCUsernamePrefix = s.OIDC.UsernamePrefix
-		ret.OIDCSigningAlgs = s.OIDC.SigningAlgs
-		ret.OIDCRequiredClaims = s.OIDC.RequiredClaims
+	if o.OIDC != nil {
+		ret.OIDCCAFile = o.OIDC.CAFile
+		ret.OIDCClientID = o.OIDC.ClientID
+		ret.OIDCGroupsClaim = o.OIDC.GroupsClaim
+		ret.OIDCGroupsPrefix = o.OIDC.GroupsPrefix
+		ret.OIDCIssuerURL = o.OIDC.IssuerURL
+		ret.OIDCUsernameClaim = o.OIDC.UsernameClaim
+		ret.OIDCUsernamePrefix = o.OIDC.UsernamePrefix
+		ret.OIDCSigningAlgs = o.OIDC.SigningAlgs
+		ret.OIDCRequiredClaims = o.OIDC.RequiredClaims
 	}
 
-	if s.PasswordFile != nil {
-		ret.BasicAuthFile = s.PasswordFile.BasicAuthFile
+	if o.PasswordFile != nil {
+		ret.BasicAuthFile = o.PasswordFile.BasicAuthFile
 	}
 
-	if s.RequestHeader != nil {
-		ret.RequestHeaderConfig = s.RequestHeader.ToAuthenticationRequestHeaderConfig()
+	if o.RequestHeader != nil {
+		ret.RequestHeaderConfig = o.RequestHeader.ToAuthenticationRequestHeaderConfig()
 	}
 
-	ret.APIAudiences = s.APIAudiences
-	if s.ServiceAccounts != nil {
-		if s.ServiceAccounts.Issuer != "" && len(s.APIAudiences) == 0 {
-			ret.APIAudiences = authenticator.Audiences{s.ServiceAccounts.Issuer}
+	ret.APIAudiences = o.APIAudiences
+	if o.ServiceAccounts != nil {
+		if o.ServiceAccounts.Issuer != "" && len(o.APIAudiences) == 0 {
+			ret.APIAudiences = authenticator.Audiences{o.ServiceAccounts.Issuer}
 		}
-		ret.ServiceAccountKeyFiles = s.ServiceAccounts.KeyFiles
-		ret.ServiceAccountIssuer = s.ServiceAccounts.Issuer
-		ret.ServiceAccountLookup = s.ServiceAccounts.Lookup
+		ret.ServiceAccountKeyFiles = o.ServiceAccounts.KeyFiles
+		ret.ServiceAccountIssuer = o.ServiceAccounts.Issuer
+		ret.ServiceAccountLookup = o.ServiceAccounts.Lookup
 	}
 
-	if s.TokenFile != nil {
-		ret.TokenAuthFile = s.TokenFile.TokenFile
+	if o.TokenFile != nil {
+		ret.TokenAuthFile = o.TokenFile.TokenFile
 	}
 
-	if s.WebHook != nil {
-		ret.WebhookTokenAuthnConfigFile = s.WebHook.ConfigFile
-		ret.WebhookTokenAuthnCacheTTL = s.WebHook.CacheTTL
+	if o.WebHook != nil {
+		ret.WebhookTokenAuthnConfigFile = o.WebHook.ConfigFile
+		ret.WebhookTokenAuthnCacheTTL = o.WebHook.CacheTTL
 
-		if len(s.WebHook.ConfigFile) > 0 && s.WebHook.CacheTTL > 0 {
-			if s.TokenSuccessCacheTTL > 0 && s.WebHook.CacheTTL < s.TokenSuccessCacheTTL {
-				glog.Warningf("the webhook cache ttl of %s is shorter than the overall cache ttl of %s for successful token authentication attempts.", s.WebHook.CacheTTL, s.TokenSuccessCacheTTL)
+		if len(o.WebHook.ConfigFile) > 0 && o.WebHook.CacheTTL > 0 {
+			if o.TokenSuccessCacheTTL > 0 && o.WebHook.CacheTTL < o.TokenSuccessCacheTTL {
+				glog.Warningf("the webhook cache ttl of %s is shorter than the overall cache ttl of %s for successful token authentication attempts.", o.WebHook.CacheTTL, o.TokenSuccessCacheTTL)
 			}
-			if s.TokenFailureCacheTTL > 0 && s.WebHook.CacheTTL < s.TokenFailureCacheTTL {
-				glog.Warningf("the webhook cache ttl of %s is shorter than the overall cache ttl of %s for failed token authentication attempts.", s.WebHook.CacheTTL, s.TokenFailureCacheTTL)
+			if o.TokenFailureCacheTTL > 0 && o.WebHook.CacheTTL < o.TokenFailureCacheTTL {
+				glog.Warningf("the webhook cache ttl of %s is shorter than the overall cache ttl of %s for failed token authentication attempts.", o.WebHook.CacheTTL, o.TokenFailureCacheTTL)
 			}
 		}
 	}
@@ -361,6 +385,8 @@ func (s *BuiltInAuthenticationOptions) ToAuthenticationConfig() kubeauthenticato
 	return ret
 }
 
+// ApplyTo configures an existing genericapiserver.Config from the settings in
+// BuiltInAuthenticationOptions.
 func (o *BuiltInAuthenticationOptions) ApplyTo(c *genericapiserver.Config) error {
 	if o == nil {
 		return nil
@@ -388,7 +414,7 @@ func (o *BuiltInAuthenticationOptions) ApplyTo(c *genericapiserver.Config) error
 	return nil
 }
 
-// ApplyAuthorization will conditionally modify the authentication options based on the authorization options
+// ApplyAuthorization will conditionally modify the authentication options based on the authorization options.
 func (o *BuiltInAuthenticationOptions) ApplyAuthorization(authorization *BuiltInAuthorizationOptions) {
 	if o == nil || authorization == nil || o.Anonymous == nil {
 		return

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -138,7 +138,7 @@ func TestToAuthenticationConfig(t *testing.T) {
 		TokenFailureCacheTTL: 0,
 	}
 
-	expectConfig := kubeauthenticator.AuthenticatorConfig{
+	expectConfig := kubeauthenticator.Config{
 		APIAudiences:                authenticator.Audiences{"http://foo.bar.com"},
 		Anonymous:                   false,
 		BasicAuthFile:               "/testBasicAuthFile",

--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -29,6 +29,8 @@ import (
 	authzmodes "k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
 )
 
+// BuiltInAuthorizationOptions holds settings for various ways of authorizing requests provided in
+// Kubernetes out of the box.
 type BuiltInAuthorizationOptions struct {
 	Modes                       []string
 	PolicyFile                  string
@@ -37,6 +39,7 @@ type BuiltInAuthorizationOptions struct {
 	WebhookCacheUnauthorizedTTL time.Duration
 }
 
+// NewBuiltInAuthorizationOptions creates a new BuiltInAuthorizationOptions with a default config.
 func NewBuiltInAuthorizationOptions() *BuiltInAuthorizationOptions {
 	return &BuiltInAuthorizationOptions{
 		Modes:                       []string{authzmodes.ModeAlwaysAllow},
@@ -45,6 +48,7 @@ func NewBuiltInAuthorizationOptions() *BuiltInAuthorizationOptions {
 	}
 }
 
+// Validate validates a BuiltInAuthorizationOptions for errors.
 func (s *BuiltInAuthorizationOptions) Validate() []error {
 	if s == nil {
 		return nil
@@ -88,6 +92,7 @@ func (s *BuiltInAuthorizationOptions) Validate() []error {
 	return allErrors
 }
 
+// AddFlags configures a BuiltInAuthorizationOptions from options provided on the command line.
 func (s *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&s.Modes, "authorization-mode", s.Modes, ""+
 		"Ordered list of plug-ins to do authorization on secure port. Comma-delimited list of: "+
@@ -109,6 +114,7 @@ func (s *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 		"The duration to cache 'unauthorized' responses from the webhook authorizer.")
 }
 
+// ToAuthorizationConfig creates and initializes an authorizer.AuthorizationConfig.
 func (s *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFactory versionedinformers.SharedInformerFactory) authorizer.AuthorizationConfig {
 	return authorizer.AuthorizationConfig{
 		AuthorizationModes:          s.Modes,

--- a/pkg/kubeapiserver/options/cloudprovider.go
+++ b/pkg/kubeapiserver/options/cloudprovider.go
@@ -20,20 +20,24 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CloudProviderOptions holds settings for different cloud providers.
 type CloudProviderOptions struct {
 	CloudConfigFile string
 	CloudProvider   string
 }
 
+// NewCloudProviderOptions creates a new CloudProviderOptions with a default config.
 func NewCloudProviderOptions() *CloudProviderOptions {
 	return &CloudProviderOptions{}
 }
 
+// Validate validates a CloudProviderOptions for errors. Currently a no-op.
 func (s *CloudProviderOptions) Validate() []error {
 	allErrors := []error{}
 	return allErrors
 }
 
+// AddFlags configures a CloudProviderOptions from options provided on the command line.
 func (s *CloudProviderOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.CloudProvider, "cloud-provider", s.CloudProvider,
 		"The provider for cloud services. Empty string for no provider.")

--- a/pkg/kubeapiserver/options/options.go
+++ b/pkg/kubeapiserver/options/options.go
@@ -26,4 +26,4 @@ import (
 var DefaultServiceNodePortRange = utilnet.PortRange{Base: 30000, Size: 2768}
 
 // DefaultServiceIPCIDR is a CIDR notation of IP range from which to allocate service cluster IPs
-var DefaultServiceIPCIDR net.IPNet = net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)}
+var DefaultServiceIPCIDR = net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)}

--- a/pkg/kubeapiserver/options/storage_versions.go
+++ b/pkg/kubeapiserver/options/storage_versions.go
@@ -26,6 +26,7 @@ import (
 )
 
 const (
+	// DefaultEtcdPathPrefix is used as the etcd path prefix when a prefix has not been provided.
 	DefaultEtcdPathPrefix = "/registry"
 )
 
@@ -38,6 +39,8 @@ type StorageSerializationOptions struct {
 	DefaultStorageVersions string
 }
 
+// NewStorageSerializationOptions creates a new NewStorageSerializationOptions with a default
+// config.
 func NewStorageSerializationOptions() *StorageSerializationOptions {
 	return &StorageSerializationOptions{
 		DefaultStorageVersions: ToPreferredVersionString(legacyscheme.Scheme.PreferredVersionAllGroups()),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR removes `pkg/kubeapiserver` from `hack/.golint_failures` as a small part of #68026.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to #68026

**Special notes for your reviewer**:

Several changes that might be risky or questionable:
* `admission.AdmissionConfig` → `admission.Config`
* `authenticator.AuthenticatorConfig` → `authenticator.Config`
* `StorageFactoryConfig.ApiResourceConfig` → `StorageFactoryConfig.APIResourceConfig`
* `kubeapiserver.completedStorageFactoryConfig` → `kubeapiserver.CompletedStorageFactoryConfig`

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
