### PR TITLE
Improve`kubectl get` sorting efficiency

### DIFF
--- a/pkg/kubectl/sorter.go
+++ b/pkg/kubectl/sorter.go
@@ -306,8 +306,9 @@ func (r *RuntimeSort) OriginalPosition(ix int) int {
 }
 
 type TableSorter struct {
-	field string
-	obj   *metav1beta1.Table
+	field      string
+	obj        *metav1beta1.Table
+	parsedRows [][][]reflect.Value
 }
 
 func (t *TableSorter) Len() int {
@@ -319,32 +320,8 @@ func (t *TableSorter) Swap(i, j int) {
 }
 
 func (t *TableSorter) Less(i, j int) bool {
-	iObj := t.obj.Rows[i].Object.Object
-	jObj := t.obj.Rows[j].Object.Object
-
-	var iValues [][]reflect.Value
-	var jValues [][]reflect.Value
-	var err error
-
-	parser := jsonpath.New("sorting").AllowMissingKeys(true)
-	err = parser.Parse(t.field)
-	if err != nil {
-		glog.Fatalf("sorting error: %v\n", err)
-	}
-
-	// TODO(juanvallejo): this is expensive for very large sets.
-	// To improve runtime complexity, build an array which contains all
-	// resolved fields, and sort that instead.
-	iValues, err = findJSONPathResults(parser, iObj)
-	if err != nil {
-		glog.Fatalf("Failed to get i values for %#v using %s (%#v)", iObj, t.field, err)
-	}
-
-	jValues, err = findJSONPathResults(parser, jObj)
-	if err != nil {
-		glog.Fatalf("Failed to get j values for %#v using %s (%v)", jObj, t.field, err)
-	}
-
+	iValues := t.parsedRows[i]
+	jValues := t.parsedRows[j]
 	if len(iValues) == 0 || len(iValues[0]) == 0 || len(jValues) == 0 || len(jValues[0]) == 0 {
 		glog.Fatalf("couldn't find any field with path %q in the list of objects", t.field)
 	}
@@ -354,7 +331,7 @@ func (t *TableSorter) Less(i, j int) bool {
 
 	less, err := isLess(iField, jField)
 	if err != nil {
-		glog.Fatalf("Field %s in %T is an unsortable type: %s, err: %v", t.field, iObj, iField.Kind().String(), err)
+		glog.Fatalf("Field %s in %T is an unsortable type: %s, err: %v", t.field, t.parsedRows, iField.Kind().String(), err)
 	}
 	return less
 }
@@ -365,16 +342,31 @@ func (t *TableSorter) Sort() error {
 }
 
 func NewTableSorter(table *metav1beta1.Table, field string) *TableSorter {
+	var parsedRows [][][]reflect.Value
+
+	parser := jsonpath.New("sorting").AllowMissingKeys(true)
+	err := parser.Parse(field)
+	if err != nil {
+		glog.Fatalf("sorting error: %v\n", err)
+	}
+
+	for i := range table.Rows {
+		parsedRow, err := findJSONPathResults(parser, table.Rows[i].Object.Object)
+		if err != nil {
+			glog.Fatalf("Failed to get values for %#v using %s (%#v)", parsedRow, field, err)
+		}
+		parsedRows = append(parsedRows, parsedRow)
+	}
+
 	return &TableSorter{
-		obj:   table,
-		field: field,
+		obj:        table,
+		field:      field,
+		parsedRows: parsedRows,
 	}
 }
-
 func findJSONPathResults(parser *jsonpath.JSONPath, from runtime.Object) ([][]reflect.Value, error) {
 	if unstructuredObj, ok := from.(*unstructured.Unstructured); ok {
 		return parser.FindResults(unstructuredObj.Object)
 	}
-
 	return parser.FindResults(reflect.ValueOf(from).Elem().Interface())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Sorting is currently inefficient because as it iterates through all of the Rows in a table, it has to parse each one to extract out the JSONPath value.

This PR implements parsing all the rows before they are sorted.

**Which issue(s) this PR fixes** :
Fixes #

**Special notes for your reviewer**:

/sig cli
/area kubectl

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
