### PR TITLE
Fix kubeadm etcd manifests to use brackets around IPv6 addrs

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -282,7 +282,7 @@ func performEtcdStaticPodUpgrade(client clientset.Interface, waiter apiclient.Wa
 	if err != nil {
 		return true, errors.Wrap(err, "failed to retrieve the current etcd version")
 	}
-	currentEtcdVersionStr, ok := currentEtcdVersions[fmt.Sprintf("https://%s:%d", cfg.LocalAPIEndpoint.AdvertiseAddress, constants.EtcdListenClientPort)]
+	currentEtcdVersionStr, ok := currentEtcdVersions[etcdutil.GetClientURL(cfg)]
 	if !ok {
 		fmt.Println(currentEtcdVersions)
 		return true, errors.Wrap(err, "failed to retrieve the current etcd version")

--- a/cmd/kubeadm/app/util/etcd/BUILD
+++ b/cmd/kubeadm/app/util/etcd/BUILD
@@ -24,6 +24,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/test:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/util/etcd/etcd_test.go
+++ b/cmd/kubeadm/app/util/etcd/etcd_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package etcd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 )
 
@@ -306,5 +309,92 @@ func TestCheckConfigurationIsHA(t *testing.T) {
 				t.Errorf("expected isHA to be %v, got %v", test.expected, isHA)
 			}
 		})
+	}
+}
+
+func testGetURL(t *testing.T, getURLFunc func(*kubeadmapi.InitConfiguration) string, port int) {
+	portStr := strconv.Itoa(port)
+	var tests = []struct {
+		name             string
+		advertiseAddress string
+		expectedURL      string
+	}{
+		{
+			name:             "IPv4",
+			advertiseAddress: "10.10.10.10",
+			expectedURL:      fmt.Sprintf("https://10.10.10.10:%s", portStr),
+		},
+		{
+			name:             "IPv6",
+			advertiseAddress: "2001:db8::2",
+			expectedURL:      fmt.Sprintf("https://[2001:db8::2]:%s", portStr),
+		},
+		{
+			name:             "IPv4 localhost",
+			advertiseAddress: "127.0.0.1",
+			expectedURL:      fmt.Sprintf("https://127.0.0.1:%s", portStr),
+		},
+		{
+			name:             "IPv6 localhost",
+			advertiseAddress: "::1",
+			expectedURL:      fmt.Sprintf("https://[::1]:%s", portStr),
+		},
+	}
+
+	for _, test := range tests {
+		cfg := &kubeadmapi.InitConfiguration{
+			LocalAPIEndpoint: kubeadmapi.APIEndpoint{
+				AdvertiseAddress: test.advertiseAddress,
+			},
+		}
+		url := getURLFunc(cfg)
+		if url != test.expectedURL {
+			t.Errorf("expected %s, got %s", test.expectedURL, url)
+		}
+	}
+}
+
+func TestGetClientURL(t *testing.T) {
+	testGetURL(t, GetClientURL, constants.EtcdListenClientPort)
+}
+
+func TestGetPeerURL(t *testing.T) {
+	testGetURL(t, GetClientURL, constants.EtcdListenClientPort)
+}
+
+func TestGetClientURLByIP(t *testing.T) {
+	portStr := strconv.Itoa(constants.EtcdListenClientPort)
+	var tests = []struct {
+		name        string
+		ip          string
+		expectedURL string
+	}{
+		{
+			name:        "IPv4",
+			ip:          "10.10.10.10",
+			expectedURL: fmt.Sprintf("https://10.10.10.10:%s", portStr),
+		},
+		{
+			name:        "IPv6",
+			ip:          "2001:db8::2",
+			expectedURL: fmt.Sprintf("https://[2001:db8::2]:%s", portStr),
+		},
+		{
+			name:        "IPv4 localhost",
+			ip:          "127.0.0.1",
+			expectedURL: fmt.Sprintf("https://127.0.0.1:%s", portStr),
+		},
+		{
+			name:        "IPv6 localhost",
+			ip:          "::1",
+			expectedURL: fmt.Sprintf("https://[::1]:%s", portStr),
+		},
+	}
+
+	for _, test := range tests {
+		url := GetClientURLByIP(test.ip)
+		if url != test.expectedURL {
+			t.Errorf("expected %s, got %s", test.expectedURL, url)
+		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Kubeadm init with an IPv6-only configuration is currently failing to bring up a cluster. In this failure condition, kubeadm is waiting forever for the control plane to come up. This failure is described in [kubernetes/kubeadm Issue # 1212](https://github.com/kubernetes/kubeadm/issues/1212). The root cause is that kubeadm is generating an erroneous etcd.yaml manifest that has entries of the form:
```
   - --advertise-client-urls=https://fd00:20::2:2379
```
And this is causing the etcd server to crash.
For IPv6 addresses, this URL should use square brackets around the IPv6 address, e.g.:
```
   - --advertise-client-urls=https://[fd00:20::2]:2379
```
The fix is to use net.JoinHostPort() to generate URLs such as the above.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [kubernetes/kubeadm # 1212](https://github.com/kubernetes/kubeadm/issues/1212)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```