### PR TITLE
Fix end-to-end test logic to get image name

### DIFF
--- a/test/e2e/framework/rc_util.go
+++ b/test/e2e/framework/rc_util.go
@@ -247,7 +247,7 @@ func ValidateController(c clientset.Interface, containerImage string, replicas i
 	// You can read about the syntax here: http://golang.org/pkg/text/template/.
 	getContainerStateTemplate := fmt.Sprintf(`--template={{if (exists . "status" "containerStatuses")}}{{range .status.containerStatuses}}{{if (and (eq .name "%s") (exists . "state" "running"))}}true{{end}}{{end}}{{end}}`, containername)
 
-	getImageTemplate := fmt.Sprintf(`--template={{if (exists . "status" "containerStatuses")}}{{range .status.containerStatuses}}{{if eq .name "%s"}}{{.image}}{{end}}{{end}}{{end}}`, containername)
+	getImageTemplate := fmt.Sprintf(`--template={{if (exists . "spec" "containers")}}{{range .spec.containers}}{{if eq .name "%s"}}{{.image}}{{end}}{{end}}{{end}}`, containername)
 
 	By(fmt.Sprintf("waiting for all containers in %s pods to come up.", testname)) //testname should be selector
 waitLoop:


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
It is needed to support multiple architectures when running the end-to-end tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None, as far as I know.

**Special notes for your reviewer**:
This was tested for ARM64 for conformance tests, using Kubernetes v1.12.1 (Docker v18.03.1-ce, Ubuntu 18.04.4)

**Does this PR introduce a user-facing change?**:
NONE
