### PR TITLE
fix golint in pkg/volume

### DIFF
--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -71,15 +71,15 @@ func getDevFromImageAndPool(pool, image string) (string, bool) {
 // Search /sys/bus for rbd device that matches given pool and image.
 func getRbdDevFromImageAndPool(pool string, image string) (string, bool) {
 	// /sys/bus/rbd/devices/X/name and /sys/bus/rbd/devices/X/pool
-	sys_path := "/sys/bus/rbd/devices"
-	if dirs, err := ioutil.ReadDir(sys_path); err == nil {
+	sysPath := "/sys/bus/rbd/devices"
+	if dirs, err := ioutil.ReadDir(sysPath); err == nil {
 		for _, f := range dirs {
 			// Pool and name format:
 			// see rbd_pool_show() and rbd_name_show() at
 			// https://github.com/torvalds/linux/blob/master/drivers/block/rbd.c
 			name := f.Name()
 			// First match pool, then match name.
-			poolFile := path.Join(sys_path, name, "pool")
+			poolFile := path.Join(sysPath, name, "pool")
 			poolBytes, err := ioutil.ReadFile(poolFile)
 			if err != nil {
 				glog.V(4).Infof("error reading %s: %v", poolFile, err)
@@ -89,7 +89,7 @@ func getRbdDevFromImageAndPool(pool string, image string) (string, bool) {
 				glog.V(4).Infof("device %s is not %q: %q", name, pool, string(poolBytes))
 				continue
 			}
-			imgFile := path.Join(sys_path, name, "name")
+			imgFile := path.Join(sysPath, name, "name")
 			imgBytes, err := ioutil.ReadFile(imgFile)
 			if err != nil {
 				glog.V(4).Infof("error reading %s: %v", imgFile, err)
@@ -222,11 +222,10 @@ func execRbdMap(b rbdMounter, rbdCmd string, mon string) ([]byte, error) {
 	imgPath := fmt.Sprintf("%s/%s", b.Pool, b.Image)
 	if b.Secret != "" {
 		return b.exec.Run(rbdCmd,
-			"map", imgPath, "--id", b.Id, "-m", mon, "--key="+b.Secret)
-	} else {
-		return b.exec.Run(rbdCmd,
-			"map", imgPath, "--id", b.Id, "-m", mon, "-k", b.Keyring)
+			"map", imgPath, "--id", b.ID, "-m", mon, "--key="+b.Secret)
 	}
+	return b.exec.Run(rbdCmd,
+		"map", imgPath, "--id", b.ID, "-m", mon, "-k", b.Keyring)
 }
 
 // Check if rbd-nbd tools are installed.
@@ -303,15 +302,15 @@ func (util *RBDUtil) rbdUnlock(b rbdMounter) error {
 	var err error
 	var output, locker string
 	var cmd []byte
-	var secret_opt []string
+	var secretOpt []string
 
 	if b.Secret != "" {
-		secret_opt = []string{"--key=" + b.Secret}
+		secretOpt = []string{"--key=" + b.Secret}
 	} else {
-		secret_opt = []string{"-k", b.Keyring}
+		secretOpt = []string{"-k", b.Keyring}
 	}
-	if len(b.adminId) == 0 {
-		b.adminId = b.Id
+	if len(b.adminID) == 0 {
+		b.adminID = b.ID
 	}
 	if len(b.adminSecret) == 0 {
 		b.adminSecret = b.Secret
@@ -322,20 +321,20 @@ func (util *RBDUtil) rbdUnlock(b rbdMounter) error {
 	if err != nil {
 		return err
 	}
-	lock_id := kubeLockMagic + hostName
+	lockID := kubeLockMagic + hostName
 
 	mon := util.kernelRBDMonitorsOpt(b.Mon)
 
 	// Get the locker name, something like "client.1234".
-	args := []string{"lock", "list", b.Image, "--pool", b.Pool, "--id", b.Id, "-m", mon}
-	args = append(args, secret_opt...)
+	args := []string{"lock", "list", b.Image, "--pool", b.Pool, "--id", b.ID, "-m", mon}
+	args = append(args, secretOpt...)
 	cmd, err = b.exec.Run("rbd", args...)
 	output = string(cmd)
 	glog.V(4).Infof("lock list output %q", output)
 	if err != nil {
 		return err
 	}
-	ind := strings.LastIndex(output, lock_id) - 1
+	ind := strings.LastIndex(output, lockID) - 1
 	for i := ind; i >= 0; i-- {
 		if output[i] == '\n' {
 			locker = output[(i + 1):ind]
@@ -345,13 +344,13 @@ func (util *RBDUtil) rbdUnlock(b rbdMounter) error {
 
 	// Remove a lock if found: rbd lock remove.
 	if len(locker) > 0 {
-		args := []string{"lock", "remove", b.Image, lock_id, locker, "--pool", b.Pool, "--id", b.Id, "-m", mon}
-		args = append(args, secret_opt...)
+		args := []string{"lock", "remove", b.Image, lockID, locker, "--pool", b.Pool, "--id", b.ID, "-m", mon}
+		args = append(args, secretOpt...)
 		cmd, err = b.exec.Run("rbd", args...)
 		if err == nil {
-			glog.V(4).Infof("rbd: successfully remove lock (locker_id: %s) on image: %s/%s with id %s mon %s", lock_id, b.Pool, b.Image, b.Id, mon)
+			glog.V(4).Infof("rbd: successfully remove lock (locker_id: %s) on image: %s/%s with id %s mon %s", lockID, b.Pool, b.Image, b.ID, mon)
 		} else {
-			glog.Warningf("rbd: failed to remove lock (lock_id: %s) on image: %s/%s with id %s mon %s: %v", lock_id, b.Pool, b.Image, b.Id, mon, err)
+			glog.Warningf("rbd: failed to remove lock (lock_id: %s) on image: %s/%s with id %s mon %s: %v", lockID, b.Pool, b.Image, b.ID, mon, err)
 		}
 	}
 
@@ -560,7 +559,7 @@ func (util *RBDUtil) cleanOldRBDFile(plugin *rbdPlugin, rbdFile string) error {
 
 	decoder := json.NewDecoder(fp)
 	if err = decoder.Decode(mounter); err != nil {
-		return fmt.Errorf("rbd: decode err: %v.", err)
+		return fmt.Errorf("rbd: decode err: %v", err)
 	}
 
 	if err != nil {
@@ -589,11 +588,11 @@ func (util *RBDUtil) CreateImage(p *rbdVolumeProvisioner) (r *v1.RBDPersistentVo
 	volSz := fmt.Sprintf("%d", sz)
 	mon := util.kernelRBDMonitorsOpt(p.Mon)
 	if p.rbdMounter.imageFormat == rbdImageFormat2 {
-		glog.V(4).Infof("rbd: create %s size %s format %s (features: %s) using mon %s, pool %s id %s key %s", p.rbdMounter.Image, volSz, p.rbdMounter.imageFormat, p.rbdMounter.imageFeatures, mon, p.rbdMounter.Pool, p.rbdMounter.adminId, p.rbdMounter.adminSecret)
+		glog.V(4).Infof("rbd: create %s size %s format %s (features: %s) using mon %s, pool %s id %s key %s", p.rbdMounter.Image, volSz, p.rbdMounter.imageFormat, p.rbdMounter.imageFeatures, mon, p.rbdMounter.Pool, p.rbdMounter.adminID, p.rbdMounter.adminSecret)
 	} else {
-		glog.V(4).Infof("rbd: create %s size %s format %s using mon %s, pool %s id %s key %s", p.rbdMounter.Image, volSz, p.rbdMounter.imageFormat, mon, p.rbdMounter.Pool, p.rbdMounter.adminId, p.rbdMounter.adminSecret)
+		glog.V(4).Infof("rbd: create %s size %s format %s using mon %s, pool %s id %s key %s", p.rbdMounter.Image, volSz, p.rbdMounter.imageFormat, mon, p.rbdMounter.Pool, p.rbdMounter.adminID, p.rbdMounter.adminSecret)
 	}
-	args := []string{"create", p.rbdMounter.Image, "--size", volSz, "--pool", p.rbdMounter.Pool, "--id", p.rbdMounter.adminId, "-m", mon, "--key=" + p.rbdMounter.adminSecret, "--image-format", p.rbdMounter.imageFormat}
+	args := []string{"create", p.rbdMounter.Image, "--size", volSz, "--pool", p.rbdMounter.Pool, "--id", p.rbdMounter.adminID, "-m", mon, "--key=" + p.rbdMounter.adminSecret, "--image-format", p.rbdMounter.imageFormat}
 	if p.rbdMounter.imageFormat == rbdImageFormat2 {
 		// If no image features is provided, it results in empty string
 		// which disable all RBD image format 2 features as expected.
@@ -626,9 +625,9 @@ func (util *RBDUtil) DeleteImage(p *rbdVolumeDeleter) error {
 	}
 	// rbd rm.
 	mon := util.kernelRBDMonitorsOpt(p.rbdMounter.Mon)
-	glog.V(4).Infof("rbd: rm %s using mon %s, pool %s id %s key %s", p.rbdMounter.Image, mon, p.rbdMounter.Pool, p.rbdMounter.adminId, p.rbdMounter.adminSecret)
+	glog.V(4).Infof("rbd: rm %s using mon %s, pool %s id %s key %s", p.rbdMounter.Image, mon, p.rbdMounter.Pool, p.rbdMounter.adminID, p.rbdMounter.adminSecret)
 	output, err = p.exec.Run("rbd",
-		"rm", p.rbdMounter.Image, "--pool", p.rbdMounter.Pool, "--id", p.rbdMounter.adminId, "-m", mon, "--key="+p.rbdMounter.adminSecret)
+		"rm", p.rbdMounter.Image, "--pool", p.rbdMounter.Pool, "--id", p.rbdMounter.adminID, "-m", mon, "--key="+p.rbdMounter.adminSecret)
 	if err == nil {
 		return nil
 	}
@@ -658,9 +657,9 @@ func (util *RBDUtil) ExpandImage(rbdExpander *rbdVolumeExpander, oldSize resourc
 
 	// rbd resize.
 	mon := util.kernelRBDMonitorsOpt(rbdExpander.rbdMounter.Mon)
-	glog.V(4).Infof("rbd: resize %s using mon %s, pool %s id %s key %s", rbdExpander.rbdMounter.Image, mon, rbdExpander.rbdMounter.Pool, rbdExpander.rbdMounter.adminId, rbdExpander.rbdMounter.adminSecret)
+	glog.V(4).Infof("rbd: resize %s using mon %s, pool %s id %s key %s", rbdExpander.rbdMounter.Image, mon, rbdExpander.rbdMounter.Pool, rbdExpander.rbdMounter.adminID, rbdExpander.rbdMounter.adminSecret)
 	output, err = rbdExpander.exec.Run("rbd",
-		"resize", rbdExpander.rbdMounter.Image, "--size", newVolSz, "--pool", rbdExpander.rbdMounter.Pool, "--id", rbdExpander.rbdMounter.adminId, "-m", mon, "--key="+rbdExpander.rbdMounter.adminSecret)
+		"resize", rbdExpander.rbdMounter.Image, "--size", newVolSz, "--pool", rbdExpander.rbdMounter.Pool, "--id", rbdExpander.rbdMounter.adminID, "-m", mon, "--key="+rbdExpander.rbdMounter.adminSecret)
 	if err == nil {
 		return newSizeQuant, nil
 	}
@@ -676,10 +675,10 @@ func (util *RBDUtil) rbdInfo(b *rbdMounter) (int, error) {
 	var cmd []byte
 
 	// If we don't have admin id/secret (e.g. attaching), fallback to user id/secret.
-	id := b.adminId
+	id := b.adminID
 	secret := b.adminSecret
 	if id == "" {
-		id = b.Id
+		id = b.ID
 		secret = b.Secret
 	}
 
@@ -745,10 +744,10 @@ func (util *RBDUtil) rbdStatus(b *rbdMounter) (bool, string, error) {
 	var cmd []byte
 
 	// If we don't have admin id/secret (e.g. attaching), fallback to user id/secret.
-	id := b.adminId
+	id := b.adminID
 	secret := b.adminSecret
 	if id == "" {
-		id = b.Id
+		id = b.ID
 		secret = b.Secret
 	}
 
@@ -788,8 +787,7 @@ func (util *RBDUtil) rbdStatus(b *rbdMounter) (bool, string, error) {
 	if strings.Contains(output, imageWatcherStr) {
 		glog.V(4).Infof("rbd: watchers on %s: %s", b.Image, output)
 		return true, output, nil
-	} else {
-		glog.Warningf("rbd: no watchers on %s", b.Image)
-		return false, output, nil
 	}
+	glog.Warningf("rbd: no watchers on %s", b.Image)
+	return false, output, nil
 }

--- a/pkg/volume/scaleio/sio_client.go
+++ b/pkg/volume/scaleio/sio_client.go
@@ -74,7 +74,7 @@ type sioClient struct {
 	spClient         *sio.StoragePool
 	provisionMode    string
 	sdcPath          string
-	sdcGuid          string
+	sdcGUID          string
 	instanceID       string
 	inited           bool
 	diskRegex        *regexp.Regexp
@@ -301,7 +301,7 @@ func (c *sioClient) IID() (string, error) {
 
 	// if instanceID not set, retrieve it
 	if c.instanceID == "" {
-		guid, err := c.getGuid()
+		guid, err := c.getGUID()
 		if err != nil {
 			return "", err
 		}
@@ -318,8 +318,8 @@ func (c *sioClient) IID() (string, error) {
 
 // getGuid returns instance GUID, if not set using resource labels
 // it attempts to fallback to using drv_cfg binary
-func (c *sioClient) getGuid() (string, error) {
-	if c.sdcGuid == "" {
+func (c *sioClient) getGUID() (string, error) {
+	if c.sdcGUID == "" {
 		glog.V(4).Info(log("sdc guid label not set, falling back to using drv_cfg"))
 		cmd := c.getSdcCmd()
 		output, err := c.exec.Run(cmd, "--query_guid")
@@ -327,9 +327,9 @@ func (c *sioClient) getGuid() (string, error) {
 			glog.Error(log("drv_cfg --query_guid failed: %v", err))
 			return "", err
 		}
-		c.sdcGuid = strings.TrimSpace(string(output))
+		c.sdcGUID = strings.TrimSpace(string(output))
 	}
-	return c.sdcGuid, nil
+	return c.sdcGUID, nil
 }
 
 // getSioDiskPaths traverse local disk devices to retrieve device path
@@ -342,10 +342,10 @@ func (c *sioClient) getSioDiskPaths() ([]os.FileInfo, error) {
 		if os.IsNotExist(err) {
 			// sioDiskIDPath may not exist yet which is fine
 			return []os.FileInfo{}, nil
-		} else {
-			glog.Error(log("failed to ReadDir %s: %v", sioDiskIDPath, err))
-			return nil, err
 		}
+		glog.Error(log("failed to ReadDir %s: %v", sioDiskIDPath, err))
+		return nil, err
+
 	}
 	result := []os.FileInfo{}
 	for _, file := range files {
@@ -360,13 +360,13 @@ func (c *sioClient) getSioDiskPaths() ([]os.FileInfo, error) {
 
 // GetVolumeRefs counts the number of references an SIO volume has a disk device.
 // This is useful in preventing premature detach.
-func (c *sioClient) GetVolumeRefs(volId sioVolumeID) (refs int, err error) {
+func (c *sioClient) GetVolumeRefs(volID sioVolumeID) (refs int, err error) {
 	files, err := c.getSioDiskPaths()
 	if err != nil {
 		return 0, err
 	}
 	for _, file := range files {
-		if strings.Contains(file.Name(), string(volId)) {
+		if strings.Contains(file.Name(), string(volID)) {
 			refs++
 		}
 	}

--- a/pkg/volume/scaleio/sio_mgr.go
+++ b/pkg/volume/scaleio/sio_mgr.go
@@ -81,7 +81,7 @@ func (m *sioMgr) getClient() (sioInterface, error) {
 		client.spName = configs[confKey.storagePool]
 		client.sdcPath = configs[confKey.sdcRootPath]
 		client.provisionMode = configs[confKey.storageMode]
-		client.sdcGuid = configs[confKey.sdcGuid]
+		client.sdcGUID = configs[confKey.sdcGUID]
 
 		m.client = client
 

--- a/pkg/volume/scaleio/sio_mgr_test.go
+++ b/pkg/volume/scaleio/sio_mgr_test.go
@@ -311,7 +311,7 @@ func (f *fakeSio) Devs() (map[string]string, error) {
 	return f.devs, nil
 }
 
-func (f *fakeSio) GetVolumeRefs(volId sioVolumeID) (int, error) {
+func (f *fakeSio) GetVolumeRefs(volID sioVolumeID) (int, error) {
 	if f.volume == nil {
 		return 0, nil
 	}

--- a/pkg/volume/scaleio/sio_util.go
+++ b/pkg/volume/scaleio/sio_util.go
@@ -54,7 +54,7 @@ var (
 		username,
 		password,
 		secretNamespace,
-		sdcGuid string
+		sdcGUID string
 	}{
 		gateway:          "gateway",
 		sslEnabled:       "sslEnabled",
@@ -71,18 +71,17 @@ var (
 		readOnly:         "readOnly",
 		username:         "username",
 		password:         "password",
-		sdcGuid:          "sdcGuid",
+		sdcGUID:          "sdcGUID",
 	}
-	sdcGuidLabelName = "scaleio.sdcGuid"
+	sdcGUIDLabelName = "scaleio.sdcGUID"
 	sdcRootPath      = "/opt/emc/scaleio/sdc/bin"
 
-	secretNotFoundErr              = errors.New("secret not found")
-	configMapNotFoundErr           = errors.New("configMap not found")
-	gatewayNotProvidedErr          = errors.New("ScaleIO gateway not provided")
-	secretRefNotProvidedErr        = errors.New("secret ref not provided")
-	systemNotProvidedErr           = errors.New("ScaleIO system not provided")
-	storagePoolNotProvidedErr      = errors.New("ScaleIO storage pool not provided")
-	protectionDomainNotProvidedErr = errors.New("ScaleIO protection domain not provided")
+	errSecretNotFound              = errors.New("secret not found")
+	errGatewayNotProvided          = errors.New("ScaleIO gateway not provided")
+	errSecretRefNotProvided        = errors.New("secret ref not provided")
+	errSystemNotProvided           = errors.New("ScaleIO system not provided")
+	errStoragePoolNotProvided      = errors.New("ScaleIO storage pool not provided")
+	errProtectionDomainNotProvided = errors.New("ScaleIO protection domain not provided")
 )
 
 // mapVolumeSpec maps attributes from either ScaleIOVolumeSource  or ScaleIOPersistentVolumeSource to config
@@ -118,19 +117,19 @@ func mapVolumeSpec(config map[string]string, spec *volume.Spec) {
 
 func validateConfigs(config map[string]string) error {
 	if config[confKey.gateway] == "" {
-		return gatewayNotProvidedErr
+		return errGatewayNotProvided
 	}
 	if config[confKey.secretName] == "" {
-		return secretRefNotProvidedErr
+		return errSecretRefNotProvided
 	}
 	if config[confKey.system] == "" {
-		return systemNotProvidedErr
+		return errSystemNotProvided
 	}
 	if config[confKey.storagePool] == "" {
-		return storagePoolNotProvidedErr
+		return errStoragePoolNotProvided
 	}
 	if config[confKey.protectionDomain] == "" {
-		return protectionDomainNotProvidedErr
+		return errProtectionDomainNotProvided
 	}
 
 	return nil
@@ -222,7 +221,7 @@ func attachSecret(plug *sioPlugin, namespace string, configData map[string]strin
 	secretMap, err := volutil.GetSecretForPV(namespace, secretRefName, sioPluginName, kubeClient)
 	if err != nil {
 		glog.Error(log("failed to get secret: %v", err))
-		return secretNotFoundErr
+		return errSecretNotFound
 	}
 	// merge secret data
 	for key, val := range secretMap {
@@ -232,30 +231,30 @@ func attachSecret(plug *sioPlugin, namespace string, configData map[string]strin
 	return nil
 }
 
-// attachSdcGuid injects the sdc guid node label value into config
-func attachSdcGuid(plug *sioPlugin, conf map[string]string) error {
-	guid, err := getSdcGuidLabel(plug)
+// attachSdcGUID injects the sdc guid node label value into config
+func attachSdcGUID(plug *sioPlugin, conf map[string]string) error {
+	guid, err := getSdcGUIDLabel(plug)
 	if err != nil {
 		return err
 	}
-	conf[confKey.sdcGuid] = guid
+	conf[confKey.sdcGUID] = guid
 	return nil
 }
 
-// getSdcGuidLabel fetches the scaleio.sdcGuid node label
+// getSdcGUIDLabel fetches the scaleio.sdcGuid node label
 // associated with the node executing this code.
-func getSdcGuidLabel(plug *sioPlugin) (string, error) {
+func getSdcGUIDLabel(plug *sioPlugin) (string, error) {
 	nodeLabels, err := plug.host.GetNodeLabels()
 	if err != nil {
 		return "", err
 	}
-	label, ok := nodeLabels[sdcGuidLabelName]
+	label, ok := nodeLabels[sdcGUIDLabelName]
 	if !ok {
-		glog.V(4).Info(log("node label %s not found", sdcGuidLabelName))
+		glog.V(4).Info(log("node label %s not found", sdcGUIDLabelName))
 		return "", nil
 	}
 
-	glog.V(4).Info(log("found node label %s=%s", sdcGuidLabelName, label))
+	glog.V(4).Info(log("found node label %s=%s", sdcGUIDLabelName, label))
 	return label, nil
 }
 

--- a/pkg/volume/scaleio/sio_util_test.go
+++ b/pkg/volume/scaleio/sio_util_test.go
@@ -93,7 +93,7 @@ func TestUtilValidateConfigs(t *testing.T) {
 		confKey.secretName: "sio-secret",
 		confKey.system:     "sio",
 	}
-	if err := validateConfigs(data); err != gatewayNotProvidedErr {
+	if err := validateConfigs(data); err != errGatewayNotProvided {
 		t.Error("Expecting error for missing gateway, but did not get it")
 	}
 }

--- a/pkg/volume/scaleio/sio_volume.go
+++ b/pkg/volume/scaleio/sio_volume.go
@@ -393,7 +393,7 @@ func (v *sioVolume) setSioMgr() error {
 		}
 
 		// merge in Sdc Guid label value
-		if err := attachSdcGuid(v.plugin, configData); err != nil {
+		if err := attachSdcGUID(v.plugin, configData); err != nil {
 			glog.Error(log("failed to retrieve sdc guid: %v", err))
 			return err
 		}
@@ -432,7 +432,7 @@ func (v *sioVolume) resetSioMgr() error {
 		}
 
 		// merge in Sdc Guid label value
-		if err := attachSdcGuid(v.plugin, configData); err != nil {
+		if err := attachSdcGUID(v.plugin, configData); err != nil {
 			glog.Error(log("failed to retrieve sdc guid: %v", err))
 			return err
 		}

--- a/pkg/volume/scaleio/sio_volume_test.go
+++ b/pkg/volume/scaleio/sio_volume_test.go
@@ -56,7 +56,7 @@ func newPluginMgr(t *testing.T, apiObject runtime.Object) (*volume.VolumePluginM
 		tmpDir,
 		fakeClient,
 		nil,
-		map[string]string{sdcGuidLabelName: "abc-123"},
+		map[string]string{sdcGUIDLabelName: "abc-123"},
 	)
 	plugMgr := &volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
@@ -206,9 +206,9 @@ func TestVolumeMounterUnmounter(t *testing.T) {
 		t.Errorf("SetUp() - expecting multiple volume disabled by default")
 	}
 
-	// did we read sdcGuid label
-	if _, ok := sioVol.sioMgr.configData[confKey.sdcGuid]; !ok {
-		t.Errorf("Expected to find node label scaleio.sdcGuid, but did not find it")
+	// did we read sdcGUID label
+	if _, ok := sioVol.sioMgr.configData[confKey.sdcGUID]; !ok {
+		t.Errorf("Expected to find node label scaleio.sdcGUID, but did not find it")
 	}
 
 	// rebuild spec
@@ -263,8 +263,8 @@ func TestVolumeProvisioner(t *testing.T) {
 	}
 
 	options := volume.VolumeOptions{
-		ClusterName:                   "testcluster",
-		PVC:                           volumetest.CreateTestPVC("100Mi", []api.PersistentVolumeAccessMode{api.ReadWriteOnce}),
+		ClusterName: "testcluster",
+		PVC:         volumetest.CreateTestPVC("100Mi", []api.PersistentVolumeAccessMode{api.ReadWriteOnce}),
 		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
 	}
 	options.PVC.Name = "testpvc"
@@ -350,7 +350,7 @@ func TestVolumeProvisioner(t *testing.T) {
 	}
 
 	// did we read sdcGuid label
-	if _, ok := sioVol.sioMgr.configData[confKey.sdcGuid]; !ok {
+	if _, ok := sioVol.sioMgr.configData[confKey.sdcGUID]; !ok {
 		t.Errorf("Expected to find node label scaleio.sdcGuid, but did not find it")
 	}
 
@@ -408,9 +408,9 @@ func TestVolumeProvisionerWithIncompleteConfig(t *testing.T) {
 	}
 
 	options := volume.VolumeOptions{
-		ClusterName:                   "testcluster",
-		PVName:                        "pvc-sio-dynamic-vol",
-		PVC:                           volumetest.CreateTestPVC("100Mi", []api.PersistentVolumeAccessMode{api.ReadWriteOnce}),
+		ClusterName: "testcluster",
+		PVName:      "pvc-sio-dynamic-vol",
+		PVC:         volumetest.CreateTestPVC("100Mi", []api.PersistentVolumeAccessMode{api.ReadWriteOnce}),
 		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
 	}
 	options.PVC.Namespace = testns
@@ -440,9 +440,9 @@ func TestVolumeProvisionerWithZeroCapacity(t *testing.T) {
 	}
 
 	options := volume.VolumeOptions{
-		ClusterName:                   "testcluster",
-		PVName:                        "pvc-sio-dynamic-vol",
-		PVC:                           volumetest.CreateTestPVC("0Mi", []api.PersistentVolumeAccessMode{api.ReadWriteOnce}),
+		ClusterName: "testcluster",
+		PVName:      "pvc-sio-dynamic-vol",
+		PVC:         volumetest.CreateTestPVC("0Mi", []api.PersistentVolumeAccessMode{api.ReadWriteOnce}),
 		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
 	}
 	options.PVC.Namespace = testns
@@ -488,9 +488,9 @@ func TestVolumeProvisionerWithSecretNamespace(t *testing.T) {
 	}
 
 	options := volume.VolumeOptions{
-		ClusterName:                   "testcluster",
-		PVName:                        "pvc-sio-dynamic-vol",
-		PVC:                           volumetest.CreateTestPVC("100Mi", []api.PersistentVolumeAccessMode{api.ReadWriteOnce}),
+		ClusterName: "testcluster",
+		PVName:      "pvc-sio-dynamic-vol",
+		PVC:         volumetest.CreateTestPVC("100Mi", []api.PersistentVolumeAccessMode{api.ReadWriteOnce}),
 		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
 	}
 

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -281,9 +281,9 @@ func MakePayload(mappings []v1.KeyToPath, secret *v1.Secret, defaultMode *int32,
 				if optional {
 					continue
 				}
-				err_msg := "references non-existent secret key"
-				glog.Errorf(err_msg)
-				return nil, fmt.Errorf(err_msg)
+				errMsg := "references non-existent secret key"
+				glog.Errorf(errMsg)
+				return nil, fmt.Errorf(errMsg)
 			}
 
 			fileProjection.Data = []byte(content)

--- a/pkg/volume/storageos/storageos_util_test.go
+++ b/pkg/volume/storageos/storageos_util_test.go
@@ -30,7 +30,6 @@ import (
 	"testing"
 )
 
-var testApiSecretName = "storageos-api"
 var testVolName = "storageos-test-vol"
 var testPVName = "storageos-test-pv"
 var testNamespace = "storageos-test-namespace"

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -926,7 +926,7 @@ func VerifyAttachCallCount(
 	}
 
 	return fmt.Errorf(
-		"No attachers have expected AttachCallCount. Expected: <%v>.",
+		"No attachers have expected AttachCallCount. Expected: <%v>",
 		expectedAttachCallCount)
 }
 
@@ -937,7 +937,7 @@ func VerifyZeroAttachCalls(fakeVolumePlugin *FakeVolumePlugin) error {
 		actualCallCount := attacher.GetAttachCallCount()
 		if actualCallCount != 0 {
 			return fmt.Errorf(
-				"At least one attacher has non-zero AttachCallCount: <%v>.",
+				"At least one attacher has non-zero AttachCallCount: <%v>",
 				actualCallCount)
 		}
 	}
@@ -959,7 +959,7 @@ func VerifyWaitForAttachCallCount(
 	}
 
 	return fmt.Errorf(
-		"No Attachers have expected WaitForAttachCallCount. Expected: <%v>.",
+		"No Attachers have expected WaitForAttachCallCount. Expected: <%v>",
 		expectedWaitForAttachCallCount)
 }
 
@@ -970,7 +970,7 @@ func VerifyZeroWaitForAttachCallCount(fakeVolumePlugin *FakeVolumePlugin) error 
 		actualCallCount := attacher.GetWaitForAttachCallCount()
 		if actualCallCount != 0 {
 			return fmt.Errorf(
-				"At least one attacher has non-zero WaitForAttachCallCount: <%v>.",
+				"At least one attacher has non-zero WaitForAttachCallCount: <%v>",
 				actualCallCount)
 		}
 	}
@@ -992,7 +992,7 @@ func VerifyMountDeviceCallCount(
 	}
 
 	return fmt.Errorf(
-		"No Attachers have expected MountDeviceCallCount. Expected: <%v>.",
+		"No Attachers have expected MountDeviceCallCount. Expected: <%v>",
 		expectedMountDeviceCallCount)
 }
 
@@ -1003,7 +1003,7 @@ func VerifyZeroMountDeviceCallCount(fakeVolumePlugin *FakeVolumePlugin) error {
 		actualCallCount := attacher.GetMountDeviceCallCount()
 		if actualCallCount != 0 {
 			return fmt.Errorf(
-				"At least one attacher has non-zero MountDeviceCallCount: <%v>.",
+				"At least one attacher has non-zero MountDeviceCallCount: <%v>",
 				actualCallCount)
 		}
 	}
@@ -1025,7 +1025,7 @@ func VerifySetUpCallCount(
 	}
 
 	return fmt.Errorf(
-		"No Mounters have expected SetUpCallCount. Expected: <%v>.",
+		"No Mounters have expected SetUpCallCount. Expected: <%v>",
 		expectedSetUpCallCount)
 }
 
@@ -1036,7 +1036,7 @@ func VerifyZeroSetUpCallCount(fakeVolumePlugin *FakeVolumePlugin) error {
 		actualCallCount := mounter.GetSetUpCallCount()
 		if actualCallCount != 0 {
 			return fmt.Errorf(
-				"At least one mounter has non-zero SetUpCallCount: <%v>.",
+				"At least one mounter has non-zero SetUpCallCount: <%v>",
 				actualCallCount)
 		}
 	}
@@ -1058,7 +1058,7 @@ func VerifyTearDownCallCount(
 	}
 
 	return fmt.Errorf(
-		"No Unmounters have expected SetUpCallCount. Expected: <%v>.",
+		"No Unmounters have expected SetUpCallCount. Expected: <%v>",
 		expectedTearDownCallCount)
 }
 
@@ -1069,7 +1069,7 @@ func VerifyZeroTearDownCallCount(fakeVolumePlugin *FakeVolumePlugin) error {
 		actualCallCount := mounter.GetTearDownCallCount()
 		if actualCallCount != 0 {
 			return fmt.Errorf(
-				"At least one mounter has non-zero TearDownCallCount: <%v>.",
+				"At least one mounter has non-zero TearDownCallCount: <%v>",
 				actualCallCount)
 		}
 	}
@@ -1091,7 +1091,7 @@ func VerifyDetachCallCount(
 	}
 
 	return fmt.Errorf(
-		"No Detachers have expected DetachCallCount. Expected: <%v>.",
+		"No Detachers have expected DetachCallCount. Expected: <%v>",
 		expectedDetachCallCount)
 }
 
@@ -1102,7 +1102,7 @@ func VerifyZeroDetachCallCount(fakeVolumePlugin *FakeVolumePlugin) error {
 		actualCallCount := detacher.GetDetachCallCount()
 		if actualCallCount != 0 {
 			return fmt.Errorf(
-				"At least one detacher has non-zero DetachCallCount: <%v>.",
+				"At least one detacher has non-zero DetachCallCount: <%v>",
 				actualCallCount)
 		}
 	}
@@ -1124,7 +1124,7 @@ func VerifySetUpDeviceCallCount(
 	}
 
 	return fmt.Errorf(
-		"No Mapper have expected SetUpDeviceCallCount. Expected: <%v>.",
+		"No Mapper have expected SetUpDeviceCallCount. Expected: <%v>",
 		expectedSetUpDeviceCallCount)
 }
 
@@ -1142,7 +1142,7 @@ func VerifyTearDownDeviceCallCount(
 	}
 
 	return fmt.Errorf(
-		"No Unmapper have expected TearDownDeviceCallCount. Expected: <%v>.",
+		"No Unmapper have expected TearDownDeviceCallCount. Expected: <%v>",
 		expectedTearDownDeviceCallCount)
 }
 
@@ -1153,7 +1153,7 @@ func VerifyZeroTearDownDeviceCallCount(fakeVolumePlugin *FakeVolumePlugin) error
 		actualCallCount := unmapper.GetTearDownDeviceCallCount()
 		if actualCallCount != 0 {
 			return fmt.Errorf(
-				"At least one unmapper has non-zero TearDownDeviceCallCount: <%v>.",
+				"At least one unmapper has non-zero TearDownDeviceCallCount: <%v>",
 				actualCallCount)
 		}
 	}
@@ -1175,7 +1175,7 @@ func VerifyGetGlobalMapPathCallCount(
 	}
 
 	return fmt.Errorf(
-		"No Mappers have expected GetGlobalMapPathCallCount. Expected: <%v>.",
+		"No Mappers have expected GetGlobalMapPathCallCount. Expected: <%v>",
 		expectedGlobalMapPathCallCount)
 }
 
@@ -1193,7 +1193,7 @@ func VerifyGetPodDeviceMapPathCallCount(
 	}
 
 	return fmt.Errorf(
-		"No Mappers have expected GetPodDeviceMapPathCallCount. Expected: <%v>.",
+		"No Mappers have expected GetPodDeviceMapPathCallCount. Expected: <%v>",
 		expectedPodDeviceMapPathCallCount)
 }
 
@@ -1211,7 +1211,7 @@ func VerifyGetMapDeviceCallCount(
 	}
 
 	return fmt.Errorf(
-		"No Mapper have expected MapdDeviceCallCount. Expected: <%v>.",
+		"No Mapper have expected MapdDeviceCallCount. Expected: <%v>",
 		expectedMapDeviceCallCount)
 }
 

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -201,9 +201,9 @@ func PathExists(path string) (bool, error) {
 		return false, nil
 	} else if IsCorruptedMnt(err) {
 		return true, err
-	} else {
-		return false, err
 	}
+	return false, err
+
 }
 
 // IsCorruptedMnt return true if err is about corrupted mount point


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
fix golint problem in pkg/volume that like follow
/media/B/src/k8s.io/kubernetes/pkg/volume/rbd/rbd_util.go:305:6: don't use underscores in Go names; var secret_opt should be secretOpt
/media/B/src/k8s.io/kubernetes/pkg/volume/rbd/rbd_util.go:324:2: don't use underscores in Go names; var lock_id should be lockID
/media/B/src/k8s.io/kubernetes/pkg/volume/rbd/rbd_util.go:562:21: error strings should not be capitalized or end with punctuation or a newline
/media/B/src/k8s.io/kubernetes/pkg/volume/rbd/rbd_util.go:790:9: if block ends with a return statement, so drop this else and outdent its block
Found 4 lint suggestions; failing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
