### PR TITLE
kubelet: get IP based on service network IP mode for dual-stack support.

### DIFF
--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_linux_test.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_linux_test.go
@@ -53,6 +53,7 @@ func TestGetPodNetworkStatus(t *testing.T) {
 	podIPMap := make(map[kubecontainer.ContainerID]string)
 	podIPMap[kubecontainer.ContainerID{ID: "1"}] = "10.245.0.2"
 	podIPMap[kubecontainer.ContainerID{ID: "2"}] = "10.245.0.3"
+	podIPMap[kubecontainer.ContainerID{ID: "3"}] = "2001:db8:10::4"
 
 	testCases := []struct {
 		id          string
@@ -70,9 +71,14 @@ func TestGetPodNetworkStatus(t *testing.T) {
 			false,
 			"10.245.0.3",
 		},
-		//not in podCIDR map
 		{
 			"3",
+			false,
+			"2001:db8:10::4",
+		},
+		//not in podCIDR map
+		{
+			"4",
 			true,
 			"",
 		},


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allows kubelet to obtain the correct IP from pods, when operating in dual-stack mode.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #70653

**Special notes for your reviewer**:
Intent of this is to allow IPv4 only and IPv6 only to work as they do today, but adapt kubelet for when running in dual-stack cluster.

**Does this PR introduce a user-facing change?**:
NONE

/area ipv6
/sig network