### PR TITLE
Add `With` method for allowed paths on delegated authorization

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -75,6 +75,12 @@ func (s *DelegatingAuthorizationOptions) WithAlwaysAllowGroups(groups ...string)
 	return s
 }
 
+// WithAlwaysAllowPaths appends the list of paths to AlwaysAllowPaths
+func (s *DelegatingAuthorizationOptions) WithAlwaysAllowPaths(paths ...string) *DelegatingAuthorizationOptions {
+	s.AlwaysAllowPaths = append(s.AlwaysAllowPaths, paths...)
+	return s
+}
+
 func (s *DelegatingAuthorizationOptions) Validate() []error {
 	allErrors := []error{}
 	return allErrors


### PR DESCRIPTION
The `With` pattern on our options is an easy way to add default values.  `/heathz` should be an unprotected endpoint that doesn't expose confidential information.  This is true of all our processes and makes sense as a general recommendation that should be easy to set.

@kubernetes/sig-api-machinery-pr-reviews @kubernetes/sig-auth-pr-reviews 

```release-note
NONE
```