### PR TITLE
Fix slice sharing bug in cgroup manager

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -67,7 +67,10 @@ func NewCgroupName(base CgroupName, components ...string) CgroupName {
 			panic(fmt.Errorf("invalid character in component [%q] of CgroupName", component))
 		}
 	}
-	return CgroupName(append(base, components...))
+	// copy data from the base cgroup to eliminate cases where CgroupNames share underlying slices.  See #68416
+	baseCopy := make([]string, len(base))
+	copy(baseCopy, base)
+	return CgroupName(append(baseCopy, components...))
 }
 
 func escapeSystemdCgroupName(part string) string {

--- a/pkg/kubelet/cm/cgroup_manager_linux_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux_test.go
@@ -20,8 +20,33 @@ package cm
 
 import (
 	"path"
+	"reflect"
 	"testing"
 )
+
+// TestNewCgroupName tests confirms that #68416 is fixed
+func TestNewCgroupName(t *testing.T) {
+	a := ParseCgroupfsToCgroupName("/a/")
+	ab := NewCgroupName(a, "b")
+
+	expectedAB := CgroupName([]string{"a", "", "b"})
+	if !reflect.DeepEqual(ab, expectedAB) {
+		t.Errorf("Expected %d%+v; got %d%+v", len(expectedAB), expectedAB, len(ab), ab)
+	}
+
+	abc := NewCgroupName(ab, "c")
+
+	expectedABC := CgroupName([]string{"a", "", "b", "c"})
+	if !reflect.DeepEqual(abc, expectedABC) {
+		t.Errorf("Expected %d%+v; got %d%+v", len(expectedABC), expectedABC, len(abc), abc)
+	}
+
+	_ = NewCgroupName(ab, "d")
+
+	if !reflect.DeepEqual(abc, expectedABC) {
+		t.Errorf("Expected %d%+v; got %d%+v", len(expectedABC), expectedABC, len(abc), abc)
+	}
+}
 
 func TestCgroupNameToSystemdBasename(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
See https://play.golang.org/p/QQOELuf56v8 for an example of what can happen when sharing underlying slices.  Slices are only resized when the slice cannot hold the additional elements, and are increased by powers of two.  So appending to a slice may or may not create a new slice to hold the input slice.  

We just happened to be lucky that the default for `--cgroup-root` didn't trigger this behavior because getting pod cgroup slices (`[]string{"kubepods", "burstable"}` -> `[]string{"kubepods", "burstable", "<pod_uid>"}` always triggered a resize of the former slice, as the size goes from 2 -> 4 each time.  But when you specify a cgroup root (`[]string{"root", "kubepods", "burstable"}` -> `[]string{"root", "kubepods", "burstable", "<pod_uid>"}`, the initial slice is already size 4 (because it was constructed by appending to a size 2 slice), and thus does not trigger a resize, and re-uses the parent slice for each child slice.  In this way, after appending one pod uid to the QoS cgroup, the second append produces `[]string{"root", "kubepods", "burstable", "<pod_uid_1>", "<pod_uid_2>"}`, which is a slice resize (4->8).

All of this is to say that we should create a new slice and copy the parent into it when we create a new cgroup.  I included my reproduction case as a test case to ensure we don't break this in the future.

**Which issue(s) this PR fixes**:
Fixes #68416

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a bug in previous releases where a pod could be placed inside another pod's cgroup when specifying --cgroup-root
```

cc @sreis @derekwaynecarr @filbranden @dchen1107 @Random-Liu @yujuhong 
/assign @derekwaynecarr @Random-Liu 