### PR TITLE
Fix bug in 'InClusterConfig' method in windows system

### DIFF
--- a/staging/src/k8s.io/client-go/rest/BUILD
+++ b/staging/src/k8s.io/client-go/rest/BUILD
@@ -51,6 +51,8 @@ go_library(
     srcs = [
         "client.go",
         "config.go",
+        "defaults_unix.go",
+        "defaults_windows.go",
         "plugin.go",
         "request.go",
         "token_source.go",

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -314,8 +314,8 @@ func DefaultKubernetesUserAgent() string {
 // if called from a process not running in a kubernetes environment.
 func InClusterConfig() (*Config, error) {
 	const (
-		tokenFile  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-		rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+		tokenFile  = DefaultTokenFile
+		rootCAFile = DefaultRootCAFile
 	)
 	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
 	if len(host) == 0 || len(port) == 0 {

--- a/staging/src/k8s.io/client-go/rest/defaults_unix.go
+++ b/staging/src/k8s.io/client-go/rest/defaults_unix.go
@@ -1,0 +1,24 @@
+// +build !windows
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+const (
+	DefaultTokenFile  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	DefaultRootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+)

--- a/staging/src/k8s.io/client-go/rest/defaults_windows.go
+++ b/staging/src/k8s.io/client-go/rest/defaults_windows.go
@@ -1,0 +1,24 @@
+// +build windows
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+const (
+	DefaultTokenFile  = "C:/secrets/kubernetes.io/serviceaccount/token"
+	DefaultRootCAFile = "C:/secrets/kubernetes.io/serviceaccount/ca.crt"
+)


### PR DESCRIPTION
When we run some projects like 'service catalog api' in 'windows
system', we found it runs with errors like 'The system cannot
find the path specified.'. So I think it should adapt each system
and needs to be fixed.


