### PR TITLE
kubectl version should print just client information in the absence of kubeconfig

### DIFF
--- a/pkg/kubectl/cmd/version/BUILD
+++ b/pkg/kubectl/cmd/version/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],


### PR DESCRIPTION
If the kubeconfig is empty (distinct from kubeconfig is invalid or failed to build), then we should output the client information instead of failing

```release-note
NONE
```

@kubernetes/sig-cli-maintainers 
/kind bug
/priority important-soon