### PR TITLE
Mark configmap and downward_api e2e tests under [sig-node]

### DIFF
--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -27,7 +27,7 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
-var _ = Describe("[sig-api-machinery] ConfigMap", func() {
+var _ = Describe("[sig-node] ConfigMap", func() {
 	f := framework.NewDefaultFramework("configmap")
 
 	/*

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -35,7 +35,7 @@ var (
 	podUIDVersion = utilversion.MustParseSemantic("v1.8.0")
 )
 
-var _ = Describe("[sig-api-machinery] Downward API", func() {
+var _ = Describe("[sig-node] Downward API", func() {
 	f := framework.NewDefaultFramework("downward-api")
 
 	/*


### PR DESCRIPTION
/kind documentation

Non volume-related e2e tests for ConfigMap and Downward API were prefixed with [sig-api-machinery] in https://github.com/kubernetes/kubernetes/pull/51567. SIG api-machinery does not own these APIs, and these tests show up in [flaky report](https://github.com/kubernetes/kubernetes/issues/70446) as:

`[sig-api-machinery] ConfigMap should be consumable via environment variable [NodeConformance] [Conformance]`

Being node conformance tests suggests that these tests should be owned by sig-node ([SIG charter](https://github.com/kubernetes/community/blob/master/sig-node/charter.md)). This PR changes the prefixes. 

```release-note
NONE
```

/sig node
/sig api-machinery