### PR TITLE
Add doc.go imports for k8s.io/kubernetes/pkg/scheduler

### DIFF
--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "scheduler.go",
         "testutil.go",
     ],

--- a/pkg/scheduler/algorithm/predicates/BUILD
+++ b/pkg/scheduler/algorithm/predicates/BUILD
@@ -10,6 +10,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "csi_volume_predicate.go",
+        "doc.go",
         "error.go",
         "metadata.go",
         "predicates.go",

--- a/pkg/scheduler/algorithm/predicates/doc.go
+++ b/pkg/scheduler/algorithm/predicates/doc.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package predicates are a set of strategies applied one by one to filter out
+// inappropriate nodes. All of them are mandatory strategies. They
+// traverse all the Nodes and filter out the matching Node list
+// according to the specific pre-selection strategy. If no Node meets
+// the Predicate strategies, the Pod will be suspended until a Node
+// can satisfy.
+package predicates // import "k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"

--- a/pkg/scheduler/algorithm/priorities/BUILD
+++ b/pkg/scheduler/algorithm/priorities/BUILD
@@ -10,6 +10,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "balanced_resource_allocation.go",
+        "doc.go",
         "image_locality.go",
         "interpod_affinity.go",
         "least_requested.go",

--- a/pkg/scheduler/algorithm/priorities/doc.go
+++ b/pkg/scheduler/algorithm/priorities/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package priorities are a set of strategies applied one by one to rank
+// nodes (that made it through the filter of the predicates). They are to
+// sort the nodes to be selected according to the preferred strategy on
+// the basis of the first step screening, and obtain the optimal one.
+package priorities // import "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities"

--- a/pkg/scheduler/algorithm/priorities/util/BUILD
+++ b/pkg/scheduler/algorithm/priorities/util/BUILD
@@ -27,6 +27,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "non_zero.go",
         "topologies.go",
     ],

--- a/pkg/scheduler/algorithm/priorities/util/doc.go
+++ b/pkg/scheduler/algorithm/priorities/util/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package util contains resource request interface and topologies information of nodes.
+package util // import "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util"

--- a/pkg/scheduler/algorithmprovider/BUILD
+++ b/pkg/scheduler/algorithmprovider/BUILD
@@ -8,7 +8,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["plugins.go"],
+    srcs = [
+        "doc.go",
+        "plugins.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/algorithmprovider",
     deps = ["//pkg/scheduler/algorithmprovider/defaults:go_default_library"],
 )

--- a/pkg/scheduler/algorithmprovider/defaults/BUILD
+++ b/pkg/scheduler/algorithmprovider/defaults/BUILD
@@ -8,7 +8,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["defaults.go"],
+    srcs = [
+        "defaults.go",
+        "doc.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/algorithmprovider/defaults",
     deps = [
         "//pkg/features:go_default_library",

--- a/pkg/scheduler/algorithmprovider/defaults/doc.go
+++ b/pkg/scheduler/algorithmprovider/defaults/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package defaults applies default algorithm by feature gates.
+package defaults // import "k8s.io/kubernetes/pkg/scheduler/algorithmprovider/defaults"

--- a/pkg/scheduler/algorithmprovider/doc.go
+++ b/pkg/scheduler/algorithmprovider/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package algorithmprovider applies algorithm by feature gates.
+package algorithmprovider // import "k8s.io/kubernetes/pkg/scheduler/algorithmprovider"

--- a/pkg/scheduler/cache/BUILD
+++ b/pkg/scheduler/cache/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "host_ports.go",
         "node_info.go",
         "util.go",

--- a/pkg/scheduler/cache/doc.go
+++ b/pkg/scheduler/cache/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cache contains node information and compute resource implementation.
+package cache // import "k8s.io/kubernetes/pkg/scheduler/cache"

--- a/pkg/scheduler/core/BUILD
+++ b/pkg/scheduler/core/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "extender.go",
         "generic_scheduler.go",
     ],

--- a/pkg/scheduler/core/doc.go
+++ b/pkg/scheduler/core/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package core contains algorithm.SchedulerExtender interface and
+// the generic scheduler implementation. It is the core logic of scheduler.
+package core // import "k8s.io/kubernetes/pkg/scheduler/core"

--- a/pkg/scheduler/core/equivalence/BUILD
+++ b/pkg/scheduler/core/equivalence/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["eqivalence.go"],
+    srcs = [
+        "doc.go",
+        "eqivalence.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/core/equivalence",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/scheduler/core/equivalence/doc.go
+++ b/pkg/scheduler/core/equivalence/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package equivalence defines Pod equivalence classes and the equivalence class
+// cache.
+package equivalence // import "k8s.io/kubernetes/pkg/scheduler/core/equivalence"

--- a/pkg/scheduler/core/equivalence/eqivalence.go
+++ b/pkg/scheduler/core/equivalence/eqivalence.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package equivalence defines Pod equivalence classes and the equivalence class
-// cache.
 package equivalence
 
 import (

--- a/pkg/scheduler/doc.go
+++ b/pkg/scheduler/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package scheduler is the package that contains the libraries that drive the Scheduler binary.
+// The scheduler is responsible for pod scheduling.
+package scheduler // import "k8s.io/kubernetes/pkg/scheduler"

--- a/pkg/scheduler/factory/BUILD
+++ b/pkg/scheduler/factory/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "factory.go",
         "plugins.go",
         "signal.go",

--- a/pkg/scheduler/factory/doc.go
+++ b/pkg/scheduler/factory/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package factory can set up a scheduler. This code is here instead of
+// cmd/scheduler for both testability and reuse.
+package factory // import "k8s.io/kubernetes/pkg/scheduler/factory"

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package factory can set up a scheduler. This code is here instead of
-// cmd/scheduler for both testability and reuse.
 package factory
 
 import (

--- a/pkg/scheduler/internal/cache/BUILD
+++ b/pkg/scheduler/internal/cache/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "cache.go",
+        "doc.go",
         "interface.go",
         "node_tree.go",
     ],

--- a/pkg/scheduler/internal/cache/doc.go
+++ b/pkg/scheduler/internal/cache/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cache implements the cache module of the scheduler, which
+// can greatly improve the performance of the scheduler.
+package cache // import "k8s.io/kubernetes/pkg/scheduler/internal/cache"

--- a/pkg/scheduler/internal/queue/BUILD
+++ b/pkg/scheduler/internal/queue/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["scheduling_queue.go"],
+    srcs = [
+        "doc.go",
+        "scheduling_queue.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/internal/queue",
     visibility = ["//pkg/scheduler:__subpackages__"],
     deps = [

--- a/pkg/scheduler/internal/queue/doc.go
+++ b/pkg/scheduler/internal/queue/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package queue queues hold pods waiting to be scheduled.
+package queue // import "k8s.io/kubernetes/pkg/scheduler/internal/queue"


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

We perfer to use vanity urls instead of directly using github.com to refer to code, so this helps ensure that tools honor our wish. See https://golang.org/doc/go1.4#canonicalimports

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
