### PR TITLE
fix golint error if block ends with a return statement

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_fakes.go
+++ b/pkg/cloudprovider/providers/aws/aws_fakes.go
@@ -352,8 +352,6 @@ func (m *FakeMetadata) GetMetadata(key string) (string, error) {
 				}
 			}
 		}
-
-		return "", nil
 	}
 
 	return "", nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind cleanup

**What this PR does / why we need it**:
run command ./hack/verify-golint.sh
get

```
Errors from golint:
pkg/cloudprovider/providers/aws/aws_fakes.go:357:9: if block ends with a return statement, so drop this else and outdent its block
pkg/volume/util/util.go:204:9: if block ends with a return statement, so drop this else and outdent its block
```
I think maybe releated with #69387 and #68491.

The strange thing is why CI has always been happy?

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
