### PR TITLE
Follow-up of #70409: use glog fatal instead of *OrDie in master endpoint reconciler

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -204,7 +204,10 @@ type Master struct {
 }
 
 func (c *Config) createMasterCountReconciler() reconcilers.EndpointReconciler {
-	endpointClient := corev1client.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
+	endpointClient, err := corev1client.NewForConfig(c.GenericConfig.LoopbackClientConfig)
+	if err != nil {
+		glog.Fatalf("fail to create endpoint client for master count reconciler: %v", err)
+	}
 	return reconcilers.NewMasterCountEndpointReconciler(c.ExtraConfig.MasterCount, endpointClient)
 }
 
@@ -213,7 +216,10 @@ func (c *Config) createNoneReconciler() reconcilers.EndpointReconciler {
 }
 
 func (c *Config) createLeaseReconciler() reconcilers.EndpointReconciler {
-	endpointClient := corev1client.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
+	endpointClient, err := corev1client.NewForConfig(c.GenericConfig.LoopbackClientConfig)
+	if err != nil {
+		glog.Fatalf("fail to create endpoint client for master lease reconciler: %v", err)
+	}
 	ttl := c.ExtraConfig.MasterEndpointReconcileTTL
 	config, err := c.ExtraConfig.StorageFactory.NewConfig(api.Resource("apiServerIPInfo"))
 	if err != nil {

--- a/pkg/master/reconcilers/BUILD
+++ b/pkg/master/reconcilers/BUILD
@@ -32,6 +32,7 @@ go_test(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
     ],
 )


### PR DESCRIPTION
/sig api-machinery
/kind cleanup
/assign @deads2k 

```release-note
NONE
```
addressing missed review comments in #70409
