### PR TITLE
Fix index out of range error when sorting kubectl get

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -314,11 +314,14 @@ type RuntimeSorter struct {
 }
 
 func (r *RuntimeSorter) Sort() error {
-	if len(r.objects) <= 1 {
-		// a list is only considered "sorted" if there are 0 or 1 items in it
-		// AND (if 1 item) the item is not a Table object
+	// a list is only considered "sorted" if there are 0 or 1 items in it
+	// AND (if 1 item) the item is not a Table object
+	if len(r.objects) == 0 {
+		return nil
+	}
+	if len(r.objects) == 1 {
 		_, isTable := r.objects[0].(*metav1beta1.Table)
-		if len(r.objects) == 0 || !isTable {
+		if !isTable {
 			return nil
 		}
 	}

--- a/pkg/kubectl/cmd/get/get_test.go
+++ b/pkg/kubectl/cmd/get/get_test.go
@@ -561,6 +561,15 @@ func TestRuntimeSorter(t *testing.T) {
 		expectError string
 	}{
 		{
+			name:  "ensure sorter works with an empty object list",
+			field: "metadata.name",
+			objs:  []runtime.Object{},
+			op: func(sorter *RuntimeSorter, objs []runtime.Object, out io.Writer) error {
+				return nil
+			},
+			expect: "",
+		},
+		{
 			name:  "ensure sorter returns original position",
 			field: "metadata.name",
 			objs:  sortTestData(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

There's an unsafe access to the `[0]` element of  `r.objects` which can cause this error to happen:

```kubectl get po -n datadog-system -l app=datadog-agent --sort-by=.metadata.creationTimestamp
panic: runtime error: index out of range

goroutine 1 [running]:
k8s.io/kubernetes/pkg/kubectl/cmd/get.(*RuntimeSorter).Sort(0xc0008980f0, 0x0, 0x0)
    /private/tmp/kubernetes-cli-20180928-18549-oxqbkv/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/get/get.go:320 +0x3bc
k8s.io/kubernetes/pkg/kubectl/cmd/get.(*GetOptions).Run(0xc0002ba540, 0x25fa0c0, 0xc000567e60, 0xc000538280, 0xc0000a12c0, 0x1, 0x6, 0x0, 0x0)
    /private/tmp/kubernetes-cli-20180928-18549-oxqbkv/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/get/get.go:489 +0x1391
k8s.io/kubernetes/pkg/kubectl/cmd/get.NewCmdGet.func1(0xc000538280, 0xc0000a12c0, 0x1, 0x6)
    /private/tmp/kubernetes-cli-20180928-18549-oxqbkv/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/get/get.go:161 +0x115
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).execute(0xc000538280, 0xc0000a1260, 0x6, 0x6, 0xc000538280, 0xc0000a1260)
    /private/tmp/kubernetes-cli-20180928-18549-oxqbkv/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:760 +0x2cc
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc00012b180, 0xc0003a2930, 0x12a05f200, 0xc0007f5f10)
    /private/tmp/kubernetes-cli-20180928-18549-oxqbkv/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:846 +0x2fd
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).Execute(0xc00012b180, 0x248e758, 0x3597a80)
    /private/tmp/kubernetes-cli-20180928-18549-oxqbkv/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:794 +0x2b
main.main()
    /private/tmp/kubernetes-cli-20180928-18549-oxqbkv/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/cmd/kubectl/kubectl.go:50 +0x150
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
fixes a runtime error occuring when sorting the output of `kubectl get` with empty results
```
