### PR TITLE
kubeadm: Remove feature gates from JoinConfiguration

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -295,9 +295,6 @@ type JoinConfiguration struct {
 
 	// APIEndpoint represents the endpoint of the instance of the API server eventually to be deployed on this node.
 	APIEndpoint APIEndpoint
-
-	// FeatureGates enabled by the user.
-	FeatureGates map[string]bool
 }
 
 // Discovery specifies the options for the kubelet to use during the TLS Bootstrap process

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/BUILD
@@ -47,7 +47,15 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["bootstraptokenstring_test.go"],
+    srcs = [
+        "bootstraptokenstring_test.go",
+        "conversion_test.go",
+    ],
     embed = [":go_default_library"],
-    deps = ["//vendor/github.com/pkg/errors:go_default_library"],
+    deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/scheme:go_default_library",
+        "//cmd/kubeadm/test:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+    ],
 )

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/conversion.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -26,6 +27,10 @@ import (
 func Convert_v1alpha3_JoinConfiguration_To_kubeadm_JoinConfiguration(in *JoinConfiguration, out *kubeadm.JoinConfiguration, s conversion.Scope) error {
 	if err := autoConvert_v1alpha3_JoinConfiguration_To_kubeadm_JoinConfiguration(in, out, s); err != nil {
 		return err
+	}
+
+	if len(in.FeatureGates) != 0 {
+		return errors.New("featureGates has been removed from JoinConfiguration and featureGates from ClusterConfiguration will be used instead. Please cleanup JoinConfiguration.FeatureGates fields")
 	}
 
 	out.Discovery.Timeout = in.DiscoveryTimeout

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/conversion_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/conversion_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3_test
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha3"
+	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+)
+
+func TestJoinConfigurationConversion(t *testing.T) {
+	testcases := map[string]struct {
+		old         *v1alpha3.JoinConfiguration
+		expectedErr string
+	}{
+		"conversion succeeds": {
+			old:         &v1alpha3.JoinConfiguration{},
+			expectedErr: "",
+		},
+		"feature gates fails to be converted": {
+			old: &v1alpha3.JoinConfiguration{
+				FeatureGates: map[string]bool{
+					"someGate": true,
+				},
+			},
+			expectedErr: "featureGates has been removed from JoinConfiguration and featureGates from ClusterConfiguration will be used instead. Please cleanup JoinConfiguration.FeatureGates fields",
+		},
+	}
+	for _, tc := range testcases {
+		internal := &kubeadm.JoinConfiguration{}
+		err := scheme.Scheme.Convert(tc.old, internal, nil)
+		if len(tc.expectedErr) != 0 {
+			testutil.AssertError(t, err, tc.expectedErr)
+		} else if err != nil {
+			t.Errorf("no error was expected but '%s' was found", err)
+		}
+	}
+}

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/zz_generated.conversion.go
@@ -502,7 +502,7 @@ func autoConvert_v1alpha3_JoinConfiguration_To_kubeadm_JoinConfiguration(in *Joi
 	if err := Convert_v1alpha3_APIEndpoint_To_kubeadm_APIEndpoint(&in.APIEndpoint, &out.APIEndpoint, s); err != nil {
 		return err
 	}
-	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
+	// WARNING: in.FeatureGates requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -517,7 +517,6 @@ func autoConvert_kubeadm_JoinConfiguration_To_v1alpha3_JoinConfiguration(in *kub
 	if err := Convert_kubeadm_APIEndpoint_To_v1alpha3_APIEndpoint(&in.APIEndpoint, &out.APIEndpoint, s); err != nil {
 		return err
 	}
-	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/types.go
@@ -274,9 +274,6 @@ type JoinConfiguration struct {
 
 	// APIEndpoint represents the endpoint of the instance of the API server eventually to be deployed on this node.
 	APIEndpoint APIEndpoint `json:"apiEndpoint,omitempty"`
-
-	// FeatureGates enabled by the user.
-	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 }
 
 // Discovery specifies the options for the kubelet to use during the TLS Bootstrap process

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/zz_generated.conversion.go
@@ -667,7 +667,6 @@ func autoConvert_v1beta1_JoinConfiguration_To_kubeadm_JoinConfiguration(in *Join
 	if err := Convert_v1beta1_APIEndpoint_To_kubeadm_APIEndpoint(&in.APIEndpoint, &out.APIEndpoint, s); err != nil {
 		return err
 	}
-	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
 
@@ -689,7 +688,6 @@ func autoConvert_kubeadm_JoinConfiguration_To_v1beta1_JoinConfiguration(in *kube
 	if err := Convert_kubeadm_APIEndpoint_To_v1beta1_APIEndpoint(&in.APIEndpoint, &out.APIEndpoint, s); err != nil {
 		return err
 	}
-	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/zz_generated.deepcopy.go
@@ -417,13 +417,6 @@ func (in *JoinConfiguration) DeepCopyInto(out *JoinConfiguration) {
 	in.NodeRegistration.DeepCopyInto(&out.NodeRegistration)
 	in.Discovery.DeepCopyInto(&out.Discovery)
 	out.APIEndpoint = in.APIEndpoint
-	if in.FeatureGates != nil {
-		in, out := &in.FeatureGates, &out.FeatureGates
-		*out = make(map[string]bool, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	return
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
@@ -446,13 +446,6 @@ func (in *JoinConfiguration) DeepCopyInto(out *JoinConfiguration) {
 	in.NodeRegistration.DeepCopyInto(&out.NodeRegistration)
 	in.Discovery.DeepCopyInto(&out.Discovery)
 	out.APIEndpoint = in.APIEndpoint
-	if in.FeatureGates != nil {
-		in, out := &in.FeatureGates, &out.FeatureGates
-		*out = make(map[string]bool, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	return
 }
 

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"text/template"
 
 	"github.com/golang/glog"
@@ -164,7 +163,6 @@ func NewCmdJoin(out io.Writer) *cobra.Command {
 
 	var token string
 	var cfgPath string
-	var featureGatesString string
 	var ignorePreflightErrors []string
 
 	cmd := &cobra.Command{
@@ -192,13 +190,13 @@ func NewCmdJoin(out io.Writer) *cobra.Command {
 				cfg.Discovery.TLSBootstrapToken = token
 			}
 
-			j, err := NewValidJoin(cmd.PersistentFlags(), cfg, cfgPath, featureGatesString, ignorePreflightErrors)
+			j, err := NewValidJoin(cmd.PersistentFlags(), cfg, cfgPath, ignorePreflightErrors)
 			kubeadmutil.CheckErr(err)
 			kubeadmutil.CheckErr(j.Run(out))
 		},
 	}
 
-	AddJoinConfigFlags(cmd.PersistentFlags(), cfg, &featureGatesString, &token)
+	AddJoinConfigFlags(cmd.PersistentFlags(), cfg, &token)
 	AddJoinBootstrapTokenDiscoveryFlags(cmd.PersistentFlags(), btd)
 	AddJoinFileDiscoveryFlags(cmd.PersistentFlags(), fd)
 	AddJoinOtherFlags(cmd.PersistentFlags(), &cfgPath, &ignorePreflightErrors)
@@ -207,13 +205,10 @@ func NewCmdJoin(out io.Writer) *cobra.Command {
 }
 
 // NewValidJoin validates the command line that are passed to the cobra command
-func NewValidJoin(flagSet *flag.FlagSet, cfg *kubeadmapiv1beta1.JoinConfiguration, cfgPath, featureGatesString string, ignorePreflightErrors []string) (*Join, error) {
+func NewValidJoin(flagSet *flag.FlagSet, cfg *kubeadmapiv1beta1.JoinConfiguration, cfgPath string, ignorePreflightErrors []string) (*Join, error) {
 	var err error
-	if cfg.FeatureGates, err = features.NewFeatureGate(&features.InitFeatureGates, featureGatesString); err != nil {
-		return nil, err
-	}
 
-	if err := validation.ValidateMixedArguments(flagSet); err != nil {
+	if err = validation.ValidateMixedArguments(flagSet); err != nil {
 		return nil, err
 	}
 
@@ -226,17 +221,13 @@ func NewValidJoin(flagSet *flag.FlagSet, cfg *kubeadmapiv1beta1.JoinConfiguratio
 }
 
 // AddJoinConfigFlags adds join flags bound to the config to the specified flagset
-func AddJoinConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiv1beta1.JoinConfiguration, featureGatesString *string, token *string) {
+func AddJoinConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiv1beta1.JoinConfiguration, token *string) {
 	flagSet.StringVar(
 		&cfg.NodeRegistration.Name, "node-name", cfg.NodeRegistration.Name,
 		"Specify the node name.")
 	flagSet.StringVar(
 		token, "token", "",
 		"Use this token for both discovery-token and tls-bootstrap-token when those values are not provided.")
-	flagSet.StringVar(
-		featureGatesString, "feature-gates", *featureGatesString,
-		"A set of key=value pairs that describe feature gates for various features. "+
-			"Options are:\n"+strings.Join(features.KnownFeatures(&features.InitFeatureGates), "\n"))
 	flagSet.StringVar(
 		&cfg.NodeRegistration.CRISocket, "cri-socket", cfg.NodeRegistration.CRISocket,
 		`Specify the CRI socket to connect to.`,
@@ -513,7 +504,7 @@ func (j *Join) BootstrapKubelet(tlsBootstrapCfg *clientcmdapi.Config) error {
 	// register the joining node with the specified taints if the node
 	// is not a master. The markmaster phase will register the taints otherwise.
 	registerTaintsUsingFlags := !j.cfg.ControlPlane
-	if err := kubeletphase.WriteKubeletDynamicEnvFile(&j.cfg.NodeRegistration, j.cfg.FeatureGates, registerTaintsUsingFlags, kubeadmconstants.KubeletRunDirectory); err != nil {
+	if err := kubeletphase.WriteKubeletDynamicEnvFile(&j.cfg.NodeRegistration, j.initCfg.FeatureGates, registerTaintsUsingFlags, kubeadmconstants.KubeletRunDirectory); err != nil {
 		return err
 	}
 
@@ -542,7 +533,7 @@ func (j *Join) BootstrapKubelet(tlsBootstrapCfg *clientcmdapi.Config) error {
 	}
 
 	// This feature is disabled by default in kubeadm
-	if features.Enabled(j.cfg.FeatureGates, features.DynamicKubeletConfig) {
+	if features.Enabled(j.initCfg.FeatureGates, features.DynamicKubeletConfig) {
 		if err := kubeletphase.EnableDynamicConfigForNode(client, j.cfg.NodeRegistration.Name, kubeletVersion); err != nil {
 			return errors.Wrap(err, "error consuming base kubelet configuration")
 		}

--- a/cmd/kubeadm/app/cmd/join_test.go
+++ b/cmd/kubeadm/app/cmd/join_test.go
@@ -73,7 +73,6 @@ func TestNewValidJoin(t *testing.T) {
 		skipPreFlight         bool
 		cfgPath               string
 		configToWrite         string
-		featureGatesString    string
 		ignorePreflightErrors []string
 		testJoinValidate      bool
 		testJoinRun           bool
@@ -108,11 +107,6 @@ func TestNewValidJoin(t *testing.T) {
 			configToWrite:         testConfig,
 			ignorePreflightErrors: []string{"some-unsupported-preflight-arg"},
 			expectedError:         true,
-		},
-		{
-			name:               "invalid: incorrect featureGatesString",
-			featureGatesString: "bad-feature-gate-string",
-			expectedError:      true,
 		},
 		{
 			name:             "invalid: fail Join.Validate() with wrong flags",
@@ -162,7 +156,7 @@ func TestNewValidJoin(t *testing.T) {
 			}
 		}
 
-		join, err := NewValidJoin(cmd.PersistentFlags(), cfg, tc.cfgPath, tc.featureGatesString, tc.ignorePreflightErrors)
+		join, err := NewValidJoin(cmd.PersistentFlags(), cfg, tc.cfgPath, tc.ignorePreflightErrors)
 
 		if tc.nodeConfig != nil {
 			join.cfg = tc.nodeConfig

--- a/cmd/kubeadm/app/util/config/testdata/conversion/node/internal.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/node/internal.yaml
@@ -13,7 +13,6 @@ Discovery:
   File: null
   TLSBootstrapToken: abcdef.0123456789abcdef
   Timeout: 5m0s
-FeatureGates: null
 NodeRegistration:
   CRISocket: /var/run/dockershim.sock
   KubeletExtraArgs: null


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Relay on the feature gates provided by the ClusterConfiguration
when downloaded from the cluster during the join process.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/1088

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
`--feature-gates` argument has been removed from the `kubeadm join` command. Feature gates will be retrieved from the cluster configuration during the join process.
```
