### PR TITLE
[Feature Branch] Convert ManagedFields api type to type used by SMD repo.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -4009,6 +4009,14 @@
 			"Rev": "66066c83e385e385ccc3c964b44fd7dcd413d0ed"
 		},
 		{
+			"ImportPath": "sigs.k8s.io/structured-merge-diff/fieldpath",
+			"Rev": "261cd9791e59cf384903eff0e7281c6522f5cec7"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/structured-merge-diff/value",
+			"Rev": "261cd9791e59cf384903eff0e7281c6522f5cec7"
+		},
+		{
 			"ImportPath": "vbom.ml/util/sortorder",
 			"Rev": "db5cfe13f5cc80a4990d98e2e1b0707a4d1a5394"
 		}

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -2025,6 +2025,14 @@
 		{
 			"ImportPath": "k8s.io/utils/pointer",
 			"Rev": "66066c83e385e385ccc3c964b44fd7dcd413d0ed"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/structured-merge-diff/fieldpath",
+			"Rev": "261cd9791e59cf384903eff0e7281c6522f5cec7"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/structured-merge-diff/value",
+			"Rev": "261cd9791e59cf384903eff0e7281c6522f5cec7"
 		}
 	]
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
@@ -109,6 +109,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters:all-srcs",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply/BUILD
@@ -1,0 +1,44 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "decode.go",
+        "encode.go",
+    ],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers/apply",
+    importpath = "k8s.io/apiserver/pkg/endpoints/handlers/apply",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/fieldpath:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/value:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "decode_test.go",
+        "roundtrip_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/github.com/ghodss/yaml:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply/decode.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply/decode.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"sigs.k8s.io/structured-merge-diff/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/value"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DecodeManagedFields converts ManagedFields from the wire format (api format)
+// to the format used by sigs.k8s.io/structured-merge-diff
+func DecodeManagedFields(encodedManagedFields map[string]metav1.VersionedFieldSet) (managedFields fieldpath.ManagedFields, err error) {
+	managedFields = make(map[string]*fieldpath.VersionedSet, len(encodedManagedFields))
+	for manager, encodedVersionedSet := range encodedManagedFields {
+		managedFields[manager], err = decodeVersionedSet(&encodedVersionedSet)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding versioned set for %v: %v", manager, err)
+		}
+	}
+	return managedFields, nil
+}
+
+func decodeVersionedSet(encodedVersionedSet *metav1.VersionedFieldSet) (versionedSet *fieldpath.VersionedSet, err error) {
+	versionedSet = &fieldpath.VersionedSet{}
+	versionedSet.APIVersion = fieldpath.APIVersion(encodedVersionedSet.APIVersion)
+	versionedSet.Set = &fieldpath.Set{}
+	err = decodeSetInto(&encodedVersionedSet.Fields, versionedSet.Set)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding set: %v", err)
+	}
+	return versionedSet, nil
+}
+
+func decodeSetInto(encodedSet *metav1.FieldSet, set *fieldpath.Set) (err error) {
+	m, err := decodePathElementSet(encodedSet.Members)
+	if err != nil {
+		return fmt.Errorf("error decoding path element set: %v", err)
+	}
+	set.Members = *m
+	c, err := decodeSetNodeMap(encodedSet.Children)
+	if err != nil {
+		return fmt.Errorf("error decoding children: %v", err)
+	}
+	set.Children = *c
+	return nil
+}
+
+func decodePathElementSet(encodedPathElementSet []metav1.FieldPathElement) (pathElementSet *fieldpath.PathElementSet, err error) {
+	pathElementSet = &fieldpath.PathElementSet{}
+	for _, encodedPathElement := range encodedPathElementSet {
+		pathElement, err := decodePathElement(&encodedPathElement)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding path element: %v", err)
+		}
+		pathElementSet.Insert(*pathElement)
+	}
+	return pathElementSet, nil
+}
+
+func decodeSetNodeMap(encodedSetNodeMap []metav1.FieldSetNode) (setNodeMap *fieldpath.SetNodeMap, err error) {
+	setNodeMap = &fieldpath.SetNodeMap{}
+	for _, encodedSetNode := range encodedSetNodeMap {
+		pathElement, err := decodePathElement(&encodedSetNode.PathElement)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding path element: %v", err)
+		}
+		set := setNodeMap.Descend(*pathElement)
+		decodeSetInto(encodedSetNode.Set, set)
+	}
+	return setNodeMap, nil
+}
+
+func decodePathElement(encodedPathElement *metav1.FieldPathElement) (pathElement *fieldpath.PathElement, err error) {
+	if encodedPathElement == nil {
+		return nil, nil
+	}
+	if !validateOneOf(encodedPathElement.FieldName, encodedPathElement.Key, encodedPathElement.Value, encodedPathElement.Index) {
+		return nil, fmt.Errorf("too many fields set: %v", encodedPathElement)
+	}
+
+	pathElement = &fieldpath.PathElement{}
+	pathElement.FieldName = encodedPathElement.FieldName
+	if encodedPathElement.Key != nil {
+		pathElement.Key = make([]value.Field, len(encodedPathElement.Key))
+		for i, encodedField := range encodedPathElement.Key {
+			pathElement.Key[i], err = decodeField(&encodedField)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding field: %v", err)
+			}
+		}
+	}
+	pathElement.Value, err = decodeValue(encodedPathElement.Value)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding value: %v", err)
+	}
+	if encodedPathElement.Index != nil {
+		v := int(*encodedPathElement.Index)
+		pathElement.Index = &v
+	}
+	return pathElement, nil
+}
+
+func decodeField(encodedField *metav1.FieldNameValuePair) (field value.Field, err error) {
+	field = value.Field{}
+	if encodedField == nil {
+		return field, fmt.Errorf("unexpected nil pointer")
+	}
+	field.Name = encodedField.Name
+	v, err := decodeValue(&encodedField.Value)
+	if err != nil {
+		return field, fmt.Errorf("error decoding value: %v", err)
+	}
+	if v != nil {
+		field.Value = *v
+	}
+	return field, nil
+}
+
+func decodeValue(encodedValue *metav1.FieldValue) (v *value.Value, err error) {
+	if encodedValue == nil {
+		return nil, nil
+	}
+	if !validateOneOf(encodedValue.FloatValue, encodedValue.IntValue, encodedValue.StringValue, encodedValue.BooleanValue) {
+		return nil, fmt.Errorf("too many fields set: %v", encodedValue)
+	}
+
+	v = &value.Value{}
+	if encodedValue.FloatValue != nil {
+		f, err := strconv.ParseFloat(*encodedValue.FloatValue, 64)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing float: %v", err)
+		}
+		v.FloatValue = (*value.Float)(&f)
+	}
+	if encodedValue.IntValue != nil {
+		i := int64(*encodedValue.IntValue)
+		v.IntValue = (*value.Int)(&i)
+	}
+	v.StringValue = (*value.String)(encodedValue.StringValue)
+	v.BooleanValue = (*value.Boolean)(encodedValue.BooleanValue)
+	v.Null = encodedValue.Null
+	return v, nil
+}
+
+func validateOneOf(fields ...interface{}) bool {
+	nonNilCount := 0
+	for _, field := range fields {
+		if !reflect.ValueOf(field).IsNil() {
+			nonNilCount++
+		}
+	}
+	return nonNilCount <= 1
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply/decode_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply/decode_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import (
+	"testing"
+)
+
+// TestValidateOneOf tests that validateOneOf returns true if <= 1
+// non-nil fields are passed to it are and false otherwise
+func TestValidateOneOf(t *testing.T) {
+	var nilValue *string
+	nonNilValue := strPtr("test")
+
+	tests := []struct {
+		fields   []interface{}
+		expected bool
+	}{
+		{
+			fields:   []interface{}{},
+			expected: true,
+		}, {
+			fields:   []interface{}{nilValue},
+			expected: true,
+		}, {
+			fields:   []interface{}{nonNilValue},
+			expected: true,
+		}, {
+			fields:   []interface{}{nilValue, nonNilValue, nilValue},
+			expected: true,
+		}, {
+			fields:   []interface{}{nonNilValue, nonNilValue},
+			expected: false,
+		}, {
+			fields:   []interface{}{nilValue, nonNilValue, nonNilValue, nilValue},
+			expected: false,
+		},
+	}
+
+	for i, tc := range tests {
+		actual := validateOneOf(tc.fields...)
+		if actual != tc.expected {
+			t.Errorf("[%v]expected validateOneOf(%v) to return:\n\t%+v\nbut got:\n\t%+v", i, tc.fields, tc.expected, actual)
+		}
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply/encode.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply/encode.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	"sigs.k8s.io/structured-merge-diff/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/value"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EncodeManagedFields converts ManagedFields from the the format used by
+// sigs.k8s.io/structured-merge-diff to the the wire format (api format)
+func EncodeManagedFields(managedFields fieldpath.ManagedFields) (encodedManagedFields map[string]metav1.VersionedFieldSet, err error) {
+	encodedManagedFields = make(map[string]metav1.VersionedFieldSet, len(managedFields))
+	for manager, versionedSet := range managedFields {
+		v, err := encodeVersionedSet(versionedSet)
+		if err != nil {
+			return nil, fmt.Errorf("error encoding versioned set for %v: %v", manager, err)
+		}
+		encodedManagedFields[manager] = *v
+	}
+	return encodedManagedFields, nil
+}
+
+func encodeVersionedSet(versionedSet *fieldpath.VersionedSet) (encodedVersionedSet *metav1.VersionedFieldSet, err error) {
+	encodedVersionedSet = &metav1.VersionedFieldSet{}
+	encodedVersionedSet.APIVersion = string(versionedSet.APIVersion)
+	f, err := encodeSet(versionedSet.Set)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding set: %v", err)
+	}
+	encodedVersionedSet.Fields = *f
+	return encodedVersionedSet, nil
+}
+
+func encodeSet(set *fieldpath.Set) (encodedSet *metav1.FieldSet, err error) {
+	encodedSet = &metav1.FieldSet{}
+	encodedSet.Members, err = encodePathElementSet(&set.Members)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding path element set: %v", err)
+	}
+	encodedSet.Children, err = encodeSetNodeMap(&set.Children)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding children: %v", err)
+	}
+	return encodedSet, nil
+}
+
+func encodePathElementSet(pathElementSet *fieldpath.PathElementSet) (encodedPathElementSet []metav1.FieldPathElement, err error) {
+	// Get a list of the elements in the pathElementSet and sort it
+	pathElementList := make(sortablePathElementList, 0)
+	pathElementSet.Iterate(func(pathElement fieldpath.PathElement) {
+		pathElementList = append(pathElementList, &pathElement)
+	})
+	sort.Sort(pathElementList)
+	if len(pathElementList) == 0 {
+		return nil, nil
+	}
+
+	encodedPathElementSet = make([]metav1.FieldPathElement, len(pathElementList))
+	for i, pathElement := range pathElementList {
+		encodedPathElement, err := encodePathElement(pathElement)
+		if err != nil {
+			return nil, fmt.Errorf("error encoding path element: %v", err)
+		}
+		encodedPathElementSet[i] = encodedPathElement
+	}
+	return encodedPathElementSet, nil
+}
+
+func encodeSetNodeMap(setNodeMap *fieldpath.SetNodeMap) (encodedSetNodeMap []metav1.FieldSetNode, err error) {
+	// Get a list of the keys in the setNodeMap and sort it
+	pathElementList := make(sortablePathElementList, 0)
+	setNodeMap.Iterate(func(pathElement fieldpath.PathElement) {
+		pathElementList = append(pathElementList, &pathElement)
+	})
+	sort.Sort(pathElementList)
+	if len(pathElementList) == 0 {
+		return nil, nil
+	}
+
+	encodedSetNodeMap = make([]metav1.FieldSetNode, len(pathElementList))
+	for i, pathElement := range pathElementList {
+		encodedPathElement, err := encodePathElement(pathElement)
+		if err != nil {
+			return nil, fmt.Errorf("error encoding path element %v: %v", pathElement.String(), err)
+		}
+		set, ok := setNodeMap.Get(*pathElement)
+		if !ok {
+			return nil, fmt.Errorf("error looking up path element %v", pathElement.String())
+		}
+		encodedSet, err := encodeSet(set)
+		if err != nil {
+			return nil, fmt.Errorf("error encoding set for %v: %v", pathElement.String(), err)
+		}
+		encodedSetNodeMap[i] = metav1.FieldSetNode{
+			PathElement: encodedPathElement,
+			Set:         encodedSet,
+		}
+	}
+	return encodedSetNodeMap, nil
+}
+
+func encodePathElement(pathElement *fieldpath.PathElement) (encodedPathElement metav1.FieldPathElement, err error) {
+	encodedPathElement = metav1.FieldPathElement{}
+	if pathElement == nil {
+		return encodedPathElement, nil
+	}
+	encodedPathElement.FieldName = pathElement.FieldName
+	if pathElement.Key != nil {
+		encodedPathElement.Key = make([]metav1.FieldNameValuePair, len(pathElement.Key))
+		for i, field := range pathElement.Key {
+			encodedPathElement.Key[i], err = encodeField(&field)
+			if err != nil {
+				return encodedPathElement, fmt.Errorf("error encoding field: %v", err)
+			}
+		}
+	}
+	encodedPathElement.Value, err = encodeValue(pathElement.Value)
+	if err != nil {
+		return encodedPathElement, fmt.Errorf("error encoding value: %v", err)
+	}
+	if pathElement.Index != nil {
+		v := int32(*pathElement.Index)
+		encodedPathElement.Index = &v
+	}
+	return encodedPathElement, nil
+}
+
+func encodeField(field *value.Field) (encodedField metav1.FieldNameValuePair, err error) {
+	encodedField = metav1.FieldNameValuePair{}
+	if field == nil {
+		return encodedField, fmt.Errorf("unexpected nil pointer")
+	}
+	encodedField.Name = field.Name
+	v, err := encodeValue(&field.Value)
+	if err != nil {
+		return encodedField, fmt.Errorf("error encoding value: %v", err)
+	}
+	if v != nil {
+		encodedField.Value = *v
+	}
+	return encodedField, nil
+}
+
+func encodeValue(v *value.Value) (encodedValue *metav1.FieldValue, err error) {
+	if v == nil {
+		return nil, nil
+	}
+	encodedValue = &metav1.FieldValue{}
+	if v.FloatValue != nil {
+		f := strconv.FormatFloat(float64(*v.FloatValue), 'f', -1, 64)
+		encodedValue.FloatValue = &f
+	}
+	if v.IntValue != nil {
+		i := int32(int64(*v.IntValue))
+		encodedValue.IntValue = &i
+	}
+	encodedValue.StringValue = (*string)(v.StringValue)
+	encodedValue.BooleanValue = (*bool)(v.BooleanValue)
+	encodedValue.Null = v.Null
+	return encodedValue, nil
+}
+
+type sortablePathElementList []*fieldpath.PathElement
+
+func (p sortablePathElementList) Len() int           { return len(p) }
+func (p sortablePathElementList) Less(i, j int) bool { return p[i].String() < p[j].String() }
+func (p sortablePathElementList) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply/roundtrip_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply/roundtrip_test.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ghodss/yaml"
+)
+
+// TestRoundTripManagedFields will roundtrip ManagedFields from the format used by
+// sigs.k8s.io/structured-merge-diff to the wire format (api format) and back
+func TestRoundTripManagedFields(t *testing.T) {
+	tests := []struct {
+		yaml      []byte
+		errString string
+	}{
+		{
+			yaml: []byte(`foo:
+  apiVersion: v1
+  fields:
+    children:
+    - pathElement:
+        index: 5
+      set:
+        members:
+        - fieldName: i
+    - pathElement:
+        value:
+          floatValue: 3.1415
+      set:
+        members:
+        - fieldName: pi
+    - pathElement:
+        value:
+          intValue: 3
+      set:
+        members:
+        - fieldName: alsoPi
+    - pathElement:
+        value:
+          booleanValue: false
+      set:
+        members:
+        - fieldName: notTrue`),
+		}, {
+			yaml: []byte(`foo:
+  apiVersion: v1
+  fields:
+    children:
+    - pathElement:
+        fieldName: spec
+      set:
+        children:
+        - pathElement:
+            fieldName: containers
+          set:
+            children:
+            - pathElement:
+                key:
+                - name: name
+                  value:
+                    stringValue: c
+                    'null': false
+              set:
+                members:
+                - fieldName: image
+                - fieldName: name`),
+		}, {
+			yaml: []byte(`foo:
+  apiVersion: v1
+  fields:
+    members:
+    - fieldName: apiVersion
+    - fieldName: kind
+    children:
+    - pathElement:
+        fieldName: metadata
+      set:
+        members:
+        - fieldName: name
+        children:
+        - pathElement:
+            fieldName: labels
+          set:
+            members:
+            - fieldName: app
+    - pathElement:
+        fieldName: spec
+      set:
+        members:
+        - fieldName: replicas
+        children:
+        - pathElement:
+            fieldName: selector
+          set:
+            children:
+            - pathElement:
+                fieldName: matchLabels
+              set:
+                members:
+                - fieldName: app
+        - pathElement:
+            fieldName: template
+          set:
+            children:
+            - pathElement:
+                fieldName: metadata
+              set:
+                children:
+                - pathElement:
+                    fieldName: labels
+                  set:
+                    members:
+                    - fieldName: app
+            - pathElement:
+                fieldName: spec
+              set:
+                children:
+                - pathElement:
+                    fieldName: containers
+                  set:
+                    children:
+                    - pathElement:
+                        key:
+                        - name: name
+                          value:
+                            stringValue: nginx
+                            'null': false
+                      set:
+                        members:
+                        - fieldName: image
+                        - fieldName: name
+                        children:
+                        - pathElement:
+                            fieldName: ports
+                          set:
+                            children:
+                            - pathElement:
+                                index: 0
+                              set:
+                                members:
+                                - fieldName: containerPort`),
+		}, {
+			yaml: []byte(`foo:
+  apiVersion: v1
+  fields:
+    members:
+    - fieldName: allowVolumeExpansion
+    - fieldName: apiVersion
+    - fieldName: kind
+    - fieldName: provisioner
+    children:
+    - pathElement:
+        fieldName: metadata
+      set:
+        members:
+        - fieldName: name
+    - pathElement:
+        fieldName: parameters
+      set:
+        members:
+        - fieldName: resturl
+        - fieldName: restuser
+        - fieldName: secretName
+        - fieldName: secretNamespace`),
+		}, {
+			yaml: []byte(`foo:
+  apiVersion: v1
+  fields:
+    members:
+    - fieldName: apiVersion
+    - fieldName: kind
+    children:
+    - pathElement:
+        fieldName: metadata
+      set:
+        members:
+        - fieldName: name
+    - pathElement:
+        fieldName: spec
+      set:
+        members:
+        - fieldName: group
+        - fieldName: scope
+        children:
+        - pathElement:
+            fieldName: names
+          set:
+            members:
+            - fieldName: kind
+            - fieldName: plural
+            - fieldName: singular
+            children:
+            - pathElement:
+                fieldName: shortNames
+              set:
+                members:
+                - index: 0
+        - pathElement:
+            fieldName: versions
+          set:
+            children:
+            - pathElement:
+                key:
+                - name: name
+                  value:
+                    stringValue: v1
+                    'null': false
+              set:
+                members:
+                - fieldName: name
+                - fieldName: served
+                - fieldName: storage`),
+		},
+	}
+
+	for i, tc := range tests {
+		var original map[string]metav1.VersionedFieldSet
+		if err := yaml.Unmarshal(tc.yaml, &original); err != nil {
+			t.Errorf("[%v]did not expect yaml unmarshalling error but got: %v", i, err)
+			continue
+		}
+
+		decoded, err := DecodeManagedFields(original)
+		if err == nil && len(tc.errString) > 0 {
+			t.Errorf("[%v]expected error but got none.", i)
+			continue
+		}
+		if err != nil && len(tc.errString) == 0 {
+			t.Errorf("[%v]did not expect error but got: %v", i, err)
+			continue
+		}
+		if err != nil && len(tc.errString) > 0 && !strings.Contains(err.Error(), tc.errString) {
+			t.Errorf("[%v]expected error with %q but got: %v", i, tc.errString, err)
+			continue
+		}
+		encoded, err := EncodeManagedFields(decoded)
+		if err != nil {
+			t.Errorf("[%v]did not expect round trip error but got: %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(encoded, original) {
+			t.Errorf("[%v]expected:\n\t%+v\nbut got:\n\t%+v", i, original, encoded)
+		}
+	}
+}

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -467,6 +467,8 @@ filegroup(
         "//vendor/k8s.io/utils/clock:all-srcs",
         "//vendor/k8s.io/utils/exec:all-srcs",
         "//vendor/k8s.io/utils/pointer:all-srcs",
+        "//vendor/sigs.k8s.io/structured-merge-diff/fieldpath:all-srcs",
+        "//vendor/sigs.k8s.io/structured-merge-diff/value:all-srcs",
         "//vendor/vbom.ml/util/sortorder:all-srcs",
     ],
     tags = ["automanaged"],

--- a/vendor/sigs.k8s.io/structured-merge-diff/LICENSE
+++ b/vendor/sigs.k8s.io/structured-merge-diff/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/BUILD
+++ b/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/BUILD
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "element.go",
+        "fromvalue.go",
+        "managers.go",
+        "path.go",
+        "set.go",
+    ],
+    importmap = "k8s.io/kubernetes/vendor/sigs.k8s.io/structured-merge-diff/fieldpath",
+    importpath = "sigs.k8s.io/structured-merge-diff/fieldpath",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/sigs.k8s.io/structured-merge-diff/value:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/doc.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fieldpath defines a way for referencing path elements (e.g., an
+// index in an array, or a key in a map). It provides types for arranging these
+// into paths for referencing nested fields, and for grouping those into sets,
+// for referencing multiple nested fields.
+package fieldpath

--- a/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/element.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/element.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/structured-merge-diff/value"
+)
+
+// PathElement describes how to select a child field given a containing object.
+type PathElement struct {
+	// Exactly one of the following fields should be non-nil.
+
+	// FieldName selects a single field from a map (reminder: this is also
+	// how structs are represented). The containing object must be a map.
+	FieldName *string
+
+	// Key selects the list element which has fields matching those given.
+	// The containing object must be an associative list with map typed
+	// elements.
+	Key []value.Field
+
+	// Value selects the list element with the given value. The containing
+	// object must be an associative list with a primitive typed element
+	// (i.e., a set).
+	Value *value.Value
+
+	// Index selects a list element by its index number. The containing
+	// object must be an atomic list.
+	Index *int
+}
+
+// String presents the path element as a human-readable string.
+func (e PathElement) String() string {
+	switch {
+	case e.FieldName != nil:
+		return "." + *e.FieldName
+	case len(e.Key) > 0:
+		strs := make([]string, len(e.Key))
+		for i, k := range e.Key {
+			strs[i] = fmt.Sprintf("%v=%v", k.Name, k.Value)
+		}
+		// The order must be canonical, since we use the string value
+		// in a set structure.
+		sort.Strings(strs)
+		return "[" + strings.Join(strs, ",") + "]"
+	case e.Value != nil:
+		return fmt.Sprintf("[=%v]", e.Value)
+	case e.Index != nil:
+		return fmt.Sprintf("[%v]", *e.Index)
+	default:
+		return "{{invalid path element}}"
+	}
+}
+
+// KeyByFields is a helper function which constructs a key for an associative
+// list type. `nameValues` must have an even number of entries, alternating
+// names (type must be string) with values (type must be value.Value). If these
+// conditions are not met, KeyByFields will panic--it's intended for static
+// construction and shouldn't have user-produced values passed to it.
+func KeyByFields(nameValues ...interface{}) []value.Field {
+	if len(nameValues)%2 != 0 {
+		panic("must have a value for every name")
+	}
+	out := []value.Field{}
+	for i := 0; i < len(nameValues)-1; i += 2 {
+		out = append(out, value.Field{
+			Name:  nameValues[i].(string),
+			Value: nameValues[i+1].(value.Value),
+		})
+	}
+	return out
+}
+
+// PathElementSet is a set of path elements.
+// TODO: serialize as a list.
+type PathElementSet struct {
+	// The strange construction is because there's no way to test
+	// PathElements for equality (it can't be used as a key for a map).
+	members map[string]PathElement
+}
+
+// Insert adds pe to the set.
+func (s *PathElementSet) Insert(pe PathElement) {
+	serialized := pe.String()
+	if s.members == nil {
+		s.members = map[string]PathElement{
+			serialized: pe,
+		}
+		return
+	}
+	if _, ok := s.members[serialized]; !ok {
+		s.members[serialized] = pe
+	}
+}
+
+// Union returns a set containing elements that appear in either s or s2.
+func (s *PathElementSet) Union(s2 *PathElementSet) *PathElementSet {
+	out := &PathElementSet{
+		members: map[string]PathElement{},
+	}
+	for k, v := range s.members {
+		out.members[k] = v
+	}
+	for k, v := range s2.members {
+		out.members[k] = v
+	}
+	return out
+}
+
+// Intersection returns a set containing elements which appear in both s and s2.
+func (s *PathElementSet) Intersection(s2 *PathElementSet) *PathElementSet {
+	out := &PathElementSet{
+		members: map[string]PathElement{},
+	}
+	for k, v := range s.members {
+		if _, ok := s2.members[k]; ok {
+			out.members[k] = v
+		}
+	}
+	return out
+}
+
+// Difference returns a set containing elements which appear in s but not in s2.
+func (s *PathElementSet) Difference(s2 *PathElementSet) *PathElementSet {
+	out := &PathElementSet{
+		members: map[string]PathElement{},
+	}
+	for k, v := range s.members {
+		if _, ok := s2.members[k]; !ok {
+			out.members[k] = v
+		}
+	}
+	return out
+}
+
+// Size retuns the number of elements in the set.
+func (s *PathElementSet) Size() int { return len(s.members) }
+
+// Has returns true if pe is a member of the set.
+func (s *PathElementSet) Has(pe PathElement) bool {
+	if s.members == nil {
+		return false
+	}
+	_, ok := s.members[pe.String()]
+	return ok
+}
+
+// Equals returns true if s and s2 have exactly the same members.
+func (s *PathElementSet) Equals(s2 *PathElementSet) bool {
+	if len(s.members) != len(s2.members) {
+		return false
+	}
+	for k := range s.members {
+		if _, ok := s2.members[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// Iterate calls f for each PathElement in the set.
+func (s *PathElementSet) Iterate(f func(PathElement)) {
+	for _, pe := range s.members {
+		f(pe)
+	}
+}

--- a/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/fromvalue.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/fromvalue.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+import (
+	"sigs.k8s.io/structured-merge-diff/value"
+)
+
+// SetFromValue creates a set containing every leaf field mentioned in v.
+func SetFromValue(v value.Value) *Set {
+	s := NewSet()
+
+	w := objectWalker{
+		path:  Path{},
+		value: v,
+		do:    func(p Path) { s.Insert(p) },
+	}
+
+	w.walk()
+	return s
+}
+
+type objectWalker struct {
+	path  Path
+	value value.Value
+
+	do func(Path)
+}
+
+func (w *objectWalker) walk() {
+	switch {
+	case w.value.Null:
+	case w.value.FloatValue != nil:
+	case w.value.IntValue != nil:
+	case w.value.StringValue != nil:
+	case w.value.BooleanValue != nil:
+		// All leaf fields handled the same way (after the switch
+		// statement).
+
+	// Descend
+	case w.value.ListValue != nil:
+		// If the list were atomic, we'd break here, but we don't have
+		// a schema, so we can't tell.
+
+		for i, child := range w.value.ListValue.Items {
+			w2 := *w
+			w2.path = append(w.path, GuessBestListPathElement(i, child))
+			w2.value = child
+			w2.walk()
+		}
+		return
+	case w.value.MapValue != nil:
+		// If the map/struct were atomic, we'd break here, but we don't
+		// have a schema, so we can't tell.
+
+		for i := range w.value.MapValue.Items {
+			child := w.value.MapValue.Items[i]
+			w2 := *w
+			w2.path = append(w.path, PathElement{FieldName: &child.Name})
+			w2.value = child.Value
+			w2.walk()
+		}
+		return
+	}
+
+	// Leaf fields get added to the set.
+	if len(w.path) > 0 {
+		w.do(w.path)
+	}
+}
+
+// AssociativeListCandidateFieldNames lists the field names which are
+// considered keys if found in a list element.
+var AssociativeListCandidateFieldNames = []string{
+	"key",
+	"id",
+	"name",
+}
+
+// GuessBestListPathElement guesses whether item is an associative list
+// element, which should be referenced by key(s), or if it is not and therefore
+// referencing by index is acceptable. Currently this is done by checking
+// whether item has any of the fields listed in
+// AssociativeListCandidateFieldNames which have scalar values.
+func GuessBestListPathElement(index int, item value.Value) PathElement {
+	if item.MapValue == nil {
+		// Non map items could be parts of sets or regular "atomic"
+		// lists. We won't try to guess whether something should be a
+		// set or not.
+		return PathElement{Index: &index}
+	}
+
+	var keys []value.Field
+	for _, name := range AssociativeListCandidateFieldNames {
+		f, ok := item.MapValue.Get(name)
+		if !ok {
+			continue
+		}
+		// only accept primitive/scalar types as keys.
+		if f.Value.Null || f.Value.MapValue != nil || f.Value.ListValue != nil {
+			continue
+		}
+		keys = append(keys, *f)
+	}
+	if len(keys) > 0 {
+		return PathElement{Key: keys}
+	}
+	return PathElement{Index: &index}
+}

--- a/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/managers.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/managers.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+// APIVersion describes the version of an object or of a fieldset.
+type APIVersion string
+
+// VersionedSet associates a version to a set.
+type VersionedSet struct {
+	*Set
+	APIVersion APIVersion
+}
+
+// ManagedFields is a map from manager to VersionedSet (what they own in
+// what version).
+type ManagedFields map[string]*VersionedSet
+
+// Difference returns a symmetric difference between two Managers. If a
+// given user's entry has version X in lhs and version Y in rhs, then
+// the return value for that user will be from rhs. If the difference for
+// a user is an empty set, that user will not be inserted in the map.
+func (lhs ManagedFields) Difference(rhs ManagedFields) ManagedFields {
+	diff := ManagedFields{}
+
+	for manager, left := range lhs {
+		right, ok := rhs[manager]
+		if !ok {
+			if !left.Empty() {
+				diff[manager] = left
+			}
+			continue
+		}
+
+		// If we have sets in both but their version
+		// differs, we don't even diff and keep the
+		// entire thing.
+		if left.APIVersion != right.APIVersion {
+			diff[manager] = right
+			continue
+		}
+
+		newSet := left.Difference(right.Set).Union(right.Difference(left.Set))
+		if !newSet.Empty() {
+			diff[manager] = &VersionedSet{
+				Set:        newSet,
+				APIVersion: right.APIVersion,
+			}
+		}
+	}
+
+	for manager, set := range rhs {
+		if _, ok := lhs[manager]; ok {
+			// Already done
+			continue
+		}
+		if !set.Empty() {
+			diff[manager] = set
+		}
+	}
+
+	return diff
+}

--- a/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/path.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/path.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+import (
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/structured-merge-diff/value"
+)
+
+// Path describes how to select a potentially deeply-nested child field given a
+// containing object.
+type Path []PathElement
+
+func (fp Path) String() string {
+	strs := make([]string, len(fp))
+	for i := range fp {
+		strs[i] = fp[i].String()
+	}
+	return strings.Join(strs, "")
+}
+
+// MakePath constructs a Path. The parts may be PathElements, ints, strings.
+func MakePath(parts ...interface{}) (Path, error) {
+	var fp Path
+	for _, p := range parts {
+		switch t := p.(type) {
+		case PathElement:
+			fp = append(fp, t)
+		case int:
+			// TODO: Understand schema and object and convert this to the
+			// FieldSpecifier below if appropriate.
+			fp = append(fp, PathElement{Index: &t})
+		case string:
+			fp = append(fp, PathElement{FieldName: &t})
+		case []value.Field:
+			if len(t) == 0 {
+				return nil, fmt.Errorf("associative list key type path elements must have at least one key (got zero)")
+			}
+			fp = append(fp, PathElement{Key: t})
+		case value.Value:
+			// TODO: understand schema and verify that this is a set type
+			// TODO: make a copy of t
+			fp = append(fp, PathElement{Value: &t})
+		default:
+			return nil, fmt.Errorf("unable to make %#v into a path element", p)
+		}
+	}
+	return fp, nil
+}
+
+// MakePathOrDie panics if parts can't be turned into a path. Good for things
+// that are known at complie time.
+func MakePathOrDie(parts ...interface{}) Path {
+	fp, err := MakePath(parts...)
+	if err != nil {
+		panic(err)
+	}
+	return fp
+}

--- a/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/set.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/fieldpath/set.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+import (
+	"strings"
+)
+
+// Set identifies a set of fields.
+type Set struct {
+	// Members lists fields that are part of the set.
+	// TODO: will be serialized as a list of path elements.
+	Members PathElementSet
+
+	// Children lists child fields which themselves have children that are
+	// members of the set. Appearance in this list does not imply membership.
+	// Note: this is a tree, not an arbitrary graph.
+	Children SetNodeMap
+}
+
+// NewSet makes a set from a list of paths.
+func NewSet(paths ...Path) *Set {
+	s := &Set{}
+	for _, p := range paths {
+		s.Insert(p)
+	}
+	return s
+}
+
+// Insert adds the field identified by `p` to the set. Important: parent fields
+// are NOT added to the set; if that is desired, they must be added separately.
+func (s *Set) Insert(p Path) {
+	if len(p) == 0 {
+		// Zero-length path identifies the entire object; we don't
+		// track top-level ownership.
+		return
+	}
+	for {
+		if len(p) == 1 {
+			s.Members.Insert(p[0])
+			return
+		}
+		s = s.Children.Descend(p[0])
+		p = p[1:]
+	}
+}
+
+// Union returns a Set containing elements which appear in either s or s2.
+func (s *Set) Union(s2 *Set) *Set {
+	return &Set{
+		Members:  *s.Members.Union(&s2.Members),
+		Children: *s.Children.Union(&s2.Children),
+	}
+}
+
+// Intersection returns a Set containing leaf elements which appear in both s
+// and s2. Intersection can be constructed from Union and Difference operations
+// (example in the tests) but it's much faster to do it in one pass.
+func (s *Set) Intersection(s2 *Set) *Set {
+	return &Set{
+		Members:  *s.Members.Intersection(&s2.Members),
+		Children: *s.Children.Intersection(&s2.Children),
+	}
+}
+
+// Difference returns a Set containing elements which:
+// * appear in s
+// * do not appear in s2
+// * and are not children of elements that appear in s2.
+//
+// In other words, for leaf fields, this acts like a regular set difference
+// operation. When non leaf fields are compared with leaf fields ("parents"
+// which contain "children"), the effect is:
+// * parent - child = parent
+// * child - parent = {empty set}
+func (s *Set) Difference(s2 *Set) *Set {
+	return &Set{
+		Members:  *s.Members.Difference(&s2.Members),
+		Children: *s.Children.Difference(s2),
+	}
+}
+
+// Size returns the number of members of the set.
+func (s *Set) Size() int {
+	return s.Members.Size() + s.Children.Size()
+}
+
+// Empty returns true if there are no members of the set. It is a separate
+// function from Size since it's common to check whether size > 0, and
+// potentially much faster to return as soon as a single element is found.
+func (s *Set) Empty() bool {
+	if s.Members.Size() > 0 {
+		return false
+	}
+	return s.Children.Empty()
+}
+
+// Has returns true if the field referenced by `p` is a member of the set.
+func (s *Set) Has(p Path) bool {
+	if len(p) == 0 {
+		// No one owns "the entire object"
+		return false
+	}
+	for {
+		if len(p) == 1 {
+			return s.Members.Has(p[0])
+		}
+		var ok bool
+		s, ok = s.Children.Get(p[0])
+		if !ok {
+			return false
+		}
+		p = p[1:]
+	}
+}
+
+// Equals returns true if s and s2 have exactly the same members.
+func (s *Set) Equals(s2 *Set) bool {
+	return s.Members.Equals(&s2.Members) && s.Children.Equals(&s2.Children)
+}
+
+// String returns the set one element per line.
+func (s *Set) String() string {
+	elements := []string{}
+	s.Iterate(func(p Path) {
+		elements = append(elements, p.String())
+	})
+	return strings.Join(elements, "\n")
+}
+
+// Iterate calls f once for each field that is a member of the set (preorder
+// DFS). The path passed to f will be reused so make a copy if you wish to keep
+// it.
+func (s *Set) Iterate(f func(Path)) {
+	s.iteratePrefix(Path{}, f)
+}
+
+func (s *Set) iteratePrefix(prefix Path, f func(Path)) {
+	s.Members.Iterate(func(pe PathElement) { f(append(prefix, pe)) })
+	s.Children.iteratePrefix(prefix, f)
+}
+
+// setNode is a pair of PathElement / Set, for the purpose of expressing
+// nested set membership.
+type setNode struct {
+	pathElement PathElement
+	set         *Set
+}
+
+// SetNodeMap is a map of PathElement to subset.
+type SetNodeMap struct {
+	members map[string]setNode
+}
+
+// Descend adds pe to the set if necessary, returning the associated subset.
+func (s *SetNodeMap) Descend(pe PathElement) *Set {
+	serialized := pe.String()
+	if s.members == nil {
+		s.members = map[string]setNode{}
+	}
+	if n, ok := s.members[serialized]; ok {
+		return n.set
+	}
+	ss := &Set{}
+	s.members[serialized] = setNode{
+		pathElement: pe,
+		set:         ss,
+	}
+	return ss
+}
+
+// Size returns the sum of the number of members of all subsets.
+func (s *SetNodeMap) Size() int {
+	count := 0
+	for _, v := range s.members {
+		count += v.set.Size()
+	}
+	return count
+}
+
+// Empty returns false if there's at least one member in some child set.
+func (s *SetNodeMap) Empty() bool {
+	for _, n := range s.members {
+		if !n.set.Empty() {
+			return false
+		}
+	}
+	return true
+}
+
+// Get returns (the associated set, true) or (nil, false) if there is none.
+func (s *SetNodeMap) Get(pe PathElement) (*Set, bool) {
+	if s.members == nil {
+		return nil, false
+	}
+	serialized := pe.String()
+	if n, ok := s.members[serialized]; ok {
+		return n.set, true
+	}
+	return nil, false
+}
+
+// Equals returns true if s and s2 have the same structure (same nested
+// child sets).
+func (s *SetNodeMap) Equals(s2 *SetNodeMap) bool {
+	if len(s.members) != len(s2.members) {
+		return false
+	}
+	for k, v := range s.members {
+		v2, ok := s2.members[k]
+		if !ok {
+			return false
+		}
+		if !v.set.Equals(v2.set) {
+			return false
+		}
+	}
+	return true
+}
+
+// Union returns a SetNodeMap with members that appear in either s or s2.
+func (s *SetNodeMap) Union(s2 *SetNodeMap) *SetNodeMap {
+	out := &SetNodeMap{}
+	for k, sn := range s.members {
+		pe := sn.pathElement
+		if sn2, ok := s2.members[k]; ok {
+			*out.Descend(pe) = *sn.set.Union(sn2.set)
+		} else {
+			*out.Descend(pe) = *sn.set
+		}
+	}
+	for k, sn2 := range s2.members {
+		pe := sn2.pathElement
+		if _, ok := s.members[k]; ok {
+			// already handled
+			continue
+		}
+		*out.Descend(pe) = *sn2.set
+	}
+	return out
+}
+
+// Intersection returns a SetNodeMap with members that appear in both s and s2.
+func (s *SetNodeMap) Intersection(s2 *SetNodeMap) *SetNodeMap {
+	out := &SetNodeMap{}
+	for k, sn := range s.members {
+		pe := sn.pathElement
+		if sn2, ok := s2.members[k]; ok {
+			i := *sn.set.Intersection(sn2.set)
+			if !i.Empty() {
+				*out.Descend(pe) = i
+			}
+		}
+	}
+	return out
+}
+
+// Difference returns a SetNodeMap with members that appear in s but not in s2.
+func (s *SetNodeMap) Difference(s2 *Set) *SetNodeMap {
+	out := &SetNodeMap{}
+	for k, sn := range s.members {
+		pe := sn.pathElement
+		if s2.Members.Has(pe) {
+			continue
+		}
+		if sn2, ok := s2.Children.members[k]; ok {
+			diff := *sn.set.Difference(sn2.set)
+			// We aren't permitted to add nodes with no elements.
+			if !diff.Empty() {
+				*out.Descend(pe) = diff
+			}
+		} else {
+			*out.Descend(pe) = *sn.set
+		}
+	}
+	return out
+}
+
+// Iterate calls f for each PathElement in the set.
+func (s *SetNodeMap) Iterate(f func(PathElement)) {
+	for _, n := range s.members {
+		f(n.pathElement)
+	}
+}
+
+func (s *SetNodeMap) iteratePrefix(prefix Path, f func(Path)) {
+	for _, n := range s.members {
+		pe := n.pathElement
+		n.set.iteratePrefix(append(prefix, pe), f)
+	}
+}

--- a/vendor/sigs.k8s.io/structured-merge-diff/value/BUILD
+++ b/vendor/sigs.k8s.io/structured-merge-diff/value/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "unstructured.go",
+        "value.go",
+    ],
+    importmap = "k8s.io/kubernetes/vendor/sigs.k8s.io/structured-merge-diff/value",
+    importpath = "sigs.k8s.io/structured-merge-diff/value",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/gopkg.in/yaml.v2:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/sigs.k8s.io/structured-merge-diff/value/doc.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/value/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package value defines types for an in-memory representation of yaml or json
+// objects, organized for convenient comparison with a schema (as defined by
+// the sibling schema package). Functions for reading and writing the objects
+// are also provided.
+package value

--- a/vendor/sigs.k8s.io/structured-merge-diff/value/unstructured.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/value/unstructured.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package value
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+// FromYAML is a helper function for reading a YAML document; it attempts to
+// preserve order of keys within maps/structs. This is as a convenience to
+// humans keeping YAML documents, not because there is a behavior difference.
+//
+// Known bug: objects with top-level arrays don't parse correctly.
+func FromYAML(input []byte) (Value, error) {
+	var decoded interface{}
+
+	if len(input) == 0 || (len(input) == 4 && string(input) == "null") {
+		// Special case since the yaml package doesn't accurately
+		// preserve this.
+		return Value{Null: true}, nil
+	}
+
+	// This attempts to enable order sensitivity; note the yaml package is
+	// broken for documents that have root-level arrays, hence the two-step
+	// approach. TODO: This is a horrific hack. Is it worth it?
+	var ms yaml.MapSlice
+	if err := yaml.Unmarshal(input, &ms); err == nil {
+		decoded = ms
+	} else if err := yaml.Unmarshal(input, &decoded); err != nil {
+		return Value{}, err
+	}
+
+	v, err := FromUnstructured(decoded)
+	if err != nil {
+		return Value{}, fmt.Errorf("failed to interpret (%v):\n%s", err, input)
+	}
+	return v, nil
+}
+
+// FromUnstructured will convert a go interface to a Value.
+// It's most commonly expected to be used with map[string]interface{} as the
+// input. `in` must not have any structures with cycles in them.
+// yaml.MapSlice may be used for order-preservation.
+func FromUnstructured(in interface{}) (Value, error) {
+	if in == nil {
+		return Value{Null: true}, nil
+	}
+	switch t := in.(type) {
+	case map[interface{}]interface{}:
+		m := Map{}
+		for rawKey, rawVal := range t {
+			k, ok := rawKey.(string)
+			if !ok {
+				return Value{}, fmt.Errorf("key %#v: not a string", k)
+			}
+			v, err := FromUnstructured(rawVal)
+			if err != nil {
+				return Value{}, fmt.Errorf("key %v: %v", k, err)
+			}
+			m.Set(k, v)
+		}
+		return Value{MapValue: &m}, nil
+	case map[string]interface{}:
+		m := Map{}
+		for k, rawVal := range t {
+			v, err := FromUnstructured(rawVal)
+			if err != nil {
+				return Value{}, fmt.Errorf("key %v: %v", k, err)
+			}
+			m.Set(k, v)
+		}
+		return Value{MapValue: &m}, nil
+	case yaml.MapSlice:
+		m := Map{}
+		for _, item := range t {
+			k, ok := item.Key.(string)
+			if !ok {
+				return Value{}, fmt.Errorf("key %#v is not a string", item.Key)
+			}
+			v, err := FromUnstructured(item.Value)
+			if err != nil {
+				return Value{}, fmt.Errorf("key %v: %v", k, err)
+			}
+			m.Set(k, v)
+		}
+		return Value{MapValue: &m}, nil
+	case []interface{}:
+		l := List{}
+		for i, rawVal := range t {
+			v, err := FromUnstructured(rawVal)
+			if err != nil {
+				return Value{}, fmt.Errorf("index %v: %v", i, err)
+			}
+			l.Items = append(l.Items, v)
+		}
+		return Value{ListValue: &l}, nil
+	case int:
+		n := Int(t)
+		return Value{IntValue: &n}, nil
+	case int8:
+		n := Int(t)
+		return Value{IntValue: &n}, nil
+	case int16:
+		n := Int(t)
+		return Value{IntValue: &n}, nil
+	case int32:
+		n := Int(t)
+		return Value{IntValue: &n}, nil
+	case int64:
+		n := Int(t)
+		return Value{IntValue: &n}, nil
+	case uint:
+		n := Int(t)
+		return Value{IntValue: &n}, nil
+	case uint8:
+		n := Int(t)
+		return Value{IntValue: &n}, nil
+	case uint16:
+		n := Int(t)
+		return Value{IntValue: &n}, nil
+	case uint32:
+		n := Int(t)
+		return Value{IntValue: &n}, nil
+	case float32:
+		f := Float(t)
+		return Value{FloatValue: &f}, nil
+	case float64:
+		f := Float(t)
+		return Value{FloatValue: &f}, nil
+	case string:
+		return StringValue(t), nil
+	case bool:
+		return BooleanValue(t), nil
+	default:
+		return Value{}, fmt.Errorf("type unimplemented: %t", in)
+	}
+}
+
+// ToYAML is a helper function for producing a YAML document; it attempts to
+// preserve order of keys within maps/structs. This is as a convenience to
+// humans keeping YAML documents, not because there is a behavior difference.
+func (v *Value) ToYAML() ([]byte, error) {
+	out := v.ToUnstructured(true)
+	b, err := yaml.Marshal(out)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// ToUnstructured will convert the Value into a go-typed object.
+// If preserveOrder is true, then maps will be converted to the yaml.MapSlice
+// type. Otherwise, map[string]interface{} must be used-- this destroys
+// ordering information and is not recommended if the result of this will be
+// serialized. Other types:
+// * list -> []interface{}
+// * others -> corresponding go type, wrapped in an interface{}
+//
+// Of note, floats and ints will always come out as float64 and int64,
+// respectively.
+func (v *Value) ToUnstructured(preserveOrder bool) interface{} {
+	switch {
+	case v.FloatValue != nil:
+		f := float64(*v.FloatValue)
+		return f
+	case v.IntValue != nil:
+		i := int64(*v.IntValue)
+		return i
+	case v.StringValue != nil:
+		return *v.StringValue
+	case v.BooleanValue != nil:
+		return *v.BooleanValue
+	case v.ListValue != nil:
+		out := []interface{}{}
+		for _, item := range v.ListValue.Items {
+			out = append(out, item.ToUnstructured(preserveOrder))
+		}
+		return out
+	case v.MapValue != nil:
+		m := v.MapValue
+		if preserveOrder {
+			ms := make(yaml.MapSlice, len(m.Items))
+			for i := range m.Items {
+				ms[i] = yaml.MapItem{
+					Key:   m.Items[i].Name,
+					Value: m.Items[i].Value.ToUnstructured(preserveOrder),
+				}
+			}
+			return ms
+		}
+		// This case is unavoidably lossy.
+		out := map[string]interface{}{}
+		for i := range m.Items {
+			out[m.Items[i].Name] = m.Items[i].Value.ToUnstructured(preserveOrder)
+		}
+		return out
+	default:
+		fallthrough
+	case v.Null == true:
+		return nil
+	}
+}

--- a/vendor/sigs.k8s.io/structured-merge-diff/value/value.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/value/value.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package value
+
+import (
+	"fmt"
+	"strings"
+)
+
+// A Value is an object; it corresponds to an 'atom' in the schema.
+type Value struct {
+	// Exactly one of the below must be set.
+	FloatValue   *Float
+	IntValue     *Int
+	StringValue  *String
+	BooleanValue *Boolean
+	ListValue    *List
+	MapValue     *Map
+	Null         bool // represents an explicit `"foo" = null`
+}
+
+type Int int64
+type Float float64
+type String string
+type Boolean bool
+
+// Field is an individual key-value pair.
+type Field struct {
+	Name  string
+	Value Value
+}
+
+// List is a list of items.
+type List struct {
+	Items []Value
+}
+
+// Map is a map of key-value pairs. It represents both structs and maps. We use
+// a list and a go-language map to preserve order.
+//
+// Set and Get helpers are provided.
+type Map struct {
+	Items []Field
+
+	// may be nil; lazily constructed.
+	// TODO: Direct modifications to Items above will cause serious problems.
+	index map[string]*Field
+}
+
+// Get returns the (Field, true) or (nil, false) if it is not present
+func (m *Map) Get(key string) (*Field, bool) {
+	if m.index == nil {
+		m.index = map[string]*Field{}
+		for i := range m.Items {
+			f := &m.Items[i]
+			m.index[f.Name] = f
+		}
+	}
+	f, ok := m.index[key]
+	return f, ok
+}
+
+// Set inserts or updates the given item.
+func (m *Map) Set(key string, value Value) {
+	if f, ok := m.Get(key); ok {
+		f.Value = value
+		return
+	}
+	m.Items = append(m.Items, Field{Name: key, Value: value})
+	m.index = nil // Since the append might have reallocated
+}
+
+// StringValue returns s as a scalar string Value.
+func StringValue(s string) Value {
+	s2 := String(s)
+	return Value{StringValue: &s2}
+}
+
+// IntValue returns i as a scalar numeric (integer) Value.
+func IntValue(i int) Value {
+	i2 := Int(i)
+	return Value{IntValue: &i2}
+}
+
+// FloatValue returns f as a scalar numeric (float) Value.
+func FloatValue(f float64) Value {
+	f2 := Float(f)
+	return Value{FloatValue: &f2}
+}
+
+// BooleanValue returns b as a scalar boolean Value.
+func BooleanValue(b bool) Value {
+	b2 := Boolean(b)
+	return Value{BooleanValue: &b2}
+}
+
+// String returns a human-readable representation of the value.
+func (v Value) String() string {
+	switch {
+	case v.FloatValue != nil:
+		return fmt.Sprintf("%v", *v.FloatValue)
+	case v.IntValue != nil:
+		return fmt.Sprintf("%v", *v.IntValue)
+	case v.StringValue != nil:
+		return fmt.Sprintf("%q", *v.StringValue)
+	case v.BooleanValue != nil:
+		return fmt.Sprintf("%v", *v.BooleanValue)
+	case v.ListValue != nil:
+		strs := []string{}
+		for _, item := range v.ListValue.Items {
+			strs = append(strs, item.String())
+		}
+		return "[" + strings.Join(strs, ",") + "]"
+	case v.MapValue != nil:
+		strs := []string{}
+		for _, i := range v.MapValue.Items {
+			strs = append(strs, fmt.Sprintf("%v=%v", i.Name, i.Value))
+		}
+		return "{" + strings.Join(strs, ";") + "}"
+	default:
+		fallthrough
+	case v.Null == true:
+		return "null"
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Convert ManagedFields from the api type (meta/v1) to and from the type consumed by SMD repo.
Also vendors in "sigs.k8s.io/structured-merge-diff/fieldpath" and "sigs.k8s.io/structured-merge-diff/value"

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery
/cc @apelisse @lavalamp 