### PR TITLE
Fix test driver's unique name consistent

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -192,7 +192,7 @@ var _ = utils.SIGDescribe("CSI Volumes", func() {
 			test := t
 			It(test.name, func() {
 				if test.driverExists {
-					csiDriver := createCSIDriver(csics, "csi-hostpath-"+f.UniqueName, test.driverAttachable)
+					csiDriver := createCSIDriver(csics, drivers.GetUniqueDriverName(driver), test.driverAttachable)
 					if csiDriver != nil {
 						defer csics.CsiV1alpha1().CSIDrivers().Delete(csiDriver.Name, nil)
 					}

--- a/test/e2e/storage/drivers/base.go
+++ b/test/e2e/storage/drivers/base.go
@@ -176,3 +176,8 @@ func getStorageClass(
 		VolumeBindingMode: bindingMode,
 	}
 }
+
+// GetUniqueDriverName returns unique driver name that can be used parallelly in tests
+func GetUniqueDriverName(driver TestDriver) string {
+	return fmt.Sprintf("%s-%s", driver.GetDriverInfo().Name, driver.GetDriverInfo().Framework.UniqueName)
+}

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -82,7 +82,7 @@ func (h *hostpathCSIDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern
 }
 
 func (h *hostpathCSIDriver) GetDynamicProvisionStorageClass(fsType string) *storagev1.StorageClass {
-	provisioner := h.driverInfo.Name + h.driverInfo.Framework.UniqueName
+	provisioner := GetUniqueDriverName(h)
 	parameters := map[string]string{}
 	ns := h.driverInfo.Framework.Namespace.Name
 	suffix := fmt.Sprintf("%s-sc", provisioner)
@@ -105,7 +105,7 @@ func (h *hostpathCSIDriver) CreateDriver() {
 	// settings are ignored for this test. We could patch the image definitions.
 	o := utils.PatchCSIOptions{
 		OldDriverName:            h.driverInfo.Name,
-		NewDriverName:            h.driverInfo.Name + h.driverInfo.Framework.UniqueName,
+		NewDriverName:            GetUniqueDriverName(h),
 		DriverContainerName:      "hostpath",
 		ProvisionerContainerName: "csi-provisioner",
 		NodeName:                 h.driverInfo.Config.ServerNodeName,
@@ -199,8 +199,8 @@ func (g *gcePDCSIDriver) CreateDriver() {
 	//
 	// These are the options which would have to be used:
 	// o := utils.PatchCSIOptions{
-	// 	OldDriverName:            "com.google.csi.gcepd",
-	// 	NewDriverName:            "com.google.csi.gcepd-" + g.f.UniqueName,
+	// 	OldDriverName:            g.driverInfo.Name,
+	// 	NewDriverName:            GetUniqueDriverName(g),
 	// 	DriverContainerName:      "gce-driver",
 	// 	ProvisionerContainerName: "csi-external-provisioner",
 	// }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
This PR makes test driver's unique name consistent. This will fix #70760, by making volume name in crd and provisioner name consistent. Also, this will reduce a risk of causing driver's unique name mismatch by putting naming logic in one place.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: #70760

**Special notes for your reviewer**:
/sig storage

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
