### PR TITLE
Update containerized mounter's glusterfs and nfs version

### DIFF
--- a/cluster/gce/gci/mounter/Dockerfile
+++ b/cluster/gce/gci/mounter/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
+FROM ubuntu:cosmic
 
-RUN apt-get update && apt-get install -y netbase nfs-common=1:1.2.8-9ubuntu12 glusterfs-client=3.7.6-1ubuntu1
+RUN apt-get update && apt-get install -y netbase nfs-common=1:1.3.4-2.2ubuntu3 glusterfs-client=4.1.2-1
 
 ENTRYPOINT ["/bin/mount"]

--- a/cluster/gce/gci/mounter/Makefile
+++ b/cluster/gce/gci/mounter/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=v2
+TAG=v3
 REGISTRY=staging-k8s.gcr.io
 IMAGE=gci-mounter
 


### PR DESCRIPTION
This PR is to update the glusterfs and nfs version pre-installed in
containerized mounter package 

**What type of PR is this?**
 /kind bug

**Special notes for your reviewer**:
Update nfs and glusterfs client version might affect user's workload.

**Does this PR introduce a user-facing change?**:
None

