### PR TITLE
kubeadm: use client-go's MakeCSRFromTemplate() in 'renew'

### DIFF
--- a/cmd/kubeadm/app/phases/certs/renewal/certsapi.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/certsapi.go
@@ -17,7 +17,6 @@ limitations under the License.
 package renewal
 
 import (
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -70,7 +69,7 @@ func (r *CertsAPIRenewal) Renew(cfg *certutil.Config) (*x509.Certificate, *rsa.P
 		return nil, nil, errors.Wrap(err, "couldn't create new private key")
 	}
 
-	csr, err := x509.CreateCertificateRequest(rand.Reader, reqTmp, key)
+	csr, err := certutil.MakeCSRFromTemplate(key, reqTmp)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "couldn't create certificate signing request")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Create CSR using the mentioned function which also encodes the
type CertificateRequestBlockType.

Without that 'certs renew' is failing with:
'PEM block type must be CERTIFICATE REQUEST'

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#1216

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
kubeadm: fix a bug in "certs renew" related to unknown certificate requests
```

/area kubeadm
/assign @liztio @timothysc 
@kubernetes/sig-cluster-lifecycle-pr-reviews 
/priority critical-urgent
