### PR TITLE
Add debug info: scheduler extenders's score and its name for each pod

### DIFF
--- a/pkg/scheduler/algorithm/scheduler_interface.go
+++ b/pkg/scheduler/algorithm/scheduler_interface.go
@@ -26,6 +26,9 @@ import (
 // decisions made by Kubernetes. This is typically needed for resources not directly
 // managed by Kubernetes.
 type SchedulerExtender interface {
+	// Name returns a unique name that identifies the extender.
+	Name() string
+
 	// Filter based on extender-implemented predicate functions. The filtered list is
 	// expected to be a subset of the supplied list. failedNodesMap optionally contains
 	// the list of failed nodes and failure reasons.

--- a/pkg/scheduler/core/extender.go
+++ b/pkg/scheduler/core/extender.go
@@ -107,6 +107,11 @@ func NewHTTPExtender(config *schedulerapi.ExtenderConfig) (algorithm.SchedulerEx
 	}, nil
 }
 
+// Name returns extenderURL to identifies the extender.
+func (h *HTTPExtender) Name() string {
+	return h.extenderURL
+}
+
 // IsIgnorable returns true indicates scheduling should not fail when this extender
 // is unavailable
 func (h *HTTPExtender) IsIgnorable() bool {

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -120,6 +120,10 @@ type FakeExtender struct {
 	cachedNodeNameToInfo map[string]*schedulercache.NodeInfo
 }
 
+func (f *FakeExtender) Name() string {
+	return "FakeExtender"
+}
+
 func (f *FakeExtender) IsIgnorable() bool {
 	return f.ignorable
 }

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -692,7 +692,7 @@ func PrioritizeNodes(
 			}
 			if glog.V(10) {
 				for _, hostPriority := range results[index] {
-					glog.Infof("%v -> %v: %v, Score: (%d)", pod.Name, hostPriority.Host, config.Name, hostPriority.Score)
+					glog.Infof("%v -> %v: %v, Score: (%d)", util.GetPodFullName(pod), hostPriority.Host, config.Name, hostPriority.Score)
 				}
 			}
 		}(i, priorityConfig)
@@ -730,6 +730,9 @@ func PrioritizeNodes(
 				mu.Lock()
 				for i := range *prioritizedList {
 					host, score := (*prioritizedList)[i].Host, (*prioritizedList)[i].Score
+					if glog.V(10) {
+						glog.Infof("%v -> %v: %v, Score: (%d)", util.GetPodFullName(pod), host, ext.Name(), score)
+					}
 					combinedScores[host] += score * weight
 				}
 				mu.Unlock()

--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -532,6 +532,10 @@ type fakeExtender struct {
 	ignorable         bool
 }
 
+func (f *fakeExtender) Name() string {
+	return "fakeExtender"
+}
+
 func (f *fakeExtender) IsIgnorable() bool {
 	return f.ignorable
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
In `pkg/scheduler/core/generic_scheduler#PrioritizeNodes` , add some debug info: each scheduler extender's score and its name for each pod. If there are two or more scheduler extenders configured for scheduler(and we have now), it will be very useful to debug why kubelet nodes get so high/low score.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #70723 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
