### PR TITLE
fix some typos

### DIFF
--- a/pkg/kubelet/errors.go
+++ b/pkg/kubelet/errors.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package kubelet
 
+import "errors"
+
 const (
 	NetworkNotReadyErrorMsg = "network is not ready"
+)
+
+var (
+	ErrNetworkUnknown = errors.New("network state unknown")
 )

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1563,9 +1563,9 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 	}
 
 	// If the network plugin is not ready, only start the pod if it uses the host network
-	if rs := kl.runtimeState.networkErrors(); len(rs) != 0 && !kubecontainer.IsHostNetworkPod(pod) {
-		kl.recorder.Eventf(pod, v1.EventTypeWarning, events.NetworkNotReady, "%s: %v", NetworkNotReadyErrorMsg, rs)
-		return fmt.Errorf("%s: %v", NetworkNotReadyErrorMsg, rs)
+	if err := kl.runtimeState.networkErrors(); err != nil && !kubecontainer.IsHostNetworkPod(pod) {
+		kl.recorder.Eventf(pod, v1.EventTypeWarning, events.NetworkNotReady, "%s: %v", NetworkNotReadyErrorMsg, err)
+		return fmt.Errorf("%s: %v", NetworkNotReadyErrorMsg, err)
 	}
 
 	// Create Cgroups for the pod and apply resource parameters
@@ -1820,8 +1820,8 @@ func (kl *Kubelet) syncLoop(updates <-chan kubetypes.PodUpdate, handler SyncHand
 	)
 	duration := base
 	for {
-		if rs := kl.runtimeState.runtimeErrors(); len(rs) != 0 {
-			klog.Infof("skipping pod synchronization - %v", rs)
+		if err := kl.runtimeState.runtimeErrors(); err != nil {
+			klog.Infof("skipping pod synchronization - %v", err)
 			// exponential backoff
 			time.Sleep(duration)
 			duration = time.Duration(math.Min(float64(max), factor*float64(duration)))

--- a/pkg/kubelet/nodestatus/BUILD
+++ b/pkg/kubelet/nodestatus/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",

--- a/pkg/kubelet/runtime.go
+++ b/pkg/kubelet/runtime.go
@@ -17,9 +17,12 @@ limitations under the License.
 package kubelet
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 type runtimeState struct {
@@ -70,32 +73,32 @@ func (s *runtimeState) podCIDR() string {
 	return s.cidr
 }
 
-func (s *runtimeState) runtimeErrors() []string {
+func (s *runtimeState) runtimeErrors() error {
 	s.RLock()
 	defer s.RUnlock()
-	var ret []string
+	errs := []error{}
 	if s.lastBaseRuntimeSync.IsZero() {
-		ret = append(ret, "container runtime status check may not have completed yet")
+		errs = append(errs, errors.New("container runtime status check may not have completed yet."))
 	} else if !s.lastBaseRuntimeSync.Add(s.baseRuntimeSyncThreshold).After(time.Now()) {
-		ret = append(ret, "container runtime is down")
+		errs = append(errs, errors.New("container runtime is down."))
 	}
 	for _, hc := range s.healthChecks {
 		if ok, err := hc.fn(); !ok {
-			ret = append(ret, fmt.Sprintf("%s is not healthy: %v", hc.name, err))
+			errs = append(errs, fmt.Errorf("%s is not healthy: %v.", hc.name, err))
 		}
 	}
 
-	return ret
+	return utilerrors.NewAggregate(errs)
 }
 
-func (s *runtimeState) networkErrors() []string {
+func (s *runtimeState) networkErrors() error {
 	s.RLock()
 	defer s.RUnlock()
-	var ret []string
+	errs := []error{}
 	if s.networkError != nil {
-		ret = append(ret, s.networkError.Error())
+		errs = append(errs, s.networkError)
 	}
-	return ret
+	return utilerrors.NewAggregate(errs)
 }
 
 func newRuntimeState(
@@ -104,6 +107,6 @@ func newRuntimeState(
 	return &runtimeState{
 		lastBaseRuntimeSync:      time.Time{},
 		baseRuntimeSyncThreshold: runtimeSyncThreshold,
-		networkError:             fmt.Errorf("network state unknown"),
+		networkError:             ErrNetworkUnknown,
 	}
 }

--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -89,7 +89,7 @@ type Reconciler interface {
 //   safely (prevents more than one operation from being triggered on the same
 //   volume)
 // mounter - mounter passed in from kubelet, passed down unmount path
-// volumePluginMrg - volume plugin manager passed from kubelet
+// volumePluginMgr - volume plugin manager passed from kubelet
 func NewReconciler(
 	kubeClient clientset.Interface,
 	controllerAttachDetachEnabled bool,


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
the orignal log output is: `I1108 12:44:39.353048   17315 kubelet.go:1820] skipping pod synchronization - [container runtime status check may not have completed yet PLEG is not healthy: pleg has yet to be successful] `  
This log contains two error messages, one is container runtime status check may not have completed, the other is pleg has yet to be successful , add a period to separate it and increase log readability.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
