### PR TITLE
remove duplicate setting of NormalizeFunc

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -415,7 +415,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	}
 
 	flags := cmds.PersistentFlags()
-	flags.SetNormalizeFunc(utilflag.WarnWordSepNormalizeFunc) // Warn for "_" flags
+	//flags.SetNormalizeFunc(utilflag.WarnWordSepNormalizeFunc) // Warn for "_" flags
 
 	// Normalize all flags that are coming from other packages or pre-configurations
 	// a.k.a. change all "_" to "-". e.g. glog package


### PR DESCRIPTION

**What type of PR is this?**
> /kind cleanup


**What this PR does / why we need it**:
remove duplicate setting of NormalizeFunc
```go
flags.SetNormalizeFunc(utilflag.WarnWordSepNormalizeFunc)
flags.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
