### PR TITLE
kubeadm: print the join command

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -153,6 +153,9 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 			// via the subcommands automatically created by initRunner.BindToCommand
 			err = runInit(&data, out)
 			kubeadmutil.CheckErr(err)
+
+			err = showJoinCommand(&data, out)
+			kubeadmutil.CheckErr(err)
 		},
 	}
 
@@ -397,6 +400,9 @@ func (d initData) KubeConfigDir() string {
 
 // KubeConfigPath returns the path to the kubeconfig file to use for connecting to Kubernetes
 func (d initData) KubeConfigPath() string {
+	if d.dryRun {
+		d.kubeconfigPath = filepath.Join(d.dryRunDir, kubeadmconstants.AdminKubeConfigFileName)
+	}
 	return d.kubeconfigPath
 }
 
@@ -458,18 +464,15 @@ func (d initData) Tokens() []string {
 
 // runInit executes master node provisioning
 func runInit(i *initData, out io.Writer) error {
-
 	// Get directories to write files to; can be faked if we're dry-running
 	klog.V(1).Infof("[init] Getting certificates directory from configuration")
-	certsDirToWriteTo, kubeConfigDir, _, _, err := getDirectoriesToUse(i.dryRun, i.dryRunDir, i.cfg.CertificatesDir)
+	certsDirToWriteTo, _, _, _, err := getDirectoriesToUse(i.dryRun, i.dryRunDir, i.cfg.CertificatesDir)
 	if err != nil {
 		return errors.Wrap(err, "error getting directories to use")
 	}
 
 	// certsDirToWriteTo is gonna equal cfg.CertificatesDir in the normal case, but gonna be a temp directory if dryrunning
 	i.cfg.CertificatesDir = certsDirToWriteTo
-
-	adminKubeConfigPath := filepath.Join(kubeConfigDir, kubeadmconstants.AdminKubeConfigFileName)
 
 	// TODO: client and waiter are temporary until the rest of the phases that use them
 	// are removed from this function.
@@ -526,12 +529,6 @@ func runInit(i *initData, out io.Writer) error {
 		return nil
 	}
 
-	// Prints the join command, multiple times in case the user has multiple tokens
-	for _, token := range i.Tokens() {
-		if err := printJoinCommand(out, adminKubeConfigPath, token, i.skipTokenPrint); err != nil {
-			return errors.Wrap(err, "failed to print join command")
-		}
-	}
 	return nil
 }
 
@@ -558,4 +555,18 @@ func getDirectoriesToUse(dryRun bool, dryRunDir string, defaultPkiDir string) (s
 	}
 
 	return defaultPkiDir, kubeadmconstants.KubernetesDir, kubeadmconstants.GetStaticPodDirectory(), kubeadmconstants.KubeletRunDirectory, nil
+}
+
+// showJoinCommand prints the join command after all the phases in init have finished
+func showJoinCommand(i *initData, out io.Writer) error {
+	adminKubeConfigPath := i.KubeConfigPath()
+
+	// Prints the join command, multiple times in case the user has multiple tokens
+	for _, token := range i.Tokens() {
+		if err := printJoinCommand(out, adminKubeConfigPath, token, i.skipTokenPrint); err != nil {
+			return errors.Wrap(err, "failed to print join command")
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug

 /kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
move `printJoinCommand`  out of  `runInit` and create a new function to print the join command.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref # https://github.com/kubernetes/kubeadm/issues/1163
Fixes # https://github.com/kubernetes/kubeadm/issues/1233

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
