### PR TITLE
kube-scheduler: generate certs in cluster/gce and extend e2e tests

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -511,6 +511,18 @@ function create-master-pki {
   APISERVER_CLIENT_KEY_PATH="${pki_dir}/apiserver-client.key"
   write-pki-data "${APISERVER_CLIENT_KEY}" "${APISERVER_CLIENT_KEY_PATH}"
 
+  if [[ -z "${SCHEDULER_SERVER_CERT:-}" || -z "${SCHEDULER_SERVER_KEY:-}" ]]; then
+    # TODO:  make SCHEDULER_SERVER_CERT/KEY available on GKE and remove apiserver fallback
+    SCHEDULER_SERVER_CERT="${MASTER_CERT:-${APISERVER_SERVER_CERT}}"
+    SCHEDULER_SERVER_KEY="${MASTER_KEY:-${APISERVER_SERVER_KEY}}"
+  fi
+
+  SCHEDULER_SERVER_CERT_PATH="${pki_dir}/scheduler.crt"
+  write-pki-data "${SCHEDULER_SERVER_CERT}" "${SCHEDULER_SERVER_CERT_PATH}"
+
+  SCHEDULER_SERVER_KEY_PATH="${pki_dir}/scheduler.key"
+  write-pki-data "${SCHEDULER_SERVER_KEY}" "${SCHEDULER_SERVER_KEY_PATH}"
+
   if [[ -z "${SERVICEACCOUNT_CERT:-}" || -z "${SERVICEACCOUNT_KEY:-}" ]]; then
     SERVICEACCOUNT_CERT="${MASTER_CERT}"
     SERVICEACCOUNT_KEY="${MASTER_KEY}"
@@ -2034,6 +2046,8 @@ function start-kube-scheduler {
   # Calculate variables and set them in the manifest.
   params="${SCHEDULER_TEST_LOG_LEVEL:-"--v=2"} ${SCHEDULER_TEST_ARGS:-}"
   params+=" --kubeconfig=/etc/srv/kubernetes/kube-scheduler/kubeconfig"
+  params+=" --tls-cert-file=${SCHEDULER_SERVER_CERT_PATH}"
+  params+=" --tls-private-key-file=${SCHEDULER_SERVER_KEY_PATH}"
   if [[ -n "${FEATURE_GATES:-}" ]]; then
     params+=" --feature-gates=${FEATURE_GATES}"
   fi

--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -60,24 +60,26 @@ const (
 // restartDaemonConfig is a config to restart a running daemon on a node, and wait till
 // it comes back up. It uses ssh to send a SIGTERM to the daemon.
 type restartDaemonConfig struct {
-	nodeName     string
-	daemonName   string
-	healthzPort  int
-	pollInterval time.Duration
-	pollTimeout  time.Duration
+	nodeName            string
+	daemonName          string
+	insecureHealthzPort int
+	secureHealthzPort   int
+	pollInterval        time.Duration
+	pollTimeout         time.Duration
 }
 
 // NewRestartConfig creates a restartDaemonConfig for the given node and daemon.
-func NewRestartConfig(nodeName, daemonName string, healthzPort int, pollInterval, pollTimeout time.Duration) *restartDaemonConfig {
+func NewRestartConfig(nodeName, daemonName string, insecureHealthzPort int, secureHealthzPort int, pollInterval, pollTimeout time.Duration) *restartDaemonConfig {
 	if !framework.ProviderIs("gce") {
 		framework.Logf("WARNING: SSH through the restart config might not work on %s", framework.TestContext.Provider)
 	}
 	return &restartDaemonConfig{
-		nodeName:     nodeName,
-		daemonName:   daemonName,
-		healthzPort:  healthzPort,
-		pollInterval: pollInterval,
-		pollTimeout:  pollTimeout,
+		nodeName:            nodeName,
+		daemonName:          daemonName,
+		insecureHealthzPort: insecureHealthzPort,
+		secureHealthzPort:   secureHealthzPort,
+		pollInterval:        pollInterval,
+		pollTimeout:         pollTimeout,
 	}
 }
 
@@ -85,28 +87,41 @@ func (r *restartDaemonConfig) String() string {
 	return fmt.Sprintf("Daemon %v on node %v", r.daemonName, r.nodeName)
 }
 
-// waitUp polls healthz of the daemon till it returns "ok" or the polling hits the pollTimeout
+// waitUp polls healthz of the daemon through secure or insecure port till it returns "ok" or the polling
+// hits the pollTimeout
 func (r *restartDaemonConfig) waitUp() {
 	framework.Logf("Checking if %v is up by polling for a 200 on its /healthz endpoint", r)
-	healthzCheck := fmt.Sprintf(
-		"curl -s -o /dev/null -I -w \"%%{http_code}\" http://localhost:%v/healthz", r.healthzPort)
+	var healthzChecks []string
+	if r.insecureHealthzPort != 0 {
+		healthzChecks = append(healthzChecks,
+			fmt.Sprintf("curl -s -o /dev/null -I -w \"%%{http_code}\" http://localhost:%v/healthz",
+				r.insecureHealthzPort))
+	}
+	if r.secureHealthzPort != 0 {
+		healthzChecks = append(healthzChecks,
+			fmt.Sprintf("curl -s -k -o /dev/null -I -w \"%%{http_code}\" https://localhost:%v/healthz",
+				r.secureHealthzPort))
+	}
 
-	err := wait.Poll(r.pollInterval, r.pollTimeout, func() (bool, error) {
-		result, err := framework.NodeExec(r.nodeName, healthzCheck)
-		framework.ExpectNoError(err)
-		if result.Code == 0 {
-			httpCode, err := strconv.Atoi(result.Stdout)
-			if err != nil {
-				framework.Logf("Unable to parse healthz http return code: %v", err)
-			} else if httpCode == 200 {
-				return true, nil
+	for _, healthzCheck := range healthzChecks {
+		err := wait.Poll(r.pollInterval, r.pollTimeout, func() (bool, error) {
+			result, err := framework.NodeExec(r.nodeName, healthzCheck)
+			framework.ExpectNoError(err)
+			if result.Code == 0 {
+				httpCode, err := strconv.Atoi(result.Stdout)
+				if err != nil {
+					framework.Logf("Unable to parse healthz http return code: %v", err)
+				} else if httpCode == 200 {
+					return true, nil
+				}
 			}
-		}
-		framework.Logf("node %v exec command, '%v' failed with exitcode %v: \n\tstdout: %v\n\tstderr: %v",
-			r.nodeName, healthzCheck, result.Code, result.Stdout, result.Stderr)
-		return false, nil
-	})
-	framework.ExpectNoError(err, "%v did not respond with a 200 via %v within %v", r, healthzCheck, r.pollTimeout)
+			framework.Logf("node %v exec command, '%v' failed with exitcode %v: \n\tstdout: %v\n\tstderr: %v",
+				r.nodeName, healthzCheck, result.Code, result.Stdout, result.Stderr)
+			return false, nil
+		})
+		framework.ExpectNoError(err, "%v did not respond with a 200 via %v within %v", r, healthzCheck, r.pollTimeout)
+		return
+	}
 }
 
 // kill sends a SIGTERM to the daemon
@@ -250,7 +265,7 @@ var _ = SIGDescribe("DaemonRestart [Disruptive]", func() {
 		// Requires master ssh access.
 		framework.SkipUnlessProviderIs("gce", "aws")
 		restarter := NewRestartConfig(
-			framework.GetMasterHost(), "kube-controller", ports.InsecureKubeControllerManagerPort, restartPollInterval, restartTimeout)
+			framework.GetMasterHost(), "kube-controller", ports.InsecureKubeControllerManagerPort, 0, restartPollInterval, restartTimeout)
 		restarter.restart()
 
 		// The intent is to ensure the replication controller manager has observed and reported status of
@@ -281,7 +296,7 @@ var _ = SIGDescribe("DaemonRestart [Disruptive]", func() {
 		// Requires master ssh access.
 		framework.SkipUnlessProviderIs("gce", "aws")
 		restarter := NewRestartConfig(
-			framework.GetMasterHost(), "kube-scheduler", ports.InsecureSchedulerPort, restartPollInterval, restartTimeout)
+			framework.GetMasterHost(), "kube-scheduler", ports.InsecureSchedulerPort, ports.KubeSchedulerPort, restartPollInterval, restartTimeout)
 
 		// Create pods while the scheduler is down and make sure the scheduler picks them up by
 		// scaling the rc to the same size.
@@ -304,7 +319,7 @@ var _ = SIGDescribe("DaemonRestart [Disruptive]", func() {
 		}
 		for _, ip := range nodeIPs {
 			restarter := NewRestartConfig(
-				ip, "kubelet", ports.KubeletReadOnlyPort, restartPollInterval, restartTimeout)
+				ip, "kubelet", ports.KubeletReadOnlyPort, 0, restartPollInterval, restartTimeout)
 			restarter.restart()
 		}
 		postRestarts, badNodes := getContainerRestarts(f.ClientSet, ns, labelSelector)

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -179,17 +179,18 @@ var _ = SIGDescribe("Firewall rule", func() {
 
 		masterAddresses := framework.GetAllMasterAddresses(cs)
 		for _, masterAddress := range masterAddresses {
-			assertNotReachableHTTPTimeout(masterAddress, ports.InsecureKubeControllerManagerPort, gce.FirewallTestTcpTimeout)
-			assertNotReachableHTTPTimeout(masterAddress, ports.InsecureSchedulerPort, gce.FirewallTestTcpTimeout)
+			assertNotReachableHTTPTimeout(masterAddress, ports.InsecureKubeControllerManagerPort, gce.FirewallTestTcpTimeout, false)
+			assertNotReachableHTTPTimeout(masterAddress, ports.InsecureSchedulerPort, gce.FirewallTestTcpTimeout, false)
+			assertNotReachableHTTPTimeout(masterAddress, ports.KubeSchedulerPort, gce.FirewallTestTcpTimeout, true)
 		}
-		assertNotReachableHTTPTimeout(nodeAddrs[0], ports.KubeletPort, gce.FirewallTestTcpTimeout)
-		assertNotReachableHTTPTimeout(nodeAddrs[0], ports.KubeletReadOnlyPort, gce.FirewallTestTcpTimeout)
-		assertNotReachableHTTPTimeout(nodeAddrs[0], ports.ProxyStatusPort, gce.FirewallTestTcpTimeout)
+		assertNotReachableHTTPTimeout(nodeAddrs[0], ports.KubeletPort, gce.FirewallTestTcpTimeout, false)
+		assertNotReachableHTTPTimeout(nodeAddrs[0], ports.KubeletReadOnlyPort, gce.FirewallTestTcpTimeout, false)
+		assertNotReachableHTTPTimeout(nodeAddrs[0], ports.ProxyStatusPort, gce.FirewallTestTcpTimeout, false)
 	})
 })
 
-func assertNotReachableHTTPTimeout(ip string, port int, timeout time.Duration) {
-	unreachable, err := framework.TestNotReachableHTTPTimeout(ip, port, timeout)
+func assertNotReachableHTTPTimeout(ip string, port int, timeout time.Duration, isSecure bool) {
+	unreachable, err := framework.TestNotReachableHTTPTimeout(ip, port, timeout, isSecure)
 	if err != nil {
 		framework.Failf("Unexpected error checking for reachability of %s:%d: %v", ip, port, err)
 	}


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/kubernetes/pull/69663 with the changes against the gce e2e tests.

Only last commit is new (note: Github orders them wrongly. The one with "kube-scheduler: add secure serving e2e test" is the real last one).