### PR TITLE
DeltaFIFO cleanup

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -320,17 +320,15 @@ func (f *DeltaFIFO) queueActionLocked(actionType DeltaType, obj interface{}) err
 	newDeltas := append(f.items[id], Delta{actionType, obj})
 	newDeltas = dedupDeltas(newDeltas)
 
-	_, exists := f.items[id]
 	if len(newDeltas) > 0 {
-		if !exists {
+		if _, exists := f.items[id]; !exists {
 			f.queue = append(f.queue, id)
 		}
 		f.items[id] = newDeltas
 		f.cond.Broadcast()
-	} else if exists {
-		// We need to remove this from our map (extra items
-		// in the queue are ignored if they are not in the
-		// map).
+	} else {
+		// We need to remove this from our map (extra items in the queue are
+		// ignored if they are not in the map).
 		delete(f.items, id)
 	}
 	return nil
@@ -348,9 +346,6 @@ func (f *DeltaFIFO) List() []interface{} {
 func (f *DeltaFIFO) listLocked() []interface{} {
 	list := make([]interface{}, 0, len(f.items))
 	for _, item := range f.items {
-		// Copy item's slice so operations on this slice
-		// won't interfere with the object we return.
-		item = copyDeltas(item)
 		list = append(list, item.Newest().Object)
 	}
 	return list
@@ -398,10 +393,7 @@ func (f *DeltaFIFO) GetByKey(key string) (item interface{}, exists bool, err err
 func (f *DeltaFIFO) IsClosed() bool {
 	f.closedLock.Lock()
 	defer f.closedLock.Unlock()
-	if f.closed {
-		return true
-	}
-	return false
+	return f.closed
 }
 
 // Pop blocks until an item is added to the queue, and then returns it.  If
@@ -432,10 +424,10 @@ func (f *DeltaFIFO) Pop(process PopProcessFunc) (interface{}, error) {
 		}
 		id := f.queue[0]
 		f.queue = f.queue[1:]
-		item, ok := f.items[id]
 		if f.initialPopulationCount > 0 {
 			f.initialPopulationCount--
 		}
+		item, ok := f.items[id]
 		if !ok {
 			// Item may have been deleted subsequently.
 			continue


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig api-machinery

**What this PR does / why we need it**:
It does a clean up of some parts of the `DeltaFIFO` code:

1. A conditional that could never happen was being considered. This case checks for 0-length slices of Deltas. This slice is formed by adding a Delta to a previous slice, so it will always have at least one. After that the slice is deduped, but this method will never reduce the length to zero unless it was already zero. The behavior for zero length arrays is kept as a comment in case this can happen in the future.
EDIT: this change has been removed from this PR as a case where this could be possible was shown by @lavalamp. Instead some cleanup has been made in the same part: the else condition is not needed as delete is a no-op for non-existing keys.
2. A swallow copy of a slice is being done to instantly get the last element, thus making the copy useless. Issue #70751 tracks if a deep copy is needed, what would require a fix, but this PR keeps the current behavior.
3. Return the closed attribute directly instead of checking it and then returning a constant.
4. Reorder a counter decrease to stay near the element extraction

**Special notes for your reviewer**:
The first and last ones are mostly syntactic sugar, but the middle one should slightly improve the performance.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```