### PR TITLE
Add lookupOnly flag to Windows CNI ADDs that are done for status.

### DIFF
--- a/pkg/kubelet/dockershim/network/cni/cni.go
+++ b/pkg/kubelet/dockershim/network/cni/cni.go
@@ -416,5 +416,12 @@ func (plugin *cniNetworkPlugin) buildCNIRuntimeConf(podName string, podNs string
 		}
 	}
 
+	// On Windows, kubelet needs a way to look up the pod IP but the HNS API doesn't expose a way
+	// to do that.  Until we have CNI CHECK, expose a flag to let the CNI plugin know not to
+	// re-network the pod.
+	if options["lookupOnly"] == "true" {
+		rt.CapabilityArgs["lookupOnly"] = true
+	}
+
 	return rt, nil
 }

--- a/pkg/kubelet/dockershim/network/cni/cni_windows.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_windows.go
@@ -43,7 +43,13 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 		return nil, fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
 	}
 
-	result, err := plugin.addToNetwork(plugin.getDefaultNetwork(), name, namespace, id, netnsPath, nil, nil)
+	// For CNI plugins that support it, flag that, even if the pod has not been networked, we only want the CNI
+	// plugin to do a lookup.  This avoids re-networking a pod that we're currently deleting.
+	// TODO Once it's supported, we could use CNI CHECK here.
+	// TODO Once it's supported, we can switch to HNS namespace lookup here.
+	options := map[string]string{"lookupOnly": "true"}
+	result, err := plugin.addToNetwork(plugin.getDefaultNetwork(), name, namespace, id, netnsPath, nil,
+		options)
 
 	glog.V(5).Infof("GetPodNetworkStatus result %+v", result)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

On Windows, we currently call CNI ADD from `GetPodNetworkStatus()`; this can race with a pod deletion resulting re-networking a pod that is being torn down.  This PR adds an opt-in hint to the CNI plugin to tell it _not_ to re-network the pod for this request.

Longer-term the Microsoft team are planning a replacement API that will remove the need for the repeat CNI ADD hack: https://github.com/Microsoft/hcsshim/pull/361#issuecomment-436401633 but it's not ready yet.  

This PR aims to maintain the existing shape of the hack with minimal changes to solve the race.

The alternative approach here: https://github.com/kubernetes/kubernetes/pull/70482 stalled because it needs a tweak to the HCSShim API, which conflicts with the longer-term plan.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #70279

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
