### PR TITLE
Fix a CloudProvider-vs-nodeIP edge case

### DIFF
--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -90,17 +90,16 @@ func NodeAddress(nodeIP net.IP, // typically Kubelet.nodeIP
 			if nodeIP != nil {
 				enforcedNodeAddresses := []v1.NodeAddress{}
 
-				var nodeIPType v1.NodeAddressType
+				nodeIPTypes := make(map[v1.NodeAddressType]bool)
 				for _, nodeAddress := range nodeAddresses {
 					if nodeAddress.Address == nodeIP.String() {
 						enforcedNodeAddresses = append(enforcedNodeAddresses, v1.NodeAddress{Type: nodeAddress.Type, Address: nodeAddress.Address})
-						nodeIPType = nodeAddress.Type
-						break
+						nodeIPTypes[nodeAddress.Type] = true
 					}
 				}
 				if len(enforcedNodeAddresses) > 0 {
 					for _, nodeAddress := range nodeAddresses {
-						if nodeAddress.Type != nodeIPType && nodeAddress.Type != v1.NodeHostName {
+						if !nodeIPTypes[nodeAddress.Type] && nodeAddress.Type != v1.NodeHostName {
 							enforcedNodeAddresses = append(enforcedNodeAddresses, v1.NodeAddress{Type: nodeAddress.Type, Address: nodeAddress.Address})
 						}
 					}

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -94,6 +94,8 @@ func TestNodeAddress(t *testing.T) {
 			name:   "InternalIP and ExternalIP are the same",
 			nodeIP: net.ParseIP("55.55.55.55"),
 			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "44.44.44.44"},
+				{Type: v1.NodeExternalIP, Address: "44.44.44.44"},
 				{Type: v1.NodeInternalIP, Address: "55.55.55.55"},
 				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
 				{Type: v1.NodeHostName, Address: testKubeletHostname},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In #49202 @cbonte fixed the case where nodeIP was set and the CloudProvider returned both an InternalIP and an ExternalIP matching that IP (which vSphere does), but it broke CloudProviders that returned address types *other* than InternalIP and ExternalIP (or that returned a different InternalIP and ExternalIP).

In #63170, @micahhausler fixed the non-vSphere case, but re-broke the vSphere case in a way that wasn't caught by the existing unit test; specifically, if the node has multiple IPs, and the one matching the kubelet nodeIP isn't first in the list, then kubelet will now end up picking a mismatched pair of InternalIP and ExternalIP (and specifically, if the node has secondary IP addresses on its primary network interface, then one of them might get picked as the InternalIP rather than always picking the nodeIP as the InternalIP).

I believe this patch should fix that without breaking anything else.

**Which issue(s) this PR fixes**:
(none; downstream bug is https://bugzilla.redhat.com/show_bug.cgi?id=1643348)

**Special notes for your reviewer**:
I debated using `sets.String` but then you have to cast the `v1.NodeAddressType`s to `string` and it was messy...

**Does this PR introduce a user-facing change?**:
```release-note
Fixes the setting of NodeAddresses when using the vSphere CloudProvider and nodes that have multiple IP addresses.
```
