### PR TITLE
kubectl convert: add deprecation warning for 1.13

### DIFF
--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -134,6 +134,14 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) (err er
 
 // RunConvert implements the generic Convert command
 func (o *ConvertOptions) RunConvert() error {
+
+	// Convert must be removed from kubectl, since kubectl can not depend on
+	// Kubernetes "internal" dependencies. These "internal" dependencies can
+	// not be removed from convert. Another way to convert a resource is to
+	// "kubectl apply" it to the cluster, then "kubectl get" at the desired version.
+	// Another possible solution is to make convert a plugin.
+	fmt.Fprintf(o.ErrOut, "kubectl convert is DEPRECATED and will be removed in a future version.\nIn order to convert, kubectl apply the object to the cluster, then kubectl get at the desired version.\n")
+
 	b := o.builder().
 		WithScheme(scheme.Scheme).
 		LocalParam(o.local)


### PR DESCRIPTION
* Adds deprecation warning for `kubectl convert`

```release-note
In a future release the kubectl convert command will be deprecated.
```

/sig cli
/are kubectl
/kind cleanup
/assign