### PR TITLE
Fix volumes e2e test to check fsType

### DIFF
--- a/pkg/volume/awsebs/aws_util.go
+++ b/pkg/volume/awsebs/aws_util.go
@@ -120,8 +120,10 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner, node *
 	}
 
 	fstype := ""
-	if v, ok := c.options.Parameters[volume.VolumeParameterFSType]; ok {
-		fstype = v
+	for k, v := range c.options.Parameters {
+		if strings.ToLower(k) == volume.VolumeParameterFSType {
+			fstype = v
+		}
 	}
 
 	return name, volumeOptions.CapacityGB, labels, fstype, nil

--- a/test/e2e/common/volumes.go
+++ b/test/e2e/common/volumes.go
@@ -91,7 +91,7 @@ var _ = Describe("[sig-storage] GCP Volumes", func() {
 			}
 
 			// Must match content of test/images/volumes-tester/nfs/index.html
-			framework.TestVolumeClient(c, config, nil, tests)
+			framework.TestVolumeClient(c, config, nil, "" /* fsType */, tests)
 		})
 	})
 
@@ -114,7 +114,7 @@ var _ = Describe("[sig-storage] GCP Volumes", func() {
 				},
 			}
 			// Must match content of test/images/volume-tester/nfs/index.html
-			framework.TestVolumeClient(c, config, nil, tests)
+			framework.TestVolumeClient(c, config, nil, "" /* fsType */, tests)
 		})
 	})
 
@@ -147,7 +147,7 @@ var _ = Describe("[sig-storage] GCP Volumes", func() {
 					ExpectedContent: "Hello from GlusterFS!",
 				},
 			}
-			framework.TestVolumeClient(c, config, nil, tests)
+			framework.TestVolumeClient(c, config, nil, "" /* fsType */, tests)
 		})
 	})
 })

--- a/test/e2e/framework/volume_util.go
+++ b/test/e2e/framework/volume_util.go
@@ -479,7 +479,7 @@ func TestVolumeClient(client clientset.Interface, config VolumeTestConfig, fsGro
 
 	if fsType != "" {
 		By("Checking fsType is correct.")
-		_, err = LookForStringInPodExec(config.Namespace, clientPod.Name, []string{"grep", fmt.Sprintf(" /opt/0 %s", fsType), "/proc/mounts"}, fsType, time.Minute)
+		_, err = LookForStringInPodExec(config.Namespace, clientPod.Name, []string{"grep", " /opt/0 ", "/proc/mounts"}, fsType, time.Minute)
 		Expect(err).NotTo(HaveOccurred(), "failed: getting the right fsType %s", fsType)
 	}
 }

--- a/test/e2e/framework/volume_util.go
+++ b/test/e2e/framework/volume_util.go
@@ -401,7 +401,7 @@ func VolumeTestCleanup(f *Framework, config VolumeTestConfig) {
 // and check that the pod sees expected data, e.g. from the server pod.
 // Multiple VolumeTests can be specified to mount multiple volumes to a single
 // pod.
-func TestVolumeClient(client clientset.Interface, config VolumeTestConfig, fsGroup *int64, tests []VolumeTest) {
+func TestVolumeClient(client clientset.Interface, config VolumeTestConfig, fsGroup *int64, fsType string, tests []VolumeTest) {
 	By(fmt.Sprint("starting ", config.Prefix, " client"))
 	var gracePeriod int64 = 1
 	clientPod := &v1.Pod{
@@ -475,6 +475,12 @@ func TestVolumeClient(client clientset.Interface, config VolumeTestConfig, fsGro
 		By("Checking fsGroup is correct.")
 		_, err = LookForStringInPodExec(config.Namespace, clientPod.Name, []string{"ls", "-ld", "/opt/0"}, strconv.Itoa(int(*fsGroup)), time.Minute)
 		Expect(err).NotTo(HaveOccurred(), "failed: getting the right privileges in the file %v", int(*fsGroup))
+	}
+
+	if fsType != "" {
+		By("Checking fsType is correct.")
+		_, err = LookForStringInPodExec(config.Namespace, clientPod.Name, []string{"grep", fmt.Sprintf(" /opt/0 %s", fsType), "/proc/mounts"}, fsType, time.Minute)
+		Expect(err).NotTo(HaveOccurred(), "failed: getting the right fsType %s", fsType)
 	}
 }
 

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -312,6 +312,9 @@ func (g *gcePDCSIDriver) GetDynamicProvisionStorageClass(fsType string) *storage
 	suffix := fmt.Sprintf("%s-sc", g.driverInfo.Name)
 
 	parameters := map[string]string{"type": "pd-standard"}
+	if fsType != "" {
+		parameters["fsType"] = fsType
+	}
 
 	return testsuites.GetStorageClass(provisioner, parameters, nil, ns, suffix)
 }
@@ -412,6 +415,9 @@ func (g *gcePDExternalCSIDriver) GetDynamicProvisionStorageClass(fsType string) 
 	suffix := fmt.Sprintf("%s-sc", g.driverInfo.Name)
 
 	parameters := map[string]string{"type": "pd-standard"}
+	if fsType != "" {
+		parameters["fsType"] = fsType
+	}
 
 	return testsuites.GetStorageClass(provisioner, parameters, nil, ns, suffix)
 }

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -316,7 +316,7 @@ func (g *gcePDCSIDriver) GetDynamicProvisionStorageClass(fsType string) *storage
 
 	parameters := map[string]string{"type": "pd-standard"}
 	if fsType != "" {
-		parameters["fsType"] = fsType
+		parameters["csi.storage.k8s.io/fstype"] = fsType
 	}
 
 	return testsuites.GetStorageClass(provisioner, parameters, nil, ns, suffix)
@@ -422,7 +422,7 @@ func (g *gcePDExternalCSIDriver) GetDynamicProvisionStorageClass(fsType string) 
 
 	parameters := map[string]string{"type": "pd-standard"}
 	if fsType != "" {
-		parameters["fsType"] = fsType
+		parameters["csi.storage.k8s.io/fstype"] = fsType
 	}
 
 	return testsuites.GetStorageClass(provisioner, parameters, nil, ns, suffix)

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -304,6 +304,9 @@ func (g *gcePDCSIDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 		// tests to fail.
 		framework.SkipIfMultizone(f.ClientSet)
 	}
+	if pattern.FsType == "xfs" {
+		framework.SkipUnlessNodeOSDistroIs("ubuntu", "custom")
+	}
 }
 
 func (g *gcePDCSIDriver) GetDynamicProvisionStorageClass(fsType string) *storagev1.StorageClass {
@@ -407,6 +410,9 @@ func (g *gcePDExternalCSIDriver) GetDriverInfo() *testsuites.DriverInfo {
 func (g *gcePDExternalCSIDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 	framework.SkipUnlessProviderIs("gce", "gke")
 	framework.SkipIfMultizone(g.driverInfo.Config.Framework.ClientSet)
+	if pattern.FsType == "xfs" {
+		framework.SkipUnlessNodeOSDistroIs("ubuntu", "custom")
+	}
 }
 
 func (g *gcePDExternalCSIDriver) GetDynamicProvisionStorageClass(fsType string) *storagev1.StorageClass {

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -259,9 +259,6 @@ func (g *glusterFSDriver) GetDriverInfo() *testsuites.DriverInfo {
 
 func (g *glusterFSDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 	framework.SkipUnlessNodeOSDistroIs("gci", "ubuntu", "custom")
-	if pattern.FsType == "xfs" {
-		framework.SkipUnlessNodeOSDistroIs("ubuntu", "custom")
-	}
 }
 
 func (g *glusterFSDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
@@ -1178,9 +1175,6 @@ func (g *gcePdDriver) GetDriverInfo() *testsuites.DriverInfo {
 
 func (g *gcePdDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 	framework.SkipUnlessProviderIs("gce", "gke")
-	if pattern.FsType == "xfs" {
-		framework.SkipUnlessNodeOSDistroIs("ubuntu", "custom")
-	}
 }
 
 func (g *gcePdDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {

--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -63,7 +63,7 @@ func testFlexVolume(driver string, cs clientset.Interface, config framework.Volu
 			ExpectedContent: "Hello from flexvolume!",
 		},
 	}
-	framework.TestVolumeClient(cs, config, nil, tests)
+	framework.TestVolumeClient(cs, config, nil, "" /* fsType */, tests)
 
 	framework.VolumeTestCleanup(f, config)
 }

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -80,7 +80,7 @@ func RunTestSuite(f *framework.Framework, driver TestDriver, tsInits []func() Te
 // is not suitable to be tested.
 // Whether it needs to be skipped is checked by following steps:
 // 1. Check if Whether volType is supported by driver from its interface
-// 2. Check if fsType is supported by driver
+// 2. Check if fsType is supported
 // 3. Check with driver specific logic
 // 4. Check with testSuite specific logic
 func skipUnsupportedTest(suite TestSuite, driver TestDriver, pattern testpatterns.TestPattern) {
@@ -103,9 +103,12 @@ func skipUnsupportedTest(suite TestSuite, driver TestDriver, pattern testpattern
 		framework.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolType)
 	}
 
-	// 2. Check if fsType is supported by driver
+	// 2. Check if fsType is supported
 	if !dInfo.SupportedFsType.Has(pattern.FsType) {
 		framework.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.FsType)
+	}
+	if pattern.FsType == "xfs" && framework.NodeOSDistroIs("gci") {
+		framework.Skipf("Distro doesn't support xfs -- skipping")
 	}
 
 	// 3. Check with driver specific logic

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -111,6 +111,7 @@ func createVolumesTestInput(pattern testpatterns.TestPattern, resource genericVo
 		config:   &dInfo.Config,
 		fsGroup:  fsGroup,
 		resource: resource,
+		fsType:   pattern.FsType,
 		tests: []framework.VolumeTest{
 			{
 				Volume: *volSource,
@@ -160,6 +161,7 @@ type volumesTestInput struct {
 	name     string
 	config   *TestConfig
 	fsGroup  *int64
+	fsType   string
 	tests    []framework.VolumeTest
 	resource genericVolumeTestResource
 }
@@ -175,7 +177,7 @@ func testVolumes(input *volumesTestInput) {
 		volumeTest := input.tests
 		config := convertTestConfig(input.config)
 		framework.InjectHtml(cs, config, volumeTest[0].Volume, volumeTest[0].ExpectedContent)
-		framework.TestVolumeClient(cs, config, input.fsGroup, input.tests)
+		framework.TestVolumeClient(cs, config, input.fsGroup, input.fsType, input.tests)
 	})
 	It("should allow exec of files on the volume", func() {
 		f := input.f

--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -106,7 +106,7 @@ var _ = utils.SIGDescribe("Volumes", func() {
 					ExpectedContent: "this is the second file",
 				},
 			}
-			framework.TestVolumeClient(cs, config, nil, tests)
+			framework.TestVolumeClient(cs, config, nil, "" /* fsType */, tests)
 		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
Volumes test doesn't check fsType, as a result, e2e test which requires particular fsType could pass even when driver doesn't provide the right fsType. Also, current ```gcePDCSIDriver.GetDynamicProvisionStorageClass``` in e2e test code is broken, so this PR will also fix it.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #70822

**Special notes for your reviewer**:
/sig storage

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
