### PR TITLE
Revert "Hold mutex lock shorter when processing inter-pod affinity/anti-affin…"

### DIFF
--- a/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -92,13 +92,15 @@ func (p *podAffinityPriorityMap) processTerm(term *v1.PodAffinityTerm, podDefini
 	}
 	match := priorityutil.PodMatchesTermsNamespaceAndSelector(podToCheck, namespaces, selector)
 	if match {
-		for _, node := range p.nodes {
-			if priorityutil.NodesHaveSameTopologyKey(node, fixedNode, term.TopologyKey) {
-				p.Lock()
-				p.counts[node.Name] += weight
-				p.Unlock()
+		func() {
+			p.Lock()
+			defer p.Unlock()
+			for _, node := range p.nodes {
+				if priorityutil.NodesHaveSameTopologyKey(node, fixedNode, term.TopologyKey) {
+					p.counts[node.Name] += weight
+				}
 			}
-		}
+		}()
 	}
 }
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#70605

Given the increase in the number of locking/unlocking and recent scalability failures starting at the same time that this PR got merged, we suspect it could cause slow down. Reverting for now. We may revisit this again.

```release-note
NONE
```

/sig scheduling
xref #70708