### PR TITLE
[WIP] runtime/serializer: use DisallowUnknownFields for the json-iter config

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -113,6 +113,7 @@ func CaseSensitiveJsonIterator() jsoniter.API {
 		SortMapKeys:            true,
 		ValidateJsonRawMessage: true,
 		CaseSensitive:          true,
+		DisallowUnknownFields:  true,
 	}.Froze()
 	// Force jsoniter to decode number to interface{} via int64/float64, if possible.
 	config.RegisterExtension(&customNumberExtension{})


### PR DESCRIPTION
**TEST PR - DO NOT MERGE**

@dims 
we are now using the k-sigs/yaml repo, but a number of locations call yaml.Unmarshal instead of yaml.UnmarshalStrict.
we can potentially enumerate those locations and see what can be changed?

kubeadm on the other hand is using codecs for unmarshaling, which goes deep into apimachinery where instead of k-sigs/yaml it's using the json-iter library instead of k-sigs/yaml 's yaml.Unmarshal() or encoding/json.

@timothysc if we want to support checks for unknown fields we either have to try to pre-process a configuration file using k-sigs/yaml or a change like the one in this PR has to go into apimachinery.
...the change in this PR seems quite hazardous.

i'm just sending this PR to see how many tests would break.
cc @kubernetes/sig-api-machinery-pr-reviews 
cc @kubernetes/sig-cluster-lifecycle-pr-reviews 
cc @thockin @ash2k 

xref https://github.com/kubernetes/kubeadm/issues/1066
