### PR TITLE
combine syncs in rootcacertpublisher

### DIFF
--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -143,7 +143,6 @@ func startRootCACertPublisher(ctx ControllerContext) (http.Handler, bool, error)
 
 	sac, err := rootcacertpublisher.NewPublisher(
 		ctx.InformerFactory.Core().V1().ConfigMaps(),
-		ctx.InformerFactory.Core().V1().Namespaces(),
 		ctx.ClientBuilder.ClientOrDie("root-ca-cert-publisher"),
 		rootCA,
 	)

--- a/pkg/controller/certificates/rootcacertpublisher/BUILD
+++ b/pkg/controller/certificates/rootcacertpublisher/BUILD
@@ -44,8 +44,8 @@ go_test(
         "//pkg/controller:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
-        "//staging/src/k8s.io/client-go/testing:go_default_library",
     ],
 )


### PR DESCRIPTION
Everything should just trigger a namespace sync, and a namespace sync should reapply or create the configmap. Added some misc cleanup too.

/kind cleanup
/sig auth

```release-note
NONE
```
