### PR TITLE
GlusterFS: Move GetVolumeName() to unimplemented func.

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -106,30 +106,7 @@ func (plugin *glusterfsPlugin) GetPluginName() string {
 }
 
 func (plugin *glusterfsPlugin) GetVolumeName(spec *volume.Spec) (string, error) {
-	var endpointName string
-	var endpointsNsPtr *string
-
-	volPath, _, err := getVolumeInfo(spec)
-	if err != nil {
-		return "", err
-	}
-
-	if spec.Volume != nil && spec.Volume.Glusterfs != nil {
-		endpointName = spec.Volume.Glusterfs.EndpointsName
-	} else if spec.PersistentVolume != nil &&
-		spec.PersistentVolume.Spec.Glusterfs != nil {
-		endpointName = spec.PersistentVolume.Spec.Glusterfs.EndpointsName
-		endpointsNsPtr = spec.PersistentVolume.Spec.Glusterfs.EndpointsNamespace
-		if endpointsNsPtr != nil && *endpointsNsPtr != "" {
-			return fmt.Sprintf("%v:%v:%v", endpointName, *endpointsNsPtr, volPath), nil
-		}
-		return "", fmt.Errorf("invalid endpointsnamespace in provided glusterfs PV spec")
-
-	} else {
-		return "", fmt.Errorf("unable to fetch required parameters from provided glusterfs spec")
-	}
-
-	return fmt.Sprintf("%v:%v", endpointName, volPath), nil
+	return "", fmt.Errorf("GetVolumeName() is unimplemented for GlusterFS")
 }
 
 func (plugin *glusterfsPlugin) CanSupport(spec *volume.Spec) bool {


### PR DESCRIPTION
GetVolumeName() is used in a few places, all of which are not applicable to gluster:

    AD controller
    kubelet volume manager actual/desired sw for attachable volumes
    volume reconstruction

This is a followup PR based on comment#
https://github.com/kubernetes/kubernetes/pull/60195#discussion_r231675596

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note

```
