### PR TITLE
iptables reset text message

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -27,10 +27,9 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
 	kubeadmapiv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
@@ -166,6 +165,7 @@ func (r *Reset) Run(out io.Writer, client clientset.Interface) error {
 	if err := removeContainers(utilsexec.New(), r.criSocketPath); err != nil {
 		klog.Errorf("[reset] failed to remove containers: %+v", err)
 	}
+
 	dirsToClean = append(dirsToClean, []string{kubeadmconstants.KubeletRunDirectory, "/etc/cni/net.d", "/var/lib/dockershim", "/var/run/kubernetes"}...)
 
 	// Then clean contents from the stateful kubelet, etcd and cni directories
@@ -181,6 +181,18 @@ func (r *Reset) Run(out io.Writer, client clientset.Interface) error {
 		klog.Warningf("[reset] WARNING: cleaning a non-default certificates directory: %q\n", r.certsDir)
 	}
 	resetConfigDir(kubeadmconstants.KubernetesDir, r.certsDir)
+
+	// Output help text instructing user how to remove iptables rules
+	msg := `
+	The reset process does not reset or clean up iptables rules or IPVS tables.
+	If you wish to reset iptables, you must do so manually.
+	For example: 
+	iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X
+
+	If your cluster was setup to utilize IPVS, run ipvsadm --clear (or similar)
+	to reset your system's IPVS tables.
+	`
+	fmt.Print(msg)
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Ruben Orduz <rubenoz@gmail.com>

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Presently `kubeadm reset` does not delete or clean up iptables rules. The way components are separated and decoupled makes a programmatic solution rather cumbersome. Thus, it was agreed to expand the reset console output to include  instructions how a user might want to reset their iptables.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [#689](https://github.com/kubernetes/kubeadm/issues/689)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
YES 
-->
```release-note
`kubeadm reset` now outputs instructions about manual iptables rules cleanup.
```
