### PR TITLE
kubeadm: Adds tests to node patching

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/BUILD
+++ b/cmd/kubeadm/app/util/apiclient/BUILD
@@ -62,14 +62,17 @@ go_test(
     name = "go_default_test",
     srcs = [
         "dryrunclient_test.go",
+        "idempotency_test.go",
         "init_dryrun_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/kubelet/apis:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/util/apiclient/idempotency_test.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/kubeadm/app/util/apiclient/idempotency_test.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiclient_test
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
+)
+
+func TestPatchNodeNonErrorCases(t *testing.T) {
+	testcases := []struct {
+		name       string
+		lookupName string
+		node       v1.Node
+		success    bool
+	}{
+		{
+			name:       "simple update",
+			lookupName: "testnode",
+			node: v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "testnode",
+					Labels: map[string]string{kubeletapis.LabelHostname: ""},
+				},
+			},
+			success: true,
+		},
+		{
+			name:       "node does not exist",
+			lookupName: "whale",
+			success:    false,
+		},
+		{
+			name:       "node not labelled yet",
+			lookupName: "robin",
+			node: v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "robin",
+				},
+			},
+			success: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			_, err := client.Core().Nodes().Create(&tc.node)
+			if err != nil {
+				t.Fatalf("failed to create node to fake client: %v", err)
+			}
+			conditionFunction := apiclient.PatchNodeOnce(client, tc.lookupName, func(node *v1.Node) {
+				node.Name = "testNewNode"
+			})
+			success, err := conditionFunction()
+			if err != nil {
+				t.Fatalf("did not expect error: %v", err)
+			}
+			if success != tc.success {
+				t.Fatalf("expected %v got %v", tc.success, success)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds tests to a function that has none but will likely need to change.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
It's related to kubernetes/kubeadm#937

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 