### PR TITLE
add a metric that can be used to notice stuck worker threads

### DIFF
--- a/pkg/util/workqueue/prometheus/prometheus.go
+++ b/pkg/util/workqueue/prometheus/prometheus.go
@@ -71,6 +71,16 @@ func (prometheusMetricsProvider) NewWorkDurationMetric(name string) workqueue.Su
 	return workDuration
 }
 
+func (prometheusMetricsProvider) NewUnfinishedWorkMicrosecondsMetric(name string) workqueue.SettableGaugeMetric {
+	unfinished := prometheus.NewGauge(prometheus.GaugeOpts{
+		Subsystem: name,
+		Name:      "unfinished_work_microseconds",
+		Help:      "How many microseconds of work has " + name + " done that is still in progress and hasn't yet been observed by work_duration.",
+	})
+	prometheus.Register(unfinished)
+	return unfinished
+}
+
 func (prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
 	retries := prometheus.NewCounter(prometheus.CounterOpts{
 		Subsystem: name,

--- a/pkg/util/workqueue/prometheus/prometheus.go
+++ b/pkg/util/workqueue/prometheus/prometheus.go
@@ -71,11 +71,14 @@ func (prometheusMetricsProvider) NewWorkDurationMetric(name string) workqueue.Su
 	return workDuration
 }
 
-func (prometheusMetricsProvider) NewUnfinishedWorkMicrosecondsMetric(name string) workqueue.SettableGaugeMetric {
+func (prometheusMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
 	unfinished := prometheus.NewGauge(prometheus.GaugeOpts{
 		Subsystem: name,
-		Name:      "unfinished_work_microseconds",
-		Help:      "How many microseconds of work has " + name + " done that is still in progress and hasn't yet been observed by work_duration.",
+		Name:      "unfinished_work_seconds",
+		Help: "How many seconds of work " + name + " has done that " +
+			"is in progress and hasn't been observed by work_duration. Large " +
+			"values indicate stuck threads. One can deduce the number of stuck " +
+			"threads by observing the rate at which this increases.",
 	})
 	prometheus.Register(unfinished)
 	return unfinished

--- a/pkg/util/workqueue/prometheus/prometheus.go
+++ b/pkg/util/workqueue/prometheus/prometheus.go
@@ -87,7 +87,7 @@ func (prometheusMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) wor
 func (prometheusMetricsProvider) NewLongestRunningProcessorMicrosecondsMetric(name string) workqueue.SettableGaugeMetric {
 	unfinished := prometheus.NewGauge(prometheus.GaugeOpts{
 		Subsystem: name,
-		Name:      "longest_running_procesor_microseconds",
+		Name:      "longest_running_processor_microseconds",
 		Help: "How many microseconds has the longest running " +
 			"processor for " + name + " been running.",
 	})

--- a/pkg/util/workqueue/prometheus/prometheus.go
+++ b/pkg/util/workqueue/prometheus/prometheus.go
@@ -84,6 +84,17 @@ func (prometheusMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) wor
 	return unfinished
 }
 
+func (prometheusMetricsProvider) NewLongestRunningProcessorMicrosecondsMetric(name string) workqueue.SettableGaugeMetric {
+	unfinished := prometheus.NewGauge(prometheus.GaugeOpts{
+		Subsystem: name,
+		Name:      "longest_running_procesor_microseconds",
+		Help: "How many microseconds has the longest running " +
+			"processor for " + name + " been running.",
+	})
+	prometheus.Register(unfinished)
+	return unfinished
+}
+
 func (prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
 	retries := prometheus.NewCounter(prometheus.CounterOpts{
 		Subsystem: name,

--- a/staging/src/k8s.io/client-go/util/workqueue/BUILD
+++ b/staging/src/k8s.io/client-go/util/workqueue/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = [
         "default_rate_limiters_test.go",
         "delaying_queue_test.go",
+        "metrics_test.go",
         "queue_test.go",
         "rate_limitting_queue_test.go",
     ],

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -94,6 +94,7 @@ type testMetricsProvider struct {
 	latency    testMetric
 	duration   testMetric
 	unfinished testMetric
+	longest    testMetric
 	retries    testMetric
 }
 
@@ -115,6 +116,10 @@ func (m *testMetricsProvider) NewWorkDurationMetric(name string) SummaryMetric {
 
 func (m *testMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric {
 	return &m.unfinished
+}
+
+func (m *testMetricsProvider) NewLongestRunningProcessorMicrosecondsMetric(name string) SettableGaugeMetric {
+	return &m.longest
 }
 
 func (m *testMetricsProvider) NewRetriesMetric(name string) CounterMetric {
@@ -230,6 +235,9 @@ func TestMetrics(t *testing.T) {
 	<-ch
 	mp.unfinished.notifyCh = nil
 	if e, a := .001, mp.unfinished.gaugeValue(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := 1000.0, mp.longest.gaugeValue(); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -19,6 +19,8 @@ package workqueue
 import (
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
 )
 
 type testMetrics struct {
@@ -32,18 +34,211 @@ func (m *testMetrics) get(item t)            { m.gotten++ }
 func (m *testMetrics) done(item t)           { m.finished++ }
 func (m *testMetrics) updateUnfinishedWork() { m.updateCalled <- struct{}{} }
 
-func TestMetrics(t *testing.T) {
+func TestMetricShutdown(t *testing.T) {
 	ch := make(chan struct{})
 	m := &testMetrics{
 		updateCalled: ch,
 	}
-	q := newQueue("test", m, time.Millisecond)
+	c := clock.NewFakeClock(time.Now())
+	q := newQueue(c, m, time.Millisecond)
+	for !c.HasWaiters() {
+		// Wait for the go routine to call NewTicker()
+		time.Sleep(time.Millisecond)
+	}
+
+	c.Step(time.Millisecond)
 	<-ch
 	q.ShutDown()
+
+	c.Step(time.Hour)
 	select {
-	case <-time.After(time.Second):
+	default:
 		return
 	case <-ch:
 		t.Errorf("Unexpected update after shutdown was called.")
+	}
+}
+
+type testMetric struct {
+	inc int64
+	dec int64
+	set float64
+
+	observedValue float64
+	observedCount int
+
+	notifyCh chan<- struct{}
+}
+
+func (m *testMetric) Inc()              { m.inc++; m.notify() }
+func (m *testMetric) Dec()              { m.dec++; m.notify() }
+func (m *testMetric) Set(f float64)     { m.set = f; m.notify() }
+func (m *testMetric) Observe(f float64) { m.observedValue = f; m.observedCount++; m.notify() }
+
+func (m *testMetric) gaugeValue() float64 {
+	if m.set != 0 {
+		return m.set
+	}
+	return float64(m.inc - m.dec)
+}
+
+func (m *testMetric) notify() {
+	if m.notifyCh != nil {
+		m.notifyCh <- struct{}{}
+	}
+}
+
+type testMetricsProvider struct {
+	depth      testMetric
+	adds       testMetric
+	latency    testMetric
+	duration   testMetric
+	unfinished testMetric
+	retries    testMetric
+}
+
+func (m *testMetricsProvider) NewDepthMetric(name string) GaugeMetric {
+	return &m.depth
+}
+
+func (m *testMetricsProvider) NewAddsMetric(name string) CounterMetric {
+	return &m.adds
+}
+
+func (m *testMetricsProvider) NewLatencyMetric(name string) SummaryMetric {
+	return &m.latency
+}
+
+func (m *testMetricsProvider) NewWorkDurationMetric(name string) SummaryMetric {
+	return &m.duration
+}
+
+func (m *testMetricsProvider) NewUnfinishedWorkMicrosecondsMetric(name string) SettableGaugeMetric {
+	return &m.unfinished
+}
+
+func (m *testMetricsProvider) NewRetriesMetric(name string) CounterMetric {
+	return &m.retries
+}
+
+func TestSinceInMicroseconds(t *testing.T) {
+	mp := testMetricsProvider{}
+	c := clock.NewFakeClock(time.Now())
+	mf := metricsFactory{metricsProvider: &mp}
+	m := mf.newQueueMetrics("test", c)
+	dqm := m.(*defaultQueueMetrics)
+
+	for _, i := range []int{1, 50, 100, 500, 1000, 10000, 100000, 1000000} {
+		n := c.Now()
+		c.Step(time.Duration(i) * time.Microsecond)
+		if e, a := float64(i), dqm.sinceInMicroseconds(n); e != a {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	mp := testMetricsProvider{}
+	t0 := time.Unix(0, 0)
+	c := clock.NewFakeClock(t0)
+	mf := metricsFactory{metricsProvider: &mp}
+	m := mf.newQueueMetrics("test", c)
+	q := newQueue(c, m, time.Millisecond)
+	defer q.ShutDown()
+	for !c.HasWaiters() {
+		// Wait for the go routine to call NewTicker()
+		time.Sleep(time.Millisecond)
+	}
+
+	q.Add("foo")
+	if e, a := 1.0, mp.adds.gaugeValue(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+
+	if e, a := 1.0, mp.depth.gaugeValue(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+
+	c.Step(50 * time.Microsecond)
+
+	// Start processing
+	i, _ := q.Get()
+	if i != "foo" {
+		t.Errorf("Expected %v, got %v", "foo", i)
+	}
+
+	if e, a := 50.0, mp.latency.observedValue; e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := 1, mp.latency.observedCount; e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := 0.0, mp.depth.gaugeValue(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+
+	// Add it back while processing; multiple adds of the same item are
+	// de-duped.
+	q.Add(i)
+	q.Add(i)
+	q.Add(i)
+	q.Add(i)
+	q.Add(i)
+	if e, a := 2.0, mp.adds.gaugeValue(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	// One thing remains in the queue
+	if e, a := 1.0, mp.depth.gaugeValue(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+
+	c.Step(25 * time.Microsecond)
+
+	// Finish it up
+	q.Done(i)
+
+	if e, a := 25.0, mp.duration.observedValue; e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := 1, mp.duration.observedCount; e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+
+	// One thing remains in the queue
+	if e, a := 1.0, mp.depth.gaugeValue(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+
+	// It should be back on the queue
+	i, _ = q.Get()
+	if i != "foo" {
+		t.Errorf("Expected %v, got %v", "foo", i)
+	}
+
+	if e, a := 25.0, mp.latency.observedValue; e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := 2, mp.latency.observedCount; e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+
+	// use a channel to ensure we don't look at the metric before it's
+	// been set.
+	ch := make(chan struct{}, 1)
+	mp.unfinished.notifyCh = ch
+	c.Step(time.Millisecond)
+	<-ch
+	mp.unfinished.notifyCh = nil
+	if e, a := 1000.0, mp.unfinished.gaugeValue(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+
+	// Finish that one up
+	q.Done(i)
+	if e, a := 1000.0, mp.duration.observedValue; e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := 2, mp.duration.observedCount; e != a {
+		t.Errorf("expected %v, got %v", e, a)
 	}
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -124,7 +124,7 @@ func (m *testMetricsProvider) NewRetriesMetric(name string) CounterMetric {
 func TestSinceInMicroseconds(t *testing.T) {
 	mp := testMetricsProvider{}
 	c := clock.NewFakeClock(time.Now())
-	mf := metricsFactory{metricsProvider: &mp}
+	mf := queueMetricsFactory{metricsProvider: &mp}
 	m := mf.newQueueMetrics("test", c)
 	dqm := m.(*defaultQueueMetrics)
 
@@ -141,7 +141,7 @@ func TestMetrics(t *testing.T) {
 	mp := testMetricsProvider{}
 	t0 := time.Unix(0, 0)
 	c := clock.NewFakeClock(t0)
-	mf := metricsFactory{metricsProvider: &mp}
+	mf := queueMetricsFactory{metricsProvider: &mp}
 	m := mf.newQueueMetrics("test", c)
 	q := newQueue(c, m, time.Millisecond)
 	defer q.ShutDown()

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"testing"
+	"time"
+)
+
+type testMetrics struct {
+	added, gotten, finished int64
+
+	updateCalled chan<- struct{}
+}
+
+func (m *testMetrics) add(item t)            { m.added++ }
+func (m *testMetrics) get(item t)            { m.gotten++ }
+func (m *testMetrics) done(item t)           { m.finished++ }
+func (m *testMetrics) updateUnfinishedWork() { m.updateCalled <- struct{}{} }
+
+func TestMetrics(t *testing.T) {
+	ch := make(chan struct{})
+	m := &testMetrics{
+		updateCalled: ch,
+	}
+	q := newQueue("test", m, time.Millisecond)
+	<-ch
+	q.ShutDown()
+	select {
+	case <-time.After(time.Second):
+		return
+	case <-ch:
+		t.Errorf("Unexpected update after shutdown was called.")
+	}
+}

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -113,7 +113,7 @@ func (m *testMetricsProvider) NewWorkDurationMetric(name string) SummaryMetric {
 	return &m.duration
 }
 
-func (m *testMetricsProvider) NewUnfinishedWorkMicrosecondsMetric(name string) SettableGaugeMetric {
+func (m *testMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric {
 	return &m.unfinished
 }
 
@@ -229,7 +229,7 @@ func TestMetrics(t *testing.T) {
 	c.Step(time.Millisecond)
 	<-ch
 	mp.unfinished.notifyCh = nil
-	if e, a := 1000.0, mp.unfinished.gaugeValue(); e != a {
+	if e, a := .001, mp.unfinished.gaugeValue(); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 

--- a/staging/src/k8s.io/client-go/util/workqueue/queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue.go
@@ -18,6 +18,7 @@ package workqueue
 
 import (
 	"sync"
+	"time"
 )
 
 type Interface interface {
@@ -35,13 +36,26 @@ func New() *Type {
 }
 
 func NewNamed(name string) *Type {
-	return &Type{
-		dirty:      set{},
-		processing: set{},
-		cond:       sync.NewCond(&sync.Mutex{}),
-		metrics:    newQueueMetrics(name),
-	}
+	return newQueue(
+		name,
+		newQueueMetrics(name),
+		defaultUnfinishedWorkUpdatePeriod,
+	)
 }
+
+func newQueue(name string, metrics queueMetrics, updatePeriod time.Duration) *Type {
+	t := &Type{
+		dirty:                      set{},
+		processing:                 set{},
+		cond:                       sync.NewCond(&sync.Mutex{}),
+		metrics:                    metrics,
+		unfinishedWorkUpdatePeriod: updatePeriod,
+	}
+	go t.updateUnfinishedWorkLook()
+	return t
+}
+
+const defaultUnfinishedWorkUpdatePeriod = 500 * time.Millisecond
 
 // Type is a work queue (see the package comment).
 type Type struct {
@@ -64,6 +78,8 @@ type Type struct {
 	shuttingDown bool
 
 	metrics queueMetrics
+
+	unfinishedWorkUpdatePeriod time.Duration
 }
 
 type empty struct{}
@@ -169,4 +185,23 @@ func (q *Type) ShuttingDown() bool {
 	defer q.cond.L.Unlock()
 
 	return q.shuttingDown
+}
+
+func (q *Type) updateUnfinishedWorkLook() {
+	t := time.NewTicker(q.unfinishedWorkUpdatePeriod)
+	defer t.Stop()
+	for range t.C {
+		if !func() bool {
+			q.cond.L.Lock()
+			defer q.cond.L.Unlock()
+			if !q.shuttingDown {
+				q.metrics.updateUnfinishedWork()
+				return true
+			}
+			return false
+
+		}() {
+			return
+		}
+	}
 }


### PR DESCRIPTION
```release-note
"unfinished_work_microseconds" is added to the workqueue metrics; it can be used to detect stuck worker threads. (kube-controller-manager runs many workqueues.)
```
