### PR TITLE
adding in-order  arrival to priority function for pod with same priorities 

### DIFF
--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -95,5 +95,12 @@ func (l *SortableList) Sort() {
 // the second one. It takes arguments of the type "interface{}" to be used with
 // SortableList, but expects those arguments to be *v1.Pod.
 func HigherPriorityPod(pod1, pod2 interface{}) bool {
+	if GetPodPriority(pod1.(*v1.Pod)) == GetPodPriority(pod2.(*v1.Pod)) {
+		if (pod1.(*v1.Pod)).CreationTimestamp.Before(&(pod2.(*v1.Pod)).CreationTimestamp) {
+			return true
+		} else {
+			return false
+		}
+	}
 	return GetPodPriority(pod1.(*v1.Pod)) > GetPodPriority(pod2.(*v1.Pod))
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #70899

**Special notes for your reviewer**:
Before pods with equal priority were chosen at random in the Priority Queue for Scheduling.
This patch allows pods which were created earlier to be considered before the late arrivals if they share the same priority.

**Does this PR introduce a user-facing change?**:
"NONE".
