### PR TITLE
Fixes error message in e2e tests for kubectl port-forward

### DIFF
--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -184,7 +184,7 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 
 	listenPort, err := strconv.Atoi(match[2])
 	if err != nil {
-		framework.Failf("Error converting %s to an int: %v", match[1], err)
+		framework.Failf("Error converting %s to an int: %v", match[2], err)
 	}
 
 	return &portForwardCommand{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Fixes an error message in kubectl port-forward tests (e2e). Related to [this]( https://github.com/kubernetes/kubernetes/pull/46517/files#diff-07e65bd5a7c9a6e9bcac7d08253998adR185) change from #46517.

Noticed it while looking into flaky tests in (https://github.com/kubernetes/kubectl/issues/558)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig testing
/sig cli