### PR TITLE
Fixes inconsistent behaviour in portforward

### DIFF
--- a/pkg/kubectl/cmd/portforward/portforward.go
+++ b/pkg/kubectl/cmd/portforward/portforward.go
@@ -120,7 +120,7 @@ func NewCmdPortForward(f cmdutil.Factory, streams genericclioptions.IOStreams) *
 		},
 	}
 	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodPortForwardWaitTimeout)
-	cmd.Flags().StringSliceVar(&opts.Address, "address", []string{"localhost"}, "Addresses to listen on (comma separated)")
+	cmd.Flags().StringSliceVar(&opts.Address, "address", []string{"localhost"}, "Addresses to listen on (comma separated). Only accepts IP addresses or localhost as a value. When localhost is supplied, kubectl will try to bind on both 127.0.0.1 and ::1 and will fail if neither of these addresses are available to bind.")
 	// TODO support UID
 	return cmd
 }

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
@@ -84,6 +84,62 @@ func TestParsePortsAndNew(t *testing.T) {
 			},
 		},
 		{
+			input:     []string{"5000:5000"},
+			addresses: []string{"localhost", "::1"},
+			expectedPorts: []ForwardedPort{
+				{5000, 5000},
+			},
+			expectedAddresses: []listenAddress{
+				{protocol: "tcp4", address: "127.0.0.1", failureMode: "all"},
+				{protocol: "tcp6", address: "::1", failureMode: "any"},
+			},
+		},
+		{
+			input:     []string{"5000:5000"},
+			addresses: []string{"localhost", "127.0.0.1", "::1"},
+			expectedPorts: []ForwardedPort{
+				{5000, 5000},
+			},
+			expectedAddresses: []listenAddress{
+				{protocol: "tcp4", address: "127.0.0.1", failureMode: "any"},
+				{protocol: "tcp6", address: "::1", failureMode: "any"},
+			},
+		},
+		{
+			input:     []string{"5000:5000"},
+			addresses: []string{"localhost", "127.0.0.1", "10.10.10.1"},
+			expectedPorts: []ForwardedPort{
+				{5000, 5000},
+			},
+			expectedAddresses: []listenAddress{
+				{protocol: "tcp4", address: "127.0.0.1", failureMode: "any"},
+				{protocol: "tcp6", address: "::1", failureMode: "all"},
+				{protocol: "tcp4", address: "10.10.10.1", failureMode: "any"},
+			},
+		},
+		{
+			input:     []string{"5000:5000"},
+			addresses: []string{"127.0.0.1", "::1", "localhost"},
+			expectedPorts: []ForwardedPort{
+				{5000, 5000},
+			},
+			expectedAddresses: []listenAddress{
+				{protocol: "tcp4", address: "127.0.0.1", failureMode: "any"},
+				{protocol: "tcp6", address: "::1", failureMode: "any"},
+			},
+		},
+		{
+			input:     []string{"5000:5000"},
+			addresses: []string{"10.0.0.1", "127.0.0.1"},
+			expectedPorts: []ForwardedPort{
+				{5000, 5000},
+			},
+			expectedAddresses: []listenAddress{
+				{protocol: "tcp4", address: "10.0.0.1", failureMode: "any"},
+				{protocol: "tcp4", address: "127.0.0.1", failureMode: "any"},
+			},
+		},
+		{
 			input:     []string{"5000", "5000:5000", "8888:5000", "5000:8888", ":5000", "0:5000"},
 			addresses: []string{"127.0.0.1", "::1"},
 			expectedPorts: []ForwardedPort{


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

Fixes address parsing in port-forward (`client-go` & `kubectl`).

The rules for address parsing are:

* Explicitly specified addresses must bind successfully
* `localhost` is pinned to `127.0.0.1` and `::1` and at least one of those must bind successfully

This change also makes output of the command consistent between runs with the same arguments. Previously the command was using the range via map of addresses which sometimes was producing different output because the order of values is not guaranteed in Go.

**Which issue(s) this PR fixes**:

#71017

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```


---

/sig cli
/priority P2