### PR TITLE
CSI topology e2e tests

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -48,6 +48,11 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
+const (
+	GCEPDCSIProvisionerName = "pd.csi.storage.gke.io"
+	GCEPDCSIZoneTopologyKey = "topology.gke.io/zone"
+)
+
 // hostpathCSI
 type hostpathCSIDriver struct {
 	cleanup    func()
@@ -265,7 +270,7 @@ var _ testsuites.DynamicPVTestDriver = &gcePDCSIDriver{}
 func InitGcePDCSIDriver(config testsuites.TestConfig) testsuites.TestDriver {
 	return &gcePDCSIDriver{
 		driverInfo: testsuites.DriverInfo{
-			Name:        "pd.csi.storage.gke.io",
+			Name:        GCEPDCSIProvisionerName,
 			FeatureTag:  "[Serial]",
 			MaxFileSize: testpatterns.FileSizeMedium,
 			SupportedFsType: sets.NewString(
@@ -293,7 +298,12 @@ func (g *gcePDCSIDriver) GetDriverInfo() *testsuites.DriverInfo {
 func (g *gcePDCSIDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 	f := g.driverInfo.Config.Framework
 	framework.SkipUnlessProviderIs("gce", "gke")
-	framework.SkipIfMultizone(f.ClientSet)
+	if !g.driverInfo.Config.TopologyEnabled {
+		// Topology is disabled in external-provisioner, so in a multizone cluster, a pod could be
+		// scheduled in a different zone from the provisioned volume, causing basic provisioning
+		// tests to fail.
+		framework.SkipIfMultizone(f.ClientSet)
+	}
 }
 
 func (g *gcePDCSIDriver) GetDynamicProvisionStorageClass(fsType string) *storagev1.StorageClass {
@@ -326,14 +336,20 @@ func (g *gcePDCSIDriver) CreateDriver() {
 	// }
 	createGCESecrets(g.driverInfo.Config.Framework.ClientSet, g.driverInfo.Config.Framework.Namespace.Name)
 
-	cleanup, err := g.driverInfo.Config.Framework.CreateFromManifests(nil,
+	manifests := []string{
 		"test/e2e/testing-manifests/storage-csi/driver-registrar/rbac.yaml",
 		"test/e2e/testing-manifests/storage-csi/external-attacher/rbac.yaml",
 		"test/e2e/testing-manifests/storage-csi/external-provisioner/rbac.yaml",
 		"test/e2e/testing-manifests/storage-csi/gce-pd/csi-controller-rbac.yaml",
 		"test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml",
-		"test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml",
-	)
+	}
+
+	if g.driverInfo.Config.TopologyEnabled {
+		manifests = append(manifests, "test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss_alpha.yaml")
+	} else {
+		manifests = append(manifests, "test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml")
+	}
+	cleanup, err := g.driverInfo.Config.Framework.CreateFromManifests(nil, manifests...)
 	g.cleanup = cleanup
 	if err != nil {
 		framework.Failf("deploying csi gce-pd driver: %v", err)
@@ -359,8 +375,7 @@ var _ testsuites.DynamicPVTestDriver = &gcePDExternalCSIDriver{}
 func InitGcePDExternalCSIDriver(config testsuites.TestConfig) testsuites.TestDriver {
 	return &gcePDExternalCSIDriver{
 		driverInfo: testsuites.DriverInfo{
-			Name: "pd.csi.storage.gke.io",
-
+			Name: GCEPDCSIProvisionerName,
 			// TODO(#70258): this is temporary until we can figure out how to make e2e tests a library
 			FeatureTag:  "[Feature: gcePD-external]",
 			MaxFileSize: testpatterns.FileSizeMedium,

--- a/test/e2e/storage/regional_pd.go
+++ b/test/e2e/storage/regional_pd.go
@@ -319,7 +319,7 @@ func testRegionalDelayedBinding(c clientset.Interface, ns string, pvcCount int) 
 		claim.Spec.StorageClassName = &class.Name
 		claims = append(claims, claim)
 	}
-	pvs, node := testBindingWaitForFirstConsumerMultiPVC(c, claims, class)
+	pvs, node := testsuites.TestBindingWaitForFirstConsumerMultiPVC(test, c, claims, class)
 	if node == nil {
 		framework.Failf("unexpected nil node found")
 	}
@@ -376,7 +376,7 @@ func testRegionalAllowedTopologiesWithDelayedBinding(c clientset.Interface, ns s
 		claim.Spec.StorageClassName = &class.Name
 		claims = append(claims, claim)
 	}
-	pvs, node := testBindingWaitForFirstConsumerMultiPVC(c, claims, class)
+	pvs, node := testsuites.TestBindingWaitForFirstConsumerMultiPVC(test, c, claims, class)
 	if node == nil {
 		framework.Failf("unexpected nil node found")
 	}

--- a/test/e2e/storage/testsuites/BUILD
+++ b/test/e2e/storage/testsuites/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
@@ -37,18 +38,20 @@ import (
 
 // StorageClassTest represents parameters to be used by provisioning tests
 type StorageClassTest struct {
-	Name               string
-	CloudProviders     []string
-	Provisioner        string
-	StorageClassName   string
-	Parameters         map[string]string
-	DelayBinding       bool
-	ClaimSize          string
-	ExpectedSize       string
-	PvCheck            func(volume *v1.PersistentVolume) error
-	NodeName           string
-	SkipWriteReadCheck bool
-	VolumeMode         *v1.PersistentVolumeMode
+	Name                string
+	CloudProviders      []string
+	Provisioner         string
+	StorageClassName    string
+	Parameters          map[string]string
+	DelayBinding        bool
+	ClaimSize           string
+	ExpectedSize        string
+	PvCheck             func(volume *v1.PersistentVolume) error
+	NodeName            string
+	SkipWriteReadCheck  bool
+	VolumeMode          *v1.PersistentVolumeMode
+	NodeSelector        map[string]string // NodeSelector for the pod
+	ExpectUnschedulable bool              // Whether the test pod is expected to be unschedulable
 }
 
 type provisioningTestSuite struct {
@@ -280,10 +283,10 @@ func TestDynamicProvisioning(t StorageClassTest, client clientset.Interface, cla
 			command += fmt.Sprintf(" && ( mount | grep 'on /mnt/test' | awk '{print $6}' | sed 's/^(/,/; s/)$/,/' | grep -q ,%s, )", option)
 		}
 		command += " || (mount | grep 'on /mnt/test'; false)"
-		runInPodWithVolume(client, claim.Namespace, claim.Name, t.NodeName, command)
+		runInPodWithVolume(client, claim.Namespace, claim.Name, t.NodeName, command, t.NodeSelector, t.ExpectUnschedulable)
 
 		By("checking the created volume is readable and retains data")
-		runInPodWithVolume(client, claim.Namespace, claim.Name, t.NodeName, "grep 'hello world' /mnt/test/data")
+		runInPodWithVolume(client, claim.Namespace, claim.Name, t.NodeName, "grep 'hello world' /mnt/test/data", t.NodeSelector, t.ExpectUnschedulable)
 	}
 	By(fmt.Sprintf("deleting claim %q/%q", claim.Namespace, claim.Name))
 	framework.ExpectNoError(client.CoreV1().PersistentVolumeClaims(claim.Namespace).Delete(claim.Name, nil))
@@ -303,8 +306,97 @@ func TestDynamicProvisioning(t StorageClassTest, client clientset.Interface, cla
 	return pv
 }
 
+func TestBindingWaitForFirstConsumer(t StorageClassTest, client clientset.Interface, claim *v1.PersistentVolumeClaim, class *storage.StorageClass) (*v1.PersistentVolume, *v1.Node) {
+	pvs, node := TestBindingWaitForFirstConsumerMultiPVC(t, client, []*v1.PersistentVolumeClaim{claim}, class)
+	if pvs == nil {
+		return nil, node
+	}
+	return pvs[0], node
+}
+
+func TestBindingWaitForFirstConsumerMultiPVC(t StorageClassTest, client clientset.Interface, claims []*v1.PersistentVolumeClaim, class *storage.StorageClass) ([]*v1.PersistentVolume, *v1.Node) {
+	var err error
+	Expect(len(claims)).ToNot(Equal(0))
+	namespace := claims[0].Namespace
+
+	By("creating a storage class " + class.Name)
+	class, err = client.StorageV1().StorageClasses().Create(class)
+	Expect(err).NotTo(HaveOccurred())
+	defer deleteStorageClass(client, class.Name)
+
+	By("creating claims")
+	var claimNames []string
+	var createdClaims []*v1.PersistentVolumeClaim
+	for _, claim := range claims {
+		c, err := client.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(claim)
+		claimNames = append(claimNames, c.Name)
+		createdClaims = append(createdClaims, c)
+		Expect(err).NotTo(HaveOccurred())
+	}
+	defer func() {
+		var errors map[string]error
+		for _, claim := range createdClaims {
+			err := framework.DeletePersistentVolumeClaim(client, claim.Name, claim.Namespace)
+			if err != nil {
+				errors[claim.Name] = err
+			}
+		}
+		if len(errors) > 0 {
+			for claimName, err := range errors {
+				framework.Logf("Failed to delete PVC: %s due to error: %v", claimName, err)
+			}
+		}
+	}()
+
+	// Wait for ClaimProvisionTimeout (across all PVCs in parallel) and make sure the phase did not become Bound i.e. the Wait errors out
+	By("checking the claims are in pending state")
+	err = framework.WaitForPersistentVolumeClaimsPhase(v1.ClaimBound, client, namespace, claimNames, 2*time.Second /* Poll */, framework.ClaimProvisionShortTimeout, true)
+	Expect(err).To(HaveOccurred())
+	verifyPVCsPending(client, createdClaims)
+
+	By("creating a pod referring to the claims")
+	// Create a pod referring to the claim and wait for it to get to running
+	var pod *v1.Pod
+	if t.ExpectUnschedulable {
+		pod, err = framework.CreateUnschedulablePod(client, namespace, t.NodeSelector, createdClaims, true /* isPrivileged */, "" /* command */)
+	} else {
+		pod, err = framework.CreatePod(client, namespace, nil /* nodeSelector */, createdClaims, true /* isPrivileged */, "" /* command */)
+	}
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		framework.DeletePodOrFail(client, pod.Namespace, pod.Name)
+		framework.WaitForPodToDisappear(client, pod.Namespace, pod.Name, labels.Everything(), framework.Poll, framework.PodDeleteTimeout)
+	}()
+	if t.ExpectUnschedulable {
+		// Verify that no claims are provisioned.
+		verifyPVCsPending(client, createdClaims)
+		return nil, nil
+	}
+
+	// collect node details
+	node, err := client.CoreV1().Nodes().Get(pod.Spec.NodeName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("re-checking the claims to see they binded")
+	var pvs []*v1.PersistentVolume
+	for _, claim := range createdClaims {
+		// Get new copy of the claim
+		claim, err = client.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(claim.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		// make sure claim did bind
+		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, claim.Namespace, claim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		Expect(err).NotTo(HaveOccurred())
+
+		pv, err := client.CoreV1().PersistentVolumes().Get(claim.Spec.VolumeName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		pvs = append(pvs, pv)
+	}
+	Expect(len(pvs)).To(Equal(len(createdClaims)))
+	return pvs, node
+}
+
 // runInPodWithVolume runs a command in a pod with given claim mounted to /mnt directory.
-func runInPodWithVolume(c clientset.Interface, ns, claimName, nodeName, command string) {
+func runInPodWithVolume(c clientset.Interface, ns, claimName, nodeName, command string, nodeSelector map[string]string, unschedulable bool) {
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -340,6 +432,7 @@ func runInPodWithVolume(c clientset.Interface, ns, claimName, nodeName, command 
 					},
 				},
 			},
+			NodeSelector: nodeSelector,
 		},
 	}
 
@@ -357,5 +450,19 @@ func runInPodWithVolume(c clientset.Interface, ns, claimName, nodeName, command 
 		}
 		framework.DeletePodOrFail(c, ns, pod.Name)
 	}()
-	framework.ExpectNoError(framework.WaitForPodSuccessInNamespaceSlow(c, pod.Name, pod.Namespace))
+
+	if unschedulable {
+		framework.ExpectNoError(framework.WaitForPodNameUnschedulableInNamespace(c, pod.Name, pod.Namespace))
+	} else {
+		framework.ExpectNoError(framework.WaitForPodSuccessInNamespaceSlow(c, pod.Name, pod.Namespace))
+	}
+}
+
+func verifyPVCsPending(client clientset.Interface, pvcs []*v1.PersistentVolumeClaim) {
+	for _, claim := range pvcs {
+		// Get new copy of the claim
+		claim, err := client.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(claim.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(claim.Status.Phase).To(Equal(v1.ClaimPending))
+	}
 }

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -130,4 +130,8 @@ type TestConfig struct {
 	// the configuration that then has to be used to run tests.
 	// The values above are ignored for such tests.
 	ServerConfig *framework.VolumeTestConfig
+
+	// TopologyEnabled indicates that the Topology feature gate
+	// should be enabled in external-provisioner
+	TopologyEnabled bool
 }

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -39,6 +39,7 @@ import (
 	storagebeta "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	clientset "k8s.io/client-go/kubernetes"
@@ -57,85 +58,6 @@ const (
 	// Number of PVCs for multi PVC tests
 	multiPVCcount = 3
 )
-
-func testBindingWaitForFirstConsumer(client clientset.Interface, claim *v1.PersistentVolumeClaim, class *storage.StorageClass) (*v1.PersistentVolume, *v1.Node) {
-	pvs, node := testBindingWaitForFirstConsumerMultiPVC(client, []*v1.PersistentVolumeClaim{claim}, class)
-	return pvs[0], node
-}
-
-func testBindingWaitForFirstConsumerMultiPVC(client clientset.Interface, claims []*v1.PersistentVolumeClaim, class *storage.StorageClass) ([]*v1.PersistentVolume, *v1.Node) {
-	var err error
-	Expect(len(claims)).ToNot(Equal(0))
-	namespace := claims[0].Namespace
-
-	By("creating a storage class " + class.Name)
-	class, err = client.StorageV1().StorageClasses().Create(class)
-	Expect(err).NotTo(HaveOccurred())
-	defer deleteStorageClass(client, class.Name)
-
-	By("creating claims")
-	var claimNames []string
-	var createdClaims []*v1.PersistentVolumeClaim
-	for _, claim := range claims {
-		c, err := client.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(claim)
-		claimNames = append(claimNames, c.Name)
-		createdClaims = append(createdClaims, c)
-		Expect(err).NotTo(HaveOccurred())
-	}
-	defer func() {
-		var errors map[string]error
-		for _, claim := range createdClaims {
-			err := framework.DeletePersistentVolumeClaim(client, claim.Name, claim.Namespace)
-			if err != nil {
-				errors[claim.Name] = err
-			}
-		}
-		if len(errors) > 0 {
-			for claimName, err := range errors {
-				framework.Logf("Failed to delete PVC: %s due to error: %v", claimName, err)
-			}
-		}
-	}()
-
-	// Wait for ClaimProvisionTimeout (across all PVCs in parallel) and make sure the phase did not become Bound i.e. the Wait errors out
-	By("checking the claims are in pending state")
-	err = framework.WaitForPersistentVolumeClaimsPhase(v1.ClaimBound, client, namespace, claimNames, 2*time.Second, framework.ClaimProvisionShortTimeout, true)
-	Expect(err).To(HaveOccurred())
-	for _, claim := range createdClaims {
-		// Get new copy of the claim
-		claim, err = client.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(claim.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(claim.Status.Phase).To(Equal(v1.ClaimPending))
-	}
-
-	By("creating a pod referring to the claims")
-	// Create a pod referring to the claim and wait for it to get to running
-	pod, err := framework.CreatePod(client, namespace, nil /* nodeSelector */, createdClaims, true /* isPrivileged */, "" /* command */)
-	Expect(err).NotTo(HaveOccurred())
-	defer func() {
-		framework.DeletePodOrFail(client, pod.Namespace, pod.Name)
-	}()
-	// collect node details
-	node, err := client.CoreV1().Nodes().Get(pod.Spec.NodeName, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred())
-
-	By("re-checking the claims to see they binded")
-	var pvs []*v1.PersistentVolume
-	for _, claim := range createdClaims {
-		// Get new copy of the claim
-		claim, err = client.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(claim.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		// make sure claim did bind
-		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, claim.Namespace, claim.Name, framework.Poll, framework.ClaimProvisionTimeout)
-		Expect(err).NotTo(HaveOccurred())
-
-		pv, err := client.CoreV1().PersistentVolumes().Get(claim.Spec.VolumeName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		pvs = append(pvs, pv)
-	}
-	Expect(len(pvs)).ToNot(Equal(0))
-	return pvs, node
-}
 
 func checkZoneFromLabelAndAffinity(pv *v1.PersistentVolume, zone string, matchZone bool) {
 	checkZonesFromLabelAndAffinity(pv, sets.NewString(zone), matchZone)
@@ -295,7 +217,7 @@ func testZonalDelayedBinding(c clientset.Interface, ns string, specifyAllowedTop
 		if specifyAllowedTopology {
 			action += " and allowedTopologies"
 			suffix += "-topo"
-			topoZone = getRandomCloudZone(c)
+			topoZone = getRandomClusterZone(c)
 			addSingleZoneAllowedTopologyToStorageClass(c, class, topoZone)
 		}
 		By(action)
@@ -305,7 +227,7 @@ func testZonalDelayedBinding(c clientset.Interface, ns string, specifyAllowedTop
 			claim.Spec.StorageClassName = &class.Name
 			claims = append(claims, claim)
 		}
-		pvs, node := testBindingWaitForFirstConsumerMultiPVC(c, claims, class)
+		pvs, node := testsuites.TestBindingWaitForFirstConsumerMultiPVC(test, c, claims, class)
 		if node == nil {
 			framework.Failf("unexpected nil node found")
 		}
@@ -336,7 +258,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 	Describe("DynamicProvisioner [Slow]", func() {
 		It("should provision storage with different parameters", func() {
-			cloudZone := getRandomCloudZone(c)
+			cloudZone := getRandomClusterZone(c)
 
 			// This test checks that dynamic provisioning can provision a volume
 			// that can be used to persist data among pods.
@@ -968,7 +890,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				By("creating a claim with class with allowedTopologies set")
 				suffix := "topology"
 				class := newStorageClass(test, ns, suffix)
-				zone := getRandomCloudZone(c)
+				zone := getRandomClusterZone(c)
 				addSingleZoneAllowedTopologyToStorageClass(c, class, zone)
 				claim := newClaim(test, ns, suffix)
 				claim.Spec.StorageClassName = &class.Name
@@ -1244,10 +1166,11 @@ func deleteProvisionedVolumesAndDisks(c clientset.Interface, pvs []*v1.Persisten
 	}
 }
 
-func getRandomCloudZone(c clientset.Interface) string {
+func getRandomClusterZone(c clientset.Interface) string {
 	zones, err := framework.GetClusterZones(c)
 	Expect(err).ToNot(HaveOccurred())
-	// return "" in case that no node has zone label
-	zone, _ := zones.PopAny()
-	return zone
+	Expect(len(zones)).ToNot(Equal(0))
+
+	zonesList := zones.UnsortedList()
+	return zonesList[rand.Intn(zones.Len())]
 }

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss_alpha.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss_alpha.yaml
@@ -20,6 +20,7 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
+            - "--feature-gates=Topology=true"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
@@ -36,7 +36,7 @@ spec:
         - name: gce-pd-driver
           securityContext:
             privileged: true
-          image: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v0.3.0-gke.0
+          image: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v0.3.1-gke.0
           args:
             - "--v=5"
             - "--endpoint=unix:/csi/csi.sock"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind bug

**What this PR does / why we need it**: Adds CSI e2e tests for topology, using the GCE PD driver.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69703

**Special notes for your reviewer**:
* Since the `CSINodeInfo` object has a breaking change, these e2e tests now depend on external-provisioner and external-attacher versions 0.5.x and later. Version 0.4 uses the old CSINodeInfo object. As a result these tests will fail until 0.5 is released. Also, since external-provisioner 0.5 enables Topology by default, there's no need to explicitly set the Topology feature gate in these e2e tests.
* Given time constraints I've deferred fully integrating with the storage e2e testing framework for now.
* Currently these tests fail, but I verified the tests pass without the `CSINodeInfo` change and before rebasing with the new e2e framework. Currently working on verifying them with the e2e framework change.
* Since Topology will be enabled on external-provisioner by default, in CSI provisioning tests it's no longer necessary if the GCE PD driver is multi-zone.

**Does this PR introduce a user-facing change?**: No
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

/priority critical-urgent
/sig storage
/assign @msau42 @ddebroy @davidz627 
/cc @mkimuram 