### PR TITLE
Set HTTP transport with better proxy handling

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/clock"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -475,7 +476,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 			clusterDNS = append(clusterDNS, ip)
 		}
 	}
-	httpClient := &http.Client{}
+	tr := utilnet.SetTransportDefaults(&http.Transport{})
+	httpClient := &http.Client{Transport: tr}
 	parsedNodeIP := net.ParseIP(nodeIP)
 	protocol := utilipt.ProtocolIpv4
 	if parsedNodeIP != nil && parsedNodeIP.To4() == nil {


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
Sets up better proxy handling for Kubelet and particularly for pod hooks.
Since pod hooks tests are part of conformance tests it would be nice to backport it to at least 1.12 .

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #70922

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
* allows using NO_PROXY setting with CIDRs in pod hooks.
```
