### PR TITLE
Add test for CRD server-dry-run and fix bug

### DIFF
--- a/pkg/kubectl/cmd/util/crdfinder.go
+++ b/pkg/kubectl/cmd/util/crdfinder.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"reflect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,10 +35,10 @@ func CRDFromDynamic(client dynamic.Interface) CRDGetter {
 		list, err := client.Resource(schema.GroupVersionResource{
 			Group:    "apiextensions.k8s.io",
 			Version:  "v1beta1",
-			Resource: "curstomresourcedefinitions",
+			Resource: "customresourcedefinitions",
 		}).List(metav1.ListOptions{})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to list CRDs: %v", err)
 		}
 		if list == nil {
 			return nil, nil

--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -93,6 +93,37 @@ run_kubectl_apply_tests() {
   # clean-up
   kubectl delete -f hack/testdata/pod.yaml "${kube_flags[@]}"
 
+  ## kubectl apply dry-run on CR
+  # Create CRD
+  kubectl "${kube_flags_with_token[@]}" create -f - << __EOF__
+{
+  "kind": "CustomResourceDefinition",
+  "apiVersion": "apiextensions.k8s.io/v1beta1",
+  "metadata": {
+    "name": "resources.mygroup.example.com"
+  },
+  "spec": {
+    "group": "mygroup.example.com",
+    "version": "v1alpha1",
+    "scope": "Namespaced",
+    "names": {
+      "plural": "resources",
+      "singular": "resource",
+      "kind": "Kind",
+      "listKind": "KindList"
+    }
+  }
+}
+__EOF__
+
+  # Dry-run create the CR
+  kubectl "${kube_flags[@]}" apply --server-dry-run -f hack/testdata/CRD/resource.yaml "${kube_flags[@]}"
+  # Make sure that the CR doesn't exist
+  ! kubectl "${kube_flags[@]}" get resource/myobj
+
+  # clean-up
+  kubectl "${kube_flags[@]}" delete customresourcedefinition resources.mygroup.example.com
+
   ## kubectl apply --prune
   # Pre-Condition: no POD exists
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''


### PR DESCRIPTION
Add a new test to make sure we can server-dry-run CRDs and also fix a
typo now that we have a test, we could notice that it doesn't work.


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a bug in `kubectl diff`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
