### PR TITLE
Obsolete storage class beta annotations

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -501,22 +501,12 @@ func GetTaintsFromNodeAnnotations(annotations map[string]string) ([]core.Taint, 
 
 // GetPersistentVolumeClass returns StorageClassName.
 func GetPersistentVolumeClass(volume *core.PersistentVolume) string {
-	// Use beta annotation first
-	if class, found := volume.Annotations[core.BetaStorageClassAnnotation]; found {
-		return class
-	}
-
 	return volume.Spec.StorageClassName
 }
 
 // GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
 // requested, it returns "".
 func GetPersistentVolumeClaimClass(claim *core.PersistentVolumeClaim) string {
-	// Use beta annotation first
-	if class, found := claim.Annotations[core.BetaStorageClassAnnotation]; found {
-		return class
-	}
-
 	if claim.Spec.StorageClassName != nil {
 		return *claim.Spec.StorageClassName
 	}
@@ -526,11 +516,6 @@ func GetPersistentVolumeClaimClass(claim *core.PersistentVolumeClaim) string {
 
 // PersistentVolumeClaimHasClass returns true if given claim has set StorageClassName field.
 func PersistentVolumeClaimHasClass(claim *core.PersistentVolumeClaim) bool {
-	// Use beta annotation first
-	if _, found := claim.Annotations[core.BetaStorageClassAnnotation]; found {
-		return true
-	}
-
 	if claim.Spec.StorageClassName != nil {
 		return true
 	}

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -244,10 +244,6 @@ type PersistentVolumeClaimVolumeSource struct {
 }
 
 const (
-	// BetaStorageClassAnnotation represents the beta/previous StorageClass annotation.
-	// It's deprecated and will be removed in a future release. (#51440)
-	BetaStorageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
-
 	// MountOptionAnnotation defines mount option annotation used in PVs
 	MountOptionAnnotation = "volume.beta.kubernetes.io/mount-options"
 )

--- a/pkg/apis/core/v1/helper/helpers.go
+++ b/pkg/apis/core/v1/helper/helpers.go
@@ -478,22 +478,12 @@ func GetAvoidPodsFromNodeAnnotations(annotations map[string]string) (v1.AvoidPod
 
 // GetPersistentVolumeClass returns StorageClassName.
 func GetPersistentVolumeClass(volume *v1.PersistentVolume) string {
-	// Use beta annotation first
-	if class, found := volume.Annotations[v1.BetaStorageClassAnnotation]; found {
-		return class
-	}
-
 	return volume.Spec.StorageClassName
 }
 
 // GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
 // requested, it returns "".
 func GetPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
-	// Use beta annotation first
-	if class, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
-		return class
-	}
-
 	if claim.Spec.StorageClassName != nil {
 		return *claim.Spec.StorageClassName
 	}

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -1883,15 +1883,7 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
 		oldPvcClone.Spec.VolumeName = newPvcClone.Spec.VolumeName
 	}
 
-	if validateStorageClassUpgrade(oldPvcClone.Annotations, newPvcClone.Annotations,
-		oldPvcClone.Spec.StorageClassName, newPvcClone.Spec.StorageClassName) {
-		newPvcClone.Spec.StorageClassName = nil
-		metav1.SetMetaDataAnnotation(&newPvcClone.ObjectMeta, core.BetaStorageClassAnnotation, oldPvcClone.Annotations[core.BetaStorageClassAnnotation])
-	} else {
-		// storageclass annotation should be immutable after creation
-		// TODO: remove Beta when no longer needed
-		allErrs = append(allErrs, ValidateImmutableAnnotation(newPvc.ObjectMeta.Annotations[v1.BetaStorageClassAnnotation], oldPvc.ObjectMeta.Annotations[v1.BetaStorageClassAnnotation], v1.BetaStorageClassAnnotation, field.NewPath("metadata"))...)
-	}
+	allErrs = append(allErrs, ValidateImmutableField(newPvc.Spec.StorageClassName, oldPvc.Spec.StorageClassName, field.NewPath("storageClassName"))...)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ExpandPersistentVolumes) {
 		// lets make sure storage values are same.
@@ -1921,22 +1913,6 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
 		allErrs = append(allErrs, ValidateImmutableField(newPvc.Spec.VolumeMode, oldPvc.Spec.VolumeMode, field.NewPath("volumeMode"))...)
 	}
 	return allErrs
-}
-
-// Provide an upgrade path from PVC with storage class specified in beta
-// annotation to storage class specified in attribute. We allow update of
-// StorageClassName only if following four conditions are met at the same time:
-// 1. The old pvc's StorageClassAnnotation is set
-// 2. The old pvc's StorageClassName is not set
-// 3. The new pvc's StorageClassName is set and equal to the old value in annotation
-// 4. If the new pvc's StorageClassAnnotation is set,it must be equal to the old pv/pvc's StorageClassAnnotation
-func validateStorageClassUpgrade(oldAnnotations, newAnnotations map[string]string, oldScName, newScName *string) bool {
-	oldSc, oldAnnotationExist := oldAnnotations[core.BetaStorageClassAnnotation]
-	newScInAnnotation, newAnnotationExist := newAnnotations[core.BetaStorageClassAnnotation]
-	return oldAnnotationExist /* condition 1 */ &&
-		oldScName == nil /* condition 2*/ &&
-		(newScName != nil && *newScName == oldSc) /* condition 3 */ &&
-		(!newAnnotationExist || newScInAnnotation == oldSc) /* condition 4 */
 }
 
 // ValidatePersistentVolumeClaimStatusUpdate validates an update to status of a PersistentVolumeClaim


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one, leave it on its own line:
/kind cleanup


**What this PR does / why we need it**:
Storage class beta annotation has been deprecated in 1.8 via https://github.com/kubernetes/kubernetes/pull/53580
So remove it after 2+ release.


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
action required: The `volume.beta.kubernetes.io/storage-class` annotation is removed. For the StorageClass API object, use v1, and in place of the annotation use `v1.PersistentVolumeClaim.Spec.StorageClassName` and `v1.PersistentVolume.Spec.StorageClassName` instead.
```
