### PR TITLE
Limit iops per container

### DIFF
--- a/pkg/kubelet/dockershim/blkio/blkiocgroup_linux.go
+++ b/pkg/kubelet/dockershim/blkio/blkiocgroup_linux.go
@@ -1,0 +1,15 @@
+// +build linux
+
+package blkio
+
+import (
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
+)
+
+func init() {
+	blkioSubsystem = &fs.BlkioGroup{}
+	// blkioSubsystem = &BlkioGroupSubsystem{}
+	// FindCgroupMountpointDir easy for test
+	FindCgroupMountpointDir = cgroups.FindCgroupMountpointDir
+}

--- a/pkg/kubelet/dockershim/blkio/blkiocgroup_linux.go
+++ b/pkg/kubelet/dockershim/blkio/blkiocgroup_linux.go
@@ -7,6 +7,10 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 )
 
+var (
+	DefaultCgroupParent = "docker"
+)
+
 func init() {
 	blkioSubsystem = &fs.BlkioGroup{}
 	// blkioSubsystem = &BlkioGroupSubsystem{}

--- a/pkg/kubelet/dockershim/blkio/blkioconfig_linux.go
+++ b/pkg/kubelet/dockershim/blkio/blkioconfig_linux.go
@@ -86,17 +86,17 @@ func getBlkioThrottleDevice(d *deviceValue, rootfsDevice string) (t configs.Thro
 }
 
 func getBlkioResource(b *Blkio, rootfsDevice string) (blkioResource configs.Resources, err error) {
-	blkioResource.BlkioWeight = b.Weight
-	if b.Weight < DeviceWeightMin || b.Weight > DeviceWeightMax {
+	if b.Weight != 0 && (b.Weight < DeviceWeightMin || b.Weight > DeviceWeightMax) {
 		return blkioResource, fmt.Errorf("blkio.weight:%d is out of rage. Currently allowed range of weights is from %d to %d.", b.Weight, DeviceWeightMin, DeviceWeightMax)
 	}
+	blkioResource.BlkioWeight = b.Weight
 
 	for _, w := range b.WeightDevice {
 		d, err := getBlkioWeightDevice(&w, rootfsDevice)
 		if err != nil {
 			return blkioResource, err
 		}
-		if d.Weight < DeviceWeightMin || d.Weight > DeviceWeightMax {
+		if d.Weight != 0 && (d.Weight < DeviceWeightMin || d.Weight > DeviceWeightMax) {
 			return blkioResource, fmt.Errorf("blkio.weight_device:%d is out of rage. Currently allowed range of weights is from %d to %d.", d.Weight, DeviceWeightMin, DeviceWeightMax)
 		}
 		blkioResource.BlkioWeightDevice = append(blkioResource.BlkioWeightDevice, &d)
@@ -106,7 +106,7 @@ func getBlkioResource(b *Blkio, rootfsDevice string) (blkioResource configs.Reso
 		if err != nil {
 			return blkioResource, err
 		}
-		if t.Rate < DeviceBPSMin {
+		if t.Rate != 0 && t.Rate < DeviceBPSMin {
 			return blkioResource, fmt.Errorf("blkio.device_read_bps:%d is out of rage. The Rate must be greater than %d.", t.Rate, DeviceBPSMin)
 		}
 		blkioResource.BlkioThrottleReadBpsDevice = append(blkioResource.BlkioThrottleReadBpsDevice, &t)
@@ -116,7 +116,7 @@ func getBlkioResource(b *Blkio, rootfsDevice string) (blkioResource configs.Reso
 		if err != nil {
 			return blkioResource, err
 		}
-		if t.Rate < DeviceBPSMin {
+		if t.Rate != 0 && t.Rate < DeviceBPSMin {
 			return blkioResource, fmt.Errorf("blkio.device_write_bps:%d is out of rage. The Rate must be greater than %d.", t.Rate, DeviceBPSMin)
 		}
 		blkioResource.BlkioThrottleWriteBpsDevice = append(blkioResource.BlkioThrottleWriteBpsDevice, &t)
@@ -126,7 +126,7 @@ func getBlkioResource(b *Blkio, rootfsDevice string) (blkioResource configs.Reso
 		if err != nil {
 			return blkioResource, err
 		}
-		if t.Rate < DeviceIOPSMin {
+		if t.Rate != 0 && t.Rate < DeviceIOPSMin {
 			return blkioResource, fmt.Errorf("blkio.device_read_iops:%d is out of rage. The Rate must be greater than %d.", t.Rate, DeviceIOPSMin)
 		}
 		blkioResource.BlkioThrottleReadIOPSDevice = append(blkioResource.BlkioThrottleReadIOPSDevice, &t)
@@ -136,7 +136,7 @@ func getBlkioResource(b *Blkio, rootfsDevice string) (blkioResource configs.Reso
 		if err != nil {
 			return blkioResource, err
 		}
-		if t.Rate < DeviceIOPSMin {
+		if t.Rate != 0 && t.Rate < DeviceIOPSMin {
 			return blkioResource, fmt.Errorf("blkio.device_write_iops:%d is out of rage. The Rate must be greater than %d.", t.Rate, DeviceIOPSMin)
 		}
 		blkioResource.BlkioThrottleWriteIOPSDevice = append(blkioResource.BlkioThrottleWriteIOPSDevice, &t)

--- a/pkg/kubelet/dockershim/blkio/blkioconfig_linux.go
+++ b/pkg/kubelet/dockershim/blkio/blkioconfig_linux.go
@@ -1,0 +1,129 @@
+// +build linux
+
+package blkio
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	// copy from dockershim/docker_service.go:61
+
+	containerTypeLabelKey       = "io.kubernetes.docker.type"
+	containerTypeLabelSandbox   = "podsandbox"
+	containerTypeLabelContainer = "container"
+	containerLogPathLabelKey    = "io.kubernetes.container.logpath"
+	sandboxIDLabelKey           = "io.kubernetes.sandbox.id"
+
+	BlkioKey = "annotation.io.kubernetes.container.blkio"
+
+	GraphDriverName          = "devicemapper"
+	GraphDriverDeviceIdKey   = "DeviceId"
+	GraphDriverDeviceNameKey = "DeviceName"
+	GraphDriverDeviceSizeKey = "DeviceSize"
+
+	RootfsDeviceKey = "rootfs"
+
+	BlkioSubsystemName = "blkio"
+)
+
+// Value resource.Quantity  `json:"value"`
+type deviceValue struct {
+	Device string `json:"device"`
+	Value  string `json:"value"`
+}
+
+type Blkio struct {
+	Weight          uint16        `json:"weight,omitempty"`
+	WeightDevice    []deviceValue `json:"weight_device,omitempty"`
+	DeviceReadBps   []deviceValue `json:"device_read_bps,omitempty"`
+	DeviceWriteBps  []deviceValue `json:"device_write_bps,omitempty"`
+	DeviceReadIOps  []deviceValue `json:"device_read_iops,omitempty"`
+	DeviceWriteIOps []deviceValue `json:"device_write_iops,omitempty"`
+}
+
+func getBlkioDeviceValue(d *deviceValue, rootfsDevice string) (q, Major, Minor int64, err error) {
+	quantity, err := resource.ParseQuantity(d.Value)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("the %s.DeviceValue:%+v format error. %s", BlkioKey, d, err.Error())
+	}
+	q = quantity.Value()
+
+	if d.Device == RootfsDeviceKey {
+		d.Device = rootfsDevice
+
+	}
+	cfg, err := DeviceFromPath(d.Device, "")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return q, cfg.Major, cfg.Minor, nil
+}
+
+func getBlkioWeightDevice(d *deviceValue, rootfsDevice string) (w configs.WeightDevice, err error) {
+	q, Major, Minor, err := getBlkioDeviceValue(d, rootfsDevice)
+	w.Weight = uint16(q & 0x00ffff)
+	w.Major = Major
+	w.Minor = Minor
+	return w, err
+}
+
+func getBlkioThrottleDevice(d *deviceValue, rootfsDevice string) (t configs.ThrottleDevice, err error) {
+	q, Major, Minor, err := getBlkioDeviceValue(d, rootfsDevice)
+	t.Rate = uint64(q)
+	t.Major = Major
+	t.Minor = Minor
+	return t, err
+}
+
+func getBlkioResource(b *Blkio, rootfsDevice string) (blkioResource configs.Resources, err error) {
+	blkioResource.BlkioWeight = b.Weight
+	for _, w := range b.WeightDevice {
+		d, err := getBlkioWeightDevice(&w, rootfsDevice)
+		if err != nil {
+			return blkioResource, err
+		}
+		blkioResource.BlkioWeightDevice = append(blkioResource.BlkioWeightDevice, &d)
+	}
+	for _, w := range b.DeviceReadBps {
+		t, err := getBlkioThrottleDevice(&w, rootfsDevice)
+		if err != nil {
+			return blkioResource, err
+		}
+		blkioResource.BlkioThrottleReadBpsDevice = append(blkioResource.BlkioThrottleReadBpsDevice, &t)
+	}
+	for _, w := range b.DeviceWriteBps {
+		t, err := getBlkioThrottleDevice(&w, rootfsDevice)
+		if err != nil {
+			return blkioResource, err
+		}
+		blkioResource.BlkioThrottleWriteBpsDevice = append(blkioResource.BlkioThrottleWriteBpsDevice, &t)
+	}
+	for _, w := range b.DeviceReadIOps {
+		t, err := getBlkioThrottleDevice(&w, rootfsDevice)
+		if err != nil {
+			return blkioResource, err
+		}
+		blkioResource.BlkioThrottleReadIOPSDevice = append(blkioResource.BlkioThrottleReadIOPSDevice, &t)
+	}
+	for _, w := range b.DeviceWriteIOps {
+		t, err := getBlkioThrottleDevice(&w, rootfsDevice)
+		if err != nil {
+			return blkioResource, err
+		}
+		blkioResource.BlkioThrottleWriteIOPSDevice = append(blkioResource.BlkioThrottleWriteIOPSDevice, &t)
+	}
+	return blkioResource, nil
+}
+
+func cgroupToString(cgroup *configs.Cgroup) string {
+	if cgroup == nil {
+		return ""
+	}
+	data, _ := json.Marshal(cgroup)
+	return string(data)
+}

--- a/pkg/kubelet/dockershim/blkio/cgoup_linux.go
+++ b/pkg/kubelet/dockershim/blkio/cgoup_linux.go
@@ -1,0 +1,58 @@
+// +build linux
+
+package blkio
+
+import (
+	"path/filepath"
+	"sync"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+var (
+	// The absolute path to the root of the cgroup hierarchies.
+	cgroupRootLock sync.Mutex
+	cgroupRoot     string
+	blkioSubsystem Subsystem
+	// FindCgroupMountpointDir easy for test
+	FindCgroupMountpointDir func() (string, error)
+)
+
+type Subsystem interface {
+	// Name returns the name of the subsystem.
+	Name() string
+	// Set the cgroup represented by cgroup.
+	Set(path string, cgroup *configs.Cgroup) error
+}
+
+func getBlkioCgroupPath(subsystemName, cgroupParent, containerID string) (path string, err error) {
+	root, err := getCgroupRoot()
+	if err != nil {
+		return "", err
+	}
+	path = filepath.Join(root, subsystemName, cgroupParent, containerID)
+	// path = filepath.Join(root, "blkio", cgroupParent, containerID)
+	return path, nil
+}
+
+// Gets the cgroupRoot.
+func getCgroupRoot() (string, error) {
+	cgroupRootLock.Lock()
+	defer cgroupRootLock.Unlock()
+
+	if cgroupRoot != "" {
+		return cgroupRoot, nil
+	}
+
+	root, err := FindCgroupMountpointDir()
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := unixos.Stat(root); err != nil {
+		return "", err
+	}
+
+	cgroupRoot = root
+	return cgroupRoot, nil
+}

--- a/pkg/kubelet/dockershim/blkio/cgoup_linux.go
+++ b/pkg/kubelet/dockershim/blkio/cgoup_linux.go
@@ -30,6 +30,9 @@ func getBlkioCgroupPath(subsystemName, cgroupParent, containerID string) (path s
 	if err != nil {
 		return "", err
 	}
+	if len(cgroupParent) <= 0 {
+		cgroupParent = DefaultCgroupParent
+	}
 	path = filepath.Join(root, subsystemName, cgroupParent, containerID)
 	// path = filepath.Join(root, "blkio", cgroupParent, containerID)
 	return path, nil

--- a/pkg/kubelet/dockershim/blkio/devices_linux.go
+++ b/pkg/kubelet/dockershim/blkio/devices_linux.go
@@ -1,0 +1,69 @@
+// +build linux
+
+package blkio
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"golang.org/x/sys/unix"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+)
+
+const (
+	DeviceRoot = "/dev/mapper"
+)
+
+var (
+	ErrNotADevice = errors.New("not a device node")
+
+	unixos kubecontainer.OSInterface = &kubecontainer.RealOS{}
+)
+
+// DeviceFromPath given the path to a device and its cgroup_permissions(which cannot be easily queried)
+// look up the information about a linux device and return that information as a Device struct.
+func DeviceFromPath(path, permissions string) (device *configs.Device, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("%s", e)
+		}
+	}()
+	var stat *syscall.Stat_t
+	// var stat *os.fileStat
+	fsinfo, err := unixos.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	stat = fsinfo.Sys().(*syscall.Stat_t)
+	var (
+		devNumber = stat.Rdev
+		major     = unix.Major(devNumber)
+	)
+	if major == 0 {
+		return nil, ErrNotADevice
+	}
+
+	var (
+		devType rune
+		mode    = stat.Mode
+	)
+	switch {
+	case mode&unix.S_IFBLK == unix.S_IFBLK:
+		devType = 'b'
+	case mode&unix.S_IFCHR == unix.S_IFCHR:
+		devType = 'c'
+	}
+	return &configs.Device{
+		Type:        devType,
+		Path:        path,
+		Major:       int64(major),
+		Minor:       int64(unix.Minor(devNumber)),
+		Permissions: permissions,
+		FileMode:    os.FileMode(mode),
+		Uid:         stat.Uid,
+		Gid:         stat.Gid,
+	}, nil
+}

--- a/pkg/kubelet/dockershim/blkio/manager_linux.go
+++ b/pkg/kubelet/dockershim/blkio/manager_linux.go
@@ -1,0 +1,78 @@
+// +build linux
+
+package blkio
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/golang/glog"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
+)
+
+func UpdateBlkio(containerId string, docker libdocker.Interface) (err error) {
+	info, err := docker.InspectContainer(containerId)
+	if err != nil {
+		return fmt.Errorf("failed to inspect container %q: %v", containerId, err)
+	}
+	containerType, ok := info.Config.Labels[containerTypeLabelKey]
+	if !ok {
+		return fmt.Errorf("the container: %s is neither a regular container is a sandbox.", containerId)
+	}
+	if containerType != containerTypeLabelContainer {
+		// Limit regular containers only
+		return nil
+	}
+	sandboxID, ok := info.Config.Labels[sandboxIDLabelKey]
+	if !ok {
+		return fmt.Errorf("the container: %s is not a regular container,the %s could not be found", containerId, sandboxIDLabelKey)
+	}
+
+	sandboxInfo, err := docker.InspectContainer(sandboxID)
+	if err != nil {
+		return fmt.Errorf("failed to inspect sandbox %q: %v", sandboxID, err)
+	}
+	blkiolable, ok := sandboxInfo.Config.Labels[BlkioKey]
+	if !ok {
+		glog.V(4).Infof("the sandbox is not set %s, sandboxID:%s, containerId:%s", BlkioKey, sandboxID, containerId)
+		return nil
+	}
+	blkio := Blkio{}
+	err = json.Unmarshal([]byte(blkiolable), &blkio)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal blkio config,%s, sandboxID:%s, containerId:%s", err.Error(), sandboxID, containerId)
+	}
+
+	driverName := info.GraphDriver.Name
+	if driverName != GraphDriverName {
+		glog.V(4).Infof("the container driver is %v, sandboxID:%s, containerId:%s", driverName, sandboxID, containerId)
+		return nil
+	}
+	deviceName, ok := info.GraphDriver.Data[GraphDriverDeviceNameKey]
+	if !ok {
+		glog.V(4).Infof("the container GraphDriverDeviceName not found. sandboxID:%s, containerId:%s", sandboxID, containerId)
+		return nil
+	}
+	containerRoot := filepath.Join(DeviceRoot, deviceName)
+	blkioResource, err := getBlkioResource(&blkio, containerRoot)
+	if err != nil {
+		return fmt.Errorf("getBlkioResource failed. sandboxID:%s, containerId:%s, %v", sandboxID, containerId, err.Error())
+	}
+
+	cpath, err := getBlkioCgroupPath(BlkioSubsystemName, info.HostConfig.CgroupParent, containerId)
+	if err != nil {
+		return fmt.Errorf("getBlkioCgroupPath failed. sandboxID:%s, containerId:%s, %v", sandboxID, containerId, err.Error())
+	}
+	cg := &configs.Cgroup{
+		Path:      cpath,
+		Resources: &blkioResource,
+	}
+	err = blkioSubsystem.Set(cpath, cg)
+	if err != nil {
+		return fmt.Errorf("blkioSubsystem.Set failed. sandboxID:%s, containerId:%s, %v", sandboxID, containerId, err.Error())
+	}
+	glog.V(4).Infof("set Blkio cgroup success. sandboxID:%s, containerId:%s, cgroup path:%v, cgroup:%+v", sandboxID, containerId, cpath, cgroupToString(cg))
+	return nil
+}

--- a/pkg/kubelet/dockershim/blkio/manager_linux.go
+++ b/pkg/kubelet/dockershim/blkio/manager_linux.go
@@ -13,10 +13,16 @@ import (
 )
 
 func UpdateBlkio(containerId string, docker libdocker.Interface) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("failed update blkio. containerID:%q, %v", e)
+		}
+	}()
 	info, err := docker.InspectContainer(containerId)
 	if err != nil {
 		return fmt.Errorf("failed to inspect container %q: %v", containerId, err)
 	}
+
 	containerType, ok := info.Config.Labels[containerTypeLabelKey]
 	if !ok {
 		return fmt.Errorf("the container: %s is neither a regular container is a sandbox.", containerId)

--- a/pkg/kubelet/dockershim/blkio/manager_test.go
+++ b/pkg/kubelet/dockershim/blkio/manager_test.go
@@ -1,0 +1,481 @@
+// +build linux
+
+package blkio
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/golang/glog"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"k8s.io/apimachinery/pkg/api/resource"
+	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
+)
+
+// var cgrouproot = "/sys/fs/zmp/test"
+
+var ErrorNotFound error
+
+// FakeFileStat
+type FakeFileStat struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	// sys     unix.Stat_t
+	sys syscall.Stat_t
+}
+
+func (fs *FakeFileStat) Size() int64        { return fs.size }
+func (fs *FakeFileStat) Mode() os.FileMode  { return fs.mode }
+func (fs *FakeFileStat) ModTime() time.Time { return fs.modTime }
+func (fs *FakeFileStat) Sys() interface{}   { return &fs.sys }
+func (fs *FakeFileStat) Name() string       { return fs.name }
+func (fs *FakeFileStat) IsDir() bool        { return false }
+
+// FakeSubSystem
+type FakeSubSystem struct {
+	name         string
+	expectPath   string
+	expectcgroup *configs.Cgroup
+}
+
+func (f *FakeSubSystem) Name() string { return f.name }
+func (f *FakeSubSystem) Set(path string, cgroup *configs.Cgroup) error {
+	if f.expectPath != path {
+		return fmt.Errorf("Set CGroup failed. cgroup path: %v, expect cgroup path is :%v ", path, f.expectPath)
+	}
+	if path != cgroup.Path {
+		return fmt.Errorf("Set CGroup failed. set cgroup path: %v, configs.Cgroup.path is : %v", path, cgroup.Path)
+	}
+
+	if err := cgroupMustEqual(f.expectcgroup, cgroup); err != nil {
+		return fmt.Errorf("Set CGroup failed. set cgroup expect cgroup : %+s", err.Error())
+	}
+	fmt.Printf("Successfull. Set CGroup: %+v cgroup:%+v Resources:%+v \n", path, cgroup, *cgroup.Resources)
+
+	return nil
+}
+func weightDeviceEqual(A, B []*configs.WeightDevice) bool {
+	for _, a := range A {
+		if !findWeightDevice(a, B) {
+			return false
+		}
+	}
+	for _, b := range B {
+		if !findWeightDevice(b, A) {
+			return false
+		}
+	}
+	return true
+}
+func findWeightDevice(w *configs.WeightDevice, wds []*configs.WeightDevice) bool {
+	for _, wd := range wds {
+		if *w == *wd {
+			return true
+		}
+	}
+	return false
+}
+func findThrottleDevice(t *configs.ThrottleDevice, tds []*configs.ThrottleDevice) bool {
+	for _, td := range tds {
+		if *t == *td {
+			return true
+		}
+	}
+	return false
+}
+func throttleDeviceEqual(A, B []*configs.ThrottleDevice) bool {
+	for _, a := range A {
+		if !findThrottleDevice(a, B) {
+			return false
+		}
+	}
+	for _, b := range B {
+		if !findThrottleDevice(b, A) {
+			return false
+		}
+	}
+	return true
+}
+func cgroupMustEqual(A, B *configs.Cgroup) error {
+	if A.Name != B.Name || A.Parent != B.Parent || A.Path != B.Path || A.ScopePrefix != B.ScopePrefix {
+		return fmt.Errorf("cgroup not equal. A:%+v, B:%+v", *A, *B)
+	}
+	if weightDeviceEqual(A.Resources.BlkioWeightDevice, B.Resources.BlkioWeightDevice) {
+		return fmt.Errorf("cgroupMustEqual BlkioWeightDevice A : %+v, B: %+v",
+			A.Resources.BlkioWeightDevice, B.Resources.BlkioWeightDevice)
+	}
+	if throttleDeviceEqual(A.Resources.BlkioThrottleReadBpsDevice, B.Resources.BlkioThrottleReadBpsDevice) {
+		return fmt.Errorf("cgroupMustEqual BlkioThrottleReadBpsDevice A : %+v, B: %+v",
+			A.Resources.BlkioThrottleReadBpsDevice, B.Resources.BlkioThrottleReadBpsDevice)
+	}
+	if throttleDeviceEqual(A.Resources.BlkioThrottleWriteBpsDevice, B.Resources.BlkioThrottleWriteBpsDevice) {
+		return fmt.Errorf("cgroupMustEqual BlkioThrottleWriteBpsDevice A : %+v, B: %+v",
+			A.Resources.BlkioThrottleWriteBpsDevice, B.Resources.BlkioThrottleWriteBpsDevice)
+	}
+	if throttleDeviceEqual(A.Resources.BlkioThrottleReadIOPSDevice, B.Resources.BlkioThrottleReadIOPSDevice) {
+		return fmt.Errorf("cgroupMustEqual BlkioThrottleReadIOPSDevice A : %+v, B: %+v",
+			A.Resources.BlkioThrottleReadIOPSDevice, B.Resources.BlkioThrottleReadIOPSDevice)
+	}
+	if throttleDeviceEqual(A.Resources.BlkioThrottleWriteIOPSDevice, B.Resources.BlkioThrottleWriteIOPSDevice) {
+		return fmt.Errorf("cgroupMustEqual BlkioThrottleWriteIOPSDevice A : %+v, B: %+v",
+			A.Resources.BlkioThrottleWriteIOPSDevice, B.Resources.BlkioThrottleWriteIOPSDevice)
+	}
+
+	return nil
+
+}
+
+//
+type BlkioMockBuilder struct {
+	ContainnerID string
+	Fsinfo       map[string]*FakeFileStat
+	ExpectCroup  *configs.Cgroup
+	CGrouproot   string
+	CGroupParent string
+	ContainerMap *dockertypes.ContainerJSON
+	SandboxMap   *dockertypes.ContainerJSON
+}
+
+func (b *BlkioMockBuilder) setMock() (docker libdocker.Interface, err error) {
+	expectCgroupPath := filepath.Join(b.CGrouproot, "blkio", b.CGroupParent, b.ContainerMap.ID)
+	unixos = &containertest.FakeOS{
+		StatFn: func(name string) (info os.FileInfo, err error) {
+			info, ok := b.Fsinfo[name]
+			if !ok {
+				glog.Errorf("Notfound the file %s, Fsinfo:%+v", name, b.Fsinfo)
+				return info, ErrorNotFound
+			}
+			return info, nil
+		},
+	}
+	blkioSubsystem = &FakeSubSystem{
+		name:         BlkioSubsystemName,
+		expectcgroup: b.ExpectCroup,
+		expectPath:   expectCgroupPath,
+	}
+	FindCgroupMountpointDir = func() (string, error) {
+		return b.CGrouproot, nil
+	}
+
+	ld := libdocker.NewFakeDockerClient()
+	ld.ContainerMap[b.ContainerMap.ID] = b.ContainerMap
+	ld.ContainerMap[b.SandboxMap.ID] = b.SandboxMap
+
+	return ld, nil
+}
+
+func getMockBuilder(containerID, sandboxID, roofsDevName, cgrouprootPath, cgroupParent string, blkioCfg *Blkio, ecgroup *configs.Cgroup, fstats map[string]*FakeFileStat) (data BlkioMockBuilder) {
+	blkioData, _ := json.Marshal(blkioCfg)
+	data = BlkioMockBuilder{
+		ContainnerID: containerID,
+		CGrouproot:   cgrouprootPath,
+		CGroupParent: cgroupParent,
+		Fsinfo:       fstats,
+		ExpectCroup:  ecgroup,
+		ContainerMap: &dockertypes.ContainerJSON{
+			ContainerJSONBase: &dockertypes.ContainerJSONBase{
+				ID: containerID,
+				GraphDriver: dockertypes.GraphDriverData{
+					Data: map[string]string{
+						GraphDriverDeviceIdKey:   "9856789098",
+						GraphDriverDeviceNameKey: roofsDevName,
+						GraphDriverDeviceSizeKey: "98765445678",
+					},
+					Name: GraphDriverName,
+				},
+				HostConfig: &container.HostConfig{
+					Resources: container.Resources{
+						CgroupParent: cgroupParent,
+					},
+				},
+			},
+			Config: &container.Config{
+				Labels: map[string]string{
+					containerTypeLabelKey: containerTypeLabelContainer,
+					sandboxIDLabelKey:     sandboxID,
+				},
+			},
+		},
+		SandboxMap: &dockertypes.ContainerJSON{
+			ContainerJSONBase: &dockertypes.ContainerJSONBase{
+				ID: sandboxID,
+				HostConfig: &container.HostConfig{
+					Resources: container.Resources{
+						CgroupParent: cgroupParent,
+					},
+				},
+			},
+			Config: &container.Config{
+				Labels: map[string]string{
+					containerTypeLabelKey: containerTypeLabelSandbox,
+					BlkioKey:              string(blkioData),
+				},
+			},
+		},
+	}
+	return
+}
+
+func buildSubSystemData(filedatas []DeviceCgroupMeta, weight uint16, rootfsDevName, cgroupRootPath, cgroupParent, containerID string) (*configs.Cgroup, *Blkio, map[string]*FakeFileStat, error) {
+	Blkiocfg := Blkio{
+		Weight: uint16(87),
+	}
+	fileStats := make(map[string]*FakeFileStat)
+	fileStats[cgroupRootPath] = &FakeFileStat{
+		name: cgroupRootPath, //
+		size: int64(876567),
+		mode: os.FileMode(7777),
+		sys: syscall.Stat_t{
+			Rdev: uint64(76557734),
+		},
+	}
+
+	blkioResource := configs.Resources{}
+	blkioResource.BlkioWeight = weight
+	for _, filedata := range filedatas {
+		DevicePath := filedata.DevicePath
+		if DevicePath == "rootfs" {
+			DevicePath = filepath.Join("/dev/mapper/", rootfsDevName)
+		}
+		fileStats[DevicePath] = &FakeFileStat{
+			name: DevicePath, //
+			size: filedata.Size,
+			mode: filedata.Mode,
+			sys: syscall.Stat_t{
+				Rdev: filedata.Rdev,
+			},
+		}
+		for key, value := range filedata.CGSet {
+			switch key {
+			case "weight_device":
+				quantity, err := resource.ParseQuantity(value)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				q := quantity.Value()
+				wd := &configs.WeightDevice{}
+				wd.Major = int64((filedata.Rdev >> 24) & 0xff)
+				wd.Minor = int64(filedata.Rdev & 0xffffff)
+				wd.Weight = uint16(q & 0x00ffff)
+				blkioResource.BlkioWeightDevice = append(blkioResource.BlkioWeightDevice, wd)
+
+				Blkiocfg.WeightDevice = append(Blkiocfg.WeightDevice,
+					deviceValue{
+						Device: filedata.DevicePath,
+						Value:  value,
+					})
+
+			case "device_read_bps":
+				quantity, err := resource.ParseQuantity(value)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				q := quantity.Value()
+				td := &configs.ThrottleDevice{}
+				td.Major = int64((filedata.Rdev >> 24) & 0xff)
+				td.Minor = int64(filedata.Rdev & 0xffffff)
+				td.Rate = uint64(q)
+
+				blkioResource.BlkioThrottleReadBpsDevice = append(blkioResource.BlkioThrottleReadBpsDevice, td)
+
+				Blkiocfg.DeviceReadBps = append(Blkiocfg.DeviceReadBps,
+					deviceValue{
+						Device: filedata.DevicePath,
+						Value:  value,
+					})
+
+			case "device_write_bps":
+				quantity, err := resource.ParseQuantity(value)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				q := quantity.Value()
+				td := &configs.ThrottleDevice{}
+				td.Major = int64((filedata.Rdev >> 24) & 0xff)
+				td.Minor = int64(filedata.Rdev & 0xffffff)
+				td.Rate = uint64(q)
+				blkioResource.BlkioThrottleWriteBpsDevice = append(blkioResource.BlkioThrottleWriteBpsDevice, td)
+
+				Blkiocfg.DeviceWriteBps = append(Blkiocfg.DeviceWriteBps,
+					deviceValue{
+						Device: filedata.DevicePath,
+						Value:  value,
+					})
+			case "device_read_iops":
+				quantity, err := resource.ParseQuantity(value)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				q := quantity.Value()
+				td := &configs.ThrottleDevice{}
+				td.Major = int64((filedata.Rdev >> 24) & 0xff)
+				td.Minor = int64(filedata.Rdev & 0xffffff)
+				td.Rate = uint64(q)
+				blkioResource.BlkioThrottleReadIOPSDevice = append(blkioResource.BlkioThrottleReadIOPSDevice, td)
+				Blkiocfg.DeviceReadIOps = append(Blkiocfg.DeviceReadIOps,
+					deviceValue{
+						Device: filedata.DevicePath,
+						Value:  value,
+					})
+			case "device_write_iops":
+				quantity, err := resource.ParseQuantity(value)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				q := quantity.Value()
+				td := &configs.ThrottleDevice{}
+				td.Major = int64((filedata.Rdev >> 24) & 0xff)
+				td.Minor = int64(filedata.Rdev & 0xffffff)
+				td.Rate = uint64(q)
+				blkioResource.BlkioThrottleWriteIOPSDevice = append(blkioResource.BlkioThrottleWriteIOPSDevice, td)
+				Blkiocfg.DeviceWriteIOps = append(Blkiocfg.DeviceWriteIOps,
+					deviceValue{
+						Device: filedata.DevicePath,
+						Value:  value,
+					})
+			}
+		}
+	}
+
+	expectcgroup := configs.Cgroup{
+		Path:      filepath.Join(cgroupRootPath, "blkio", cgroupParent, containerID),
+		Resources: &blkioResource,
+	}
+	return &expectcgroup, &Blkiocfg, fileStats, nil
+}
+
+type DeviceCgroupMeta struct {
+	CGroupBlkioType string
+	DevicePath      string
+	CGSet           map[string]string
+	Rdev            uint64
+	Mode            os.FileMode
+	Size            int64
+}
+
+func getMockBuilderTables() ([]BlkioMockBuilder, error) {
+	ErrorNotFound = fmt.Errorf("Not found")
+	MockBuilderTables := []BlkioMockBuilder{}
+	cgroupRootPath := "/sys/fs/cgroup" + strconv.FormatInt(time.Now().Unix(), 10)
+	for i := 0; i < 10; i++ {
+		roofsDevName := "docker-253:2-6029320-525bf5183e7a4753a719b8eca03c06ed4bafbac66477bde246f6bd6f36ffb981-" + strconv.Itoa(i)
+		rootrdev := uint64(0x10106655) + uint64(i)
+		containerID := "JamesBryce-Avanpourm1-98766194yfkjhgfqGHGF-" + strconv.Itoa(i)
+		sandboxID := "container-JamesBryce-Avanpourm-01-" + strconv.Itoa(i)
+		cgroupParent := "/kubepods/podd6f49e33-d7a7-11e8-ae45-c81f66bda7a1-" + strconv.Itoa(i)
+		DeviceCgroupMetas := testCase(rootrdev, i)
+		weight := uint16(876 + i)
+		CG, blkiocfg, Fsinfos, err := buildSubSystemData(DeviceCgroupMetas, weight, roofsDevName, cgroupRootPath, cgroupParent, containerID)
+		if err != nil {
+			return nil, err
+		}
+
+		MockBuilderTables = append(MockBuilderTables,
+			getMockBuilder(containerID, sandboxID, roofsDevName, cgroupRootPath, cgroupParent, blkiocfg, CG, Fsinfos))
+	}
+	return MockBuilderTables, nil
+}
+
+func testCase(rootrdev uint64, i int) []DeviceCgroupMeta {
+	DeviceCgroupMetas := []DeviceCgroupMeta{
+		{
+			DevicePath: "rootfs",
+			CGSet: map[string]string{
+				"weight_device":     "123" + strconv.Itoa(i),
+				"device_read_bps":   "125" + strconv.Itoa(i) + "k",
+				"device_write_bps":  "125" + strconv.Itoa(i) + "M",
+				"device_read_iops":  "325" + strconv.Itoa(i) + "G",
+				"device_write_iops": "525" + strconv.Itoa(i) + "k",
+			},
+			Rdev: rootrdev,
+			Mode: os.FileMode(777),
+			Size: int64(987654567) + int64(i),
+		},
+		{
+			DevicePath: "/dev/mpa-9",
+			CGSet: map[string]string{
+				// "weight": "823" + strconv.Itoa(i),
+				"weight_device":     "129" + strconv.Itoa(i),
+				"device_read_bps":   "135" + strconv.Itoa(i) + "k",
+				"device_write_bps":  "225" + strconv.Itoa(i) + "m",
+				"device_read_iops":  "325" + strconv.Itoa(i) + "M",
+				"device_write_iops": "325" + strconv.Itoa(i) + "G",
+			},
+			Rdev: uint64(0x20206657) + uint64(i),
+			Mode: os.FileMode(777),
+			Size: int64(187654567) + int64(i),
+		},
+		{
+			DevicePath: "/dev/mpa-8",
+			CGSet: map[string]string{
+				"weight_device":     "229" + strconv.Itoa(i),
+				"device_read_bps":   "335" + strconv.Itoa(i) + "m",
+				"device_write_bps":  "225" + strconv.Itoa(i) + "k",
+				"device_read_iops":  "325" + strconv.Itoa(i) + "M",
+				"device_write_iops": "525" + strconv.Itoa(i) + "G",
+			},
+			Rdev: uint64(0x20226655) + uint64(i),
+			Mode: os.FileMode(777),
+			Size: int64(187654567) + int64(i),
+		},
+		{
+			DevicePath: "/dev/mp8",
+			CGSet: map[string]string{
+				"weight_device":     "529" + strconv.Itoa(i),
+				"device_read_bps":   "735" + strconv.Itoa(i) + "k",
+				"device_write_bps":  "795" + strconv.Itoa(i) + "m",
+				"device_read_iops":  "735" + strconv.Itoa(i) + "M",
+				"device_write_iops": "355" + strconv.Itoa(i) + "G",
+			},
+			Rdev: uint64(0x20203655) + uint64(i),
+			Mode: os.FileMode(777),
+			Size: int64(187654567) + int64(i),
+		},
+		{
+			DevicePath: "/dev/zmpbbg-Avanpourm-JamesBryce",
+			CGSet: map[string]string{
+				"weight_device":     "929" + strconv.Itoa(i),
+				"device_read_bps":   "835" + strconv.Itoa(i) + "M",
+				"device_write_bps":  "725" + strconv.Itoa(i) + "k",
+				"device_read_iops":  "625" + strconv.Itoa(i) + "M",
+				"device_write_iops": "525" + strconv.Itoa(i) + "G",
+			},
+			Rdev: uint64(0x20206755) + uint64(i),
+			Mode: os.FileMode(777),
+			Size: int64(187654567) + int64(i),
+		},
+	}
+
+	return DeviceCgroupMetas
+}
+
+func TestUpdateBlkioLimit(t *testing.T) {
+	Tables, err := getMockBuilderTables()
+	if err != nil {
+		t.Fatalf(err.Error())
+		return
+	}
+	for _, builder := range Tables {
+		docker, err := builder.setMock()
+		if err != nil {
+			t.Fatalf(err.Error())
+			return
+		}
+		err = UpdateBlkio(builder.ContainnerID, docker)
+		if err != nil {
+			t.Errorf("UpdateBlkioLimit containerID:%s, err:%s ", builder.ContainnerID, err.Error())
+		}
+
+	}
+}

--- a/pkg/kubelet/dockershim/blkio/manager_unsupported.go
+++ b/pkg/kubelet/dockershim/blkio/manager_unsupported.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package blkio
+
+import (
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
+)
+
+func UpdateBlkio(containerId string, docker libdocker.Interface) (err error) {
+	return nil
+}

--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -258,7 +258,7 @@ func (ds *dockerService) StartContainer(_ context.Context, r *runtimeapi.StartCo
 	}
 	err = blkio.UpdateBlkio(r.ContainerId, ds.client)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start container %q: %v", r.ContainerId, err)
+		return nil, fmt.Errorf("failed to set blkio when the container %q starts, %v", r.ContainerId, err)
 	}
 
 	return &runtimeapi.StartContainerResponse{}, nil

--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golang/glog"
 
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/blkio"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
 
@@ -253,6 +254,10 @@ func (ds *dockerService) StartContainer(_ context.Context, r *runtimeapi.StartCo
 
 	if err != nil {
 		err = transformStartContainerError(err)
+		return nil, fmt.Errorf("failed to start container %q: %v", r.ContainerId, err)
+	}
+	err = blkio.UpdateBlkio(r.ContainerId, ds.client)
+	if err != nil {
 		return nil, fmt.Errorf("failed to start container %q: %v", r.ContainerId, err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
I need to limit the read and write iops of rootfs
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #70364

**Special notes for your reviewer**:
Thankyou !!！

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Use the annotation of kubernetes to pass the parameters of the cgroup to control the container blkio
Specifying the device path as "rootfs" indicates that you specify limiting rootfs
For example:
io.kubernetes.container.blkio: '{"weight":200,"weight_device":[{"device":"rootfs","value":"200k"}],"device_read_bps":[{"device":"/dev/sda1","value":"20m"}],"device_write_bps":[{"device":"rootfs","value":"20m"}],"device_read_iops":[{"device":"rootfs","value":"200"}]"device_write_iops":[{"device":"rootfs","value":"300"}]}'

```
### Parameter
| parameter | type | default value | means | parameter range | example | corresponds to Cgoup |
| --- | --- | --- | --- | --- | --- | --- |
| weight | Uint16 | 0 | Weight value for all devices | 10-1000 | 1 |   |
| weight_device | Array | nil | Weight value for all devices | - |  |  |
| weight_device.[*].device | String |  | The absolute path of the device |  | /dev/sda1 |  |
| weight_device.[*].value | String |  | Weight value of the device|10-1000  |  |  |
| device_read_bps | Array | nil | A device reads the maximum number of bytes per second |  |  |  |
| device_read_bps.[*].device | String |  | The absolute path of the device. You can use "rootfs" for the specified root directory|  |  |  |
| device_read_bps.[*].value | String |  |Value ,like: 1[ K M G ]. Limit the minimum to prevent the process from entering a D state | >1k | 1M |  |
| device_write_bps | Array | nil | Maximum number of bytes per second allowed to write to the device |  |  |  |
| device_write_bps.[*].device | String |  | The absolute path of the device. You can use "rootfs" for the specified root directory |  |  |  |
| device_write_bps.[*].value | String |  |Value ,like: 1[ K M G ]. Limit the minimum to prevent the process from entering a D state | >1k |  |  |
| device_read_iops | Array | nil | Max IOPS |  |  |  |
| device_read_iops.[*].device | String |  | The absolute path of the device. You can use "rootfs" for the specified root directory |  |  |  |
| device_read_iops.[*].value | String |  | Value ,like: 1[ K M G ]. Limit the minimum to prevent the process from entering a D state | >5 |  |  |
| device_write_iops | Array | nil | Max IOPS |  |  |  |
| device_write_iops.[*].device | String |  | The absolute path of the device. You can use "rootfs" for the specified root directory|  |  |  |
| device_write_iops.[*].value | String |  | Value ,like: 1[ K M G ]. Limit the minimum to prevent the process from entering a D state | >5 |  | |

### Deployment Example

```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: iops-app
  name: iops-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: iops-app
  template:
    metadata:
      labels:
        app: iops-app
      annotations:
        io.kubernetes.container.blkio: '{"weight":200,"weight_device":[{"device":"rootfs","value":"200k"}],"device_read_bps":[{"device":"/dev/sad1","value":"20m"}],"device_write_bps":[{"device":"rootfs","value":"20m"}],"device_read_iops":[{"device":"rootfs","value":"200"}],"device_write_iops":[{"device":"rootfs","value":"300"}]}'
    spec:
      nodeSelector:
        kubernetes.io/hostname: szdc-k8sm-2-2.meitu-inc.com
      containers:
      - image: docker.io/centos:7
        command: ["/bin/sh","-c"]
        args: ["while(true);do /bin/sleep 10;done"]
        name: iops-app
        resources:
          requests:
            memory: "200Mi"
            cpu: 1
          limits:
            memory: "200Mi"
            cpu: 1
        volumeMounts:
        - name: host-time
          mountPath: /etc/localtime
      volumes:
      - name: host-time
        hostPath:
          path: /etc/localtime
```
