### PR TITLE
Add some invalidPredicates for InvalidateCachedPredicateItemForPodAdd

### DIFF
--- a/pkg/scheduler/core/equivalence/eqivalence.go
+++ b/pkg/scheduler/core/equivalence/eqivalence.go
@@ -206,7 +206,10 @@ func (c *Cache) InvalidateCachedPredicateItemForPodAdd(pod *v1.Pod, nodeName str
 	// it will also fits to equivalence class of existing pods
 
 	// GeneralPredicates: will always be affected by adding a new pod
-	invalidPredicates := sets.NewString(predicates.GeneralPred)
+	// PodFitsResourcesPred and PodFitsHostPortsPred in GeneralPredicates are also added because
+	// they might be configured in scheduler policy file instead of GeneralPredicates.
+	invalidPredicates := sets.NewString(predicates.GeneralPred, predicates.PodFitsResourcesPred,
+		predicates.PodFitsHostPortsPred)
 
 	// MaxPDVolumeCountPredicate: we check the volumes of pod to make decisioc.
 	for _, vol := range pod.Spec.Volumes {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In file `kube-scheduler-policy.json`, we config predicates to `PodFitsResources` and `PodFitsHostPorts` instead of `GeneralPredicates`.  And in `pkg/scheduler/core/equivalence/eqivalence.go#InvalidateCachedPredicateItemForPodAdd`, it will not invalidate `PodFitsResources` and `PodFitsHostPorts`, then they will not be invalidated when a pod is added.

In this PR, the two basic predicates(they are in `GeneralPredicates`, and other predicates in `GeneralPredicates` will not be affected by adding a pod ) are added to  invalidPredicates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
