### PR TITLE
e2e/storage: avoid definining unusable tests

### DIFF
--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -33,6 +33,7 @@ go_library(
         "rs_util.go",
         "service_util.go",
         "size.go",
+        "specs.go",
         "statefulset_utils.go",
         "test_context.go",
         "upgrade_util.go",

--- a/test/e2e/framework/specs.go
+++ b/test/e2e/framework/specs.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"github.com/onsi/ginkgo"
+)
+
+type spec struct {
+	text string
+	body func()
+}
+
+var specs []spec
+
+// DescribeWithTestContext is like ginkgo.Describe, but in contrast to
+// ginkgo, the framework implementation will invoke the spec body at a
+// time when TestContext has been fully initialized. A callback
+// invoked via framework.Describe therefore can add or parameterize
+// specs depending on the test configuration.
+func DescribeWithTestContext(text string, body func()) bool {
+	specs = append(specs, spec{text, body})
+
+	// Always returns a value for use in
+	// var _ = framework.DescribeWithContext(...).
+	return true
+}
+
+func describeSpecs() {
+	for _, spec := range specs {
+		ginkgo.Describe(spec.text, spec.body)
+	}
+}

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -401,20 +401,23 @@ func AfterReadingAllFlags(t *TestContextType) {
 	// Make sure that all test runs have a valid TestContext.CloudConfig.Provider.
 	var err error
 	TestContext.CloudConfig.Provider, err = SetupProviderConfig(TestContext.Provider)
-	if err == nil {
-		return
-	}
-	if !os.IsNotExist(errors.Cause(err)) {
-		Failf("Failed to setup provider config: %v", err)
-	}
-	// We allow unknown provider parameters for historic reasons. At least log a
-	// warning to catch typos.
-	// TODO (https://github.com/kubernetes/kubernetes/issues/70200):
-	// - remove the fallback for unknown providers
-	// - proper error message instead of Failf (which panics)
-	klog.Warningf("Unknown provider %q, proceeding as for --provider=skeleton.", TestContext.Provider)
-	TestContext.CloudConfig.Provider, err = SetupProviderConfig("skeleton")
 	if err != nil {
-		Failf("Failed to setup fallback skeleton provider config: %v", err)
+		if !os.IsNotExist(errors.Cause(err)) {
+			Failf("Failed to setup provider config: %v", err)
+		}
+		// We allow unknown provider parameters for historic reasons. At least log a
+		// warning to catch typos.
+		// TODO (https://github.com/kubernetes/kubernetes/issues/70200):
+		// - remove the fallback for unknown providers
+		// - proper error message instead of Failf (which panics)
+		klog.Warningf("Unknown provider %q, proceeding as for --provider=skeleton.", TestContext.Provider)
+		TestContext.CloudConfig.Provider, err = SetupProviderConfig("skeleton")
+		if err != nil {
+			Failf("Failed to setup fallback skeleton provider config: %v", err)
+		}
 	}
+
+	// Register Ginkgo specs in Gingko that wanted to wait for the
+	// TestContext to be initialized.
+	describeSpecs()
 }

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -94,9 +94,6 @@ func (h *hostpathCSIDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &h.driverInfo
 }
 
-func (h *hostpathCSIDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-}
-
 func (h *hostpathCSIDriver) GetDynamicProvisionStorageClass(fsType string) *storagev1.StorageClass {
 	provisioner := testsuites.GetUniqueDriverName(h)
 	parameters := map[string]string{}
@@ -197,12 +194,6 @@ func (g *gcePDCSIDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &g.driverInfo
 }
 
-func (g *gcePDCSIDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-	f := g.driverInfo.Config.Framework
-	framework.SkipUnlessProviderIs("gce", "gke")
-	framework.SkipIfMultizone(f.ClientSet)
-}
-
 func (g *gcePDCSIDriver) GetDynamicProvisionStorageClass(fsType string) *storagev1.StorageClass {
 	ns := g.driverInfo.Config.Framework.Namespace.Name
 	provisioner := g.driverInfo.Name
@@ -218,6 +209,9 @@ func (g *gcePDCSIDriver) GetClaimSize() string {
 }
 
 func (g *gcePDCSIDriver) CreateDriver() {
+	framework.SkipUnlessProviderIs("gce", "gke")
+	framework.SkipIfMultizone(g.driverInfo.Config.Framework.ClientSet)
+
 	By("deploying csi gce-pd driver")
 	// It would be safer to rename the gcePD driver, but that
 	// hasn't been done before either and attempts to do so now led to
@@ -293,11 +287,6 @@ func (g *gcePDExternalCSIDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &g.driverInfo
 }
 
-func (g *gcePDExternalCSIDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-	framework.SkipUnlessProviderIs("gce", "gke")
-	framework.SkipIfMultizone(g.driverInfo.Config.Framework.ClientSet)
-}
-
 func (g *gcePDExternalCSIDriver) GetDynamicProvisionStorageClass(fsType string) *storagev1.StorageClass {
 	ns := g.driverInfo.Config.Framework.Namespace.Name
 	provisioner := g.driverInfo.Name
@@ -313,6 +302,8 @@ func (g *gcePDExternalCSIDriver) GetClaimSize() string {
 }
 
 func (g *gcePDExternalCSIDriver) CreateDriver() {
+	framework.SkipUnlessProviderIs("gce", "gke")
+	framework.SkipIfMultizone(g.driverInfo.Config.Framework.ClientSet)
 }
 
 func (g *gcePDExternalCSIDriver) CleanupDriver() {

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -105,9 +105,6 @@ func (n *nfsDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &n.driverInfo
 }
 
-func (n *nfsDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-}
-
 func (n *nfsDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
 	ntr, ok := testResource.(*nfsTestResource)
 	Expect(ok).To(BeTrue(), "Failed to cast test resource to NFS Test Resource")
@@ -233,6 +230,7 @@ var _ testsuites.TestDriver = &glusterFSDriver{}
 var _ testsuites.PreprovisionedVolumeTestDriver = &glusterFSDriver{}
 var _ testsuites.InlineVolumeTestDriver = &glusterFSDriver{}
 var _ testsuites.PreprovisionedPVTestDriver = &glusterFSDriver{}
+var _ testsuites.FilterTestDriver = &glusterFSDriver{}
 
 // InitGlusterFSDriver returns glusterFSDriver that implements TestDriver interface
 func InitGlusterFSDriver(config testsuites.TestConfig) testsuites.TestDriver {
@@ -257,11 +255,9 @@ func (g *glusterFSDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &g.driverInfo
 }
 
-func (g *glusterFSDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-	framework.SkipUnlessNodeOSDistroIs("gci", "ubuntu", "custom")
-	if pattern.FsType == "xfs" {
-		framework.SkipUnlessNodeOSDistroIs("ubuntu", "custom")
-	}
+func (g *glusterFSDriver) IsTestSupported(pattern testpatterns.TestPattern) bool {
+	return framework.NodeOSDistroIs("gci", "ubuntu", "custom") &&
+		(pattern.FsType != "xfs" || framework.NodeOSDistroIs("ubuntu", "custom"))
 }
 
 func (g *glusterFSDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
@@ -383,9 +379,6 @@ func (i *iSCSIDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &i.driverInfo
 }
 
-func (i *iSCSIDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-}
-
 func (i *iSCSIDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
 	itr, ok := testResource.(*iSCSITestResource)
 	Expect(ok).To(BeTrue(), "Failed to cast test resource to iSCSI Test Resource")
@@ -495,9 +488,6 @@ func InitRbdDriver(config testsuites.TestConfig) testsuites.TestDriver {
 
 func (r *rbdDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &r.driverInfo
-}
-
-func (r *rbdDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 }
 
 func (r *rbdDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
@@ -621,9 +611,6 @@ func (c *cephFSDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &c.driverInfo
 }
 
-func (c *cephFSDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-}
-
 func (c *cephFSDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
 	ctr, ok := testResource.(*cephTestResource)
 	Expect(ok).To(BeTrue(), "Failed to cast test resource to Ceph Test Resource")
@@ -722,9 +709,6 @@ func (h *hostPathDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &h.driverInfo
 }
 
-func (h *hostPathDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-}
-
 func (h *hostPathDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
 	// hostPath doesn't support readOnly volume
 	if readOnly {
@@ -794,9 +778,6 @@ func InitHostPathSymlinkDriver(config testsuites.TestConfig) testsuites.TestDriv
 
 func (h *hostPathSymlinkDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &h.driverInfo
-}
-
-func (h *hostPathSymlinkDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 }
 
 func (h *hostPathSymlinkDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
@@ -938,9 +919,6 @@ func (e *emptydirDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &e.driverInfo
 }
 
-func (e *emptydirDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-}
-
 func (e *emptydirDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
 	// emptydir doesn't support readOnly volume
 	if readOnly {
@@ -983,6 +961,7 @@ var _ testsuites.PreprovisionedVolumeTestDriver = &cinderDriver{}
 var _ testsuites.InlineVolumeTestDriver = &cinderDriver{}
 var _ testsuites.PreprovisionedPVTestDriver = &cinderDriver{}
 var _ testsuites.DynamicPVTestDriver = &cinderDriver{}
+var _ testsuites.FilterTestDriver = &cinderDriver{}
 
 // InitCinderDriver returns cinderDriver that implements TestDriver interface
 func InitCinderDriver(config testsuites.TestConfig) testsuites.TestDriver {
@@ -1009,8 +988,8 @@ func (c *cinderDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &c.driverInfo
 }
 
-func (c *cinderDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-	framework.SkipUnlessProviderIs("openstack")
+func (c *cinderDriver) IsTestSupported(pattern testpatterns.TestPattern) bool {
+	return framework.ProviderIs("openstack")
 }
 
 func (c *cinderDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
@@ -1145,6 +1124,7 @@ var _ testsuites.PreprovisionedVolumeTestDriver = &gcePdDriver{}
 var _ testsuites.InlineVolumeTestDriver = &gcePdDriver{}
 var _ testsuites.PreprovisionedPVTestDriver = &gcePdDriver{}
 var _ testsuites.DynamicPVTestDriver = &gcePdDriver{}
+var _ testsuites.FilterTestDriver = &gcePdDriver{}
 
 // InitGceDriver returns gcePdDriver that implements TestDriver interface
 func InitGcePdDriver(config testsuites.TestConfig) testsuites.TestDriver {
@@ -1176,11 +1156,9 @@ func (g *gcePdDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &g.driverInfo
 }
 
-func (g *gcePdDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-	framework.SkipUnlessProviderIs("gce", "gke")
-	if pattern.FsType == "xfs" {
-		framework.SkipUnlessNodeOSDistroIs("ubuntu", "custom")
-	}
+func (g *gcePdDriver) IsTestSupported(pattern testpatterns.TestPattern) bool {
+	return framework.ProviderIs("gce", "gke") &&
+		(pattern.FsType != "xfs" || framework.NodeOSDistroIs("ubuntu", "custom"))
 }
 
 func (g *gcePdDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
@@ -1272,6 +1250,7 @@ var _ testsuites.PreprovisionedVolumeTestDriver = &vSphereDriver{}
 var _ testsuites.InlineVolumeTestDriver = &vSphereDriver{}
 var _ testsuites.PreprovisionedPVTestDriver = &vSphereDriver{}
 var _ testsuites.DynamicPVTestDriver = &vSphereDriver{}
+var _ testsuites.FilterTestDriver = &vSphereDriver{}
 
 // InitVSphereDriver returns vSphereDriver that implements TestDriver interface
 func InitVSphereDriver(config testsuites.TestConfig) testsuites.TestDriver {
@@ -1297,8 +1276,8 @@ func (v *vSphereDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &v.driverInfo
 }
 
-func (v *vSphereDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-	framework.SkipUnlessProviderIs("vsphere")
+func (v *vSphereDriver) IsTestSupported(pattern testpatterns.TestPattern) bool {
+	return framework.ProviderIs("vsphere")
 }
 
 func (v *vSphereDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
@@ -1396,6 +1375,7 @@ var _ testsuites.PreprovisionedVolumeTestDriver = &azureDriver{}
 var _ testsuites.InlineVolumeTestDriver = &azureDriver{}
 var _ testsuites.PreprovisionedPVTestDriver = &azureDriver{}
 var _ testsuites.DynamicPVTestDriver = &azureDriver{}
+var _ testsuites.FilterTestDriver = &azureDriver{}
 
 // InitAzureDriver returns azureDriver that implements TestDriver interface
 func InitAzureDriver(config testsuites.TestConfig) testsuites.TestDriver {
@@ -1423,8 +1403,8 @@ func (a *azureDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &a.driverInfo
 }
 
-func (a *azureDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-	framework.SkipUnlessProviderIs("azure")
+func (a *azureDriver) IsTestSupported(pattern testpatterns.TestPattern) bool {
+	return framework.ProviderIs("azure")
 }
 
 func (a *azureDriver) GetVolumeSource(readOnly bool, fsType string, testResource interface{}) *v1.VolumeSource {
@@ -1517,6 +1497,7 @@ var _ testsuites.TestDriver = &awsDriver{}
 //var _ testsuites.InlineVolumeTestDriver = &awsDriver{}
 //var _ testsuites.PreprovisionedPVTestDriver = &awsDriver{}
 var _ testsuites.DynamicPVTestDriver = &awsDriver{}
+var _ testsuites.FilterTestDriver = &awsDriver{}
 
 // InitAwsDriver returns awsDriver that implements TestDriver interface
 func InitAwsDriver(config testsuites.TestConfig) testsuites.TestDriver {
@@ -1545,8 +1526,8 @@ func (a *awsDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &a.driverInfo
 }
 
-func (a *awsDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
-	framework.SkipUnlessProviderIs("aws")
+func (a *awsDriver) IsTestSupported(pattern testpatterns.TestPattern) bool {
+	return framework.ProviderIs("aws")
 }
 
 // TODO: Fix authorization error in attach operation and uncomment below

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -37,8 +37,8 @@ import (
 type TestSuite interface {
 	// getTestSuiteInfo returns the TestSuiteInfo for this TestSuite
 	getTestSuiteInfo() TestSuiteInfo
-	// skipUnsupportedTest skips the test if this TestSuite is not suitable to be tested with the combination of TestPattern and TestDriver
-	skipUnsupportedTest(testpatterns.TestPattern, TestDriver)
+	// isTestSupported returns true if this TestSuite can be tested with the combination of TestPattern and TestDriver
+	isTestSupported(testpatterns.TestPattern, TestDriver) bool
 	// execTest executes test of the testpattern for the driver
 	execTest(TestDriver, testpatterns.TestPattern)
 }
@@ -64,26 +64,31 @@ func getTestNameStr(suite TestSuite, pattern testpatterns.TestPattern) string {
 	return fmt.Sprintf("[Testpattern: %s]%s %s%s", pattern.Name, pattern.FeatureTag, tsInfo.name, tsInfo.featureTag)
 }
 
-// RunTestSuite runs all testpatterns of all testSuites for a driver
+// RunTestSuite defines tests for all testpatterns and all testSuites for a driver
 func RunTestSuite(f *framework.Framework, driver TestDriver, tsInits []func() TestSuite, tunePatternFunc func([]testpatterns.TestPattern) []testpatterns.TestPattern) {
 	for _, testSuiteInit := range tsInits {
 		suite := testSuiteInit()
 		patterns := tunePatternFunc(suite.getTestSuiteInfo().testPatterns)
 
 		for _, pattern := range patterns {
+			if !isTestSupported(suite, driver, pattern) {
+				continue
+			}
+
 			suite.execTest(driver, pattern)
 		}
 	}
 }
 
-// skipUnsupportedTest will skip tests if the combination of driver, testsuite, and testpattern
-// is not suitable to be tested.
-// Whether it needs to be skipped is checked by following steps:
-// 1. Check if Whether volType is supported by driver from its interface
+// isTestSupported will determine if the combination of driver, testsuite, and testpattern
+// can be tested.
+//
+// Whether the test combination is supported is checked by the following steps:
+// 1. Check if volType is supported by driver from its interface
 // 2. Check if fsType is supported by driver
 // 3. Check with driver specific logic
 // 4. Check with testSuite specific logic
-func skipUnsupportedTest(suite TestSuite, driver TestDriver, pattern testpatterns.TestPattern) {
+func isTestSupported(suite TestSuite, driver TestDriver, pattern testpatterns.TestPattern) bool {
 	dInfo := driver.GetDriverInfo()
 
 	// 1. Check if Whether volType is supported by driver from its interface
@@ -100,19 +105,25 @@ func skipUnsupportedTest(suite TestSuite, driver TestDriver, pattern testpattern
 	}
 
 	if !isSupported {
-		framework.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolType)
+		return false
 	}
 
 	// 2. Check if fsType is supported by driver
 	if !dInfo.SupportedFsType.Has(pattern.FsType) {
-		framework.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.FsType)
+		return false
 	}
 
 	// 3. Check with driver specific logic
-	driver.SkipUnsupportedTest(pattern)
+	if fDriver, ok := driver.(FilterTestDriver); ok && !fDriver.IsTestSupported(pattern) {
+		return false
+	}
 
 	// 4. Check with testSuite specific logic
-	suite.skipUnsupportedTest(pattern, driver)
+	if !suite.isTestSupported(pattern, driver) {
+		return false
+	}
+
+	return true
 }
 
 // genericVolumeTestResource is a generic implementation of TestResource that wil be able to

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -74,7 +74,8 @@ func (p *provisioningTestSuite) getTestSuiteInfo() TestSuiteInfo {
 }
 
 func (p *provisioningTestSuite) isTestSupported(pattern testpatterns.TestPattern, driver TestDriver) bool {
-	return true
+	_, ok := driver.(DynamicPVTestDriver)
+	return ok
 }
 
 func createProvisioningTestInput(driver TestDriver, pattern testpatterns.TestPattern) (provisioningTestResource, provisioningTestInput) {
@@ -149,6 +150,7 @@ func (p *provisioningTestResource) setupResource(driver TestDriver, pattern test
 			framework.Logf("In creating storage class object and pvc object for driver - sc: %v, pvc: %v", p.sc, p.pvc)
 		}
 	default:
+		// Should never get here because of the check in skipUnsupportedTest above.
 		framework.Failf("Dynamic Provision test doesn't support: %s", pattern.VolType)
 	}
 }

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -73,7 +73,8 @@ func (p *provisioningTestSuite) getTestSuiteInfo() TestSuiteInfo {
 	return p.tsInfo
 }
 
-func (p *provisioningTestSuite) skipUnsupportedTest(pattern testpatterns.TestPattern, driver TestDriver) {
+func (p *provisioningTestSuite) isTestSupported(pattern testpatterns.TestPattern, driver TestDriver) bool {
+	return true
 }
 
 func createProvisioningTestInput(driver TestDriver, pattern testpatterns.TestPattern) (provisioningTestResource, provisioningTestInput) {
@@ -102,25 +103,17 @@ func createProvisioningTestInput(driver TestDriver, pattern testpatterns.TestPat
 func (p *provisioningTestSuite) execTest(driver TestDriver, pattern testpatterns.TestPattern) {
 	Context(getTestNameStr(p, pattern), func() {
 		var (
-			resource     provisioningTestResource
-			input        provisioningTestInput
-			needsCleanup bool
+			resource provisioningTestResource
+			input    provisioningTestInput
 		)
 
 		BeforeEach(func() {
-			needsCleanup = false
-			// Skip unsupported tests to avoid unnecessary resource initialization
-			skipUnsupportedTest(p, driver, pattern)
-			needsCleanup = true
-
 			// Create test input
 			resource, input = createProvisioningTestInput(driver, pattern)
 		})
 
 		AfterEach(func() {
-			if needsCleanup {
-				resource.cleanupResource(driver, pattern)
-			}
+			resource.cleanupResource(driver, pattern)
 		})
 
 		// Ginkgo's "Global Shared Behaviors" require arguments for a shared function

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -71,7 +71,8 @@ func (s *subPathTestSuite) getTestSuiteInfo() TestSuiteInfo {
 	return s.tsInfo
 }
 
-func (s *subPathTestSuite) skipUnsupportedTest(pattern testpatterns.TestPattern, driver TestDriver) {
+func (s *subPathTestSuite) isTestSupported(pattern testpatterns.TestPattern, driver TestDriver) bool {
+	return true
 }
 
 func createSubPathTestInput(pattern testpatterns.TestPattern, resource subPathTestResource) subPathTestInput {
@@ -97,17 +98,11 @@ func createSubPathTestInput(pattern testpatterns.TestPattern, resource subPathTe
 func (s *subPathTestSuite) execTest(driver TestDriver, pattern testpatterns.TestPattern) {
 	Context(getTestNameStr(s, pattern), func() {
 		var (
-			resource     subPathTestResource
-			input        subPathTestInput
-			needsCleanup bool
+			resource subPathTestResource
+			input    subPathTestInput
 		)
 
 		BeforeEach(func() {
-			needsCleanup = false
-			// Skip unsupported tests to avoid unnecessary resource initialization
-			skipUnsupportedTest(s, driver, pattern)
-			needsCleanup = true
-
 			// Setup test resource for driver and testpattern
 			resource = subPathTestResource{}
 			resource.setupResource(driver, pattern)
@@ -117,9 +112,7 @@ func (s *subPathTestSuite) execTest(driver TestDriver, pattern testpatterns.Test
 		})
 
 		AfterEach(func() {
-			if needsCleanup {
-				resource.cleanupResource(driver, pattern)
-			}
+			resource.cleanupResource(driver, pattern)
 		})
 
 		testSubPath(&input)

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -29,12 +29,23 @@ type TestDriver interface {
 	// GetDriverInfo returns DriverInfo for the TestDriver
 	GetDriverInfo() *DriverInfo
 	// CreateDriver creates all driver resources that is required for TestDriver method
-	// except CreateVolume
+	// except CreateVolume. May be called more than once and should only do something on
+	// the first call.
 	CreateDriver()
-	// CreateDriver cleanup all the resources that is created in CreateDriver
+	// CreateDriver cleanup all the resources that is created in CreateDriver. There is
+	// no guarantee that CreateDriver succeeded or even was called at all, so the test driver
+	// has to track resources.
 	CleanupDriver()
-	// SkipUnsupportedTest skips test in Testpattern is not suitable to test with the TestDriver
-	SkipUnsupportedTest(testpatterns.TestPattern)
+}
+
+// FilterTestDriver is an optional interface that drivers can
+// implement to filter out unsuitable tests while tests get defined.
+type FilterTestDriver interface {
+	// IsTestSupported returns true if the Testpattern is
+	// suitable to test with the TestDriver. This will be called
+	// already while defining tests and unsupported tests will not even
+	// be added to the test suite.
+	IsTestSupported(testpatterns.TestPattern) bool
 }
 
 // PreprovisionedVolumeTestDriver represents an interface for a TestDriver that has pre-provisioned volume

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -74,7 +74,8 @@ func (t *volumeIOTestSuite) getTestSuiteInfo() TestSuiteInfo {
 	return t.tsInfo
 }
 
-func (t *volumeIOTestSuite) skipUnsupportedTest(pattern testpatterns.TestPattern, driver TestDriver) {
+func (t *volumeIOTestSuite) isTestSupported(pattern testpatterns.TestPattern, driver TestDriver) bool {
+	return true
 }
 
 func createVolumeIOTestInput(pattern testpatterns.TestPattern, resource genericVolumeTestResource) volumeIOTestInput {
@@ -110,17 +111,11 @@ func createVolumeIOTestInput(pattern testpatterns.TestPattern, resource genericV
 func (t *volumeIOTestSuite) execTest(driver TestDriver, pattern testpatterns.TestPattern) {
 	Context(getTestNameStr(t, pattern), func() {
 		var (
-			resource     genericVolumeTestResource
-			input        volumeIOTestInput
-			needsCleanup bool
+			resource genericVolumeTestResource
+			input    volumeIOTestInput
 		)
 
 		BeforeEach(func() {
-			needsCleanup = false
-			// Skip unsupported tests to avoid unnecessary resource initialization
-			skipUnsupportedTest(t, driver, pattern)
-			needsCleanup = true
-
 			// Setup test resource for driver and testpattern
 			resource = genericVolumeTestResource{}
 			resource.setupResource(driver, pattern)
@@ -130,9 +125,7 @@ func (t *volumeIOTestSuite) execTest(driver TestDriver, pattern testpatterns.Tes
 		})
 
 		AfterEach(func() {
-			if needsCleanup {
-				resource.cleanupResource(driver, pattern)
-			}
+			resource.cleanupResource(driver, pattern)
 		})
 
 		execTestVolumeIO(&input)

--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -61,7 +61,8 @@ func (t *volumeModeTestSuite) getTestSuiteInfo() TestSuiteInfo {
 	return t.tsInfo
 }
 
-func (t *volumeModeTestSuite) skipUnsupportedTest(pattern testpatterns.TestPattern, driver TestDriver) {
+func (t *volumeModeTestSuite) isTestSupported(pattern testpatterns.TestPattern, driver TestDriver) bool {
+	return true
 }
 
 func createVolumeModeTestInput(pattern testpatterns.TestPattern, resource volumeModeTestResource) volumeModeTestInput {
@@ -107,20 +108,14 @@ func getVolumeModeTestFunc(pattern testpatterns.TestPattern, driver TestDriver) 
 func (t *volumeModeTestSuite) execTest(driver TestDriver, pattern testpatterns.TestPattern) {
 	Context(getTestNameStr(t, pattern), func() {
 		var (
-			resource     volumeModeTestResource
-			input        volumeModeTestInput
-			testFunc     func(*volumeModeTestInput)
-			needsCleanup bool
+			resource volumeModeTestResource
+			input    volumeModeTestInput
+			testFunc func(*volumeModeTestInput)
 		)
 
 		testFunc = getVolumeModeTestFunc(pattern, driver)
 
 		BeforeEach(func() {
-			needsCleanup = false
-			// Skip unsupported tests to avoid unnecessary resource initialization
-			skipUnsupportedTest(t, driver, pattern)
-			needsCleanup = true
-
 			// Setup test resource for driver and testpattern
 			resource = volumeModeTestResource{}
 			resource.setupResource(driver, pattern)
@@ -130,9 +125,7 @@ func (t *volumeModeTestSuite) execTest(driver TestDriver, pattern testpatterns.T
 		})
 
 		AfterEach(func() {
-			if needsCleanup {
-				resource.cleanupResource(driver, pattern)
-			}
+			resource.cleanupResource(driver, pattern)
 		})
 
 		testFunc(&input)

--- a/test/e2e/storage/utils/framework.go
+++ b/test/e2e/storage/utils/framework.go
@@ -16,8 +16,12 @@ limitations under the License.
 
 package utils
 
-import "github.com/onsi/ginkgo"
+import "k8s.io/kubernetes/test/e2e/framework"
 
+// SIGDescribe adds the sig-storage tag and ensures that the body only
+// gets called after TestContext is valid. Therefore it is okay to use
+// functions like framework.NodeDistroOSIs or framework.ProviderIs to
+// add specs conditionally.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-storage] "+text, body)
+	return framework.DescribeWithTestContext("[sig-storage] "+text, body)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

After the recent `test/e2e/storage` refactoring (merged for 1.13), a lot of tests get defined that can only run with specific cluster providers. Those tests then get skipped at runtime. Even tests that get skipped take time (test setup, creating client set or worse, deploying the driver if the driver needs that) and the list of skipped tests in the CI grew a lot without adding any information (skip reason not captured). Therefore this PR:
- enables the definition of tests depending on the test context
- changes the "skip test" API so that test definition gets skipped, while still allowing runtime skipping
- changes the CSI and in-tree drivers to skip definition as much as possible

**Special notes for your reviewer**:

This contains PR #70862 because of code conflicts, so that PR must be merged first.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

/sig storage
/cc @mkimuram 
/assign @msau42 
