### PR TITLE
Refactor the memcached discovery client

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/BUILD
+++ b/staging/src/k8s.io/client-go/discovery/cached/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = ["memcache_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/client-go/discovery/fake:go_default_library",
     ],
@@ -22,6 +23,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/discovery/cached",
     importpath = "k8s.io/client-go/discovery/cached",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",

--- a/staging/src/k8s.io/client-go/discovery/cached/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memcache_test.go
@@ -18,27 +18,35 @@ package cached
 
 import (
 	"errors"
+	"net/http"
 	"reflect"
 	"sync"
 	"testing"
 
+	errorsutil "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery/fake"
 )
 
+type resourceMapEntry struct {
+	list *metav1.APIResourceList
+	err  error
+}
+
 type fakeDiscovery struct {
 	*fake.FakeDiscovery
 
-	lock        sync.Mutex
-	groupList   *metav1.APIGroupList
-	resourceMap map[string]*metav1.APIResourceList
+	lock         sync.Mutex
+	groupList    *metav1.APIGroupList
+	groupListErr error
+	resourceMap  map[string]*resourceMapEntry
 }
 
 func (c *fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if rl, ok := c.resourceMap[groupVersion]; ok {
-		return rl, nil
+		return rl.list, rl.err
 	}
 	return nil, errors.New("doesn't exist")
 }
@@ -49,7 +57,7 @@ func (c *fakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
 	if c.groupList == nil {
 		return nil, errors.New("doesn't exist")
 	}
-	return c.groupList, nil
+	return c.groupList, c.groupListErr
 }
 
 func TestClient(t *testing.T) {
@@ -63,32 +71,36 @@ func TestClient(t *testing.T) {
 				}},
 			}},
 		},
-		resourceMap: map[string]*metav1.APIResourceList{
+		resourceMap: map[string]*resourceMapEntry{
 			"astronomy/v8beta1": {
-				GroupVersion: "astronomy/v8beta1",
-				APIResources: []metav1.APIResource{{
-					Name:         "dwarfplanets",
-					SingularName: "dwarfplanet",
-					Namespaced:   true,
-					Kind:         "DwarfPlanet",
-					ShortNames:   []string{"dp"},
-				}},
+				list: &metav1.APIResourceList{
+					GroupVersion: "astronomy/v8beta1",
+					APIResources: []metav1.APIResource{{
+						Name:         "dwarfplanets",
+						SingularName: "dwarfplanet",
+						Namespaced:   true,
+						Kind:         "DwarfPlanet",
+						ShortNames:   []string{"dp"},
+					}},
+				},
 			},
 		},
 	}
 
 	c := NewMemCacheClient(fake)
-	g, err := c.ServerGroups()
-	if err == nil {
-		t.Errorf("Unexpected non-error.")
-	}
 	if c.Fresh() {
 		t.Errorf("Expected not fresh.")
 	}
-
-	c.Invalidate()
+	g, err := c.ServerGroups()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 	if !c.Fresh() {
 		t.Errorf("Expected fresh.")
+	}
+	c.Invalidate()
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
 	}
 
 	g, err = c.ServerGroups()
@@ -98,25 +110,30 @@ func TestClient(t *testing.T) {
 	if e, a := fake.groupList, g; !reflect.DeepEqual(e, a) {
 		t.Errorf("Expected %#v, got %#v", e, a)
 	}
+	if !c.Fresh() {
+		t.Errorf("Expected fresh.")
+	}
 	r, err := c.ServerResourcesForGroupVersion("astronomy/v8beta1")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if e, a := fake.resourceMap["astronomy/v8beta1"], r; !reflect.DeepEqual(e, a) {
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
 		t.Errorf("Expected %#v, got %#v", e, a)
 	}
 
 	fake.lock.Lock()
-	fake.resourceMap = map[string]*metav1.APIResourceList{
+	fake.resourceMap = map[string]*resourceMapEntry{
 		"astronomy/v8beta1": {
-			GroupVersion: "astronomy/v8beta1",
-			APIResources: []metav1.APIResource{{
-				Name:         "stars",
-				SingularName: "star",
-				Namespaced:   true,
-				Kind:         "Star",
-				ShortNames:   []string{"s"},
-			}},
+			list: &metav1.APIResourceList{
+				GroupVersion: "astronomy/v8beta1",
+				APIResources: []metav1.APIResource{{
+					Name:         "stars",
+					SingularName: "star",
+					Namespaced:   true,
+					Kind:         "Star",
+					ShortNames:   []string{"s"},
+				}},
+			},
 		},
 	}
 	fake.lock.Unlock()
@@ -126,7 +143,235 @@ func TestClient(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if e, a := fake.resourceMap["astronomy/v8beta1"], r; !reflect.DeepEqual(e, a) {
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+}
+
+func TestServerGroupsFails(t *testing.T) {
+	fake := &fakeDiscovery{
+		groupList: &metav1.APIGroupList{
+			Groups: []metav1.APIGroup{{
+				Name: "astronomy",
+				Versions: []metav1.GroupVersionForDiscovery{{
+					GroupVersion: "astronomy/v8beta1",
+					Version:      "v8beta1",
+				}},
+			}},
+		},
+		groupListErr: errors.New("some error"),
+		resourceMap: map[string]*resourceMapEntry{
+			"astronomy/v8beta1": {
+				list: &metav1.APIResourceList{
+					GroupVersion: "astronomy/v8beta1",
+					APIResources: []metav1.APIResource{{
+						Name:         "dwarfplanets",
+						SingularName: "dwarfplanet",
+						Namespaced:   true,
+						Kind:         "DwarfPlanet",
+						ShortNames:   []string{"dp"},
+					}},
+				},
+			},
+		},
+	}
+
+	c := NewMemCacheClient(fake)
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	_, err := c.ServerGroups()
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	fake.lock.Lock()
+	fake.groupListErr = nil
+	fake.lock.Unlock()
+	r, err := c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+	if !c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+}
+
+func TestPartialPermanentFailure(t *testing.T) {
+	fake := &fakeDiscovery{
+		groupList: &metav1.APIGroupList{
+			Groups: []metav1.APIGroup{{
+				Name: "astronomy",
+				Versions: []metav1.GroupVersionForDiscovery{{
+					GroupVersion: "astronomy/v8beta1",
+					Version:      "v8beta1",
+				}, {
+					GroupVersion: "astronomy2/v8beta1",
+					Version:      "v8beta1",
+				}},
+			}},
+		},
+		resourceMap: map[string]*resourceMapEntry{
+			"astronomy/v8beta1": {
+				err: errors.New("some permanent error"),
+			},
+			"astronomy2/v8beta1": {
+				list: &metav1.APIResourceList{
+					GroupVersion: "astronomy2/v8beta1",
+					APIResources: []metav1.APIResource{{
+						Name:         "dwarfplanets",
+						SingularName: "dwarfplanet",
+						Namespaced:   true,
+						Kind:         "DwarfPlanet",
+						ShortNames:   []string{"dp"},
+					}},
+				},
+			},
+		},
+	}
+
+	c := NewMemCacheClient(fake)
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	r, err := c.ServerResourcesForGroupVersion("astronomy2/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy2/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+
+	fake.lock.Lock()
+	fake.resourceMap["astronomy/v8beta1"] = &resourceMapEntry{
+		list: &metav1.APIResourceList{
+			GroupVersion: "astronomy/v8beta1",
+			APIResources: []metav1.APIResource{{
+				Name:         "dwarfplanets",
+				SingularName: "dwarfplanet",
+				Namespaced:   true,
+				Kind:         "DwarfPlanet",
+				ShortNames:   []string{"dp"},
+			}},
+		},
+		err: nil,
+	}
+	fake.lock.Unlock()
+	// We don't retry permanent errors, so it should fail.
+	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	c.Invalidate()
+
+	// After Invalidate, we should retry.
+	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+}
+
+func TestPartialRetryableFailure(t *testing.T) {
+	fake := &fakeDiscovery{
+		groupList: &metav1.APIGroupList{
+			Groups: []metav1.APIGroup{{
+				Name: "astronomy",
+				Versions: []metav1.GroupVersionForDiscovery{{
+					GroupVersion: "astronomy/v8beta1",
+					Version:      "v8beta1",
+				}, {
+					GroupVersion: "astronomy2/v8beta1",
+					Version:      "v8beta1",
+				}},
+			}},
+		},
+		resourceMap: map[string]*resourceMapEntry{
+			"astronomy/v8beta1": {
+				err: &errorsutil.StatusError{
+					ErrStatus: metav1.Status{
+						Message: "Some retryable error",
+						Code:    int32(http.StatusServiceUnavailable),
+						Reason:  metav1.StatusReasonServiceUnavailable,
+					},
+				},
+			},
+			"astronomy2/v8beta1": {
+				list: &metav1.APIResourceList{
+					GroupVersion: "astronomy2/v8beta1",
+					APIResources: []metav1.APIResource{{
+						Name:         "dwarfplanets",
+						SingularName: "dwarfplanet",
+						Namespaced:   true,
+						Kind:         "DwarfPlanet",
+						ShortNames:   []string{"dp"},
+					}},
+				},
+			},
+		},
+	}
+
+	c := NewMemCacheClient(fake)
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	r, err := c.ServerResourcesForGroupVersion("astronomy2/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy2/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+
+	fake.lock.Lock()
+	fake.resourceMap["astronomy/v8beta1"] = &resourceMapEntry{
+		list: &metav1.APIResourceList{
+			GroupVersion: "astronomy/v8beta1",
+			APIResources: []metav1.APIResource{{
+				Name:         "dwarfplanets",
+				SingularName: "dwarfplanet",
+				Namespaced:   true,
+				Kind:         "DwarfPlanet",
+				ShortNames:   []string{"dp"},
+			}},
+		},
+		err: nil,
+	}
+	fake.lock.Unlock()
+	// We should retry retryable error even without Invalidate() being called,
+	// so no error is expected.
+	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+
+	// Check that the last result was cached and we don't retry further.
+	fake.lock.Lock()
+	fake.resourceMap["astronomy/v8beta1"].err = errors.New("some permanent error")
+	fake.lock.Unlock()
+	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
 		t.Errorf("Expected %#v, got %#v", e, a)
 	}
 }

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/googleapis/gnostic/OpenAPIv2"
+	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,6 +60,9 @@ type DiscoveryInterface interface {
 }
 
 // CachedDiscoveryInterface is a DiscoveryInterface with cache invalidation and freshness.
+// Note that If the ServerResourcesForGroupVersion method returns a cache miss
+// error, the user needs to explicitly call Invalidate to clear the cache,
+// otherwise the same cache miss error will be returned next time.
 type CachedDiscoveryInterface interface {
 	DiscoveryInterface
 	// Fresh is supposed to tell the caller whether or not to retry if the cache
@@ -68,7 +71,8 @@ type CachedDiscoveryInterface interface {
 	// TODO: this needs to be revisited, this interface can't be locked properly
 	// and doesn't make a lot of sense.
 	Fresh() bool
-	// Invalidate enforces that no cached data is used in the future that is older than the current time.
+	// Invalidate enforces that no cached data that is older than the current time
+	// is used.
 	Invalidate()
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR implements a proposal of refactoring described in #68865. This way, if apiserver is unable to populate cache on the initialization, the attempt to refresh the cache will happen on the next request.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68865, fixes #68735

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
discovery.CachedDiscoveryInterface implementation returned by NewMemCacheClient has changed semantics of Invalidate method -- the cache refresh is now deferred to the first cache lookup.
```
