### PR TITLE
manually default kube-apiserver liveness probe

### DIFF
--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -37,7 +37,10 @@
         "path": "/healthz"
       },
       "initialDelaySeconds": {{liveness_probe_initial_delay}},
-      "timeoutSeconds": 15
+      "timeoutSeconds": 15,
+      "periodSeconds": 10,
+      "successThreshold": 1,
+      "failureThreshold": 3
     },
     "ports":[
       { "name": "https",


### PR DESCRIPTION
To fix flaky tests.

https://github.com/kubernetes/kubernetes/issues/70972
https://github.com/kubernetes/kubernetes/issues/70305

/kind bug

```release-note
NONE
```
