### PR TITLE
Recognize newer docker versions without -ce/-ee suffix: 18.09.0

### DIFF
--- a/cmd/kubeadm/app/util/system/docker_validator.go
+++ b/cmd/kubeadm/app/util/system/docker_validator.go
@@ -73,7 +73,7 @@ func (d *DockerValidator) validateDockerInfo(spec *DockerSpec, info types.Info) 
 	if !matched {
 		// If it's of the new Docker version scheme but didn't match above, it
 		// must be a newer version than the most recently validated one.
-		ver := `\d{2}\.\d+\.\d+-[a-z]{2}`
+		ver := `\d{2}\.\d+\.\d+(?:-[a-z]{2})?`
 		r := regexp.MustCompile(ver)
 		if r.MatchString(info.ServerVersion) {
 			d.Reporter.Report(dockerConfigPrefix+"VERSION", info.ServerVersion, good)

--- a/cmd/kubeadm/app/util/system/docker_validator_test.go
+++ b/cmd/kubeadm/app/util/system/docker_validator_test.go
@@ -81,6 +81,11 @@ func TestValidateDockerInfo(t *testing.T) {
 			err:  false,
 			warn: false,
 		},
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "18.09.0"},
+			err:  false,
+			warn: true,
+		},
 	} {
 		warn, err := v.validateDockerInfo(spec, test.info)
 		if !test.err {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
Is it really a feature? 
> users will notice and come to rely on

Maybe?

**What this PR does / why we need it**:
Since docker 18.09, the ServerVersion field format changed: the `-ce`
or `-ee` suffix disappeared:

- docker 18.06: `18.06.1-ce`
- docker 18.09: `18.09.0`

This was not expected by the docker_validator version regexp, which
assumed newer docker versions ended with `-[a-z]{2}`.
This made the validator return an error, whereas we expect it to
return only a warning (by recognizing it as a newer but not yet
supported docker version).

This commit relax the version regexp to also recognize `18.09.0`.
The docker validator now returns a warning, as tested.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
I did not open or find a related https://github.com/kubernetes/kubernetes issue. Should I open an issue for that?

Initially encountered in minikube: https://github.com/kubernetes/minikube/issues/3323

**Special notes for your reviewer**:
I am not sure the proposed fix is enough, as the new regexp does not match the whole version: it accepts matches on a substring of the docker version.
This means that it's effectively equivalent to just never check for the `-ce`/`-ee` suffixes.

Should I 
1. do nothing more?
2. simplify the regexp? simply (`\d{2}\.\d+\.\d+`)
3. or match the whole version string with `^$`? (`^\d{2}\.\d+\.\d+(?:-[a-z]{2})?$`)

`3.` would be more strict, but maybe too strict? Maybe some kubernetes deployment rely on the current lax regexp (for example with docker forks identified by an addition version suffix?)?


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
Not sure about the need for a release note or its phrasing.
```release-note
Recognize newer docker versions without -ce/-ee suffix: 18.09.0
```
