### PR TITLE
Disable equivalence cache by default in the scheduler integration tests

### DIFF
--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -111,7 +111,7 @@ func setupScheduler(
 		PdbInformer:                    informerFactory.Policy().V1beta1().PodDisruptionBudgets(),
 		StorageClassInformer:           informerFactory.Storage().V1().StorageClasses(),
 		HardPodAffinitySymmetricWeight: v1.DefaultHardPodAffinitySymmetricWeight,
-		EnableEquivalenceClassCache:    true,
+		EnableEquivalenceClassCache:    false,
 		DisablePreemption:              false,
 		PercentageOfNodesToScore:       100,
 	})

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -148,7 +148,7 @@ func initTestScheduler(
 ) *TestContext {
 	// Pod preemption is enabled by default scheduler configuration, but preemption only happens when PodPriority
 	// feature gate is enabled at the same time.
-	return initTestSchedulerWithOptions(t, context, setPodInformer, policy, false, false, time.Second)
+	return initTestSchedulerWithOptions(t, context, setPodInformer, policy, false, true, time.Second)
 }
 
 // initTestSchedulerWithOptions initializes a test environment and creates a scheduler with default
@@ -257,7 +257,7 @@ func initTest(t *testing.T, nsPrefix string) *TestContext {
 // configuration but with pod preemption disabled.
 func initTestDisablePreemption(t *testing.T, nsPrefix string) *TestContext {
 	return initTestSchedulerWithOptions(
-		t, initTestMaster(t, nsPrefix, nil), true, nil, true, false, time.Second)
+		t, initTestMaster(t, nsPrefix, nil), true, nil, true, true, time.Second)
 }
 
 // cleanupTest deletes the scheduler and the test namespace. It should be called

--- a/test/integration/scheduler/volume_binding_test.go
+++ b/test/integration/scheduler/volume_binding_test.go
@@ -99,7 +99,7 @@ func TestVolumeBinding(t *testing.T) {
 		"VolumeScheduling":       true,
 		"PersistentLocalVolumes": true,
 	}
-	config := setupCluster(t, "volume-scheduling-", 2, features, 0, 0, false)
+	config := setupCluster(t, "volume-scheduling-", 2, features, 0, 0, true)
 	defer config.teardown()
 
 	cases := map[string]struct {
@@ -272,7 +272,7 @@ func TestVolumeBindingRescheduling(t *testing.T) {
 		"VolumeScheduling":       true,
 		"PersistentLocalVolumes": true,
 	}
-	config := setupCluster(t, "volume-scheduling-", 2, features, 0, 0, false)
+	config := setupCluster(t, "volume-scheduling-", 2, features, 0, 0, true)
 	defer config.teardown()
 
 	storageClassName := "local-storage"
@@ -418,7 +418,7 @@ func testVolumeBindingStress(t *testing.T, schedulerResyncPeriod time.Duration, 
 		"VolumeScheduling":       true,
 		"PersistentLocalVolumes": true,
 	}
-	config := setupCluster(t, "volume-binding-stress-", 1, features, schedulerResyncPeriod, provisionDelaySeconds, false)
+	config := setupCluster(t, "volume-binding-stress-", 1, features, schedulerResyncPeriod, provisionDelaySeconds, true)
 	defer config.teardown()
 
 	// Set max volume limit to the number of PVCs the test will create
@@ -625,7 +625,7 @@ func TestPVAffinityConflict(t *testing.T) {
 		"VolumeScheduling":       true,
 		"PersistentLocalVolumes": true,
 	}
-	config := setupCluster(t, "volume-scheduling-", 3, features, 0, 0, false)
+	config := setupCluster(t, "volume-scheduling-", 3, features, 0, 0, true)
 	defer config.teardown()
 
 	pv := makePV("local-pv", classImmediate, "", "", node1)
@@ -688,7 +688,7 @@ func TestVolumeProvision(t *testing.T) {
 		"VolumeScheduling":       true,
 		"PersistentLocalVolumes": true,
 	}
-	config := setupCluster(t, "volume-scheduling", 1, features, 0, 0, false)
+	config := setupCluster(t, "volume-scheduling", 1, features, 0, 0, true)
 	defer config.teardown()
 
 	cases := map[string]struct {

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -94,9 +94,6 @@ func createSchedulerConfigurator(
 	informerFactory informers.SharedInformerFactory,
 	stopCh <-chan struct{},
 ) factory.Configurator {
-	// Enable EnableEquivalenceClassCache for all integration tests.
-	utilfeature.DefaultFeatureGate.Set("EnableEquivalenceClassCache=true")
-
 	return factory.NewConfigFactory(&factory.ConfigFactoryArgs{
 		SchedulerName:                  v1.DefaultSchedulerName,
 		Client:                         clientSet,


### PR DESCRIPTION
Equivalence cache was an alpha feature in the scheduler designed to improve performance, but it didn't deliver much performance while adding a significant code complexity. So, we decided to decommission it. This PR disables equivalence cache in the scheduler integration tests to ensure that the tests run under conditions closer to real clusters.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

/sig scheduling