### PR TITLE
rootcacertpublisher: trigger resync on namespace add and update

### DIFF
--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -143,6 +143,7 @@ func startRootCACertPublisher(ctx ControllerContext) (http.Handler, bool, error)
 
 	sac, err := rootcacertpublisher.NewPublisher(
 		ctx.InformerFactory.Core().V1().ConfigMaps(),
+		ctx.InformerFactory.Core().V1().Namespaces(),
 		ctx.ClientBuilder.ClientOrDie("root-ca-cert-publisher"),
 		rootCA,
 	)

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -43,7 +43,7 @@ const RootCACertCofigMapName = "kube-root-ca.crt"
 // NewPublisher construct a new controller which would manage the configmap
 // which stores certificates in each namespace. It will make sure certificate
 // configmap exists in each namespace.
-func NewPublisher(cmInformer coreinformers.ConfigMapInformer, cl clientset.Interface, rootCA []byte) (*Publisher, error) {
+func NewPublisher(cmInformer coreinformers.ConfigMapInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, rootCA []byte) (*Publisher, error) {
 	e := &Publisher{
 		client: cl,
 		rootCA: rootCA,
@@ -62,6 +62,12 @@ func NewPublisher(cmInformer coreinformers.ConfigMapInformer, cl clientset.Inter
 	e.cmLister = cmInformer.Lister()
 	e.cmListerSynced = cmInformer.Informer().HasSynced
 
+	nsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    e.namespaceAdded,
+		UpdateFunc: e.namespaceUpdated,
+	})
+	e.nsListerSynced = nsInformer.Informer().HasSynced
+
 	e.syncHandler = e.syncNamespace
 
 	return e, nil
@@ -78,6 +84,8 @@ type Publisher struct {
 
 	cmLister       corelisters.ConfigMapLister
 	cmListerSynced cache.InformerSynced
+
+	nsListerSynced cache.InformerSynced
 
 	queue workqueue.RateLimitingInterface
 }

--- a/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
@@ -120,7 +120,8 @@ func TestConfigMapCreation(t *testing.T) {
 			client := fake.NewSimpleClientset(caConfigMap, existNS)
 			informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
 			cmInformer := informers.Core().V1().ConfigMaps()
-			controller, err := NewPublisher(cmInformer, client, fakeRootCA)
+			nsInformer := informers.Core().V1().Namespaces()
+			controller, err := NewPublisher(cmInformer, nsInformer, client, fakeRootCA)
 			if err != nil {
 				t.Fatalf("error creating ServiceAccounts controller: %v", err)
 			}


### PR DESCRIPTION
Last cleanup was a bit overzealous.

/kind bug
/sig auth

```release-note
NONE
```
