### PR TITLE
update kubectl run to generate apps/v1 deployments

### DIFF
--- a/pkg/kubectl/cmd/run/run.go
+++ b/pkg/kubectl/cmd/run/run.go
@@ -316,7 +316,7 @@ func (o *RunOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 	if len(generatorName) == 0 {
 		switch restartPolicy {
 		case corev1.RestartPolicyAlways:
-			generatorName = generateversioned.DeploymentAppsV1Beta1GeneratorName
+			generatorName = generateversioned.DeploymentAppsV1GeneratorName
 		case corev1.RestartPolicyOnFailure:
 			generatorName = generateversioned.JobV1GeneratorName
 		case corev1.RestartPolicyNever:

--- a/pkg/kubectl/generate/versioned/generator.go
+++ b/pkg/kubectl/generate/versioned/generator.go
@@ -51,6 +51,7 @@ const (
 	HorizontalPodAutoscalerV1GeneratorName  = "horizontalpodautoscaler/v1"
 	DeploymentV1Beta1GeneratorName          = "deployment/v1beta1"
 	DeploymentAppsV1Beta1GeneratorName      = "deployment/apps.v1beta1"
+	DeploymentAppsV1GeneratorName           = "deployment/apps.v1"
 	DeploymentBasicV1Beta1GeneratorName     = "deployment-basic/v1beta1"
 	DeploymentBasicAppsV1Beta1GeneratorName = "deployment-basic/apps.v1beta1"
 	DeploymentBasicAppsV1GeneratorName      = "deployment-basic/apps.v1"
@@ -105,6 +106,7 @@ func DefaultGenerators(cmdName string) map[string]generate.Generator {
 			RunPodV1GeneratorName:              BasicPod{},
 			DeploymentV1Beta1GeneratorName:     DeploymentV1Beta1{},
 			DeploymentAppsV1Beta1GeneratorName: DeploymentAppsV1Beta1{},
+			DeploymentAppsV1GeneratorName:      DeploymentAppsV1{},
 			JobV1GeneratorName:                 JobV1{},
 			CronJobV2Alpha1GeneratorName:       CronJobV2Alpha1{},
 			CronJobV1Beta1GeneratorName:        CronJobV1Beta1{},
@@ -146,6 +148,14 @@ func FallbackGeneratorNameIfNecessary(
 	cmdErr io.Writer,
 ) (string, error) {
 	switch generatorName {
+	case DeploymentAppsV1GeneratorName:
+		hasResource, err := HasResource(discoveryClient, appsv1.SchemeGroupVersion.WithResource("deployments"))
+		if err != nil {
+			return "", err
+		}
+		if !hasResource {
+			return FallbackGeneratorNameIfNecessary(DeploymentAppsV1Beta1GeneratorName, discoveryClient, cmdErr)
+		}
 	case DeploymentAppsV1Beta1GeneratorName:
 		hasResource, err := HasResource(discoveryClient, appsv1beta1.SchemeGroupVersion.WithResource("deployments"))
 		if err != nil {

--- a/test/cmd/run.sh
+++ b/test/cmd/run.sh
@@ -45,17 +45,17 @@ run_kubectl_run_tests() {
   # Post-Condition: Deployment "nginx" is created
   kube::test::get_object_assert deployment.extensions "{{range.items}}{{$id_field}}:{{end}}" 'nginx-extensions:'
   # new generator was used
-  output_message=$(kubectl get deployment.extensions/nginx-extensions -o jsonpath='{.spec.revisionHistoryLimit}')
-  kube::test::if_has_string "${output_message}" '2'
+  output_message=$(kubectl get deployment.apps/nginx-extensions -o jsonpath='{.spec.revisionHistoryLimit}')
+  kube::test::if_has_string "${output_message}" '10'
   # Clean up
   kubectl delete deployment nginx-extensions "${kube_flags[@]}"
   # Command
-  kubectl run nginx-apps "--image=$IMAGE_NGINX" --generator=deployment/apps.v1beta1 "${kube_flags[@]}"
+  kubectl run nginx-apps "--image=$IMAGE_NGINX" --generator=deployment/apps.v1 "${kube_flags[@]}"
   # Post-Condition: Deployment "nginx" is created
   kube::test::get_object_assert deployment.apps "{{range.items}}{{$id_field}}:{{end}}" 'nginx-apps:'
   # and new generator was used, iow. new defaults are applied
   output_message=$(kubectl get deployment/nginx-apps -o jsonpath='{.spec.revisionHistoryLimit}')
-  kube::test::if_has_string "${output_message}" '2'
+  kube::test::if_has_string "${output_message}" '10'
   # Clean up
   kubectl delete deployment nginx-apps "${kube_flags[@]}"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

moves default kubectl deployment generation behavior to the stable apps/v1 API

extracted from https://github.com/kubernetes/kubernetes/pull/70370 for easier review

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref https://github.com/kubernetes/kubernetes/issues/43214

**Does this PR introduce a user-facing change?**:
```release-note
kubectl run now generates apps/v1 deployments by default
```

/sig cli
/sig apps