### PR TITLE
Revert "kubeadm: Create control plane with ClusterFirstWithHostNet dns policy"

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -68,7 +68,6 @@ func ComponentPod(container v1.Container, volumes map[string]v1.Volume) v1.Pod {
 			Containers:        []v1.Container{container},
 			PriorityClassName: "system-cluster-critical",
 			HostNetwork:       true,
-			DNSPolicy:         v1.DNSClusterFirstWithHostNet,
 			Volumes:           VolumeMapToSlice(volumes),
 		},
 	}

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -369,7 +369,6 @@ func TestComponentPod(t *testing.T) {
 					},
 					PriorityClassName: "system-cluster-critical",
 					HostNetwork:       true,
-					DNSPolicy:         v1.DNSClusterFirstWithHostNet,
 					Volumes:           []v1.Volume{},
 				},
 			},


### PR DESCRIPTION
Reverts kubernetes/kubernetes#68890

This is causing issues as described in the linked issue:
fixes kubernetes/kubeadm#1236

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/priority critical-urgent
/kind bug
/assign @timothysc @chuckha 
/hold
