### PR TITLE
Remove self-deletion permissions from kubelets

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -107,7 +107,7 @@ func NodeRules() []rbacv1.PolicyRule {
 		// Use the NodeRestriction admission plugin to limit a node to creating/updating its own API object.
 		rbacv1helpers.NewRule("create", "get", "list", "watch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 		rbacv1helpers.NewRule("update", "patch").Groups(legacyGroup).Resources("nodes/status").RuleOrDie(),
-		rbacv1helpers.NewRule("update", "patch", "delete").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+		rbacv1helpers.NewRule("update", "patch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 
 		// TODO: restrict to the bound node as creator in the NodeRestrictions admission plugin
 		rbacv1helpers.NewRule("create", "update", "patch").Groups(legacyGroup).Resources("events").RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -882,7 +882,6 @@ items:
     resources:
     - nodes
     verbs:
-    - delete
     - patch
     - update
   - apiGroups:

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -530,7 +530,10 @@ func TestNodeAuthorizer(t *testing.T) {
 	expectAllowed(t, createNode2MirrorPodEviction(node2Client))
 	expectAllowed(t, createNode2(node2Client))
 	expectAllowed(t, updateNode2Status(node2Client))
-	expectAllowed(t, deleteNode2(node2Client))
+	// self deletion is not allowed
+	expectForbidden(t, deleteNode2(node2Client))
+	// clean up node2
+	expectAllowed(t, deleteNode2(superuserClient))
 
 	// create a pod as an admin to add object references
 	expectAllowed(t, createNode2NormalPod(superuserClient))
@@ -621,7 +624,7 @@ func TestNodeAuthorizer(t *testing.T) {
 	// node2 can no longer get the configmap after it is unassigned as its config source
 	expectForbidden(t, getConfigMapConfigSource(node2Client))
 	// clean up node2
-	expectAllowed(t, deleteNode2(node2Client))
+	expectAllowed(t, deleteNode2(superuserClient))
 
 	//TODO(mikedanese): integration test node restriction of TokenRequest
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Removes the ability of kubelets to delete their own Node API objects. Kubelets stopped doing this in 1.11, which means a 1.13 API server no longer needs to grant them this permission.

This closes a method by which a kubelet on a compromised node could delete and recreate its Node object, effectively removing any taints the cluster administrator had added to the Node object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref https://github.com/kubernetes/community/pull/911
xref https://github.com/kubernetes/enhancements/issues/279

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kubelets are no longer allowed to delete their own Node API object. Prior to 1.11, in rare circumstances related to cloudprovider node ID changes, kubelets would attempt to delete/recreate their Node object at startup. Kubelets older than 1.11 are not supported running against a v1.13+ API server. If an unsupported legacy kubelet encounters this situation, a cluster admin can remove the Node object:
* `kubectl delete node/<nodeName>`
or grant self-deletion permission explicitly:
* `kubectl create clusterrole self-deleting-nodes --verb=delete --resource=nodes`
* `kubectl create clusterrolebinding self-deleting-nodes --clusterrole=self-deleting-nodes --group=system:nodes`
```

@kubernetes/sig-auth-pr-reviews 
@kubernetes/sig-node-pr-reviews 