### PR TITLE
Fix NewLeaderElector to return all the errors

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -261,9 +261,9 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error
 				utilruntime.HandleError(fmt.Errorf("lost master"))
 			},
 		}
-		leaderElector, err := leaderelection.NewLeaderElector(*cc.LeaderElection)
-		if err != nil {
-			return fmt.Errorf("couldn't create leader elector: %v", err)
+		leaderElector, errs := leaderelection.NewLeaderElector(*cc.LeaderElection)
+		if errs != nil {
+			return fmt.Errorf("couldn't create leader elector: %v", utilerrors.NewAggregate(errs))
 		}
 
 		leaderElector.Run(ctx)


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
We validate the validity of the LeaderElectionConfig value in function "NewLeaderElector", but it returns only one error, I think we should check all values at once and return all errors.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE