### PR TITLE
Forbid inter unstructured conversion in default converter

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/conversion/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/BUILD
@@ -30,7 +30,10 @@ go_library(
     ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/conversion",
     importpath = "k8s.io/apimachinery/pkg/conversion",
-    deps = ["//staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect:go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect:go_default_library",
+    ],
 )
 
 filegroup(

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go
@@ -19,6 +19,8 @@ package conversion
 import (
 	"fmt"
 	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type typePair struct {
@@ -485,6 +487,12 @@ func (c *Converter) DefaultConvert(src, dest interface{}, flags FieldMatchingFla
 type conversionFunc func(sv, dv reflect.Value, scope *scope) error
 
 func (c *Converter) doConversion(src, dest interface{}, flags FieldMatchingFlags, meta *Meta, f conversionFunc) error {
+	_, srcUnstructured := src.(runtime.Unstructured)
+	_, dstUnstructured := dest.(runtime.Unstructured)
+	if srcUnstructured && dstUnstructured {
+		return fmt.Errorf("must not do conversion between unstructured")
+	}
+
 	pair := typePair{reflect.TypeOf(src), reflect.TypeOf(dest)}
 	scope := &scope{
 		converter: c,


### PR DESCRIPTION
today, the default converter allows any conversion between unstructured objects via this reflection equality check. but unstructured converion itself is not making sense. this pull explicitly forbids that usage. 

[https://github.com/kubernetes/kubernetes/blob/a44c2b9eeb745c0d4b56e5058859743f5ef5ef69/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go#L116-L134](https://github.com/kubernetes/kubernetes/blob/a44c2b9eeb745c0d4b56e5058859743f5ef5ef69/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go#L116-L134)

note that for CR, we have another dedicated convertor so the default convertor won't do any inter-unstructured conversion there. 

/sig api-machinery
/kind bug

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
