### PR TITLE
kubeadm: document required etcd configuration

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/types.go
@@ -276,15 +276,22 @@ type LocalEtcd struct {
 	PeerCertSANs []string `json:"peerCertSANs,omitempty"`
 }
 
-// ExternalEtcd describes an external etcd cluster
+// ExternalEtcd describes an external etcd cluster.
+// Kubeadm has no knowledge of where certificate files live and they must be supplied.
 type ExternalEtcd struct {
 	// Endpoints of etcd members. Required for ExternalEtcd.
 	Endpoints []string `json:"endpoints"`
+
 	// CAFile is an SSL Certificate Authority file used to secure etcd communication.
+	// Required if using a TLS connection.
 	CAFile string `json:"caFile"`
+
 	// CertFile is an SSL certification file used to secure etcd communication.
+	// Required if using a TLS connection.
 	CertFile string `json:"certFile"`
+
 	// KeyFile is an SSL key file used to secure etcd communication.
+	// Required if using a TLS connection.
 	KeyFile string `json:"keyFile"`
 }
 


### PR DESCRIPTION
Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds documentation to the configuration struct for external etcd outlining why certificates for external etcd are required and that they cannot be left blank.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#1240

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

/assign @fabriziopandini 
/cc @neolit123 
@kubernetes/sig-cluster-lifecycle-pr-reviews 