### PR TITLE
Bump k8s.io/uitls to 8e7ff06

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -4003,19 +4003,19 @@
 		},
 		{
 			"ImportPath": "k8s.io/utils/clock",
-			"Rev": "66066c83e385e385ccc3c964b44fd7dcd413d0ed"
+			"Rev": "8e7ff06bf0e2d3289061230af203e430a15b6dcc"
 		},
 		{
 			"ImportPath": "k8s.io/utils/exec",
-			"Rev": "66066c83e385e385ccc3c964b44fd7dcd413d0ed"
+			"Rev": "8e7ff06bf0e2d3289061230af203e430a15b6dcc"
 		},
 		{
 			"ImportPath": "k8s.io/utils/exec/testing",
-			"Rev": "66066c83e385e385ccc3c964b44fd7dcd413d0ed"
+			"Rev": "8e7ff06bf0e2d3289061230af203e430a15b6dcc"
 		},
 		{
 			"ImportPath": "k8s.io/utils/pointer",
-			"Rev": "66066c83e385e385ccc3c964b44fd7dcd413d0ed"
+			"Rev": "8e7ff06bf0e2d3289061230af203e430a15b6dcc"
 		},
 		{
 			"ImportPath": "sigs.k8s.io/yaml",

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -34,14 +34,19 @@ type fakeCmd struct {
 	err error
 }
 
-func (f fakeCmd) Run() error                      { return f.err }
-func (f fakeCmd) CombinedOutput() ([]byte, error) { return f.b, f.err }
-func (f fakeCmd) Output() ([]byte, error)         { return f.b, f.err }
-func (f fakeCmd) SetDir(dir string)               {}
-func (f fakeCmd) SetStdin(in io.Reader)           {}
-func (f fakeCmd) SetStdout(out io.Writer)         {}
-func (f fakeCmd) SetStderr(out io.Writer)         {}
-func (f fakeCmd) Stop()                           {}
+func (f fakeCmd) Run() error                         { return f.err }
+func (f fakeCmd) CombinedOutput() ([]byte, error)    { return f.b, f.err }
+func (f fakeCmd) Output() ([]byte, error)            { return f.b, f.err }
+func (f fakeCmd) SetDir(dir string)                  {}
+func (f fakeCmd) SetStdin(in io.Reader)              {}
+func (f fakeCmd) SetStdout(out io.Writer)            {}
+func (f fakeCmd) SetStderr(out io.Writer)            {}
+func (f fakeCmd) SetEnv([]string)                    {}
+func (f fakeCmd) Stop()                              {}
+func (f fakeCmd) Start() error                       { return nil }
+func (f fakeCmd) Wait() error                        { return nil }
+func (f fakeCmd) StdoutPipe() (io.ReadCloser, error) { return nil, nil }
+func (f fakeCmd) StderrPipe() (io.ReadCloser, error) { return nil, nil }
 
 type fakeExecer struct {
 	ioMap map[string]fakeCmd

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -274,6 +274,26 @@ func (eic execInContainer) SetStderr(out io.Writer) {
 	//unimplemented
 }
 
+func (eic execInContainer) SetEnv(env []string) {
+	//unimplemented
+}
+
 func (eic execInContainer) Stop() {
 	//unimplemented
+}
+
+func (eic execInContainer) Start() error {
+	return fmt.Errorf("unimplemented")
+}
+
+func (eic execInContainer) Wait() error {
+	return fmt.Errorf("unimplemented")
+}
+
+func (eic execInContainer) StdoutPipe() (io.ReadCloser, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+func (eic execInContainer) StderrPipe() (io.ReadCloser, error) {
+	return nil, fmt.Errorf("unimplemented")
 }

--- a/pkg/probe/exec/exec_test.go
+++ b/pkg/probe/exec/exec_test.go
@@ -50,7 +50,21 @@ func (f *FakeCmd) SetStdout(out io.Writer) {}
 
 func (f *FakeCmd) SetStderr(out io.Writer) {}
 
+func (f *FakeCmd) SetEnv(env []string) {}
+
 func (f *FakeCmd) Stop() {}
+
+func (f *FakeCmd) Start() error { return nil }
+
+func (f *FakeCmd) Wait() error { return nil }
+
+func (f *FakeCmd) StdoutPipe() (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (f *FakeCmd) StderrPipe() (io.ReadCloser, error) {
+	return nil, nil
+}
 
 type fakeExitError struct {
 	exited     bool

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -2024,7 +2024,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/utils/pointer",
-			"Rev": "66066c83e385e385ccc3c964b44fd7dcd413d0ed"
+			"Rev": "8e7ff06bf0e2d3289061230af203e430a15b6dcc"
 		},
 		{
 			"ImportPath": "sigs.k8s.io/yaml",

--- a/staging/src/k8s.io/kube-controller-manager/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-controller-manager/Godeps/Godeps.json
@@ -160,7 +160,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/utils/pointer",
-			"Rev": "66066c83e385e385ccc3c964b44fd7dcd413d0ed"
+			"Rev": "8e7ff06bf0e2d3289061230af203e430a15b6dcc"
 		}
 	]
 }

--- a/staging/src/k8s.io/kube-scheduler/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-scheduler/Godeps/Godeps.json
@@ -160,7 +160,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/utils/pointer",
-			"Rev": "66066c83e385e385ccc3c964b44fd7dcd413d0ed"
+			"Rev": "8e7ff06bf0e2d3289061230af203e430a15b6dcc"
 		}
 	]
 }

--- a/vendor/k8s.io/utils/clock/clock.go
+++ b/vendor/k8s.io/utils/clock/clock.go
@@ -44,21 +44,24 @@ func (RealClock) Since(ts time.Time) time.Duration {
 	return time.Since(ts)
 }
 
-// Same as time.After(d).
+// After is the same as time.After(d).
 func (RealClock) After(d time.Duration) <-chan time.Time {
 	return time.After(d)
 }
 
+// NewTimer is the same as time.NewTimer(d)
 func (RealClock) NewTimer(d time.Duration) Timer {
 	return &realTimer{
 		timer: time.NewTimer(d),
 	}
 }
 
+// Tick is the same as time.Tick(d)
 func (RealClock) Tick(d time.Duration) <-chan time.Time {
 	return time.Tick(d)
 }
 
+// Sleep is the same as time.Sleep(d)
 func (RealClock) Sleep(d time.Duration) {
 	time.Sleep(d)
 }

--- a/vendor/k8s.io/utils/exec/testing/fake_exec.go
+++ b/vendor/k8s.io/utils/exec/testing/fake_exec.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/utils/exec"
 )
 
-// A simple scripted Interface type.
+// FakeExec is a simple scripted Interface type.
 type FakeExec struct {
 	CommandScript []FakeCommandAction
 	CommandCalls  int
@@ -33,8 +33,10 @@ type FakeExec struct {
 
 var _ exec.Interface = &FakeExec{}
 
+// FakeCommandAction is the function to be executed
 type FakeCommandAction func(cmd string, args ...string) exec.Cmd
 
+// Command is to track the commands that are executed
 func (fake *FakeExec) Command(cmd string, args ...string) exec.Cmd {
 	if fake.CommandCalls > len(fake.CommandScript)-1 {
 		panic(fmt.Sprintf("ran out of Command() actions. Could not handle command [%d]: %s args: %v", fake.CommandCalls, cmd, args))
@@ -44,15 +46,17 @@ func (fake *FakeExec) Command(cmd string, args ...string) exec.Cmd {
 	return fake.CommandScript[i](cmd, args...)
 }
 
+// CommandContext wraps arguments into exec.Cmd
 func (fake *FakeExec) CommandContext(ctx context.Context, cmd string, args ...string) exec.Cmd {
 	return fake.Command(cmd, args...)
 }
 
+// LookPath is for finding the path of a file
 func (fake *FakeExec) LookPath(file string) (string, error) {
 	return fake.LookPathFunc(file)
 }
 
-// A simple scripted Cmd type.
+// FakeCmd is a simple scripted Cmd type.
 type FakeCmd struct {
 	Argv                 []string
 	CombinedOutputScript []FakeCombinedOutputAction
@@ -65,34 +69,84 @@ type FakeCmd struct {
 	Stdin                io.Reader
 	Stdout               io.Writer
 	Stderr               io.Writer
+	Env                  []string
+	StdoutPipeResponse   FakeStdIOPipeResponse
+	StderrPipeResponse   FakeStdIOPipeResponse
+	WaitResponse         error
+	StartResponse        error
 }
 
 var _ exec.Cmd = &FakeCmd{}
 
+// InitFakeCmd is for creating a fake exec.Cmd
 func InitFakeCmd(fake *FakeCmd, cmd string, args ...string) exec.Cmd {
 	fake.Argv = append([]string{cmd}, args...)
 	return fake
 }
 
+// FakeStdIOPipeResponse holds responses to use as fakes for the StdoutPipe and
+// StderrPipe method calls
+type FakeStdIOPipeResponse struct {
+	ReadCloser io.ReadCloser
+	Error      error
+}
+
+// FakeCombinedOutputAction is a function type
 type FakeCombinedOutputAction func() ([]byte, error)
+
+// FakeRunAction is a function type
 type FakeRunAction func() ([]byte, []byte, error)
 
+// SetDir sets the directory
 func (fake *FakeCmd) SetDir(dir string) {
 	fake.Dirs = append(fake.Dirs, dir)
 }
 
+// SetStdin sets the stdin
 func (fake *FakeCmd) SetStdin(in io.Reader) {
 	fake.Stdin = in
 }
 
+// SetStdout sets the stdout
 func (fake *FakeCmd) SetStdout(out io.Writer) {
 	fake.Stdout = out
 }
 
+// SetStderr sets the stderr
 func (fake *FakeCmd) SetStderr(out io.Writer) {
 	fake.Stderr = out
 }
 
+// SetEnv sets the environment variables
+func (fake *FakeCmd) SetEnv(env []string) {
+	fake.Env = env
+}
+
+// StdoutPipe returns an injected ReadCloser & error (via StdoutPipeResponse)
+// to be able to inject an output stream on Stdout
+func (fake *FakeCmd) StdoutPipe() (io.ReadCloser, error) {
+	return fake.StdoutPipeResponse.ReadCloser, fake.StdoutPipeResponse.Error
+}
+
+// StderrPipe returns an injected ReadCloser & error (via StderrPipeResponse)
+// to be able to inject an output stream on Stderr
+func (fake *FakeCmd) StderrPipe() (io.ReadCloser, error) {
+	return fake.StderrPipeResponse.ReadCloser, fake.StderrPipeResponse.Error
+}
+
+// Start mimicks starting the process (in the background) and returns the
+// injected StartResponse
+func (fake *FakeCmd) Start() error {
+	return fake.StartResponse
+}
+
+// Wait mimicks waiting for the process to exit returns the
+// injected WaitResponse
+func (fake *FakeCmd) Wait() error {
+	return fake.WaitResponse
+}
+
+// Run sets runs the command
 func (fake *FakeCmd) Run() error {
 	if fake.RunCalls > len(fake.RunScript)-1 {
 		panic("ran out of Run() actions")
@@ -113,6 +167,7 @@ func (fake *FakeCmd) Run() error {
 	return err
 }
 
+// CombinedOutput returns the output from the command
 func (fake *FakeCmd) CombinedOutput() ([]byte, error) {
 	if fake.CombinedOutputCalls > len(fake.CombinedOutputScript)-1 {
 		panic("ran out of CombinedOutput() actions")
@@ -126,15 +181,17 @@ func (fake *FakeCmd) CombinedOutput() ([]byte, error) {
 	return fake.CombinedOutputScript[i]()
 }
 
+// Output is the response from the command
 func (fake *FakeCmd) Output() ([]byte, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
 
+// Stop is to stop the process
 func (fake *FakeCmd) Stop() {
 	// no-op
 }
 
-// A simple fake ExitError type.
+// FakeExitError is a simple fake ExitError type.
 type FakeExitError struct {
 	Status int
 }
@@ -149,10 +206,12 @@ func (fake FakeExitError) Error() string {
 	return fake.String()
 }
 
+// Exited always returns true
 func (fake FakeExitError) Exited() bool {
 	return true
 }
 
+// ExitStatus returns the fake status
 func (fake FakeExitError) ExitStatus() int {
 	return fake.Status
 }

--- a/vendor/k8s.io/utils/pointer/OWNERS
+++ b/vendor/k8s.io/utils/pointer/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+- apelisse
+- stewart-yu
+- thockin
+reviewers:
+- apelisse
+- stewart-yu
+- thockin

--- a/vendor/k8s.io/utils/pointer/pointer.go
+++ b/vendor/k8s.io/utils/pointer/pointer.go
@@ -74,3 +74,13 @@ func BoolPtr(b bool) *bool {
 func StringPtr(s string) *string {
 	return &s
 }
+
+// Float32Ptr returns a pointer to the passed float32.
+func Float32Ptr(i float32) *float32 {
+	return &i
+}
+
+// Float64Ptr returns a pointer to the passed float64.
+func Float64Ptr(i float64) *float64 {
+	return &i
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The reason for the bump is the new functionality of the
k8s.io/utils/exec package which allows
- to get a hold of the process' std{out,err} as `io.Reader`s
- to `Start` a process and `Wait` for it

This should help on addressing #70890 by allowing to wrap std{out,err}
of the process to be wrapped with a `io.limitedReader`.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Update k8s.io/utils to allow for asynchronous process control
```
