### PR TITLE
Remove misleading case of volume scheduling

### DIFF
--- a/test/integration/scheduler/volume_binding_test.go
+++ b/test/integration/scheduler/volume_binding_test.go
@@ -721,12 +721,6 @@ func TestVolumeProvision(t *testing.T) {
 			boundPvcs:       []*testPVC{{"pvc-i-pv-prebound", classImmediate, ""}},
 			provisionedPvcs: []*testPVC{{"pvc-canprovision", classWait, ""}},
 		},
-		"wait one pv prebound, one provisioned": {
-			pod:             makePod("pod-w-pv-prebound-w-provisioned", config.ns, []string{"pvc-w-pv-prebound", "pvc-canprovision"}),
-			pvs:             []*testPV{{"pv-w-prebound", classWait, "pvc-w-pv-prebound", node1}},
-			boundPvcs:       []*testPVC{{"pvc-w-pv-prebound", classWait, ""}},
-			provisionedPvcs: []*testPVC{{"pvc-canprovision", classWait, ""}},
-		},
 		"immediate provisioned by controller": {
 			pod: makePod("pod-i-unbound", config.ns, []string{"pvc-controller-provisioned"}),
 			// A pvc of immediate binding mode is expected to be provisioned by controller,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind flake
/sig storage
/sig scheduling

**What this PR does / why we need it**:
remove misleading case of volume scheduling

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially address #70180 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
