### PR TITLE
cloudstack: add regex which replaces invalid chars in service offering

### DIFF
--- a/pkg/cloudprovider/providers/cloudstack/metadata.go
+++ b/pkg/cloudprovider/providers/cloudstack/metadata.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"regexp"
 
 	"github.com/d2g/dhcp4"
 	"k8s.io/api/core/v1"
@@ -97,7 +98,11 @@ func (m *metadata) InstanceID(ctx context.Context, name types.NodeName) (string,
 
 // InstanceType returns the type of the specified instance.
 func (m *metadata) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
-	instanceType, err := m.get(metadataTypeInstanceType)
+	instanceTypeCS, err := m.get(metadataTypeInstanceType)
+	// Replace everything that doesn't match the metadata.labels regex
+	re := regexp.MustCompile(`([^A-Za-z0-9][^-A-Za-z0-9_.]*)?[^A-Za-z0-9]`)
+	instanceType := re.ReplaceAllString(instanceTypeCS, ``)
+
 	if err != nil {
 		return "", fmt.Errorf("could not get instance type: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Kubernetes gets metadata about the vm in cloudstack from the router in the virtual network. The service offering metadata only reply's the display name. In cloudstack the displayname can contain various chars, while kubernetes metadata.label only can consist of alphanumeric characters, '-', '_' or '.'. 
With this PR all invalid chars get replaced.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
This code is tested in production with cloudstack.
There aren't any user-facing changes because if you for instance had whitespaces in your offering display name it didn't work.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
/sig cloud-provider