### PR TITLE
Rename tag for CSI skip attach tests

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -144,7 +144,7 @@ var _ = utils.SIGDescribe("CSI Volumes", func() {
 	}
 
 	// The CSIDriverRegistry feature gate is needed for this test in Kubernetes 1.12.
-	Context("CSI attach test using HostPath driver [Feature:CSISkipAttach]", func() {
+	Context("CSI attach test using HostPath driver [Feature:CSIDriverRegistry]", func() {
 		var (
 			cs     clientset.Interface
 			csics  csiclient.Interface


### PR DESCRIPTION
So it has the same name as alpha feature. I'll enable `Feature:CSIDriverRegistry` in alpha e2e tests so it's actually run.

/kind cleanup
/sig storage

**What this PR does / why we need it**:

<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

@msau42, PTAL