### PR TITLE
photon provider: guard against wrong cloudprovider type

### DIFF
--- a/pkg/volume/photon_pd/photon_util.go
+++ b/pkg/volume/photon_pd/photon_util.go
@@ -146,8 +146,8 @@ func getCloudProvider(cloud cloudprovider.Interface) (*photon.PCCloud, error) {
 		return nil, fmt.Errorf("Photon Controller Util: Cloud provider not initialized properly")
 	}
 
-	pcc := cloud.(*photon.PCCloud)
-	if pcc == nil {
+	pcc, ok := cloud.(*photon.PCCloud)
+	if !ok || pcc == nil {
 		klog.Errorf("Invalid cloud provider: expected Photon Controller")
 		return nil, fmt.Errorf("Invalid cloud provider: expected Photon Controller")
 	}


### PR DESCRIPTION
If the cloudprovider wasn't of the expected type, we panic, but we
should return an error (the existing check wasn't quite right).


/kind bug

```release-note
NONE
```