### PR TITLE
Increase service test timeout value

### DIFF
--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -87,7 +87,7 @@ const (
 	MaxNodesForEndpointsTests = 3
 
 	// ServiceTestTimeout is used for most polling/waiting activities
-	ServiceTestTimeout = 60 * time.Second
+	ServiceTestTimeout = 120 * time.Second
 
 	// GCPMaxInstancesInInstanceGroup is the maximum number of instances supported in
 	// one instance group on GCP.


### PR DESCRIPTION
Increase the service tests timeout value from 60 seconds
to 120 seconds. We are seeing timeouts on more constrained
servers and increasing the timeout values gets rid of the test
failures.

cc @mrunalp 

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>