### PR TITLE
Updated external GCE PD CSI test with new driver name

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -237,7 +237,7 @@ var _ DynamicPVTestDriver = &gcePDExternalCSIDriver{}
 func InitGcePDExternalCSIDriver() TestDriver {
 	return &gcePDExternalCSIDriver{
 		driverInfo: DriverInfo{
-			Name: "com.google.csi.gcepd",
+			Name: "pd.csi.storage.gke.io",
 			// TODO(#70258): this is temporary until we can figure out how to make e2e tests a library
 			FeatureTag:  "[Feature: gcePD-external]",
 			MaxFileSize: testpatterns.FileSizeMedium,


### PR DESCRIPTION
Test change only. Driver name was changed externally so this needs to be updated.

/kind failing-test
/sig storage
/assign @msau42 @saad-ali 

```release-note
NONE
```