### PR TITLE
WIP Per node volume bytes limits for storage classes

### DIFF
--- a/pkg/controller/volume/persistentvolume/scheduler_binder.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder.go
@@ -94,6 +94,8 @@ type SchedulerVolumeBinder interface {
 
 	// GetBindingsCache returns the cache used (if any) to store volume binding decisions.
 	GetBindingsCache() PodBindingCache
+
+	GetPVAssumeCache() PVAssumeCache
 }
 
 type volumeBinder struct {
@@ -137,6 +139,10 @@ func NewVolumeBinder(
 
 func (b *volumeBinder) GetBindingsCache() PodBindingCache {
 	return b.podBindingCache
+}
+
+func (b *volumeBinder) GetPVAssumeCache() PVAssumeCache {
+	return b.pvCache
 }
 
 // FindPodVolumes caches the matching PVs and PVCs to provision per node in podBindingCache

--- a/pkg/controller/volume/persistentvolume/scheduler_binder_fake.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder_fake.go
@@ -58,3 +58,7 @@ func (b *FakeVolumeBinder) BindPodVolumes(assumedPod *v1.Pod) error {
 func (b *FakeVolumeBinder) GetBindingsCache() PodBindingCache {
 	return nil
 }
+
+func (b *FakeVolumeBinder) GetPVAssumeCache() PVAssumeCache {
+	return nil
+}

--- a/pkg/scheduler/algorithm/predicates/csi_volume_max_bytes.go
+++ b/pkg/scheduler/algorithm/predicates/csi_volume_max_bytes.go
@@ -1,0 +1,148 @@
+package predicates
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm"
+	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
+	"strconv"
+	"github.com/golang/glog"
+	"strings"
+	"k8s.io/kubernetes/pkg/kubelet/apis"
+)
+
+const CSIMaxVolumeBytesLabel = "csi.kubernetes.io/max_bytes"
+
+var CSIMaxVolumeBytesNoAvailableBytes = newPredicateFailureError("CSIMaxVolumeBytes", "node(s) exceed csi max volume bytes")
+
+type CSIMaxVolumeBytesChecker struct {
+	pvInfo  PersistentVolumeInfo
+	pvcInfo PersistentVolumeClaimInfo
+	storageCl StorageClassInfo
+}
+
+func NewCSIMaxVolumeBytesChecker(pvInfo PersistentVolumeInfo, pvcInfo PersistentVolumeClaimInfo, storageCl StorageClassInfo) algorithm.FitPredicate {
+	c := &CSIMaxVolumeBytesChecker{
+		pvInfo:  pvInfo,
+		pvcInfo: pvcInfo,
+		storageCl: storageCl,
+	}
+	return c.attachableLimitPredicate
+}
+
+func (c *CSIMaxVolumeBytesChecker) attachableLimitPredicate(pod *v1.Pod, meta algorithm.PredicateMetadata, nodeInfo *schedulercache.NodeInfo) (bool, []algorithm.PredicateFailureReason, error) {
+	// If a pod doesn't have any volume attached to it, the predicate will always be true.
+	// Thus we make a fast path for it, to avoid unnecessary computations in this case.
+	if len(pod.Spec.Volumes) == 0 {
+		return true, nil, nil
+	}
+
+	// If node doesn't have max bytes label we have to assume it can't fit any volumes
+	if _, ok := nodeInfo.Node().Labels[CSIMaxVolumeBytesLabel]; !ok {
+		return false, []algorithm.PredicateFailureReason{CSIMaxVolumeBytesNoAvailableBytes}, nil
+	}
+
+	maxBytes := make(map[string]int64, 0)
+
+	for label, value := range nodeInfo.Node().Labels {
+		if strings.HasPrefix(label, CSIMaxVolumeBytesLabel) {
+			csiName := strings.Replace(label, CSIMaxVolumeBytesLabel+"/", "", 1)
+			csiMaxBytes, err := strconv.Atoi(value)
+			// The CSI was dumb and didn't put a integer in the label so lets skip it
+			if err != nil {
+				glog.Infof("CSI Label %s doesn't have a int value", label)
+				continue
+			}
+			maxBytes[csiName] = int64(csiMaxBytes)
+		}
+	}
+
+	// No max bytes so nothing available
+	if len(maxBytes) == 0 {
+		return false, []algorithm.PredicateFailureReason{CSIMaxVolumeBytesNoAvailableBytes}, nil
+	}
+
+	attachedVolumes := nodeInfo.Node().Status.VolumesAttached
+	glog.Infof("Attached volumes on node %s: ", nodeInfo.Node().Name, attachedVolumes)
+
+	for _, fullVolName := range attachedVolumes {
+		//what happens when volume is not seperated via ^
+		volName := strings.Split(string(fullVolName.Name), "^")[1]
+
+		pv, err := c.pvInfo.GetPersistentVolumeInfo(volName)
+		if err != nil {
+			glog.V(4).Infof("Unable to look up PV info for %s", volName)
+			continue
+		}
+
+		csiSource := pv.Spec.PersistentVolumeSource.CSI
+		if csiSource == nil {
+			glog.V(4).Infof("Not considering non-CSI volume %s", volName)
+			continue
+		}
+
+		if _, ok := maxBytes[csiSource.Driver]; ok {
+			maxBytes[csiSource.Driver] -= pv.Spec.Capacity[v1.ResourceStorage].Value()
+
+			if maxBytes[csiSource.Driver] <= 0 {
+				return false, []algorithm.PredicateFailureReason{CSIMaxVolumeBytesNoAvailableBytes}, nil
+			}
+		}
+	}
+
+
+	for _, podVol := range pod.Spec.Volumes {
+		if podVol.PersistentVolumeClaim == nil {
+			continue
+		}
+
+		pvc, err := c.pvcInfo.GetPersistentVolumeClaimInfo(pod.Namespace, podVol.Name)
+		if err != nil {
+			glog.V(4).Infof("Unable to look up PVC info in namespace %s on pod %ws for %s", pod.Namespace, pod.Name, podVol.Name)
+			continue
+		}
+
+		// If pvc is bound only consider it if it is on the node
+		if pvc.Status.Phase == v1.ClaimBound {
+			pv, err := c.pvInfo.GetPersistentVolumeInfo(pvc.Spec.VolumeName)
+			if err != nil {
+				glog.V(4).Infof("Unable to look up PV info for %s", pvc.Spec.VolumeName)
+				continue
+			}
+
+			myNode := false
+			for _, nst := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms {
+				for _, nsr := range nst.MatchExpressions {
+					if nsr.Key == apis.LabelHostname && nsr.Operator == v1.NodeSelectorOpIn {
+						for _, value := range nsr.Values {
+							if value == nodeInfo.Node().Name {
+								myNode = true
+								break
+							}
+						}
+						if myNode {
+							break
+						}
+					}
+				}
+				if myNode {
+					break
+				}
+			}
+			if !myNode {
+				continue
+			}
+		}
+
+
+		// Going to assume storage class name = driver name
+		if _, ok := maxBytes[*pvc.Spec.StorageClassName]; ok {
+			maxBytes[*pvc.Spec.StorageClassName] -= pvc.Spec.Resources.Requests[v1.ResourceStorage].Value()
+			if maxBytes[*pvc.Spec.StorageClassName] <= 0 {
+				return false, []algorithm.PredicateFailureReason{CSIMaxVolumeBytesNoAvailableBytes}, nil
+			}
+		}
+	}
+
+
+	return true, nil, nil
+}

--- a/pkg/scheduler/algorithm/predicates/csi_volume_max_bytes.go
+++ b/pkg/scheduler/algorithm/predicates/csi_volume_max_bytes.go
@@ -1,51 +1,51 @@
 package predicates
 
 import (
+	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
-	"strconv"
-	"github.com/golang/glog"
-	"strings"
-	"k8s.io/kubernetes/pkg/kubelet/apis"
+	"k8s.io/kubernetes/pkg/scheduler/volumebinder"
+	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 )
 
-const CSIMaxVolumeBytesLabel = "csi.kubernetes.io/max_bytes"
+const CSIMaxVolumeBytesLabel = "csi.kubernetes.io/max_bytes-"
 
 var CSIMaxVolumeBytesNoAvailableBytes = newPredicateFailureError("CSIMaxVolumeBytes", "node(s) exceed csi max volume bytes")
 
 type CSIMaxVolumeBytesChecker struct {
 	pvInfo  PersistentVolumeInfo
 	pvcInfo PersistentVolumeClaimInfo
-	storageCl StorageClassInfo
+	binder  *volumebinder.VolumeBinder
 }
 
-func NewCSIMaxVolumeBytesChecker(pvInfo PersistentVolumeInfo, pvcInfo PersistentVolumeClaimInfo, storageCl StorageClassInfo) algorithm.FitPredicate {
+func NewCSIMaxVolumeBytesChecker(pvInfo PersistentVolumeInfo, pvcInfo PersistentVolumeClaimInfo, binder  *volumebinder.VolumeBinder) algorithm.FitPredicate {
 	c := &CSIMaxVolumeBytesChecker{
 		pvInfo:  pvInfo,
 		pvcInfo: pvcInfo,
-		storageCl: storageCl,
+		binder: binder,
 	}
-	return c.attachableLimitPredicate
+	return c.predicate
 }
 
-func (c *CSIMaxVolumeBytesChecker) attachableLimitPredicate(pod *v1.Pod, meta algorithm.PredicateMetadata, nodeInfo *schedulercache.NodeInfo) (bool, []algorithm.PredicateFailureReason, error) {
+func (c *CSIMaxVolumeBytesChecker) predicate(pod *v1.Pod, meta algorithm.PredicateMetadata, nodeInfo *schedulercache.NodeInfo) (bool, []algorithm.PredicateFailureReason, error) {
+	glog.Info("IN CSIMaxVolumeBytesChecker predicate")
+
 	// If a pod doesn't have any volume attached to it, the predicate will always be true.
 	// Thus we make a fast path for it, to avoid unnecessary computations in this case.
 	if len(pod.Spec.Volumes) == 0 {
 		return true, nil, nil
 	}
 
-	// If node doesn't have max bytes label we have to assume it can't fit any volumes
-	if _, ok := nodeInfo.Node().Labels[CSIMaxVolumeBytesLabel]; !ok {
-		return false, []algorithm.PredicateFailureReason{CSIMaxVolumeBytesNoAvailableBytes}, nil
-	}
-
 	maxBytes := make(map[string]int64, 0)
 
+	glog.Info("Finding CSI Max Bytes Labels")
 	for label, value := range nodeInfo.Node().Labels {
 		if strings.HasPrefix(label, CSIMaxVolumeBytesLabel) {
-			csiName := strings.Replace(label, CSIMaxVolumeBytesLabel+"/", "", 1)
+			csiName := strings.Replace(label, CSIMaxVolumeBytesLabel, "", 1)
 			csiMaxBytes, err := strconv.Atoi(value)
 			// The CSI was dumb and didn't put a integer in the label so lets skip it
 			if err != nil {
@@ -56,93 +56,61 @@ func (c *CSIMaxVolumeBytesChecker) attachableLimitPredicate(pod *v1.Pod, meta al
 		}
 	}
 
-	// No max bytes so nothing available
+	//No max bytes so nothing available
 	if len(maxBytes) == 0 {
-		return false, []algorithm.PredicateFailureReason{CSIMaxVolumeBytesNoAvailableBytes}, nil
+		glog.Infof("No maxBytes label for node %s", nodeInfo.Node().Name)
+		return true, nil, nil
 	}
-
-	attachedVolumes := nodeInfo.Node().Status.VolumesAttached
-	glog.Infof("Attached volumes on node %s: ", nodeInfo.Node().Name, attachedVolumes)
-
-	for _, fullVolName := range attachedVolumes {
-		//what happens when volume is not seperated via ^
-		volName := strings.Split(string(fullVolName.Name), "^")[1]
-
-		pv, err := c.pvInfo.GetPersistentVolumeInfo(volName)
-		if err != nil {
-			glog.V(4).Infof("Unable to look up PV info for %s", volName)
-			continue
-		}
-
-		csiSource := pv.Spec.PersistentVolumeSource.CSI
-		if csiSource == nil {
-			glog.V(4).Infof("Not considering non-CSI volume %s", volName)
-			continue
-		}
-
-		if _, ok := maxBytes[csiSource.Driver]; ok {
-			maxBytes[csiSource.Driver] -= pv.Spec.Capacity[v1.ResourceStorage].Value()
-
-			if maxBytes[csiSource.Driver] <= 0 {
-				return false, []algorithm.PredicateFailureReason{CSIMaxVolumeBytesNoAvailableBytes}, nil
-			}
-		}
-	}
-
 
 	for _, podVol := range pod.Spec.Volumes {
 		if podVol.PersistentVolumeClaim == nil {
 			continue
 		}
 
-		pvc, err := c.pvcInfo.GetPersistentVolumeClaimInfo(pod.Namespace, podVol.Name)
+		pvc, err := c.pvcInfo.GetPersistentVolumeClaimInfo(pod.Namespace, podVol.PersistentVolumeClaim.ClaimName)
 		if err != nil {
 			glog.V(4).Infof("Unable to look up PVC info in namespace %s on pod %ws for %s", pod.Namespace, pod.Name, podVol.Name)
 			continue
 		}
 
-		// If pvc is bound only consider it if it is on the node
-		if pvc.Status.Phase == v1.ClaimBound {
-			pv, err := c.pvInfo.GetPersistentVolumeInfo(pvc.Spec.VolumeName)
-			if err != nil {
-				glog.V(4).Infof("Unable to look up PV info for %s", pvc.Spec.VolumeName)
-				continue
-			}
-
-			myNode := false
-			for _, nst := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms {
-				for _, nsr := range nst.MatchExpressions {
-					if nsr.Key == apis.LabelHostname && nsr.Operator == v1.NodeSelectorOpIn {
-						for _, value := range nsr.Values {
-							if value == nodeInfo.Node().Name {
-								myNode = true
-								break
-							}
-						}
-						if myNode {
-							break
-						}
-					}
-				}
-				if myNode {
-					break
-				}
-			}
-			if !myNode {
-				continue
-			}
-		}
-
-
 		// Going to assume storage class name = driver name
-		if _, ok := maxBytes[*pvc.Spec.StorageClassName]; ok {
-			maxBytes[*pvc.Spec.StorageClassName] -= pvc.Spec.Resources.Requests[v1.ResourceStorage].Value()
+		if _, ok := maxBytes[*pvc.Spec.StorageClassName]; ok && pvc.Spec.VolumeName == "" {
+			capacity := pvc.Spec.Resources.Requests[v1.ResourceStorage]
+			capacityPtr := &capacity
+			maxBytes[*pvc.Spec.StorageClassName] -= capacityPtr.Value()
 			if maxBytes[*pvc.Spec.StorageClassName] <= 0 {
 				return false, []algorithm.PredicateFailureReason{CSIMaxVolumeBytesNoAvailableBytes}, nil
 			}
 		}
 	}
 
+	for k := range maxBytes {
+		volsForClass := c.binder.Binder.GetPVAssumeCache().ListPVs(k)
+		glog.Infof("Attached volumes in class %s on node %s: ", k, nodeInfo.Node().Name, volsForClass)
+
+		for _, pv := range volsForClass {
+			csiSource := pv.Spec.PersistentVolumeSource.CSI
+			if csiSource == nil {
+				glog.V(4).Infof("Not considering non-CSI volume %s", pv.Name)
+				continue
+			}
+			err := volumeutil.CheckNodeAffinity(pv, nodeInfo.Node().Labels)
+			if err != nil {
+				continue
+			}
+
+			if _, ok := maxBytes[k]; ok {
+				capacity := pv.Spec.Capacity[v1.ResourceStorage]
+				capacityPtr := &capacity
+				maxBytes[k] -= capacityPtr.Value()
+
+
+				if maxBytes[k] <= 0 {
+					return false, []algorithm.PredicateFailureReason{CSIMaxVolumeBytesNoAvailableBytes}, nil
+				}
+			}
+		}
+	}
 
 	return true, nil, nil
 }

--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -85,6 +85,7 @@ const (
 	MaxAzureDiskVolumeCountPred = "MaxAzureDiskVolumeCount"
 	// MaxCSIVolumeCountPred defines the predicate that decides how many CSI volumes should be attached
 	MaxCSIVolumeCountPred = "MaxCSIVolumeCountPred"
+	MaxCSIVolumeBytesPred = "MaxCSIVolumeBytesPred"
 	// NoVolumeZoneConflictPred defines the name of predicate NoVolumeZoneConflict.
 	NoVolumeZoneConflictPred = "NoVolumeZoneConflict"
 	// CheckNodeMemoryPressurePred defines the name of predicate CheckNodeMemoryPressure.

--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -132,7 +132,7 @@ var (
 		GeneralPred, HostNamePred, PodFitsHostPortsPred,
 		MatchNodeSelectorPred, PodFitsResourcesPred, NoDiskConflictPred,
 		PodToleratesNodeTaintsPred, PodToleratesNodeNoExecuteTaintsPred, CheckNodeLabelPresencePred,
-		CheckServiceAffinityPred, MaxEBSVolumeCountPred, MaxGCEPDVolumeCountPred, MaxCSIVolumeCountPred,
+		CheckServiceAffinityPred, MaxEBSVolumeCountPred, MaxGCEPDVolumeCountPred, MaxCSIVolumeCountPred, MaxCSIVolumeBytesPred,
 		MaxAzureDiskVolumeCountPred, CheckVolumeBindingPred, NoVolumeZoneConflictPred,
 		CheckNodeMemoryPressurePred, CheckNodePIDPressurePred, CheckNodeDiskPressurePred, MatchInterPodAffinityPred}
 )

--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -142,7 +142,7 @@ func defaultPredicates() sets.String {
 		factory.RegisterFitPredicateFactory(
 			predicates.MaxCSIVolumeBytesPred,
 			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
-				return predicates.NewCSIMaxVolumeBytesChecker(args.PVInfo, args.PVCInfo, args.StorageClassInfo)
+				return predicates.NewCSIMaxVolumeBytesChecker(args.PVInfo, args.PVCInfo, args.VolumeBinder)
 			},
 		),
 		// Fit is determined by inter-pod affinity.

--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -139,6 +139,12 @@ func defaultPredicates() sets.String {
 				return predicates.NewCSIMaxVolumeLimitPredicate(args.PVInfo, args.PVCInfo)
 			},
 		),
+		factory.RegisterFitPredicateFactory(
+			predicates.MaxCSIVolumeBytesPred,
+			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
+				return predicates.NewCSIMaxVolumeBytesChecker(args.PVInfo, args.PVCInfo, args.StorageClassInfo)
+			},
+		),
 		// Fit is determined by inter-pod affinity.
 		factory.RegisterFitPredicateFactory(
 			predicates.MatchInterPodAffinityPred,

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -493,6 +493,10 @@ func (c *configFactory) invalidatePredicatesForPv(pv *v1.PersistentVolume) {
 		invalidPredicates.Insert(predicates.MaxCSIVolumeCountPred)
 	}
 
+	if pv.Spec.CSI != nil {
+		invalidPredicates.Insert(predicates.MaxCSIVolumeBytesPred)
+	}
+
 	// If PV contains zone related label, it may impact cached NoVolumeZoneConflict
 	for k := range pv.Labels {
 		if isZoneRegionLabel(k) {
@@ -573,6 +577,8 @@ func (c *configFactory) invalidatePredicatesForPvc(pvc *v1.PersistentVolumeClaim
 		invalidPredicates.Insert(predicates.MaxCSIVolumeCountPred)
 	}
 
+	invalidPredicates.Insert(predicates.MaxCSIVolumeBytesPred)
+
 	// The bound volume's label may change
 	invalidPredicates.Insert(predicates.NoVolumeZoneConflictPred)
 
@@ -597,6 +603,8 @@ func (c *configFactory) invalidatePredicatesForPvcUpdate(old, new *v1.Persistent
 		if utilfeature.DefaultFeatureGate.Enabled(features.AttachVolumeLimit) {
 			invalidPredicates.Insert(predicates.MaxCSIVolumeCountPred)
 		}
+
+		invalidPredicates.Insert(predicates.MaxCSIVolumeBytesPred)
 	}
 
 	c.equivalencePodCache.InvalidatePredicates(invalidPredicates)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This is a POC just to get my self familiar with the kubernetes scheduling code as well as a solve a problem that I have. I don't intend on getting this merged in however I felt it would be useful for the community to take a look at as I know there are some proposals to add a similar feature for local lvm dynamic provisioning.

This allows each kubelet to report the maximum amount of bytes for volumes that can be attached to the node under a certain storage class.

A default scheduler predicate has been added that looks for the label prefix `csi.kubernetes.io/max_bytes-` on each node with the suffix being the storage class name. It then finds all the volumes on the current node and subtracts the currently bound (and unbound for late volume scheduling) pvs' sizes from the max bytes reported. If there is still room on the node then the predicate is true.

There are probably some bugs and I may not have fully understood how the scheduler works so this implementation may be totally wrong.