### PR TITLE
fix wrong log when do a rollback to a succeed rolling-update

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate/rollingupdate.go
@@ -356,6 +356,9 @@ func (o *RollingUpdateOptions) Run() error {
 
 	if o.Rollback {
 		newName := o.FindNewName(oldRc)
+		if len(newName) == 0 {
+			return fmt.Errorf("Could not rollback a succeed rolling-update or a non-rolling-update RC")
+		}
 		if newRc, err = kubectl.LoadExistingNextReplicationController(coreClient, o.Namespace, newName); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
If user did a rollback to a succeed rolling-update RC
They will get the following:
[root@k8s-master:/home/ubuntu/cka]$ kubectl rolling-update rc-rool2 --rollback=true
error: Could not find  to rollback.

after this pr
User will get the following
root@k8s-master:/home/ubuntu/cka]$ kubectl rolling-update rc-rool2 --rollback=true
error: Could not rollback a succeed roling-update or a non-rolling-update RC


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
