### PR TITLE
support statefulset in kubectl autoscale command

### DIFF
--- a/pkg/kubectl/cmd/autoscale/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale/autoscale.go
@@ -42,7 +42,7 @@ var (
 	autoscaleLong = templates.LongDesc(i18n.T(`
 		Creates an autoscaler that automatically chooses and sets the number of pods that run in a kubernetes cluster.
 
-		Looks up a Deployment, ReplicaSet, or ReplicationController by name and creates an autoscaler that uses the given resource as a reference.
+		Looks up a Deployment, ReplicaSet, StatefulSet, or ReplicationController by name and creates an autoscaler that uses the given resource as a reference.
 		An autoscaler can automatically increase or decrease number of pods deployed within the system as needed.`))
 
 	autoscaleExample = templates.Examples(i18n.T(`

--- a/pkg/kubectl/polymorphichelpers/canbeautoscaled.go
+++ b/pkg/kubectl/polymorphichelpers/canbeautoscaled.go
@@ -31,6 +31,7 @@ func canBeAutoscaled(kind schema.GroupKind) error {
 		corev1.SchemeGroupVersion.WithKind("ReplicationController").GroupKind(),
 		appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
 		appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(),
+		appsv1.SchemeGroupVersion.WithKind("StatefulSet").GroupKind(),
 		extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
 		extensionsv1beta1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind():
 		// nothing to do here

--- a/pkg/kubectl/polymorphichelpers/canbeautoscaled_test.go
+++ b/pkg/kubectl/polymorphichelpers/canbeautoscaled_test.go
@@ -39,6 +39,10 @@ func TestCanBeAutoscaled(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			kind:      appsv1.SchemeGroupVersion.WithKind("StatefulSet").GroupKind(),
+			expectErr: false,
+		},
+		{
 			kind:      extensionsv1beta1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(),
 			expectErr: false,
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
support `kubectl autoscale statefulset ...`command
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
ref #70709 
**Special notes for your reviewer**:
/cc @soltysh 
**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
StatefulSet is supported in `kubectl autoscale` command
```
