### PR TITLE
fix IPVS low throughput issue

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -161,6 +161,7 @@ var ipsetWithIptablesChain = []struct {
 const sysctlRouteLocalnet = "net/ipv4/conf/all/route_localnet"
 const sysctlBridgeCallIPTables = "net/bridge/bridge-nf-call-iptables"
 const sysctlVSConnTrack = "net/ipv4/vs/conntrack"
+const sysctlConnReuse = "net/ipv4/vs/conn_reuse_mode"
 const sysctlForward = "net/ipv4/ip_forward"
 const sysctlArpIgnore = "net/ipv4/conf/all/arp_ignore"
 const sysctlArpAnnounce = "net/ipv4/conf/all/arp_announce"
@@ -310,6 +311,13 @@ func NewProxier(ipt utiliptables.Interface,
 	if val, _ := sysctl.GetSysctl(sysctlVSConnTrack); val != 1 {
 		if err := sysctl.SetSysctl(sysctlVSConnTrack, 1); err != nil {
 			return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlVSConnTrack, err)
+		}
+	}
+
+	// Set the connection reuse mode
+	if val, _ := sysctl.GetSysctl(sysctlConnReuse); val != 0 {
+		if err := sysctl.SetSysctl(sysctlConnReuse, 0); err != nil {
+			return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlConnReuse, err)
 		}
 	}
 


### PR DESCRIPTION


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This pr make IPVS proxier set net/ipv4/vs/conn_reuse_mode to 0 by default, which will fix the  IPVS low throughput issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #70747

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
IPVS proxier now set net/ipv4/vs/conn_reuse_mode to 0 by default, which will highly improve IPVS proxier performance.
```
