### PR TITLE
Implement fmt.Stringer on rest.Config to sanitize sensitive fields

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/BUILD
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//staging/src/k8s.io/client-go/transport:go_default_library",
         "//staging/src/k8s.io/client-go/util/connrotation:go_default_library",
+        "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
         "//vendor/golang.org/x/crypto/ssh/terminal:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"golang.org/x/crypto/ssh/terminal"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -73,8 +74,10 @@ func newCache() *cache {
 	return &cache{m: make(map[string]*Authenticator)}
 }
 
+var spewConfig = &spew.ConfigState{DisableMethods: true, Indent: " "}
+
 func cacheKey(c *api.ExecConfig) string {
-	return fmt.Sprintf("%#v", c)
+	return spewConfig.Sprint(c)
 }
 
 type cache struct {

--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -19,6 +19,7 @@ package rest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -26,6 +27,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -378,6 +380,143 @@ func TestCopyConfig(t *testing.T) {
 
 		if !reflect.DeepEqual(*actual, expected) {
 			t.Fatalf("CopyConfig  dropped unexpected fields, identify whether they are security related or not: %s", diff.ObjectReflectDiff(expected, *actual))
+		}
+	}
+}
+
+func TestConfigStringer(t *testing.T) {
+	formatBytes := func(b []byte) string {
+		// %#v for []byte always pre-pends "[]byte{".
+		// %#v for struct with []byte field always pre-pends "[]uint8{".
+		return strings.Replace(fmt.Sprintf("%#v", b), "byte", "uint8", 1)
+	}
+	tests := []struct {
+		desc            string
+		c               *Config
+		expectContent   []string
+		prohibitContent []string
+	}{
+		{
+			desc:          "nil config",
+			c:             nil,
+			expectContent: []string{"<nil>"},
+		},
+		{
+			desc: "non-sensitive config",
+			c: &Config{
+				Host:      "localhost:8080",
+				APIPath:   "v1",
+				UserAgent: "gobot",
+			},
+			expectContent: []string{"localhost:8080", "v1", "gobot"},
+		},
+		{
+			desc: "sensitive config",
+			c: &Config{
+				Host:        "localhost:8080",
+				Username:    "gopher",
+				Password:    "g0ph3r",
+				BearerToken: "1234567890",
+				TLSClientConfig: TLSClientConfig{
+					CertFile: "a.crt",
+					KeyFile:  "a.key",
+					CertData: []byte("fake cert"),
+					KeyData:  []byte("fake key"),
+				},
+				AuthProvider: &clientcmdapi.AuthProviderConfig{
+					Config: map[string]string{"secret": "s3cr3t"},
+				},
+				ExecProvider: &clientcmdapi.ExecConfig{
+					Args: []string{"secret"},
+					Env:  []clientcmdapi.ExecEnvVar{{Name: "secret", Value: "s3cr3t"}},
+				},
+			},
+			expectContent: []string{
+				"localhost:8080",
+				"gopher",
+				"a.crt",
+				"a.key",
+				"--- REDACTED ---",
+				formatBytes([]byte("--- REDACTED ---")),
+				formatBytes([]byte("--- TRUNCATED ---")),
+			},
+			prohibitContent: []string{
+				"g0ph3r",
+				"1234567890",
+				formatBytes([]byte("fake cert")),
+				formatBytes([]byte("fake key")),
+				"secret",
+				"s3cr3t",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := tt.c.String()
+			t.Logf("formatted config: %q", got)
+
+			for _, expect := range tt.expectContent {
+				if !strings.Contains(got, expect) {
+					t.Errorf("missing expected string %q", expect)
+				}
+			}
+			for _, prohibit := range tt.prohibitContent {
+				if strings.Contains(got, prohibit) {
+					t.Errorf("found prohibited string %q", prohibit)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigSprint(t *testing.T) {
+	c := &Config{
+		Host:    "localhost:8080",
+		APIPath: "v1",
+		ContentConfig: ContentConfig{
+			AcceptContentTypes: "application/json",
+			ContentType:        "application/json",
+		},
+		Username:    "gopher",
+		Password:    "g0ph3r",
+		BearerToken: "1234567890",
+		Impersonate: ImpersonationConfig{
+			UserName: "gopher2",
+		},
+		AuthProvider: &clientcmdapi.AuthProviderConfig{
+			Name:   "gopher",
+			Config: map[string]string{"secret": "s3cr3t"},
+		},
+		AuthConfigPersister: fakeAuthProviderConfigPersister{},
+		ExecProvider: &clientcmdapi.ExecConfig{
+			Command: "sudo",
+			Args:    []string{"secret"},
+			Env:     []clientcmdapi.ExecEnvVar{{Name: "secret", Value: "s3cr3t"}},
+		},
+		TLSClientConfig: TLSClientConfig{
+			CertFile: "a.crt",
+			KeyFile:  "a.key",
+			CertData: []byte("fake cert"),
+			KeyData:  []byte("fake key"),
+		},
+		UserAgent:     "gobot",
+		Transport:     &fakeRoundTripper{},
+		WrapTransport: fakeWrapperFunc,
+		QPS:           1,
+		Burst:         2,
+		RateLimiter:   &fakeLimiter{},
+		Timeout:       3 * time.Second,
+		Dial:          fakeDialFunc,
+	}
+	want := fmt.Sprintf(
+		`&rest.Config{Host:"localhost:8080", APIPath:"v1", ContentConfig:rest.ContentConfig{AcceptContentTypes:"application/json", ContentType:"application/json", GroupVersion:(*schema.GroupVersion)(nil), NegotiatedSerializer:runtime.NegotiatedSerializer(nil)}, Username:"gopher", Password:"--- REDACTED ---", BearerToken:"--- REDACTED ---", BearerTokenFile:"", Impersonate:rest.ImpersonationConfig{UserName:"gopher2", Groups:[]string(nil), Extra:map[string][]string(nil)}, AuthProvider:api.AuthProviderConfig{Name: "gopher", Config: map[string]string{--- REDACTED ---}}, AuthConfigPersister:rest.AuthProviderConfigPersister(--- REDACTED ---), ExecProvider:api.AuthProviderConfig{Command: "sudo", Args: []string{"--- REDACTED ---"}, Env: []ExecEnvVar{--- REDACTED ---}, APIVersion: ""}, TLSClientConfig:rest.sanitizedTLSClientConfig{Insecure:false, ServerName:"", CertFile:"a.crt", KeyFile:"a.key", CAFile:"", CertData:[]uint8{0x2d, 0x2d, 0x2d, 0x20, 0x54, 0x52, 0x55, 0x4e, 0x43, 0x41, 0x54, 0x45, 0x44, 0x20, 0x2d, 0x2d, 0x2d}, KeyData:[]uint8{0x2d, 0x2d, 0x2d, 0x20, 0x52, 0x45, 0x44, 0x41, 0x43, 0x54, 0x45, 0x44, 0x20, 0x2d, 0x2d, 0x2d}, CAData:[]uint8(nil)}, UserAgent:"gobot", Transport:(*rest.fakeRoundTripper)(%p), WrapTransport:(transport.WrapperFunc)(%p), QPS:1, Burst:2, RateLimiter:(*rest.fakeLimiter)(%p), Timeout:3000000000, Dial:(func(context.Context, string, string) (net.Conn, error))(%p)}`,
+		c.Transport, fakeWrapperFunc, c.RateLimiter, fakeDialFunc,
+	)
+
+	for _, f := range []string{"%s", "%v", "%+v", "%#v"} {
+		if got := fmt.Sprintf(f, c); want != got {
+			t.Errorf("fmt.Sprintf(%q, c)\ngot:  %q\nwant: %q", f, got, want)
 		}
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package api
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -150,6 +152,25 @@ type AuthProviderConfig struct {
 	Config map[string]string `json:"config,omitempty"`
 }
 
+var _ fmt.Stringer = new(AuthProviderConfig)
+var _ fmt.GoStringer = new(AuthProviderConfig)
+
+// GoString implements fmt.GoStringer and sanitizes sensitive fields of
+// AuthProviderConfig to prevent accidental leaking via logs.
+func (c AuthProviderConfig) GoString() string {
+	return c.String()
+}
+
+// String implements fmt.Stringer and sanitizes sensitive fields of
+// AuthProviderConfig to prevent accidental leaking via logs.
+func (c AuthProviderConfig) String() string {
+	cfg := "<nil>"
+	if c.Config != nil {
+		cfg = "--- REDACTED ---"
+	}
+	return fmt.Sprintf("api.AuthProviderConfig{Name: %q, Config: map[string]string{%s}}", c.Name, cfg)
+}
+
 // ExecConfig specifies a command to provide client credentials. The command is exec'd
 // and outputs structured stdout holding credentials.
 //
@@ -170,6 +191,29 @@ type ExecConfig struct {
 	// Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
 	// the same encoding version as the input.
 	APIVersion string `json:"apiVersion,omitempty"`
+}
+
+var _ fmt.Stringer = new(ExecConfig)
+var _ fmt.GoStringer = new(ExecConfig)
+
+// GoString implements fmt.GoStringer and sanitizes sensitive fields of
+// ExecConfig to prevent accidental leaking via logs.
+func (c ExecConfig) GoString() string {
+	return c.String()
+}
+
+// String implements fmt.Stringer and sanitizes sensitive fields of ExecConfig
+// to prevent accidental leaking via logs.
+func (c ExecConfig) String() string {
+	var args []string
+	if len(c.Args) > 0 {
+		args = []string{"--- REDACTED ---"}
+	}
+	env := "[]ExecEnvVar(nil)"
+	if len(c.Env) > 0 {
+		env = "[]ExecEnvVar{--- REDACTED ---}"
+	}
+	return fmt.Sprintf("api.AuthProviderConfig{Command: %q, Args: %#v, Env: %s, APIVersion: %q}", c.Command, args, env, c.APIVersion)
 }
 
 // ExecEnvVar is used for setting environment variables when executing an exec-based

--- a/staging/src/k8s.io/sample-cli-plugin/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-cli-plugin/Godeps/Godeps.json
@@ -7,6 +7,10 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "github.com/davecgh/go-spew/spew",
+			"Rev": "782f4967f2dc4564575ca782fe2d04090b5faca8"
+		},
+		{
 			"ImportPath": "github.com/evanphx/json-patch",
 			"Rev": "36442dbdb585210f8d5a1b45e67aa323c197d5c4"
 		},


### PR DESCRIPTION
It's very easy to add glog.Info(config) calls for debugging (or actual
logging). In some scenarios those configs will carry sensitive tokens
and those tokens will end up in logs or response bodies.
Leaking of those stringified configs compromises the cluster.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
