### PR TITLE
Don't allow --csr-only for CA certs or all

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/certs.go
@@ -91,7 +91,6 @@ func newCertSubPhases() []workflow.Phase {
 		Short:          "Generates all certificates",
 		InheritFlags:   getCertPhaseFlags("all"),
 		RunAllSiblings: true,
-		LocalFlags:     localFlags(),
 	}
 
 	subPhases = append(subPhases, allPhase)
@@ -104,6 +103,7 @@ func newCertSubPhases() []workflow.Phase {
 
 		for _, cert := range certList {
 			certPhase := newCertSubPhase(cert, runCertPhase(cert, ca))
+			certPhase.LocalFlags = localFlags()
 			subPhases = append(subPhases, certPhase)
 		}
 	}
@@ -133,7 +133,6 @@ func newCertSubPhase(certSpec *certsphase.KubeadmCert, run func(c workflow.RunDa
 		),
 		Run:          run,
 		InheritFlags: getCertPhaseFlags(certSpec.Name),
-		LocalFlags:   localFlags(),
 	}
 	return phase
 }

--- a/cmd/kubeadm/test/cmd/BUILD
+++ b/cmd/kubeadm/test/cmd/BUILD
@@ -36,6 +36,7 @@ go_test(
         "//cmd/kubeadm/app/phases/certs:go_default_library",
         "//cmd/kubeadm/app/util/pkiutil:go_default_library",
         "//cmd/kubeadm/test:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/renstrom/dedent:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/cmd/kubeadm/test/cmd/util.go
+++ b/cmd/kubeadm/test/cmd/util.go
@@ -43,7 +43,7 @@ func runCmdNoWrap(command string, args ...string) (string, string, error) {
 func RunCmd(command string, args ...string) (string, string, error) {
 	stdout, stderr, err := runCmdNoWrap(command, args...)
 	if err != nil {
-		return "", "", errors.Wrapf(err, "error running %s %v; \nstdout %q, \nstderr %q, \ngot error",
+		return stdout, stderr, errors.Wrapf(err, "error running %s %v; \nstdout %q, \nstderr %q, \ngot error",
 			command, args, stdout, stderr)
 	}
 	return stdout, stderr, nil


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

Having a CSR doesn't make sense for CAs. Nor does it make sense to "generate all" for CSRs: this will end up failing for CA certificates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
