### PR TITLE
 Use overridden hostname in vSphere cloud provider

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -678,6 +678,7 @@ func (vs *VSphere) AddSSHKeyToAllInstances(ctx context.Context, user string, key
 
 // CurrentNodeName gives the current node name
 func (vs *VSphere) CurrentNodeName(ctx context.Context, hostname string) (k8stypes.NodeName, error) {
+	vs.hostName = hostname
 	return convertToK8sType(vs.hostName), nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When using a cloud provider, the node name is set based on what the cloud provider returns from `CurrentNodeName`. The vSphere cloud provider returns the OS's hostname. This prevents the node from registering with the k8s api when the OS hostname contains capital letters (#71140).

Because the vSphere cloud provider does not respect the hostname override argument to kubelet, it is not possible to work around a capitalized hostname. This PR makes the vSphere cloud provider respect the hostname override.

I saw that Photon cloud provider was using [this same strategy](https://github.com/kubernetes/kubernetes/blob/3ea3cfc3bea08c425593a25533bf14c703f90420/pkg/cloudprovider/providers/photon/photon.go#L432-L435) of memoizing the hostname passed in when `CurrentNodeName` was called. It seems less than great as a general approach but it works around this problem.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
vSphere cloud provider will use a node name matching the value of `--hostname-override` if it is supplied
```
