### PR TITLE
Fix kubelet panic.

### DIFF
--- a/pkg/kubelet/metrics/collectors/log_metrics.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics.go
@@ -62,7 +62,7 @@ func (c *logMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 
 	for _, ps := range podStats {
 		for _, c := range ps.Containers {
-			if c.Logs.UsedBytes != nil {
+			if c.Logs != nil && c.Logs.UsedBytes != nil {
 				ch <- prometheus.MustNewConstMetric(
 					descLogSize,
 					prometheus.GaugeValue,


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/pull/70749

This causes panic in containerd clusters: https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce/8905

For CRI container runtime, log stats are generated by running `du` in container log directory https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/stats/cri_stats_provider.go#L473. However, because of all kinds of race condition, it is not guaranteed that the log directory exists when the stats collection runs. When the `Logs` field is nil, it causes a panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x307c765]
goroutine 7642 [running]:
k8s.io/kubernetes/pkg/kubelet/metrics/collectors.(*logMetricsCollector).Collect(0xc000229be8, 0xc00193faa0)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/metrics/collectors/log_metrics.go:65 +0xe5
k8s.io/kubernetes/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func2(0xc00076bb00, 0xc00193faa0, 0x4473fc0, 0xc000229be8)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/prometheus/client_golang/prometheus/registry.go:382 +0x61
created by k8s.io/kubernetes/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/prometheus/client_golang/prometheus/registry.go:380 +0x302
```

This doesn't break docker, because docker log stats come all together with other container stats from cadvisor.

/cc @kubernetes/sig-node-bugs @brancz

Signed-off-by: Lantao Liu <lantaol@google.com>

```release-note
none
```
