### PR TITLE
Call cancel functions to avoid context leaks

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/until_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until_test.go
@@ -53,7 +53,9 @@ func TestUntil(t *testing.T) {
 		func(event watch.Event) (bool, error) { return event.Type == watch.Modified, nil },
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
 	lastEvent, err := UntilWithoutRetry(ctx, fw, conditions...)
 	if err != nil {
 		t.Fatalf("expected nil error, got %#v", err)
@@ -80,7 +82,9 @@ func TestUntilMultipleConditions(t *testing.T) {
 		func(event watch.Event) (bool, error) { return event.Type == watch.Added, nil },
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
 	lastEvent, err := UntilWithoutRetry(ctx, fw, conditions...)
 	if err != nil {
 		t.Fatalf("expected nil error, got %#v", err)
@@ -108,7 +112,9 @@ func TestUntilMultipleConditionsFail(t *testing.T) {
 		func(event watch.Event) (bool, error) { return event.Type == watch.Deleted, nil },
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	lastEvent, err := UntilWithoutRetry(ctx, fw, conditions...)
 	if err != wait.ErrWaitTimeout {
 		t.Fatalf("expected ErrWaitTimeout error, got %#v", err)
@@ -169,6 +175,7 @@ func TestUntilErrorCondition(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
+
 	_, err := UntilWithoutRetry(ctx, fw, conditions...)
 	if err == nil {
 		t.Fatal("expected an error")


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```