### PR TITLE
use better cacheKey for client-go oidc

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc_test.go
@@ -119,19 +119,27 @@ func TestExpired(t *testing.T) {
 func TestClientCache(t *testing.T) {
 	cache := newClientCache()
 
-	if _, ok := cache.getClient("issuer1", "id1"); ok {
+	config1 := &config{
+		issueURL:     "issuer1",
+		clientID:     "id1",
+		clientSecret: "fakesecret",
+		idToken:      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+		refreshToken: "fdb8fdbecf1d03ce5e6125c067733c0d51de209c",
+	}
+
+	if _, ok := cache.getClient(config1); ok {
 		t.Fatalf("got client before putting one in the cache")
 	}
 
 	cli1 := new(oidcAuthProvider)
 	cli2 := new(oidcAuthProvider)
 
-	gotcli := cache.setClient("issuer1", "id1", cli1)
+	gotcli := cache.setClient(config1, cli1)
 	if cli1 != gotcli {
 		t.Fatalf("set first client and got a different one")
 	}
 
-	gotcli = cache.setClient("issuer1", "id1", cli2)
+	gotcli = cache.setClient(config1, cli2)
 	if cli1 != gotcli {
 		t.Fatalf("set a second client and didn't get the first")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

When an idToken expired, the internal cache should also be expired, that means we need a better cacheKey here.

This should be able to fix https://github.com/kubernetes/client-go/issues/268

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes https://github.com/kubernetes/client-go/issues/268

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
