### PR TITLE
Tolerate empty resource list in APIResourceList discovery client cache

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memcache.go
@@ -131,7 +131,7 @@ func (d *memCacheClient) Invalidate() {
 	for _, g := range gl.Groups {
 		for _, v := range g.Versions {
 			r, err := d.delegate.ServerResourcesForGroupVersion(v.GroupVersion)
-			if err != nil || len(r.APIResources) == 0 {
+			if err != nil {
 				utilruntime.HandleError(fmt.Errorf("couldn't get resource list for %v: %v", v.GroupVersion, err))
 				if cur, ok := d.groupToServerResources[v.GroupVersion]; ok {
 					// retain the existing list, if we had it.
@@ -139,6 +139,10 @@ func (d *memCacheClient) Invalidate() {
 				} else {
 					continue
 				}
+			}
+			if len(r.APIResources) == 0 {
+				// retain the existing list, if we had it.
+				continue
 			}
 			rl[v.GroupVersion] = r
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/DirectXMan12/k8s-prometheus-adapter/issues/131

**Special notes for your reviewer**:
Some custom API servers are dynamic proxies and don't have a static list of API resources, and their discovery response looks like
```
❯ kubectl get --raw "/apis/custom.metrics.k8s.io/" | jq .
{
  "kind": "APIGroup",
  "apiVersion": "v1",
  "name": "custom.metrics.k8s.io",
  "versions": [
    {
      "groupVersion": "custom.metrics.k8s.io/v1beta1",
      "version": "v1beta1"
    }
  ],
  "preferredVersion": {
    "groupVersion": "custom.metrics.k8s.io/v1beta1",
    "version": "v1beta1"
  }
}
```
This is probably fine, and discovery client shouldn't throw errors in that case.
Currently we get the following:
```
I1118 22:59:54.902823       1 request.go:530] Throttling request took 197.9992ms, request: GET:https://10.96.0.1:443/apis/custom.metrics.k8s.io/v1beta1?timeout=32s
E1118 22:59:54.913976       1 memcache.go:134] couldn't get resource list for custom.metrics.k8s.io/v1beta1: <nil>
```

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->

```release-note
NONE
```
