### PR TITLE
Automated cherry pick of #71063: fix a scheduler panic due to internal cache inconsistency

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -817,7 +817,6 @@ func selectNodesForPreemption(pod *v1.Pod,
 	queue SchedulingQueue,
 	pdbs []*policy.PodDisruptionBudget,
 ) (map[*v1.Node]*schedulerapi.Victims, error) {
-
 	nodeToVictims := map[*v1.Node]*schedulerapi.Victims{}
 	var resultLock sync.Mutex
 
@@ -906,6 +905,9 @@ func selectVictimsOnNode(
 	queue SchedulingQueue,
 	pdbs []*policy.PodDisruptionBudget,
 ) ([]*v1.Pod, int, bool) {
+	if nodeInfo == nil {
+		return nil, 0, false
+	}
 	potentialVictims := util.SortableList{CompFunc: util.HigherPriorityPod}
 	nodeInfoCopy := nodeInfo.Clone()
 

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -944,6 +944,11 @@ func TestSelectNodesForPreemption(t *testing.T) {
 			test.predicates[algorithmpredicates.MatchInterPodAffinityPred] = algorithmpredicates.NewPodAffinityPredicate(FakeNodeInfo(*nodes[0]), schedulertesting.FakePodLister(test.pods))
 		}
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, nodes)
+		// newnode simulate a case that a new node is added to the cluster, but nodeNameToInfo
+		// doesn't have it yet.
+		newnode := makeNode("newnode", 1000*5, priorityutil.DefaultMemoryRequest*5)
+		newnode.ObjectMeta.Labels = map[string]string{"hostname": "newnode"}
+		nodes = append(nodes, newnode)
 		nodeToPods, err := selectNodesForPreemption(test.pod, nodeNameToInfo, nodes, test.predicates, PredicateMetadata, nil, nil)
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
Cherry pick of #71063 on release-1.11.

#71063: fix a scheduler panic due to internal cache inconsistency