### PR TITLE
No need to pass GOFLAGS to $goflags variables with go 1.11

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -677,9 +677,7 @@ kube::golang::build_binaries() {
     local host_platform
     host_platform=$(kube::golang::host_platform)
 
-    # Use eval to preserve embedded quoted strings.
     local goflags goldflags goasmflags gogcflags
-    eval "goflags=(${GOFLAGS:-})"
     goldflags="${GOLDFLAGS:-} -s -w $(kube::version::ldflags)"
     goasmflags="-trimpath=${KUBE_ROOT}"
     gogcflags="${GOGCFLAGS:-} -trimpath=${KUBE_ROOT}"

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -171,7 +171,6 @@ done
 shift $((OPTIND - 1))
 
 # Use eval to preserve embedded quoted strings.
-eval "goflags=(${GOFLAGS:-})"
 eval "testargs=(${KUBE_TEST_ARGS:-})"
 
 # Used to filter verbose test output.

--- a/hack/make-rules/vet.sh
+++ b/hack/make-rules/vet.sh
@@ -35,9 +35,6 @@ fi
 # See https://github.com/golang/go/issues/16086 for details.
 go install ./cmd/...
 
-# Use eval to preserve embedded quoted strings.
-eval "goflags=(${GOFLAGS:-})"
-
 # Filter out arguments that start with "-" and move them to goflags.
 targets=()
 for arg; do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Do not save `GOFLAGS` in `$goflags`. 

In go 1.11, go commands will use `GOFLAGS` as default flags, see
https://golang.org/doc/go1.11#go_command.

There is no need to pass GOFLAGS to $goflags, and if we do, go commands
will fail with "duplicate flags" error, e.g.

```
$ make test-integration WHAT=./test/integration/scheduler GOFLAGS="-v"
...
go test: v flag may be set only once
run "go help test" or "go help testflag" for more information
...
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #70062 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
