### PR TITLE
e2e/auth: fix NodeAuthenticator tests not working

### DIFF
--- a/test/e2e/auth/node_authn.go
+++ b/test/e2e/auth/node_authn.go
@@ -68,7 +68,7 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 		newSA := &v1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns,
-				Name:      "node-auth-newSA",
+				Name:      "node-auth-newsa",
 			},
 			AutomountServiceAccountToken: &trueValue,
 		}
@@ -98,7 +98,7 @@ func createNodeAuthTestPod(f *framework.Framework) *v1.Pod {
 			Containers: []v1.Container{{
 				Name:    "test-node-authn",
 				Image:   imageutils.GetE2EImage(imageutils.Hostexec),
-				Command: []string{"sleep 3600"},
+				Command: []string{"sleep", "3600"},
 			}},
 			RestartPolicy: v1.RestartPolicyNever,
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
I found the following 2 e2e tests did not work.
- [sig-auth] [Feature:NodeAuthenticator] [It] The kubelet's main port 10250 should reject requests with no credentials
- [sig-auth] [Feature:NodeAuthenticator] [It] The kubelet can delegate ServiceAccount tokens to the API server

I believe that run command and service account name are not appropriate from the following error messages.
```
[It] The kubelet's main port 10250 should reject requests with no credentials
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/node_authn.go:56
Nov 16 15:33:56.305: INFO: Unexpected error occurred: pod ran to completion
...
sponse from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"sleep 3600\": executable file not found in $PATH": unknown
```
Error message indecates "sleep 3600" command was run and not found, not "sleep" with argument "3600".
It was caused by inappropriate command format of creating pod. So, I fixed.

```
The kubelet can delegate ServiceAccount tokens to the API server [It]
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/node_authn.go:65

failed to create service account (e2e-tests-node-authn-hm674:node-auth-newSA)
Expected error:
    <*errors.StatusError | 0xc0017efcb0>: {
        ErrStatus: {
            TypeMeta: {Kind: "", APIVersion: ""},
            ListMeta: {SelfLink: "", ResourceVersion: "", Continue: ""},
            Status: "Failure",
            Message: "ServiceAccount \"node-auth-newSA\" is invalid: metadata.name: Invalid value: \"node-auth-newSA\": a DNS-1123 subdomain must consist of lower case alphanumeric
characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
```
I changed "node-auth-newSA" to "node-auth-newsa" because ServiceAccount should be lower case alphanumeric from error message.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE