### PR TITLE
add a default mtu value for kube-ipvs0

### DIFF
--- a/pkg/proxy/ipvs/netlink_linux.go
+++ b/pkg/proxy/ipvs/netlink_linux.go
@@ -28,6 +28,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const defaultDummyDeviceMTU int = 65520
+
 type netlinkHandle struct {
 	netlink.Handle
 }
@@ -82,8 +84,12 @@ func (h *netlinkHandle) EnsureDummyDevice(devName string) (bool, error) {
 		// found dummy device
 		return true, nil
 	}
+	linkAttrs := netlink.LinkAttrs{Name: devName}
+	if devName == DefaultDummyDevice {
+		linkAttrs.MTU = defaultDummyDeviceMTU
+	}
 	dummy := &netlink.Dummy{
-		LinkAttrs: netlink.LinkAttrs{Name: devName},
+		LinkAttrs: linkAttrs,
 	}
 	return false, h.LinkAdd(dummy)
 }


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68546

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
