### PR TITLE
WIP: debug CSI SkipAttach tests

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -584,6 +584,7 @@ func hasStageUnstageCapability(ctx context.Context, csi csiClient) (bool, error)
 // getAttachmentName returns csi-<sha252(volName,csiDriverName,NodeName>
 func getAttachmentName(volName, csiDriverName, nodeName string) string {
 	result := sha256.Sum256([]byte(fmt.Sprintf("%s%s%s", volName, csiDriverName, nodeName)))
+	klog.Infof("JSAF: volName: %s, csiDriverName: %s, nodeName: %s, hash: %s", volName, csiDriverName, nodeName, result)
 	return fmt.Sprintf("csi-%x", result)
 }
 

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -235,6 +235,7 @@ var _ = utils.SIGDescribe("CSI Volumes", func() {
 				handle := getVolumeHandle(cs, claim)
 				attachmentHash := sha256.Sum256([]byte(fmt.Sprintf("%s%s%s", handle, scTest.Provisioner, nodeName)))
 				attachmentName := fmt.Sprintf("csi-%x", attachmentHash)
+				framework.Logf("handle: %s, provisioner: %s, NodeName: %s, hash: %s", handle, scTest.Provisioner, nodeName, attachmentName)
 				_, err = cs.StorageV1beta1().VolumeAttachments().Get(attachmentName, metav1.GetOptions{})
 				if err != nil {
 					if errors.IsNotFound(err) {


### PR DESCRIPTION
Do not merge!

This adds just some log messages around VolumeAttachment creation. There is something wrong in e2e infrastructure, the test runs OK on a GCE cluster created by cluster/kube-up.sh. It seems that the tests and volume plugin compute different VolumeAttachment names from some reason.

/test pull-kubernetes-e2e-gce-alpha-features