### PR TITLE
remove unreachable check for --image

### DIFF
--- a/pkg/kubectl/cmd/run/run.go
+++ b/pkg/kubectl/cmd/run/run.go
@@ -260,9 +260,6 @@ func (o *RunOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 
 	// validate image name
 	imageName := o.Image
-	if imageName == "" {
-		return fmt.Errorf("--image is required")
-	}
 	validImageRef := reference.ReferenceRegexp.MatchString(imageName)
 	if !validImageRef {
 		return fmt.Errorf("Invalid image name %q: %v", imageName, reference.ErrReferenceInvalidFormat)


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup


**What this PR does / why we need it**:
code cleanup for pkg/kubectl/cmd/run/run.go
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
--image FlagRequired is marked,this check is unreachable.
`cmd.MarkFlagRequired("image")`
```shell
# kubectl run nginx
Error: required flag(s) "image" not set
```
**Does this PR introduce a user-facing change?**:
NONE
```release-note

```
