### PR TITLE
Rename '--experimental-encryption-provider-config' to '--encryption-provider-config'

### DIFF
--- a/cluster/gce/gci/apiserver_manifest_test.go
+++ b/cluster/gce/gci/apiserver_manifest_test.go
@@ -98,7 +98,7 @@ func TestEncryptionProviderFlag(t *testing.T) {
 		//   "-c",      - Index 1
 		//   "exec /usr/local/bin/kube-apiserver " - Index 2
 		execArgsIndex        = 2
-		encryptionConfigFlag = "--experimental-encryption-provider-config"
+		encryptionConfigFlag = "--encryption-provider-config"
 	)
 
 	testCases := []struct {

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1815,7 +1815,7 @@ function start-kube-apiserver {
 # Sets-up etcd encryption.
 # Configuration of etcd level encryption consists of the following steps:
 # 1. Writing encryption provider config to disk
-# 2. Adding experimental-encryption-provider-config flag to kube-apiserver
+# 2. Adding encryption-provider-config flag to kube-apiserver
 # 3. Add kms-socket-vol and kms-socket-vol-mnt to enable communication with kms-plugin (if requested)
 #
 # Expects parameters:
@@ -1855,7 +1855,7 @@ function setup-etcd-encryption {
   encryption_provider_config_path=${ENCRYPTION_PROVIDER_CONFIG_PATH:-/etc/srv/kubernetes/encryption-provider-config.yml}
 
   echo "${ENCRYPTION_PROVIDER_CONFIG}" | base64 --decode > "${encryption_provider_config_path}"
-  kube_api_server_params+=" --experimental-encryption-provider-config=${encryption_provider_config_path}"
+  kube_api_server_params+=" --encryption-provider-config=${encryption_provider_config_path}"
 
   default_encryption_provider_config_vol=$(echo "{ \"name\": \"encryptionconfig\", \"hostPath\": {\"path\": \"${encryption_provider_config_path}\", \"type\": \"File\"}}" | base64 | tr -d '\r\n')
   default_encryption_provider_config_vol_mnt=$(echo "{ \"name\": \"encryptionconfig\", \"mountPath\": \"${encryption_provider_config_path}\", \"readOnly\": true}" | base64 | tr -d '\r\n')

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -164,6 +164,10 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.EncryptionProviderConfigFilepath, "experimental-encryption-provider-config", s.EncryptionProviderConfigFilepath,
 		"The file containing configuration for encryption providers to be used for storing secrets in etcd")
+	fs.MarkDeprecated("experimental-encryption-provider-config", "use --encryption-provider-config.")
+
+	fs.StringVar(&s.EncryptionProviderConfigFilepath, "encryption-provider-config", s.EncryptionProviderConfigFilepath,
+		"The file containing configuration for encryption providers to be used for storing secrets in etcd")
 
 	fs.DurationVar(&s.StorageConfig.CompactionInterval, "etcd-compaction-interval", s.StorageConfig.CompactionInterval,
 		"The interval of compaction requests. If 0, the compaction request from apiserver is disabled.")

--- a/test/integration/master/transformation_testcase.go
+++ b/test/integration/master/transformation_testcase.go
@@ -164,7 +164,7 @@ func (e *transformTest) getRawSecretFromETCD() ([]byte, error) {
 
 func (e *transformTest) getEncryptionOptions() []string {
 	if e.transformerConfig != "" {
-		return []string{"--experimental-encryption-provider-config", path.Join(e.configDir, encryptionConfigFileName)}
+		return []string{"--encryption-provider-config", path.Join(e.configDir, encryptionConfigFileName)}
 	}
 
 	return nil


### PR DESCRIPTION
This change renames the '--experimental-encryption-provider-config' flag to '--encryption-provider-config'. The old flag is accepted but generates a warning.
    
In 1.14, we will drop support for '--experimental-encryption-provider-config' entirely.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
This PR follows up on the `EncryptionConfiguration` alpha->stable move from https://github.com/kubernetes/kubernetes/pull/67383/

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/61420

**Special notes for your reviewer**:
This is a rebase of original PR https://github.com/kubernetes/kubernetes/pull/61592

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
API server flag `--experimental-encryption-provider-config` was renamed to `--encryption-provider-config`. The old flag is accepted with a warning but will be removed in 1.14.
```
