### PR TITLE
Fix unit test to run with random UID

### DIFF
--- a/pkg/util/mount/nsenter_mount_test.go
+++ b/pkg/util/mount/nsenter_mount_test.go
@@ -169,11 +169,19 @@ func newFakeNsenterMounter(tmpdir string, t *testing.T) (mounter *NsenterMounter
 }
 
 func TestNsenterExistsFile(t *testing.T) {
-	user, err := user.Current()
-	if err != nil {
-		t.Error(err)
+	var isRoot bool
+	usr, err := user.Current()
+	if err == nil {
+		isRoot = usr.Username == "root"
+	} else {
+		switch err.(type) {
+		case user.UnknownUserIdError:
+			// Root should be always known, this is some random UID
+			isRoot = false
+		default:
+			t.Fatal(err)
+		}
 	}
-	isRoot := user.Username == "root"
 
 	tests := []struct {
 		name           string


### PR DESCRIPTION
User that runs the tests desn't need to be in /etc/passwd and thus `user.Current()` can fail. Assume the user is not root in this case.

/kind failing-test
/sig storage

```release-note
NONE
```
