### PR TITLE
Refactor status PrepareForUpdate into standalone method

### DIFF
--- a/pkg/registry/storage/volumeattachment/BUILD
+++ b/pkg/registry/storage/volumeattachment/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//pkg/apis/storage:go_default_library",
         "//pkg/apis/storage/validation:go_default_library",
         "//staging/src/k8s.io/api/storage/v1beta1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",

--- a/pkg/registry/storage/volumeattachment/strategy.go
+++ b/pkg/registry/storage/volumeattachment/strategy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	storageapiv1beta1 "k8s.io/api/storage/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -134,14 +135,5 @@ func (volumeAttachmentStatusStrategy) PrepareForUpdate(ctx context.Context, obj,
 	oldVolumeAttachment := old.(*storage.VolumeAttachment)
 
 	newVolumeAttachment.Spec = oldVolumeAttachment.Spec
-
-	oldMeta := oldVolumeAttachment.ObjectMeta
-	newMeta := &newVolumeAttachment.ObjectMeta
-	newMeta.SetDeletionTimestamp(oldMeta.GetDeletionTimestamp())
-	newMeta.SetGeneration(oldMeta.GetGeneration())
-	newMeta.SetSelfLink(oldMeta.GetSelfLink())
-	newMeta.SetLabels(oldMeta.GetLabels())
-	newMeta.SetAnnotations(oldMeta.GetAnnotations())
-	newMeta.SetFinalizers(oldMeta.GetFinalizers())
-	newMeta.SetOwnerReferences(oldMeta.GetOwnerReferences())
+	metav1.ResetObjectMetaForStatus(&newVolumeAttachment.ObjectMeta, &oldVolumeAttachment.ObjectMeta)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
@@ -25,6 +25,9 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
@@ -232,3 +232,15 @@ func HasObjectMetaSystemFieldValues(meta Object) bool {
 	return !meta.GetCreationTimestamp().Time.IsZero() ||
 		len(meta.GetUID()) != 0
 }
+
+// ResetObjectMetaForStatus forces the meta fields for a status update to match the meta fields
+// for a pre-existing object. This is opt-in for new objects with Status subresource.
+func ResetObjectMetaForStatus(meta, existingMeta Object) {
+	meta.SetDeletionTimestamp(existingMeta.GetDeletionTimestamp())
+	meta.SetGeneration(existingMeta.GetGeneration())
+	meta.SetSelfLink(existingMeta.GetSelfLink())
+	meta.SetLabels(existingMeta.GetLabels())
+	meta.SetAnnotations(existingMeta.GetAnnotations())
+	meta.SetFinalizers(existingMeta.GetFinalizers())
+	meta.SetOwnerReferences(existingMeta.GetOwnerReferences())
+}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
@@ -22,7 +22,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/gofuzz"
+
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
 )
 
 func TestLabelSelectorAsSelector(t *testing.T) {
@@ -157,5 +161,38 @@ func TestLabelSelectorAsMap(t *testing.T) {
 		if !reflect.DeepEqual(out, tc.out) {
 			t.Errorf("[%v]expected:\n\t%+v\nbut got:\n\t%+v", i, tc.out, out)
 		}
+	}
+}
+
+func TestResetObjectMetaForStatus(t *testing.T) {
+	meta := &ObjectMeta{}
+	existingMeta := &ObjectMeta{}
+
+	// fuzz the existingMeta to set every field, no nils
+	f := fuzz.New().NilChance(0).NumElements(1, 1)
+	f.Fuzz(existingMeta)
+	ResetObjectMetaForStatus(meta, existingMeta)
+
+	// not all fields are stomped during the reset.  These fields should not have been set. False
+	// set them all to their zero values.  Before you add anything to this list, consider whether or not
+	// you're enforcing immutability (those are fine) and whether /status should be able to update
+	// these values (these are usually not fine).
+
+	// generateName doesn't do anything after create
+	existingMeta.SetGenerateName("")
+	// resourceVersion is enforced in validation and used during the storage update
+	existingMeta.SetResourceVersion("")
+	// fields made immutable in validation
+	existingMeta.SetUID(types.UID(""))
+	existingMeta.SetName("")
+	existingMeta.SetNamespace("")
+	existingMeta.SetClusterName("")
+	existingMeta.SetCreationTimestamp(Time{})
+	existingMeta.SetDeletionTimestamp(nil)
+	existingMeta.SetDeletionGracePeriodSeconds(nil)
+	existingMeta.SetInitializers(nil)
+
+	if !reflect.DeepEqual(meta, existingMeta) {
+		t.Error(diff.ObjectDiff(meta, existingMeta))
 	}
 }


### PR DESCRIPTION
Someone else might find reseting metadata fields useful. Note that this does not modify any existing behavior, status update of an API object is likely to be allowed to update metadata. It is opt-in for new objects.

/kind cleanup
/sig api-machinery

**What this PR does / why we need it**:
It's follow up of https://github.com/kubernetes/kubernetes/pull/69929#pullrequestreview-174514578 and fixes part of #71056

<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

@liggitt, PTAL
