### PR TITLE
Update PV/PVC assume cache with invalidations in scheduler factory.

### DIFF
--- a/pkg/controller/volume/persistentvolume/scheduler_assume_cache_test.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_assume_cache_test.go
@@ -107,14 +107,14 @@ func TestAssumePV(t *testing.T) {
 	}
 
 	for name, scenario := range scenarios {
-		cache := NewPVAssumeCache(nil)
+		cache := NewPVAssumeCache()
 		internal_cache, ok := cache.(*pvAssumeCache)
 		if !ok {
 			t.Fatalf("Failed to get internal cache")
 		}
 
 		// Add oldPV to cache
-		internal_cache.add(scenario.oldPV)
+		internal_cache.Add(scenario.oldPV)
 		if err := verifyPV(cache, scenario.oldPV.Name, scenario.oldPV); err != nil {
 			t.Errorf("Failed to GetPV() after initial update: %v", err)
 			continue
@@ -141,7 +141,7 @@ func TestAssumePV(t *testing.T) {
 }
 
 func TestRestorePV(t *testing.T) {
-	cache := NewPVAssumeCache(nil)
+	cache := NewPVAssumeCache()
 	internal_cache, ok := cache.(*pvAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
@@ -154,7 +154,7 @@ func TestRestorePV(t *testing.T) {
 	cache.Restore("nothing")
 
 	// Add oldPV to cache
-	internal_cache.add(oldPV)
+	internal_cache.Add(oldPV)
 	if err := verifyPV(cache, oldPV.Name, oldPV); err != nil {
 		t.Fatalf("Failed to GetPV() after initial update: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestRestorePV(t *testing.T) {
 }
 
 func TestBasicPVCache(t *testing.T) {
-	cache := NewPVAssumeCache(nil)
+	cache := NewPVAssumeCache()
 	internal_cache, ok := cache.(*pvAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
@@ -201,7 +201,7 @@ func TestBasicPVCache(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		pv := makePV(fmt.Sprintf("test-pv%v", i), "1", "")
 		pvs[pv.Name] = pv
-		internal_cache.add(pv)
+		internal_cache.Add(pv)
 	}
 
 	// List them
@@ -210,7 +210,7 @@ func TestBasicPVCache(t *testing.T) {
 	// Update a PV
 	updatedPV := makePV("test-pv3", "2", "")
 	pvs[updatedPV.Name] = updatedPV
-	internal_cache.update(nil, updatedPV)
+	internal_cache.Update(nil, updatedPV)
 
 	// List them
 	verifyListPVs(t, cache, pvs, "")
@@ -218,14 +218,14 @@ func TestBasicPVCache(t *testing.T) {
 	// Delete a PV
 	deletedPV := pvs["test-pv7"]
 	delete(pvs, deletedPV.Name)
-	internal_cache.delete(deletedPV)
+	internal_cache.Delete(deletedPV)
 
 	// List them
 	verifyListPVs(t, cache, pvs, "")
 }
 
 func TestPVCacheWithStorageClasses(t *testing.T) {
-	cache := NewPVAssumeCache(nil)
+	cache := NewPVAssumeCache()
 	internal_cache, ok := cache.(*pvAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
@@ -236,7 +236,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		pv := makePV(fmt.Sprintf("test-pv%v", i), "1", "class1")
 		pvs1[pv.Name] = pv
-		internal_cache.add(pv)
+		internal_cache.Add(pv)
 	}
 
 	// Add a bunch of PVs
@@ -244,7 +244,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		pv := makePV(fmt.Sprintf("test2-pv%v", i), "1", "class2")
 		pvs2[pv.Name] = pv
-		internal_cache.add(pv)
+		internal_cache.Add(pv)
 	}
 
 	// List them
@@ -254,7 +254,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 	// Update a PV
 	updatedPV := makePV("test-pv3", "2", "class1")
 	pvs1[updatedPV.Name] = updatedPV
-	internal_cache.update(nil, updatedPV)
+	internal_cache.Update(nil, updatedPV)
 
 	// List them
 	verifyListPVs(t, cache, pvs1, "class1")
@@ -263,7 +263,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 	// Delete a PV
 	deletedPV := pvs1["test-pv7"]
 	delete(pvs1, deletedPV.Name)
-	internal_cache.delete(deletedPV)
+	internal_cache.Delete(deletedPV)
 
 	// List them
 	verifyListPVs(t, cache, pvs1, "class1")
@@ -271,7 +271,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 }
 
 func TestAssumeUpdatePVCache(t *testing.T) {
-	cache := NewPVAssumeCache(nil)
+	cache := NewPVAssumeCache()
 	internal_cache, ok := cache.(*pvAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
@@ -281,7 +281,7 @@ func TestAssumeUpdatePVCache(t *testing.T) {
 
 	// Add a PV
 	pv := makePV(pvName, "1", "")
-	internal_cache.add(pv)
+	internal_cache.Add(pv)
 	if err := verifyPV(cache, pvName, pv); err != nil {
 		t.Fatalf("failed to get PV: %v", err)
 	}
@@ -297,7 +297,7 @@ func TestAssumeUpdatePVCache(t *testing.T) {
 	}
 
 	// Add old PV
-	internal_cache.add(pv)
+	internal_cache.Add(pv)
 	if err := verifyPV(cache, pvName, newPV); err != nil {
 		t.Fatalf("failed to get PV after old PV added: %v", err)
 	}
@@ -364,14 +364,14 @@ func TestAssumePVC(t *testing.T) {
 	}
 
 	for name, scenario := range scenarios {
-		cache := NewPVCAssumeCache(nil)
+		cache := NewPVCAssumeCache()
 		internal_cache, ok := cache.(*pvcAssumeCache)
 		if !ok {
 			t.Fatalf("Failed to get internal cache")
 		}
 
 		// Add oldPVC to cache
-		internal_cache.add(scenario.oldPVC)
+		internal_cache.Add(scenario.oldPVC)
 		if err := verifyPVC(cache, getPVCName(scenario.oldPVC), scenario.oldPVC); err != nil {
 			t.Errorf("Failed to GetPVC() after initial update: %v", err)
 			continue
@@ -398,7 +398,7 @@ func TestAssumePVC(t *testing.T) {
 }
 
 func TestRestorePVC(t *testing.T) {
-	cache := NewPVCAssumeCache(nil)
+	cache := NewPVCAssumeCache()
 	internal_cache, ok := cache.(*pvcAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
@@ -411,7 +411,7 @@ func TestRestorePVC(t *testing.T) {
 	cache.Restore("nothing")
 
 	// Add oldPVC to cache
-	internal_cache.add(oldPVC)
+	internal_cache.Add(oldPVC)
 	if err := verifyPVC(cache, getPVCName(oldPVC), oldPVC); err != nil {
 		t.Fatalf("Failed to GetPVC() after initial update: %v", err)
 	}
@@ -438,7 +438,7 @@ func TestRestorePVC(t *testing.T) {
 }
 
 func TestAssumeUpdatePVCCache(t *testing.T) {
-	cache := NewPVCAssumeCache(nil)
+	cache := NewPVCAssumeCache()
 	internal_cache, ok := cache.(*pvcAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
@@ -449,7 +449,7 @@ func TestAssumeUpdatePVCCache(t *testing.T) {
 
 	// Add a PVC
 	pvc := makeClaim(pvcName, "1", pvcNamespace)
-	internal_cache.add(pvc)
+	internal_cache.Add(pvc)
 	if err := verifyPVC(cache, getPVCName(pvc), pvc); err != nil {
 		t.Fatalf("failed to get PVC: %v", err)
 	}
@@ -465,7 +465,7 @@ func TestAssumeUpdatePVCCache(t *testing.T) {
 	}
 
 	// Add old PVC
-	internal_cache.add(pvc)
+	internal_cache.Add(pvc)
 	if err := verifyPVC(cache, getPVCName(pvc), newPVC); err != nil {
 		t.Fatalf("failed to get PVC after old PVC added: %v", err)
 	}

--- a/pkg/controller/volume/persistentvolume/scheduler_binder.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
-	coreinformers "k8s.io/client-go/informers/core/v1"
 	storageinformers "k8s.io/client-go/informers/storage/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
@@ -113,8 +112,8 @@ type volumeBinder struct {
 // NewVolumeBinder sets up all the caches needed for the scheduler to make volume binding decisions.
 func NewVolumeBinder(
 	kubeClient clientset.Interface,
-	pvcInformer coreinformers.PersistentVolumeClaimInformer,
-	pvInformer coreinformers.PersistentVolumeInformer,
+	pvcCache PVCAssumeCache,
+	pvCache PVAssumeCache,
 	storageClassInformer storageinformers.StorageClassInformer,
 	bindTimeout time.Duration) SchedulerVolumeBinder {
 
@@ -126,8 +125,8 @@ func NewVolumeBinder(
 
 	b := &volumeBinder{
 		ctrl:            ctrl,
-		pvcCache:        NewPVCAssumeCache(pvcInformer.Informer()),
-		pvCache:         NewPVAssumeCache(pvInformer.Informer()),
+		pvcCache:        pvcCache,
+		pvCache:         pvCache,
 		podBindingCache: NewPodBindingCache(),
 		bindTimeout:     bindTimeout,
 	}

--- a/pkg/scheduler/volumebinder/BUILD
+++ b/pkg/scheduler/volumebinder/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/controller/volume/persistentvolume:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/informers/storage/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
     ],

--- a/pkg/scheduler/volumebinder/volume_binder.go
+++ b/pkg/scheduler/volumebinder/volume_binder.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"k8s.io/api/core/v1"
-	coreinformers "k8s.io/client-go/informers/core/v1"
 	storageinformers "k8s.io/client-go/informers/storage/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/controller/volume/persistentvolume"
@@ -28,19 +27,23 @@ import (
 
 // VolumeBinder sets up the volume binding library
 type VolumeBinder struct {
-	Binder persistentvolume.SchedulerVolumeBinder
+	Binder         persistentvolume.SchedulerVolumeBinder
+	PVCAssumeCache persistentvolume.PVCAssumeCache
+	PVAssumeCache  persistentvolume.PVAssumeCache
 }
 
 // NewVolumeBinder sets up the volume binding library and binding queue
 func NewVolumeBinder(
 	client clientset.Interface,
-	pvcInformer coreinformers.PersistentVolumeClaimInformer,
-	pvInformer coreinformers.PersistentVolumeInformer,
 	storageClassInformer storageinformers.StorageClassInformer,
 	bindTimeout time.Duration) *VolumeBinder {
 
+	pvcCache := persistentvolume.NewPVCAssumeCache()
+	pvCache := persistentvolume.NewPVAssumeCache()
 	return &VolumeBinder{
-		Binder: persistentvolume.NewVolumeBinder(client, pvcInformer, pvInformer, storageClassInformer, bindTimeout),
+		Binder:         persistentvolume.NewVolumeBinder(client, pvcCache, pvCache, storageClassInformer, bindTimeout),
+		PVCAssumeCache: pvcCache,
+		PVAssumeCache:  pvCache,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Update PV/PVC assume cache with invalidations in scheduler factory.

There is no guarantee in which order different event handlers will be
called. If we use different event handlers, it's possible PV/PVC assume
cache will be updated after invalidations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
