### PR TITLE
kubeadm: use rotateCertificates from user config

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/defaults.go
+++ b/cmd/kubeadm/app/componentconfigs/defaults.go
@@ -102,7 +102,11 @@ func DefaultKubeletConfiguration(internalcfg *kubeadmapi.ClusterConfiguration) {
 	externalkubeletcfg.ReadOnlyPort = 0
 
 	// Enables client certificate rotation for the kubelet
-	externalkubeletcfg.RotateCertificates = true
+	if internalcfg.ComponentConfigs.Kubelet != nil {
+		externalkubeletcfg.RotateCertificates = internalcfg.ComponentConfigs.Kubelet.RotateCertificates
+	} else {
+		externalkubeletcfg.RotateCertificates = true
+	}
 
 	// Serve a /healthz webserver on localhost:10248 that kubeadm can talk to
 	externalkubeletcfg.HealthzBindAddress = "127.0.0.1"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Kubeadm sets rotateCertificates = true in kubelet config
unconditionally, which makes it impossible for user to change.

It's better to use this parameter from the user config if it's set
there.

**Which issue(s) this PR fixes** :

Fixes: kubernetes/kubeadm#1252

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: override default rotateCertificates parameter from config file provided by user 
```