### PR TITLE
kubeadm: adds etcd server version for 1.13

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
@@ -388,6 +387,7 @@ var (
 		10: "3.1.12",
 		11: "3.2.18",
 		12: "3.2.24",
+		13: "3.2.24",
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR sets the etcd server version for kubeadm for upgrades.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#1256

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
