### PR TITLE
Sparse cert creation for `kubeadm init`

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/BUILD
+++ b/cmd/kubeadm/app/cmd/phases/BUILD
@@ -44,6 +44,7 @@ go_library(
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//cmd/kubeadm/app/util/config:go_default_library",
         "//cmd/kubeadm/app/util/dryrun:go_default_library",
+        "//cmd/kubeadm/app/util/pkiutil:go_default_library",
         "//pkg/util/normalizer:go_default_library",
         "//pkg/version:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
@@ -72,7 +73,9 @@ go_test(
         "//cmd/kubeadm/app/phases/certs:go_default_library",
         "//cmd/kubeadm/app/util/pkiutil:go_default_library",
         "//cmd/kubeadm/test:go_default_library",
+        "//cmd/kubeadm/test/certs:go_default_library",
         "//pkg/version:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/cmd/phases/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/certs.go
@@ -31,6 +31,7 @@ import (
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	"k8s.io/kubernetes/pkg/util/normalizer"
 )
 
@@ -228,9 +229,13 @@ func runCAPhase(ca *certsphase.KubeadmCert) func(c workflow.RunData) error {
 			return errors.New("certs phase invoked with an invalid data struct")
 		}
 
-		// if external CA mode, skips certificate authority generation
-		if data.ExternalCA() {
-			fmt.Printf("[certs] External CA mode: Using existing %s certificate authority\n", ca.BaseName)
+		// TODO(EKF): can we avoid loading these certificates every time?
+		if _, err := pkiutil.TryLoadCertFromDisk(data.CertificateDir(), ca.BaseName); err == nil {
+			if _, err := pkiutil.TryLoadKeyFromDisk(data.CertificateDir(), ca.BaseName); err == nil {
+				fmt.Printf("[certs] Using existing %s certificate authority\n", ca.BaseName)
+				return nil
+			}
+			fmt.Printf("[certs] Using existing %s keyless certificate authority", ca.BaseName)
 			return nil
 		}
 
@@ -257,9 +262,18 @@ func runCertPhase(cert *certsphase.KubeadmCert, caCert *certsphase.KubeadmCert) 
 			return errors.New("certs phase invoked with an invalid data struct")
 		}
 
-		// if external CA mode, skip certificate generation
-		if data.ExternalCA() {
-			fmt.Printf("[certs] External CA mode: Using existing %s certificate\n", cert.BaseName)
+		// TODO(EKF): can we avoid loading these certificates every time?
+		if certData, _, err := pkiutil.TryLoadCertAndKeyFromDisk(data.CertificateDir(), cert.BaseName); err == nil {
+			caCertData, err := pkiutil.TryLoadCertFromDisk(data.CertificateDir(), caCert.BaseName)
+			if err != nil {
+				return errors.Wrapf(err, "couldn't load CA certificate %s", caCert.Name)
+			}
+
+			if err := certData.CheckSignatureFrom(caCertData); err != nil {
+				return errors.Wrapf(err, "[certs] certificate %s not signed by CA certificate %s", cert.BaseName, caCert.BaseName)
+			}
+
+			fmt.Printf("[certs] Using existing %s certificate and key on disk\n", cert.BaseName)
 			return nil
 		}
 


### PR DESCRIPTION

**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

"Sparse certs" refers to the scenario where some, but not all, kubeadm certs are pre-populated. 

This PR solves the issues of #71150 in a much more robust way. The logic of whether a cert needs to created is decided within each individual phase. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #71150 kubernetes/kubeadm#918

**Special notes for your reviewer**:

A lot of the moving around in this pull request comes from me not wanting to duplicate the test cases and infra of the existing functionality (which is still used elsewhere). 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
