### PR TITLE
Remove stale loadbalancer for edge cases in aws

### DIFF
--- a/pkg/cloudprovider/providers/aws/BUILD
+++ b/pkg/cloudprovider/providers/aws/BUILD
@@ -88,6 +88,7 @@ go_test(
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/elb:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/elbv2:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/mock:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -4309,9 +4309,9 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
 
 	if isNLB(service.Annotations) {
 		return c.deleteLoadBalancerv2(loadBalancerName)
-	} else {
-		return c.deleteLoadBalancer(loadBalancerName, service)
 	}
+
+	return c.deleteLoadBalancer(loadBalancerName, service)
 }
 
 // UpdateLoadBalancer implements LoadBalancer.UpdateLoadBalancer

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -3515,7 +3515,6 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 		}
 
 		if staleLoadBalancer != nil {
-			// TODO: anything else to clean up?
 			err = c.deleteLoadBalancer(loadBalancerName, apiService)
 
 			if err != nil {
@@ -3777,7 +3776,6 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 	}
 
 	if staleLoadBalancer != nil {
-		// TODO: anything else to clean up?
 		err = c.deleteLoadBalancerv2(loadBalancerName)
 
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When user change from classic load balancer(elb) to network load balancer(nlb) or from nlb to elb, aws actually doesn't delete stale one and every load balancer cost $20 per month. This PR help to fix this issue and people doesn't need to have them cleaned up manually. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68605 #66306

**Special notes for your reviewer**:
This is my first PR, please let me know if anything I am missing

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE". NONE
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
This feature fix an issue that old load balancer is not deleted when user decide to use different kind of load balancer type by annotating kubernetes service. For example, changing from ELB to NLB or NLB to ELB. In this case, aws will create the new one and then delete the stable one which has been addressed in this PR
```
