### PR TITLE
Set the oom_score_adj of guaranteed pod to -997

### DIFF
--- a/pkg/kubelet/qos/policy.go
+++ b/pkg/kubelet/qos/policy.go
@@ -31,7 +31,7 @@ const (
 	KubeletOOMScoreAdj    int = -999
 	DockerOOMScoreAdj     int = -999
 	KubeProxyOOMScoreAdj  int = -999
-	guaranteedOOMScoreAdj int = -998
+	guaranteedOOMScoreAdj int = -997
 	besteffortOOMScoreAdj int = 1000
 )
 

--- a/pkg/kubelet/qos/policy_test.go
+++ b/pkg/kubelet/qos/policy_test.go
@@ -187,8 +187,8 @@ func TestGetContainerOOMScoreAdjust(t *testing.T) {
 		{
 			pod:             &equalRequestLimitCPUMemory,
 			memoryCapacity:  123456789,
-			lowOOMScoreAdj:  -998,
-			highOOMScoreAdj: -998,
+			lowOOMScoreAdj:  -997,
+			highOOMScoreAdj: -997,
 		},
 		{
 			pod:             &cpuUnlimitedMemoryLimitedWithRequests,
@@ -199,14 +199,14 @@ func TestGetContainerOOMScoreAdjust(t *testing.T) {
 		{
 			pod:             &requestNoLimit,
 			memoryCapacity:  standardMemoryAmount,
-			lowOOMScoreAdj:  2,
-			highOOMScoreAdj: 2,
+			lowOOMScoreAdj:  3,
+			highOOMScoreAdj: 3,
 		},
 		{
 			pod:             &critical,
 			memoryCapacity:  4000000000,
-			lowOOMScoreAdj:  -998,
-			highOOMScoreAdj: -998,
+			lowOOMScoreAdj:  -997,
+			highOOMScoreAdj: -997,
 		},
 	}
 	for _, test := range oomTests {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When oom happens, the sandbox maybe killed first, so set the oom_score_adj of guaranteed pod to -997. 

**Which issue(s) this PR fixes**:

Fixes #71269 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```
NONE
```