### PR TITLE
kubeadm: override node registration options from command line

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -307,6 +307,15 @@ func NewJoin(cfgPath string, defaultcfg *kubeadmapiv1beta1.JoinConfiguration, ig
 	if err != nil {
 		return nil, err
 	}
+
+	// override node name and CRI socket from the command line options
+	if defaultcfg.NodeRegistration.Name != "" {
+		internalCfg.NodeRegistration.Name = defaultcfg.NodeRegistration.Name
+	}
+	if defaultcfg.NodeRegistration.CRISocket != kubeadmapiv1beta1.DefaultCRISocket {
+		internalCfg.NodeRegistration.CRISocket = defaultcfg.NodeRegistration.CRISocket
+	}
+
 	if defaultcfg.ControlPlane != nil {
 		if err := configutil.VerifyAPIServerBindAddress(internalCfg.ControlPlane.LocalAPIEndpoint.AdvertiseAddress); err != nil {
 			return nil, err


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

'kubeadm join' silently ignores --node-name and --cri-socket
command line options if --config option is specified.

In some cases it's much easier for users to override these parameters
from the command line instead of updating config, especially for
multi-node automatic deployments where only node name should be changed.

Implemented setting 'name' and 'criSocket' options from the command
line even if --config command line option is used.

**Special notes for your reviewer**:

You can see more details in [this comment](url
https://github.com/kubernetes/kubeadm/issues/857#issuecomment-437704313)

**Does this PR introduce a user-facing change?**:

```release-note
kubeadm join correctly uses --node-name and --cri-socket when --config option is also used
```