### PR TITLE
unstructured: return not-found if intermediate path is not found

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -47,6 +47,9 @@ func NestedFieldNoCopy(obj map[string]interface{}, fields ...string) (interface{
 	var val interface{} = obj
 
 	for i, field := range fields {
+		if val == nil {
+			return nil, false, nil
+		}
 		if m, ok := val.(map[string]interface{}); ok {
 			val, ok = m[field]
 			if !ok {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -95,6 +95,19 @@ func TestNestedFieldNoCopy(t *testing.T) {
 	assert.False(t, exists)
 	assert.Nil(t, err)
 	assert.Nil(t, res)
+
+	// case 5: intermediate field does not exist
+	res, exists, err = NestedFieldNoCopy(obj, "a", "e", "f")
+	assert.False(t, exists)
+	assert.Nil(t, err)
+	assert.Nil(t, res)
+
+	// case 6: intermediate field is null
+	//         (background: happens easily in YAML)
+	res, exists, err = NestedFieldNoCopy(obj, "a", "c", "f")
+	assert.False(t, exists)
+	assert.Nil(t, err)
+	assert.Nil(t, res)
 }
 
 func TestNestedFieldCopy(t *testing.T) {


### PR DESCRIPTION
The behaviour of `unstructured.Nested*(obj, "a", "b", "c")` was undefined if
- `b` is not existing
- `b` is null.

Both cases are tested now. The later gave a type error which is not what to expect.