### PR TITLE
only update the apiservice status if the status has changed

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/BUILD
@@ -13,6 +13,7 @@ go_library(
     importpath = "k8s.io/kube-aggregator/pkg/controllers/status",
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
@@ -46,6 +47,7 @@ go_test(
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/fake:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion:go_default_library",
+        "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller_test.go
@@ -19,6 +19,8 @@ package apiserver
 import (
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1listers "k8s.io/client-go/listers/core/v1"
@@ -227,4 +229,22 @@ func TestSync(t *testing.T) {
 			t.Errorf("%v expected %v, got %#v", tc.name, e, condition)
 		}
 	}
+}
+
+func TestUpdateAPIServiceStatus(t *testing.T) {
+	foo := &apiregistration.APIService{Status: apiregistration.APIServiceStatus{Conditions: []apiregistration.APIServiceCondition{{Type: "foo"}}}}
+	bar := &apiregistration.APIService{Status: apiregistration.APIServiceStatus{Conditions: []apiregistration.APIServiceCondition{{Type: "bar"}}}}
+
+	fakeClient := fake.NewSimpleClientset()
+	updateAPIServiceStatus(fakeClient.Apiregistration(), foo, foo)
+	if e, a := 0, len(fakeClient.Actions()); e != a {
+		t.Error(spew.Sdump(fakeClient.Actions()))
+	}
+
+	fakeClient.ClearActions()
+	updateAPIServiceStatus(fakeClient.Apiregistration(), foo, bar)
+	if e, a := 1, len(fakeClient.Actions()); e != a {
+		t.Error(spew.Sdump(fakeClient.Actions()))
+	}
+
 }


### PR DESCRIPTION
The APIService controller currently issues status updates and counts on the server to not issue etcd updates like a normal controller.  However, we have a tight resync loop to quickly detect dead apiservices.  Doing that means we don't want to quickly issue no-op updates.  This is slightly different than a "normal" controller with a long resync.

/kind bug

@kubernetes/sig-api-machinery-pr-reviews 
@smarterclayton your updates I believe

```release-note
NONE
```