### PR TITLE
Updates to always pass spec.nodeName as --hostname-override

### DIFF
--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -80,6 +80,7 @@ spec:
         command:
         - /usr/local/bin/kube-proxy
         - --config=/var/lib/kube-proxy/{{ .ProxyConfigMapKey }}
+        - --hostname-override=$(NODE_NAME)
         securityContext:
           privileged: true
         volumeMounts:
@@ -91,6 +92,11 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
       hostNetwork: true
       serviceAccountName: kube-proxy
       volumes:


### PR DESCRIPTION
per kubernetes/kubeadm#857 updated manifest file to always pass spec.nodeName as the --hostname-override.


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Fixes kubernetes/kubeadm#857

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #kubernetes/kubeadm#857

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

-->
```release-note
kubeadm: always pass spec.nodeName as --hostname-override for kube-proxy
```
