### PR TITLE
Automated cherry pick of #70676 #70971 upstream release 1.12

### DIFF
--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -35,9 +35,17 @@
       "httpGet": {
         "host": "127.0.0.1",
         "port": 8080,
-        "path": "/healthz"
+        "path": "/healthz?exclude=etcd"
       },
       "initialDelaySeconds": {{liveness_probe_initial_delay}},
+      "timeoutSeconds": 15
+    },
+    "readinessProbe": {
+      "httpGet": {
+        "host": "127.0.0.1",
+        "port": 8080,
+        "path": "/healthz"
+      },
       "timeoutSeconds": 15
     },
     "ports":[

--- a/cmd/cloud-controller-manager/app/BUILD
+++ b/cmd/cloud-controller-manager/app/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/tools/leaderelection:go_default_library",

--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/healthz"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
@@ -125,16 +126,24 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, stopCh <-chan struct{}) error
 		glog.Errorf("unable to register configz: %c", err)
 	}
 
+	// Setup any healthz checks we will want to use.
+	var checks []healthz.HealthzChecker
+	var electionChecker *leaderelection.HealthzAdaptor
+	if c.ComponentConfig.Generic.LeaderElection.LeaderElect {
+		electionChecker = leaderelection.NewLeaderHealthzAdaptor(time.Second * 20)
+		checks = append(checks, electionChecker)
+	}
+
 	// Start the controller manager HTTP server
 	if c.SecureServing != nil {
-		unsecuredMux := genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging)
+		unsecuredMux := genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging, checks...)
 		handler := genericcontrollermanager.BuildHandlerChain(unsecuredMux, &c.Authorization, &c.Authentication)
 		if err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
 			return err
 		}
 	}
 	if c.InsecureServing != nil {
-		unsecuredMux := genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging)
+		unsecuredMux := genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging, checks...)
 		insecureSuperuserAuthn := server.AuthenticationInfo{Authenticator: &server.InsecureSuperuser{}}
 		handler := genericcontrollermanager.BuildHandlerChain(unsecuredMux, nil, &insecureSuperuserAuthn)
 		if err := c.InsecureServing.Serve(handler, 0, stopCh); err != nil {
@@ -186,6 +195,8 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, stopCh <-chan struct{}) error
 				glog.Fatalf("leaderelection lost")
 			},
 		},
+		WatchDog: electionChecker,
+		Name:     "cloud-controller-manager",
 	})
 	panic("unreachable")
 }

--- a/cmd/controller-manager/app/serve.go
+++ b/cmd/controller-manager/app/serve.go
@@ -17,10 +17,9 @@ limitations under the License.
 package app
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	"net/http"
 	goruntime "runtime"
-
-	"github.com/prometheus/client_golang/prometheus"
 
 	apiserverconfig "k8s.io/apiserver/pkg/apis/config"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
@@ -53,9 +52,9 @@ func BuildHandlerChain(apiHandler http.Handler, authorizationInfo *apiserver.Aut
 }
 
 // NewBaseHandler takes in CompletedConfig and returns a handler.
-func NewBaseHandler(c *apiserverconfig.DebuggingConfiguration) *mux.PathRecorderMux {
+func NewBaseHandler(c *apiserverconfig.DebuggingConfiguration, checks ...healthz.HealthzChecker) *mux.PathRecorderMux {
 	mux := mux.NewPathRecorderMux("controller-manager")
-	healthz.InstallHandler(mux)
+	healthz.InstallHandler(mux, checks...)
 	if c.EnableProfiling {
 		routes.Profiling{}.Install(mux)
 		if c.EnableContentionProfiling {

--- a/cmd/kube-controller-manager/app/BUILD
+++ b/cmd/kube-controller-manager/app/BUILD
@@ -113,6 +113,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/mux:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/server/mux"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
 	cacheddiscovery "k8s.io/client-go/discovery/cached"
@@ -148,18 +149,26 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 		glog.Errorf("unable to register configz: %c", err)
 	}
 
+	// Setup any healthz checks we will want to use.
+	var checks []healthz.HealthzChecker
+	var electionChecker *leaderelection.HealthzAdaptor
+	if c.ComponentConfig.Generic.LeaderElection.LeaderElect {
+		electionChecker = leaderelection.NewLeaderHealthzAdaptor(time.Second * 20)
+		checks = append(checks, electionChecker)
+	}
+
 	// Start the controller manager HTTP server
 	// unsecuredMux is the handler for these controller *after* authn/authz filters have been applied
 	var unsecuredMux *mux.PathRecorderMux
 	if c.SecureServing != nil {
-		unsecuredMux = genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging)
+		unsecuredMux = genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging, checks...)
 		handler := genericcontrollermanager.BuildHandlerChain(unsecuredMux, &c.Authorization, &c.Authentication)
 		if err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
 			return err
 		}
 	}
 	if c.InsecureServing != nil {
-		unsecuredMux = genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging)
+		unsecuredMux = genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging, checks...)
 		insecureSuperuserAuthn := server.AuthenticationInfo{Authenticator: &server.InsecureSuperuser{}}
 		handler := genericcontrollermanager.BuildHandlerChain(unsecuredMux, nil, &insecureSuperuserAuthn)
 		if err := c.InsecureServing.Serve(handler, 0, stopCh); err != nil {
@@ -238,6 +247,8 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 				glog.Fatalf("leaderelection lost")
 			},
 		},
+		WatchDog: electionChecker,
+		Name:     "kube-controller-manager",
 	})
 	panic("unreachable")
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/BUILD
@@ -10,6 +10,9 @@ go_test(
     name = "go_default_test",
     srcs = ["healthz_test.go"],
     embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
 )
 
 go_library(
@@ -21,6 +24,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/healthz",
     importpath = "k8s.io/apiserver/pkg/server/healthz",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -141,12 +142,28 @@ func (c *healthzCheck) Check(r *http.Request) error {
 	return c.check(r)
 }
 
+// getExcludedChecks extracts the health check names to be excluded from the query param
+func getExcludedChecks(r *http.Request) sets.String {
+	checks, found := r.URL.Query()["exclude"]
+	if found {
+		return sets.NewString(checks...)
+	}
+	return sets.NewString()
+}
+
 // handleRootHealthz returns an http.HandlerFunc that serves the provided checks.
 func handleRootHealthz(checks ...HealthzChecker) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		failed := false
+		excluded := getExcludedChecks(r)
 		var verboseOut bytes.Buffer
 		for _, check := range checks {
+			// no-op the check if we've specified we want to exclude the check
+			if excluded.Has(check.Name()) {
+				excluded.Delete(check.Name())
+				fmt.Fprintf(&verboseOut, "[+]%v excluded: ok\n", check.Name())
+				continue
+			}
 			if err := check.Check(r); err != nil {
 				// don't include the error since this endpoint is public.  If someone wants more detail
 				// they should have explicit permission to the detailed checks.
@@ -156,6 +173,11 @@ func handleRootHealthz(checks ...HealthzChecker) http.HandlerFunc {
 			} else {
 				fmt.Fprintf(&verboseOut, "[+]%v ok\n", check.Name())
 			}
+		}
+		if excluded.Len() > 0 {
+			fmt.Fprintf(&verboseOut, "warn: some health checks cannot be excluded: no matches for %v\n", formatQuoted(excluded.List()...))
+			klog.Warningf("cannot exclude some health checks, no health checks are installed matching %v",
+				formatQuoted(excluded.List()...))
 		}
 		// always be verbose on failure
 		if failed {

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
@@ -21,8 +21,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestInstallHandler(t *testing.T) {
@@ -82,6 +85,10 @@ func testMultipleChecks(path string, t *testing.T) {
 		addBadCheck      bool
 	}{
 		{"?verbose", "[+]ping ok\nhealthz check passed\n", http.StatusOK, false},
+		{"?exclude=dontexist", "ok", http.StatusOK, false},
+		{"?exclude=bad", "ok", http.StatusOK, true},
+		{"?verbose=true&exclude=bad", "[+]ping ok\n[+]bad excluded: ok\nhealthz check passed\n", http.StatusOK, true},
+		{"?verbose=true&exclude=dontexist", "[+]ping ok\nwarn: some health checks cannot be excluded: no matches for \"dontexist\"\nhealthz check passed\n", http.StatusOK, false},
 		{"/ping", "ok", http.StatusOK, false},
 		{"", "ok", http.StatusOK, false},
 		{"?verbose", "[+]ping ok\n[-]bad failed: reason withheld\nhealthz check failed\n", http.StatusInternalServerError, true},
@@ -154,4 +161,44 @@ func TestCheckerNames(t *testing.T) {
 		})
 	}
 
+}
+
+func TestGetExcludedChecks(t *testing.T) {
+	type args struct {
+		r *http.Request
+	}
+	tests := []struct {
+		name string
+		r    *http.Request
+		want sets.String
+	}{
+		{"Should have no excluded health checks",
+			createGetRequestWithUrl("/healthz?verbose=true"),
+			sets.NewString(),
+		},
+		{"Should extract out the ping health check",
+			createGetRequestWithUrl("/healthz?exclude=ping"),
+			sets.NewString("ping"),
+		},
+		{"Should extract out ping and log health check",
+			createGetRequestWithUrl("/healthz?exclude=ping&exclude=log"),
+			sets.NewString("ping", "log"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getExcludedChecks(tt.r); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getExcludedChecks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func createGetRequestWithUrl(rawUrlString string) *http.Request {
+	url, _ := url.Parse(rawUrlString)
+	return &http.Request{
+		Method: http.MethodGet,
+		Proto:  "HTTP/1.1",
+		URL:    url,
+	}
 }

--- a/staging/src/k8s.io/client-go/tools/leaderelection/BUILD
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/BUILD
@@ -8,12 +8,16 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["leaderelection.go"],
+    srcs = [
+        "healthzadaptor.go",
+        "leaderelection.go",
+    ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/tools/leaderelection",
     importpath = "k8s.io/client-go/tools/leaderelection",
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/tools/leaderelection/resourcelock:go_default_library",
@@ -23,13 +27,17 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["leaderelection_test.go"],
+    srcs = [
+        "healthzadaptor_test.go",
+        "leaderelection_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/client-go/tools/leaderelection/resourcelock:go_default_library",

--- a/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+// HealthzAdaptor associates the /healthz endpoint with the LeaderElection object.
+// It helps deal with the /healthz endpoint being set up prior to the LeaderElection.
+// This contains the code needed to act as an adaptor between the leader
+// election code the health check code. It allows us to provide health
+// status about the leader election. Most specifically about if the leader
+// has failed to renew without exiting the process. In that case we should
+// report not healthy and rely on the kubelet to take down the process.
+type HealthzAdaptor struct {
+	pointerLock sync.Mutex
+	le          *LeaderElector
+	timeout     time.Duration
+}
+
+// Name returns the name of the health check we are implementing.
+func (l *HealthzAdaptor) Name() string {
+	return "leaderElection"
+}
+
+// Check is called by the healthz endpoint handler.
+// It fails (returns an error) if we own the lease but had not been able to renew it.
+func (l *HealthzAdaptor) Check(req *http.Request) error {
+	l.pointerLock.Lock()
+	defer l.pointerLock.Unlock()
+	if l.le == nil {
+		return nil
+	}
+	return l.le.Check(l.timeout)
+}
+
+// SetLeaderElection ties a leader election object to a HealthzAdaptor
+func (l *HealthzAdaptor) SetLeaderElection(le *LeaderElector) {
+	l.pointerLock.Lock()
+	defer l.pointerLock.Unlock()
+	l.le = le
+}
+
+// NewLeaderHealthzAdaptor creates a basic healthz adaptor to monitor a leader election.
+// timeout determines the time beyond the lease expiry to be allowed for timeout.
+// checks within the timeout period after the lease expires will still return healthy.
+func NewLeaderHealthzAdaptor(timeout time.Duration) *HealthzAdaptor {
+	result := &HealthzAdaptor{
+		timeout: timeout,
+	}
+	return result
+}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
+	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
+	"net/http"
+)
+
+type fakeLock struct {
+	identity string
+}
+
+// Get is a dummy to allow us to have a fakeLock for testing.
+func (fl *fakeLock) Get() (ler *rl.LeaderElectionRecord, err error) {
+	return nil, nil
+}
+
+// Create is a dummy to allow us to have a fakeLock for testing.
+func (fl *fakeLock) Create(ler rl.LeaderElectionRecord) error {
+	return nil
+}
+
+// Update is a dummy to allow us to have a fakeLock for testing.
+func (fl *fakeLock) Update(ler rl.LeaderElectionRecord) error {
+	return nil
+}
+
+// RecordEvent is a dummy to allow us to have a fakeLock for testing.
+func (fl *fakeLock) RecordEvent(string) {}
+
+// Identity is a dummy to allow us to have a fakeLock for testing.
+func (fl *fakeLock) Identity() string {
+	return fl.identity
+}
+
+// Describe is a dummy to allow us to have a fakeLock for testing.
+func (fl *fakeLock) Describe() string {
+	return "Dummy implementation of lock for testing"
+}
+
+// TestLeaderElectionHealthChecker tests that the healthcheck for leader election handles its edge cases.
+func TestLeaderElectionHealthChecker(t *testing.T) {
+	current := time.Now()
+	req := &http.Request{}
+
+	tests := []struct {
+		description    string
+		expected       error
+		adaptorTimeout time.Duration
+		elector        *LeaderElector
+	}{
+		{
+			description:    "call check before leader elector initialized",
+			expected:       nil,
+			adaptorTimeout: time.Second * 20,
+			elector:        nil,
+		},
+		{
+			description:    "call check when the the lease is far expired",
+			expected:       fmt.Errorf("failed election to renew leadership on lease %s", "foo"),
+			adaptorTimeout: time.Second * 20,
+			elector: &LeaderElector{
+				config: LeaderElectionConfig{
+					Lock:          &fakeLock{identity: "healthTest"},
+					LeaseDuration: time.Minute,
+					Name:          "foo",
+				},
+				observedRecord: rl.LeaderElectionRecord{
+					HolderIdentity: "healthTest",
+				},
+				observedTime: current,
+				clock:        clock.NewFakeClock(current.Add(time.Hour)),
+			},
+		},
+		{
+			description:    "call check when the the lease is far expired but held by another server",
+			expected:       nil,
+			adaptorTimeout: time.Second * 20,
+			elector: &LeaderElector{
+				config: LeaderElectionConfig{
+					Lock:          &fakeLock{identity: "healthTest"},
+					LeaseDuration: time.Minute,
+					Name:          "foo",
+				},
+				observedRecord: rl.LeaderElectionRecord{
+					HolderIdentity: "otherServer",
+				},
+				observedTime: current,
+				clock:        clock.NewFakeClock(current.Add(time.Hour)),
+			},
+		},
+		{
+			description:    "call check when the the lease is not expired",
+			expected:       nil,
+			adaptorTimeout: time.Second * 20,
+			elector: &LeaderElector{
+				config: LeaderElectionConfig{
+					Lock:          &fakeLock{identity: "healthTest"},
+					LeaseDuration: time.Minute,
+					Name:          "foo",
+				},
+				observedRecord: rl.LeaderElectionRecord{
+					HolderIdentity: "healthTest",
+				},
+				observedTime: current,
+				clock:        clock.NewFakeClock(current),
+			},
+		},
+		{
+			description:    "call check when the the lease is expired but inside the timeout",
+			expected:       nil,
+			adaptorTimeout: time.Second * 20,
+			elector: &LeaderElector{
+				config: LeaderElectionConfig{
+					Lock:          &fakeLock{identity: "healthTest"},
+					LeaseDuration: time.Minute,
+					Name:          "foo",
+				},
+				observedRecord: rl.LeaderElectionRecord{
+					HolderIdentity: "healthTest",
+				},
+				observedTime: current,
+				clock:        clock.NewFakeClock(current.Add(time.Minute).Add(time.Second)),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		adaptor := NewLeaderHealthzAdaptor(test.adaptorTimeout)
+		if adaptor.le != nil {
+			t.Errorf("[%s] leaderChecker started with a LeaderElector %v", test.description, adaptor.le)
+		}
+		if test.elector != nil {
+			test.elector.config.WatchDog = adaptor
+			adaptor.SetLeaderElection(test.elector)
+			if adaptor.le == nil {
+				t.Errorf("[%s] adaptor failed to set the LeaderElector", test.description)
+			}
+		}
+		err := adaptor.Check(req)
+		if test.expected == nil {
+			if err == nil {
+				continue
+			}
+			t.Errorf("[%s] called check, expected no error but received \"%v\"", test.description, err)
+		} else {
+			if err == nil {
+				t.Errorf("[%s] called check and failed to received the expected error \"%v\"", test.description, test.expected)
+			}
+			if err.Error() != test.expected.Error() {
+				t.Errorf("[%s] called check, expected %v, received %v", test.description, test.expected, err)
+			}
+		}
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -56,6 +56,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -90,6 +91,7 @@ func NewLeaderElector(lec LeaderElectionConfig) (*LeaderElector, error) {
 	}
 	return &LeaderElector{
 		config: lec,
+		clock:  clock.RealClock{},
 	}, nil
 }
 
@@ -111,6 +113,13 @@ type LeaderElectionConfig struct {
 	// Callbacks are callbacks that are triggered during certain lifecycle
 	// events of the LeaderElector
 	Callbacks LeaderCallbacks
+
+	// WatchDog is the associated health checker
+	// WatchDog may be null if its not needed/configured.
+	WatchDog *HealthzAdaptor
+
+	// Name is the name of the resource lock for debugging
+	Name string
 }
 
 // LeaderCallbacks are callbacks that are triggered during certain
@@ -139,6 +148,12 @@ type LeaderElector struct {
 	// value observedRecord.HolderIdentity if the transition has
 	// not yet been reported.
 	reportedLeader string
+
+	// clock is wrapper around time to allow for less flaky testing
+	clock clock.Clock
+
+	// name is the name of the resource lock for debugging
+	name string
 }
 
 // Run starts the leader election loop
@@ -162,6 +177,9 @@ func RunOrDie(ctx context.Context, lec LeaderElectionConfig) {
 	le, err := NewLeaderElector(lec)
 	if err != nil {
 		panic(err)
+	}
+	if lec.WatchDog != nil {
+		lec.WatchDog.SetLeaderElection(le)
 	}
 	le.Run(ctx)
 }
@@ -257,14 +275,14 @@ func (le *LeaderElector) tryAcquireOrRenew() bool {
 			return false
 		}
 		le.observedRecord = leaderElectionRecord
-		le.observedTime = time.Now()
+		le.observedTime = le.clock.Now()
 		return true
 	}
 
 	// 2. Record obtained, check the Identity & Time
 	if !reflect.DeepEqual(le.observedRecord, *oldLeaderElectionRecord) {
 		le.observedRecord = *oldLeaderElectionRecord
-		le.observedTime = time.Now()
+		le.observedTime = le.clock.Now()
 	}
 	if le.observedTime.Add(le.config.LeaseDuration).After(now.Time) &&
 		!le.IsLeader() {
@@ -287,7 +305,7 @@ func (le *LeaderElector) tryAcquireOrRenew() bool {
 		return false
 	}
 	le.observedRecord = leaderElectionRecord
-	le.observedTime = time.Now()
+	le.observedTime = le.clock.Now()
 	return true
 }
 
@@ -299,4 +317,20 @@ func (le *LeaderElector) maybeReportTransition() {
 	if le.config.Callbacks.OnNewLeader != nil {
 		go le.config.Callbacks.OnNewLeader(le.reportedLeader)
 	}
+}
+
+// Check will determine if the current lease is expired by more than timeout.
+func (le *LeaderElector) Check(maxTolerableExpiredLease time.Duration) error {
+	if !le.IsLeader() {
+		// Currently not concerned with the case that we are hot standby
+		return nil
+	}
+	// If we are more than timeout seconds after the lease duration that is past the timeout
+	// on the lease renew. Time to start reporting ourselves as unhealthy. We should have
+	// died but conditions like deadlock can prevent this. (See #70819)
+	if le.clock.Since(le.observedTime) > le.config.LeaseDuration+maxTolerableExpiredLease {
+		return fmt.Errorf("failed election to renew leadership on lease %s", le.config.Name)
+	}
+
+	return nil
 }

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/clock"
 	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
 	core "k8s.io/client-go/testing"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -257,6 +258,7 @@ func testTryAcquireOrRenew(t *testing.T, objectType string) {
 			config:         lec,
 			observedRecord: test.observedRecord,
 			observedTime:   test.observedTime,
+			clock:          clock.RealClock{},
 		}
 
 		if test.expectSuccess != le.tryAcquireOrRenew() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Cherry pick of #70676 and #70971 on release-1.12.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
#70676 add ability to disable health checks on kube-apiserver for healthz using query-params
#70971 Report KCM as unhealthy if leader election is wedged.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
