### PR TITLE
Default pv controller and scheduler to immediate mode if volume binding mode is nil

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -290,7 +290,9 @@ func (ctrl *PersistentVolumeController) shouldDelayBinding(claim *v1.PersistentV
 	}
 
 	if class.VolumeBindingMode == nil {
-		return false, fmt.Errorf("VolumeBindingMode not set for StorageClass %q", className)
+		// In an HA upgrade scenario, the API server may still be on a lower version
+		// than the controller-manager. Default to behavior as if the feature is off.
+		return false, nil
 	}
 
 	// TODO: add check to handle dynamic provisioning later

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -281,7 +281,6 @@ func TestDelayBinding(t *testing.T) {
 		"no-mode-class": {
 			pvc:         makePVCClass(&classNoMode),
 			shouldDelay: false,
-			shouldFail:  true,
 		},
 		"immediate-mode-class": {
 			pvc:         makePVCClass(&classImmediateMode),

--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -588,12 +588,14 @@ func (c *VolumeZoneChecker) predicate(pod *v1.Pod, meta algorithm.PredicateMetad
 					if scName != nil && len(*scName) > 0 {
 						class, _ := c.classInfo.GetStorageClassInfo(*scName)
 						if class != nil {
-							if class.VolumeBindingMode == nil {
-								return false, nil, fmt.Errorf("VolumeBindingMode not set for StorageClass %q", scName)
-							}
-							if *class.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer {
-								// Skip unbound volumes
-								continue
+							if class.VolumeBindingMode != nil {
+								// In an HA Upgrade scenario, the API server may still be
+								// on a lower version than the scheduler. Default to
+								// behavior as if the feature is off
+								if *class.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer {
+									// Skip unbound volumes
+									continue
+								}
 							}
 						}
 					}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
@kubernetes/sig-storage-bugs 

**What this PR does / why we need it**:
Allow volume binding mode to be nil even if the feature is enabled to handle HA master component skew.  The behavior defaults to immediate mode.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Fixes issue where an apiserver on 1.9 and controller-manager on 1.10 can cause volume provisioning and binding to fail.
```
