### PR TITLE
Fix golint verify errors.

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_fakes.go
+++ b/pkg/cloudprovider/providers/aws/aws_fakes.go
@@ -354,9 +354,9 @@ func (m *FakeMetadata) GetMetadata(key string) (string, error) {
 		}
 
 		return "", nil
-	} else {
-		return "", nil
 	}
+
+	return "", nil
 }
 
 // FakeELB is a fake ELB client used for testing

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -201,9 +201,9 @@ func PathExists(path string) (bool, error) {
 		return false, nil
 	} else if IsCorruptedMnt(err) {
 		return true, err
-	} else {
-		return false, err
 	}
+
+	return false, err
 }
 
 // IsCorruptedMnt return true if err is about corrupted mount point


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
$ hack/verify-golint.sh
Errors from golint:
pkg/cloudprovider/providers/aws/aws_fakes.go:357:9: if block ends with a return statement, so drop this else and outdent its block
pkg/volume/util/util.go:204:9: if block ends with a return statement, so drop this else and outdent its block

**Which issue(s) this PR fixes** *(optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
```
NONE
```