### PR TITLE
Unify Kubelet server TLS options and run dockershim streamer with TLS

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2273,9 +2273,9 @@ func getStreamingConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, kub
 		config.BaseURL = &url.URL{
 			Path: "/cri/",
 		}
-		if kubeDeps.ServerTLSConfig != nil {
-			config.TLSConfig = kubeDeps.ServerTLSConfig
-		}
+	}
+	if kubeDeps.ServerTLSConfig != nil {
+		config.TLSConfig = kubeDeps.ServerTLSConfig
 	}
 	return config
 }

--- a/pkg/kubelet/server/BUILD
+++ b/pkg/kubelet/server/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/proxy:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -38,7 +38,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
-	"k8s.io/klog"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,6 +53,7 @@ import (
 	"k8s.io/apiserver/pkg/server/routes"
 	"k8s.io/apiserver/pkg/util/flushwriter"
 	"k8s.io/component-base/logs"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/v1/validation"
@@ -86,12 +86,6 @@ type Server struct {
 	restfulCont                containerInterface
 	resourceAnalyzer           stats.ResourceAnalyzer
 	redirectContainerStreaming bool
-}
-
-type TLSOptions struct {
-	Config   *tls.Config
-	CertFile string
-	KeyFile  string
 }
 
 // containerInterface defines the restful.Container functions used on the root container
@@ -128,7 +122,7 @@ func ListenAndServeKubeletServer(
 	resourceAnalyzer stats.ResourceAnalyzer,
 	address net.IP,
 	port uint,
-	tlsOptions *TLSOptions,
+	tlsOptions *tls.Config,
 	auth AuthInterface,
 	enableDebuggingHandlers,
 	enableContentionProfiling,
@@ -142,11 +136,11 @@ func ListenAndServeKubeletServer(
 		MaxHeaderBytes: 1 << 20,
 	}
 	if tlsOptions != nil {
-		s.TLSConfig = tlsOptions.Config
+		s.TLSConfig = tlsOptions
 		// Passing empty strings as the cert and key files means no
 		// cert/keys are specified and GetCertificate in the TLSConfig
 		// should be called instead.
-		klog.Fatal(s.ListenAndServeTLS(tlsOptions.CertFile, tlsOptions.KeyFile))
+		klog.Fatal(s.ListenAndServeTLS("", ""))
 	} else {
 		klog.Fatal(s.ListenAndServe())
 	}

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -331,7 +331,7 @@ func newServerTestWithDebug(enableDebugging, redirectContainerStreaming bool, st
 	fw.criHandler = &utiltesting.FakeHandler{
 		StatusCode: http.StatusOK,
 	}
-	server := NewServer(
+	server := newServer(
 		fw.fakeKubelet,
 		stats.NewResourceAnalyzer(fw.fakeKubelet, time.Minute),
 		fw.fakeAuth,

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -75,7 +75,7 @@ func NewHollowKubelet(
 		OSInterface:        &containertest.FakeOS{},
 		ContainerManager:   containerManager,
 		VolumePlugins:      volumePlugins,
-		TLSOptions:         nil,
+		ServerTLSConfig:    nil,
 		OOMAdjuster:        oom.NewFakeOOMAdjuster(),
 		Mounter:            mount.New("" /* default mount path */),
 	}


### PR DESCRIPTION
### first commit

delete the TLSOptions struct  …
initializeServerTLS should return a full tls.Config for servers without
the certificate manager. Today, the TLSOptions.Config only has a valid
certificate if rotation is enabled so cri streaming servers were not
picking up the correct config. If --tls-* options were passed with
server TLS bootstrap enabled, the main server would use those
certificates silently instead.

Also:
* rename InitializeTLS to initializeServerTLS
* rename TLSOptions to ServerTLSConfig

### second commit

start the streaming server with TLS even when proxying.

/sig node
/sig auth
/kind bug

```release-note
NONE
```
