### PR TITLE
Log when connection is reset and print decimal status code

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -746,6 +746,7 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 			}
 			// For the purpose of retry, we set the artificial "retry-after" response.
 			// TODO: Should we clean the original response if it exists?
+			klog.V(5).Infof("Retrying a connection reset error")
 			resp = &http.Response{
 				StatusCode: http.StatusInternalServerError,
 				Header:     http.Header{"Retry-After": []string{"1"}},

--- a/staging/src/k8s.io/client-go/transport/round_trippers.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers.go
@@ -300,9 +300,9 @@ type requestInfo struct {
 	RequestVerb    string
 	RequestURL     string
 
-	ResponseStatus  string
-	ResponseHeaders http.Header
-	ResponseErr     error
+	ResponseStatusCode int
+	ResponseHeaders    http.Header
+	ResponseErr        error
 
 	Duration time.Duration
 }
@@ -322,7 +322,7 @@ func (r *requestInfo) complete(response *http.Response, err error) {
 		r.ResponseErr = err
 		return
 	}
-	r.ResponseStatus = response.Status
+	r.ResponseStatusCode = response.StatusCode
 	r.ResponseHeaders = response.Header
 }
 
@@ -402,10 +402,10 @@ func (rt *debuggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	reqInfo.complete(response, err)
 
 	if rt.levels[debugURLTiming] {
-		klog.Infof("%s %s %s in %d milliseconds", reqInfo.RequestVerb, reqInfo.RequestURL, reqInfo.ResponseStatus, reqInfo.Duration.Nanoseconds()/int64(time.Millisecond))
+		klog.Infof("%s %s %d in %d milliseconds", reqInfo.RequestVerb, reqInfo.RequestURL, reqInfo.ResponseStatusCode, reqInfo.Duration.Nanoseconds()/int64(time.Millisecond))
 	}
 	if rt.levels[debugResponseStatus] {
-		klog.Infof("Response Status: %s in %d milliseconds", reqInfo.ResponseStatus, reqInfo.Duration.Nanoseconds()/int64(time.Millisecond))
+		klog.Infof("Response Status: %d in %d milliseconds", reqInfo.ResponseStatusCode, reqInfo.Duration.Nanoseconds()/int64(time.Millisecond))
 	}
 	if rt.levels[debugResponseHeaders] {
 		klog.Infof("Response Headers:")


### PR DESCRIPTION
A connection reset has an empty status line and status code 0 - code
0 is slightly more readable when debugging and has less possibility to
be altered by intervening proxies. Also log when a connection reset happens.

Noticed this when debugging a flaky load balancer.

/kind cleanup

```release-note
NONE
```