### PR TITLE
apiserver: set klog as etcdclient logger

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/BUILD
@@ -47,6 +47,7 @@ go_library(
         "errors.go",
         "event.go",
         "lease_manager.go",
+        "logger.go",
         "store.go",
         "watcher.go",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/logger.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/logger.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd3
+
+import (
+	"fmt"
+
+	"github.com/coreos/etcd/clientv3"
+	"k8s.io/klog"
+)
+
+func init() {
+	clientv3.SetLogger(klogWrapper{})
+}
+
+type klogWrapper struct{}
+
+const klogWrapperDepth = 4
+
+func (klogWrapper) Info(args ...interface{}) {
+	klog.InfoDepth(klogWrapperDepth, args...)
+}
+
+func (klogWrapper) Infoln(args ...interface{}) {
+	klog.InfoDepth(klogWrapperDepth, fmt.Sprintln(args...))
+}
+
+func (klogWrapper) Infof(format string, args ...interface{}) {
+	klog.InfoDepth(klogWrapperDepth, fmt.Sprintf(format, args...))
+}
+
+func (klogWrapper) Warning(args ...interface{}) {
+	klog.WarningDepth(klogWrapperDepth, args...)
+}
+
+func (klogWrapper) Warningln(args ...interface{}) {
+	klog.WarningDepth(klogWrapperDepth, fmt.Sprintln(args...))
+}
+
+func (klogWrapper) Warningf(format string, args ...interface{}) {
+	klog.WarningDepth(klogWrapperDepth, fmt.Sprintf(format, args...))
+}
+
+func (klogWrapper) Error(args ...interface{}) {
+	klog.ErrorDepth(klogWrapperDepth, args...)
+}
+
+func (klogWrapper) Errorln(args ...interface{}) {
+	klog.ErrorDepth(klogWrapperDepth, fmt.Sprintln(args...))
+}
+
+func (klogWrapper) Errorf(format string, args ...interface{}) {
+	klog.ErrorDepth(klogWrapperDepth, fmt.Sprintf(format, args...))
+}
+
+func (klogWrapper) Fatal(args ...interface{}) {
+	klog.FatalDepth(klogWrapperDepth, args...)
+}
+
+func (klogWrapper) Fatalln(args ...interface{}) {
+	klog.FatalDepth(klogWrapperDepth, fmt.Sprintln(args...))
+}
+
+func (klogWrapper) Fatalf(format string, args ...interface{}) {
+	klog.FatalDepth(klogWrapperDepth, fmt.Sprintf(format, args...))
+}
+
+func (klogWrapper) V(l int) bool {
+	return bool(klog.V(klog.Level(l)))
+}


### PR DESCRIPTION
Before this PR:
- the etcd client logger writes to `io.Discard`.
- TLS errors for example just lead to a "context deadline exceeded" error message, but are not printed.

This leads to the following output in case of TLS errors:
```
I1121 15:43:34.455966   57452 serving.go:311] Generated self-signed cert (/var/folders/gg/zn9yfdld21j7xg5jnj5zz5d80000gn/T/kubernetes-kube-apiserver993219963/apiserver.crt, /var/folders/gg/zn9yfdld21j7xg5jnj5zz5d80000gn/T/kubernetes-kube-apiserver993219963/apiserver.key)
I1121 15:43:34.455982   57452 server.go:553] external host was not specified, using 127.0.0.1
W1121 15:43:34.455992   57452 authentication.go:415] AnonymousAuth is not allowed with the AlwaysAllow authorizer. Resetting AnonymousAuth to false. You should use a different authorizer
I1121 15:43:34.787364   57452 plugins.go:158] Loaded 7 mutating admission controller(s) successfully in the following order: NamespaceLifecycle,LimitRanger,ServiceAccount,Priority,DefaultTolerationSeconds,DefaultStorageClass,MutatingAdmissionWebhook.
I1121 15:43:34.787377   57452 plugins.go:161] Loaded 6 validating admission controller(s) successfully in the following order: LimitRanger,ServiceAccount,Priority,PersistentVolumeClaimResize,ValidatingAdmissionWebhook,ResourceQuota.
I1121 15:43:34.788227   57452 plugins.go:158] Loaded 7 mutating admission controller(s) successfully in the following order: NamespaceLifecycle,LimitRanger,ServiceAccount,Priority,DefaultTolerationSeconds,DefaultStorageClass,MutatingAdmissionWebhook.
I1121 15:43:34.788242   57452 plugins.go:161] Loaded 6 validating admission controller(s) successfully in the following order: LimitRanger,ServiceAccount,Priority,PersistentVolumeClaimResize,ValidatingAdmissionWebhook,ResourceQuota.
I1121 15:43:34.789747   57452 clientconn.go:551] parsed scheme: ""
I1121 15:43:34.789761   57452 clientconn.go:557] scheme "" not registered, fallback to default scheme
I1121 15:43:34.789846   57452 resolver_conn_wrapper.go:116] ccResolverWrapper: sending new addresses to cc: [{127.0.0.1:2379 0  <nil>}]
I1121 15:43:34.789942   57452 balancer_v1_wrapper.go:125] balancerWrapper: got update addr from Notify: [{127.0.0.1:2379 <nil>}]
W1121 15:43:34.977344   57452 clientconn.go:1304] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs". Reconnecting...
I1121 15:43:35.787250   57452 clientconn.go:551] parsed scheme: ""
I1121 15:43:35.787272   57452 clientconn.go:557] scheme "" not registered, fallback to default scheme
I1121 15:43:35.787310   57452 resolver_conn_wrapper.go:116] ccResolverWrapper: sending new addresses to cc: [{127.0.0.1:2379 0  <nil>}]
I1121 15:43:35.787394   57452 balancer_v1_wrapper.go:125] balancerWrapper: got update addr from Notify: [{127.0.0.1:2379 <nil>}]
W1121 15:43:35.806679   57452 clientconn.go:1304] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs". Reconnecting...
W1121 15:43:35.810166   57452 clientconn.go:1304] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs". Reconnecting...
W1121 15:43:36.815003   57452 clientconn.go:1304] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs". Reconnecting...
W1121 15:43:37.223406   57452 clientconn.go:1304] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs". Reconnecting...
W1121 15:43:38.643355   57452 clientconn.go:1304] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs". Reconnecting...
W1121 15:43:39.969945   57452 clientconn.go:1304] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs". Reconnecting...
W1121 15:43:41.002079   57452 clientconn.go:1304] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs". Reconnecting...
W1121 15:43:43.302688   57452 clientconn.go:1304] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs". Reconnecting...
W1121 15:43:45.438973   57452 clientconn.go:1304] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs". Reconnecting...
W1121 15:43:50.822631   57452 clientconn.go:1304] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs". Reconnecting...
W1121 15:43:51.385480   57452 clientconn.go:1304] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs". Reconnecting...
I1121 15:43:54.789255   57452 balancer_v1_wrapper.go:125] balancerWrapper: got update addr from Notify: []
I1121 15:43:54.789305   57452 balancer_v1_wrapper.go:125] balancerWrapper: got update addr from Notify: [{127.0.0.1:2379 <nil>}]
W1121 15:43:54.789315   57452 clientconn.go:953] Failed to dial 127.0.0.1:2379: context canceled; please retry.
I1121 15:43:54.789344   57452 balancer_v1_wrapper.go:125] balancerWrapper: got update addr from Notify: [{127.0.0.1:2379 <nil>}]
F1121 15:43:54.794015   57452 storage_decorator.go:57] Unable to create storage backend: config (&{ f1a66b85-6dd5-40c9-8842-e209663e2f70/registry [https://127.0.0.1:2379]    true 0xc0005c14d0 <nil> 5m0s 0s}), err (context deadline exceeded)
W1121 15:43:54.794367   57452 clientconn.go:953] Failed to dial 127.0.0.1:2379: grpc: the connection is closing; please retry.
```

```release-note
Log etcd client errors. The verbosity is set with the usual `-v` flag.
```