### PR TITLE
cluster/eks: initial commit

### DIFF
--- a/cluster/eks/OWNERS
+++ b/cluster/eks/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- gyuho
+- shyamjvs
+reviewers:
+- gyuho
+- shyamjvs

--- a/cluster/eks/util.sh
+++ b/cluster/eks/util.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Perform preparations required to run e2e tests
+function prepare-e2e() {
+  echo "EKS provider doesn't need special preparations for e2e tests" 1>&2
+}
+
+# Configure parameters to talk to EKS control plane
+function detect-master {
+  if [[ "${KUBE_MASTER_URL}" ]]; then
+    echo "Using KUBE_MASTER_URL: ${KUBE_MASTER_URL}"
+  else
+    echo "KUBE_MASTER_URL is not defined!"
+    exit 255
+  fi
+}
+
+echo "kubectl path:" $(which kubectl)
+echo "KUBECTL_PATH:" ${KUBECTL_PATH}
+echo "KUBE_MASTER_URL:" ${KUBE_MASTER_URL}
+echo "KUBECONFIG:" ${KUBECONFIG}


### PR DESCRIPTION
Add EKS e2e script.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Kubernetes e2e tests require each provider to implement its own util script, and EKS does not have one (fix https://github.com/aws/aws-k8s-tester/issues/12).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Trying to fix https://github.com/aws/aws-k8s-tester/issues/12.

**Special notes for your reviewer**:

@krzyzacy @BenTheElder 

ref. https://github.com/kubernetes/test-infra/issues/9814

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
