### PR TITLE
kubeadm: override node registration options from command line (follow-up)

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -399,7 +399,7 @@ func ValidateMixedArguments(flag *pflag.FlagSet) error {
 
 	mixedInvalidFlags := []string{}
 	flag.Visit(func(f *pflag.Flag) {
-		if f.Name == "config" || f.Name == "ignore-preflight-errors" || strings.HasPrefix(f.Name, "skip-") || f.Name == "dry-run" || f.Name == "kubeconfig" || f.Name == "v" || f.Name == "rootfs" || f.Name == "print-join-command" {
+		if f.Name == "config" || f.Name == "ignore-preflight-errors" || strings.HasPrefix(f.Name, "skip-") || f.Name == "dry-run" || f.Name == "kubeconfig" || f.Name == "v" || f.Name == "rootfs" || f.Name == "print-join-command" || f.Name == "node-name" || f.Name == "cri-socket" {
 			// "--skip-*" flags or other whitelisted flags can be set with --config
 			return
 		}

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -305,6 +305,15 @@ func newInitData(cmd *cobra.Command, options *initOptions, out io.Writer) (initD
 	if err != nil {
 		return initData{}, err
 	}
+
+	// override node name and CRI socket from the command line options
+	if options.externalcfg.NodeRegistration.Name != "" {
+		cfg.NodeRegistration.Name = options.externalcfg.NodeRegistration.Name
+	}
+	if options.externalcfg.NodeRegistration.CRISocket != kubeadmapiv1beta1.DefaultCRISocket {
+		cfg.NodeRegistration.CRISocket = options.externalcfg.NodeRegistration.CRISocket
+	}
+
 	if err := configutil.VerifyAPIServerBindAddress(cfg.LocalAPIEndpoint.AdvertiseAddress); err != nil {
 		return initData{}, err
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

It turned out after the discussion in the [similar PR](https://github.com/kubernetes/kubernetes/pull/71270) that 'kubeadm init' also suffers from this issue. This fix is almost identical to the previous one:

'kubeadm init' silently ignores --node-name and --cri-socket
command line options if --config option is specified.

Implemented setting 'name' and 'criSocket' options from the command
line even if --config command line option is used.

**Does this PR introduce a user-facing change?**:

```release-note
kubeadm init correctly uses --node-name and --cri-socket when --config option is also used
```