### PR TITLE
Disable matching on few selectors. Include all pods while scoring.

### DIFF
--- a/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
+++ b/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
@@ -186,8 +186,8 @@ func TestSelectorSpreadPriority(t *testing.T) {
 			rcs:      []*v1.ReplicationController{{Spec: v1.ReplicationControllerSpec{Selector: map[string]string{"foo": "bar"}}}},
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: map[string]string{"baz": "blah"}}}},
 			// "baz=blah" matches both labels1 and labels2, and "foo=bar" matches only labels 1. This means that we assume that we want to
-			// do spreading between all pods. The result should be exactly as above.
-			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 5}},
+			// do spreading between pod2 and pod3 and not pod1.
+			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}},
 			name:         "service with partial pod label matches with service and replication controller",
 		},
 		{
@@ -201,7 +201,7 @@ func TestSelectorSpreadPriority(t *testing.T) {
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: map[string]string{"baz": "blah"}}}},
 			rss:      []*apps.ReplicaSet{{Spec: apps.ReplicaSetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}}}},
 			// We use ReplicaSet, instead of ReplicationController. The result should be exactly as above.
-			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 5}},
+			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}},
 			name:         "service with partial pod label matches with service and replica set",
 		},
 		{
@@ -214,8 +214,8 @@ func TestSelectorSpreadPriority(t *testing.T) {
 			nodes:        []string{"machine1", "machine2"},
 			services:     []*v1.Service{{Spec: v1.ServiceSpec{Selector: map[string]string{"baz": "blah"}}}},
 			sss:          []*apps.StatefulSet{{Spec: apps.StatefulSetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}}}},
-			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 5}},
-			name:         "service with partial pod label matches with service and replica set",
+			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}},
+			name:         "service with partial pod label matches with service and stateful set",
 		},
 		{
 			pod: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar", "bar": "foo"}, OwnerReferences: controllerRef("ReplicationController", "name", "abc123")}},
@@ -227,9 +227,9 @@ func TestSelectorSpreadPriority(t *testing.T) {
 			nodes:    []string{"machine1", "machine2"},
 			rcs:      []*v1.ReplicationController{{Spec: v1.ReplicationControllerSpec{Selector: map[string]string{"foo": "bar"}}}},
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: map[string]string{"bar": "foo"}}}},
-			// Taken together Service and Replication Controller should match all Pods, hence result should be equal to one above.
-			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 5}},
-			name:         "disjoined service and replication controller should be treated equally",
+			// Taken together Service and Replication Controller should match no Pods.
+			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 10}, {Host: "machine2", Score: 10}},
+			name:         "disjoined service and replication controller matches no pods",
 		},
 		{
 			pod: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar", "bar": "foo"}, OwnerReferences: controllerRef("ReplicaSet", "name", "abc123")}},
@@ -242,8 +242,8 @@ func TestSelectorSpreadPriority(t *testing.T) {
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: map[string]string{"bar": "foo"}}}},
 			rss:      []*apps.ReplicaSet{{Spec: apps.ReplicaSetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}}}},
 			// We use ReplicaSet, instead of ReplicationController. The result should be exactly as above.
-			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 5}},
-			name:         "disjoined service and replica set should be treated equally",
+			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 10}, {Host: "machine2", Score: 10}},
+			name:         "disjoined service and replica set matches no pods",
 		},
 		{
 			pod: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar", "bar": "foo"}, OwnerReferences: controllerRef("StatefulSet", "name", "abc123")}},
@@ -255,8 +255,8 @@ func TestSelectorSpreadPriority(t *testing.T) {
 			nodes:        []string{"machine1", "machine2"},
 			services:     []*v1.Service{{Spec: v1.ServiceSpec{Selector: map[string]string{"bar": "foo"}}}},
 			sss:          []*apps.StatefulSet{{Spec: apps.StatefulSetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}}}},
-			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 5}},
-			name:         "disjoined service and replica set should be treated equally",
+			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 10}, {Host: "machine2", Score: 10}},
+			name:         "disjoined service and stateful set matches no pods",
 		},
 		{
 			pod: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: labels1, OwnerReferences: controllerRef("ReplicationController", "name", "abc123")}},
@@ -345,6 +345,7 @@ func TestSelectorSpreadPriority(t *testing.T) {
 				controllerLister:  schedulertesting.FakeControllerLister(test.rcs),
 				replicaSetLister:  schedulertesting.FakeReplicaSetLister(test.rss),
 				statefulSetLister: schedulertesting.FakeStatefulSetLister(test.sss),
+				podLister:         schedulertesting.FakePodLister(test.pods),
 			}
 
 			metaDataProducer := NewPriorityMetadataFactory(
@@ -581,6 +582,7 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 				controllerLister:  schedulertesting.FakeControllerLister(test.rcs),
 				replicaSetLister:  schedulertesting.FakeReplicaSetLister(test.rss),
 				statefulSetLister: schedulertesting.FakeStatefulSetLister(test.sss),
+				podLister:         schedulertesting.FakePodLister(test.pods),
 			}
 
 			metaDataProducer := NewPriorityMetadataFactory(

--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -85,7 +85,7 @@ func init() {
 		"ServiceSpreadingPriority",
 		factory.PriorityConfigFactory{
 			MapReduceFunction: func(args factory.PluginFactoryArgs) (algorithm.PriorityMapFunction, algorithm.PriorityReduceFunction) {
-				return priorities.NewSelectorSpreadPriority(args.ServiceLister, algorithm.EmptyControllerLister{}, algorithm.EmptyReplicaSetLister{}, algorithm.EmptyStatefulSetLister{})
+				return priorities.NewSelectorSpreadPriority(args.ServiceLister, algorithm.EmptyControllerLister{}, algorithm.EmptyReplicaSetLister{}, algorithm.EmptyStatefulSetLister{}, args.PodLister)
 			},
 			Weight: 1,
 		},
@@ -235,7 +235,7 @@ func defaultPriorities() sets.String {
 			"SelectorSpreadPriority",
 			factory.PriorityConfigFactory{
 				MapReduceFunction: func(args factory.PluginFactoryArgs) (algorithm.PriorityMapFunction, algorithm.PriorityReduceFunction) {
-					return priorities.NewSelectorSpreadPriority(args.ServiceLister, args.ControllerLister, args.ReplicaSetLister, args.StatefulSetLister)
+					return priorities.NewSelectorSpreadPriority(args.ServiceLister, args.ControllerLister, args.ReplicaSetLister, args.StatefulSetLister, args.PodLister)
 				},
 				Weight: 1,
 			},

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -700,7 +700,8 @@ func TestZeroRequest(t *testing.T) {
 				schedulertesting.FakeServiceLister([]*v1.Service{}),
 				schedulertesting.FakeControllerLister([]*v1.ReplicationController{}),
 				schedulertesting.FakeReplicaSetLister([]*apps.ReplicaSet{}),
-				schedulertesting.FakeStatefulSetLister([]*apps.StatefulSet{}))
+				schedulertesting.FakeStatefulSetLister([]*apps.StatefulSet{}),
+				schedulertesting.FakePodLister([]*v1.Pod{}))
 			pc := algorithm.PriorityConfig{Map: selectorSpreadPriorityMap, Reduce: selectorSpreadPriorityReduce, Weight: 1}
 			priorityConfigs = append(priorityConfigs, pc)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Problem 1: Predicates filter nodes. Existing pods on those nodes will be not be counted when calculating max pods per (zone or node) resulting in imbalanced cluster.

Fix: Filter all pods that match all selectors in filteredPodsMatchAllSelectors, instead of counting pods from  CalculateSpreadPriorityMap function.

Problem 2: When there are 2 selectors(service and replication controller), it is sufficient to match any one selector for distribution. This creates imbalance [[selector match code](https://github.com/kubernetes/kubernetes/blob/e20c15174e96957c4e1faf7822125c7d295316a4/pkg/scheduler/algorithm/priorities/selector_spreading.go#L101)].

Pods from previous deploys matches `service selector` and are counted when distributing pods across zones/nodes (Even though they do not match `replicaset selector`) . These pods will be deleted. After the deploy completes, the cluster is imbalanced - by zone and/or pods per node.

Fix: All selectors must match pods. Partial matches are still allowed.

**Which issue(s) this PR fixes** :

Fixes https://github.com/kubernetes/kubernetes/issues/71327

**Special notes for your reviewer**:

As illustrated in test cases
* service with partial pod label matches 
`{"baz": "blah"}` in service matches   `{"foo": "bar", "baz": "blah"}, {"bar": "foo", "baz": "blah"}`
* Replication controller with partial pod label matches
`{"foo": "bar"}` in ReplicationController
matches `{"foo": "bar", "baz": "blah"}`
* Replica set with partial pod label matches
`{"foo": "bar"}` in ReplicaSet
matches `{"foo": "bar", "baz": "blah"}`
* Stateful set with partial pod label matches
`{"foo": "bar"}` in StatefulSet
matches `{"foo": "bar", "baz": "blah"}`
* service with partial pod label matches service and replication controller 
`{"baz": "blah"}` in service and `{"foo": "bar"}` in rc 
matches `{"foo": "bar", "baz": "blah"}` and 
does not match  `{"bar": "foo", "baz": "blah"}` [Change in behaviour]
* service with partial pod label matches service and replica set
{"baz": "blah"} in service and {"foo": "bar"} in rs
matches {"foo": "bar", "baz": "blah"} and 
does not match  {"bar": "foo", "baz": "blah"} [Change in behaviour]
* service with partial pod label matches service and stateful set
`{"baz": "blah"}` in service and `{"foo": "bar"}` in stateful set
matches `{"foo": "bar", "baz": "blah"}` and 
does not match  `{"bar": "foo", "baz": "blah"}` [Change in behaviour]
* disjoined service and replication controller matches no pods
`{"bar": "foo"}` in service and `{"foo": "bar"}` in ReplicationController
does not match any pods with labels `{"bar": "foo", "baz": "blah"}` or `{"bar": "foo", "baz": "blah"}` [Change in behaviour]
* disjoined service and replica set matches no pods
`{"bar": "foo"}` in service and `{"foo": "bar"}` in ReplicaSet
does not match any pods with labels `{"bar": "foo", "baz": "blah"}` or `{"bar": "foo", "baz": "blah"}` [Change in behaviour]
* disjoined service and replication controller matches no pods
`{"bar": "foo"}` in service and `{"foo": "bar"}` in StatefulSet
does not match any pods with labels `{"bar": "foo", "baz": "blah"}` or `{"bar": "foo", "baz": "blah"}` [Change in behaviour]



**Does this PR introduce a user-facing change?**:
```release-note
Fix pod scheduler to match all selectors when distributing pods.
```
/sig scheduling