### PR TITLE
Fixing address locking in CP fake.

### DIFF
--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -228,6 +228,8 @@ func (f *FakeCloud) SetNodeAddresses(nodeAddresses []v1.NodeAddress) {
 // It adds an entry "node-addresses-by-provider-id" into the internal method call record.
 func (f *FakeCloud) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
 	f.addCall("node-addresses-by-provider-id")
+	f.addressesMux.Lock()
+	defer f.addressesMux.Unlock()
 	return f.Addresses, f.Err
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
Follow on to https://github.com/kubernetes/kubernetes/pull/65226.
Makes the use of address lock to protect the address field consistent.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
