### PR TITLE
Add prebound pvs test cases in integration stress tests

### DIFF
--- a/test/integration/scheduler/volume_binding_test.go
+++ b/test/integration/scheduler/volume_binding_test.go
@@ -389,7 +389,7 @@ func TestVolumeBindingRescheduling(t *testing.T) {
 	}
 }
 
-// TestVolumeBindingStress creates <podLimit> pods, each with <volsPerPod> unbound PVCs.
+// TestVolumeBindingStress creates <podLimit> pods, each with <volsPerPod> unbound or prebound PVCs.
 // PVs are precreated.
 func TestVolumeBindingStress(t *testing.T) {
 	testVolumeBindingStress(t, 0, false, 0)
@@ -441,16 +441,31 @@ func testVolumeBindingStress(t *testing.T, schedulerResyncPeriod time.Duration, 
 	pvs := []*v1.PersistentVolume{}
 	pvcs := []*v1.PersistentVolumeClaim{}
 	for i := 0; i < podLimit*volsPerPod; i++ {
+		var (
+			pv      *v1.PersistentVolume
+			pvc     *v1.PersistentVolumeClaim
+			pvName  = fmt.Sprintf("pv-stress-%v", i)
+			pvcName = fmt.Sprintf("pvc-stress-%v", i)
+		)
 		// Don't create pvs for dynamic provisioning test
 		if !dynamic {
-			pv := makePV(fmt.Sprintf("pv-stress-%v", i), *scName, "", "", node1)
+			if rand.Int()%2 == 0 {
+				// static unbound pvs
+				pv = makePV(pvName, *scName, "", "", node1)
+			} else {
+				// static prebound pvs
+				pv = makePV(pvName, classImmediate, pvcName, config.ns, node1)
+			}
 			if pv, err := config.client.CoreV1().PersistentVolumes().Create(pv); err != nil {
 				t.Fatalf("Failed to create PersistentVolume %q: %v", pv.Name, err)
 			}
 			pvs = append(pvs, pv)
 		}
-
-		pvc := makePVC(fmt.Sprintf("pvc-stress-%v", i), config.ns, scName, "")
+		if pv != nil && pv.Spec.ClaimRef != nil && pv.Spec.ClaimRef.Name == pvcName {
+			pvc = makePVC(pvcName, config.ns, &classImmediate, pv.Name)
+		} else {
+			pvc = makePVC(pvcName, config.ns, scName, "")
+		}
 		if pvc, err := config.client.CoreV1().PersistentVolumeClaims(config.ns).Create(pvc); err != nil {
 			t.Fatalf("Failed to create PersistentVolumeClaim %q: %v", pvc.Name, err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Add prebound pvs test cases in integration stress tests. This helps to detect race conditions in volume binding.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #71301

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
