### PR TITLE
Add warning for kubectl apply during termination

### DIFF
--- a/pkg/kubectl/cmd/apply/apply.go
+++ b/pkg/kubectl/cmd/apply/apply.go
@@ -424,6 +424,10 @@ func (o *ApplyOptions) Run() error {
 				fmt.Fprintf(o.ErrOut, warningNoLastAppliedConfigAnnotation, o.cmdBaseName)
 			}
 
+			if metadata.GetDeletionTimestamp() != nil {
+				fmt.Fprintf(o.ErrOut,"Warning: applying \"%s\": the object %s/%s is being deleted\n", info.Source, strings.ToLower(info.Object.GetObjectKind().GroupVersionKind().Kind), info.Name)
+			}
+
 			helper := resource.NewHelper(info.Client, info.Mapping)
 			patcher := &Patcher{
 				Mapping:       info.Mapping,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
/sig cli

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #71260 

**Special notes for your reviewer**:
If an object is being deleted, kubectl apply will success in most of time. It's not harmful to the object, but it's better to provide an error/warning message to inform user of the object status.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
