### PR TITLE
Automated cherry pick of #70696: Filter out spammy audit logs from cluster autoscaler.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -843,6 +843,13 @@ rules:
     resources:
       - group: "" # core
         resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+  - level: None
+    users: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+    namespaces: ["kube-system"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps", "endpoints"]
   # Don't log HPA fetching metrics.
   - level: None
     users:


### PR DESCRIPTION
Cherry pick of #70696 on release-1.12.

#70696: Filter out spammy audit logs from cluster autoscaler.