### PR TITLE
fix unit test failure in ./pkg/api/testing/serialization_test.go 

### DIFF
--- a/pkg/api/testing/serialization_test.go
+++ b/pkg/api/testing/serialization_test.go
@@ -86,9 +86,11 @@ func TestSetControllerConversion(t *testing.T) {
 
 	rs := &apps.ReplicaSet{}
 	rc := &api.ReplicationController{}
+	extGroup := schema.GroupVersion{Group: "apps", Version: "v1"}
+	extCodec := legacyscheme.Codecs.LegacyCodec(extGroup)
 
-	extGroup := testapi.Apps
-	defaultGroup := testapi.Default
+	defaultGroup := schema.GroupVersion{Group: "", Version: "v1"}
+	defaultCodec := legacyscheme.Codecs.LegacyCodec(defaultGroup)
 
 	fuzzInternalObject(t, schema.GroupVersion{Group: "apps", Version: runtime.APIVersionInternal}, rs, rand.Int63())
 
@@ -102,7 +104,7 @@ func TestSetControllerConversion(t *testing.T) {
 	}
 
 	t.Logf("rs._internal.apps -> rs.v1.apps")
-	data, err := runtime.Encode(extGroup.Codec(), rs)
+	data, err := runtime.Encode(extCodec, rs)
 	if err != nil {
 		t.Fatalf("unexpected encoding error: %v", err)
 	}
@@ -110,9 +112,9 @@ func TestSetControllerConversion(t *testing.T) {
 	decoder := legacyscheme.Codecs.DecoderToVersion(
 		legacyscheme.Codecs.UniversalDeserializer(),
 		runtime.NewMultiGroupVersioner(
-			*defaultGroup.GroupVersion(),
-			schema.GroupKind{Group: defaultGroup.GroupVersion().Group},
-			schema.GroupKind{Group: extGroup.GroupVersion().Group},
+			defaultGroup,
+			schema.GroupKind{Group: defaultGroup.Group},
+			schema.GroupKind{Group: extGroup.Group},
 		),
 	)
 
@@ -122,7 +124,7 @@ func TestSetControllerConversion(t *testing.T) {
 	}
 
 	t.Logf("rc._internal -> rc.v1")
-	data, err = runtime.Encode(defaultGroup.Codec(), rc)
+	data, err = runtime.Encode(defaultCodec, rc)
 	if err != nil {
 		t.Fatalf("unexpected encoding error: %v", err)
 	}


### PR DESCRIPTION
> /kind failing-test


**What this PR does / why we need it**:
fix unit test failure in ./pkg/api/testing/serialization_test.go with error like:
```
--- FAIL: TestSetControllerConversion (0.00s)
    serialization_test.go:104: rs._internal.apps -> rs.v1.apps
    serialization_test.go:107: unexpected encoding error: no kind "ReplicaSet" is registered for version "apps/v1beta1" in scheme "k8s.io/kubernetes/pkg/api/legacyscheme/scheme.go:29"
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #71369 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
