### PR TITLE
Fix kubeadm reset in case of external etcd

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -207,7 +207,7 @@ func getEtcdDataDir(manifestPath string, client clientset.Interface) (string, er
 
 	if client != nil {
 		cfg, err := configutil.FetchConfigFromFileOrCluster(client, os.Stdout, "reset", "", false)
-		if err == nil {
+		if err == nil && cfg.Etcd.Local != nil {
 			return cfg.Etcd.Local.DataDir, nil
 		}
 		klog.Warningf("[reset] Unable to fetch the kubeadm-config ConfigMap, using etcd pod spec as fallback: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:

Fixes https://github.com/kubernetes/kubeadm/issues/1273

**Special notes for your reviewer**:
I did not add a test for this case, because we need to make some changes to allow this kind of test, I'll let this to the next cycle (https://github.com/kubernetes/kubeadm/issues/1188)
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/kind bug
/priority critical-urgent 
/area kubeadm
/sig cluster-lifecycle
/assign @fabriziopandini @neolit123 