### PR TITLE
kubeadm: add missing --config flag to mark-control-plane phase

### DIFF
--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -31,7 +31,7 @@ const APIServerExtraArgs = "apiserver-extra-args"
 // CertificatesDir flag sets the path where to save and read the certificates.
 const CertificatesDir = "cert-dir"
 
-// CfgPath flag sets the path to kubeadm config file. WARNING: Usage of a configuration file is experimental.
+// CfgPath flag sets the path to kubeadm config file.
 const CfgPath = "config"
 
 // ControllerManagerExtraArgs flag sets extra flags to pass to the Controller Manager or override default ones in form of <flagname>=<value>.

--- a/cmd/kubeadm/app/cmd/options/generic.go
+++ b/cmd/kubeadm/app/cmd/options/generic.go
@@ -33,7 +33,7 @@ func AddKubeConfigDirFlag(fs *pflag.FlagSet, kubeConfigDir *string) {
 
 // AddConfigFlag adds the --config flag to the given flagset
 func AddConfigFlag(fs *pflag.FlagSet, cfgPath *string) {
-	fs.StringVar(cfgPath, CfgPath, *cfgPath, "Path to kubeadm config file (WARNING: Usage of a configuration file is experimental).")
+	fs.StringVar(cfgPath, CfgPath, *cfgPath, "Path to a kubeadm configuration file.")
 }
 
 // AddIgnorePreflightErrorsFlag adds the --ignore-preflight-errors flag to the given flagset

--- a/cmd/kubeadm/app/cmd/phases/markcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/markcontrolplane.go
@@ -50,6 +50,7 @@ func NewMarkControlPlanePhase() workflow.Phase {
 		Example: markControlPlaneExample,
 		InheritFlags: []string{
 			options.NodeName,
+			options.CfgPath,
 		},
 		Run: runMarkControlPlane,
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

1. add missing --config flag to mark-control-plane
2. fix "experimental" language in flag description (the feature is now GA)

without 1. mark-control-plane is not fully functional from the CLI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

/assign @yagonobre @fabriziopandini 
@kubernetes/sig-cluster-lifecycle-pr-reviews 
/kind bug
/priority critical-urgent
