### PR TITLE
fix WithEquivalenceClassCacheEnabled in cmd/kube-scheduler

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -187,7 +187,7 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error
 		stopCh,
 		scheduler.WithName(cc.ComponentConfig.SchedulerName),
 		scheduler.WithHardPodAffinitySymmetricWeight(cc.ComponentConfig.HardPodAffinitySymmetricWeight),
-		scheduler.WithEquivalenceClassCacheEnabled(cc.ComponentConfig.EnableContentionProfiling),
+		scheduler.WithEquivalenceClassCacheEnabled(utilfeature.DefaultFeatureGate.Enabled(features.EnableEquivalenceClassCache)),
 		scheduler.WithPreemptionDisabled(cc.ComponentConfig.DisablePreemption),
 		scheduler.WithPercentageOfNodesToScore(cc.ComponentConfig.PercentageOfNodesToScore),
 		scheduler.WithBindTimeoutSeconds(*cc.ComponentConfig.BindTimeoutSeconds))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix WithEquivalenceClassCacheEnabled in cmd/kube-scheduler

**Special notes for your reviewer**:
cc @resouer @k82cn @Huang-Wei 

```release-note
1.13
```

/priority important-soon
/release 
/sig scheduling


