### PR TITLE
Fix for race condition caused by concurrent fsnotify (CREATE and REMOVE) in kubelet/plugin_watcher.go

### DIFF
--- a/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
@@ -111,7 +111,7 @@ func (w *Watcher) Start() error {
 				//TODO: Handle errors by taking corrective measures
 
 				w.wg.Add(1)
-				go func() {
+				func() {
 					defer w.wg.Done()
 
 					if event.Op&fsnotify.Create == fsnotify.Create {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a race condition that can cause CSI annotations added to Node API object to suddenly disappear after a driver-registrar pod has been deleted and recreated by replica controller (see https://github.com/kubernetes/kubernetes/issues/71424 for detail). 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #71424 

**Does this PR introduce a user-facing change?**: NONE

```release-note
NONE
```
