### PR TITLE
Update Cluster Autoscaler version to 1.13.0-rc.2

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.12.0",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.13.0-rc.2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
This PR updates CA version in gce manifests to 1.13.0-rc.2.

We need to merge it during freeze because, Cluster Autoscaler imports large amount of k8s code to simulate scheduler behavior, yet it lives in separate repository. Therefore 
we need to build final release candidate just at the end of k8s release cycle.

```release-note
Update Cluster Autoscaler version to 1.13.0-rc.2. Release notes: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.13.0-rc.2
```
