### PR TITLE
apis/kubeadm/v1beta1: fix typo in localApiEndpoint -> localAPIEndpoint

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/doc.go
@@ -181,7 +181,7 @@ limitations under the License.
 // 	    effect: "NoSchedule"
 // 	  kubeletExtraArgs:
 // 	    cgroupDriver: "cgroupfs"
-// 	localApiEndpoint:
+// 	localAPIEndpoint:
 // 	  advertiseAddress: "10.100.0.1"
 // 	  bindPort: 6443
 // 	---


### PR DESCRIPTION
As localApiEndpoint is ignored by json.Unmarshaller this should be
localAPIEndpoint as defined in the json tag of the source code.

Signed-off-by: André Martins <aanm90@gmail.com>
