### PR TITLE
Fix bazel //build/rpms

### DIFF
--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -149,7 +149,7 @@ k8s_deb(
     name = "kubelet",
     depends = [
         "iptables (>= 1.4.21)",
-        "kubernetes-cni (>= 0.5.1)",
+        "kubernetes-cni (>= 0.6.0)",
         "iproute2",
         "socat",
         "util-linux",

--- a/build/rpms/BUILD
+++ b/build/rpms/BUILD
@@ -47,6 +47,8 @@ pkg_rpm(
     changelog = "//:CHANGELOG.md",
     data = [
         "10-kubeadm.conf",
+        "50-kubeadm.conf",
+        "kubeadm.conf",
         "kubelet.env",
         "//cmd/kubeadm",
     ],

--- a/build/rpms/cri-tools.spec
+++ b/build/rpms/cri-tools.spec
@@ -11,7 +11,7 @@ Binaries to interface with the container runtime.
 
 %prep
 # This has to be hard coded because bazel does a path substitution before rpm's %{version} is substituted.
-tar -xzf {crictl-v1.12.0-linux-amd64.tar.gz}
+tar -xzf {cri_tools.tgz}
 
 %install
 install -m 755 -d %{buildroot}%{_bindir}

--- a/build/rpms/kubeadm.spec
+++ b/build/rpms/kubeadm.spec
@@ -24,7 +24,7 @@ install -p -m 644 -T {kubelet.env} %{buildroot}%{_sysconfdir}/sysconfig/kubelet
 mkdir -p %{buildroot}%{_libexecdir}/modules-load.d
 mkdir -p %{buildroot}%{_sysctldir}
 install -p -m 0644 -t %{buildroot}%{_libexecdir}/modules-load.d/ {kubeadm.conf}
-install -p -m 0644 -t %{buildroot}%{_sysctldir} %{50-kubeadm.conf}
+install -p -m 0644 -t %{buildroot}%{_sysctldir} {50-kubeadm.conf}
 
 %files
 %{_bindir}/kubeadm

--- a/build/rpms/kubelet.spec
+++ b/build/rpms/kubelet.spec
@@ -7,7 +7,7 @@ Summary: Container Cluster Manager - Kubernetes Node Agent
 URL: https://kubernetes.io
 
 Requires: iptables >= 1.4.21
-Requires: kubernetes-cni >= 0.5.1
+Requires: kubernetes-cni >= 0.6.0
 Requires: socat
 Requires: util-linux
 Requires: ethtool

--- a/build/rpms/kubernetes-cni.spec
+++ b/build/rpms/kubernetes-cni.spec
@@ -11,7 +11,7 @@ Binaries required to provision container networking.
 
 %prep
 mkdir -p ./bin
-tar -C ./bin -xz -f {cni-plugins-amd64-v0.6.0.tgz}
+tar -C ./bin -xz -f {kubernetes_cni.tgz}
 
 %install
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes the `build/rpms` target for bazel

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
