### PR TITLE
PodPreset: Add same functionality for init containers as standard containers

### DIFF
--- a/plugin/pkg/admission/podpreset/admission.go
+++ b/plugin/pkg/admission/podpreset/admission.go
@@ -184,6 +184,12 @@ func safeToApplyPodPresetsOnPod(pod *api.Pod, podPresets []*settingsv1alpha1.Pod
 			errs = append(errs, err)
 		}
 	}
+	for _, iCtr := range pod.Spec.InitContainers {
+		if err := safeToApplyPodPresetsOnContainer(&iCtr, podPresets); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
 	return utilerrors.NewAggregate(errs)
 }
 
@@ -380,6 +386,10 @@ func applyPodPresetsOnPod(pod *api.Pod, podPresets []*settingsv1alpha1.PodPreset
 	for i, ctr := range pod.Spec.Containers {
 		applyPodPresetsOnContainer(&ctr, podPresets)
 		pod.Spec.Containers[i] = ctr
+	}
+	for i, iCtr := range pod.Spec.InitContainers {
+		applyPodPresetsOnContainer(&iCtr, podPresets)
+		pod.Spec.InitContainers[i] = iCtr
 	}
 
 	// add annotation

--- a/test/e2e/servicecatalog/podpreset.go
+++ b/test/e2e/servicecatalog/podpreset.go
@@ -99,6 +99,13 @@ var _ = SIGDescribe("[Feature:PodPreset] PodPreset", func() {
 						Image: imageutils.GetE2EImage(imageutils.Nginx),
 					},
 				},
+				InitContainers: []v1.Container{
+					{
+						Name:    "init1",
+						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+						Command: []string{"/bin/true"},
+					},
+				},
 			},
 		}
 
@@ -152,6 +159,9 @@ var _ = SIGDescribe("[Feature:PodPreset] PodPreset", func() {
 		// verify the env is the same
 		if !reflect.DeepEqual(pip.Spec.Env, pod.Spec.Containers[0].Env) {
 			framework.Failf("env of pod container does not match the env of the pip: expected %#v, got: %#v", pip.Spec.Env, pod.Spec.Containers[0].Env)
+		}
+		if !reflect.DeepEqual(pip.Spec.Env, pod.Spec.InitContainers[0].Env) {
+			framework.Failf("env of pod init container does not match the env of the pip: expected %#v, got: %#v", pip.Spec.Env, pod.Spec.InitContainers[0].Env)
 		}
 	})
 
@@ -208,6 +218,14 @@ var _ = SIGDescribe("[Feature:PodPreset] PodPreset", func() {
 						Env:   []v1.EnvVar{{Name: "abc", Value: "value2"}, {Name: "ABC", Value: "value"}},
 					},
 				},
+				InitContainers: []v1.Container{
+					{
+						Name:    "init1",
+						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+						Env:     []v1.EnvVar{{Name: "abc", Value: "value2"}, {Name: "ABC", Value: "    value"}},
+						Command: []string{"/bin/true"},
+					},
+				},
 			},
 		}
 
@@ -262,6 +280,10 @@ var _ = SIGDescribe("[Feature:PodPreset] PodPreset", func() {
 		if !reflect.DeepEqual(originalPod.Spec.Containers[0].Env, pod.Spec.Containers[0].Env) {
 			framework.Failf("env of pod container does not match the env of the original pod: expected %#v, got: %#v", originalPod.Spec.Containers[0].Env, pod.Spec.Containers[0].Env)
 		}
+		if !reflect.DeepEqual(originalPod.Spec.InitContainers[0].Env, pod.Spec.InitContainers[0].Env) {
+			framework.Failf("env of pod init container does not match the env of the original pod: expected %#v, g    ot: %#v", originalPod.Spec.InitContainers[0].Env, pod.Spec.InitContainers[0].Env)
+		}
+
 	})
 })
 

--- a/test/e2e/servicecatalog/podpreset.go
+++ b/test/e2e/servicecatalog/podpreset.go
@@ -222,7 +222,7 @@ var _ = SIGDescribe("[Feature:PodPreset] PodPreset", func() {
 					{
 						Name:    "init1",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Env:     []v1.EnvVar{{Name: "abc", Value: "value2"}, {Name: "ABC", Value: "    value"}},
+						Env:     []v1.EnvVar{{Name: "abc", Value: "value2"}, {Name: "ABC", Value: "value"}},
 						Command: []string{"/bin/true"},
 					},
 				},
@@ -281,7 +281,7 @@ var _ = SIGDescribe("[Feature:PodPreset] PodPreset", func() {
 			framework.Failf("env of pod container does not match the env of the original pod: expected %#v, got: %#v", originalPod.Spec.Containers[0].Env, pod.Spec.Containers[0].Env)
 		}
 		if !reflect.DeepEqual(originalPod.Spec.InitContainers[0].Env, pod.Spec.InitContainers[0].Env) {
-			framework.Failf("env of pod init container does not match the env of the original pod: expected %#v, g    ot: %#v", originalPod.Spec.InitContainers[0].Env, pod.Spec.InitContainers[0].Env)
+			framework.Failf("env of pod init container does not match the env of the original pod: expected %#v, got: %#v", originalPod.Spec.InitContainers[0].Env, pod.Spec.InitContainers[0].Env)
 		}
 
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds the same functionality for init containers as standard containers in the PodPreset admission controller.  

**Which issue(s) this PR fixes**:
Fixes #55410 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Adds the same information to an init container as a standard container in a pod when using PodPresets.
```
