### PR TITLE
Remove legacy gci flex directory from e2e tests

### DIFF
--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -44,10 +44,8 @@ const (
 	// On gci, root is read-only and controller-manager containerized. Assume
 	// controller-manager has started with --flex-volume-plugin-dir equal to this
 	// (see cluster/gce/config-test.sh)
-	gciVolumePluginDir        = "/home/kubernetes/flexvolume"
-	gciVolumePluginDirLegacy  = "/etc/srv/kubernetes/kubelet-plugins/volume/exec"
-	gciVolumePluginDirVersion = "1.10.0"
-	detachTimeout             = 10 * time.Second
+	gciVolumePluginDir = "/home/kubernetes/flexvolume"
+	detachTimeout      = 10 * time.Second
 )
 
 // testFlexVolume tests that a client pod using a given flexvolume driver
@@ -130,24 +128,7 @@ func uninstallFlex(c clientset.Interface, node *v1.Node, vendor, driver string) 
 func getFlexDir(c clientset.Interface, node *v1.Node, vendor, driver string) string {
 	volumePluginDir := defaultVolumePluginDir
 	if framework.ProviderIs("gce") {
-		if node == nil && framework.MasterOSDistroIs("gci", "ubuntu") {
-			v, err := getMasterVersion(c)
-			if err != nil {
-				framework.Failf("Error getting master version: %v", err)
-			}
-
-			if v.AtLeast(versionutil.MustParseGeneric(gciVolumePluginDirVersion)) {
-				volumePluginDir = gciVolumePluginDir
-			} else {
-				volumePluginDir = gciVolumePluginDirLegacy
-			}
-		} else if node != nil && framework.NodeOSDistroIs("gci", "ubuntu") {
-			if getNodeVersion(node).AtLeast(versionutil.MustParseGeneric(gciVolumePluginDirVersion)) {
-				volumePluginDir = gciVolumePluginDir
-			} else {
-				volumePluginDir = gciVolumePluginDirLegacy
-			}
-		}
+		volumePluginDir = gciVolumePluginDir
 	}
 	flexDir := path.Join(volumePluginDir, fmt.Sprintf("/%s~%s/", vendor, driver))
 	return flexDir


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
cos and ubuntu jobs that are used to qualify distro versions set node os distro to "custom".  We are beyond 2 version support for the legacy gci flex volume directory, so I'm just removing that logic from the test entirely and just using the new flexplugin directory for all gce platforms.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #71439

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
