### PR TITLE
Collapse not shared NSG rules with multiple source ranges

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_standard.go
+++ b/pkg/cloudprovider/providers/azure/azure_standard.go
@@ -236,6 +236,11 @@ func (az *Cloud) getSecurityRuleName(service *v1.Service, port v1.ServicePort, s
 		safePrefix := strings.Replace(sourceAddrPrefix, "/", "_", -1)
 		return fmt.Sprintf("shared-%s-%d-%s", port.Protocol, port.Port, safePrefix)
 	}
+	if sourceAddrPrefix == "" {
+		rulePrefix := az.getRulePrefix(service)
+		return fmt.Sprintf("%s-%s-%d", rulePrefix, port.Protocol, port.Port)
+	}
+	// ensure backward compatibility
 	safePrefix := strings.Replace(sourceAddrPrefix, "/", "_", -1)
 	rulePrefix := az.getRulePrefix(service)
 	return fmt.Sprintf("%s-%s-%d-%s", rulePrefix, port.Protocol, port.Port, safePrefix)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind flake

/kind feature

**What this PR does / why we need it**:
When creating a service with annotation: `service.beta.kubernetes.io/load-balancer-source-ranges` containing multiple source ranges and service.beta.kubernetes.io/azure-shared-securityrule: "false", the cloud provider will create a single rule with the source range collapsed in the NSG. This feature supports creation of more rules in the cloud provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #71482

**Special notes for your reviewer**:
Expected behavior for the following service annotations:
Not shared:
`service.beta.kubernetes.io/azure-shared-securityrule: "false"`
With source range provided:
`service.beta.kubernetes.io/load-balancer-source-ranges: "17.0.0.0/8,57.0.0.0/8"`
Internal:
`service.beta.kubernetes.io/azure-load-balancer-internal: "true"`

|Shared|With Source Range|Internal|Expected Behavior|
|---|---|---|---|
|n|y|n|UUID-PROTOCOL-PORT|
|n|n|n|UUID-PROTOCOL-PORT|
|n|y|y|UUID-PROTOCOL-PORT|
|n|n|y|no security rule will be created|
|y|y|n|shared-PROTOCOL-PORT-SOURCE-SourceRangePublicIP|
|y|n|n|shared-PROTOCOL-PORT-SOURCE-Internet|
|y|y|y|shared-PROTOCOL-PORT-SOURCE-SourceRangeInternalIP|
|y|n|y|no security rule will be created|

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
When creating a service with annotation: service.beta.kubernetes.io/load-balancer-source-ranges containing multiple source ranges and service.beta.kubernetes.io/azure-shared-securityrule: "false",  the NSG rules will be collapsed.
```

/sig azure
cc: @khenidak @weinong @feiskyer 