### PR TITLE
reuse the global flag logic for kubelet component

### DIFF
--- a/cmd/kubelet/app/BUILD
+++ b/cmd/kubelet/app/BUILD
@@ -137,6 +137,7 @@ go_library(
         "//staging/src/k8s.io/client-go/util/keyutil:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
         "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
+        "//staging/src/k8s.io/component-base/cli/globalflag:go_default_library",
         "//staging/src/k8s.io/kubelet/config/v1beta1:go_default_library",
         "//vendor/github.com/coreos/go-systemd/daemon:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",

--- a/cmd/kubelet/app/options/BUILD
+++ b/cmd/kubelet/app/options/BUILD
@@ -37,10 +37,9 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
-        "//staging/src/k8s.io/component-base/logs:go_default_library",
+        "//staging/src/k8s.io/component-base/cli/globalflag:go_default_library",
         "//staging/src/k8s.io/kubelet/config/v1beta1:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:linux": [
             "//vendor/github.com/google/cadvisor/container/common:go_default_library",

--- a/cmd/kubelet/app/options/globalflags_linux.go
+++ b/cmd/kubelet/app/options/globalflags_linux.go
@@ -19,9 +19,6 @@ limitations under the License.
 package options
 
 import (
-	"flag"
-	"os"
-
 	"github.com/spf13/pflag"
 
 	// ensure libs have a chance to globally register their flags
@@ -32,48 +29,45 @@ import (
 	_ "github.com/google/cadvisor/machine"
 	_ "github.com/google/cadvisor/manager"
 	_ "github.com/google/cadvisor/storage"
+
+	"k8s.io/component-base/cli/globalflag"
 )
 
 // addCadvisorFlags adds flags from cadvisor
 func addCadvisorFlags(fs *pflag.FlagSet) {
-	// lookup flags in global flag set and re-register the values with our flagset
-	global := flag.CommandLine
-	local := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+	// lookup flags in global flag set and re-register the values with flag.CommandLine.
 
 	// These flags were also implicit from cadvisor, but are actually used by something in the core repo:
 	// TODO(mtaufen): This one is stil used by our salt, but for heaven's sake it's even deprecated in cadvisor
-	register(global, local, "docker_root")
+	globalflag.Register(fs, "docker_root")
 	// e2e node tests rely on this
-	register(global, local, "housekeeping_interval")
+	globalflag.Register(fs, "housekeeping_interval")
 
 	// These flags were implicit from cadvisor, and are mistakes that should be registered deprecated:
 	const deprecated = "This is a cadvisor flag that was mistakenly registered with the Kubelet. Due to legacy concerns, it will follow the standard CLI deprecation timeline before being removed."
 
-	registerDeprecated(global, local, "application_metrics_count_limit", deprecated)
-	registerDeprecated(global, local, "boot_id_file", deprecated)
-	registerDeprecated(global, local, "container_hints", deprecated)
-	registerDeprecated(global, local, "containerd", deprecated)
-	registerDeprecated(global, local, "docker", deprecated)
-	registerDeprecated(global, local, "docker_env_metadata_whitelist", deprecated)
-	registerDeprecated(global, local, "docker_only", deprecated)
-	registerDeprecated(global, local, "docker-tls", deprecated)
-	registerDeprecated(global, local, "docker-tls-ca", deprecated)
-	registerDeprecated(global, local, "docker-tls-cert", deprecated)
-	registerDeprecated(global, local, "docker-tls-key", deprecated)
-	registerDeprecated(global, local, "enable_load_reader", deprecated)
-	registerDeprecated(global, local, "event_storage_age_limit", deprecated)
-	registerDeprecated(global, local, "event_storage_event_limit", deprecated)
-	registerDeprecated(global, local, "global_housekeeping_interval", deprecated)
-	registerDeprecated(global, local, "log_cadvisor_usage", deprecated)
-	registerDeprecated(global, local, "machine_id_file", deprecated)
-	registerDeprecated(global, local, "storage_driver_user", deprecated)
-	registerDeprecated(global, local, "storage_driver_password", deprecated)
-	registerDeprecated(global, local, "storage_driver_host", deprecated)
-	registerDeprecated(global, local, "storage_driver_db", deprecated)
-	registerDeprecated(global, local, "storage_driver_table", deprecated)
-	registerDeprecated(global, local, "storage_driver_secure", deprecated)
-	registerDeprecated(global, local, "storage_driver_buffer_duration", deprecated)
-
-	// finally, add cadvisor flags to the provided flagset
-	fs.AddFlagSet(local)
+	globalflag.RegisterDeprecated(fs, "application_metrics_count_limit", deprecated)
+	globalflag.RegisterDeprecated(fs, "boot_id_file", deprecated)
+	globalflag.RegisterDeprecated(fs, "container_hints", deprecated)
+	globalflag.RegisterDeprecated(fs, "containerd", deprecated)
+	globalflag.RegisterDeprecated(fs, "docker", deprecated)
+	globalflag.RegisterDeprecated(fs, "docker_env_metadata_whitelist", deprecated)
+	globalflag.RegisterDeprecated(fs, "docker_only", deprecated)
+	globalflag.RegisterDeprecated(fs, "docker-tls", deprecated)
+	globalflag.RegisterDeprecated(fs, "docker-tls-ca", deprecated)
+	globalflag.RegisterDeprecated(fs, "docker-tls-cert", deprecated)
+	globalflag.RegisterDeprecated(fs, "docker-tls-key", deprecated)
+	globalflag.RegisterDeprecated(fs, "enable_load_reader", deprecated)
+	globalflag.RegisterDeprecated(fs, "event_storage_age_limit", deprecated)
+	globalflag.RegisterDeprecated(fs, "event_storage_event_limit", deprecated)
+	globalflag.RegisterDeprecated(fs, "global_housekeeping_interval", deprecated)
+	globalflag.RegisterDeprecated(fs, "log_cadvisor_usage", deprecated)
+	globalflag.RegisterDeprecated(fs, "machine_id_file", deprecated)
+	globalflag.RegisterDeprecated(fs, "storage_driver_user", deprecated)
+	globalflag.RegisterDeprecated(fs, "storage_driver_password", deprecated)
+	globalflag.RegisterDeprecated(fs, "storage_driver_host", deprecated)
+	globalflag.RegisterDeprecated(fs, "storage_driver_db", deprecated)
+	globalflag.RegisterDeprecated(fs, "storage_driver_table", deprecated)
+	globalflag.RegisterDeprecated(fs, "storage_driver_secure", deprecated)
+	globalflag.RegisterDeprecated(fs, "storage_driver_buffer_duration", deprecated)
 }

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -35,7 +35,6 @@ import (
 	"github.com/coreos/go-systemd/daemon"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/klog"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -60,6 +59,8 @@ import (
 	"k8s.io/client-go/util/keyutil"
 	cloudprovider "k8s.io/cloud-provider"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/cli/globalflag"
+	"k8s.io/klog"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -275,8 +276,8 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 	// keep cleanFlagSet separate, so Cobra doesn't pollute it with the global flags
 	kubeletFlags.AddFlags(cleanFlagSet)
 	options.AddKubeletConfigFlags(cleanFlagSet, kubeletConfig)
-	options.AddGlobalFlags(cleanFlagSet)
-	cleanFlagSet.BoolP("help", "h", false, fmt.Sprintf("help for %s", cmd.Name()))
+	globalflag.AddGlobalFlags(cleanFlagSet, cmd.Name())
+	options.AddCustomGlobalFlags(cleanFlagSet)
 
 	// ugly, but necessary, because Cobra's default UsageFunc and HelpFunc pollute the flagset with global flags
 	const usageFmt = "Usage:\n  %s\n\nFlags:\n%s"
@@ -298,7 +299,8 @@ func newFlagSetWithGlobals() *pflag.FlagSet {
 	// set the normalize func, similar to k8s.io/component-base/cli//flags.go:InitFlags
 	fs.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	// explicitly add flags from libs that register global flags
-	options.AddGlobalFlags(fs)
+	globalflag.AddGlobalFlags(fs, componentKubelet)
+	options.AddCustomGlobalFlags(fs)
 	return fs
 }
 

--- a/staging/src/k8s.io/component-base/cli/globalflag/globalflags.go
+++ b/staging/src/k8s.io/component-base/cli/globalflag/globalflags.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/spf13/pflag"
+
 	"k8s.io/component-base/logs"
 	"k8s.io/klog"
 )
@@ -62,4 +63,21 @@ func Register(local *pflag.FlagSet, globalName string) {
 	} else {
 		panic(fmt.Sprintf("failed to find flag in global flagset (flag): %s", globalName))
 	}
+}
+
+// RegisterPflag adds a flag to local that targets the Value associated with the Flag
+// named globalName in pflag.CommandLine.
+func RegisterPflag(fs *pflag.FlagSet, globalName string) {
+	if f := pflag.CommandLine.Lookup(globalName); f != nil {
+		f.Name = normalize(f.Name)
+		fs.AddFlag(f)
+	} else {
+		panic(fmt.Sprintf("failed to find flag in global flagset (pflag): %s", globalName))
+	}
+}
+
+// RegisterDeprecated registers the flag with register, and then marks it deprecated.
+func RegisterDeprecated(fs *pflag.FlagSet, globalName, deprecated string) {
+	Register(fs, globalName)
+	fs.Lookup(normalize(globalName)).Deprecated = deprecated
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We had accomplish some global flag logic in `staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags.go`, we should reuse those logic for kubelet also. and rich the global flag logic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
