### PR TITLE
fix detach azure disk issue due to dirty cache

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_controller_standard.go
+++ b/pkg/cloudprovider/providers/azure/azure_controller_standard.go
@@ -77,6 +77,9 @@ func (as *availabilitySet) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
+	// Invalidate the cache right after updating
+	defer as.cloud.vmCache.Delete(vmName)
+
 	_, err = as.VirtualMachinesClient.CreateOrUpdate(ctx, nodeResourceGroup, vmName, newVM)
 	if err != nil {
 		klog.Errorf("azureDisk - attach disk(%s) failed, err: %v", diskName, err)
@@ -88,8 +91,6 @@ func (as *availabilitySet) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 		}
 	} else {
 		klog.V(2).Infof("azureDisk - attach disk(%s) succeeded", diskName)
-		// Invalidate the cache right after updating
-		as.cloud.vmCache.Delete(vmName)
 	}
 	return err
 }
@@ -139,13 +140,15 @@ func (as *availabilitySet) DetachDiskByName(diskName, diskURI string, nodeName t
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - detach disk(%s)", nodeResourceGroup, vmName, diskName)
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
+
+	// Invalidate the cache right after updating
+	defer as.cloud.vmCache.Delete(vmName)
+
 	_, err = as.VirtualMachinesClient.CreateOrUpdate(ctx, nodeResourceGroup, vmName, newVM)
 	if err != nil {
 		klog.Errorf("azureDisk - detach disk(%s) failed, err: %v", diskName, err)
 	} else {
 		klog.V(2).Infof("azureDisk - detach disk(%s) succeeded", diskName)
-		// Invalidate the cache right after updating
-		as.cloud.vmCache.Delete(vmName)
 	}
 	return err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix detch azure disk issue by cleaning up vm cache right after every update vm operation in disk attach/detach

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #71453

**Special notes for your reviewer**:
When detaching lots of disks in one node, detach failure may happen, in the before, we use backoff mechanism to retries 6 times which is not good solution; now we switch to use k8s controller to detach disk volume, and it finally depends on `DisksAreAttached` func to decide whether one disk is attached or not: 
https://github.com/kubernetes/kubernetes/blob/5dfe48b0ff464ca1f11805079476e72d3fe8ece0/pkg/volume/azure_dd/attacher.go#L135

Unfortunately `DisksAreAttached` func is invoked right after `DetachDiskByName` failure which already make the vm cache **dirty**, this PR makes sure vm cache will be cleaned after every update vm operation in disk attach/detach operation. And this PR will also solve strange issue, e.g. detach disk failure due to the last attach disk failure.

The invocation chain for using `vmCache` in `DisksAreAttached` func:
```
DisksAreAttached --> getNodeDataDisks--> GetDataDisks --> getVirtualMachine --> vmCache.Get
```

```
I1128 05:04:58.206841       1 attacher.go:145] azureDisk - VolumesAreAttached: check volume "andy-vmss11010-dynamic-pvc-884809b5-f2ca-11e8-a757-000d3a01450e" (specName: "pvc-884809b5-f2ca-11e8-a757-000d3a01450e") is no longer attached
I1128 05:04:58.206945       1 operation_generator.go:193] VerifyVolumesAreAttached determined volume "kubernetes.io/azure-disk//subscriptions/.../resourceGroups/andy-vmss11010/providers/Microsoft.Compute/disks/andy-vmss11010-dynamic-pvc-049158b4-f2ba-11e8-ade9-000d3a01450e" (spec.Name: "pvc-049158b4-f2ba-11e8-ade9-000d3a01450e") is no longer attached to node "k8s-agentpool-39687990-vmss000000", therefore it was marked as detached.
```

**Release note**:
```
fix detach azure disk issue
```

/sig azure
/assign @feiskyer 
cc @khenidak @brendandburns 
@antoineco