### PR TITLE
Allow CSI Drivers suporting 0.x/1.x to use old dir

### DIFF
--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -705,15 +705,15 @@ func highestSupportedVersion(versions []string) (*utilversion.Version, error) {
 	return nil, fmt.Errorf("None of the CSI versions reported by this driver are supported")
 }
 
-// Only CSI 0.x drivers are allowed to use deprecated socket dir.
+// Only drivers that implement CSI 0.x are allowed to use deprecated socket dir.
 func isDeprecatedSocketDirAllowed(versions []string) bool {
 	for _, version := range versions {
-		if !isV0Version(version) {
-			return false
+		if isV0Version(version) {
+			return true
 		}
 	}
 
-	return true
+	return false
 }
 
 func isV0Version(version string) bool {

--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -617,7 +617,7 @@ func TestValidatePlugin(t *testing.T) {
 			endpoint:             "/var/log/kubelet/plugins/myplugin/csi.sock",
 			versions:             []string{"0.2.0", "v1.0.0"},
 			foundInDeprecatedDir: true,
-			shouldFail:           true,
+			shouldFail:           false,
 		},
 		{
 			pluginName:           "test.plugin",
@@ -631,7 +631,7 @@ func TestValidatePlugin(t *testing.T) {
 			endpoint:             "/var/log/kubelet/plugins/myplugin/csi.sock",
 			versions:             []string{"0.2.0", "v1.2.3"},
 			foundInDeprecatedDir: true,
-			shouldFail:           true,
+			shouldFail:           false,
 		},
 		{
 			pluginName:           "test.plugin",
@@ -645,7 +645,7 @@ func TestValidatePlugin(t *testing.T) {
 			endpoint:             "/var/log/kubelet/plugins/myplugin/csi.sock",
 			versions:             []string{"v1.2.3", "v0.3.0"},
 			foundInDeprecatedDir: true,
-			shouldFail:           true,
+			shouldFail:           false,
 		},
 		{
 			pluginName:           "test.plugin",
@@ -659,14 +659,14 @@ func TestValidatePlugin(t *testing.T) {
 			endpoint:             "/var/log/kubelet/plugins/myplugin/csi.sock",
 			versions:             []string{"v1.2.3", "v0.3.0", "2.0.1"},
 			foundInDeprecatedDir: true,
-			shouldFail:           true,
+			shouldFail:           false,
 		},
 		{
 			pluginName:           "test.plugin",
 			endpoint:             "/var/log/kubelet/plugins/myplugin/csi.sock",
 			versions:             []string{"v0.3.0", "2.0.1"},
 			foundInDeprecatedDir: true,
-			shouldFail:           true,
+			shouldFail:           false,
 		},
 		{
 			pluginName:           "test.plugin",
@@ -680,7 +680,7 @@ func TestValidatePlugin(t *testing.T) {
 			endpoint:             "/var/log/kubelet/plugins/myplugin/csi.sock",
 			versions:             []string{"v1.2.3", "4.9.12", "v0.3.0", "2.0.1"},
 			foundInDeprecatedDir: true,
-			shouldFail:           true,
+			shouldFail:           false,
 		},
 		{
 			pluginName:           "test.plugin",
@@ -694,7 +694,7 @@ func TestValidatePlugin(t *testing.T) {
 			endpoint:             "/var/log/kubelet/plugins/myplugin/csi.sock",
 			versions:             []string{"v1.2.3", "boo", "v0.3.0", "2.0.1"},
 			foundInDeprecatedDir: true,
-			shouldFail:           true,
+			shouldFail:           false,
 		},
 		{
 			pluginName:           "test.plugin",


### PR DESCRIPTION
Allow drivers implmenting both CSI 0.x and 1.x to use the old volume
plugin directory in addition to the the new volume plugin directory.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubernetes/issues/71517

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
None
```
