### PR TITLE
Modify GetDriverDaemonSet to take variable namespace depending on driver

### DIFF
--- a/test/e2e/storage/drivers/base.go
+++ b/test/e2e/storage/drivers/base.go
@@ -80,6 +80,9 @@ type DynamicPVTestDriver interface {
 type DriverInfo struct {
 	Name       string // Name of the driver
 	FeatureTag string // FeatureTag for the driver
+	// Namespace the driver is installed to, default is empty which represents the
+	// test namespace
+	InstalledNamespace string
 
 	MaxFileSize          int64       // Max file size to be tested for this driver
 	SupportedFsType      sets.String // Map of string for supported fs type

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -42,6 +42,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
@@ -323,7 +324,8 @@ var _ DynamicPVTestDriver = &gcePDExternalCSIDriver{}
 func InitGcePDExternalCSIDriver() TestDriver {
 	return &gcePDExternalCSIDriver{
 		driverInfo: DriverInfo{
-			Name: "pd.csi.storage.gke.io",
+			Name:               "pd.csi.storage.gke.io",
+			InstalledNamespace: metav1.NamespaceDefault,
 			// TODO(#70258): this is temporary until we can figure out how to make e2e tests a library
 			FeatureTag:  "[Feature: gcePD-external]",
 			MaxFileSize: testpatterns.FileSizeMedium,


### PR DESCRIPTION
/kind failing-test
/sig storage
/assign @msau42 @jsafrane 

**What this PR does / why we need it**:
https://testgrid.k8s.io/sig-gcp-compute-persistent-disk-csi-driver#Kubernetes%20Master%20Driver%20Stable

The driver "should work after update" test is failing on the GCE PD External CI because we deploy one driver for the entire test as opposed to one per namespace.
This change should be able to perform the update on the default namespace driver for external GCE PD.

```release-note
NONE
```
