### PR TITLE
Automated cherry pick of #70144: add mTLS encription between etcd and kube-apiserver in GCE

### DIFF
--- a/cluster/gce/gci/master-helper.sh
+++ b/cluster/gce/gci/master-helper.sh
@@ -62,6 +62,19 @@ function replicate-master-instance() {
   kube_env="$(echo "${kube_env}" | grep -v "ETCD_PEER_CERT")"
   kube_env="$(echo -e "${kube_env}\nETCD_PEER_CERT: '${ETCD_PEER_CERT_BASE64}'")"
 
+  ETCD_KAS_CA_KEY="$(echo "${kube_env}" | grep "ETCD_KAS_CA_KEY" |  sed "s/^.*: '//" | sed "s/'$//")"
+  ETCD_KAS_CA_CERT="$(echo "${kube_env}" | grep "ETCD_KAS_CA_CERT" |  sed "s/^.*: '//" | sed "s/'$//")"
+  create-etcd-kas-certs "etcd-${REPLICA_NAME}" "${REPLICA_NAME}" "${ETCD_KAS_CA_CERT}" "${ETCD_KAS_CA_KEY}"
+
+  kube_env="$(echo "${kube_env}" | grep -v "ETCD_KAS_SERVER_KEY")"
+  kube_env="$(echo -e "${kube_env}\nETCD_KAS_SERVER_KEY: '${ETCD_KAS_SERVER_KEY_BASE64}'")"
+  kube_env="$(echo "${kube_env}" | grep -v "ETCD_KAS_SERVER_CERT")"
+  kube_env="$(echo -e "${kube_env}\nETCD_KAS_SERVER_CERT: '${ETCD_KAS_SERVER_CERT_BASE64}'")"
+  kube_env="$(echo "${kube_env}" | grep -v "ETCD_KAS_CLIENT_KEY")"
+  kube_env="$(echo -e "${kube_env}\nETCD_KAS_CLIENT_KEY: '${ETCD_KAS_CLIENT_KEY_BASE64}'")"
+  kube_env="$(echo "${kube_env}" | grep -v "ETCD_KAS_CLIENT_CERT")"
+  kube_env="$(echo -e "${kube_env}\nETCD_KAS_CLIENT_CERT: '${ETCD_KAS_CLIENT_CERT_BASE64}'")"
+
   echo "${kube_env}" > ${KUBE_TEMP}/master-kube-env.yaml
   get-metadata "${existing_master_zone}" "${existing_master_name}" cluster-name > "${KUBE_TEMP}/cluster-name.txt"
   get-metadata "${existing_master_zone}" "${existing_master_name}" gci-update-strategy > "${KUBE_TEMP}/gci-update.txt"

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -23,7 +23,7 @@
     "command": [
               "/bin/sh",
               "-c",
-              "if [ -e /usr/local/bin/migrate-if-needed.sh ]; then /usr/local/bin/migrate-if-needed.sh 1>>/var/log/etcd{{ suffix }}.log 2>&1; fi; exec /usr/local/bin/etcd --name etcd-{{ hostname }} --listen-peer-urls {{ etcd_protocol }}://{{ host_ip }}:{{ server_port }} --initial-advertise-peer-urls {{ etcd_protocol }}://{{ hostname }}:{{ server_port }} --advertise-client-urls http://127.0.0.1:{{ port }} --listen-client-urls http://127.0.0.1:{{ port }} {{ quota_bytes }} --data-dir /var/etcd/data{{ suffix }} --initial-cluster-state {{ cluster_state }} --initial-cluster {{ etcd_cluster }} {{ etcd_creds }} {{ etcd_extra_args }} 1>>/var/log/etcd{{ suffix }}.log 2>&1"
+              "if [ -e /usr/local/bin/migrate-if-needed.sh ]; then /usr/local/bin/migrate-if-needed.sh 1>>/var/log/etcd{{ suffix }}.log 2>&1; fi; exec /usr/local/bin/etcd --name etcd-{{ hostname }} --listen-peer-urls {{ etcd_protocol }}://{{ host_ip }}:{{ server_port }} --initial-advertise-peer-urls {{ etcd_protocol }}://{{ hostname }}:{{ server_port }} --advertise-client-urls http://127.0.0.1:{{ port }} --listen-client-urls http://127.0.0.1:{{ port }} {{ quota_bytes }} --data-dir /var/etcd/data{{ suffix }} --initial-cluster-state {{ cluster_state }} --initial-cluster {{ etcd_cluster }} {{ etcd_creds }} {{ etcd_kas_creds }} {{ etcd_extra_args }} 1>>/var/log/etcd{{ suffix }}.log 2>&1"
             ],
     "env": [
       { "name": "TARGET_STORAGE",
@@ -46,6 +46,9 @@
       },
       { "name": "ETCD_CREDS",
         "value": "{{ etcd_creds }}"
+      },
+      { "name": "ETCD_KAS_CREDS",
+        "value": "{{ etcd_kas_creds }}"
       },
       { "name": "ETCD_SNAPSHOT_COUNT",
         "value": "10000"


### PR DESCRIPTION
Cherry pick of #70144 on release-1.13.

#70144: add mTLS encription between etcd and kube-apiserver in GCE