### PR TITLE
Create cloud-sa on GCE PD Driver creation

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -38,7 +38,6 @@ package drivers
 import (
 	"fmt"
 	"math/rand"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	storagev1 "k8s.io/api/storage/v1"
@@ -256,14 +255,8 @@ func (g *gcePDCSIDriver) GetDriverInfo() *DriverInfo {
 
 func (g *gcePDCSIDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 	f := g.driverInfo.Framework
-	cs := f.ClientSet
-	config := g.driverInfo.Config
 	framework.SkipUnlessProviderIs("gce", "gke")
-	framework.SkipIfMultizone(cs)
-
-	// TODO(#62561): Use credentials through external pod identity when that goes GA instead of downloading keys.
-	createGCESecrets(cs, config)
-	framework.SkipUnlessSecretExistsAfterWait(cs, "cloud-sa", config.Namespace, 3*time.Minute)
+	framework.SkipIfMultizone(f.ClientSet)
 }
 
 func (g *gcePDCSIDriver) GetDynamicProvisionStorageClass(fsType string) *storagev1.StorageClass {
@@ -290,6 +283,8 @@ func (g *gcePDCSIDriver) CreateDriver() {
 	// 	DriverContainerName:      "gce-driver",
 	// 	ProvisionerContainerName: "csi-external-provisioner",
 	// }
+	createGCESecrets(g.driverInfo.Framework.ClientSet, g.driverInfo.Config)
+
 	cleanup, err := g.driverInfo.Framework.CreateFromManifests(nil,
 		"test/e2e/testing-manifests/storage-csi/driver-registrar/rbac.yaml",
 		"test/e2e/testing-manifests/storage-csi/external-attacher/rbac.yaml",

--- a/test/e2e/storage/drivers/csi_objects.go
+++ b/test/e2e/storage/drivers/csi_objects.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 
 	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
@@ -115,5 +116,7 @@ func createGCESecrets(client clientset.Interface, config framework.VolumeTestCon
 	}
 
 	_, err = client.CoreV1().Secrets(config.Namespace).Create(s)
-	framework.ExpectNoError(err, "Failed to create Secret %v", s.GetName())
+	if !apierrors.IsAlreadyExists(err) {
+		framework.ExpectNoError(err, "Failed to create Secret %v", s.GetName())
+	}
 }


### PR DESCRIPTION
/hold until I run the test on my local env

Fixes: #71536

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Creates Service Account secret that driver needs on driver creation, not when skipping tests

/assign @msau42 @saad-ali 

/cc @mkimuram 
Could you take a look at this and make sure it wasn't in the skip tests function for a specific reason I am not aware of. Don't want to break everything if it was necessary to be there before.

```release-note
NONE
```
