### PR TITLE
register metrics for Prometheus rest requests

### DIFF
--- a/pkg/client/metrics/prometheus/prometheus.go
+++ b/pkg/client/metrics/prometheus/prometheus.go
@@ -59,6 +59,9 @@ type latencyAdapter struct {
 }
 
 func (l *latencyAdapter) Observe(verb string, u url.URL, latency time.Duration) {
+	if l.m == nil {
+		metrics.Register(&latencyAdapter{requestLatency}, &resultAdapter{requestResult})
+	}
 	l.m.WithLabelValues(verb, u.String()).Observe(latency.Seconds())
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR registers new `RequestLatency` and `RequestResult` metrics for client-go rest requests before calling `Observe()` [here](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/rest/request.go#L682). If this PR is LGTM-ed, the change should be cherry-picked to 1.9, 1.10 and 1.11 branches.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [kubernetes/client-go/issues/509](https://github.com/kubernetes/client-go/issues/509)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/kind bug
/sig api-machinery
/hold

/cc @cheftako 