### PR TITLE
fix a bug in 'kubectl describe'

### DIFF
--- a/pkg/kubectl/describe/versioned/describe.go
+++ b/pkg/kubectl/describe/versioned/describe.go
@@ -881,8 +881,8 @@ func printProjectedVolumeSource(projected *corev1.ProjectedVolumeSource, w Prefi
 				"    ConfigMapOptional:\t%v\n",
 				source.ConfigMap.Name, source.ConfigMap.Optional)
 		} else if source.ServiceAccountToken != nil {
-			w.Write(LEVEL_2, "TokenExpirationSeconds:\t%v\n",
-				source.ServiceAccountToken.ExpirationSeconds)
+			w.Write(LEVEL_2, "TokenExpirationSeconds:\t%d\n",
+				*source.ServiceAccountToken.ExpirationSeconds)
 		}
 	}
 }


### PR DESCRIPTION

/kind bug
    Before this patch, the projected volume in kubectl describe command looks like:
```
        ...
        Volumes:
          kube-api-access-jp24b:
            Type:                    Projected (a volume that contains injected data from multiple sources)
            TokenExpirationSeconds:  0xc00071bee0
        ...
```
    
    After this patch, it looks like:
```
        ...
        Volumes:
          kube-api-access-jp24b:
            Type:                    Projected (a volume that contains injected data from multiple sources)
            TokenExpirationSeconds:  3600
        ...

```