### PR TITLE
Fix 'currentMetrics' field for HPA with 'AverageValue' target type

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -373,7 +373,7 @@ func (a *HorizontalController) computeStatusForResourceMetric(currentReplicas in
 			return 0, time.Time{}, "", fmt.Errorf("failed to get %s utilization: %v", metricSpec.Resource.Name, err)
 		}
 		metricNameProposal := fmt.Sprintf("%s resource", metricSpec.Resource.Name)
-		status = &autoscalingv2.MetricStatus{
+		*status = autoscalingv2.MetricStatus{
 			Type: autoscalingv2.ResourceMetricSourceType,
 			Resource: &autoscalingv2.ResourceMetricStatus{
 				Name: metricSpec.Resource.Name,


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Currently field 'status.currentMetrics' is always empty when HPA target type is "AverageValue".
This PR fixes that.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
