### PR TITLE
Update version of GLBC controller to 1.4.0. Switch managed certificates alpha feature to on by default, switch backend config feature to on.

### DIFF
--- a/cluster/gce/addons/managedcertificate/managedcertificate-v1alpha1.yaml
+++ b/cluster/gce/addons/managedcertificate/managedcertificate-v1alpha1.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: managedcertificates.gke.googleapis.com
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  group: gke.googleapis.com
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: managedcertificates
+    singular: managedcertificate
+    kind: ManagedCertificate
+    shortNames:
+      - mcrt
+  validation:
+    openAPIV3Schema:
+      properties:
+        status:
+          properties:
+            certificateStatus:
+              type: string
+            domainStatus:
+              type: array
+              items:
+                type: object
+                required:
+                  - domain
+                  - status
+                properties:
+                  domain:
+                    type: string
+                  status:
+                    type: string
+            certificateName:
+              type: string
+            expireTime:
+              type: string
+              format: date-time
+        spec:
+          properties:
+            domains:
+              type: array
+              maxItems: 1
+              items:
+                type: string
+                maxLength: 63
+                pattern: '^(([a-zA-Z0-9]+|[a-zA-Z0-9][-a-zA-Z0-9]*[a-zA-Z0-9])\.)+[a-zA-Z][-a-zA-Z0-9]*[a-zA-Z0-9]\.?$'

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -142,6 +142,10 @@ ENABLE_DOCKER_REGISTRY_CACHE=true
 #   glbc           - CE L7 Load Balancer Controller
 ENABLE_L7_LOADBALANCING="${KUBE_ENABLE_L7_LOADBALANCING:-glbc}"
 
+# Optional: Disable including the built-in ManagedCertificate CRD so that you
+# can overwrite it with a custom definition.
+ENABLE_MANAGED_CERTIFICATE_CRD="${ENABLE_MANAGED_CERTIFICATE_CRD:-true}"
+
 # Optional: Cluster monitoring to setup as part of the cluster bring up:
 #   none           - No cluster monitoring setup
 #   influxdb       - Heapster, InfluxDB, and Grafana

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -148,6 +148,10 @@ ENABLE_DOCKER_REGISTRY_CACHE=true
 #   glbc           - CE L7 Load Balancer Controller
 ENABLE_L7_LOADBALANCING="${KUBE_ENABLE_L7_LOADBALANCING:-glbc}"
 
+# Optional: Disable including the built-in ManagedCertificate CRD so that you
+# can overwrite it with a custom definition.
+ENABLE_MANAGED_CERTIFICATE_CRD="${ENABLE_MANAGED_CERTIFICATE_CRD:-true}"
+
 # Optional: Cluster monitoring to setup as part of the cluster bring up:
 #   none           - No cluster monitoring setup
 #   influxdb       - Heapster, InfluxDB, and Grafana

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2606,11 +2606,13 @@ EOF
   if [[ "${FEATURE_GATES:-}" =~ "RuntimeClass=true" ]]; then
     setup-addon-manifests "addons" "runtimeclass"
   fi
+  if [[ "${ENABLE_MANAGED_CERTIFICATE_CRD:-}" == "true" ]]; then
+    setup-addon-manifests "addons" "managedcertificate" "gce"
+  fi
   if [[ -n "${EXTRA_ADDONS_URL:-}" ]]; then
     download-extra-addons
     setup-addon-manifests "addons" "gce-extras"
   fi
-
 
   # Place addon manager pod manifest.
   src_file="${src_dir}/kube-addon-manager.yaml"

--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -1,20 +1,20 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v1.2.3
+  name: l7-lb-controller-v1.4.0
   namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
     seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
   labels:
     k8s-app: gcp-lb-controller
-    version: v1.2.3
+    version: v1.4.0
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.2.3
+  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.4.0
     livenessProbe:
       httpGet:
         path: /healthz
@@ -45,7 +45,23 @@ spec:
     # TODO: split this out into args when we no longer need to pipe stdout to a file #6428
     - sh
     - -c
-    - 'exec /glbc --gce-ratelimit=ga.Operations.Get,qps,10,100 --gce-ratelimit=alpha.Operations.Get,qps,10,100 --gce-ratelimit=ga.BackendServices.Get,qps,1.8,1 --gce-ratelimit=ga.HealthChecks.Get,qps,1.8,1 --gce-ratelimit=alpha.HealthChecks.Get,qps,1.8,1 --gce-ratelimit=beta.NetworkEndpointGroups.Get,qps,1.8,1 --gce-ratelimit=beta.NetworkEndpointGroups.AttachNetworkEndpoints,qps,1.8,1 --gce-ratelimit=beta.NetworkEndpointGroups.DetachNetworkEndpoints,qps,1.8,1 --gce-ratelimit=beta.NetworkEndpointGroups.ListNetworkEndpoints,qps,1.8,1 --verbose --apiserver-host=http://localhost:8080 --default-backend-service=kube-system/default-http-backend --sync-period=600s --running-in-cluster=false --use-real-cloud=true --config-file-path=/etc/gce.conf --healthz-port=8086 1>>/var/log/glbc.log 2>&1'
+    - >
+       exec /glbc
+       --enable-backend-config --enable-managed-certificates
+       --gce-ratelimit=ga.Operations.Get,qps,10,100
+       --gce-ratelimit=alpha.Operations.Get,qps,10,100
+       --gce-ratelimit=beta.Operations.Get,qps,10,100
+       --gce-ratelimit=ga.BackendServices.Get,qps,1.8,1
+       --gce-ratelimit=ga.HealthChecks.Get,qps,1.8,1
+       --gce-ratelimit=alpha.HealthChecks.Get,qps,1.8,1
+       --gce-ratelimit=beta.NetworkEndpointGroups.Get,qps,1.8,1
+       --gce-ratelimit=beta.NetworkEndpointGroups.AttachNetworkEndpoints,qps,1.8,1
+       --gce-ratelimit=beta.NetworkEndpointGroups.DetachNetworkEndpoints,qps,1.8,1
+       --gce-ratelimit=beta.NetworkEndpointGroups.ListNetworkEndpoints,qps,1.8,1
+       --verbose --apiserver-host=http://localhost:8080
+       --default-backend-service=kube-system/default-http-backend
+       --sync-period=600s --running-in-cluster=false --use-real-cloud=true
+       --config-file-path=/etc/gce.conf --healthz-port=8086 1>>/var/log/glbc.log 2>&1
   volumes:
   - hostPath:
       path: /etc/gce.conf

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1132,6 +1132,11 @@ EOF
 ADDON_MANAGER_LEADER_ELECTION: $(yaml-quote ${ADDON_MANAGER_LEADER_ELECTION})
 EOF
     fi
+    if [ -n "${ENABLE_MANAGED_CERTIFICATE_CRD:-}" ]; then
+      cat >>$file <<EOF
+ENABLE_MANAGED_CERTIFICATE_CRD: $(yaml-quote ${ENABLE_MANAGED_CERTIFICATE_CRD})
+EOF
+    fi
 
   else
     # Node-only env vars.


### PR DESCRIPTION
/sig network

/kind feature

This PR updates version of GLBC controller to 1.4.0 and switches managed certificates alpha feature to on by default, and switches backend config feature to on.

```release-note
Update version of GLBC controller to 1.4.0. Switch managed certificates alpha feature to on by default. Switch backend config feature to on.
```
