### PR TITLE
Fix PortForwarder.GetPorts() returning wrong local ports

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -197,8 +197,9 @@ func (pf *PortForwarder) forward() error {
 	var err error
 
 	listenSuccess := false
-	for _, port := range pf.ports {
-		err = pf.listenOnPort(&port)
+	for i := range pf.ports {
+		port := &pf.ports[i]
+		err = pf.listenOnPort(port)
 		switch {
 		case err == nil:
 			listenSuccess = true


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

It fixes a bug where local ports are being incorrectly returned by PortForwarder when selected randomly from available ports.

**Which issue(s) this PR fixes**:

fixes #69052 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix local ports automatically chosen by portforward.PortForwarder not being returned by PortForwarder.GetPorts()
```