### PR TITLE
[e2e ingress] actually assign value to resp

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -1083,7 +1083,8 @@ func detectHttpVersionAndSchemeTest(f *framework.Framework, jig *ingress.Ingress
 	timeoutClient := &http.Client{Timeout: ingress.IngressReqTimeout}
 	resp := ""
 	err := wait.PollImmediate(framework.LoadBalancerPollInterval, framework.LoadBalancerPollTimeout, func() (bool, error) {
-		resp, err := framework.SimpleGET(timeoutClient, fmt.Sprintf("http://%s", address), "")
+		var err error
+		resp, err = framework.SimpleGET(timeoutClient, fmt.Sprintf("http://%s", address), "")
 		if err != nil {
 			framework.Logf("SimpleGET failed: %v", err)
 			return false, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
From https://github.com/kubernetes/kubernetes/issues/71521, during debugging, found that `resp` is never assigned the expected value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Special notes for your reviewer**:
cc @agau4779

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
