### PR TITLE
apimachinery: Add a strict YAML and JSON deserializer option

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/error.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/error.go
@@ -120,3 +120,77 @@ func IsMissingVersion(err error) bool {
 	_, ok := err.(*missingVersionErr)
 	return ok
 }
+
+// StrictDecoderError is a base error type that is returned by a strict Decoder such
+// as UniversalStrictDecoder.
+type StrictDecoderError struct {
+	message      string
+	gvk          schema.GroupVersionKind
+	originalData []byte
+}
+
+// UnknownFieldError is an error type that is returned in cases where the input
+// JSON or YAML contains unknown fields.
+// UnknownFieldError embeds StrictDecoderError.
+type UnknownFieldError struct {
+	StrictDecoderError
+}
+
+// DuplicateFieldError is an error type that is returned in cases where the input
+// JSON or YAML contains duplicate fields under the same parent field.
+// DuplicateFieldError embeds StrictDecoderError.
+type DuplicateFieldError struct {
+	StrictDecoderError
+}
+
+// NewStrictDecoderError creates a new NewStrictDecoderError object
+func NewStrictDecoderError(message string, gvk schema.GroupVersionKind, originalData []byte) *StrictDecoderError {
+	return &StrictDecoderError{
+		message:      message,
+		gvk:          gvk,
+		originalData: originalData,
+	}
+}
+
+func (e *StrictDecoderError) Error() string {
+	return fmt.Sprintf("strict decoder error for %#v: %s", e.gvk, e.message)
+}
+
+// GVK returns the GVK that was extacted when Decoding using a strict Decoder.
+func (e *StrictDecoderError) GVK() schema.GroupVersionKind {
+	return e.gvk
+}
+
+// OriginalData returns the original byte slice input that was passed to a strict Decoder.
+func (e *StrictDecoderError) OriginalData() []byte {
+	return e.originalData
+}
+
+// IsStrictDecoderError returns true if the error is a result of a strict Decoder.
+func IsStrictDecoderError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*StrictDecoderError)
+	return ok
+}
+
+// IsUnknownFieldError returns true if the error is a result of a strict Decoder failing
+// due to a unknown field.
+func IsUnknownFieldError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*UnknownFieldError)
+	return ok
+}
+
+// IsDuplicateFieldError returns true if the error is a result of a strict Decoder failing
+// due to a duplicate field.
+func IsDuplicateFieldError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*DuplicateFieldError)
+	return ok
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
pkg/runtime: implement a strict YAML and JSON deserializer

Add a new universal decoder and universal deserializer.
This enables checks for unknown and duplicate fields in input YAML
and JSON data.

Example usage:
```
runtime.DecodeInto(MyCodecFactory.UniversalStrictDecoder(), content, into)
MyCodecFactory.UniversalStrictDeserializer().Decode(content, gvk, into)
```

The same CodecFactory can also return the non-strict variants.

A custom json-iterator API object is used to check for unknown fields.
For duplicate fields the sigs.k8s.io/yaml.YAMLToJSONStrict() function
is used.

Also add:
- Unit tests in json_test.go.
- New error types StrictDecoderError, DuplicateFieldError,
UnknownFieldError.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref: https://github.com/kubernetes/community/pull/2977
?

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
apimachinery: Add a strict YAML and JSON deserializer option
```

/assign @liggitt @luxas 
cc @BenTheElder 
/priority important-longterm
/sig api-machinery
