### PR TITLE
Surface help for insecure ports to explain how to disable

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go
@@ -85,11 +85,13 @@ func (s *DeprecatedInsecureServingOptions) AddUnqualifiedFlags(fs *pflag.FlagSet
 	}
 
 	fs.IPVar(&s.BindAddress, "address", s.BindAddress,
-		"DEPRECATED: see --bind-address instead.")
+		"The IP address on which to serve the insecure --port (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces).")
 	fs.MarkDeprecated("address", "see --bind-address instead.")
+	fs.Lookup("address").Hidden = false
 
-	fs.IntVar(&s.BindPort, "port", s.BindPort, "DEPRECATED: see --secure-port instead.")
+	fs.IntVar(&s.BindPort, "port", s.BindPort, "The port on which to serve unsecured, unauthenticated access. Set to 0 to disable.")
 	fs.MarkDeprecated("port", "see --secure-port instead.")
+	fs.Lookup("port").Hidden = false
 }
 
 // ApplyTo adds DeprecatedInsecureServingOptions to the insecureserverinfo amd kube-controller manager configuration.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The existence of the insecure port flag was incorrectly hidden because it was marked deprecated.

Until the behavior is removed, we must show the flag so users know the default value and how to disable insecure serving.

Will pick this for 1.13.1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #71600

**Does this PR introduce a user-facing change?**:
```release-note
kube-controller-manager: fixed issue display help for the deprecated insecure --port flag
```

/cc @sttts 