### PR TITLE
[1.13.1] Automated cherry pick of #71601: Surface help for insecure ports to explain how to disable

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go
@@ -85,11 +85,13 @@ func (s *DeprecatedInsecureServingOptions) AddUnqualifiedFlags(fs *pflag.FlagSet
 	}
 
 	fs.IPVar(&s.BindAddress, "address", s.BindAddress,
-		"DEPRECATED: see --bind-address instead.")
+		"The IP address on which to serve the insecure --port (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces).")
 	fs.MarkDeprecated("address", "see --bind-address instead.")
+	fs.Lookup("address").Hidden = false
 
-	fs.IntVar(&s.BindPort, "port", s.BindPort, "DEPRECATED: see --secure-port instead.")
+	fs.IntVar(&s.BindPort, "port", s.BindPort, "The port on which to serve unsecured, unauthenticated access. Set to 0 to disable.")
 	fs.MarkDeprecated("port", "see --secure-port instead.")
+	fs.Lookup("port").Hidden = false
 }
 
 // ApplyTo adds DeprecatedInsecureServingOptions to the insecureserverinfo amd kube-controller manager configuration.


### PR DESCRIPTION
Cherry pick of #71601 on release-1.13.

#71601: Surface help for insecure ports to explain how to disable