### PR TITLE
Volume exec file test: added NodeSelector to pod

### DIFF
--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -181,11 +181,16 @@ func testVolumes(input *volumesTestInput) {
 		f := input.f
 		skipExecTest(input.resource.driver)
 
-		testScriptInPod(f, input.resource.volType, input.resource.volSource)
+		testScriptInPod(f, input.resource.volType, input.resource.volSource, input.config.NodeSelector)
 	})
 }
 
-func testScriptInPod(f *framework.Framework, volumeType string, source *v1.VolumeSource) {
+func testScriptInPod(
+	f *framework.Framework,
+	volumeType string,
+	source *v1.VolumeSource,
+	nodeSelector map[string]string) {
+
 	const (
 		volPath = "/vol1"
 		volName = "vol1"
@@ -221,6 +226,7 @@ func testScriptInPod(f *framework.Framework, volumeType string, source *v1.Volum
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever,
+			NodeSelector:  nodeSelector,
 		},
 	}
 	By(fmt.Sprintf("Creating pod %s", pod.Name))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**: The test pod now uses a NodeSelector to take into account the zone of the provisioned PD.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #71624

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

/sig storage
/assign @msau42 