### PR TITLE
Bump the version of kubernetes-cni to 0.6.0

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -92,7 +92,7 @@ grep ^STABLE_BUILD_SCM_REVISION bazel-out/stable-status.txt \
 genrule(
     name = "cni_package_version",
     outs = ["cni_version"],
-    cmd = "echo 0.5.1 >$@",
+    cmd = "echo 0.6.0 >$@",
 )
 
 release_filegroup(


### PR DESCRIPTION
This will resolve the kubernetes-anywhere e2e test.
In commit: https://github.com/kubernetes/kubernetes/pull/71540
I bumped the required version of kubernetes-cni to 0.6.0 but didn't
start packaging it. This resolve that.

Signed-off-by: Duffie Cooley <dcooley@heptio.com>

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
This bumps the version of kubernetes-cni that we package to 0.6.0

**Special notes for your reviewer**:
This is related to: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-master/1018/artifacts/e2e-1018-1ad8f-master/serial-1.log


**Does this PR introduce a user-facing change?**:
```release-note
Bumps version of kubernetes-cni to 0.6.0
```