### PR TITLE
Partial cherry-pick of #46517 to fix flaky e2e skew tests

### DIFF
--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -49,7 +49,7 @@ const (
 
 // TODO support other ports besides 80
 var (
-	portForwardRegexp = regexp.MustCompile("Forwarding from 127.0.0.1:([0-9]+) -> 80")
+	portForwardRegexp = regexp.MustCompile("Forwarding from (127.0.0.1|\\[::1\\]):([0-9]+) -> 80")
 )
 
 func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string, bindAddress string) *v1.Pod {
@@ -178,11 +178,11 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 	}
 	portForwardOutput := string(buf[:n])
 	match := portForwardRegexp.FindStringSubmatch(portForwardOutput)
-	if len(match) != 2 {
+	if len(match) != 3 {
 		framework.Failf("Failed to parse kubectl port-forward output: %s", portForwardOutput)
 	}
 
-	listenPort, err := strconv.Atoi(match[1])
+	listenPort, err := strconv.Atoi(match[2])
 	if err != nil {
 		framework.Failf("Error converting %s to an int: %v", match[1], err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:

Partial cherry pick of #46517 on `release-1.12`.

Fixes flaky skew tests for kubectl port-forward.

**Special notes for your reviewer**:

The [original PR](https://github.com/kubernetes/kubernetes/pull/46517) contains required test changes and new functionality, so it can't be cherry-picked automatically in a whole.

But would be great to have this merged because this type of flakiness in skew tests happens very often. Some recent examples:

* [Example 1](https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew/12332)
* [Example 2](https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew/12334)
* [Example 3](https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew/12337)
* [Example 4](https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew/12359)
* [Example 5](https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew/12361)

https://github.com/kubernetes/kubectl/issues/558 contains more details (start from this comment: https://github.com/kubernetes/kubectl/issues/558#issuecomment-443346341)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cli