### PR TITLE
Fix the way kubectl apply handles boolean annotations.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -20,6 +20,7 @@ import (
 	gojson "encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,6 +166,27 @@ func NestedStringMap(obj map[string]interface{}, fields ...string) (map[string]s
 	for k, v := range m {
 		if str, ok := v.(string); ok {
 			strMap[k] = str
+		} else {
+			return nil, false, fmt.Errorf("%v accessor error: contains non-string key in the map: %v is of the type %T, expected string", jsonPath(fields), v, v)
+		}
+	}
+	return strMap, true, nil
+}
+
+// NestedBoolStringMap returns a copy of map[string]string value of a nested field.
+// Converts a boolean value to a string value.
+// Returns false if value is not found and an error if not a map[string]interface{} or contains non-string values in the map.
+func NestedBoolStringMap(obj map[string]interface{}, fields ...string) (map[string]string, bool, error) {
+	m, found, err := nestedMapNoCopy(obj, fields...)
+	if !found || err != nil {
+		return nil, found, err
+	}
+	strMap := make(map[string]string, len(m))
+	for k, v := range m {
+		if str, ok := v.(string); ok {
+			strMap[k] = str
+		} else if str, ok := v.(bool); ok {
+			strMap[k] = strconv.FormatBool(str)
 		} else {
 			return nil, false, fmt.Errorf("%v accessor error: contains non-string key in the map: %v is of the type %T, expected string", jsonPath(fields), v, v)
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -375,7 +375,7 @@ func (u *Unstructured) SetLabels(labels map[string]string) {
 }
 
 func (u *Unstructured) GetAnnotations() map[string]string {
-	m, _, _ := NestedStringMap(u.Object, "metadata", "annotations")
+	m, _, _ := NestedBoolStringMap(u.Object, "metadata", "annotations")
 	return m
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR adds a new helper called `NestedBoolStringMap` which instead of failing when a value is not a string, checks for values that are boolean then casts them to strings.

**Which issue(s) this PR fixes**:
Fixes #59113

**Special notes for your reviewer**:

/sig cli
/sig api-machinery
/assign @juanvallejo @soltysh 

**Does this PR introduce a user-facing change?**:
Create a test ConfigMap file `bool-annots.yaml` with bool annotations
```release-note
apiVersion: v1
kind: ConfigMap
metadata:
  name: test
  annotations:
    bool: true
data: {}
```

Run: `kubectl apply -f ./bool-annots.yaml`
Verify: `kubectl get configmap test -o yaml`

Creates:
```
apiVersion: v1
kind: ConfigMap
metadata:
  annotations:
    bool: "true"
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{},"kind":"ConfigMap","metadata":{"annotations":{"bool":"true"},"name":"test","namespace":"default"}}
  creationTimestamp: "2018-12-02T20:50:46Z"
  name: test
  namespace: default
  resourceVersion: "973"
  selfLink: /api/v1/namespaces/default/configmaps/test
  uid: f1213344-f673-11e8-8b28-080027f658f7
```

