### PR TITLE
No timeout when Kubelet Calling cni plugin

### DIFF
--- a/pkg/kubelet/dockershim/network/cni/cni_test.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_test.go
@@ -228,8 +228,8 @@ func TestCNIPlugin(t *testing.T) {
 	cniPlugin.execer = fexec
 	cniPlugin.loNetwork.CNIConfig = mockLoCNI
 
-	mockLoCNI.On("AddNetworkList", mock.AnythingOfType("*context.emptyCtx"), cniPlugin.loNetwork.NetworkConfig, mock.AnythingOfType("*libcni.RuntimeConf")).Return(&types020.Result{IP4: &types020.IPConfig{IP: net.IPNet{IP: []byte{127, 0, 0, 1}}}}, nil)
-	mockLoCNI.On("DelNetworkList", mock.AnythingOfType("*context.emptyCtx"), cniPlugin.loNetwork.NetworkConfig, mock.AnythingOfType("*libcni.RuntimeConf")).Return(nil)
+	mockLoCNI.On("AddNetworkList", mock.AnythingOfType("*context.timerCtx"), cniPlugin.loNetwork.NetworkConfig, mock.AnythingOfType("*libcni.RuntimeConf")).Return(&types020.Result{IP4: &types020.IPConfig{IP: net.IPNet{IP: []byte{127, 0, 0, 1}}}}, nil)
+	mockLoCNI.On("DelNetworkList", mock.AnythingOfType("*context.timerCtx"), cniPlugin.loNetwork.NetworkConfig, mock.AnythingOfType("*libcni.RuntimeConf")).Return(nil)
 
 	// Check that status returns an error
 	if err := cniPlugin.Status(); err == nil {

--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_linux_test.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_linux_test.go
@@ -172,7 +172,7 @@ func TestTeardownCallsShaper(t *testing.T) {
 	kubenet.bandwidthShaper = fshaper
 	kubenet.hostportSyncer = hostporttest.NewFakeHostportSyncer()
 
-	mockcni.On("DelNetwork", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*libcni.NetworkConfig"), mock.AnythingOfType("*libcni.RuntimeConf")).Return(nil)
+	mockcni.On("DelNetwork", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*libcni.NetworkConfig"), mock.AnythingOfType("*libcni.RuntimeConf")).Return(nil)
 
 	details := make(map[string]interface{})
 	details[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR] = "10.0.0.1/24"
@@ -301,7 +301,7 @@ func TestTearDownWithoutRuntime(t *testing.T) {
 		existingContainerID := kubecontainer.BuildContainerID("docker", "123")
 		kubenet.podIPs[existingContainerID] = utilsets.NewString(tc.ip)
 
-		mockcni.On("DelNetwork", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*libcni.NetworkConfig"), mock.AnythingOfType("*libcni.RuntimeConf")).Return(nil)
+		mockcni.On("DelNetwork", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*libcni.NetworkConfig"), mock.AnythingOfType("*libcni.RuntimeConf")).Return(nil)
 
 		if err := kubenet.TearDownPod("namespace", "name", existingContainerID); err != nil {
 			t.Fatalf("Unexpected error in TearDownPod: %v", err)

--- a/pkg/kubelet/dockershim/network/network.go
+++ b/pkg/kubelet/dockershim/network/network.go
@@ -19,6 +19,9 @@ package network
 // TODO: Consider making this value configurable.
 const DefaultInterfaceName = "eth0"
 
+// CNITimeoutSec is set to be slightly less than 240sec/4mins, which is the default remote runtime request timeout.
+const CNITimeoutSec = 220
+
 // UseDefaultMTU is a marker value that indicates the plugin should determine its own MTU
 // It is the zero value, so a non-initialized value will mean "UseDefault"
 const UseDefaultMTU = 0


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65743

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
The docker container runtime now enforces a 220 second timeout on container network operations.
```