### PR TITLE
e2e/framework: absolute test file paths

### DIFF
--- a/test/e2e/framework/testfiles/testfiles.go
+++ b/test/e2e/framework/testfiles/testfiles.go
@@ -129,9 +129,16 @@ type RootFileSource struct {
 }
 
 // ReadTestFile looks for the file relative to the configured
-// root directory.
+// root directory. If the path is already absolute, for example
+// in a test that has its own method of determining where
+// files are, then the path will be used directly.
 func (r RootFileSource) ReadTestFile(filePath string) ([]byte, error) {
-	fullPath := filepath.Join(r.Root, filePath)
+	var fullPath string
+	if path.IsAbs(filePath) {
+		fullPath = filePath
+	} else {
+		fullPath = filepath.Join(r.Root, filePath)
+	}
 	data, err := ioutil.ReadFile(fullPath)
 	if os.IsNotExist(err) {
 		// Not an error (yet), some other provider may have the file.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Tests might want to use there own options for specifying a file path,
while still using the abstract file access API. For example,
framework.CreateFromManifests might be used to create a mixture of
files under the repo root and from elsewhere. To support this,
absolute paths can now be given to the testfiles package and they will
be read directly.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

/sig testing