### PR TITLE
support bazel 0.20.0+ by using starlark http rules and updating rules_go

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -1,3 +1,4 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("//build:workspace_mirror.bzl", "mirror")
 load("//build:workspace.bzl", "CRI_TOOLS_VERSION")
 
@@ -23,9 +24,9 @@ http_archive(
 
 ETCD_VERSION = "3.2.24"
 
-new_http_archive(
+http_archive(
     name = "com_coreos_etcd",
-    build_file = "third_party/etcd.BUILD",
+    build_file = "@//third_party:etcd.BUILD",
     sha256 = "947849dbcfa13927c81236fb76a7c01d587bbab42ab1e807184cd91b026ebed7",
     strip_prefix = "etcd-v%s-linux-amd64" % ETCD_VERSION,
     urls = mirror("https://github.com/coreos/etcd/releases/download/v%s/etcd-v%s-linux-amd64.tar.gz" % (ETCD_VERSION, ETCD_VERSION)),
@@ -55,12 +56,14 @@ docker_repositories()
 
 http_file(
     name = "kubernetes_cni",
+    downloaded_file_path = "kubernetes_cni.tgz",
     sha256 = "f04339a21b8edf76d415e7f17b620e63b8f37a76b2f706671587ab6464411f2d",
     urls = mirror("https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz"),
 )
 
 http_file(
     name = "cri_tools",
+    downloaded_file_path = "cri_tools.tgz",
     sha256 = "e7d913bcce40bf54e37ab1d4b75013c823d0551e6bc088b217bc1893207b4844",
     urls = mirror("https://github.com/kubernetes-incubator/cri-tools/releases/download/v%s/crictl-v%s-linux-amd64.tar.gz" % (CRI_TOOLS_VERSION, CRI_TOOLS_VERSION)),
 )

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -4,8 +4,8 @@ load("//build:workspace.bzl", "CRI_TOOLS_VERSION")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "97cf62bdef33519412167fd1e4b0810a318a7c234f5f8dc4f53e2da86241c492",
-    urls = mirror("https://github.com/bazelbuild/rules_go/releases/download/0.15.3/rules_go-0.15.3.tar.gz"),
+    sha256 = "ca79fed5b24dcc0696e1651ecdd916f7a11111283ba46ea07633a53d8e1f5199",
+    urls = mirror("https://github.com/bazelbuild/rules_go/releases/download/0.15.8/rules_go-0.15.8.tar.gz"),
 )
 
 http_archive(


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**: bazel 0.20.0 has some backwards-incompatible changes. Since we'll be supporting kubernetes 1.12 for a while, it'd be good if we could support recent versions of bazel (though we can keep CI on an old version).

I've cherry-picked in #70385, along with adding another commit which updates `rules_go` to the latest patch release.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

/sig release testing
/assign @BenTheElder @cblecker @fejta 