### PR TITLE
Update a comment in cadvisor boot function

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -100,7 +100,6 @@ func containerLabels(c *cadvisorapi.ContainerInfo) map[string]string {
 	return set
 }
 
-// New creates a cAdvisor and exports its API on the specified port if port > 0.
 func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, usingLegacyStats bool) (Interface, error) {
 	sysFs := sysfs.NewRealSysFs()
 


### PR DESCRIPTION

/kind cleanup
Update a comment in cadvisor boot function.
The cadvisor port has been totally removed by: https://github.com/kubernetes/kubernetes/pull/65707


```release-note
NONE
```
