### PR TITLE
make GetStorageAccesskey func public

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_blobDiskController.go
+++ b/pkg/cloudprovider/providers/azure/azure_blobDiskController.go
@@ -108,7 +108,7 @@ func (c *BlobDiskController) DeleteVolume(diskURI string) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse vhd URI %v", err)
 	}
-	key, err := c.common.cloud.getStorageAccesskey(accountName, c.common.resourceGroup)
+	key, err := c.common.cloud.GetStorageAccesskey(accountName, c.common.resourceGroup)
 	if err != nil {
 		return fmt.Errorf("no key for storage account %s, err %v", accountName, err)
 	}

--- a/pkg/cloudprovider/providers/azure/azure_storageaccount.go
+++ b/pkg/cloudprovider/providers/azure/azure_storageaccount.go
@@ -64,8 +64,8 @@ func (az *Cloud) getStorageAccounts(matchingAccountType, matchingAccountKind, re
 	return accounts, nil
 }
 
-// getStorageAccesskey gets the storage account access key
-func (az *Cloud) getStorageAccesskey(account, resourceGroup string) (string, error) {
+// GetStorageAccesskey gets the storage account access key
+func (az *Cloud) GetStorageAccesskey(account, resourceGroup string) (string, error) {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
@@ -137,7 +137,7 @@ func (az *Cloud) ensureStorageAccount(accountName, accountType, accountKind, res
 	}
 
 	// find the access key with this account
-	accountKey, err := az.getStorageAccesskey(accountName, resourceGroup)
+	accountKey, err := az.GetStorageAccesskey(accountName, resourceGroup)
 	if err != nil {
 		return "", "", fmt.Errorf("could not get storage key for storage account %s: %v", accountName, err)
 	}

--- a/pkg/cloudprovider/providers/azure/azure_storageaccount_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_storageaccount_test.go
@@ -64,7 +64,7 @@ func TestGetStorageAccessKeys(t *testing.T) {
 		expectedKey := test.expectedKey
 		fake.Keys = test.results
 		fake.Err = test.err
-		key, err := cloud.getStorageAccesskey("acct", "rg")
+		key, err := cloud.GetStorageAccesskey("acct", "rg")
 		if test.expectErr && err == nil {
 			t.Errorf("Unexpected non-error")
 			continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
make GetStorageAccesskey public as a lib, in the future, azure cloud provider will be removed out of k8s tree, while it will serve as a common lib for azure drivers, this PR make GetStorageAccesskey public for azure file & blobfuse CSI drivers use

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
azure file & blobfuse CSI drivers need to invoke `GetStorageAccesskey` func which is internal in azure cloud provider lib:
https://github.com/andyzhangx/azurefile-csi-driver/blob/master/pkg/azurefile/azure.go#L59-L81
I have to copy the code now. Make `GetStorageAccesskey` func public now.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```
none
```

/sig azure
/assign @feiskyer 