### PR TITLE
change default leader election resource lock from endpoints to configmap

### DIFF
--- a/pkg/client/leaderelectionconfig/config.go
+++ b/pkg/client/leaderelectionconfig/config.go
@@ -49,5 +49,5 @@ func BindFlags(l *apiserverconfig.LeaderElectionConfiguration, fs *pflag.FlagSet
 		"of a leadership. This is only applicable if leader election is enabled.")
 	fs.StringVar(&l.ResourceLock, "leader-elect-resource-lock", l.ResourceLock, ""+
 		"The type of resource object that is used for locking during "+
-		"leader election. Supported options are `endpoints` (default) and `configmaps`.")
+		"leader election. Supported options are `configmaps` (default) and `endpoints`.")
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1alpha1/defaults.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1alpha1/defaults.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -44,7 +45,7 @@ func RecommendedDefaultLeaderElectionConfiguration(obj *LeaderElectionConfigurat
 		obj.RetryPeriod = metav1.Duration{Duration: 2 * time.Second}
 	}
 	if obj.ResourceLock == "" {
-		obj.ResourceLock = EndpointsResourceLock
+		obj.ResourceLock = resourcelock.ConfigMapsResourceLock
 	}
 	if obj.LeaderElect == nil {
 		obj.LeaderElect = utilpointer.BoolPtr(true)

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1alpha1/types.go
@@ -20,8 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const EndpointsResourceLock = "endpoints"
-
 // LeaderElectionConfiguration defines the configuration of leader election
 // clients for components that can run with leader election enabled.
 type LeaderElectionConfiguration struct {


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
As mentioned in #42666,  we should deprecate endpoints locking and use configmap by default 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/cc @timothysc  PTAL, any advise?