### PR TITLE
Automated cherry pick of #71713, #71857: Plumb token and token file through rest.Config

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/authentication.go
@@ -177,6 +177,7 @@ func restConfigFromKubeconfig(configAuthInfo *clientcmdapi.AuthInfo) (*rest.Conf
 			return nil, err
 		}
 		config.BearerToken = string(tokenBytes)
+		config.BearerTokenFile = configAuthInfo.TokenFile
 	}
 	if len(configAuthInfo.Impersonate) > 0 {
 		config.Impersonate = rest.ImpersonationConfig{

--- a/staging/src/k8s.io/client-go/rest/BUILD
+++ b/staging/src/k8s.io/client-go/rest/BUILD
@@ -13,7 +13,6 @@ go_test(
         "config_test.go",
         "plugin_test.go",
         "request_test.go",
-        "token_source_test.go",
         "url_utils_test.go",
         "urlbackoff_test.go",
     ],
@@ -41,7 +40,6 @@ go_test(
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
-        "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )
@@ -53,7 +51,6 @@ go_library(
         "config.go",
         "plugin.go",
         "request.go",
-        "token_source.go",
         "transport.go",
         "url_utils.go",
         "urlbackoff.go",
@@ -80,7 +77,6 @@ go_library(
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//vendor/golang.org/x/net/http2:go_default_library",
-        "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -264,6 +264,7 @@ func TestAnonymousConfig(t *testing.T) {
 		// is added to Config, update AnonymousClientConfig to preserve the field otherwise.
 		expected.Impersonate = ImpersonationConfig{}
 		expected.BearerToken = ""
+		expected.BearerTokenFile = ""
 		expected.Username = ""
 		expected.Password = ""
 		expected.AuthProvider = nil

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -229,11 +229,12 @@ func (config *DirectClientConfig) getUserIdentificationPartialConfig(configAuthI
 	if len(configAuthInfo.Token) > 0 {
 		mergedConfig.BearerToken = configAuthInfo.Token
 	} else if len(configAuthInfo.TokenFile) > 0 {
-		ts := restclient.NewCachedFileTokenSource(configAuthInfo.TokenFile)
-		if _, err := ts.Token(); err != nil {
+		tokenBytes, err := ioutil.ReadFile(configAuthInfo.TokenFile)
+		if err != nil {
 			return nil, err
 		}
-		mergedConfig.WrapTransport = restclient.TokenSourceWrapTransport(ts)
+		mergedConfig.BearerToken = string(tokenBytes)
+		mergedConfig.BearerTokenFile = configAuthInfo.TokenFile
 	}
 	if len(configAuthInfo.Impersonate) > 0 {
 		mergedConfig.Impersonate = restclient.ImpersonationConfig{

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -18,7 +18,6 @@ package clientcmd
 
 import (
 	"io/ioutil"
-	"net/http"
 	"os"
 	"reflect"
 	"strings"
@@ -334,19 +333,7 @@ func TestBasicTokenFile(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	var out *http.Request
-	clientConfig.WrapTransport(fakeTransport(func(req *http.Request) (*http.Response, error) {
-		out = req
-		return &http.Response{}, nil
-	})).RoundTrip(&http.Request{})
-
-	matchStringArg(token, strings.TrimPrefix(out.Header.Get("Authorization"), "Bearer "), t)
-}
-
-type fakeTransport func(*http.Request) (*http.Response, error)
-
-func (ft fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	return ft(req)
+	matchStringArg(token, clientConfig.BearerToken, t)
 }
 
 func TestPrecedenceTokenFile(t *testing.T) {

--- a/staging/src/k8s.io/client-go/transport/BUILD
+++ b/staging/src/k8s.io/client-go/transport/BUILD
@@ -11,9 +11,11 @@ go_test(
     srcs = [
         "cache_test.go",
         "round_trippers_test.go",
+        "token_source_test.go",
         "transport_test.go",
     ],
     embed = [":go_default_library"],
+    deps = ["//vendor/golang.org/x/oauth2:go_default_library"],
 )
 
 go_library(
@@ -22,12 +24,14 @@ go_library(
         "cache.go",
         "config.go",
         "round_trippers.go",
+        "token_source.go",
         "transport.go",
     ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/transport",
     importpath = "k8s.io/client-go/transport",
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -39,6 +39,11 @@ type Config struct {
 	// Bearer token for authentication
 	BearerToken string
 
+	// Path to a file containing a BearerToken.
+	// If set, the contents are periodically read.
+	// The last successfully read value takes precedence over BearerToken.
+	BearerTokenFile string
+
 	// Impersonate is the config that this Config will impersonate using
 	Impersonate ImpersonationConfig
 
@@ -80,7 +85,7 @@ func (c *Config) HasBasicAuth() bool {
 
 // HasTokenAuth returns whether the configuration has token authentication or not.
 func (c *Config) HasTokenAuth() bool {
-	return len(c.BearerToken) != 0
+	return len(c.BearerToken) != 0 || len(c.BearerTokenFile) != 0
 }
 
 // HasCertAuth returns whether the configuration has certificate authentication or not.

--- a/staging/src/k8s.io/client-go/transport/round_trippers.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/oauth2"
 	"k8s.io/klog"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
@@ -44,7 +45,11 @@ func HTTPWrappersForConfig(config *Config, rt http.RoundTripper) (http.RoundTrip
 	case config.HasBasicAuth() && config.HasTokenAuth():
 		return nil, fmt.Errorf("username/password or bearer token may be set, but not both")
 	case config.HasTokenAuth():
-		rt = NewBearerAuthRoundTripper(config.BearerToken, rt)
+		var err error
+		rt, err = NewBearerAuthWithRefreshRoundTripper(config.BearerToken, config.BearerTokenFile, rt)
+		if err != nil {
+			return nil, err
+		}
 	case config.HasBasicAuth():
 		rt = NewBasicAuthRoundTripper(config.Username, config.Password, rt)
 	}
@@ -265,13 +270,35 @@ func (rt *impersonatingRoundTripper) WrappedRoundTripper() http.RoundTripper { r
 
 type bearerAuthRoundTripper struct {
 	bearer string
+	source oauth2.TokenSource
 	rt     http.RoundTripper
 }
 
 // NewBearerAuthRoundTripper adds the provided bearer token to a request
 // unless the authorization header has already been set.
 func NewBearerAuthRoundTripper(bearer string, rt http.RoundTripper) http.RoundTripper {
-	return &bearerAuthRoundTripper{bearer, rt}
+	return &bearerAuthRoundTripper{bearer, nil, rt}
+}
+
+// NewBearerAuthRoundTripper adds the provided bearer token to a request
+// unless the authorization header has already been set.
+// If tokenFile is non-empty, it is periodically read,
+// and the last successfully read content is used as the bearer token.
+// If tokenFile is non-empty and bearer is empty, the tokenFile is read
+// immediately to populate the initial bearer token.
+func NewBearerAuthWithRefreshRoundTripper(bearer string, tokenFile string, rt http.RoundTripper) (http.RoundTripper, error) {
+	if len(tokenFile) == 0 {
+		return &bearerAuthRoundTripper{bearer, nil, rt}, nil
+	}
+	source := NewCachedFileTokenSource(tokenFile)
+	if len(bearer) == 0 {
+		token, err := source.Token()
+		if err != nil {
+			return nil, err
+		}
+		bearer = token.AccessToken
+	}
+	return &bearerAuthRoundTripper{bearer, source, rt}, nil
 }
 
 func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -280,7 +307,13 @@ func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 	}
 
 	req = utilnet.CloneRequest(req)
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rt.bearer))
+	token := rt.bearer
+	if rt.source != nil {
+		if refreshedToken, err := rt.source.Token(); err == nil {
+			token = refreshedToken.AccessToken
+		}
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	return rt.rt.RoundTrip(req)
 }
 

--- a/staging/src/k8s.io/client-go/transport/token_source.go
+++ b/staging/src/k8s.io/client-go/transport/token_source.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rest
+package transport
 
 import (
 	"fmt"

--- a/staging/src/k8s.io/client-go/transport/token_source_test.go
+++ b/staging/src/k8s.io/client-go/transport/token_source_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rest
+package transport
 
 import (
 	"fmt"

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -315,7 +315,8 @@ func createKubeConfig(clientCfg *restclient.Config) *clientcmdapi.Config {
 	config := clientcmdapi.NewConfig()
 
 	credentials := clientcmdapi.NewAuthInfo()
-	credentials.TokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	credentials.Token = clientCfg.BearerToken
+	credentials.TokenFile = clientCfg.BearerTokenFile
 	credentials.ClientCertificate = clientCfg.TLSClientConfig.CertFile
 	if len(credentials.ClientCertificate) == 0 {
 		credentials.ClientCertificateData = clientCfg.TLSClientConfig.CertData


### PR DESCRIPTION
Cherry pick of #71713, #71857 on release-1.13.

#71713: Plumb token and token file through rest.Config

```release-note
client-go: restores behavior of populating the BearerToken field in rest.Config objects constructed from kubeconfig files containing tokenFile config, or from in-cluster configuration. An additional BearerTokenFile field is now populated to enable constructed clients to periodically refresh tokens.
```
