### PR TITLE
pkg/kubelet/cloudresource: fallback to old addresses if sync loop fails

### DIFF
--- a/pkg/kubelet/cloudresource/BUILD
+++ b/pkg/kubelet/cloudresource/BUILD
@@ -21,6 +21,7 @@ go_test(
     deps = [
         "//pkg/cloudprovider/providers/fake:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This does a bit more than the title.

* remove unnecessary sleeping in syncmanager
* change syncmanager to fallback to old addresses in the case that a single sync loop fails
* a bit of cleanup

/kind bug
/king sig-node

```release-note
NONE
```
