### PR TITLE
Device plugins: fix e2e test

### DIFF
--- a/test/e2e_node/device_plugin.go
+++ b/test/e2e_node/device_plugin.go
@@ -57,6 +57,7 @@ var _ = framework.KubeDescribe("Device Plugin [Feature:DevicePluginProbe][NodeFe
 })
 
 func testDevicePlugin(f *framework.Framework, enablePluginWatcher bool, pluginSockDir string) {
+	pluginSockDir = filepath.Join(pluginSockDir) + "/"
 	Context("DevicePlugin", func() {
 		By("Enabling support for Kubelet Plugins Watcher")
 		tempSetCurrentKubeletConfig(f, func(initialConfig *kubeletconfig.KubeletConfiguration) {


### PR DESCRIPTION


**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
 /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
[device plugin e2e test is failing](https://k8s-testgrid.appspot.com/sig-node-kubelet#node-kubelet-serial) because plugin socket path has a typo.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
None
```
/cc @vishh @jiayingz @RenaudWasTaken 