### PR TITLE
make all transports support http and http2

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -57,7 +57,7 @@ func createAggregatorConfig(
 	commandOptions *options.ServerRunOptions,
 	externalInformers kubeexternalinformers.SharedInformerFactory,
 	serviceResolver aggregatorapiserver.ServiceResolver,
-	proxyTransport *http.Transport,
+	proxyTransport http.RoundTripper,
 	pluginInitializers []admission.PluginInitializer,
 ) (*aggregatorapiserver.Config, error) {
 	// make a shallow copy to let us twiddle a few things

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -222,7 +222,7 @@ func CreateKubeAPIServer(kubeAPIServerConfig *master.Config, delegateAPIServer g
 }
 
 // CreateNodeDialer creates the dialer infrastructure to connect to the nodes.
-func CreateNodeDialer(s completedServerRunOptions) (tunneler.Tunneler, *http.Transport, error) {
+func CreateNodeDialer(s completedServerRunOptions) (tunneler.Tunneler, http.RoundTripper, error) {
 	// Setup nodeTunneler if needed
 	var nodeTunneler tunneler.Tunneler
 	var proxyDialerFn utilnet.DialFunc
@@ -270,7 +270,7 @@ func CreateNodeDialer(s completedServerRunOptions) (tunneler.Tunneler, *http.Tra
 func CreateKubeAPIServerConfig(
 	s completedServerRunOptions,
 	nodeTunneler tunneler.Tunneler,
-	proxyTransport *http.Transport,
+	proxyTransport http.RoundTripper,
 ) (
 	config *master.Config,
 	insecureServingInfo *genericapiserver.DeprecatedInsecureServingInfo,
@@ -368,7 +368,7 @@ func CreateKubeAPIServerConfig(
 // BuildGenericConfig takes the master server options and produces the genericapiserver.Config associated with it
 func buildGenericConfig(
 	s *options.ServerRunOptions,
-	proxyTransport *http.Transport,
+	proxyTransport http.RoundTripper,
 ) (
 	genericConfig *genericapiserver.Config,
 	versionedInformers clientgoinformers.SharedInformerFactory,

--- a/cmd/kubeadm/app/discovery/https/https.go
+++ b/cmd/kubeadm/app/discovery/https/https.go
@@ -30,7 +30,7 @@ import (
 // securely to the API Server using the provided CA cert and
 // optionally refreshes the cluster-info information from the cluster-info ConfigMap
 func RetrieveValidatedConfigInfo(httpsURL, clustername string) (*clientcmdapi.Config, error) {
-	client := &http.Client{Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
+	client := &http.Client{Transport: netutil.SetTransportDefaults(&http.Transport{})}
 	response, err := client.Get(httpsURL)
 	if err != nil {
 		return nil, err

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -435,7 +435,7 @@ func (hst HTTPProxyCheck) Check() (warnings, errorList []error) {
 		return nil, []error{err}
 	}
 
-	proxy, err := netutil.SetOldTransportDefaults(&http.Transport{}).Proxy(req)
+	proxy, err := netutil.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)(req)
 	if err != nil {
 		return nil, []error{err}
 	}
@@ -490,7 +490,7 @@ func (subnet HTTPProxyCIDRCheck) Check() (warnings, errorList []error) {
 	}
 
 	// Utilize same transport defaults as it will be used by API server
-	proxy, err := netutil.SetOldTransportDefaults(&http.Transport{}).Proxy(req)
+	proxy, err := netutil.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)(req)
 	if err != nil {
 		return nil, []error{err}
 	}
@@ -773,7 +773,7 @@ func (evc ExternalEtcdVersionCheck) configCertAndKey(config *tls.Config) (*tls.C
 
 func (evc ExternalEtcdVersionCheck) getHTTPClient(config *tls.Config) *http.Client {
 	if config != nil {
-		transport := netutil.SetOldTransportDefaults(&http.Transport{
+		transport := netutil.SetTransportDefaults(&http.Transport{
 			TLSClientConfig: config,
 		})
 		return &http.Client{
@@ -781,7 +781,7 @@ func (evc ExternalEtcdVersionCheck) getHTTPClient(config *tls.Config) *http.Clie
 			Timeout:   externalEtcdRequestTimeout,
 		}
 	}
-	return &http.Client{Timeout: externalEtcdRequestTimeout, Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
+	return &http.Client{Timeout: externalEtcdRequestTimeout, Transport: netutil.SetTransportDefaults(&http.Transport{})}
 }
 
 func getEtcdVersionResponse(client *http.Client, url string, target interface{}) error {

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -137,7 +137,7 @@ func (w *KubeWaiter) WaitForHealthyKubelet(initalTimeout time.Duration, healthzE
 	time.Sleep(initalTimeout)
 	fmt.Printf("[kubelet-check] Initial timeout of %v passed.\n", initalTimeout)
 	return TryRunCommand(func() error {
-		client := &http.Client{Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
+		client := &http.Client{Transport: netutil.SetTransportDefaults(&http.Transport{})}
 		resp, err := client.Get(healthzEndpoint)
 		if err != nil {
 			fmt.Println("[kubelet-check] It seems like the kubelet isn't running or healthy.")

--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -161,7 +161,7 @@ func splitVersion(version string) (string, string, error) {
 // Internal helper: return content of URL
 func fetchFromURL(url string, timeout time.Duration) (string, error) {
 	klog.V(2).Infof("fetching Kubernetes version from URL: %s", url)
-	client := &http.Client{Timeout: timeout, Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
+	client := &http.Client{Timeout: timeout, Transport: netutil.SetTransportDefaults(&http.Transport{})}
 	resp, err := client.Get(url)
 	if err != nil {
 		return "", pkgerrors.Errorf("unable to get URL %q: %s", url, err.Error())

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -328,7 +328,7 @@ func newOpenStack(cfg Config) (*OpenStack, error) {
 		}
 		config := &tls.Config{}
 		config.RootCAs = roots
-		provider.HTTPClient.Transport = netutil.SetOldTransportDefaults(&http.Transport{TLSClientConfig: config})
+		provider.HTTPClient.Transport = netutil.SetTransportDefaults(&http.Transport{TLSClientConfig: config})
 
 	}
 	if cfg.Global.TrustID != "" {

--- a/pkg/kubeapiserver/admission/config.go
+++ b/pkg/kubeapiserver/admission/config.go
@@ -45,7 +45,7 @@ type Config struct {
 }
 
 // New sets up the plugins and admission start hooks needed for admission
-func (c *Config) New(proxyTransport *http.Transport, serviceResolver webhook.ServiceResolver) ([]admission.PluginInitializer, server.PostStartHookFunc, error) {
+func (c *Config) New(proxyTransport http.RoundTripper, serviceResolver webhook.ServiceResolver) ([]admission.PluginInitializer, server.PostStartHookFunc, error) {
 	webhookAuthResolverWrapper := webhook.NewDefaultAuthenticationInfoResolverWrapper(proxyTransport, c.LoopbackClientConfig)
 	webhookPluginInitializer := webhookinit.NewPluginInitializer(webhookAuthResolverWrapper, serviceResolver)
 

--- a/pkg/kubectl/proxy/proxy_server.go
+++ b/pkg/kubectl/proxy/proxy_server.go
@@ -166,7 +166,7 @@ func makeUpgradeTransport(config *rest.Config, keepalive time.Duration) (proxy.U
 	if err != nil {
 		return nil, err
 	}
-	rt := utilnet.SetOldTransportDefaults(&http.Transport{
+	rt := utilnet.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: tlsConfig,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,

--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -74,7 +74,7 @@ func MakeTransport(config *KubeletClientConfig) (http.RoundTripper, error) {
 
 	rt := http.DefaultTransport
 	if config.Dial != nil || tlsConfig != nil {
-		rt = utilnet.SetOldTransportDefaults(&http.Transport{
+		rt = utilnet.SetTransportDefaults(&http.Transport{
 			DialContext:     config.Dial,
 			TLSClientConfig: tlsConfig,
 		})

--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -55,7 +55,7 @@ type Prober interface {
 }
 
 type httpProber struct {
-	transport *http.Transport
+	transport http.RoundTripper
 }
 
 // Probe returns a ProbeRunner capable of running an HTTP check.

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/BUILD
@@ -36,6 +36,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/net",
     importpath = "k8s.io/apimachinery/pkg/util/net",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/util/httpstream:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/golang.org/x/net/http2:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
@@ -414,7 +414,7 @@ func TestProxyUpgrade(t *testing.T) {
 			},
 			ProxyTransport: utilnet.SetTransportDefaults(&http.Transport{DialContext: d.DialContext, TLSClientConfig: &tls.Config{RootCAs: localhostPool}}),
 			UpgradeTransport: NewUpgradeRequestRoundTripper(
-				utilnet.SetOldTransportDefaults(&http.Transport{DialContext: d.DialContext, TLSClientConfig: &tls.Config{RootCAs: localhostPool}}),
+				utilnet.SetTransportDefaults(&http.Transport{DialContext: d.DialContext, TLSClientConfig: &tls.Config{RootCAs: localhostPool}}),
 				RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 					req = utilnet.CloneRequest(req)
 					req.Header.Set("Authorization", "Bearer 1234")

--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -31,12 +31,12 @@ import (
 // the config has no custom TLS options, http.DefaultTransport is returned.
 type tlsTransportCache struct {
 	mu         sync.Mutex
-	transports map[tlsCacheKey]*http.Transport
+	transports map[tlsCacheKey]http.RoundTripper
 }
 
 const idleConnsPerHost = 25
 
-var tlsCache = &tlsTransportCache{transports: make(map[tlsCacheKey]*http.Transport)}
+var tlsCache = &tlsTransportCache{transports: make(map[tlsCacheKey]http.RoundTripper)}
 
 type tlsCacheKey struct {
 	insecure   bool

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -64,7 +64,7 @@ type ExtraConfig struct {
 
 	// If present, the Dial method will be used for dialing out to delegate
 	// apiservers.
-	ProxyTransport *http.Transport
+	ProxyTransport http.RoundTripper
 
 	// Mechanism by which the Aggregator will resolve services. Required.
 	ServiceResolver ServiceResolver
@@ -95,7 +95,7 @@ type APIAggregator struct {
 	// this to confirm the proxy's identity
 	proxyClientCert []byte
 	proxyClientKey  []byte
-	proxyTransport  *http.Transport
+	proxyTransport  http.RoundTripper
 
 	// proxyHandlers are the proxy handlers that are currently registered, keyed by apiservice.name
 	proxyHandlers map[string]*proxyHandler

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -77,7 +77,7 @@ func NewAvailableConditionController(
 	serviceInformer v1informers.ServiceInformer,
 	endpointsInformer v1informers.EndpointsInformer,
 	apiServiceClient apiregistrationclient.APIServicesGetter,
-	proxyTransport *http.Transport,
+	proxyTransport http.RoundTripper,
 	serviceResolver ServiceResolver,
 ) *AvailableConditionController {
 	c := &AvailableConditionController{

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -298,7 +298,7 @@ func GenerateRSACerts(host string, isCA bool) ([]byte, []byte, error) {
 
 // buildTransportWithCA creates a transport for use in executing HTTPS requests with
 // the given certs. Note that the given rootCA must be configured with isCA=true.
-func buildTransportWithCA(serverName string, rootCA []byte) (*http.Transport, error) {
+func buildTransportWithCA(serverName string, rootCA []byte) (http.RoundTripper, error) {
 	pool := x509.NewCertPool()
 	ok := pool.AppendCertsFromPEM(rootCA)
 	if !ok {

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1968,7 +1968,7 @@ func curlUnix(url string, path string) (string, error) {
 	return curlTransport(url, transport)
 }
 
-func curlTransport(url string, transport *http.Transport) (string, error) {
+func curlTransport(url string, transport http.RoundTripper) (string, error) {
 	client := &http.Client{Transport: transport}
 	resp, err := client.Get(url)
 	if err != nil {

--- a/test/images/netexec/netexec.go
+++ b/test/images/netexec/netexec.go
@@ -220,10 +220,11 @@ func dialHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func dialHTTP(request, hostPort string) (string, error) {
-	transport := utilnet.SetTransportDefaults(&http.Transport{})
+	transport := utilnet.SetTransportDefaults(&http.Transport{
+		DisableKeepAlives: true,
+	})
 	httpClient := createHTTPClient(transport)
 	resp, err := httpClient.Get(fmt.Sprintf("http://%s/%s", hostPort, request))
-	defer transport.CloseIdleConnections()
 	if err == nil {
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
@@ -234,7 +235,7 @@ func dialHTTP(request, hostPort string) (string, error) {
 	return "", err
 }
 
-func createHTTPClient(transport *http.Transport) *http.Client {
+func createHTTPClient(transport http.RoundTripper) *http.Client {
 	client := &http.Client{
 		Transport: transport,
 		Timeout:   5 * time.Second,


### PR DESCRIPTION
Make all transports support http and http2. Prefer http2 unless the request is an upgrade request.

Part of https://github.com/kubernetes/kubernetes/issues/7452

/kind cleanup
/sig api-machinery

```release-note
NONE
```
