### PR TITLE
e2e: use quay.io/k8scsi images, bump versions

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath-v0/csi-hostpath-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath-v0/csi-hostpath-attacher.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: gcr.io/gke-release/csi-attacher:v0.4.1-gke.0
+          image: quay.io/k8scsi/csi-attacher:v0.4.1
           args:
             - --v=5
             - --csi-address=$(ADDRESS)

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath-v0/csi-hostpath-provisioner.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath-v0/csi-hostpath-provisioner.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner-v0
-          image: gcr.io/gke-release/csi-provisioner:v0.4.1-gke.0
+          image: quay.io/k8scsi/csi-provisioner:v0.4.1
           args:
             - "--provisioner=csi-hostpath-v0"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath-v0/csi-hostpathplugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath-v0/csi-hostpathplugin.yaml
@@ -15,7 +15,7 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: gcr.io/gke-release/csi-driver-registrar:v0.4.1-gke.0
+          image: quay.io/k8scsi/driver-registrar:v0.4.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-attacher.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: gcr.io/gke-release/csi-attacher:v1.0.0-gke.0
+          image: quay.io/k8scsi/csi-attacher:v1.0.1
           args:
             - --v=5
             - --csi-address=$(ADDRESS)

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-provisioner.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-provisioner.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: gcr.io/gke-release/csi-provisioner:v1.0.0-gke.0
+          image: quay.io/k8scsi/csi-provisioner:v1.0.1
           args:
             - "--provisioner=csi-hostpath"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpathplugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpathplugin.yaml
@@ -15,7 +15,7 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: gcr.io/gke-release/csi-driver-registrar:v1.0.1-gke.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -33,7 +33,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: hostpath
-          image: quay.io/k8scsi/hostpathplugin:v1.0.0
+          image: quay.io/k8scsi/hostpathplugin:v1.0.1
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Commit 503f654d7a6b84c6885c53ac528dfaab37f5c281, "Update CSI tests to
point to 1.0.0 external bits", changed to images published on gcr.io,
perhaps because the images on quay.io weren't ready yet. We now have
up-to-date images on quay.io and should be using those.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```

/sig storage