### PR TITLE
Add bootstrap policy to allow the scheduler to access ConfigMaps

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -427,6 +427,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("get", "list", "watch", "delete").Groups(legacyGroup).Resources("pods").RuleOrDie(),
 				rbacv1helpers.NewRule("create").Groups(legacyGroup).Resources("pods/binding", "bindings").RuleOrDie(),
 				rbacv1helpers.NewRule("patch", "update").Groups(legacyGroup).Resources("pods/status").RuleOrDie(),
+				rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("configmaps").RuleOrDie(),
 				// things that select pods
 				rbacv1helpers.NewRule(Read...).Groups(legacyGroup).Resources("services", "replicationcontrollers").RuleOrDie(),
 				rbacv1helpers.NewRule(Read...).Groups(appsGroup, extensionsGroup).Resources("replicasets").RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -756,6 +756,12 @@ items:
   - apiGroups:
     - ""
     resources:
+    - configmaps
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    resources:
     - replicationcontrollers
     - services
     verbs:


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
Adds read access to the `system:kube-scheduler` ClusterRole.
This is needed to fix crashes during the Scheduler startup:
```
W1205 10:35:37.728989       1 authentication.go:248] Unable to get configmap/extension-apiserver-authentication in kube-system.  Usually fixed by 'kubectl create rolebinding -n kube-system ROLE_NAME --role=extension-apiserver-authentication-reader --serviceaccount=YOUR_NS:YOUR_SA'
configmaps "extension-apiserver-authentication" is forbidden: User "system:kube-scheduler" cannot get resource "configmaps" in API group "" in the namespace "kube-system"
```

The same change was already done for the Controller-Manager in v1.12: https://github.com/kubernetes/kubernetes/issues/68986

With v1.13 this is required for the Scheduler as well.
Thus this change should be backported to `release-1.13`

**Does this PR introduce a user-facing change?**:
```release-note
Adds permissions for startup of an on-cluster kube-scheduler
```
