### PR TITLE
Add support for waiting by label selector or on all resources

### DIFF
--- a/pkg/kubectl/cmd/wait/wait.go
+++ b/pkg/kubectl/cmd/wait/wait.go
@@ -90,6 +90,8 @@ func NewWaitFlags(restClientGetter genericclioptions.RESTClientGetter, streams g
 		PrintFlags:       genericclioptions.NewPrintFlags("condition met"),
 		ResourceBuilderFlags: genericclioptions.NewResourceBuilderFlags().
 			WithLabelSelector("").
+			WithFieldSelector("").
+			WithAll(false).
 			WithAllNamespaces(false).
 			WithAll(false).
 			WithLatest(),
@@ -105,11 +107,12 @@ func NewCmdWait(restClientGetter genericclioptions.RESTClientGetter, streams gen
 	flags := NewWaitFlags(restClientGetter, streams)
 
 	cmd := &cobra.Command{
-		Use:                   "wait resource.group/name [--for=delete|--for condition=available]",
+		Use:     "wait ([-f FILENAME] | resource.group/resource.name | resource.group [(-l label | --all)]) [--for=delete|--for condition=available]",
+		Short:   "Experimental: Wait for a specific condition on one or many resources.",
+		Long:    waitLong,
+		Example: waitExample,
+
 		DisableFlagsInUseLine: true,
-		Short:                 "Experimental: Wait for a specific condition on one or many resources.",
-		Long:                  waitLong,
-		Example:               waitExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			o, err := flags.ToOptions(args)
 			cmdutil.CheckErr(err)

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -51,6 +51,7 @@ source "${KUBE_ROOT}/test/cmd/save-config.sh"
 source "${KUBE_ROOT}/test/cmd/storage.sh"
 source "${KUBE_ROOT}/test/cmd/template-output.sh"
 source "${KUBE_ROOT}/test/cmd/version.sh"
+source "${KUBE_ROOT}/test/cmd/wait.sh"
 
 
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
@@ -831,6 +832,12 @@ runTests() {
   # Impersonation #
   #################
   record_command run_impersonation_tests
+
+  ####################
+  # kubectl wait     #
+  ####################
+
+  record_command run_wait_tests
 
   kube::test::clear_all
 

--- a/test/cmd/wait.sh
+++ b/test/cmd/wait.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+run_wait_tests() {
+    set -o nounset
+    set -o errexit
+
+    kube::log::status "Testing kubectl wait"
+
+    create_and_use_new_namespace
+
+    ### Wait for deletion using --all flag
+
+    # create test data
+    kubectl create deployment test-1 --image=busybox
+    kubectl create deployment test-2 --image=busybox
+
+    # Post-Condition: deployments exists
+    kube::test::get_object_assert "deployments" "{{range .items}}{{.metadata.name}},{{end}}" 'test-1,test-2,'
+
+    # Delete all deployments async to kubectl wait
+    ( sleep 2 && kubectl delete deployment --all ) &
+
+    # Command: Wait for all deployments to be deleted
+    output_message=$(kubectl wait deployment --for=delete --all)
+
+    # Post-Condition: Wait was successful
+    kube::test::if_has_string "${output_message}" 'test-1 condition met'
+    kube::test::if_has_string "${output_message}" 'test-2 condition met'
+
+    set +o nounset
+    set +o errexit
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Will add support for `kubectl wait` to await resources by label selector, field selector or await all resources of a specific type. 

**Which issue(s) this PR fixes**:

Fixes #68298

**Special notes for your reviewer**:

**Testplan**

test.yaml:

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: test
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: test
  namespace: test
spec:
  replicas: 2
  template:
    metadata:
      labels:
        app: test
    spec:
      containers:
      - name: echo
        image: busybox:latest
        command:
        - sleep
        - "3600"
```

```
$ kubectl apply -f test.yaml
namespace/test created
deployment.extensions/test created

$ kubectl get pods -n test
NAME                    READY     STATUS    RESTARTS   AGE
test-74588866c5-69ldt   1/1       Running   0          9s
test-74588866c5-s4sms   1/1       Running   0          9s

# wait for resource by type and name

# async
$ _output/bin/kubectl wait --for=delete pod test-74588866c5-69ldt --timeout=120s -n test
pod/test-74588866c5-69ldt condition met

$ kubectl delete pod test-74588866c5-69ldt -n test
pod "test-74588866c5-69ldt" deleted

# wait for all resources

# async
$ _output/bin/kubectl wait --for=delete pod --all --timeout=120s -n test
pod/test-74588866c5-qdx8n condition met
pod/test-74588866c5-s4sms condition met

$ kubectl delete pod --all -n test
pod "test-74588866c5-qdx8n" deleted
pod "test-74588866c5-s4sms" deleted

# wait by label selector

# async
$ _output/bin/kubectl wait --for delete pod -l app=test --timeout=120s -n test
pod/test-74588866c5-62z92 condition met
pod/test-74588866c5-j6m4c condition met

$ kubectl delete pod -l app=test -n test
pod "test-74588866c5-62z92" deleted
pod "test-74588866c5-j6m4c" deleted

# wait by file

# async
$ _output/bin/kubectl wait --for delete -f test.yaml --timeout=120s -n test
namespace/test condition met

$ kubectl delete -f test.yaml
namespace "test" deleted
deployment "test" deleted
```

**Does this PR introduce a user-facing change?**:

```release-note
Expand kubectl wait to work with more types of selectors.
```
