### PR TITLE
implement request cancellation in token transport

### DIFF
--- a/staging/src/k8s.io/client-go/transport/round_trippers.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers.go
@@ -80,10 +80,6 @@ func DebugWrappers(rt http.RoundTripper) http.RoundTripper {
 	return rt
 }
 
-type requestCanceler interface {
-	CancelRequest(*http.Request)
-}
-
 type authProxyRoundTripper struct {
 	username string
 	groups   []string
@@ -140,11 +136,7 @@ func SetAuthProxyHeaders(req *http.Request, username string, groups []string, ex
 }
 
 func (rt *authProxyRoundTripper) CancelRequest(req *http.Request) {
-	if canceler, ok := rt.rt.(requestCanceler); ok {
-		canceler.CancelRequest(req)
-	} else {
-		klog.Errorf("CancelRequest not implemented by %T", rt.rt)
-	}
+	tryCancelRequest(rt.WrappedRoundTripper(), req)
 }
 
 func (rt *authProxyRoundTripper) WrappedRoundTripper() http.RoundTripper { return rt.rt }
@@ -168,11 +160,7 @@ func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 }
 
 func (rt *userAgentRoundTripper) CancelRequest(req *http.Request) {
-	if canceler, ok := rt.rt.(requestCanceler); ok {
-		canceler.CancelRequest(req)
-	} else {
-		klog.Errorf("CancelRequest not implemented by %T", rt.rt)
-	}
+	tryCancelRequest(rt.WrappedRoundTripper(), req)
 }
 
 func (rt *userAgentRoundTripper) WrappedRoundTripper() http.RoundTripper { return rt.rt }
@@ -199,11 +187,7 @@ func (rt *basicAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 }
 
 func (rt *basicAuthRoundTripper) CancelRequest(req *http.Request) {
-	if canceler, ok := rt.rt.(requestCanceler); ok {
-		canceler.CancelRequest(req)
-	} else {
-		klog.Errorf("CancelRequest not implemented by %T", rt.rt)
-	}
+	tryCancelRequest(rt.WrappedRoundTripper(), req)
 }
 
 func (rt *basicAuthRoundTripper) WrappedRoundTripper() http.RoundTripper { return rt.rt }
@@ -259,11 +243,7 @@ func (rt *impersonatingRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 }
 
 func (rt *impersonatingRoundTripper) CancelRequest(req *http.Request) {
-	if canceler, ok := rt.delegate.(requestCanceler); ok {
-		canceler.CancelRequest(req)
-	} else {
-		klog.Errorf("CancelRequest not implemented by %T", rt.delegate)
-	}
+	tryCancelRequest(rt.WrappedRoundTripper(), req)
 }
 
 func (rt *impersonatingRoundTripper) WrappedRoundTripper() http.RoundTripper { return rt.delegate }
@@ -318,11 +298,7 @@ func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 }
 
 func (rt *bearerAuthRoundTripper) CancelRequest(req *http.Request) {
-	if canceler, ok := rt.rt.(requestCanceler); ok {
-		canceler.CancelRequest(req)
-	} else {
-		klog.Errorf("CancelRequest not implemented by %T", rt.rt)
-	}
+	tryCancelRequest(rt.WrappedRoundTripper(), req)
 }
 
 func (rt *bearerAuthRoundTripper) WrappedRoundTripper() http.RoundTripper { return rt.rt }
@@ -402,11 +378,7 @@ func newDebuggingRoundTripper(rt http.RoundTripper, levels ...debugLevel) *debug
 }
 
 func (rt *debuggingRoundTripper) CancelRequest(req *http.Request) {
-	if canceler, ok := rt.delegatedRoundTripper.(requestCanceler); ok {
-		canceler.CancelRequest(req)
-	} else {
-		klog.Errorf("CancelRequest not implemented by %T", rt.delegatedRoundTripper)
-	}
+	tryCancelRequest(rt.WrappedRoundTripper(), req)
 }
 
 var knownAuthTypes = map[string]bool{

--- a/staging/src/k8s.io/client-go/transport/token_source.go
+++ b/staging/src/k8s.io/client-go/transport/token_source.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
+
 	"k8s.io/klog"
 )
 
@@ -79,6 +80,14 @@ func (tst *tokenSourceTransport) RoundTrip(req *http.Request) (*http.Response, e
 		return tst.base.RoundTrip(req)
 	}
 	return tst.ort.RoundTrip(req)
+}
+
+func (tst *tokenSourceTransport) CancelRequest(req *http.Request) {
+	if req.Header.Get("Authorization") != "" {
+		tryCancelRequest(tst.base, req)
+		return
+	}
+	tryCancelRequest(tst.ort, req)
 }
 
 type fileTokenSource struct {


### PR DESCRIPTION
Noticed in https://github.com/kubernetes/client-go/issues/527 although I'm not certain if it's the root cause yet.

 /kind bug
/sig auth

```release-note
Implement request cancellation in token transport to get rid of warnings when the HTTP client tries to cancel a request.
```
