### PR TITLE
Add oomichi to test/OWNERS

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -27,6 +27,7 @@ reviewers:
   - zmerlynn
   - vishh
   - MaciekPytel # for test/e2e/common/autoscaling_utils.go
+  - oomichi
 approvers:
   - bowei # for test/e2e/{dns*,network}.go
   - cblecker


### PR DESCRIPTION
**What this PR does / why we need it**:

oomichi continues reviewing PRs which are related to e2e tests,
then this adds him to a reviewer to get him involved more.

**Does this PR introduce a user-facing change?**:
```NONE```
