### PR TITLE
Log prometheus metric registration error and fix CRD metric names

### DIFF
--- a/pkg/master/controller/crdregistration/crdregistration_controller.go
+++ b/pkg/master/controller/crdregistration/crdregistration_controller.go
@@ -68,7 +68,7 @@ func NewAutoRegistrationController(crdinformer crdinformers.CustomResourceDefini
 		crdSynced:              crdinformer.Informer().HasSynced,
 		apiServiceRegistration: apiServiceRegistration,
 		syncedInitialSet:       make(chan struct{}),
-		queue:                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "crd-autoregister"),
+		queue:                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "crd_autoregistration_controller"),
 	}
 	c.syncHandler = c.handleVersionUpdate
 

--- a/pkg/util/workqueue/prometheus/BUILD
+++ b/pkg/util/workqueue/prometheus/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/util/workqueue/prometheus/prometheus.go
+++ b/pkg/util/workqueue/prometheus/prometheus.go
@@ -18,6 +18,7 @@ package prometheus
 
 import (
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -37,7 +38,9 @@ func (prometheusMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetr
 		Name:      "depth",
 		Help:      "Current depth of workqueue: " + name,
 	})
-	prometheus.Register(depth)
+	if err := prometheus.Register(depth); err != nil {
+		klog.Errorf("failed to register depth metric %v: %v", name, err)
+	}
 	return depth
 }
 
@@ -47,7 +50,9 @@ func (prometheusMetricsProvider) NewAddsMetric(name string) workqueue.CounterMet
 		Name:      "adds",
 		Help:      "Total number of adds handled by workqueue: " + name,
 	})
-	prometheus.Register(adds)
+	if err := prometheus.Register(adds); err != nil {
+		klog.Errorf("failed to register adds metric %v: %v", name, err)
+	}
 	return adds
 }
 
@@ -57,7 +62,9 @@ func (prometheusMetricsProvider) NewLatencyMetric(name string) workqueue.Summary
 		Name:      "queue_latency",
 		Help:      "How long an item stays in workqueue" + name + " before being requested.",
 	})
-	prometheus.Register(latency)
+	if err := prometheus.Register(latency); err != nil {
+		klog.Errorf("failed to register latency metric %v: %v", name, err)
+	}
 	return latency
 }
 
@@ -67,7 +74,9 @@ func (prometheusMetricsProvider) NewWorkDurationMetric(name string) workqueue.Su
 		Name:      "work_duration",
 		Help:      "How long processing an item from workqueue" + name + " takes.",
 	})
-	prometheus.Register(workDuration)
+	if err := prometheus.Register(workDuration); err != nil {
+		klog.Errorf("failed to register work_duration metric %v: %v", name, err)
+	}
 	return workDuration
 }
 
@@ -80,7 +89,9 @@ func (prometheusMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) wor
 			"values indicate stuck threads. One can deduce the number of stuck " +
 			"threads by observing the rate at which this increases.",
 	})
-	prometheus.Register(unfinished)
+	if err := prometheus.Register(unfinished); err != nil {
+		klog.Errorf("failed to register unfinished_work_seconds metric %v: %v", name, err)
+	}
 	return unfinished
 }
 
@@ -91,7 +102,9 @@ func (prometheusMetricsProvider) NewLongestRunningProcessorMicrosecondsMetric(na
 		Help: "How many microseconds has the longest running " +
 			"processor for " + name + " been running.",
 	})
-	prometheus.Register(unfinished)
+	if err := prometheus.Register(unfinished); err != nil {
+		klog.Errorf("failed to register longest_running_processor_microseconds metric %v: %v", name, err)
+	}
 	return unfinished
 }
 
@@ -101,6 +114,8 @@ func (prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.Counter
 		Name:      "retries",
 		Help:      "Total number of retries handled by workqueue: " + name,
 	})
-	prometheus.Register(retries)
+	if err := prometheus.Register(retries); err != nil {
+		klog.Errorf("failed to register retries metric %v: %v", name, err)
+	}
 	return retries
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -79,7 +79,7 @@ func NewCRDFinalizer(
 		crdLister:      crdInformer.Lister(),
 		crdSynced:      crdInformer.Informer().HasSynced,
 		crClientGetter: crClientGetter,
-		queue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "CustomResourceDefinition-CRDFinalizer"),
+		queue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "crd_finalizer"),
 	}
 
 	crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -66,7 +66,7 @@ func NewNamingConditionController(
 		crdClient: crdClient,
 		crdLister: crdInformer.Lister(),
 		crdSynced: crdInformer.Informer().HasSynced,
-		queue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "CustomResourceDefinition-NamingConditionController"),
+		queue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "crd_naming_condition_controller"),
 	}
 
 	informerIndexer := crdInformer.Informer().GetIndexer()


### PR DESCRIPTION
/kind bug

When we call `prometheus.Register(c Collector)`, we didn't handle potential error for the registration. Some metrics failed to get registered due to [invalid name](https://github.com/kubernetes/kubernetes/blob/895f483fdfba055573681ef067e16d60df7985f8/vendor/github.com/prometheus/common/model/metric.go#L93) / [duplicate](https://github.com/kubernetes/kubernetes/blob/895f483fdfba055573681ef067e16d60df7985f8/vendor/github.com/prometheus/client_golang/prometheus/registry.go#L290) metrics: [gist of errors in a local cluster](https://gist.github.com/roycaihw/1bbb77d38e198b2528651b660da6c9da). As a result the metrics don't get exposed on `/metrics` endpoint.

This PR adds log for the errors and fixes some of the invalid CRD metric names. The name change should be backwards compatible since the metrics were never exposed.

**Special notes for your reviewer**:
Alternatively we could panic on the errors. However, there are errors caused by duplication (see the [gist](https://gist.github.com/roycaihw/1bbb77d38e198b2528651b660da6c9da) above) that I don't fully understand. Also there are [metrics](https://gist.github.com/roycaihw/57c95d70e00a169223e2f73cde2fee6d) with invalid name not triggering error in my local cluster. I didn't fix those metrics. 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Prometheus metrics for crd_autoregister, crd_finalizer and crd_naming_condition_controller are exported.
```

/sig api-machinery
/cc @logicalhan @mbohlool @sttts