### PR TITLE
Automated cherry pick of #71744: fixes autoscaling types conversion

### DIFF
--- a/pkg/apis/autoscaling/v2beta1/BUILD
+++ b/pkg/apis/autoscaling/v2beta1/BUILD
@@ -26,7 +26,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["defaults_test.go"],
+    srcs = [
+        "conversion_test.go",
+        "defaults_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
@@ -37,6 +40,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/pkg/apis/autoscaling/v2beta1/conversion.go
+++ b/pkg/apis/autoscaling/v2beta1/conversion.go
@@ -185,8 +185,10 @@ func Convert_v2beta1_ObjectMetricSource_To_autoscaling_ObjectMetricSource(in *au
 }
 
 func Convert_autoscaling_PodsMetricSource_To_v2beta1_PodsMetricSource(in *autoscaling.PodsMetricSource, out *autoscalingv2beta1.PodsMetricSource, s conversion.Scope) error {
-	targetAverageValue := *in.Target.AverageValue
-	out.TargetAverageValue = targetAverageValue
+	if in.Target.AverageValue != nil {
+		targetAverageValue := *in.Target.AverageValue
+		out.TargetAverageValue = targetAverageValue
+	}
 
 	out.MetricName = in.Metric.Name
 	out.Selector = in.Metric.Selector
@@ -247,8 +249,10 @@ func Convert_autoscaling_ObjectMetricStatus_To_v2beta1_ObjectMetricStatus(in *au
 	}
 	out.MetricName = in.Metric.Name
 	out.Selector = in.Metric.Selector
-	currentAverageValue := *in.Current.AverageValue
-	out.AverageValue = &currentAverageValue
+	if in.Current.AverageValue != nil {
+		currentAverageValue := *in.Current.AverageValue
+		out.AverageValue = &currentAverageValue
+	}
 	return nil
 }
 

--- a/pkg/apis/autoscaling/v2beta1/conversion_test.go
+++ b/pkg/apis/autoscaling/v2beta1/conversion_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/apis/autoscaling"
+)
+
+// Testing nil pointer panic uncovered by #70806
+// TODO(yue9944882): Test nil/empty conversion across all resource types
+func TestNilOrEmptyConversion(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, addConversionFuncs(scheme))
+
+	testCases := []struct {
+		obj1 interface{}
+		obj2 interface{}
+	}{
+		{
+			obj1: &autoscaling.ExternalMetricSource{},
+			obj2: &v2beta1.ExternalMetricSource{},
+		},
+		{
+			obj1: &autoscaling.ExternalMetricStatus{},
+			obj2: &v2beta1.ExternalMetricStatus{},
+		},
+		{
+			obj1: &autoscaling.PodsMetricSource{},
+			obj2: &v2beta1.PodsMetricSource{},
+		},
+		{
+			obj1: &autoscaling.PodsMetricStatus{},
+			obj2: &v2beta1.PodsMetricStatus{},
+		},
+		{
+			obj1: &autoscaling.ObjectMetricSource{},
+			obj2: &v2beta1.ObjectMetricSource{},
+		},
+		{
+			obj1: &autoscaling.ObjectMetricStatus{},
+			obj2: &v2beta1.ObjectMetricStatus{},
+		},
+		{
+			obj1: &autoscaling.ResourceMetricSource{},
+			obj2: &v2beta1.ResourceMetricSource{},
+		},
+		{
+			obj1: &autoscaling.ResourceMetricStatus{},
+			obj2: &v2beta1.ResourceMetricStatus{},
+		},
+		{
+			obj1: &autoscaling.HorizontalPodAutoscaler{},
+			obj2: &v2beta1.HorizontalPodAutoscaler{},
+		},
+		{
+			obj1: &autoscaling.MetricTarget{},
+			obj2: &v2beta1.CrossVersionObjectReference{},
+		},
+	}
+	for _, testCase := range testCases {
+		assert.NoError(t, scheme.Convert(testCase.obj1, testCase.obj2, nil))
+		assert.NoError(t, scheme.Convert(testCase.obj2, testCase.obj1, nil))
+	}
+}


### PR DESCRIPTION
Cherry pick of #71744 on release-1.13.

#71744: fixes autoscaling types conversion