### PR TITLE
Make GeneralPredicates a MUST have predicate for scheduler

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -137,6 +137,12 @@ var (
 		CheckNodeMemoryPressurePred, CheckNodePIDPressurePred, CheckNodeDiskPressurePred, MatchInterPodAffinityPred}
 )
 
+// Kubelet uses these mandatoryPredicates. If they are not configured to scheduler, scheduler might
+// schedule a pod to kubelet that will reject it constantly.
+var (
+	mandatoryPredicates = []string{GeneralPred}
+)
+
 // NodeInfo interface represents anything that can get node object from node ID.
 type NodeInfo interface {
 	GetNodeInfo(nodeID string) (*v1.Node, error)
@@ -155,6 +161,10 @@ type CachedPersistentVolumeInfo struct {
 // Ordering returns the ordering of predicates.
 func Ordering() []string {
 	return predicatesOrdering
+}
+
+func MandatoryPredicates() []string {
+	return mandatoryPredicates
 }
 
 // SetPredicatesOrdering sets the ordering of predicates.

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -1136,6 +1136,10 @@ func (c *configFactory) CreateFromConfig(policy schedulerapi.Policy) (*Config, e
 			klog.V(2).Infof("Registering predicate: %s", predicate.Name)
 			predicateKeys.Insert(RegisterCustomFitPredicate(predicate))
 		}
+		for _, predicate := range predicates.MandatoryPredicates() {
+			klog.V(2).Infof("Registering mandatory predicate: %s", predicate)
+			predicateKeys.Insert(predicate)
+		}
 	}
 
 	priorityKeys := sets.NewString()

--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	latestschedulerapi "k8s.io/kubernetes/pkg/scheduler/api/latest"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
@@ -202,6 +203,7 @@ func TestCreateFromConfigWithEmptyPredicatesOrPriorities(t *testing.T) {
 	factory := newConfigFactory(client, v1.DefaultHardPodAffinitySymmetricWeight, stopCh)
 
 	RegisterFitPredicate("PredicateOne", PredicateOne)
+	RegisterFitPredicate(predicates.GeneralPred, predicates.GeneralPredicates)
 	RegisterPriorityFunction("PriorityOne", PriorityOne, 1)
 
 	RegisterAlgorithmProvider(DefaultProvider, sets.NewString("PredicateOne"), sets.NewString("PriorityOne"))
@@ -221,8 +223,8 @@ func TestCreateFromConfigWithEmptyPredicatesOrPriorities(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create scheduler from configuration: %v", err)
 	}
-	if len(config.Algorithm.Predicates()) != 0 {
-		t.Error("Expected empty predicate sets")
+	if len(config.Algorithm.Predicates()) != 1 {
+		t.Error("Expected only mandatory predicate sets")
 	}
 	if len(config.Algorithm.Prioritizers()) != 0 {
 		t.Error("Expected empty priority sets")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add GeneralPredicates as a MUST have predicate for scheduler.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #71662

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
It will add predicate GeneralPredicates if admin did not add it.
```
