### PR TITLE
Set delete propagation policy to background when removing jobs and its dependents 

### DIFF
--- a/pkg/controller/cronjob/injection.go
+++ b/pkg/controller/cronjob/injection.go
@@ -118,7 +118,8 @@ func (r realJobControl) CreateJob(namespace string, job *batchv1.Job) (*batchv1.
 }
 
 func (r realJobControl) DeleteJob(namespace string, name string) error {
-	return r.KubeClient.BatchV1().Jobs(namespace).Delete(name, nil)
+	background := metav1.DeletePropagationBackground
+	return r.KubeClient.BatchV1().Jobs(namespace).Delete(name, &metav1.DeleteOptions{PropagationPolicy: &background})
 }
 
 type fakeJobControl struct {

--- a/test/e2e/apps/cronjob.go
+++ b/test/e2e/apps/cronjob.go
@@ -250,8 +250,10 @@ var _ = SIGDescribe("CronJob", func() {
 		Expect(len(finishedJobs) == 1).To(BeTrue())
 
 		// Job should get deleted when the next job finishes the next minute
-		By("Ensuring this job does not exist anymore")
-		err = waitForJobNotExist(f.ClientSet, f.Namespace.Name, finishedJobs[0])
+		By("Ensuring this job and its pods does not exist anymore")
+		err = waitForJobToDisappear(f.ClientSet, f.Namespace.Name, finishedJobs[0])
+		Expect(err).NotTo(HaveOccurred())
+		err = waitForJobsPodToDisappear(f.ClientSet, f.Namespace.Name, finishedJobs[0])
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Ensuring there is 1 finished job by listing jobs explicitly")
@@ -380,8 +382,8 @@ func waitForJobNotActive(c clientset.Interface, ns, cronJobName, jobName string)
 	})
 }
 
-// Wait for a job to not exist by listing jobs explicitly.
-func waitForJobNotExist(c clientset.Interface, ns string, targetJob *batchv1.Job) error {
+// Wait for a job to disappear by listing them explicitly.
+func waitForJobToDisappear(c clientset.Interface, ns string, targetJob *batchv1.Job) error {
 	return wait.Poll(framework.Poll, cronJobTimeout, func() (bool, error) {
 		jobs, err := c.BatchV1().Jobs(ns).List(metav1.ListOptions{})
 		if err != nil {
@@ -394,6 +396,18 @@ func waitForJobNotExist(c clientset.Interface, ns string, targetJob *batchv1.Job
 			}
 		}
 		return true, nil
+	})
+}
+
+// Wait for a pod to disappear by listing them explicitly.
+func waitForJobsPodToDisappear(c clientset.Interface, ns string, targetJob *batchv1.Job) error {
+	return wait.Poll(framework.Poll, cronJobTimeout, func() (bool, error) {
+		options := metav1.ListOptions{LabelSelector: fmt.Sprintf("controller-uid=%s", targetJob.UID)}
+		pods, err := c.CoreV1().Pods(ns).List(options)
+		if err != nil {
+			return false, err
+		}
+		return len(pods.Items) == 0, nil
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
Fixes #71772

**Special notes for your reviewer**:
/assign @liggitt @juanvallejo 

**Does this PR introduce a user-facing change?**:
```release-note
Fixes pod deletion when cleaning old cronjobs
```
