### PR TITLE
Fix sort-by regression

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -339,8 +339,10 @@ func (r *RuntimeSorter) Sort() error {
 		case *metav1beta1.Table:
 			includesTable = true
 
-			if err := NewTableSorter(t, r.field).Sort(); err != nil {
-				continue
+			if sorter, err := NewTableSorter(t, r.field); err != nil {
+				return err
+			} else if err := sorter.Sort(); err != nil {
+				return err
 			}
 		default:
 			includesRuntimeObjs = true


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

* Fixes sort-by regression for table sorter introduced in https://github.com/kubernetes/kubernetes/pull/70629
* Makes table sorter behave consistently with normal sorter when fields are missing from objects
* Adds missing unit tests for TableSorter

**Which issue(s) this PR fixes**:
Fixes #71753

**Does this PR introduce a user-facing change?**:
```release-note
kubectl: fixes regression in --sort-by behavior
```

/assign @soltysh 