### PR TITLE
Only sync addresses of the own ip family

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1649,7 +1649,7 @@ func (proxier *Proxier) cleanLegacyBindAddr(activeBindAddrs map[string]bool, cur
 	isIpv6 := utilnet.IsIPv6(proxier.nodeIP)
 	for _, addr := range currentBindAddrs {
 		addrIsIpv6 := utilnet.IsIPv6(net.ParseIP(addr))
-		if addrIsIpv6 && ! isIpv6 || ! addrIsIpv6 && isIpv6 {
+		if addrIsIpv6 && !isIpv6 || !addrIsIpv6 && isIpv6 {
 			continue
 		}
 		if _, ok := activeBindAddrs[addr]; !ok {

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1646,7 +1646,12 @@ func (proxier *Proxier) cleanLegacyService(activeServices map[string]bool, curre
 }
 
 func (proxier *Proxier) cleanLegacyBindAddr(activeBindAddrs map[string]bool, currentBindAddrs []string) {
+	isIpv6 := utilnet.IsIPv6(proxier.nodeIP)
 	for _, addr := range currentBindAddrs {
+		addrIsIpv6 := utilnet.IsIPv6(net.ParseIP(addr))
+		if addrIsIpv6 && ! isIpv6 || ! addrIsIpv6 && isIpv6 {
+			continue
+		}
 		if _, ok := activeBindAddrs[addr]; !ok {
 			// This address was not processed in the latest sync loop
 			klog.V(4).Infof("Unbind addr %s", addr)


### PR DESCRIPTION
For ipv4 only ipv4 addresses are synced on the kube-ipvs0 device
and the same for ipv6. Fixes #70113


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The sync function tries to sync all addresses regardless of family (ipv4 or ipv6). This caused failures and will also cause problem for the upcoming dual-stack.

This PR make the sync function only care about addresses of the own family on the `kube-ipvs0` device.

**Which issue(s) this PR fixes**:

Fixes #70113

**Special notes for your reviewer**:

Testing is done manually by adding addresses of the "other" family to `kube-ipvs0` and check that they are untouched and that no failures are logged.

Also the special case in #70113 is tested; bring `kube-ipvs0` and get an automatically assigned link-local ipv6 address. The log was no longer spammed with failure records.

For ipv6 there is a problem; the bug reported in #65006 prevents proper testing.

By temporary hard-code a fix for the problem as described in the issue above it is possible to test for ipv6. The function of leaving ipv4 addresses untoched works as well as removing manually added ipv6 addresses that should no be there works fine.

But removing the auto-generated ipv6 address does not work even in a ipv6-only cluster. It can be removed manually so it is not "forbidden" to remove it. I will look at this problem and add to this PR if I find anything, but I would like to get things going and this fixes the problem for ipv4 which is most users concern.

**Does this PR introduce a user-facing change?**:

NONE

```release-note
```
