### PR TITLE
[kubeproxy/ipvs] New sysctls to improve pod termination

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -162,6 +162,8 @@ const sysctlRouteLocalnet = "net/ipv4/conf/all/route_localnet"
 const sysctlBridgeCallIPTables = "net/bridge/bridge-nf-call-iptables"
 const sysctlVSConnTrack = "net/ipv4/vs/conntrack"
 const sysctlConnReuse = "net/ipv4/vs/conn_reuse_mode"
+const sysctlExpireNoDestConn = "net/ipv4/vs/expire_nodest_conn"
+const sysctlExpireQuiescentTemplate = "net/ipv4/vs/expire_quiescent_template"
 const sysctlForward = "net/ipv4/ip_forward"
 const sysctlArpIgnore = "net/ipv4/conf/all/arp_ignore"
 const sysctlArpAnnounce = "net/ipv4/conf/all/arp_announce"
@@ -318,6 +320,20 @@ func NewProxier(ipt utiliptables.Interface,
 	if val, _ := sysctl.GetSysctl(sysctlConnReuse); val != 0 {
 		if err := sysctl.SetSysctl(sysctlConnReuse, 0); err != nil {
 			return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlConnReuse, err)
+		}
+	}
+
+	// Set the expire_nodest_conn sysctl we need for
+	if val, _ := sysctl.GetSysctl(sysctlExpireNoDestConn); val != 1 {
+		if err := sysctl.SetSysctl(sysctlExpireNoDestConn, 1); err != nil {
+			return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlExpireNoDestConn, err)
+		}
+	}
+
+	// Set the expire_quiescent_template sysctl we need for
+	if val, _ := sysctl.GetSysctl(sysctlExpireQuiescentTemplate); val != 1 {
+		if err := sysctl.SetSysctl(sysctlExpireQuiescentTemplate, 1); err != nil {
+			return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlExpireQuiescentTemplate, err)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR enables two IPVS sysctls:
- `net/ipv4/vs/expire_nodest_conn`: delete connections associated to a real server that has been deleted. This is not important with graceful termination (because real servers are removed when connections have terminated/expired) but very important without it, see #71358 (so this sysctl should be backported to 1.12 and 1.11)
- `net/ipv4/vs/expire_quiescent_template`: expire persistent connections to a real server when its weight has been set to 0 (otherwise future connections from a client with the same IP will be sent to an endpoint that is no longer available. In addition, if a client keeps trying to send traffic, the real server will not be removed until persistency expires which by default takes 3h).

**Which issue(s) this PR fixes**:
Fixes: #71809 
Partially addresses: #71358

**Special notes for your reviewer**:
`expire_quiescent_template` defaults to 0 because when using ClientIP affinity it makes sense to continue sending traffic to the same backend even its weight is set to 0. However in Kubernetes pod shutdown is (usually) pretty fast and new connections will be blackholed. In addition, if the client retries to connect often, the number of connections will never reach 0 for this backend and the real server will not be removed until the persistency timer expires.

**Does this PR introduce a user-facing change?**:
```release-note
kube-proxy in IPVS mode will stop initiating connections to terminating pods for services with sessionAffinity set.
```

/sig network
/area ipvs
/assign @m1093782566