### PR TITLE
do not report container runtime status when runtimeState is not initi…

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2147,6 +2147,7 @@ func (kl *Kubelet) LatestLoopEntryTime() time.Time {
 func (kl *Kubelet) updateRuntimeUp() {
 	kl.updateRuntimeMux.Lock()
 	defer kl.updateRuntimeMux.Unlock()
+	defer kl.runtimeState.setInitialized()
 
 	s, err := kl.containerRuntime.Status()
 	if err != nil {

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -522,7 +522,7 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(*v1.Node) error {
 		nodestatus.MemoryPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderMemoryPressure, kl.recordNodeStatusEvent),
 		nodestatus.DiskPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderDiskPressure, kl.recordNodeStatusEvent),
 		nodestatus.PIDPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderPIDPressure, kl.recordNodeStatusEvent),
-		nodestatus.ReadyCondition(kl.clock.Now, kl.runtimeState.runtimeErrors, kl.runtimeState.networkErrors, validateHostFunc, kl.containerManager.Status, kl.recordNodeStatusEvent),
+		nodestatus.ReadyCondition(kl.clock.Now, kl.runtimeState.runtimeErrors, kl.runtimeState.networkErrors, validateHostFunc, kl.containerManager.Status, kl.recordNodeStatusEvent, kl.runtimeState.isInitialized),
 		nodestatus.VolumesInUse(kl.volumeManager.ReconcilerStatesHasBeenSynced, kl.volumeManager.GetVolumesInUse),
 		// TODO(mtaufen): I decided not to move this setter for now, since all it does is send an event
 		// and record state back to the Kubelet runtime object. In the future, I'd like to isolate

--- a/pkg/kubelet/runtime.go
+++ b/pkg/kubelet/runtime.go
@@ -32,6 +32,25 @@ type runtimeState struct {
 	networkError             error
 	cidr                     string
 	healthChecks             []*healthCheck
+	runtimeUpInitialized     bool
+}
+
+func (s *runtimeState) setRuntimeSync(t time.Time) {
+	s.Lock()
+	defer s.Unlock()
+	s.lastBaseRuntimeSync = t
+}
+
+func (s *runtimeState) isInitialized() bool {
+	s.RLock()
+	defer s.RUnlock()
+	return s.runtimeUpInitialized
+}
+
+func (s *runtimeState) setInitialized() {
+	s.Lock()
+	defer s.Unlock()
+	s.runtimeUpInitialized = true
 }
 
 // A health check function should be efficient and not rely on external
@@ -47,12 +66,6 @@ func (s *runtimeState) addHealthCheck(name string, f healthCheckFnType) {
 	s.Lock()
 	defer s.Unlock()
 	s.healthChecks = append(s.healthChecks, &healthCheck{name: name, fn: f})
-}
-
-func (s *runtimeState) setRuntimeSync(t time.Time) {
-	s.Lock()
-	defer s.Unlock()
-	s.lastBaseRuntimeSync = t
 }
 
 func (s *runtimeState) setNetworkState(err error) {


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/71839

When we restart kubelet , we found that kubelet post NodeNotReady(due to container runtime states was Falsely reported before initialized) status imediately. This would result in cloud-controller-manager removing Loadbalancer backend imediately which is not expected.

After go through the kubelet log, we found that kubelet report container runtime is down but actually it is up. That is kubelet report a false container runtime status while restart , and that is not expect.

For now, this has a tremendous impact on our CloudProvider.

After some dig into the code, we found that kubelet detect container runtime status and report the runtime status councurrently. This is the main cause of the false status report.