### PR TITLE
Optimizing TestNewManagerImplStartProbeMode

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -78,6 +78,7 @@ func TestNewManagerImplStartProbeMode(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(socketDir)
 	m, _, p, w := setupInProbeMode(t, []*pluginapi.Device{}, func(n string, d []pluginapi.Device) {}, socketName, pluginSocketName)
+	time.Sleep(10 * time.Millisecond)
 	cleanup(t, m, p, w)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
The TestNewManagerImplStartProbeMode often test fail in our CI environment. I executed this test case alone in my development environment and found that executing it several times would recurrent the failure. 

--- FAIL: TestNewManagerImplStartProbeMode (11.00s)
    manager_test.go:276:
                Error Trace:    manager_test.go:276
                                                        manager_test.go:82
                Error:          Received unexpected error:
                                timeout on stopping watcher
                Test:           TestNewManagerImplStartProbeMode
FAIL
exit status 1
FAIL    k8s.io/kubernetes/pkg/kubelet/cm/devicemanager  11.020s

I check and test，the timeout is 11s, the time is enough, it should have something to do with the sync.WaitGroup Add/Wait. setupPluginWatcher and cleanup it immediately, the Add goroutine and Wait goroutine perhaps occurred error. Then I add sleep between setupInProbeMode and cleanup, after testing, the TestNewManagerImplStartProbeMode is no longer fails.

http://docs.studygolang.com/pkg/sync/#WaitGroup.Add
“Typically this means the calls to Add should execute before the statement creating the goroutine or other event to be waited for. ”

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

/release-note-none
/priority backlog
