### PR TITLE
kubeadm: use DefValue for the --kubeconfig flag

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/certs.go
+++ b/cmd/kubeadm/app/cmd/alpha/certs.go
@@ -24,7 +24,6 @@ import (
 	kubeadmapiv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/certs/renewal"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
@@ -81,9 +80,7 @@ type renewConfig struct {
 }
 
 func getRenewSubCommands() []*cobra.Command {
-	cfg := &renewConfig{
-		kubeconfigPath: constants.GetAdminKubeConfigPath(),
-	}
+	cfg := &renewConfig{}
 	// Default values for the cobra help text
 	kubeadmscheme.Scheme.Default(&cfg.cfg)
 
@@ -168,7 +165,7 @@ func generateRenewalCommand(cert *certsphase.KubeadmCert, cfg *renewConfig) *cob
 
 func getRenewer(cfg *renewConfig, caCertBaseName string) (renewal.Interface, error) {
 	if cfg.useAPI {
-		kubeConfigPath := cmdutil.FindExistingKubeConfig(cfg.kubeconfigPath)
+		kubeConfigPath := cmdutil.GetKubeConfigPath(cfg.kubeconfigPath)
 		client, err := kubeconfigutil.ClientSetFromFile(kubeConfigPath)
 		if err != nil {
 			return nil, err

--- a/cmd/kubeadm/app/cmd/alpha/kubelet.go
+++ b/cmd/kubeadm/app/cmd/alpha/kubelet.go
@@ -130,7 +130,7 @@ func getKubeletVersion(kubeletVersionStr string) (*version.Version, error) {
 // This feature is still in alpha and an experimental state
 func newCmdKubeletConfigEnableDynamic() *cobra.Command {
 	var nodeName, kubeletVersionStr string
-	kubeConfigFile := constants.GetAdminKubeConfigPath()
+	var kubeConfigFile string
 
 	cmd := &cobra.Command{
 		Use:     "enable-dynamic",
@@ -148,7 +148,7 @@ func newCmdKubeletConfigEnableDynamic() *cobra.Command {
 			kubeletVersion, err := version.ParseSemantic(kubeletVersionStr)
 			kubeadmutil.CheckErr(err)
 
-			kubeConfigFile = cmdutil.FindExistingKubeConfig(kubeConfigFile)
+			kubeConfigFile = cmdutil.GetKubeConfigPath(kubeConfigFile)
 			client, err := kubeconfigutil.ClientSetFromFile(kubeConfigFile)
 			kubeadmutil.CheckErr(err)
 

--- a/cmd/kubeadm/app/cmd/alpha/selfhosting.go
+++ b/cmd/kubeadm/app/cmd/alpha/selfhosting.go
@@ -79,9 +79,8 @@ func getSelfhostingSubCommand(in io.Reader) *cobra.Command {
 	// Default values for the cobra help text
 	kubeadmscheme.Scheme.Default(cfg)
 
-	var cfgPath, featureGatesString string
+	var cfgPath, featureGatesString, kubeConfigFile string
 	forcePivot, certsInSecrets := false, false
-	kubeConfigFile := constants.GetAdminKubeConfigPath()
 
 	// Creates the UX Command
 	cmd := &cobra.Command{
@@ -119,7 +118,7 @@ func getSelfhostingSubCommand(in io.Reader) *cobra.Command {
 			}
 
 			// Gets the Kubernetes client
-			kubeConfigFile = cmdutil.FindExistingKubeConfig(kubeConfigFile)
+			kubeConfigFile = cmdutil.GetKubeConfigPath(kubeConfigFile)
 			client, err := kubeconfigutil.ClientSetFromFile(kubeConfigFile)
 			kubeadmutil.CheckErr(err)
 

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -62,7 +62,7 @@ var (
 
 // NewCmdConfig returns cobra.Command for "kubeadm config" command
 func NewCmdConfig(out io.Writer) *cobra.Command {
-	kubeConfigFile := constants.GetAdminKubeConfigPath()
+	var kubeConfigFile string
 
 	cmd := &cobra.Command{
 		Use:   "config",
@@ -83,7 +83,7 @@ func NewCmdConfig(out io.Writer) *cobra.Command {
 
 	options.AddKubeConfigFlag(cmd.PersistentFlags(), &kubeConfigFile)
 
-	kubeConfigFile = cmdutil.FindExistingKubeConfig(kubeConfigFile)
+	kubeConfigFile = cmdutil.GetKubeConfigPath(kubeConfigFile)
 	cmd.AddCommand(NewCmdConfigPrint(out))
 	cmd.AddCommand(NewCmdConfigMigrate(out))
 	cmd.AddCommand(NewCmdConfigUpload(out, &kubeConfigFile))

--- a/cmd/kubeadm/app/cmd/options/generic.go
+++ b/cmd/kubeadm/app/cmd/options/generic.go
@@ -19,11 +19,14 @@ package options
 import (
 	"github.com/spf13/pflag"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 // AddKubeConfigFlag adds the --kubeconfig flag to the given flagset
 func AddKubeConfigFlag(fs *pflag.FlagSet, kubeConfigFile *string) {
-	fs.StringVar(kubeConfigFile, KubeconfigPath, *kubeConfigFile, "The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations are searched for an existing KubeConfig file.")
+	fs.StringVar(kubeConfigFile, KubeconfigPath, *kubeConfigFile, "The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.")
+	// Note that DefValue is the text shown in the terminal and not the default value assigned to the flag
+	fs.Lookup(KubeconfigPath).DefValue = constants.GetAdminKubeConfigPath()
 }
 
 // AddKubeConfigDirFlag adds the --kubeconfig-dir flag to the given flagset

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -61,10 +61,12 @@ func NewCmdReset(in io.Reader, out io.Writer) *cobra.Command {
 			ignorePreflightErrorsSet, err := validation.ValidateIgnorePreflightErrors(ignorePreflightErrors)
 			kubeadmutil.CheckErr(err)
 
-			kubeConfigFile = cmdutil.FindExistingKubeConfig(kubeConfigFile)
 			if _, err := os.Stat(kubeConfigFile); !os.IsNotExist(err) {
 				client, err = getClientset(kubeConfigFile, false)
 				kubeadmutil.CheckErr(err)
+				klog.V(1).Infof("[reset] loaded client set from kubeconfig file: %s", kubeConfigFile)
+			} else {
+				klog.V(1).Infof("[reset] could not get client set from missing kubeconfig file: %s", kubeConfigFile)
 			}
 
 			if criSocketPath == "" {

--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	phaseutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	tokenphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
@@ -52,7 +51,7 @@ import (
 
 // NewCmdToken returns cobra.Command for token management
 func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
-	kubeConfigFile := kubeadmconstants.GetAdminKubeConfigPath()
+	var kubeConfigFile string
 	var dryRun bool
 	tokenCmd := &cobra.Command{
 		Use:   "token",
@@ -121,7 +120,7 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 			kubeadmutil.CheckErr(err)
 
 			klog.V(1).Infoln("[token] getting Clientsets from kubeconfig file")
-			kubeConfigFile = cmdutil.FindExistingKubeConfig(kubeConfigFile)
+			kubeConfigFile = cmdutil.GetKubeConfigPath(kubeConfigFile)
 			client, err := getClientset(kubeConfigFile, dryRun)
 			kubeadmutil.CheckErr(err)
 
@@ -148,7 +147,7 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 			This command will list all bootstrap tokens for you.
 		`),
 		Run: func(tokenCmd *cobra.Command, args []string) {
-			kubeConfigFile = cmdutil.FindExistingKubeConfig(kubeConfigFile)
+			kubeConfigFile = cmdutil.GetKubeConfigPath(kubeConfigFile)
 			client, err := getClientset(kubeConfigFile, dryRun)
 			kubeadmutil.CheckErr(err)
 
@@ -172,7 +171,7 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 			if len(args) < 1 {
 				kubeadmutil.CheckErr(errors.Errorf("missing subcommand; 'token delete' is missing token of form %q", bootstrapapi.BootstrapTokenIDPattern))
 			}
-			kubeConfigFile = cmdutil.FindExistingKubeConfig(kubeConfigFile)
+			kubeConfigFile = cmdutil.GetKubeConfigPath(kubeConfigFile)
 			client, err := getClientset(kubeConfigFile, dryRun)
 			kubeadmutil.CheckErr(err)
 

--- a/cmd/kubeadm/app/cmd/upgrade/upgrade.go
+++ b/cmd/kubeadm/app/cmd/upgrade/upgrade.go
@@ -62,7 +62,6 @@ func NewCmdUpgrade(out io.Writer) *cobra.Command {
 		RunE:  cmdutil.SubCmdRunE("upgrade"),
 	}
 
-	flags.kubeConfigPath = cmdutil.FindExistingKubeConfig(flags.kubeConfigPath)
 	cmd.AddCommand(NewCmdApply(flags))
 	cmd.AddCommand(NewCmdPlan(flags))
 	cmd.AddCommand(NewCmdDiff(out))

--- a/cmd/kubeadm/app/cmd/util/BUILD
+++ b/cmd/kubeadm/app/cmd/util/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/cmd/util/cmdutil.go
+++ b/cmd/kubeadm/app/cmd/util/cmdutil.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
@@ -62,18 +63,21 @@ func ValidateExactArgNumber(args []string, supportedArgs []string) error {
 	return nil
 }
 
-// FindExistingKubeConfig returns the localtion of kubeconfig
-func FindExistingKubeConfig(file string) string {
-	// The user did provide a --kubeconfig flag. Respect that and threat it as an
-	// explicit path without building a DefaultClientConfigLoadingRules object.
-	if file != kubeadmconstants.GetAdminKubeConfigPath() {
+// GetKubeConfigPath can be used to search for a kubeconfig in standard locations
+// if and empty string is passed to the function. If a non-empty string is passed
+// the function returns the same string.
+func GetKubeConfigPath(file string) string {
+	// If a value is provided respect that.
+	if file != "" {
 		return file
 	}
-	// The user did not provide a --kubeconfig flag. Find a config in the standard
-	// locations using DefaultClientConfigLoadingRules, but also consider the default config path.
+	// Find a config in the standard locations using DefaultClientConfigLoadingRules,
+	// but also consider the default config path.
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	rules.Precedence = append(rules.Precedence, kubeadmconstants.GetAdminKubeConfigPath())
-	return rules.GetDefaultFilename()
+	file = rules.GetDefaultFilename()
+	klog.V(1).Infof("Using kubeconfig file: %s", file)
+	return file
 }
 
 // AddCRISocketFlag adds the cri-socket flag to the supplied flagSet


### PR DESCRIPTION
**What this PR does / why we need it**:

- Rename FindExistingKubeConfig to FindKubeConfigFile

- Cobra supports a DefValue option which can be used
to differentiate between the cases where the user set a flag
and when a flag was unset, while still adding a default value.
Use this in options/generic.go for the kubeconfig flag.

- Remove the FindKubeConfigFile() logic from `reset` and `upgrade`
as these are node level kubeadm commands.

- Default kubeconfig values to "" everywhere where FindKubeConfigFile
is used. This allows to search for existing kubeconfig locations.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#1304

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
kubeadm: fix a bug where standard kubeconfig paths were searched even if the user provided /etc/kubernetes/admin.conf explicitly for commands that accept --kubeconfig, like kubeadm token.
kubeadm: use the default kubeconfig (/etc/kubernetes/admin.conf) for "kubeadm reset" and "kubeadm upgrade" commands.
```

/assign @fabriziopandini 
/cc @yagonobre 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 
/priority important-longterm
/hold
