### PR TITLE
Automated cherry pick of #71515 upstream release 1.13

### DIFF
--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -164,7 +164,8 @@ func (m *GracefulTerminationManager) deleteRsFunc(rsToDelete *listItem) (bool, e
 	}
 	for _, rs := range rss {
 		if rsToDelete.RealServer.Equal(rs) {
-			if rs.ActiveConn != 0 {
+			// Don't delete TCP RS with Active Connections or UDP RS (ActiveConn is always 0 for UDP)
+			if rs.ActiveConn != 0 || (rsToDelete.VirtualServer.Protocol == "UDP" && rs.InactiveConn != 0) {
 				return false, nil
 			}
 			klog.Infof("Deleting rs: %s", rsToDelete.String())

--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -75,10 +75,10 @@ func (q *graceTerminateRSList) remove(rs *listItem) bool {
 
 	uniqueRS := rs.String()
 	if _, ok := q.list[uniqueRS]; ok {
-		return false
+		delete(q.list, uniqueRS)
+		return true
 	}
-	delete(q.list, uniqueRS)
-	return true
+	return false
 }
 
 func (q *graceTerminateRSList) flushList(handler func(rsToDelete *listItem) (bool, error)) bool {

--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -164,8 +164,10 @@ func (m *GracefulTerminationManager) deleteRsFunc(rsToDelete *listItem) (bool, e
 	}
 	for _, rs := range rss {
 		if rsToDelete.RealServer.Equal(rs) {
-			// Don't delete TCP RS with Active Connections or UDP RS (ActiveConn is always 0 for UDP)
-			if rs.ActiveConn != 0 || (rsToDelete.VirtualServer.Protocol == "UDP" && rs.InactiveConn != 0) {
+			// Delete RS with no connections
+			// For UDP, ActiveConn is always 0
+			// For TCP, InactiveConn are connections not in ESTABLISHED state
+			if rs.ActiveConn+rs.InactiveConn != 0 {
 				return false, nil
 			}
 			klog.Infof("Deleting rs: %s", rsToDelete.String())

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1602,7 +1602,7 @@ func (proxier *Proxier) syncEndpoint(svcPortName proxy.ServicePortName, onlyNode
 			Port:    uint16(portNum),
 		}
 
-		klog.V(5).Infof("Using graceful delete to delete: %v", delDest)
+		klog.V(5).Infof("Using graceful delete to delete: %v", uniqueRS)
 		err = proxier.gracefuldeleteManager.GracefulDeleteRS(appliedVirtualServer, delDest)
 		if err != nil {
 			klog.Errorf("Failed to delete destination: %v, error: %v", delDest, err)


### PR DESCRIPTION
Cherry pick of #71515 on release-1.13.

#71515 : Enable graceful termination for UDP flows when using kube-proxy in IPVS mode

This PR also include a fix in the delete function which should fix: #71071

/sig network
/area ipvs

/assign @m1093782566 