### PR TITLE
Automated cherry pick of #70898: ensure scheduler preemptor behaves in an efficient/correct #71281: add an e2e test to verify preemption running path

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -418,7 +418,7 @@ func (g *genericScheduler) findNodesThatFit(pod *v1.Pod, nodes []*v1.Node) ([]*v
 // addNominatedPods adds pods with equal or greater priority which are nominated
 // to run on the node given in nodeInfo to meta and nodeInfo. It returns 1) whether
 // any pod was found, 2) augmented meta data, 3) augmented nodeInfo.
-func addNominatedPods(podPriority int32, meta algorithm.PredicateMetadata,
+func addNominatedPods(pod *v1.Pod, meta algorithm.PredicateMetadata,
 	nodeInfo *schedulercache.NodeInfo, queue SchedulingQueue) (bool, algorithm.PredicateMetadata,
 	*schedulercache.NodeInfo) {
 	if queue == nil || nodeInfo == nil || nodeInfo.Node() == nil {
@@ -435,7 +435,7 @@ func addNominatedPods(podPriority int32, meta algorithm.PredicateMetadata,
 	}
 	nodeInfoOut := nodeInfo.Clone()
 	for _, p := range nominatedPods {
-		if util.GetPodPriority(p) >= podPriority {
+		if util.GetPodPriority(p) >= util.GetPodPriority(pod) && p.UID != pod.UID {
 			nodeInfoOut.AddPod(p)
 			if metaOut != nil {
 				metaOut.AddPod(p, nodeInfoOut)
@@ -494,7 +494,7 @@ func podFitsOnNode(
 		metaToUse := meta
 		nodeInfoToUse := info
 		if i == 0 {
-			podsAdded, metaToUse, nodeInfoToUse = addNominatedPods(util.GetPodPriority(pod), meta, info, queue)
+			podsAdded, metaToUse, nodeInfoToUse = addNominatedPods(pod, meta, info, queue)
 		} else if !podsAdded || len(failedPredicates) != 0 {
 			break
 		}

--- a/pkg/scheduler/core/scheduling_queue.go
+++ b/pkg/scheduler/core/scheduling_queue.go
@@ -58,6 +58,8 @@ type SchedulingQueue interface {
 	AssignedPodUpdated(pod *v1.Pod)
 	WaitingPodsForNode(nodeName string) []*v1.Pod
 	WaitingPods() []*v1.Pod
+	// DeleteNominatedPodIfExists deletes nominatedPod from internal cache
+	DeleteNominatedPodIfExists(pod *v1.Pod)
 }
 
 // NewSchedulingQueue initializes a new scheduling queue. If pod priority is
@@ -144,6 +146,9 @@ func (f *FIFO) WaitingPodsForNode(nodeName string) []*v1.Pod {
 	return nil
 }
 
+// DeleteNominatedPodIfExists does nothing in FIFO.
+func (f *FIFO) DeleteNominatedPodIfExists(pod *v1.Pod) {}
+
 // NewFIFO creates a FIFO object.
 func NewFIFO() *FIFO {
 	return &FIFO{FIFO: cache.NewFIFO(cache.MetaNamespaceKeyFunc)}
@@ -223,7 +228,7 @@ func (p *PriorityQueue) addNominatedPodIfNeeded(pod *v1.Pod) {
 	if len(nnn) > 0 {
 		for _, np := range p.nominatedPods[nnn] {
 			if np.UID == pod.UID {
-				glog.Errorf("Pod %v/%v already exists in the nominated map!", pod.Namespace, pod.Name)
+				glog.V(4).Infof("Pod %v/%v already exists in the nominated map!", pod.Namespace, pod.Name)
 				return
 			}
 		}
@@ -232,6 +237,7 @@ func (p *PriorityQueue) addNominatedPodIfNeeded(pod *v1.Pod) {
 }
 
 // deleteNominatedPodIfExists deletes a pod from the nominatedPods.
+// NOTE: this function assumes lock has been acquired in caller.
 func (p *PriorityQueue) deleteNominatedPodIfExists(pod *v1.Pod) {
 	nnn := NominatedNodeName(pod)
 	if len(nnn) > 0 {
@@ -340,7 +346,6 @@ func (p *PriorityQueue) Pop() (*v1.Pod, error) {
 		return nil, err
 	}
 	pod := obj.(*v1.Pod)
-	p.deleteNominatedPodIfExists(pod)
 	p.receivedMoveRequest = false
 	return pod, err
 }
@@ -409,13 +414,17 @@ func (p *PriorityQueue) Delete(pod *v1.Pod) error {
 // AssignedPodAdded is called when a bound pod is added. Creation of this pod
 // may make pending pods with matching affinity terms schedulable.
 func (p *PriorityQueue) AssignedPodAdded(pod *v1.Pod) {
+	p.lock.Lock()
 	p.movePodsToActiveQueue(p.getUnschedulablePodsWithMatchingAffinityTerm(pod))
+	p.lock.Unlock()
 }
 
 // AssignedPodUpdated is called when a bound pod is updated. Change of labels
 // may make pending pods with matching affinity terms schedulable.
 func (p *PriorityQueue) AssignedPodUpdated(pod *v1.Pod) {
+	p.lock.Lock()
 	p.movePodsToActiveQueue(p.getUnschedulablePodsWithMatchingAffinityTerm(pod))
+	p.lock.Unlock()
 }
 
 // MoveAllToActiveQueue moves all pods from unschedulableQ to activeQ. This
@@ -439,9 +448,8 @@ func (p *PriorityQueue) MoveAllToActiveQueue() {
 	p.cond.Broadcast()
 }
 
+// NOTE: this function assumes lock has been acquired in caller
 func (p *PriorityQueue) movePodsToActiveQueue(pods []*v1.Pod) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
 	for _, pod := range pods {
 		if err := p.activeQ.Add(pod); err == nil {
 			p.unschedulableQ.delete(pod)
@@ -455,9 +463,8 @@ func (p *PriorityQueue) movePodsToActiveQueue(pods []*v1.Pod) {
 
 // getUnschedulablePodsWithMatchingAffinityTerm returns unschedulable pods which have
 // any affinity term that matches "pod".
+// NOTE: this function assumes lock has been acquired in caller.
 func (p *PriorityQueue) getUnschedulablePodsWithMatchingAffinityTerm(pod *v1.Pod) []*v1.Pod {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
 	var podsToMove []*v1.Pod
 	for _, up := range p.unschedulableQ.pods {
 		affinity := up.Spec.Affinity
@@ -504,6 +511,13 @@ func (p *PriorityQueue) WaitingPods() []*v1.Pod {
 		result = append(result, pod)
 	}
 	return result
+}
+
+// DeleteNominatedPodIfExists deletes pod from internal cache if it's a nominatedPod
+func (p *PriorityQueue) DeleteNominatedPodIfExists(pod *v1.Pod) {
+	p.lock.Lock()
+	p.deleteNominatedPodIfExists(pod)
+	p.lock.Unlock()
 }
 
 // UnschedulablePodsMap holds pods that cannot be scheduled. This data structure

--- a/pkg/scheduler/core/scheduling_queue_test.go
+++ b/pkg/scheduler/core/scheduling_queue_test.go
@@ -113,8 +113,8 @@ func TestPriorityQueue_Add(t *testing.T) {
 	if p, err := q.Pop(); err != nil || p != &unschedulablePod {
 		t.Errorf("Expected: %v after Pop, but got: %v", unschedulablePod.Name, p.Name)
 	}
-	if len(q.nominatedPods) != 0 {
-		t.Errorf("Expected nomindatePods to be empty: %v", q.nominatedPods)
+	if len(q.nominatedPods["node1"]) != 2 {
+		t.Errorf("Expected medPriorityPod and unschedulablePod to be still present in nomindatePods: %v", q.nominatedPods["node1"])
 	}
 }
 
@@ -136,8 +136,8 @@ func TestPriorityQueue_AddIfNotPresent(t *testing.T) {
 	if p, err := q.Pop(); err != nil || p != &unschedulablePod {
 		t.Errorf("Expected: %v after Pop, but got: %v", unschedulablePod.Name, p.Name)
 	}
-	if len(q.nominatedPods) != 0 {
-		t.Errorf("Expected nomindatePods to be empty: %v", q.nominatedPods)
+	if len(q.nominatedPods["node1"]) != 2 {
+		t.Errorf("Expected medPriorityPod and unschedulablePod to be still present in nomindatePods: %v", q.nominatedPods["node1"])
 	}
 	if q.unschedulableQ.get(&highPriNominatedPod) != &highPriNominatedPod {
 		t.Errorf("Pod %v was not found in the unschedulableQ.", highPriNominatedPod.Name)
@@ -179,8 +179,8 @@ func TestPriorityQueue_Pop(t *testing.T) {
 		if p, err := q.Pop(); err != nil || p != &medPriorityPod {
 			t.Errorf("Expected: %v after Pop, but got: %v", medPriorityPod.Name, p.Name)
 		}
-		if len(q.nominatedPods) != 0 {
-			t.Errorf("Expected nomindatePods to be empty: %v", q.nominatedPods)
+		if len(q.nominatedPods["node1"]) != 1 {
+			t.Errorf("Expected medPriorityPod to be present in nomindatePods: %v", q.nominatedPods["node1"])
 		}
 	}()
 	q.Add(&medPriorityPod)

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -1109,9 +1109,10 @@ func (c *configFactory) CreateFromKeys(predicateKeys, priorityKeys sets.String, 
 		NextPod: func() *v1.Pod {
 			return c.getNextPod()
 		},
-		Error:          c.MakeDefaultErrorFunc(podBackoff, c.podQueue),
-		StopEverything: c.StopEverything,
-		VolumeBinder:   c.volumeBinder,
+		Error:           c.MakeDefaultErrorFunc(podBackoff, c.podQueue),
+		StopEverything:  c.StopEverything,
+		VolumeBinder:    c.volumeBinder,
+		SchedulingQueue: c.podQueue,
 	}, nil
 }
 

--- a/test/e2e/scheduling/BUILD
+++ b/test/e2e/scheduling/BUILD
@@ -35,6 +35,7 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
+        "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/api/scheduling/v1beta1:go_default_library",
@@ -42,12 +43,14 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )
 

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -432,7 +432,7 @@ var _ = SIGDescribe("PreemptionExecutionPath", func() {
 		podNamesSeen := make(map[string]struct{})
 		stopCh := make(chan struct{})
 
-		// create an pod controller to list/watch pod events from the test framework namespace
+		// create a pod controller to list/watch pod events from the test framework namespace
 		_, podController := cache.NewInformer(
 			&cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -461,7 +461,7 @@ var _ = SIGDescribe("PreemptionExecutionPath", func() {
 			{
 				Replicas: int32(5),
 				PodConfig: pausePodConfig{
-					Name:              fmt.Sprintf("pod1"),
+					Name:              "pod1",
 					Namespace:         ns,
 					Labels:            map[string]string{"name": "pod1"},
 					PriorityClassName: "p1",
@@ -475,7 +475,7 @@ var _ = SIGDescribe("PreemptionExecutionPath", func() {
 			{
 				Replicas: int32(4),
 				PodConfig: pausePodConfig{
-					Name:              fmt.Sprintf("pod2"),
+					Name:              "pod2",
 					Namespace:         ns,
 					Labels:            map[string]string{"name": "pod2"},
 					PriorityClassName: "p2",
@@ -489,7 +489,7 @@ var _ = SIGDescribe("PreemptionExecutionPath", func() {
 			{
 				Replicas: int32(4),
 				PodConfig: pausePodConfig{
-					Name:              fmt.Sprintf("pod3"),
+					Name:              "pod3",
 					Namespace:         ns,
 					Labels:            map[string]string{"name": "pod3"},
 					PriorityClassName: "p3",
@@ -503,7 +503,7 @@ var _ = SIGDescribe("PreemptionExecutionPath", func() {
 			{
 				Replicas: int32(1),
 				PodConfig: pausePodConfig{
-					Name:              fmt.Sprintf("pod4"),
+					Name:              "pod4",
 					Namespace:         ns,
 					Labels:            map[string]string{"name": "pod4"},
 					PriorityClassName: "p4",
@@ -532,16 +532,25 @@ var _ = SIGDescribe("PreemptionExecutionPath", func() {
 		framework.Logf("pods created so far: %v", podNamesSeen)
 		framework.Logf("length of pods created so far: %v", len(podNamesSeen))
 
-		// count pods number of RepliaSet3, if it's more than orignal replicas (4)
-		// then means its pods has been preempted once or more
-		rs3PodsSeen := 0
+		// count pods number of ReplicaSet{1,2,3}, if it's more than expected replicas
+		// then it denotes its pods have been over-preempted
+		// "*2" means pods of ReplicaSet{1,2} are expected to be only preempted once
+		maxRSPodsSeen := []int{5 * 2, 4 * 2, 4}
+		rsPodsSeen := []int{0, 0, 0}
 		for podName := range podNamesSeen {
-			if strings.HasPrefix(podName, "rs-pod3") {
-				rs3PodsSeen++
+			if strings.HasPrefix(podName, "rs-pod1") {
+				rsPodsSeen[0]++
+			} else if strings.HasPrefix(podName, "rs-pod2") {
+				rsPodsSeen[1]++
+			} else if strings.HasPrefix(podName, "rs-pod3") {
+				rsPodsSeen[2]++
 			}
 		}
-		if rs3PodsSeen != 4 {
-			framework.Failf("some pods of ReplicaSet3 have been preempted: expect 4 pod names, but got %d", rs3PodsSeen)
+		for i, got := range rsPodsSeen {
+			expected := maxRSPodsSeen[i]
+			if got > expected {
+				framework.Failf("pods of ReplicaSet%d have been over-preempted: expect %v pod names, but got %d", i+1, expected, got)
+			}
 		}
 	})
 

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -18,13 +18,19 @@ package scheduling
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
+	"k8s.io/client-go/tools/cache"
+
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	schedulerapi "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -349,3 +355,217 @@ var _ = SIGDescribe("PodPriorityResolution [Serial] [Feature:PodPreemption]", fu
 		}
 	})
 })
+
+// construct a fakecpu so as to set it to status of Node object
+// otherwise if we update CPU/Memory/etc, those values will be corrected back by kubelet
+var fakecpu v1.ResourceName = "example.com/fakecpu"
+
+var _ = SIGDescribe("PreemptionExecutionPath", func() {
+	var cs clientset.Interface
+	var node *v1.Node
+	var ns string
+	f := framework.NewDefaultFramework("sched-preemption-path")
+
+	AfterEach(func() {
+		if node != nil {
+			nodeCopy := node.DeepCopy()
+			// force it to update
+			nodeCopy.ResourceVersion = "0"
+			delete(nodeCopy.Status.Capacity, fakecpu)
+			_, err := cs.CoreV1().Nodes().UpdateStatus(nodeCopy)
+			framework.ExpectNoError(err)
+		}
+	})
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace.Name
+
+		// find an available node
+		By("Finding an available node")
+		nodeName := GetNodeThatCanRunPod(f)
+		framework.Logf("found a healthy node: %s", nodeName)
+
+		// get the node API object
+		var err error
+		node, err = cs.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+		if err != nil {
+			framework.Failf("error getting node %q: %v", nodeName, err)
+		}
+
+		// update Node API object with a fake resource
+		nodeCopy := node.DeepCopy()
+		// force it to update
+		nodeCopy.ResourceVersion = "0"
+		nodeCopy.Status.Capacity[fakecpu] = resource.MustParse("800")
+		node, err = cs.CoreV1().Nodes().UpdateStatus(nodeCopy)
+		framework.ExpectNoError(err)
+
+		// create four PriorityClass: p1, p2, p3, p4
+		for i := 1; i <= 4; i++ {
+			priorityName := fmt.Sprintf("p%d", i)
+			_, err := f.ClientSet.SchedulingV1beta1().PriorityClasses().Create(&schedulerapi.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: priorityName}, Value: int32(i)})
+			Expect(err == nil || errors.IsAlreadyExists(err)).To(Equal(true))
+		}
+	})
+
+	It("runs ReplicaSets to verify preemption running path", func() {
+		podNamesSeen := make(map[string]struct{})
+		stopCh := make(chan struct{})
+
+		// create an pod controller to list/watch pod events from the test framework namespace
+		_, podController := cache.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					obj, err := f.ClientSet.CoreV1().Pods(ns).List(options)
+					return runtime.Object(obj), err
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					return f.ClientSet.CoreV1().Pods(ns).Watch(options)
+				},
+			},
+			&v1.Pod{},
+			0,
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					if pod, ok := obj.(*v1.Pod); ok {
+						podNamesSeen[pod.Name] = struct{}{}
+					}
+				},
+			},
+		)
+		go podController.Run(stopCh)
+		defer close(stopCh)
+
+		// prepare four ReplicaSet
+		rsConfs := []pauseRSConfig{
+			{
+				Replicas: int32(5),
+				PodConfig: pausePodConfig{
+					Name:              fmt.Sprintf("pod1"),
+					Namespace:         ns,
+					Labels:            map[string]string{"name": "pod1"},
+					PriorityClassName: "p1",
+					NodeSelector:      map[string]string{"kubernetes.io/hostname": node.Name},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{fakecpu: resource.MustParse("40")},
+						Limits:   v1.ResourceList{fakecpu: resource.MustParse("40")},
+					},
+				},
+			},
+			{
+				Replicas: int32(4),
+				PodConfig: pausePodConfig{
+					Name:              fmt.Sprintf("pod2"),
+					Namespace:         ns,
+					Labels:            map[string]string{"name": "pod2"},
+					PriorityClassName: "p2",
+					NodeSelector:      map[string]string{"kubernetes.io/hostname": node.Name},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{fakecpu: resource.MustParse("50")},
+						Limits:   v1.ResourceList{fakecpu: resource.MustParse("50")},
+					},
+				},
+			},
+			{
+				Replicas: int32(4),
+				PodConfig: pausePodConfig{
+					Name:              fmt.Sprintf("pod3"),
+					Namespace:         ns,
+					Labels:            map[string]string{"name": "pod3"},
+					PriorityClassName: "p3",
+					NodeSelector:      map[string]string{"kubernetes.io/hostname": node.Name},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{fakecpu: resource.MustParse("95")},
+						Limits:   v1.ResourceList{fakecpu: resource.MustParse("95")},
+					},
+				},
+			},
+			{
+				Replicas: int32(1),
+				PodConfig: pausePodConfig{
+					Name:              fmt.Sprintf("pod4"),
+					Namespace:         ns,
+					Labels:            map[string]string{"name": "pod4"},
+					PriorityClassName: "p4",
+					NodeSelector:      map[string]string{"kubernetes.io/hostname": node.Name},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{fakecpu: resource.MustParse("400")},
+						Limits:   v1.ResourceList{fakecpu: resource.MustParse("400")},
+					},
+				},
+			},
+		}
+		// create ReplicaSet{1,2,3} so as to occupy 780/800 fake resource
+		rsNum := len(rsConfs)
+		for i := 0; i < rsNum-1; i++ {
+			runPauseRS(f, rsConfs[i])
+		}
+
+		framework.Logf("pods created so far: %v", podNamesSeen)
+		framework.Logf("length of pods created so far: %v", len(podNamesSeen))
+
+		// create ReplicaSet4
+		// if runPauseRS failed, it means ReplicaSet4 cannot be scheduled even after 1 minute
+		// which is unacceptable
+		runPauseRS(f, rsConfs[rsNum-1])
+
+		framework.Logf("pods created so far: %v", podNamesSeen)
+		framework.Logf("length of pods created so far: %v", len(podNamesSeen))
+
+		// count pods number of RepliaSet3, if it's more than orignal replicas (4)
+		// then means its pods has been preempted once or more
+		rs3PodsSeen := 0
+		for podName := range podNamesSeen {
+			if strings.HasPrefix(podName, "rs-pod3") {
+				rs3PodsSeen++
+			}
+		}
+		if rs3PodsSeen != 4 {
+			framework.Failf("some pods of ReplicaSet3 have been preempted: expect 4 pod names, but got %d", rs3PodsSeen)
+		}
+	})
+
+})
+
+type pauseRSConfig struct {
+	Replicas  int32
+	PodConfig pausePodConfig
+}
+
+func initPauseRS(f *framework.Framework, conf pauseRSConfig) *appsv1.ReplicaSet {
+	pausePod := initPausePod(f, conf.PodConfig)
+	pauseRS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rs-" + pausePod.Name,
+			Namespace: pausePod.Namespace,
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &conf.Replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: pausePod.Labels,
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: pausePod.ObjectMeta.Labels},
+				Spec:       pausePod.Spec,
+			},
+		},
+	}
+	return pauseRS
+}
+
+func createPauseRS(f *framework.Framework, conf pauseRSConfig) *appsv1.ReplicaSet {
+	namespace := conf.PodConfig.Namespace
+	if len(namespace) == 0 {
+		namespace = f.Namespace.Name
+	}
+	rs, err := f.ClientSet.AppsV1().ReplicaSets(namespace).Create(initPauseRS(f, conf))
+	framework.ExpectNoError(err)
+	return rs
+}
+
+func runPauseRS(f *framework.Framework, conf pauseRSConfig) *appsv1.ReplicaSet {
+	rs := createPauseRS(f, conf)
+	framework.ExpectNoError(framework.WaitForReplicaSetTargetAvailableReplicas(f.ClientSet, rs, conf.Replicas))
+	return rs
+}


### PR DESCRIPTION
Cherry pick of #70898 #71281 on release-1.11.

#70898: ensure scheduler preemptor behaves in an efficient/correct
#71281: add an e2e test to verify preemption running path

```release-note
Fix a potential bug that scheduler preempts unnecessary pods.
```