### PR TITLE
Create /var/lib/etcd with 0700

### DIFF
--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -18,6 +18,7 @@ package etcd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -48,6 +49,12 @@ func CreateLocalEtcdStaticPodManifestFile(manifestDir string, cfg *kubeadmapi.In
 	}
 	// gets etcd StaticPodSpec
 	emptyInitialCluster := []etcdutil.Member{}
+
+	// creates target folder if not already exists
+	if err := os.MkdirAll(cfg.Etcd.Local.DataDir, 0700); err != nil {
+		return errors.Wrapf(err, "failed to create etcd directory %q", cfg.Etcd.Local.DataDir)
+	}
+
 	spec := GetEtcdPodSpec(cfg, emptyInitialCluster)
 	// writes etcd StaticPod to disk
 	if err := staticpodutil.WriteStaticPodToDisk(kubeadmconstants.Etcd, manifestDir, spec); err != nil {
@@ -99,6 +106,11 @@ func CreateStackedEtcdStaticPodManifestFile(client clientset.Interface, manifest
 	}
 	fmt.Println("[etcd] Announced new etcd member joining to the existing etcd cluster")
 	klog.V(1).Infof("Updated etcd member list: %v", initialCluster)
+
+	// creates target folder if not already exists
+	if err := os.MkdirAll(cfg.Etcd.Local.DataDir, 0700); err != nil {
+		return errors.Wrapf(err, "failed to create etcd directory %q", cfg.Etcd.Local.DataDir)
+	}
 
 	klog.V(1).Info("Creating local etcd static pod manifest file")
 	// gets etcd StaticPodSpec, actualized for the current InitConfiguration and the new list of etcd members

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -67,7 +67,7 @@ func TestCreateLocalEtcdStaticPodManifestFile(t *testing.T) {
 					KubernetesVersion: "v1.7.0",
 					Etcd: kubeadmapi.Etcd{
 						Local: &kubeadmapi.LocalEtcd{
-							DataDir: "/var/lib/etcd",
+							DataDir: tmpdir + "/etcd",
 						},
 					},
 				},


### PR DESCRIPTION
If we let the hostpath with DirectoryOrCreate to create this directory
it defaults to 0755. A default install should use 0700 for better
security especially if the directory is not present.

Change-Id: Idc0266685895767b0d1c5710c8a4fb704805652f

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/1308

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
 kubeadm: Create /var/lib/etcd with correct permissions (0700) by default.
```
