### PR TITLE
Clean unused function in pkg/kubelet/kubelet.go

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1221,29 +1221,6 @@ type Kubelet struct {
 	runtimeClassManager *runtimeclass.Manager
 }
 
-func allGlobalUnicastIPs() ([]net.IP, error) {
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		return nil, fmt.Errorf("could not list network interfaces: %v", err)
-	}
-	var ips []net.IP
-	for _, i := range interfaces {
-		addresses, err := i.Addrs()
-		if err != nil {
-			return nil, fmt.Errorf("could not list the addresses for network interface %v: %v", i, err)
-		}
-		for _, address := range addresses {
-			switch v := address.(type) {
-			case *net.IPNet:
-				if v.IP.IsGlobalUnicast() {
-					ips = append(ips, v.IP)
-				}
-			}
-		}
-	}
-	return ips, nil
-}
-
 // setupDataDirs creates:
 // 1.  the root directory
 // 2.  the pods directory


### PR DESCRIPTION

> /kind cleanup

Clean unused function in pkg/kubelet/kubelet.go, and the only reference was removed in https://github.com/kubernetes/kubernetes/pull/65594

```release-note
NONE
```
