### PR TITLE
Fix unit test error in pkg/registry/apps/daemonset/storage/

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -59,9 +59,9 @@ v1 \
 admissionregistration.k8s.io/v1alpha1 \
 admissionregistration.k8s.io/v1beta1 \
 admission.k8s.io/v1beta1 \
+apps/v1 \
 apps/v1beta1 \
 apps/v1beta2 \
-apps/v1 \
 auditregistration.k8s.io/v1alpha1 \
 authentication.k8s.io/v1 \
 authentication.k8s.io/v1beta1 \

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -62,11 +62,11 @@ type Interface interface {
 	AdmissionregistrationV1beta1() admissionregistrationv1beta1.AdmissionregistrationV1beta1Interface
 	// Deprecated: please explicitly pick a version if possible.
 	Admissionregistration() admissionregistrationv1beta1.AdmissionregistrationV1beta1Interface
-	AppsV1beta1() appsv1beta1.AppsV1beta1Interface
-	AppsV1beta2() appsv1beta2.AppsV1beta2Interface
 	AppsV1() appsv1.AppsV1Interface
 	// Deprecated: please explicitly pick a version if possible.
 	Apps() appsv1.AppsV1Interface
+	AppsV1beta1() appsv1beta1.AppsV1beta1Interface
+	AppsV1beta2() appsv1beta2.AppsV1beta2Interface
 	AuditregistrationV1alpha1() auditregistrationv1alpha1.AuditregistrationV1alpha1Interface
 	// Deprecated: please explicitly pick a version if possible.
 	Auditregistration() auditregistrationv1alpha1.AuditregistrationV1alpha1Interface
@@ -134,9 +134,9 @@ type Clientset struct {
 	*discovery.DiscoveryClient
 	admissionregistrationV1alpha1 *admissionregistrationv1alpha1.AdmissionregistrationV1alpha1Client
 	admissionregistrationV1beta1  *admissionregistrationv1beta1.AdmissionregistrationV1beta1Client
+	appsV1                        *appsv1.AppsV1Client
 	appsV1beta1                   *appsv1beta1.AppsV1beta1Client
 	appsV1beta2                   *appsv1beta2.AppsV1beta2Client
-	appsV1                        *appsv1.AppsV1Client
 	auditregistrationV1alpha1     *auditregistrationv1alpha1.AuditregistrationV1alpha1Client
 	authenticationV1              *authenticationv1.AuthenticationV1Client
 	authenticationV1beta1         *authenticationv1beta1.AuthenticationV1beta1Client
@@ -182,16 +182,6 @@ func (c *Clientset) Admissionregistration() admissionregistrationv1beta1.Admissi
 	return c.admissionregistrationV1beta1
 }
 
-// AppsV1beta1 retrieves the AppsV1beta1Client
-func (c *Clientset) AppsV1beta1() appsv1beta1.AppsV1beta1Interface {
-	return c.appsV1beta1
-}
-
-// AppsV1beta2 retrieves the AppsV1beta2Client
-func (c *Clientset) AppsV1beta2() appsv1beta2.AppsV1beta2Interface {
-	return c.appsV1beta2
-}
-
 // AppsV1 retrieves the AppsV1Client
 func (c *Clientset) AppsV1() appsv1.AppsV1Interface {
 	return c.appsV1
@@ -201,6 +191,16 @@ func (c *Clientset) AppsV1() appsv1.AppsV1Interface {
 // Please explicitly pick a version.
 func (c *Clientset) Apps() appsv1.AppsV1Interface {
 	return c.appsV1
+}
+
+// AppsV1beta1 retrieves the AppsV1beta1Client
+func (c *Clientset) AppsV1beta1() appsv1beta1.AppsV1beta1Interface {
+	return c.appsV1beta1
+}
+
+// AppsV1beta2 retrieves the AppsV1beta2Client
+func (c *Clientset) AppsV1beta2() appsv1beta2.AppsV1beta2Interface {
+	return c.appsV1beta2
 }
 
 // AuditregistrationV1alpha1 retrieves the AuditregistrationV1alpha1Client
@@ -458,15 +458,15 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
+	cs.appsV1, err = appsv1.NewForConfig(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
 	cs.appsV1beta1, err = appsv1beta1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
 	cs.appsV1beta2, err = appsv1beta2.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.appsV1, err = appsv1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -592,9 +592,9 @@ func NewForConfigOrDie(c *rest.Config) *Clientset {
 	var cs Clientset
 	cs.admissionregistrationV1alpha1 = admissionregistrationv1alpha1.NewForConfigOrDie(c)
 	cs.admissionregistrationV1beta1 = admissionregistrationv1beta1.NewForConfigOrDie(c)
+	cs.appsV1 = appsv1.NewForConfigOrDie(c)
 	cs.appsV1beta1 = appsv1beta1.NewForConfigOrDie(c)
 	cs.appsV1beta2 = appsv1beta2.NewForConfigOrDie(c)
-	cs.appsV1 = appsv1.NewForConfigOrDie(c)
 	cs.auditregistrationV1alpha1 = auditregistrationv1alpha1.NewForConfigOrDie(c)
 	cs.authenticationV1 = authenticationv1.NewForConfigOrDie(c)
 	cs.authenticationV1beta1 = authenticationv1beta1.NewForConfigOrDie(c)
@@ -632,9 +632,9 @@ func New(c rest.Interface) *Clientset {
 	var cs Clientset
 	cs.admissionregistrationV1alpha1 = admissionregistrationv1alpha1.New(c)
 	cs.admissionregistrationV1beta1 = admissionregistrationv1beta1.New(c)
+	cs.appsV1 = appsv1.New(c)
 	cs.appsV1beta1 = appsv1beta1.New(c)
 	cs.appsV1beta2 = appsv1beta2.New(c)
-	cs.appsV1 = appsv1.New(c)
 	cs.auditregistrationV1alpha1 = auditregistrationv1alpha1.New(c)
 	cs.authenticationV1 = authenticationv1.New(c)
 	cs.authenticationV1beta1 = authenticationv1beta1.New(c)

--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
@@ -148,16 +148,6 @@ func (c *Clientset) Admissionregistration() admissionregistrationv1beta1.Admissi
 	return &fakeadmissionregistrationv1beta1.FakeAdmissionregistrationV1beta1{Fake: &c.Fake}
 }
 
-// AppsV1beta1 retrieves the AppsV1beta1Client
-func (c *Clientset) AppsV1beta1() appsv1beta1.AppsV1beta1Interface {
-	return &fakeappsv1beta1.FakeAppsV1beta1{Fake: &c.Fake}
-}
-
-// AppsV1beta2 retrieves the AppsV1beta2Client
-func (c *Clientset) AppsV1beta2() appsv1beta2.AppsV1beta2Interface {
-	return &fakeappsv1beta2.FakeAppsV1beta2{Fake: &c.Fake}
-}
-
 // AppsV1 retrieves the AppsV1Client
 func (c *Clientset) AppsV1() appsv1.AppsV1Interface {
 	return &fakeappsv1.FakeAppsV1{Fake: &c.Fake}
@@ -166,6 +156,16 @@ func (c *Clientset) AppsV1() appsv1.AppsV1Interface {
 // Apps retrieves the AppsV1Client
 func (c *Clientset) Apps() appsv1.AppsV1Interface {
 	return &fakeappsv1.FakeAppsV1{Fake: &c.Fake}
+}
+
+// AppsV1beta1 retrieves the AppsV1beta1Client
+func (c *Clientset) AppsV1beta1() appsv1beta1.AppsV1beta1Interface {
+	return &fakeappsv1beta1.FakeAppsV1beta1{Fake: &c.Fake}
+}
+
+// AppsV1beta2 retrieves the AppsV1beta2Client
+func (c *Clientset) AppsV1beta2() appsv1beta2.AppsV1beta2Interface {
+	return &fakeappsv1beta2.FakeAppsV1beta2{Fake: &c.Fake}
 }
 
 // AuditregistrationV1alpha1 retrieves the AuditregistrationV1alpha1Client

--- a/staging/src/k8s.io/client-go/kubernetes/fake/register.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/register.go
@@ -64,9 +64,9 @@ var parameterCodec = runtime.NewParameterCodec(scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
 	admissionregistrationv1alpha1.AddToScheme,
 	admissionregistrationv1beta1.AddToScheme,
+	appsv1.AddToScheme,
 	appsv1beta1.AddToScheme,
 	appsv1beta2.AddToScheme,
-	appsv1.AddToScheme,
 	auditregistrationv1alpha1.AddToScheme,
 	authenticationv1.AddToScheme,
 	authenticationv1beta1.AddToScheme,

--- a/staging/src/k8s.io/client-go/kubernetes/scheme/register.go
+++ b/staging/src/k8s.io/client-go/kubernetes/scheme/register.go
@@ -64,9 +64,9 @@ var ParameterCodec = runtime.NewParameterCodec(Scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
 	admissionregistrationv1alpha1.AddToScheme,
 	admissionregistrationv1beta1.AddToScheme,
+	appsv1.AddToScheme,
 	appsv1beta1.AddToScheme,
 	appsv1beta2.AddToScheme,
-	appsv1.AddToScheme,
 	auditregistrationv1alpha1.AddToScheme,
 	authenticationv1.AddToScheme,
 	authenticationv1beta1.AddToScheme,


### PR DESCRIPTION
Currently, the unit test in pkg/registry/apps/daemonset/storage will fail like:
```
--- FAIL: TestUpdate (0.32s)
    resttest.go:531: unexpected error: no kind "DaemonSet" is registered for version "apps/v1beta1" in scheme "k8s.io/kubernetes/pkg/api/legacyscheme/scheme.go:29"
    resttest.go:536: unexpected error: daemonsets.apps "foo2" not found
panic: interface conversion: runtime.Object is nil, not *apps.DaemonSet [recovered]
	panic: interface conversion: runtime.Object is nil, not *apps.DaemonSet
```
DaemonSet has no v1beta1 version in group apps, and the default version for apps group in init.sh is v1beta1.
https://github.com/kubernetes/kubernetes/blob/ae41593f8593f82cdb7fd3ebc967c5bce13323b4/hack/lib/init.sh#L58 


 /kind failing-test


```release-note
NONE
```
