### PR TITLE
pvc protection should skip unbound pvc

### DIFF
--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -208,6 +208,10 @@ func (c *Controller) removeFinalizer(pvc *v1.PersistentVolumeClaim) error {
 }
 
 func (c *Controller) isBeingUsed(pvc *v1.PersistentVolumeClaim) (bool, error) {
+	// if PVC is Pending, should be deleted
+	if pvc.Status.Phase == v1.ClaimPending || pvc.Spec.VolumeName == "" {
+		return false, nil
+	}
 	pods, err := c.podLister.Pods(pvc.Namespace).List(labels.Everything())
 	if err != nil {
 		return false, err


### PR DESCRIPTION
If PVC is pending due to volume backend issue or specified wrong storage class or some other reasons, need to skip protection for the PVC, so we can delete the PVC and recreate new one without having to delete pod.