### PR TITLE
add new predicate: max replicas limit per node

### DIFF
--- a/pkg/scheduler/algorithm/predicates/error.go
+++ b/pkg/scheduler/algorithm/predicates/error.go
@@ -80,6 +80,8 @@ var (
 	// ErrFakePredicate is used for test only. The fake predicates returning false also returns error
 	// as ErrFakePredicate.
 	ErrFakePredicate = newPredicateFailureError("FakePredicateError", "Nodes failed the fake predicate")
+	// ErrHostOutOfMaxReplicasLimit is used for HostOutOfMaxReplicasLimit predicate error.
+	ErrHostOutOfMaxReplicasLimit = newPredicateFailureError("HostOutOfMaxReplicasLimit", "The number of replicas exceeds maxReplicasNumberPerHost limit")
 )
 
 // InsufficientResourceError is an error type that indicates what kind of resource limit is

--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -112,6 +112,13 @@ func defaultPredicates() sets.String {
 				return predicates.NewVolumeZonePredicate(args.PVInfo, args.PVCInfo, args.StorageClassInfo)
 			},
 		),
+		// Fit is determined by maximum replicas per node requirement.
+		factory.RegisterFitPredicateFactory(
+			predicates.CheckMaxReplicasPerHostPred,
+			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
+				return predicates.NewReplicasSpreadPredicate()
+			},
+		),
 		// Fit is determined by whether or not there would be too many AWS EBS volumes attached to the node
 		factory.RegisterFitPredicateFactory(
 			predicates.MaxEBSVolumeCountPred,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
/kind feature

**What this PR does / why we need it**:
if we want to deploy an app on the cluster, we may want set a max replicas number per node of this app, so that on that node only limited number replicas can be deployed. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #71930 
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
add a new scheduling predicate: MaxReplicasPerHost
```
