### PR TITLE
Adding OnSync Method to differentiate Sync vs Update

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -261,6 +261,14 @@ func (r FilteringResourceEventHandler) OnDelete(obj interface{}) {
 	r.Handler.OnDelete(obj)
 }
 
+// OnSync calls the nested handler during syncs
+func (r FilteringResourceEventHandler) OnSync(obj interface{}) {
+	if !r.FilterFunc(obj) {
+		return
+	}
+	r.Handler.OnSync(obj)
+}
+
 // DeletionHandlingMetaNamespaceKeyFunc checks for
 // DeletedFinalStateUnknown objects before calling
 // MetaNamespaceKeyFunc.

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -167,17 +167,19 @@ func (c *controller) processLoop() {
 //  * OnUpdate is called when an object is modified. Note that oldObj is the
 //      last known state of the object-- it is possible that several changes
 //      were combined together, so you can't use this to see every single
-//      change. OnUpdate is also called when a re-list happens, and it will
-//      get called even if nothing changed. This is useful for periodically
-//      evaluating or syncing something.
+//      change.
 //  * OnDelete will get the final state of the item if it is known, otherwise
 //      it will get an object of type DeletedFinalStateUnknown. This can
 //      happen if the watch is closed and misses the delete event and we don't
 //      notice the deletion until the subsequent re-list.
+//  * OnSync is called when a re-list happens, and it will
+//       get called even if nothing changed. This is useful for periodically
+//       evaluating or syncing something.
 type ResourceEventHandler interface {
 	OnAdd(obj interface{})
 	OnUpdate(oldObj, newObj interface{})
 	OnDelete(obj interface{})
+	OnSync(obj interface{})
 }
 
 // ResourceEventHandlerFuncs is an adaptor to let you easily specify as many or
@@ -187,6 +189,7 @@ type ResourceEventHandlerFuncs struct {
 	AddFunc    func(obj interface{})
 	UpdateFunc func(oldObj, newObj interface{})
 	DeleteFunc func(obj interface{})
+	SyncFunc   func(obj interface{})
 }
 
 // OnAdd calls AddFunc if it's not nil.
@@ -207,6 +210,13 @@ func (r ResourceEventHandlerFuncs) OnUpdate(oldObj, newObj interface{}) {
 func (r ResourceEventHandlerFuncs) OnDelete(obj interface{}) {
 	if r.DeleteFunc != nil {
 		r.DeleteFunc(obj)
+	}
+}
+
+// OnSync calls SyncFunc if it's not nil.
+func (r ResourceEventHandlerFuncs) OnSync(obj interface{}) {
+	if r.SyncFunc != nil {
+		r.SyncFunc(obj)
 	}
 }
 
@@ -301,7 +311,12 @@ func NewInformer(
 			// from oldest to newest
 			for _, d := range obj.(Deltas) {
 				switch d.Type {
-				case Sync, Added, Updated:
+				case Sync:
+					if err := clientState.Add(d.Object); err != nil {
+						return err
+					}
+					h.OnSync(d.Object)
+				case Added, Updated:
 					if old, exists, err := clientState.Get(d.Object); err == nil && exists {
 						if err := clientState.Update(d.Object); err != nil {
 							return err


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
For K8s Go-Client Adds a New Resource Handler Event for Sync Events.
Currently,  There are 3 types of Function Handlers:
Add, Update, Delete. The `Add` and `Delete` make sense since they are only triggered when there is an update to the resource in question.

However, due to the way the update logic is written, Update gets triggered on both Syncs as well as Updates.

from a logical standpoint, We would want Updates to only trigger when a resource is updated (similar to how Add and Delete are).

as such, differentiating sync with update would be beneficial.




**Special notes for your reviewer**:
First PR. Let me know if I missed anything.

**Does this PR introduce a user-facing change?**:
OnUpdate Function will no longer be called when just syncing. Instead OnSync (SyncFunc) will be called.


```release-note
action required: Update usage of OnUpdate where the UpdateFunc is being used for Sync events.

This Change will add SyncFunc for sync events
```

