### PR TITLE
Provide option to split godeps tests from main verify job

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -30,8 +30,24 @@ EXCLUDED_PATTERNS=(
   "verify-linkcheck.sh"          # runs in separate Jenkins job once per day due to high network usage
   "verify-test-owners.sh"        # TODO(rmmh): figure out how to avoid endless conflicts
   "verify-*-dockerized.sh"       # Don't run any scripts that intended to be run dockerized
-  "verify-typecheck.sh"          # runs in separate typecheck job
   )
+
+# Exclude typecheck in certain cases, if they're running in a separate job.
+if [[ ${EXCLUDE_TYPECHECK:-} =~ ^[yY]$ ]]; then
+  EXCLUDED_PATTERNS+=(
+    "verify-typecheck.sh"          # runs in separate typecheck job
+    )
+fi
+
+
+# Exclude godep checks in certain cases, if they're running in a separate job.
+if [[ ${EXCLUDE_GODEP:-} =~ ^[yY]$ ]]; then
+  EXCLUDED_PATTERNS+=(
+    "verify-godeps.sh"             # runs in separate godeps job
+    "verify-staging-godeps.sh"     # runs in separate godeps job
+    "verify-godep-licenses.sh"     # runs in separate godeps job
+    )
+fi
 
 # Only run whitelisted fast checks in quick mode.
 # These run in <10s each on enisoc's workstation, assuming that


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This provides an options to skip typecheck and/or godeps testing via variables.
These will be used by prow to not run these as part of verify, but pull these into separate jobs.

ref: https://github.com/kubernetes/test-infra/pull/10405

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
