### PR TITLE
diff: Fix overlapping filenames

### DIFF
--- a/hack/testdata/diff/configmap.yaml
+++ b/hack/testdata/diff/configmap.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test

--- a/hack/testdata/diff/deployment.yaml
+++ b/hack/testdata/diff/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      name: test
+  template:
+    metadata:
+      labels:
+        name: test
+    spec:
+      containers:
+      - name: nginx
+        image: nginx

--- a/hack/testdata/diff/pod.yaml
+++ b/hack/testdata/diff/pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx

--- a/hack/testdata/diff/secret.yaml
+++ b/hack/testdata/diff/secret.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test

--- a/pkg/kubectl/cmd/diff/diff.go
+++ b/pkg/kubectl/cmd/diff/diff.go
@@ -289,7 +289,17 @@ func (obj InfoObject) Merged() (runtime.Object, error) {
 }
 
 func (obj InfoObject) Name() string {
-	return obj.Info.Name
+	group := ""
+	if obj.Info.Mapping.GroupVersionKind.Group != "" {
+		group = fmt.Sprintf("%v.", obj.Info.Mapping.GroupVersionKind.Group)
+	}
+	return group + fmt.Sprintf(
+		"%v.%v:%v.%v",
+		obj.Info.Mapping.GroupVersionKind.Version,
+		obj.Info.Mapping.GroupVersionKind.Kind,
+		obj.Info.Namespace,
+		obj.Info.Name,
+	)
 }
 
 // Differ creates two DiffVersion and diffs them.

--- a/test/cmd/diff.sh
+++ b/test/cmd/diff.sh
@@ -40,3 +40,20 @@ run_kubectl_diff_tests() {
     set +o nounset
     set +o errexit
 }
+
+run_kubectl_diff_same_names() {
+    set -o nounset
+    set -o errexit
+
+    create_and_use_new_namespace
+    kube::log::status "Test kubectl diff with multiple resources with the same name"
+
+    output_message=$(KUBECTL_EXTERNAL_DIFF=find kubectl diff -Rf hack/testdata/diff/)
+    kube::test::if_has_string "${output_message}" 'v1.Pod:.*.test'
+    kube::test::if_has_string "${output_message}" 'apps.v1.Deployment:.*.test'
+    kube::test::if_has_string "${output_message}" 'v1.ConfigMap:.*.test'
+    kube::test::if_has_string "${output_message}" 'v1.Secret:.*.test'
+
+    set +o nounset
+    set +o errexit
+}

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -473,6 +473,7 @@ runTests() {
   # Kubectl diff #
   ################
   record_command run_kubectl_diff_tests
+  record_command run_kubectl_diff_same_names
 
   ###############
   # Kubectl get #


### PR DESCRIPTION
The filename can overlap when multiple resources have the same name (but
obviously are of a different type). Include the name of the type in the
file name to prevent the overlap.

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #71920

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix overlapping filenames in diff if multiple resources have the same name.
```
