### PR TITLE
Replaces more references to glog with klog

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
@@ -228,7 +228,7 @@ data:
 
     # Multi-line parsing is required for all the kube logs because very large log
     # statements, such as those that include entire object bodies, get split into
-    # multiple lines by glog.
+    # multiple lines by klog.
 
     # Example:
     # I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap-old.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap-old.yaml
@@ -140,7 +140,7 @@ data:
 
     # Multi-line parsing is required for all the kube logs because very large log
     # statements, such as those that include entire object bodies, get split into
-    # multiple lines by glog.
+    # multiple lines by klog.
 
     # Example:
     # I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -155,7 +155,7 @@ data:
 
     # Multi-line parsing is required for all the kube logs because very large log
     # statements, such as those that include entire object bodies, get split into
-    # multiple lines by glog.
+    # multiple lines by klog.
 
     # Example:
     # I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]

--- a/cmd/kubelet/app/options/globalflags.go
+++ b/cmd/kubelet/app/options/globalflags.go
@@ -34,11 +34,11 @@ import (
 	_ "k8s.io/kubernetes/pkg/credentialprovider/gcp"
 )
 
-// AddGlobalFlags explicitly registers flags that libraries (glog, verflag, etc.) register
+// AddGlobalFlags explicitly registers flags that libraries (klog, verflag, etc.) register
 // against the global flagsets from "flag" and "github.com/spf13/pflag".
 // We do this in order to prevent unwanted flags from leaking into the Kubelet's flagset.
 func AddGlobalFlags(fs *pflag.FlagSet) {
-	addGlogFlags(fs)
+	addLogFlags(fs)
 	addCadvisorFlags(fs)
 	addCredentialProviderFlags(fs)
 	verflag.AddFlags(fs)
@@ -91,8 +91,8 @@ func addCredentialProviderFlags(fs *pflag.FlagSet) {
 	fs.AddFlagSet(local)
 }
 
-// addGlogFlags adds flags from k8s.io/klog
-func addGlogFlags(fs *pflag.FlagSet) {
+// addLogFlags adds flags from k8s.io/klog
+func addLogFlags(fs *pflag.FlagSet) {
 	// lookup flags in global flag set and re-register the values with our flagset
 	global := flag.CommandLine
 	local := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -35,7 +35,7 @@ KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout 600s}
 KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=${KUBE_INTEGRATION_TEST_MAX_CONCURRENCY:-"-1"}
 LOG_LEVEL=${LOG_LEVEL:-2}
 KUBE_TEST_ARGS=${KUBE_TEST_ARGS:-}
-# Default glog module settings.
+# Default klog module settings.
 KUBE_TEST_VMODULE=${KUBE_TEST_VMODULE:-"garbagecollector*=6,graph_builder*=6"}
 
 kube::test::find_integration_test_dirs() {

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -418,7 +418,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	flags.SetNormalizeFunc(utilflag.WarnWordSepNormalizeFunc) // Warn for "_" flags
 
 	// Normalize all flags that are coming from other packages or pre-configurations
-	// a.k.a. change all "_" to "-". e.g. glog package
+	// a.k.a. change all "_" to "-". e.g. klog package
 	flags.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
 
 	addProfilingFlags(flags)

--- a/pkg/kubectl/util/logs/logs.go
+++ b/pkg/kubectl/util/logs/logs.go
@@ -34,7 +34,7 @@ func init() {
 	flag.Set("logtostderr", "true")
 }
 
-// KlogWriter serves as a bridge between the standard log package and the glog package.
+// KlogWriter serves as a bridge between the standard log package and the klog package.
 type KlogWriter struct{}
 
 // Write implements the io.Writer interface.
@@ -47,7 +47,7 @@ func (writer KlogWriter) Write(data []byte) (n int, err error) {
 func InitLogs() {
 	log.SetOutput(KlogWriter{})
 	log.SetFlags(0)
-	// The default glog flush interval is 5 seconds.
+	// The default klog flush interval is 5 seconds.
 	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
 }
 

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -75,7 +75,7 @@ func shouldPullImage(container *v1.Container, imagePresent bool) bool {
 	return false
 }
 
-// records an event using ref, event msg.  log to glog using prefix, msg, logFn
+// records an event using ref, event msg.  log to klog using prefix, msg, logFn
 func (m *imageManager) logIt(ref *v1.ObjectReference, eventtype, event, prefix, msg string, logFn func(args ...interface{})) {
 	if ref != nil {
 		m.recorder.Event(ref, eventtype, event, msg)

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -205,7 +205,7 @@ func TestDeleteEndpointConnections(t *testing.T) {
 			endpoint:     "10.240.0.3:80",
 			simulatedErr: conntrack.NoConnectionToDelete,
 		}, {
-			description:  "V4 UDP, unexpected error, should be glogged",
+			description:  "V4 UDP, unexpected error, should be klogged",
 			svcName:      "v4-udp-simulated-error",
 			svcIP:        "10.96.1.1",
 			svcPort:      80,
@@ -281,7 +281,7 @@ func TestDeleteEndpointConnections(t *testing.T) {
 	// Run the test cases
 	for _, tc := range testCases {
 		priorExecs := fexec.CommandCalls
-		priorGlogErrs := klog.Stats.Error.Lines()
+		priorLogErrs := klog.Stats.Error.Lines()
 
 		input := []proxy.ServiceEndpoint{tc.epSvcPair}
 		fakeProxier.deleteEndpointConnections(input)
@@ -314,14 +314,14 @@ func TestDeleteEndpointConnections(t *testing.T) {
 			t.Errorf("%s: Expected conntrack to be executed %d times, but got %d", tc.description, expExecs, execs)
 		}
 
-		// Check the number of new glog errors
-		var expGlogErrs int64
+		// Check the number of new klog errors
+		var expKlogErrs int64
 		if tc.simulatedErr != "" && tc.simulatedErr != conntrack.NoConnectionToDelete {
-			expGlogErrs = 1
+			expKlogErrs = 1
 		}
-		glogErrs := klog.Stats.Error.Lines() - priorGlogErrs
-		if glogErrs != expGlogErrs {
-			t.Errorf("%s: Expected %d glogged errors, but got %d", tc.description, expGlogErrs, glogErrs)
+		klogErrs := klog.Stats.Error.Lines() - priorLogErrs
+		if klogErrs != expKlogErrs {
+			t.Errorf("%s: Expected %d klogged errors, but got %d", tc.description, expKlogErrs, klogErrs)
 		}
 	}
 }

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -139,7 +139,7 @@ func GetZoneKey(node *v1.Node) string {
 
 	// We include the null character just in case region or failureDomain has a colon
 	// (We do assume there's no null characters in a region or failureDomain)
-	// As a nice side-benefit, the null character is not printed by fmt.Print or glog
+	// As a nice side-benefit, the null character is not printed by fmt.Print or klog
 	return region + ":\x00:" + failureDomain
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags.go
@@ -30,14 +30,14 @@ import (
 // against the global flagsets from "flag" and "k8s.io/klog".
 // We do this in order to prevent unwanted flags from leaking into the component's flagset.
 func AddGlobalFlags(fs *pflag.FlagSet, name string) {
-	addGlogFlags(fs)
+	addLogFlags(fs)
 	logs.AddFlags(fs)
 
 	fs.BoolP("help", "h", false, fmt.Sprintf("help for %s", name))
 }
 
-// addGlogFlags explicitly registers flags that klog libraries(k8s.io/klog) register.
-func addGlogFlags(fs *pflag.FlagSet) {
+// addLogFlags explicitly registers flags that klog libraries(k8s.io/klog) register.
+func addLogFlags(fs *pflag.FlagSet) {
 	// lookup flags of klog libraries in global flag set and re-register the values with our flagset
 	Register(fs, "logtostderr")
 	Register(fs, "alsologtostderr")

--- a/staging/src/k8s.io/client-go/INSTALL.md
+++ b/staging/src/k8s.io/client-go/INSTALL.md
@@ -12,7 +12,7 @@ $ go get k8s.io/client-go/...
 
 This will install `k8s.io/client-go` in your `$GOPATH`. `k8s.io/client-go`
 includes most of its own dependencies in its `k8s.io/client-go/vendor` path,
-except for `k8s.io/apimachinery` and `glog`. `go get` will recursively download
+except for `k8s.io/apimachinery` and `klog`. `go get` will recursively download
 these excluded repos to your `$GOPATH`, if they don't already exist. If
 `k8s.io/apimachinery` preexisted in `$GOPATH`, you also need to:
 
@@ -23,7 +23,7 @@ $ go get -u k8s.io/apimachinery/...
 because the head of client-go is only guaranteed to work with the head of
 apimachinery.
 
-We excluded `k8s.io/apimachinery` and `glog` from `k8s.io/client-go/vendor` to
+We excluded `k8s.io/apimachinery` and `klog` from `k8s.io/client-go/vendor` to
 prevent `go get` users from hitting issues like
 [#19](https://github.com/kubernetes/client-go/issues/19) and
 [#83](https://github.com/kubernetes/client-go/issues/83). If your project share
@@ -40,7 +40,7 @@ HEAD from all dependencies may not even compile with client-go!
 Reasons why you might need to use a dependency management system:
 * You use a dependency that client-go also uses, and don't want two copies of
   the dependency compiled into your application. For some dependencies with
-  singletons or global inits (e.g. `glog`) this wouldn't even compile...
+  singletons or global inits (e.g. `klog`) this wouldn't even compile...
 * You want to lock in a particular version (so you don't have to change your
   code every time we change a public interface).
 * You want your install to be reproducible. For example, for your CI system or

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -385,10 +385,10 @@ func (r *Request) Body(obj interface{}) *Request {
 			r.err = err
 			return r
 		}
-		glogBody("Request Body", data)
+		logBody("Request Body", data)
 		r.body = bytes.NewReader(data)
 	case []byte:
-		glogBody("Request Body", t)
+		logBody("Request Body", t)
 		r.body = bytes.NewReader(t)
 	case io.Reader:
 		r.body = t
@@ -402,7 +402,7 @@ func (r *Request) Body(obj interface{}) *Request {
 			r.err = err
 			return r
 		}
-		glogBody("Request Body", data)
+		logBody("Request Body", data)
 		r.body = bytes.NewReader(data)
 		r.SetHeader("Content-Type", r.content.ContentType)
 	default:
@@ -817,7 +817,7 @@ func (r *Request) DoRaw() ([]byte, error) {
 	var result Result
 	err := r.request(func(req *http.Request, resp *http.Response) {
 		result.body, result.err = ioutil.ReadAll(resp.Body)
-		glogBody("Response Body", result.body)
+		logBody("Response Body", result.body)
 		if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusPartialContent {
 			result.err = r.transformUnstructuredResponseError(resp, req, result.body)
 		}
@@ -858,7 +858,7 @@ func (r *Request) transformResponse(resp *http.Response, req *http.Request) Resu
 		}
 	}
 
-	glogBody("Response Body", body)
+	logBody("Response Body", body)
 
 	// verify the content type is accurate
 	contentType := resp.Header.Get("Content-Type")
@@ -910,7 +910,7 @@ func (r *Request) transformResponse(resp *http.Response, req *http.Request) Resu
 	}
 }
 
-// truncateBody decides if the body should be truncated, based on the glog Verbosity.
+// truncateBody decides if the body should be truncated, based on the klog Verbosity.
 func truncateBody(body string) string {
 	max := 0
 	switch {
@@ -929,10 +929,10 @@ func truncateBody(body string) string {
 	return body[:max] + fmt.Sprintf(" [truncated %d chars]", len(body)-max)
 }
 
-// glogBody logs a body output that could be either JSON or protobuf. It explicitly guards against
+// logBody logs a body output that could be either JSON or protobuf. It explicitly guards against
 // allocating a new string for the body output unless necessary. Uses a simple heuristic to determine
 // whether the body is printable.
-func glogBody(prefix string, body []byte) {
+func logBody(prefix string, body []byte) {
 	if klog.V(8) {
 		if bytes.IndexFunc(body, func(r rune) bool {
 			return r < 0x0a

--- a/staging/src/k8s.io/component-base/logs/logs.go
+++ b/staging/src/k8s.io/component-base/logs/logs.go
@@ -43,7 +43,7 @@ func AddFlags(fs *pflag.FlagSet) {
 	fs.AddFlag(pflag.Lookup(logFlushFreqFlagName))
 }
 
-// KlogWriter serves as a bridge between the standard log package and the glog package.
+// KlogWriter serves as a bridge between the standard log package and the klog package.
 type KlogWriter struct{}
 
 // Write implements the io.Writer interface.
@@ -56,7 +56,7 @@ func (writer KlogWriter) Write(data []byte) (n int, err error) {
 func InitLogs() {
 	log.SetOutput(KlogWriter{})
 	log.SetFlags(0)
-	// The default glog flush interval is 5 seconds.
+	// The default klog flush interval is 5 seconds.
 	go wait.Forever(klog.Flush, *logFlushFreq)
 }
 
@@ -70,7 +70,7 @@ func NewLogger(prefix string) *log.Logger {
 	return log.New(KlogWriter{}, prefix, 0)
 }
 
-// GlogSetter is a setter to set glog level.
+// GlogSetter is a setter to set klog level.
 func GlogSetter(val string) (string, error) {
 	var level klog.Level
 	if err := level.Set(val); err != nil {

--- a/test/e2e/instrumentation/logging/stackdriver/basic.go
+++ b/test/e2e/instrumentation/logging/stackdriver/basic.go
@@ -82,7 +82,7 @@ var _ = instrumentation.SIGDescribe("Cluster level logging implemented by Stackd
 				framework.ExpectNoError(err)
 			})
 
-			ginkgo.By("Checking ingesting logs in glog format", func() {
+			ginkgo.By("Checking ingesting logs in klog format", func() {
 				logUnformatted := "Text"
 				logRaw := fmt.Sprintf("I0101 00:00:00.000000       1 main.go:1] %s", logUnformatted)
 				pod, err := utils.StartAndReturnSelf(utils.NewRepeatingLoggingPod("synthlogger-3", logRaw), f)

--- a/test/e2e_node/services/services.go
+++ b/test/e2e_node/services/services.go
@@ -56,7 +56,7 @@ func NewE2EServices(monitorParent bool) *E2EServices {
 // test binary.  Returns when all e2e services are ready or an error.
 //
 // We want to statically link e2e services into the test binary, but we don't
-// want their glog output to pollute the test result. So we run the binary in
+// want their klog output to pollute the test result. So we run the binary in
 // run-services-mode to start e2e services in another process.
 // The function starts 2 processes:
 // * internal e2e services: services which statically linked in the test binary - apiserver, etcd and

--- a/test/integration/ipamperf/README.md
+++ b/test/integration/ipamperf/README.md
@@ -3,14 +3,14 @@ IPAM Performance Test
 
 Motivation
 -----
-We wanted to be able to test the behavior of the IPAM controller's under various scenarios, 
+We wanted to be able to test the behavior of the IPAM controller's under various scenarios,
 by mocking and monitoring the edges that the controller interacts with. This has the following goals:
 
 - Save time on testing
 - To simulate various behaviors cheaply
 - To observe and model the ideal behavior of the IPAM controller code
 
-Currently the test runs through the 4 different IPAM controller modes for cases where the kube API QPS is a) 
+Currently the test runs through the 4 different IPAM controller modes for cases where the kube API QPS is a)
 equal to and b) significantly less than the number of nodes being added to observe and quantify behavior.
 
 How to run
@@ -43,8 +43,8 @@ usage: ./test-performance.sh <options>
  -l <num> gce cloud endpoint qps
 ```
 
-The tests follow the pattern TestPerformance/{AllocatorType}-KubeQPS{X}-Nodes{Y}, where AllocatorType 
-is one of 
+The tests follow the pattern TestPerformance/{AllocatorType}-KubeQPS{X}-Nodes{Y}, where AllocatorType
+is one of
 
 - RangeAllocator
 - IPAMFromCluster
@@ -53,7 +53,7 @@ is one of
 
 and X represents the QPS configured for the kubernetes API client, and Y is the number of nodes to create.
 
-The -d flags set the -v level for glog to 6, enabling nearly all of the debug logs in the code.
+The -d flags set the -v level for klog to 6, enabling nearly all of the debug logs in the code.
 
 So to run the test for CloudAllocator with 10 nodes, one can run
 
@@ -61,7 +61,7 @@ So to run the test for CloudAllocator with 10 nodes, one can run
 ./test-performance.sh -r /CloudAllocator.*Nodes10$
 ```
 
-At the end of the test, a JSON format of the results for all the tests run is printed. Passing the -o option 
+At the end of the test, a JSON format of the results for all the tests run is printed. Passing the -o option
 allows for also saving this JSON to a named file.
 
 ### Profiling the code
@@ -72,8 +72,8 @@ of nodes being simulated as the id, or 'all' in case running the full suite.
 
 ### Custom Test Configuration
 It's also possible to run a custom test configuration by passing the -c option. With this option, it then
-possible to specify the number of nodes to simulate and the API server qps values for creation, 
-IPAM allocation and cloud endpoint, along with the allocator name to run. The defaults values for the 
+possible to specify the number of nodes to simulate and the API server qps values for creation,
+IPAM allocation and cloud endpoint, along with the allocator name to run. The defaults values for the
 qps parmeters are 30 for IPAM allocation, 100 for node creation and 30 for the cloud endpoint, and the
 default allocator is the RangeAllocator.
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We've already replaced most references to `glog` this continues this to some of the comments throughout the project

**Which issue(s) this PR fixes**:
Fixes #71935

**Special notes for your reviewer**:
There are some exported funcs named `Glog*` which I didn't replace since I don't know if they are used out side of core.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
