### PR TITLE
Automated cherry pick of #71941: add VMSize info in attach/detach azure disk

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_controller_standard.go
+++ b/pkg/cloudprovider/providers/azure/azure_controller_standard.go
@@ -68,6 +68,7 @@ func (as *availabilitySet) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 	newVM := compute.VirtualMachine{
 		Location: vm.Location,
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			HardwareProfile: vm.HardwareProfile,
 			StorageProfile: &compute.StorageProfile{
 				DataDisks: &disks,
 			},
@@ -132,6 +133,7 @@ func (as *availabilitySet) DetachDiskByName(diskName, diskURI string, nodeName t
 	newVM := compute.VirtualMachine{
 		Location: vm.Location,
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			HardwareProfile: vm.HardwareProfile,
 			StorageProfile: &compute.StorageProfile{
 				DataDisks: &disks,
 			},


### PR DESCRIPTION
Cherry pick of #71941 on release-1.12.

#71941: add VMSize info in attach/detach azure disk