### PR TITLE
tests: getRestartDelay waits for the next Terminated state 

### DIFF
--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -116,8 +116,8 @@ func getRestartDelay(podClient *framework.PodClient, podName string, containerNa
 			continue
 		}
 
-		if status.State.Waiting == nil && status.State.Running != nil && status.LastTerminationState.Terminated != nil && status.State.Running.StartedAt.Time.After(beginTime) {
-			startedAt := status.State.Running.StartedAt.Time
+		if status.State.Waiting == nil && status.State.Terminated != nil && status.LastTerminationState.Terminated != nil && status.State.Terminated.StartedAt.Time.After(beginTime) {
+			startedAt := status.State.Terminated.StartedAt.Time
 			finishedAt := status.LastTerminationState.Terminated.FinishedAt.Time
 			framework.Logf("getRestartDelay: restartCount = %d, finishedAt=%s restartedAt=%s (%s)", status.RestartCount, finishedAt, startedAt, startedAt.Sub(finishedAt))
 			return startedAt.Sub(finishedAt), nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test
/kind flake

/sig testing
/sig windows

**What this PR does / why we need it**:

Kubelet might miss reporting the new Running state when restarting
a pod after its backoff period expired, and thus, the pod will
continue to remain in CrashLoopBackOff state, causing the
"should cap back-off at MaxContainerBackOff" and
"should have their auto-restart back-off timer reset on image update"
tests to fail, since they're waiting the Pods to enter a Running state.

Waiting for the next Terminated state instead of the next Running state
is more reliable.

Note that this adds 5 seconds to the restart delay due to the fact that
the Container runs for 5 seconds (it's command is "sleep 5"), but it is
within the test's expectations.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #71949

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
