### PR TITLE
Removed redundant spaces in a comment

### DIFF
--- a/cmd/hyperkube/main.go
+++ b/cmd/hyperkube/main.go
@@ -85,7 +85,7 @@ func commandFor(basename string, defaultCommand *cobra.Command, commands []func(
 
 // NewHyperKubeCommand is the entry point for hyperkube
 func NewHyperKubeCommand(stopCh <-chan struct{}) (*cobra.Command, []func() *cobra.Command) {
-	// these have to be functions since the command is polymorphic.  Cobra wants you to be  top level
+	// these have to be functions since the command is polymorphic. Cobra wants you to be top level
 	// command to get executed
 	apiserver := func() *cobra.Command {
 		ret := kubeapiserver.NewAPIServerCommand(stopCh)


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

This PR removes 2 redundant spaces in `cmd/hyperkube/main.go`

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:

NONE