### PR TITLE
diff: Make filename cross-platform compatible

### DIFF
--- a/pkg/kubectl/cmd/diff/diff.go
+++ b/pkg/kubectl/cmd/diff/diff.go
@@ -294,7 +294,7 @@ func (obj InfoObject) Name() string {
 		group = fmt.Sprintf("%v.", obj.Info.Mapping.GroupVersionKind.Group)
 	}
 	return group + fmt.Sprintf(
-		"%v.%v:%v.%v",
+		"%v.%v.%v.%v",
 		obj.Info.Mapping.GroupVersionKind.Version,
 		obj.Info.Mapping.GroupVersionKind.Kind,
 		obj.Info.Namespace,

--- a/test/cmd/diff.sh
+++ b/test/cmd/diff.sh
@@ -49,10 +49,10 @@ run_kubectl_diff_same_names() {
     kube::log::status "Test kubectl diff with multiple resources with the same name"
 
     output_message=$(KUBECTL_EXTERNAL_DIFF=find kubectl diff -Rf hack/testdata/diff/)
-    kube::test::if_has_string "${output_message}" 'v1.Pod:.*.test'
-    kube::test::if_has_string "${output_message}" 'apps.v1.Deployment:.*.test'
-    kube::test::if_has_string "${output_message}" 'v1.ConfigMap:.*.test'
-    kube::test::if_has_string "${output_message}" 'v1.Secret:.*.test'
+    kube::test::if_has_string "${output_message}" 'v1\.Pod\..*\.test'
+    kube::test::if_has_string "${output_message}" 'apps\.v1\.Deployment\..*\.test'
+    kube::test::if_has_string "${output_message}" 'v1\.ConfigMap\..*\.test'
+    kube::test::if_has_string "${output_message}" 'v1\.Secret\..*\.test'
 
     set +o nounset
     set +o errexit


### PR DESCRIPTION
```
`:` is not a valid character in Windows.
```

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
