### PR TITLE
DNS service ordering for addon manager

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2296,8 +2296,9 @@ function update-dashboard-controller {
 
 # Sets up the manifests of coreDNS for k8s addons.
 function setup-coredns-manifest {
-  local -r coredns_file="${dst_dir}/dns/coredns/coredns.yaml"
-  mv "${dst_dir}/dns/coredns/coredns.yaml.in" "${coredns_file}"
+  setup-addon-manifests "addons" "0-dns/coredns"
+  local -r coredns_file="${dst_dir}/0-dns/coredns/coredns.yaml"
+  mv "${dst_dir}/0-dns/coredns/coredns.yaml.in" "${coredns_file}"
   # Replace the salt configurations with variable values.
   sed -i -e "s@{{ *pillar\['dns_domain'\] *}}@${DNS_DOMAIN}@g" "${coredns_file}"
   sed -i -e "s@{{ *pillar\['dns_server'\] *}}@${DNS_SERVER_IP}@g" "${coredns_file}"
@@ -2340,8 +2341,9 @@ function setup-fluentd {
 
 # Sets up the manifests of kube-dns for k8s addons.
 function setup-kube-dns-manifest {
-  local -r kubedns_file="${dst_dir}/dns/kube-dns/kube-dns.yaml"
-  mv "${dst_dir}/dns/kube-dns/kube-dns.yaml.in" "${kubedns_file}"
+  setup-addon-manifests "addons" "0-dns/kube-dns"
+  local -r kubedns_file="${dst_dir}/0-dns/kube-dns/kube-dns.yaml"
+  mv "${dst_dir}/0-dns/kube-dns/kube-dns.yaml.in" "${kubedns_file}"
   if [ -n "${CUSTOM_KUBE_DNS_YAML:-}" ]; then
     # Replace with custom GKE kube-dns deployment.
     cat > "${kubedns_file}" <<EOF
@@ -2362,8 +2364,8 @@ EOF
 
 # Sets up the manifests of local dns cache agent for k8s addons.
 function setup-nodelocaldns-manifest {
-  setup-addon-manifests "addons" "dns/nodelocaldns"
-  local -r localdns_file="${dst_dir}/dns/nodelocaldns/nodelocaldns.yaml"
+  setup-addon-manifests "addons" "0-dns/nodelocaldns"
+  local -r localdns_file="${dst_dir}/0-dns/nodelocaldns/nodelocaldns.yaml"
   # Replace the sed configurations with variable values.
   sed -i -e "s/__PILLAR__DNS__DOMAIN__/${DNS_DOMAIN}/g" "${localdns_file}"
   sed -i -e "s/__PILLAR__DNS__SERVER__/${DNS_SERVER_IP}/g" "${localdns_file}"
@@ -2534,11 +2536,17 @@ EOF
       setup-node-termination-handler-manifest
   fi
   if [[ "${ENABLE_CLUSTER_DNS:-}" == "true" ]]; then
+    # Create a new directory for the DNS addon and prepend a "0" on the name.
+    # Prepending "0" to the directory ensures that add-on manager
+    # creates the dns service first. This ensures no other add-on
+    # can "steal" the designated DNS clusterIP.
+    BASE_ADDON_DIR=${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty
+    BASE_DNS_DIR=${BASE_ADDON_DIR}/dns
+    NEW_DNS_DIR=${BASE_ADDON_DIR}/0-dns
+    mkdir ${NEW_DNS_DIR} && mv ${BASE_DNS_DIR}/* ${NEW_DNS_DIR} && rm -r ${BASE_DNS_DIR}
     if [[ "${CLUSTER_DNS_CORE_DNS:-}" == "true" ]]; then
-      setup-addon-manifests "addons" "dns/coredns"
       setup-coredns-manifest
     else
-      setup-addon-manifests "addons" "dns/kube-dns"
       setup-kube-dns-manifest
     fi
     if [[ "${ENABLE_NODELOCAL_DNS:-}" == "true" ]]; then


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In certain cases, it is possible that the static clusterIP of the dns service (kube-dns or core dns) is stolen away by another service managed by add-on manager. By adding a "0" to the front of the directory name, we ensure that the dns clusterIP has priority and cannot be stolen. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

```release-note
None
```

Add-on manager logs:

Can see that the dns service is created first.

```
INFO: == Kubernetes addon ensure completed at 2018-12-12T18:45:41+00:00 ==
INFO: == Reconciling with deprecated label ==
serviceaccount/coredns unchanged
deployment.extensions/coredns unchanged
service/kube-dns unchanged
deployment.apps/l7-default-backend unchanged
service/default-http-backend unchanged
role.rbac.authorization.k8s.io/system:pod-nanny unchanged
rolebinding.rbac.authorization.k8s.io/heapster-binding unchanged
serviceaccount/heapster unchanged
deployment.extensions/heapster-v1.6.0-beta.1 unchanged
service/heapster unchanged
deployment.apps/kubernetes-dashboard unchanged
service/kubernetes-dashboard unchanged
deployment.apps/kube-dns-autoscaler unchanged
serviceaccount/event-exporter-sa unchanged
deployment.apps/event-exporter-v0.2.3 unchanged
serviceaccount/fluentd-gcp unchanged
daemonset.extensions/fluentd-gcp-v3.2.0 unchanged
serviceaccount/fluentd-gcp-scaler unchanged
role.rbac.authorization.k8s.io/system:fluentd-gcp-scaler unchanged
rolebinding.rbac.authorization.k8s.io/fluentd-gcp-scaler-binding unchanged
serviceaccount/metadata-proxy unchanged
daemonset.extensions/metadata-proxy-v0.1 unchanged
rolebinding.rbac.authorization.k8s.io/metrics-server-auth-reader unchanged
serviceaccount/metrics-server unchanged
deployment.extensions/metrics-server-v0.3.1 unchanged
service/metrics-server unchanged
INFO: == Reconciling with addon-manager label ==
serviceaccount/kubernetes-dashboard unchanged
role.rbac.authorization.k8s.io/kubernetes-dashboard-minimal unchanged
rolebinding.rbac.authorization.k8s.io/kubernetes-dashboard-minimal unchanged
serviceaccount/kube-dns-autoscaler unchanged
configmap/fluentd-gcp-config-old-v1.2.5 unchanged
configmap/fluentd-gcp-config-v1.2.5 unchanged
deployment.apps/fluentd-gcp-scaler unchanged
rolebinding.rbac.authorization.k8s.io/gce:cloud-provider unchanged
role.rbac.authorization.k8s.io/gce:cloud-provider unchanged
role.rbac.authorization.k8s.io/cloud-provider unchanged
INFO: == Kubernetes addon reconcile completed at 2018-12-12T18:45:45+00:00 ==
```