### PR TITLE
fix wrong info when did a rollout status to a non-update statefulset

### DIFF
--- a/pkg/kubectl/rollout_status.go
+++ b/pkg/kubectl/rollout_status.go
@@ -135,14 +135,14 @@ func (s *StatefulSetStatusViewer) Status(obj runtime.Unstructured, revision int6
 		return fmt.Sprintf("Waiting for %d pods to be ready...\n", *sts.Spec.Replicas-sts.Status.ReadyReplicas), false, nil
 	}
 	if sts.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType && sts.Spec.UpdateStrategy.RollingUpdate != nil {
-		if sts.Spec.Replicas != nil && sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
+		if sts.Spec.Replicas != nil && *sts.Spec.UpdateStrategy.RollingUpdate.Partition > 0 {
 			if sts.Status.UpdatedReplicas < (*sts.Spec.Replicas - *sts.Spec.UpdateStrategy.RollingUpdate.Partition) {
 				return fmt.Sprintf("Waiting for partitioned roll out to finish: %d out of %d new pods have been updated...\n",
-					sts.Status.UpdatedReplicas, *sts.Spec.Replicas-*sts.Spec.UpdateStrategy.RollingUpdate.Partition), false, nil
+					sts.Status.UpdatedReplicas, (*sts.Spec.Replicas - *sts.Spec.UpdateStrategy.RollingUpdate.Partition)), false, nil
 			}
+			return fmt.Sprintf("partitioned roll out complete: %d new pods have been updated...\n",
+				sts.Status.UpdatedReplicas), true, nil
 		}
-		return fmt.Sprintf("partitioned roll out complete: %d new pods have been updated...\n",
-			sts.Status.UpdatedReplicas), true, nil
 	}
 	if sts.Status.UpdateRevision != sts.Status.CurrentRevision {
 		return fmt.Sprintf("waiting for statefulset rolling update to complete %d pods at revision %s...\n",

--- a/pkg/kubectl/rollout_status_test.go
+++ b/pkg/kubectl/rollout_status_test.go
@@ -357,6 +357,28 @@ func TestStatefulSetStatusViewerStatus(t *testing.T) {
 			err:  false,
 		},
 		{
+			name:       "partition update is ignored if partition is zero",
+			generation: 1,
+			strategy: apps.StatefulSetUpdateStrategy{Type: apps.RollingUpdateStatefulSetStrategyType,
+				RollingUpdate: func() *apps.RollingUpdateStatefulSetStrategy {
+					partition := int32(0)
+					return &apps.RollingUpdateStatefulSetStrategy{Partition: &partition}
+				}()},
+			status: apps.StatefulSetStatus{
+				ObservedGeneration: 2,
+				Replicas:           3,
+				ReadyReplicas:      3,
+				CurrentReplicas:    3,
+				UpdatedReplicas:    0,
+				CurrentRevision:    "foo",
+				UpdateRevision:     "foo",
+			},
+
+			msg:  fmt.Sprintf("statefulset rolling update complete %d pods at revision %s...\n", 3, "foo"),
+			done: true,
+			err:  false,
+		},
+		{
 			name:       "update completes when all replicas are current",
 			generation: 1,
 			strategy:   apps.StatefulSetUpdateStrategy{Type: apps.RollingUpdateStatefulSetStrategyType},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug


**What this PR does / why we need it**:
Before this pr,when we did a "kubectl rollout status" to a non-updated statefulset or a successfully updated statefulset, we will get the following info:

[root@k8s-master:/opt/kubernetes/1.4.5]$ kubectl rollout status statefulset statefulsetexm
Waiting for partitioned roll out to finish: 0 out of 3 new pods have been updated...

and it will stuck here
After this pr ,when we did this, we will get a succefully rollout info:

[root@k8s-master:/opt/kubernetes/1.4.5]$ kubectl rollout status statefulset statefulsetexm
statefulset rolling update complete 3 pods at revision statefulsetexm-6bc465cc7b...

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
