### PR TITLE
Export EndpointsLastChangeTriggerTime annotation in endpoints_controler.

### DIFF
--- a/pkg/controller/endpoint/BUILD
+++ b/pkg/controller/endpoint/BUILD
@@ -11,6 +11,8 @@ go_library(
     srcs = [
         "doc.go",
         "endpoints_controller.go",
+        "metrics.go",
+        "trigger_time_tracker.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/controller/endpoint",
     deps = [
@@ -34,12 +36,16 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/leaderelection/resourcelock:go_default_library",
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["endpoints_controller_test.go"],
+    srcs = [
+        "endpoints_controller_test.go",
+        "trigger_time_tracker_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/api/testapi:go_default_library",
@@ -58,6 +64,7 @@ go_test(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
     ],
 )
 

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -101,6 +101,8 @@ func NewEndpointController(podInformer coreinformers.PodInformer, serviceInforme
 	e.endpointsLister = endpointsInformer.Lister()
 	e.endpointsSynced = endpointsInformer.Informer().HasSynced
 
+	e.triggerTimeTracker = newTriggerTimeTracker()
+
 	return e
 }
 
@@ -138,6 +140,9 @@ type EndpointController struct {
 
 	// workerLoopPeriod is the time between worker runs. The workers process the queue of service and pod changes.
 	workerLoopPeriod time.Duration
+
+	// Trigger time tracker to compute the EndpointsLastChangeTriggerTime annotation.
+	triggerTimeTracker *triggerTimeTracker
 }
 
 // Run will not return until stopCh is closed. workers determines how many
@@ -192,8 +197,16 @@ func (e *EndpointController) addPod(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("Unable to get pod %s/%s's service memberships: %v", pod.Namespace, pod.Name, err))
 		return
 	}
+
 	for key := range services {
 		e.queue.Add(key)
+	}
+
+
+	if triggerTime := getPodLastTransitionTime(pod); triggerTime != nil {
+		for key := range services {
+			e.triggerTimeTracker.observe(key, *triggerTime)
+		}
 	}
 }
 
@@ -295,6 +308,13 @@ func (e *EndpointController) updatePod(old, cur interface{}) {
 
 	for key := range services {
 		e.queue.Add(key)
+	}
+
+	oldTriggerTime, triggerTime  := getPodLastTransitionTime(newPod), getPodLastTransitionTime(newPod)
+	if triggerTime != nil && (oldTriggerTime == nil || triggerTime.After(*oldTriggerTime)) {
+		for key := range services {
+			e.triggerTimeTracker.observe(key, *triggerTime)
+		}
 	}
 }
 
@@ -409,12 +429,15 @@ func (e *EndpointController) syncService(key string) error {
 	}
 
 	klog.V(5).Infof("About to update endpoints for service %q", key)
+
+	e.triggerTimeTracker.startListing(key)
 	pods, err := e.podLister.Pods(service.Namespace).List(labels.Set(service.Spec.Selector).AsSelectorPreValidated())
 	if err != nil {
 		// Since we're getting stuff from a local cache, it is
 		// basically impossible to get this error.
 		return err
 	}
+	lastTriggerChangeTime := e.triggerTimeTracker.stopListingAndReset(key, getPodTriggerTimes(pods))
 
 	// If the user specified the older (deprecated) annotation, we have to respect it.
 	tolerateUnreadyEndpoints := service.Spec.PublishNotReadyAddresses
@@ -505,6 +528,10 @@ func (e *EndpointController) syncService(key string) error {
 	if newEndpoints.Annotations == nil {
 		newEndpoints.Annotations = make(map[string]string)
 	}
+	if lastTriggerChangeTime != nil {
+		newEndpoints.Annotations[v1.EndpointsLastChangeTriggerTime] =
+				lastTriggerChangeTime.Format(time.RFC3339Nano)
+	}
 
 	klog.V(4).Infof("Update endpoints for %v/%v, ready: %d not ready: %d", service.Namespace, service.Name, totalReadyEps, totalNotReadyEps)
 	if createEndpoints {
@@ -591,4 +618,31 @@ func shouldPodBeInEndpoints(pod *v1.Pod) bool {
 	default:
 		return true
 	}
+}
+
+// Computes the last-transition-time for the given pod, defined as max lastTransitionTime over
+// all pod-conditions.
+func getPodLastTransitionTime(pod *v1.Pod) (*time.Time) {
+	var lastTransitionTime time.Time
+	for _, condition := range pod.Status.Conditions {
+		val := condition.LastTransitionTime.Time
+		if lastTransitionTime.Before(val) {
+			lastTransitionTime = val
+		}
+	}
+	if lastTransitionTime.IsZero() {
+		return nil
+	}
+	return &lastTransitionTime
+}
+
+func getPodTriggerTimes(pods []*v1.Pod) []time.Time {
+  times := make([]time.Time, 0, len(pods))
+  for _, pod := range pods {
+  	podLastTransitionTime := getPodLastTransitionTime(pod)
+  	if podLastTransitionTime != nil {
+			times = append(times, *podLastTransitionTime)
+		}
+	}
+  return times;
 }

--- a/pkg/controller/endpoint/metrics.go
+++ b/pkg/controller/endpoint/metrics.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	subsystem = "endpoints_controller"
+)
+
+var (
+	LastChangeTriggerTimeMiscalculated = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "last_change_trigger_time_miscalculated",
+			Help:      "Total number of times when the EndpointsLastChangeTriggerTime was miscalculated.",
+		})
+)
+
+// Register all metrics.
+func init() {
+	prometheus.MustRegister(LastChangeTriggerTimeMiscalculated )
+}

--- a/pkg/controller/endpoint/trigger_time_tracker.go
+++ b/pkg/controller/endpoint/trigger_time_tracker.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/klog"
+)
+
+/*
+TriggerTimeTracker is a util used to compute the EndpointsLastChangeTriggerTime annotation.
+See the documentation of the EndpointsLastChangeTriggerTime annotation for more details about why
+this annotation and class is needed.
+
+This class was designed to work with the EndpointsController. It's based on the following
+assumptions.
+1. Client of this util performs two operations, it observes events and runs the sync function.
+2. Multiple events can be observed per single sync function run (there is batching).
+3. Runs of sync function are mutually exclusive per endpoints object, i.e. for a single endpoints
+   object there can be no two sync functions running at the same time.
+4. Observe function and sync function can run in parallel.
+5. Events are observed in the chronological order, i.e. if T(E1) < T(E2) then E1 will be
+   observed before E2.
+6. Sync function doesn't use state from the observed events directly. It uses the "list" method
+   that returns objects in a state that is AT LEAST as fresh as what was observed in the events,
+   i.e. it's possible that the list method will return a state that wasn't yet observed, but
+   never the other way around.
+
+Please note that the EndpointsController satisfied all this assumptions in a very strict way.
+
+// TODO(mmat@google.com): Document the interleaving that makes this class to return wrong time.
+// Refer to scalability tests results to make it clear how probable is that.
+*/
+type triggerTimeTracker struct {
+	// All maps below are indexed by the Endpoints object name.
+
+	// Map storing the min trigger change time that was saved when the endpoints object was last
+	// changed. This map will be updated only in the updateAndReset method.
+	lastSyncMinTriggerTime map[string]time.Time
+
+	// Similar map as the lastMinTriggerTime but stores the last *max* trigger change time.
+	lastSyncMaxTriggerTime map[string]time.Time
+
+	// Map storing min trigger change time observed since the last updated of the endpoints object.
+	// In contrast to lastSavedMinTriggerTime and lastSavedMaxTriggerTime this map will be updated
+	// in the observe method, i.e. every time a trigger change is observed
+	// (e.g. Pod added / updated / removed) and reset in the updateAndReset method.
+	minTriggerTime map[string]time.Time
+
+	// Map from the endpoints object name to the bool value that reflects whether the client is
+	// currently listing the objects via the list function.
+	isListingObjects map[string]bool
+
+	// Map storing all trigger times that were observed during the time the objects were listed in the
+	// "list" function. We need this multi-map to make sure that we haven't missed any event due
+	// a unfortunate race condition.
+	dirtyTriggerTimes map[string][]time.Time
+
+	// Mutex guarding this util.
+	mutex sync.Mutex
+}
+
+// Creates new instance of the TriggerTimeTracker.
+func newTriggerTimeTracker() *triggerTimeTracker {
+	return &triggerTimeTracker{
+		lastSyncMaxTriggerTime : make(map[string]time.Time),
+		lastSyncMinTriggerTime : make(map[string]time.Time),
+		minTriggerTime : make(map[string]time.Time),
+		dirtyTriggerTimes : make(map[string][]time.Time),
+		isListingObjects : make(map[string]bool),
+	}
+}
+
+// Method, updating the minTriggerTime, that should be called every time an event is observed.
+func (this *triggerTimeTracker) observe(key string, triggerTime time.Time) {
+	this.mutex.Lock()
+	defer this.mutex.Unlock()
+
+	if this.isListingObjects[key] {
+		this.dirtyTriggerTimes[key] = append(this.dirtyTriggerTimes[key], triggerTime)
+		return
+	}
+
+	if triggerTime.Before(this.lastSyncMaxTriggerTime[key]) ||
+			triggerTime == this.lastSyncMaxTriggerTime[key] {
+		// Trigger was already processed
+		if triggerTime.Before(this.lastSyncMinTriggerTime[key]) {
+			// Oops, we exported a wrong time in the last processing. Increment the error counter.
+ 			LastChangeTriggerTimeMiscalculated.Inc()
+			klog.Warningf("Miscalculated LastChangeTriggerTime annotation for service %s. " +
+				"Should export: %s, exported %s", key, triggerTime, this.lastSyncMinTriggerTime[key])
+
+			// Correct the lastSyncMinTriggerTime so we don't increment the error again for the same
+			// batch. It could happen if the trigger change times were T0, T1, T2 and we exported T2 in
+			// the last sync. Later we would observe the T0 and T1 trigger change times and because both
+			// T0<T2 and T1 < T2 we would export the metric twice.
+			this.lastSyncMinTriggerTime[key] = triggerTime
+		}
+		return
+	}
+
+	// If we are here it means that the triggerTime is after lastSyncMaxTriggerTime. If this is first
+	// such triggerTime per batch, i.e. minTriggerTime is not set, then we should set it. If it was
+	// already set then we don't need to set it anymore for this batch because events are in the
+	// chronological order.
+	if _, ok := this.minTriggerTime[key]; !ok {
+		this.minTriggerTime[key] = triggerTime
+	}
+}
+
+// Method to be called directly before the call to the "list" function.
+func (this *triggerTimeTracker) startListing(key string) {
+	this.mutex.Lock()
+	defer this.mutex.Unlock()
+	this.isListingObjects[key] = true
+}
+
+// Method that should be called directly after the listing objects has ended. It will reset the
+// state for the given endpoints key and return the time that should be exported as the
+// EndpointsLastChangeTriggerTime annotation. It may happen that the method will return nil, in such
+// case the annotation shouldn't be exported.
+func (this *triggerTimeTracker) stopListingAndReset(
+		key string, triggerTimesFromListing []time.Time) (*time.Time){
+	this.mutex.Lock()
+	defer this.mutex.Unlock()
+
+	var endpointsLastChangeTriggerTime time.Time
+
+	if _, ok := this.minTriggerTime[key]; !ok {
+		// There was no event observed that set the minTriggerTime.
+
+		minTriggerTime := func() *time.Time {
+			// Try in the dirty times.
+			if p := minGreaterThan(this.dirtyTriggerTimes[key], this.lastSyncMaxTriggerTime[key]);
+					p != nil {
+				return p
+			}
+			// If nothing found in the dirty times, try in the times from listing objects.
+			if p := minGreaterThan(triggerTimesFromListing, this.lastSyncMaxTriggerTime[key]); p != nil {
+				return p
+			}
+
+			return nil
+		}()
+
+		if minTriggerTime == nil {
+			// Nothing was observed, nothing in the dirty set, nothing fresh enough in listing times.
+			// Reset state and return nil, there is nothing to export this time.
+			this.isListingObjects[key] = false
+			this.dirtyTriggerTimes[key] = nil
+			return nil
+		}
+
+		this.minTriggerTime[key] = *minTriggerTime
+	}
+
+	endpointsLastChangeTriggerTime = this.minTriggerTime[key]
+	delete(this.minTriggerTime, key)
+
+	maxTimeFromListing := max(triggerTimesFromListing)
+	// See if there is anything in dirty times that could have been a potential new minTriggerTime.
+	if p := minGreaterThan(this.dirtyTriggerTimes[key], maxTimeFromListing); p != nil {
+		this.minTriggerTime[key] = *p
+	}
+	// Clear dirty times.
+	this.isListingObjects[key] = false
+	this.dirtyTriggerTimes[key] = nil
+
+	// Updated the lastSync min and max.
+	this.lastSyncMinTriggerTime[key] = endpointsLastChangeTriggerTime
+	this.lastSyncMaxTriggerTime[key] = maxTimeFromListing
+	return &endpointsLastChangeTriggerTime
+}
+
+
+// ----- Util Functions -----
+
+func min(times []time.Time) (minTime time.Time) {
+	for _, t := range times {
+		if minTime.IsZero() || t.Before(minTime) {
+			minTime = t
+		}
+	}
+	return minTime
+}
+
+func max(times []time.Time) (maxTime time.Time) {
+	for _, t := range times {
+		if t.After(maxTime) {
+			maxTime = t
+		}
+	}
+	return maxTime
+}
+
+func minGreaterThan(times []time.Time, greaterThan time.Time) (minTime *time.Time) {
+	for i, t := range times {
+		if t.After(greaterThan) && (minTime == nil || t.Before(*minTime)) {
+			minTime = &times[i] // Cannot use &t as t is a variable that is updated in every iteration.
+		}
+	}
+	return minTime
+}

--- a/pkg/controller/endpoint/trigger_time_tracker_test.go
+++ b/pkg/controller/endpoint/trigger_time_tracker_test.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package endpoint
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+var (
+	t0 = time.Date(2018, 01, 01, 0, 0, 0, 0, time.UTC)
+	t1 = t0.Add(time.Second)
+	t2 = t1.Add(time.Second)
+	t3 = t2.Add(time.Second)
+	t4 = t3.Add(time.Second)
+	t5 = t4.Add(time.Second)
+
+	key = "my_endpoint"
+)
+
+func TestObserveBeforeStartListing(t *testing.T) {
+	tester := newTester(t)
+
+	tester.observe(key, t0) // P0 - Pod0. To make clear which object was observed.
+	tester.observe(key, t1) // P1
+
+	tester.startListing(key)     // P0, P1
+	tester.whenListingReturned(key, t0, t1).expect(t0)
+
+	tester.observe(key, t2) // P1
+	tester.observe(key, t3) // P0
+
+	tester.startListing(key)     // P0, P1
+	tester.whenListingReturned(key, t3, t2).expect(t2)
+}
+
+func TestObserveBeforeStartListing_MultipleUpdatesOfTheSameObject(t *testing.T) {
+	tester := newTester(t)
+
+	tester.observe(key, t0) // P0
+	tester.observe(key, t1) // P1
+	tester.observe(key, t2) // P0
+
+	tester.startListing(key)     // P0, P1
+	tester.whenListingReturned(key, t2, t1).expect(t0)
+
+	tester.observe(key, t3) // P1
+	tester.observe(key, t4) // P0
+	tester.observe(key, t5) // P1
+
+	tester.startListing(key)     // P0, P1
+	tester.whenListingReturned(key, t4, t5).expect(t3)
+}
+
+func TestEventsDuringListening(t *testing.T) {
+	tester := newTester(t)
+
+	tester.observe(key, t0) // P0
+
+	tester.startListing(key)
+	tester.observe(key, t1) // P1
+	tester.observe(key, t2) // P0
+	//                              P0, P1
+	tester.whenListingReturned(key, t2, t1).expect(t0)
+
+	tester.observe(key, t3) // P1
+	tester.observe(key, t4) // P0
+
+	tester.startListing(key)     // P0, P1
+	tester.whenListingReturned(key, t4, t3).expect(t3)
+}
+
+func TestEventsDuringListening_FresherEvent(t *testing.T) {
+	tester := newTester(t)
+
+	tester.observe(key, t0) // P0
+	tester.observe(key, t1) // P1
+
+	tester.startListing(key)
+
+	// This event arrived directly after listing ended, it's possible as the mutex is unlocked outside
+	// of the list method - mutex.Lock(); List(); (event observed) mutex.Unlock();
+	tester.observe(key, t2) // P2
+	//                              P0, P1
+	tester.whenListingReturned(key, t0, t1).expect(t0)
+
+	tester.observe(key, t3) // P2
+
+	tester.startListing(key)
+	tester.observe(key, t4) // P2
+	//                              P0, P1  P2
+	tester.whenListingReturned(key, t0, t1, t4).expect(t2) // t2 wasn't lost, it was marked as dirty
+	                                                       // and processed later.
+}
+
+func TestEventsDuringListening_MultipleEvents(t *testing.T) {
+	tester := newTester(t)
+
+	tester.observe(key, t0) // P0
+	tester.observe(key, t1) // P1
+
+	tester.startListing(key)
+
+	tester.observe(key, t2) // P0
+	tester.observe(key, t3) // P2
+	//                              P0, P1
+	tester.whenListingReturned(key, t2, t1).expect(t0)
+
+	tester.observe(key, t4) // P2
+
+	tester.startListing(key)     // P0, P1  P2
+	tester.whenListingReturned(key, t0, t1, t4).expect(t3)
+}
+
+func TestEventsAfterListingInFirstBatch(t *testing.T) {
+	tester := newTester(t)
+
+	tester.startListing(key)
+	// P0, P1 already changed and will be returned in list, but no events yet.
+	//                              P0, P1
+	tester.whenListingReturned(key, t0, t1).expect(t0)
+
+	// Delayed events
+	tester.observe(key, t0) // P0
+	tester.observe(key, t1) // P1
+
+	tester.observe(key, t2) // P1
+
+	tester.startListing(key)     // P0, P1
+	tester.whenListingReturned(key, t0, t2).expect(t2) // t0 and t1 change was already processed
+}
+
+func TestEventsAfterListingInBothBatches(t *testing.T) {
+	tester := newTester(t)
+
+	tester.startListing(key)
+	// P0, P1 already changed and will be returned in list, but no events yet.
+	//                              P0, P1
+	tester.whenListingReturned(key, t0, t1).expect(t0)
+
+	// Delayed events
+	tester.observe(key, t0) // P0
+	tester.observe(key, t1) // P1
+
+	tester.startListing(key)     // P0, P1
+	tester.whenListingReturned(key, t3, t2).expect(t2) // t0 and t1 change was already processed
+
+	tester.observe(key, t2) // P1
+	tester.observe(key, t3) // P0
+
+	tester.startListing(key)     // P0, P1
+	tester.whenListingReturned(key, t3, t2).expectNil() // t2 and t3 was already processed.
+}
+
+func TestEventsAfterListing_SameObjectUpdatedMultipleTimes(t *testing.T) {
+	tester := newTester(t)
+
+	tester.startListing(key)
+	// P0, P1 already changed and will be returned in list, but no events yet.
+	//                              P0, P1
+	tester.whenListingReturned(key, t2, t1).expect(t1)
+
+	tester.assertCounterValue(LastChangeTriggerTimeMiscalculated, 0)
+	// Delayed events
+	tester.observe(key, t0) // P0 - here we realize that we exported wrong time.
+	// Error counter was incremented.
+	tester.assertCounterValue(LastChangeTriggerTimeMiscalculated, 1)
+
+	tester.observe(key, t1) // P1
+	tester.observe(key, t2) // P0
+	tester.observe(key, t3) // P1
+
+	tester.startListing(key)     // P0, P1
+	tester.whenListingReturned(key, t2, t3).expect(t3)
+}
+
+func TestMultipleKeysUpdatedSimultaneously(t *testing.T) {
+	key2 := "my-endpoints-2"
+
+	tester := newTester(t)
+
+	tester.observe(key, t0) // E0_P0
+	tester.observe(key, t1) // E0_P1
+
+	tester.observe(key2, t1) // E1_P0
+
+	tester.startListing(key)     // P0, P1
+	tester.whenListingReturned(key, t0, t1).expect(t0)
+
+	tester.startListing(key2)
+	tester.observe(key2, t2) // E1_P1
+	//                               P0  P1
+	tester.whenListingReturned(key2, t1, t2).expect(t1)
+
+	tester.observe(key, t5) // E0_P0
+
+	tester.startListing(key2)     // P0, P1
+	tester.whenListingReturned(key2, t4, t3).expect(t3)
+
+	tester.startListing(key)     // P0, P1
+	tester.whenListingReturned(key, t5, t1).expect(t5)
+}
+
+func TestNoEventsListReturnedNothing(t *testing.T) {
+	tester := newTester(t)
+
+	tester.startListing(key)
+	// This shouldn't happen, but make sure it won't crash.
+	tester.whenListingReturned(key).expectNil()
+}
+
+func TestListWithoutUpdate(t *testing.T) {
+	tester := newTester(t)
+
+	tester.observe(key, t0) // P0
+	tester.observe(key, t1) // P1
+	tester.observe(key, t2) // P1
+
+	tester.startListing(key)
+	tester.whenListingReturned(key, t0, t1, t2).expect(t0)
+
+	// No observe events, but list again. It can happen e.g. when labels where updated.
+	tester.startListing(key)
+	tester.whenListingReturned(key, t0, t1, t2).expectNil() // Nil returned, nothing will be exported.
+}
+
+
+
+// ------- Test Utils -------
+
+type tester struct {
+	*triggerTimeTracker
+	t *testing.T
+}
+
+func newTester(t *testing.T) *tester {
+	return &tester { newTriggerTimeTracker(), t}
+}
+
+func (this *tester) whenListingReturned(key string, val ...time.Time) subject {
+	return subject { this.stopListingAndReset(key, val), this.t }
+}
+
+type subject struct {
+	got *time.Time
+	t *testing.T
+}
+
+
+func (s subject) expect(val time.Time) {
+	s.expectPointer(&val)
+}
+
+func (s subject) expectNil() {
+	s.expectPointer(nil)
+}
+
+func (s subject) expectPointer(val *time.Time) {
+	if !reflect.DeepEqual(s.got, val) {
+		_, fn, line, _ := runtime.Caller(2)
+		s.t.Errorf("Wrong trigger time in %s:%d expected %s, got %s", fn, line, val, s.got)
+	}
+}
+
+func (this *tester) assertCounterValue(c prometheus.Counter, wanted float64) {
+	pb := &dto.Metric{}
+	c.Write(pb)
+	got := pb.GetCounter().GetValue()
+	if got != wanted {
+		this.t.Errorf("Wrong counter (%s) value, expected %f, got %f", c.Desc(), wanted, got)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This PR starts exporting the EndpointsLastChangeTriggerTime annotation in the endpoints_controller.
It's required to implement the in-cluster network programming latency, documented here: https://github.com/kubernetes/community/blob/master/sig-scalability/slos/network_programming_latency.md

**Does this PR introduce a user-facing change?**:
NONE
