### PR TITLE
Remove generic mount validation logic during unmount and rely on CSI driver

### DIFF
--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	kstrings "k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
-	"k8s.io/kubernetes/pkg/volume/util"
 )
 
 //TODO (vladimirvivien) move this in a central loc later
@@ -289,20 +288,6 @@ func (c *csiMountMgr) TearDown() error {
 func (c *csiMountMgr) TearDownAt(dir string) error {
 	klog.V(4).Infof(log("Unmounter.TearDown(%s)", dir))
 
-	// is dir even mounted ?
-	// TODO (vladimirvivien) this check may not work for an emptyDir or local storage
-	// see https://github.com/kubernetes/kubernetes/pull/56836#discussion_r155834524
-	mounted, err := isDirMounted(c.plugin, dir)
-	if err != nil {
-		klog.Error(log("unmounter.Teardown failed while checking mount status for dir [%s]: %v", dir, err))
-		return err
-	}
-
-	if !mounted {
-		klog.V(4).Info(log("unmounter.Teardown skipping unmount, dir not mounted [%s]", dir))
-		return nil
-	}
-
 	volID := c.volumeID
 	csi := c.csiClient
 
@@ -319,7 +304,7 @@ func (c *csiMountMgr) TearDownAt(dir string) error {
 		klog.Error(log("mounter.TearDownAt failed to clean mount dir [%s]: %v", dir, err))
 		return err
 	}
-	klog.V(4).Infof(log("mounte.TearDownAt successfully unmounted dir [%s]", dir))
+	klog.V(4).Infof(log("mounter.TearDownAt successfully unmounted dir [%s]", dir))
 
 	return nil
 }
@@ -375,21 +360,12 @@ func isDirMounted(plug *csiPlugin, dir string) (bool, error) {
 // removeMountDir cleans the mount dir when dir is not mounted and removed the volume data file in dir
 func removeMountDir(plug *csiPlugin, mountPath string) error {
 	klog.V(4).Info(log("removing mount path [%s]", mountPath))
-	if pathExists, pathErr := util.PathExists(mountPath); pathErr != nil {
-		klog.Error(log("failed while checking mount path stat [%s]", pathErr))
-		return pathErr
-	} else if !pathExists {
-		klog.Warning(log("skipping mount dir removal, path does not exist [%v]", mountPath))
-		return nil
-	}
 
-	mounter := plug.host.GetMounter(plug.GetPluginName())
-	notMnt, err := mounter.IsLikelyNotMountPoint(mountPath)
+	mnt, err := isDirMounted(plug, mountPath)
 	if err != nil {
-		klog.Error(log("mount dir removal failed [%s]: %v", mountPath, err))
 		return err
 	}
-	if notMnt {
+	if !mnt {
 		klog.V(4).Info(log("dir not mounted, deleting it [%s]", mountPath))
 		if err := os.Remove(mountPath); err != nil && !os.IsNotExist(err) {
 			klog.Error(log("failed to remove dir [%s]: %v", mountPath, err))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We remove a piece of generic logic which may not work with all the drivers and instead rely on CSI driver to run the teardown logic and report an error.

I faced an issue with a fuse mounted volume. After the fuse process responsible for the mount died, every time k8s or application tried to access the mounted volume it got an error "transport endpoint is not connected". I couldn't find a way to recover the fuse mount after that, the only thing I could do was unmount the volume. But once this happens you cannot release the volume anymore, because CSI driver which knows how to unmount the volume is never called because the check inside the `TearDownAt` function always fails.
I propose to remove that logic and rely on CSI driver's unmount logic.

/sig storage