### PR TITLE
[Fix issue scheduler cleanup 71867]: Move compatibility_test.go to pkg/scheduler/api

### DIFF
--- a/pkg/scheduler/algorithmprovider/defaults/BUILD
+++ b/pkg/scheduler/algorithmprovider/defaults/BUILD
@@ -25,25 +25,11 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = [
-        "compatibility_test.go",
-        "defaults_test.go",
-    ],
+    srcs = ["defaults_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/apis/core/install:go_default_library",
         "//pkg/scheduler/algorithm/predicates:go_default_library",
-        "//pkg/scheduler/api:go_default_library",
-        "//pkg/scheduler/api/latest:go_default_library",
-        "//pkg/scheduler/factory:go_default_library",
-        "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
-        "//staging/src/k8s.io/client-go/informers:go_default_library",
-        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
-        "//staging/src/k8s.io/client-go/rest:go_default_library",
-        "//staging/src/k8s.io/client-go/util/testing:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/api/BUILD
+++ b/pkg/scheduler/api/BUILD
@@ -37,6 +37,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/scheduler/api/compatibility:all-srcs",
         "//pkg/scheduler/api/latest:all-srcs",
         "//pkg/scheduler/api/v1:all-srcs",
         "//pkg/scheduler/api/validation:all-srcs",

--- a/pkg/scheduler/api/compatibility/BUILD
+++ b/pkg/scheduler/api/compatibility/BUILD
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["compatibility_test.go"],
+    deps = [
+        "//pkg/apis/core/install:go_default_library",
+        "//pkg/scheduler/algorithmprovider/defaults:go_default_library",
+        "//pkg/scheduler/api:go_default_library",
+        "//pkg/scheduler/api/latest:go_default_library",
+        "//pkg/scheduler/factory:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/client-go/informers:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/testing:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/scheduler/api/compatibility/compatibility_test.go
+++ b/pkg/scheduler/api/compatibility/compatibility_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package defaults
+package compatibility
 
 import (
 	"fmt"
@@ -31,6 +31,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	utiltesting "k8s.io/client-go/util/testing"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	_ "k8s.io/kubernetes/pkg/scheduler/algorithmprovider/defaults"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	latestschedulerapi "k8s.io/kubernetes/pkg/scheduler/api/latest"
 	"k8s.io/kubernetes/pkg/scheduler/factory"


### PR DESCRIPTION
**What this PR does / why we need it**:
Move compatibility_test.go to pkg/scheduler/api. 
This file should move to new package named _compatibility_ to prevent error "import cycle not allowed".
And add import _algorithmprovider/defaults_ also to get factory initialization.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#71867](https://github.com/kubernetes/kubernetes/issues/71867)

**Special notes for your reviewer**:
/ping @misterikkit

**Release note:**:
```release-note
Move compatibility_test.go to pkg/scheduler/api
```
