### PR TITLE
Fix hermetic tests in kubeadm

### DIFF
--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -79,9 +79,11 @@ func KubernetesReleaseVersion(version string) (string, error) {
 
 	// kubeReleaseLabelRegex matches labels such as: latest, latest-1, latest-1.10
 	if kubeReleaseLabelRegex.MatchString(versionLabel) {
-		var clientVersion string
 		// Try to obtain a client version.
-		clientVersion, _ = kubeadmVersion(pkgversion.Get().String())
+		clientVersion, err := kubeadmVersion(pkgversion.Get().String())
+		if err != nil {
+			return "", err
+		}
 		// Fetch version from the internet.
 		url := fmt.Sprintf("%s/%s.txt", bucketURL, versionLabel)
 		body, err := fetchFromURL(url, getReleaseVersionTimeout)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind failing-test

**What this PR does / why we need it**:

The PR fixes the Bazel-based unit test `//cmd/kubeadm/app/cmd:go_default_test` when it's run behind a corporate proxy.

**Special notes for your reviewer**:
When we run `go test` in a pristine git tree checked out to an arbitrary commit then the file `pkg/version/base.go` contains unmodified `gitVersion` variable whose default value ("v0.0.0-master+$Format:%h$") is unparsable.
    
Unfortunately this is the value fed to `kubeadmVersion()` resulting in an error. Even if the error is ignored in the hope that the remote version is used instead then this triggers a test failure in "air-gapped" environment (e.g. behind a corporate proxy)
    
In this special case fall back to the value of k8s.io/kubernetes/cmd/kubeadm/app/constants.MinimumControlPlaneVersion.

/release-note-none
/priority backlog

```release-note
NONE
```