### PR TITLE
Increase limit for object size in streaming serializer

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go
@@ -64,7 +64,7 @@ func NewDecoder(r io.ReadCloser, d runtime.Decoder) Decoder {
 		reader:   r,
 		decoder:  d,
 		buf:      make([]byte, 1024),
-		maxBytes: 1024 * 1024,
+		maxBytes: 16 * 1024 * 1024,
 	}
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
@@ -51,7 +51,7 @@ func TestDecoder(t *testing.T) {
 	frames := [][]byte{
 		make([]byte, 1025),
 		make([]byte, 1024*5),
-		make([]byte, 1024*1024*5),
+		make([]byte, 1024*1024*17),
 		make([]byte, 1025),
 	}
 	pr, pw := io.Pipe()


### PR DESCRIPTION
Given that apiserver doesn't have validation for object size, and etcd allows for writing objects larger than 1MB (I think 1.5MB is the limit @jpbetz to confirm), we should allow for reading them in the default streaming serializer.

I bumped the limit significantly to also handle situation where we write protobuf to etcd and we watch jsons which are visibly better (it doesn't guarantee it will always work, but it at least leave some slack so that can be possible).

@kubernetes/sig-api-machinery-bugs 

```release-note
Allow for watching objects larger than 1MB given etcd accepts objects of size up to 1.5MB
```