### PR TITLE
 kubeadm: refactor validateStableVersion() 

### DIFF
--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -132,7 +132,7 @@ func TestVersionFromNetwork(t *testing.T) {
 		t.Logf("Key: %q. Result: %q, Error: %v", k, ver, err)
 		switch {
 		case err != nil && !v.ErrorExpected:
-			t.Errorf("KubernetesReleaseVersion: unexpected error for %q. Error: %v", k, err)
+			t.Errorf("KubernetesReleaseVersion: unexpected error for %q. Error: %+v", k, err)
 		case err == nil && v.ErrorExpected:
 			t.Errorf("KubernetesReleaseVersion: error expected for key %q, but result is %q", k, ver)
 		case ver != v.Expected:

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -421,10 +421,10 @@ func TestValidateStableVersion(t *testing.T) {
 			output:        "v1.11.0",
 		},
 		{
-			name:          "valid: client version is empty; use remote version",
+			name:          "invalid: client version is empty",
 			remoteVersion: "v1.12.1",
 			clientVersion: "",
-			output:        "v1.12.1",
+			expectedError: true,
 		},
 		{
 			name:          "invalid: error parsing the remote version",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently the function `cmd/kubeadm/app/util.validateStableVersion()` doesn't validate remote versions in the special case when the client version is empty. This makes the code more difficult to reason about, because the function may successfully return a string which isn't a valid version. And this conflicts with name of the function.

Move handling the special case outside of the function to the place where its meaning is more obvious.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
