### PR TITLE
fix SystemReserved and KubeReserved flags

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/validation_test.go
+++ b/cmd/kubeadm/app/componentconfigs/validation_test.go
@@ -286,7 +286,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					Kubelet: &kubeletconfig.KubeletConfiguration{
 						CgroupsPerQOS:               true,
-						EnforceNodeAllocatable:      []string{"pods", "system-reserved", "kube-reserved"},
+						EnforceNodeAllocatable:      []string{"pods", "SystemReserved", "KubeReserved"},
 						SystemCgroups:               "",
 						CgroupRoot:                  "",
 						EventBurst:                  10,

--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -28,7 +28,7 @@ import (
 func TestValidateKubeletConfiguration(t *testing.T) {
 	successCase := &kubeletconfig.KubeletConfiguration{
 		CgroupsPerQOS:               true,
-		EnforceNodeAllocatable:      []string{"pods", "system-reserved", "kube-reserved"},
+		EnforceNodeAllocatable:      []string{"pods", "SystemReserved", "KubeReserved"},
 		SystemCgroups:               "",
 		CgroupRoot:                  "",
 		EventBurst:                  10,
@@ -58,7 +58,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 
 	errorCase := &kubeletconfig.KubeletConfiguration{
 		CgroupsPerQOS:               false,
-		EnforceNodeAllocatable:      []string{"pods", "system-reserved", "kube-reserved", "illegal-key"},
+		EnforceNodeAllocatable:      []string{"pods", "SystemReserved", "KubeReserved", "illegal-key"},
 		SystemCgroups:               "/",
 		CgroupRoot:                  "",
 		EventBurst:                  -10,

--- a/pkg/kubelet/types/constants.go
+++ b/pkg/kubelet/types/constants.go
@@ -26,7 +26,7 @@ const (
 
 	// User visible keys for managing node allocatable enforcement on the node.
 	NodeAllocatableEnforcementKey = "pods"
-	SystemReservedEnforcementKey  = "system-reserved"
-	KubeReservedEnforcementKey    = "kube-reserved"
+	SystemReservedEnforcementKey  = "SystemReserved"
+	KubeReservedEnforcementKey    = "KubeReserved"
 	NodeAllocatableNoneKey        = "none"
 )

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -706,7 +706,7 @@ type KubeletConfiguration struct {
 	// +optional
 	KubeReservedCgroup string `json:"kubeReservedCgroup,omitempty"`
 	// This flag specifies the various Node Allocatable enforcements that Kubelet needs to perform.
-	// This flag accepts a list of options. Acceptable options are `none`, `pods`, `system-reserved` & `kube-reserved`.
+	// This flag accepts a list of options. Acceptable options are `none`, `pods`, `SystemReserved` & `KubeReserved`.
 	// If `none` is specified, no other options may be specified.
 	// Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md) doc for more information.
 	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -98,8 +98,8 @@ func getAllocatableLimits(cpu, memory string, capacity v1.ResourceList) (*resour
 }
 
 const (
-	kubeReservedCgroup   = "kube-reserved"
-	systemReservedCgroup = "system-reserved"
+	kubeReservedCgroup   = "KubeReserved"
+	systemReservedCgroup = "SystemReserved"
 )
 
 func createIfNotExists(cm cm.CgroupManager, cgroupConfig *cm.CgroupConfig) error {


### PR DESCRIPTION


**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
The system reserved/kube reserved flag were not being used due to mismatched strings causing an if statement to fail.

In pkg kubelet we're checking whether the system/kube reserved flag is set:
https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/node_container_manager_linux.go#L105

The keys it checks for are defined here as "system-reserved/kube-reserved"
https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/types/constants.go#L29

However in cmd/kubelet we are setting the key to "SystemReserved/KubeReserved" so this code will never be executed.
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/server.go#L674

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72050

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
