### PR TITLE
Move `ScheduleAlgorithm` to the core package.

### DIFF
--- a/pkg/scheduler/algorithm/scheduler_interface.go
+++ b/pkg/scheduler/algorithm/scheduler_interface.go
@@ -72,20 +72,3 @@ type SchedulerExtender interface {
 	// is unavailable. This gives scheduler ability to fail fast and tolerate non-critical extenders as well.
 	IsIgnorable() bool
 }
-
-// ScheduleAlgorithm is an interface implemented by things that know how to schedule pods
-// onto machines.
-type ScheduleAlgorithm interface {
-	Schedule(*v1.Pod, NodeLister) (selectedMachine string, err error)
-	// Preempt receives scheduling errors for a pod and tries to create room for
-	// the pod by preempting lower priority pods if possible.
-	// It returns the node where preemption happened, a list of preempted pods, a
-	// list of pods whose nominated node name should be removed, and error if any.
-	Preempt(*v1.Pod, NodeLister, error) (selectedNode *v1.Node, preemptedPods []*v1.Pod, cleanupNominatedPods []*v1.Pod, err error)
-	// Predicates() returns a pointer to a map of predicate functions. This is
-	// exposed for testing.
-	Predicates() map[string]FitPredicate
-	// Prioritizers returns a slice of priority config. This is exposed for
-	// testing.
-	Prioritizers() []PriorityConfig
-}

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -103,7 +103,7 @@ type Config struct {
 	// successfully binding a pod
 	Ecache     *equivalence.Cache
 	NodeLister algorithm.NodeLister
-	Algorithm  algorithm.ScheduleAlgorithm
+	Algorithm  core.ScheduleAlgorithm
 	GetBinder  func(pod *v1.Pod) Binder
 	// PodConditionUpdater is used only in case of scheduling errors. If we succeed
 	// with scheduling, PodScheduled condition will be updated in apiserver in /bind

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -211,7 +211,7 @@ func TestScheduler(t *testing.T) {
 		name             string
 		injectBindError  error
 		sendPod          *v1.Pod
-		algo             algorithm.ScheduleAlgorithm
+		algo             core.ScheduleAlgorithm
 		expectErrorPod   *v1.Pod
 		expectForgetPod  *v1.Pod
 		expectAssumedPod *v1.Pod


### PR DESCRIPTION

**What this PR does / why we need it**:
This moves the type `ScheduleAlgorithm` from `pkg/scheduler/algorithm`
to `pkg/scheduler/core`. The reason for this move is to fix our import
dependency graph and allow predicate & priority types to be moved into
their appropriate packages.

The new location makes sense because `core` is the only package that
exports an implementation of this type.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/sig scheduling


**Which issue(s) this PR fixes**:
This solves import loops for #71864 and ￼ #71865

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
