### PR TITLE
Perform GCE master log rotation check every 5 minutes

### DIFF
--- a/cluster/gce/gci/master.yaml
+++ b/cluster/gce/gci/master.yaml
@@ -83,10 +83,10 @@ write_files:
     owner: root
     content: |
       [Unit]
-      Description=Hourly kube-logrotate invocation
+      Description=kube-logrotate invocation
 
       [Timer]
-      OnCalendar=hourly
+      OnCalendar=*-*-* *:00/5:00
 
       [Install]
       WantedBy=kubernetes.target


### PR DESCRIPTION
Reduce how often we check if logs in the master need to be rotate from 1hr to 5min. Rotation policy stays the same (new day starts, log file size > 100MB).  When logs are extremely spammy, the logs can grow far beyond what the rotation policy intends, this helps keep them better in check.

**What this PR does / why we need it**:

```release-note
Reduce GCE log rotation check from 1 hour to every 5 minutes.  Rotation policy is unchanged (new day starts, log file size > 100MB).
```

cc @mborsz @jlowdermilk  @cheftako @mml 