### PR TITLE
Small fix in test/images/webhook/README.md

### DIFF
--- a/test/images/webhook/.gitignore
+++ b/test/images/webhook/.gitignore
@@ -1,0 +1,1 @@
+webhook

--- a/test/images/webhook/Makefile
+++ b/test/images/webhook/Makefile
@@ -14,6 +14,7 @@
 
 SRCS=webhook
 ARCH ?= amd64
+GOARM ?= 7
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))

--- a/test/images/webhook/README.md
+++ b/test/images/webhook/README.md
@@ -8,6 +8,15 @@ TODO: add the reference when the document for admission webhook v1beta1 API is d
 
 ## Build the code
 
+The binary can be built using the following command :
+
 ```bash
-make build
+make bin
+```
+
+The images can be built using the Makefile in the parent directory (`test/images`) :
+
+```bash
+cd ..
+make all WHAT=webhook
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

`test/images/webhook/README.md` states to use `make build` : 
```
$ cd test/images/webhook
$ make build
make: Nothing to be done for `build'.
```

This patch suggests using the Makefile in the parent directory to build the webhook images : 

```
cd ..
make all WHAT=webhook
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No issue has been opened, please tell me if you need one.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
