### PR TITLE
[FEATURE-SERVERSIDE-APPLY] Toleration and modifying

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apiserver/pkg/util/dryrun"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utiltrace "k8s.io/apiserver/pkg/util/trace"
+	"k8s.io/klog"
 )
 
 func createHandler(r rest.NamedCreater, scope RequestScope, admit admission.Interface, includeName bool) http.HandlerFunc {
@@ -131,13 +132,12 @@ func createHandler(r rest.NamedCreater, scope RequestScope, admit admission.Inte
 		if scope.FieldManager != nil {
 			liveObj, err := scope.Creater.New(scope.Kind)
 			if err != nil {
-				scope.err(err, w, req)
-				return
-			}
-			obj, err = scope.FieldManager.Update(liveObj, obj, "create")
-			if err != nil {
-				scope.err(err, w, req)
-				return
+				klog.Warningf("FieldManager: Failed to create new object: %v", err)
+			} else {
+				obj, err = scope.FieldManager.Update(liveObj, obj, "create")
+				if err != nil {
+					klog.Warningf("FieldManager: Failed to update object managed fields: %v", err)
+				}
 			}
 		}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -89,8 +89,7 @@ func (f *FieldManager) Update(liveObj, newObj runtime.Object, manager string) (r
 	if err != nil {
 		return nil, fmt.Errorf("failed to create typed live object: %v", err)
 	}
-	// TODO: We don't support multiple versions yet.
-	apiVersion := fieldpath.APIVersion("v1")
+	apiVersion := fieldpath.APIVersion(f.groupVersion.String())
 	managed, err = f.updater.Update(liveObjTyped, newObjTyped, apiVersion, managed, manager)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update ManagedFields: %v", err)
@@ -129,8 +128,7 @@ func (f *FieldManager) Apply(liveObj runtime.Object, patch []byte, force bool) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to create typed live object: %v", err)
 	}
-	// TODO: We don't support multiple versions yet.
-	apiVersion := fieldpath.APIVersion("v1")
+	apiVersion := fieldpath.APIVersion(f.groupVersion.String())
 	newObjTyped, managed, err := f.updater.Apply(liveObjTyped, patchObjTyped, apiVersion, managed, applyManager, force)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -62,8 +62,13 @@ func NewFieldManager(models openapiproto.Models, objectConverter runtime.ObjectC
 // object.
 func (f *FieldManager) Update(liveObj, newObj runtime.Object, manager string) (runtime.Object, error) {
 	managed, err := internal.DecodeObjectManagedFields(newObj)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode managed fields: %v", err)
+	// If the managed field is empty or we failed to decode it,
+	// let's try the live object
+	if err != nil || len(managed) == 0 {
+		managed, err = internal.DecodeObjectManagedFields(liveObj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode managed fields: %v", err)
+		}
 	}
 	if err := internal.RemoveObjectManagedFields(newObj); err != nil {
 		return nil, fmt.Errorf("failed to remove managed fields from new obj: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/apiserver/pkg/util/dryrun"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utiltrace "k8s.io/apiserver/pkg/util/trace"
+	"k8s.io/klog"
 )
 
 // PatchResource returns a function that will handle a resource patch.
@@ -303,7 +304,10 @@ func (p *jsonPatcher) applyPatchToCurrentObject(currentObject runtime.Object) (r
 	}
 
 	if p.fieldManager != nil {
-		return p.fieldManager.Update(currentObject, objToUpdate, "jsonPatcher")
+		objToUpdate, err = p.fieldManager.Update(currentObject, objToUpdate, "jsonPatcher")
+		if err != nil {
+			klog.Warningf("FieldManager: Failed to update object managed fields: %v", err)
+		}
 	}
 	return objToUpdate, nil
 }
@@ -363,7 +367,10 @@ func (p *smpPatcher) applyPatchToCurrentObject(currentObject runtime.Object) (ru
 	}
 
 	if p.fieldManager != nil {
-		return p.fieldManager.Update(currentObject, newObj, "jsonPatcher")
+		newObj, err = p.fieldManager.Update(currentObject, newObj, "smPatcher")
+		if err != nil {
+			klog.Warningf("FieldManager: Failed to update object managed fields: %v", err)
+		}
 	}
 	return newObj, nil
 }


### PR DESCRIPTION
/kind feature

A couple of things:
1. Don't fail on error to update the managed fields,
2. Introduce the actual version of the object so we can try the conversion,
3. Allow users to change the managed fields themselves, empty it (without considering clients that just drop everything) and also allow them to make mistake: fallbacks on the former managed fields if invalid.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
