### PR TITLE
graceful pod termination with preStop container life cycle hook

### DIFF
--- a/test/e2e/node/BUILD
+++ b/test/e2e/node/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//pkg/kubelet/apis/stats/v1alpha1:go_default_library",
         "//pkg/kubelet/events:go_default_library",
         "//pkg/kubelet/runtimeclass/testing:go_default_library",
+        "//pkg/master/ports:go_default_library",
         "//pkg/util/slice:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/test/e2e/node/pre_stop.go
+++ b/test/e2e/node/pre_stop.go
@@ -24,12 +24,15 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/master/ports"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 // partially cloned from webserver.go
@@ -160,6 +163,10 @@ func testPreStop(c clientset.Interface, ns string) {
 
 var _ = SIGDescribe("PreStop", func() {
 	f := framework.NewDefaultFramework("prestop")
+	var podClient *framework.PodClient
+	BeforeEach(func() {
+		podClient = f.PodClient()
+	})
 
 	/*
 		Release : v1.9
@@ -169,4 +176,70 @@ var _ = SIGDescribe("PreStop", func() {
 	framework.ConformanceIt("should call prestop when killing a pod ", func() {
 		testPreStop(f.ClientSet, f.Namespace.Name)
 	})
+
+	It("graceful pod terminated should wait until preStop hook completes the process", func() {
+		gracefulTerminationPeriodSeconds := int64(30)
+		By("creating the pod")
+		name := "pod-prestop-hook-" + string(uuid.NewUUID())
+		pod := getPodWithpreStopLifeCycle(name)
+
+		By("submitting the pod to kubernetes")
+		podClient.Create(pod)
+
+		By("waiting for pod running")
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
+
+		var err error
+		pod, err = podClient.Get(pod.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred(), "failed to GET scheduled pod")
+
+		By("deleting the pod gracefully")
+		err = podClient.Delete(pod.Name, metav1.NewDeleteOptions(gracefulTerminationPeriodSeconds))
+		Expect(err).NotTo(HaveOccurred(), "failed to delete pod")
+
+		//wait up to graceful termination period seconds
+		time.Sleep(30 * time.Second)
+
+		By("verifying the pod running state after graceful termination")
+		result := &v1.PodList{}
+		err = wait.Poll(time.Second*5, time.Second*60, func() (bool, error) {
+			client, err := framework.NodeProxyRequest(f.ClientSet, pod.Spec.NodeName, "pods", ports.KubeletPort)
+			Expect(err).NotTo(HaveOccurred(), "failed to get the pods of the node")
+			err = client.Into(result)
+			Expect(err).NotTo(HaveOccurred(), "failed to parse the pods of the node")
+
+			for _, kubeletPod := range result.Items {
+				if pod.Name != kubeletPod.Name {
+					continue
+				} else if kubeletPod.Status.Phase == v1.PodRunning {
+					framework.Logf("pod is running")
+					return true, err
+				}
+			}
+			return false, err
+		})
+	})
 })
+
+func getPodWithpreStopLifeCycle(name string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "nginx",
+					Image: imageutils.GetE2EImage(imageutils.Nginx),
+					Lifecycle: &v1.Lifecycle{
+						PreStop: &v1.Handler{
+							Exec: &v1.ExecAction{
+								Command: []string{"sh", "-c", "while true; do echo preStop; sleep 1; done"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
 /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Added new e2e test case, for graceful pod termination with preStop container life cycle hook

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
    added test case for the definition 
    `If the pod has defined a preStop hook, it is invoked inside of the pod. If the preStop hook is still running after the grace period expires, step 2 is then invoked with a small (2 second) extended grace period`
**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/area conformance