### PR TITLE
Fix kubectl cluster-info dump command and add test coverage

### DIFF
--- a/pkg/kubectl/cmd/clusterinfo/BUILD
+++ b/pkg/kubectl/cmd/clusterinfo/BUILD
@@ -35,12 +35,9 @@ go_test(
     deps = [
         "//pkg/kubectl/cmd/testing:go_default_library",
         "//pkg/kubectl/scheme:go_default_library",
-        "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
-        "//staging/src/k8s.io/client-go/rest/fake:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
     ],
 )

--- a/pkg/kubectl/cmd/clusterinfo/BUILD
+++ b/pkg/kubectl/cmd/clusterinfo/BUILD
@@ -34,7 +34,14 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/kubectl/cmd/testing:go_default_library",
+        "//pkg/kubectl/scheme:go_default_library",
+        "//staging/src/k8s.io/api/apps/v1:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
+        "//staging/src/k8s.io/client-go/rest/fake:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
     ],
 )
 

--- a/pkg/kubectl/cmd/clusterinfo/clusterinfo_dump.go
+++ b/pkg/kubectl/cmd/clusterinfo/clusterinfo_dump.go
@@ -133,14 +133,20 @@ func (o *ClusterInfoDumpOptions) Complete(f cmdutil.Factory, cmd *cobra.Command)
 
 	o.PrintObj = printer.PrintObj
 
-	clientset, err := f.KubernetesClientSet()
+	config, err := f.ToRESTConfig()
 	if err != nil {
 		return err
 	}
 
-	o.CoreClient = clientset.CoreV1()
+	o.CoreClient, err = corev1client.NewForConfig(config)
+	if err != nil {
+		return err
+	}
 
-	o.AppsClient = clientset.AppsV1()
+	o.AppsClient, err = appsv1client.NewForConfig(config)
+	if err != nil {
+		return err
+	}
 
 	o.Timeout, err = cmdutil.GetPodRunningTimeoutFlag(cmd)
 	if err != nil {

--- a/pkg/kubectl/cmd/clusterinfo/clusterinfo_dump.go
+++ b/pkg/kubectl/cmd/clusterinfo/clusterinfo_dump.go
@@ -133,20 +133,14 @@ func (o *ClusterInfoDumpOptions) Complete(f cmdutil.Factory, cmd *cobra.Command)
 
 	o.PrintObj = printer.PrintObj
 
-	config, err := f.ToRESTConfig()
+	clientset, err := f.KubernetesClientSet()
 	if err != nil {
 		return err
 	}
 
-	o.CoreClient, err = corev1client.NewForConfig(config)
-	if err != nil {
-		return err
-	}
+	o.CoreClient = clientset.CoreV1()
 
-	o.AppsClient, err = appsv1client.NewForConfig(config)
-	if err != nil {
-		return err
-	}
+	o.AppsClient = clientset.AppsV1()
 
 	o.Timeout, err = cmdutil.GetPodRunningTimeoutFlag(cmd)
 	if err != nil {
@@ -184,7 +178,8 @@ func (o *ClusterInfoDumpOptions) Run() error {
 			namespaces = append(namespaces, namespaceList.Items[ix].Name)
 		}
 	} else {
-		if len(o.Namespaces) == 0 {
+		namespaces = o.Namespaces
+		if len(namespaces) == 0 {
 			namespaces = []string{
 				metav1.NamespaceSystem,
 				o.Namespace,

--- a/pkg/kubectl/cmd/clusterinfo/clusterinfo_dump_test.go
+++ b/pkg/kubectl/cmd/clusterinfo/clusterinfo_dump_test.go
@@ -17,13 +17,24 @@ limitations under the License.
 package clusterinfo
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path"
 	"testing"
 
+	flag "github.com/spf13/pflag"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
 func TestSetupOutputWriterNoOp(t *testing.T) {
@@ -66,5 +77,111 @@ func TestSetupOutputWriterFile(t *testing.T) {
 	}
 	if string(data) != output {
 		t.Errorf("expected: %v, saw: %v", output, data)
+	}
+}
+
+func TestCmdClusterInfoDump(t *testing.T) {
+	tf := cmdtesting.NewTestFactory()
+	defer tf.Cleanup()
+
+	ns := scheme.Codecs
+
+	encodeResp := func(obj runtime.Object, ver runtime.GroupVersioner) io.ReadCloser {
+		info, _ := runtime.SerializerInfoForMediaType(ns.SupportedMediaTypes(), runtime.ContentTypeJSON)
+		encoder := ns.EncoderForVersion(info.Serializer, ver)
+
+		return ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(encoder, obj))))
+	}
+
+	encodeRespForCoreGV := func(obj runtime.Object) io.ReadCloser {
+		return encodeResp(obj, corev1.SchemeGroupVersion)
+	}
+
+	encodeRespForAppsGV := func(obj runtime.Object) io.ReadCloser {
+		return encodeResp(obj, appsv1.SchemeGroupVersion)
+	}
+
+	tests := map[string]struct {
+		expNsListReq []string
+
+		dumpAllNs        bool
+		populateCmdFlags func(f *flag.FlagSet)
+	}{
+		"should dump default namespaces": {
+			expNsListReq: []string{"kube-system", "default"},
+
+			populateCmdFlags: func(f *flag.FlagSet) {
+				// use default options
+			},
+		},
+
+		"should dump requested namespaces": {
+			expNsListReq: []string{"qa", "production"},
+
+			populateCmdFlags: func(f *flag.FlagSet) {
+				f.Set("namespaces", "qa,production")
+			},
+		},
+
+		"should dump all available namespaces": {
+			expNsListReq: []string{"qa", "production", "test", "kube-system"},
+
+			dumpAllNs: true,
+			populateCmdFlags: func(f *flag.FlagSet) {
+				f.Set("all-namespaces", "true")
+			},
+		},
+	}
+
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			expListReq := map[string]io.ReadCloser{
+				"/api/v1/nodes": encodeRespForCoreGV(&corev1.NodeList{}),
+			}
+
+			for _, ns := range tc.expNsListReq {
+				expListReq[fmt.Sprintf("/api/v1/namespaces/%s/events", ns)] = encodeRespForCoreGV(&corev1.EventList{})
+				expListReq[fmt.Sprintf("/api/v1/namespaces/%s/replicationcontrollers", ns)] = encodeRespForCoreGV(&corev1.ReplicationControllerList{})
+				expListReq[fmt.Sprintf("/api/v1/namespaces/%s/services", ns)] = encodeRespForCoreGV(&corev1.ServiceList{})
+				expListReq[fmt.Sprintf("/api/v1/namespaces/%s/pods", ns)] = encodeRespForCoreGV(&corev1.PodList{})
+
+				expListReq[fmt.Sprintf("/apis/apps/v1/namespaces/%s/daemonsets", ns)] = encodeRespForAppsGV(&appsv1.DaemonSetList{})
+				expListReq[fmt.Sprintf("/apis/apps/v1/namespaces/%s/deployments", ns)] = encodeRespForAppsGV(&appsv1.DeploymentList{})
+				expListReq[fmt.Sprintf("/apis/apps/v1/namespaces/%s/replicasets", ns)] = encodeRespForAppsGV(&appsv1.ReplicaSetList{})
+			}
+
+			if tc.dumpAllNs { // register expected namespaces
+				var items []corev1.Namespace
+				for _, nsName := range tc.expNsListReq {
+					items = append(items, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}})
+				}
+				expListReq["/api/v1/namespaces"] = encodeRespForCoreGV(&corev1.NamespaceList{
+					Items: items,
+				})
+			}
+
+			tf.Client = &fake.RESTClient{
+				NegotiatedSerializer: ns,
+				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+					respBody, found := expListReq[req.URL.Path]
+					if !found {
+						t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+					}
+
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     cmdtesting.DefaultHeader(),
+						Body:       respBody,
+					}, nil
+				}),
+			}
+			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+			ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+			cmd := NewCmdClusterInfoDump(tf, ioStreams)
+			tc.populateCmdFlags(cmd.Flags())
+
+			cmd.Run(cmd, []string{})
+		})
 	}
 }

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -425,6 +425,7 @@ func (f *TestFactory) KubernetesClientSet() (*kubernetes.Clientset, error) {
 	clientset.RbacV1beta1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	clientset.StorageV1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	clientset.StorageV1beta1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.AppsV1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	clientset.AppsV1beta1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	clientset.AppsV1beta2().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	clientset.AppsV1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change

 /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR fixes problem with cluster-info dump command when **--namespaces** flag is specified. Additionally, proper test coverage was added, so we never regress.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/72088

**Special notes for your reviewer**:

To make the code testable I had to change the way how the clients were initialized. Now the `KubernetesClientSet()` is used from `cmdutil.Factory`.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
