### PR TITLE
Promote NodeLease to Beta and enable by default

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -455,7 +455,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	ResourceQuotaScopeSelectors:                 {Default: true, PreRelease: utilfeature.Beta},
 	CSIBlockVolume:                              {Default: false, PreRelease: utilfeature.Alpha},
 	RuntimeClass:                                {Default: false, PreRelease: utilfeature.Alpha},
-	NodeLease:                                   {Default: false, PreRelease: utilfeature.Alpha},
+	NodeLease:                                   {Default: true, PreRelease: utilfeature.Beta},
 	SCTPSupport:                                 {Default: false, PreRelease: utilfeature.Alpha},
 	VolumeSnapshotDataSource:                    {Default: false, PreRelease: utilfeature.Alpha},
 	ProcMountType:                               {Default: false, PreRelease: utilfeature.Alpha},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -971,6 +971,16 @@ items:
     - volumeattachments
     verbs:
     - get
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+    - delete
+    - get
+    - patch
+    - update
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/14733
Ref https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/0009-node-heartbeat.md

Running tests at scale confirms that the main (of reducing size of etcd) has been achieved.
Without this change: etcd DB size: ~2.2GB
With this change: etcd DB size: ~1.3GB

Note that the tests were run on 5k nodes, but pretty much without any images being present on the node. And the more images on the nodes exist, the bigger impact we will have.
So the impact here is; ~2x+

@kubernetes/sig-node-pr-reviews @kubernetes/sig-scalability-pr-reviews @kubernetes/sig-api-machinery-pr-reviews 
@mtaufen @wangzhen127 @liggitt @dchen1107 @yujuhong @lavalamp @bgrant0607 @gmarek 

```release-note
Promote NodeLease feature to Beta and enable it by default.
The feature make Lease object changes an additional healthiness signal from Node. Together with that, we reduce frequency of NodeStatus updates (from 10s to 1m by default) in case of no changes to status itself.
```