### PR TITLE
kubelet: delay cgroups cleanup

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -542,6 +542,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		experimentalHostUserNamespaceDefaulting: utilfeature.DefaultFeatureGate.Enabled(features.ExperimentalHostUserNamespaceDefaultingGate),
 		keepTerminatedPodVolumes:                keepTerminatedPodVolumes,
 		nodeStatusMaxImages:                     nodeStatusMaxImages,
+		orphanedCgroupsFirstSeen:                make(map[types.UID]time.Time),
 	}
 
 	if klet.cloud != nil {
@@ -1219,6 +1220,9 @@ type Kubelet struct {
 
 	// Handles RuntimeClass objects for the Kubelet.
 	runtimeClassManager *runtimeclass.Manager
+
+	// Used by cleanupOrphanedPodCgroups for delayed cleanups.
+	orphanedCgroupsFirstSeen map[types.UID]time.Time
 }
 
 // setupDataDirs creates:


### PR DESCRIPTION
Delay the cgroups cleanup so that the runtime has enough time for
doing a proper cleanup.

This code creates a race when a StopPodSandbox is sent to the runtime
but the runtime hadn't yet completed the request.  While this solution
is not ideal, we should probably wait for the request to complete if
there is any pending, it signficantly improves chances to not get into a
race condition.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

delay the Kubelet cleanup of cgroups

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE

```release-note

```
