### PR TITLE
kubeadm: fix nil check in join config creation

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -316,7 +316,7 @@ func NewJoin(cfgPath string, defaultcfg *kubeadmapiv1beta1.JoinConfiguration, ig
 		internalCfg.NodeRegistration.CRISocket = defaultcfg.NodeRegistration.CRISocket
 	}
 
-	if defaultcfg.ControlPlane != nil {
+	if internalCfg.ControlPlane != nil {
 		if err := configutil.VerifyAPIServerBindAddress(internalCfg.ControlPlane.LocalAPIEndpoint.AdvertiseAddress); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubeadm/issues/1324

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
kubeadm: fix a possible panic when joining a new control plane node in HA scenarios
```

/cc @rosti @neolit123 