### PR TITLE
Automated cherry pick of #72123: kubeadm: fix nil check in join config creation

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -316,7 +316,7 @@ func NewJoin(cfgPath string, defaultcfg *kubeadmapiv1beta1.JoinConfiguration, ig
 		internalCfg.NodeRegistration.CRISocket = defaultcfg.NodeRegistration.CRISocket
 	}
 
-	if defaultcfg.ControlPlane != nil {
+	if internalCfg.ControlPlane != nil {
 		if err := configutil.VerifyAPIServerBindAddress(internalCfg.ControlPlane.LocalAPIEndpoint.AdvertiseAddress); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Cherry pick of #72123 on release-1.13.

#72123: kubeadm: fix nil check in join config creation