### PR TITLE
Don't add default flags for logging in init of externally usable libraries

### DIFF
--- a/cmd/cloud-controller-manager/app/BUILD
+++ b/cmd/cloud-controller-manager/app/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/globalflag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
         "//staging/src/k8s.io/client-go/tools/leaderelection:go_default_library",
         "//staging/src/k8s.io/client-go/tools/leaderelection/resourcelock:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",

--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apiserver/pkg/server/healthz"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/globalflag"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	cloudprovider "k8s.io/cloud-provider"
@@ -86,6 +87,7 @@ the cloud specific control loops shipped with Kubernetes.`,
 	namedFlagSets := s.Flags(KnownControllers(), ControllersDisabledByDefault.List())
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
+	logs.AddFlags(namedFlagSets.FlagSet("logging"))
 	cmoptions.AddCustomGlobalFlags(namedFlagSets.FlagSet("generic"))
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)

--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -58,6 +58,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/globalflag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/webhook:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/etcd3/preflight"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/globalflag"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/apiserver/pkg/util/webhook"
 	clientgoinformers "k8s.io/client-go/informers"
 	clientgoclientset "k8s.io/client-go/kubernetes"
@@ -120,6 +121,7 @@ cluster's shared state through which all other components interact.`,
 	namedFlagSets := s.Flags()
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
+	logs.AddFlags(namedFlagSets.FlagSet("logging"))
 	options.AddCustomGlobalFlags(namedFlagSets.FlagSet("generic"))
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)

--- a/cmd/kube-controller-manager/app/BUILD
+++ b/cmd/kube-controller-manager/app/BUILD
@@ -120,6 +120,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/globalflag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
         "//staging/src/k8s.io/client-go/discovery/cached:go_default_library",
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apiserver/pkg/server/mux"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/globalflag"
+	"k8s.io/apiserver/pkg/util/logs"
 	cacheddiscovery "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/informers"
 	restclient "k8s.io/client-go/rest"
@@ -116,6 +117,7 @@ controller, and serviceaccounts controller.`,
 	namedFlagSets := s.Flags(KnownControllers(), ControllersDisabledByDefault.List())
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
+	logs.AddFlags(namedFlagSets.FlagSet("logging"))
 	cmoptions.AddCustomGlobalFlags(namedFlagSets.FlagSet("generic"))
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)

--- a/cmd/kube-proxy/app/BUILD
+++ b/cmd/kube-proxy/app/BUILD
@@ -53,6 +53,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/server/routes:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apiserver/pkg/server/routes"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
 	informers "k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -405,6 +406,7 @@ with the apiserver API to configure the proxy.`,
 	}
 
 	opts.AddFlags(cmd.Flags())
+	logs.AddFlags(cmd.Flags())
 
 	cmd.MarkFlagFilename("config", "yaml", "yml", "json")
 

--- a/cmd/kube-scheduler/app/BUILD
+++ b/cmd/kube-scheduler/app/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/server/routes:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/globalflag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/tools/leaderelection:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apiserver/pkg/server/routes"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/globalflag"
+	"k8s.io/apiserver/pkg/util/logs"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/leaderelection"
 	schedulerserverconfig "k8s.io/kubernetes/cmd/kube-scheduler/app/config"
@@ -84,6 +85,7 @@ through the API as necessary.`,
 	namedFlagSets := opts.Flags()
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
+	logs.AddFlags(namedFlagSets.FlagSet("logging"))
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)
 	}

--- a/cmd/kubelet/app/BUILD
+++ b/cmd/kubelet/app/BUILD
@@ -123,6 +123,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1:go_default_library",

--- a/cmd/kubelet/app/options/BUILD
+++ b/cmd/kubelet/app/options/BUILD
@@ -37,7 +37,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
         "//staging/src/k8s.io/kubelet/config/v1beta1:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/cmd/kubelet/app/options/globalflags.go
+++ b/cmd/kubelet/app/options/globalflags.go
@@ -38,7 +38,6 @@ import (
 // against the global flagsets from "flag" and "github.com/spf13/pflag".
 // We do this in order to prevent unwanted flags from leaking into the Kubelet's flagset.
 func AddGlobalFlags(fs *pflag.FlagSet) {
-	addGlogFlags(fs)
 	addCadvisorFlags(fs)
 	addCredentialProviderFlags(fs)
 	verflag.AddFlags(fs)
@@ -87,24 +86,6 @@ func addCredentialProviderFlags(fs *pflag.FlagSet) {
 	// TODO(#58034): This is not a static file, so it's not quite as straightforward as --google-json-key.
 	// We need to figure out how ACR users can dynamically provide pull credentials before we can deprecate this.
 	pflagRegister(global, local, "azure-container-registry-config")
-
-	fs.AddFlagSet(local)
-}
-
-// addGlogFlags adds flags from k8s.io/klog
-func addGlogFlags(fs *pflag.FlagSet) {
-	// lookup flags in global flag set and re-register the values with our flagset
-	global := flag.CommandLine
-	local := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
-
-	register(global, local, "logtostderr")
-	register(global, local, "alsologtostderr")
-	register(global, local, "v")
-	register(global, local, "stderrthreshold")
-	register(global, local, "vmodule")
-	register(global, local, "log_backtrace_at")
-	register(global, local, "log_dir")
-	register(global, local, "log_file")
 
 	fs.AddFlagSet(local)
 }

--- a/cmd/kubelet/app/options/globalflags.go
+++ b/cmd/kubelet/app/options/globalflags.go
@@ -25,11 +25,9 @@ import (
 	"github.com/spf13/pflag"
 
 	// libs that provide registration functions
-	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/version/verflag"
 
 	// ensure libs have a chance to globally register their flags
-	_ "k8s.io/klog"
 	_ "k8s.io/kubernetes/pkg/credentialprovider/azure"
 	_ "k8s.io/kubernetes/pkg/credentialprovider/gcp"
 )
@@ -41,7 +39,6 @@ func AddGlobalFlags(fs *pflag.FlagSet) {
 	addCadvisorFlags(fs)
 	addCredentialProviderFlags(fs)
 	verflag.AddFlags(fs)
-	logs.AddFlags(fs)
 }
 
 // normalize replaces underscores with hyphens

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/apiserver/pkg/server/healthz"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
 	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
@@ -268,6 +269,7 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 	kubeletFlags.AddFlags(cleanFlagSet)
 	options.AddKubeletConfigFlags(cleanFlagSet, kubeletConfig)
 	options.AddGlobalFlags(cleanFlagSet)
+	logs.AddFlags(cleanFlagSet)
 	cleanFlagSet.BoolP("help", "h", false, fmt.Sprintf("help for %s", cmd.Name()))
 
 	// ugly, but necessary, because Cobra's default UsageFunc and HelpFunc pollute the flagset with global flags

--- a/staging/src/k8s.io/apiserver/pkg/util/globalflag/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/util/globalflag/BUILD
@@ -6,10 +6,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/globalflag",
     importpath = "k8s.io/apiserver/pkg/util/globalflag",
     visibility = ["//visibility:public"],
-    deps = [
-        "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
-    ],
+    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
 )
 
 go_test(

--- a/staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags.go
@@ -30,24 +30,9 @@ import (
 // against the global flagsets from "flag" and "k8s.io/klog".
 // We do this in order to prevent unwanted flags from leaking into the component's flagset.
 func AddGlobalFlags(fs *pflag.FlagSet, name string) {
-	addGlogFlags(fs)
 	logs.AddFlags(fs)
 
 	fs.BoolP("help", "h", false, fmt.Sprintf("help for %s", name))
-}
-
-// addGlogFlags explicitly registers flags that klog libraries(k8s.io/klog) register.
-func addGlogFlags(fs *pflag.FlagSet) {
-	// lookup flags of klog libraries in global flag set and re-register the values with our flagset
-	Register(fs, "logtostderr")
-	Register(fs, "alsologtostderr")
-	Register(fs, "v")
-	Register(fs, "skip_headers")
-	Register(fs, "stderrthreshold")
-	Register(fs, "vmodule")
-	Register(fs, "log_backtrace_at")
-	Register(fs, "log_dir")
-	Register(fs, "log_file")
 }
 
 // normalize replaces underscores with hyphens

--- a/staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags.go
@@ -22,16 +22,12 @@ import (
 	"strings"
 
 	"github.com/spf13/pflag"
-
-	"k8s.io/apiserver/pkg/util/logs"
 )
 
-// AddGlobalFlags explicitly registers flags that libraries (klog, verflag, etc.) register
-// against the global flagsets from "flag" and "k8s.io/klog".
-// We do this in order to prevent unwanted flags from leaking into the component's flagset.
+// AddGlobalFlags explicitly registers flags that libraries (verflag, etc.) register
+// against the global flagsets from "flag".  We do this in order to prevent unwanted
+// flags from leaking into the component's flagset.
 func AddGlobalFlags(fs *pflag.FlagSet, name string) {
-	logs.AddFlags(fs)
-
 	fs.BoolP("help", "h", false, fmt.Sprintf("help for %s", name))
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags_test.go
@@ -58,7 +58,7 @@ func TestAddGlobalFlags(t *testing.T) {
 	}{
 		{
 			// Happy case
-			expectedFlag:  []string{"alsologtostderr", "help", "log-backtrace-at", "log-dir", "log-file", "log-flush-frequency", "logtostderr", "skip-headers", "stderrthreshold", "v", "vmodule"},
+			expectedFlag:  []string{"help"},
 			matchExpected: false,
 		},
 		{

--- a/staging/src/k8s.io/apiserver/pkg/util/logs/logs.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/logs/logs.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
 )
@@ -33,10 +34,16 @@ var logFlushFreq time.Duration
 // AddFlags registers this package's flags (plus the klog flags used by this package) on arbitrary FlagSets.
 // You should call this on *some* flag set.
 func AddFlags(fs *pflag.FlagSet) {
+	var goflagFS flag.FlagSet
+	AddFlagsGoflags(&goflagFS)
+	fs.AddGoFlagSet(&goflagFS)
+}
+
+// AddFlagsGoflags functions identically to AddFlags, except it works on a standard Go flagset.
+// This is to make including these flags in test binaries easier (since those expect standard go flags).
+func AddFlagsGoflags(fs *flag.FlagSet) {
 	fs.DurationVar(&logFlushFreq, "log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
-	var gologFlagSet flag.FlagSet
-	klog.InitFlags(&gologFlagSet)
-	fs.AddGoFlagSet(&gologFlagSet)
+	klog.InitFlags(fs)
 
 	// TODO(thockin): This is temporary until we agree on log dirs and put those into each cmd.
 	flag.Set("logtostderr", "true")

--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -166,6 +166,7 @@ go_test(
             "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
+            "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//test/utils:go_default_library",
             "//vendor/github.com/kardianos/osext:go_default_library",

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/apiserver/pkg/util/logs"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/system"
 	nodeutil "k8s.io/kubernetes/pkg/api/v1/node"
@@ -67,6 +68,8 @@ func init() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	// Mark the run-services-mode flag as hidden to prevent user from using it.
 	pflag.CommandLine.MarkHidden("run-services-mode")
+	logs.AddFlagsGoflags(flag.CommandLine)
+
 	// It's weird that if I directly use pflag in TestContext, it will report error.
 	// It seems that someone is using flag.Parse() after init() and TestMain().
 	// TODO(random-liu): Find who is using flag.Parse() and cause errors and move the following logic

--- a/test/integration/framework/BUILD
+++ b/test/integration/framework/BUILD
@@ -54,6 +54,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -19,11 +19,13 @@ limitations under the License.
 package framework
 
 import (
+	"flag"
 	"net/http/httptest"
 	"testing"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/util/logs"
 )
 
 const (
@@ -47,4 +49,8 @@ func CreateTestingNamespace(baseName string, apiserver *httptest.Server, t *test
 
 func DeleteTestingNamespace(ns *v1.Namespace, apiserver *httptest.Server, t *testing.T) {
 	// TODO: Remove all resources from a given namespace once we implement CreateTestingNamespace.
+}
+
+func init() {
+	logs.AddFlagsGoflags(flag.CommandLine)
 }


### PR DESCRIPTION
We really shouldn't add flags to the default flag set.  We try pretty
hard not to with klog, so we shouldn't defeat that by doing it elsewhere
in generic libaries, like k8s.io/apiserver's logging utilities.

/kind bug

```release-note
Don't automatically register logging flags in global flag namespace in k8s.io/apiserver
```
