### PR TITLE
Issue 71769: Correctly display '_' in the help message

### DIFF
--- a/pkg/kubectl/util/templates/markdown.go
+++ b/pkg/kubectl/util/templates/markdown.go
@@ -46,8 +46,10 @@ func (r *ASCIIRenderer) NormalText(out *bytes.Buffer, text []byte) {
 	lines := strings.Split(raw, linebreak)
 	for _, line := range lines {
 		trimmed := strings.Trim(line, " \n\t")
+		if len(trimmed) > 0 && trimmed[0] != '_' {
+			out.WriteString(" ")
+		}
 		out.WriteString(trimmed)
-		out.WriteString(" ")
 	}
 }
 

--- a/pkg/kubectl/util/templates/normalizers.go
+++ b/pkg/kubectl/util/templates/normalizers.go
@@ -70,7 +70,7 @@ type normalizer struct {
 
 func (s normalizer) markdown() normalizer {
 	bytes := []byte(s.string)
-	formatted := blackfriday.Markdown(bytes, &ASCIIRenderer{Indentation: Indentation}, 0)
+	formatted := blackfriday.Markdown(bytes, &ASCIIRenderer{Indentation: Indentation}, blackfriday.EXTENSION_NO_INTRA_EMPHASIS)
 	s.string = string(formatted)
 	return s
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Correctly display '_" in the help message

**Which issue(s) this PR fixes**:
Fixes #71769

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```