### PR TITLE
Set percentage of nodes scored in each cycle dynamically based on the…

### DIFF
--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -225,8 +225,7 @@ users:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: 50,
-				BindTimeoutSeconds:       &defaultBindTimeoutSeconds,
+				BindTimeoutSeconds: &defaultBindTimeoutSeconds,
 			},
 		},
 		{
@@ -306,8 +305,7 @@ users:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: 50,
-				BindTimeoutSeconds:       &defaultBindTimeoutSeconds,
+				BindTimeoutSeconds: &defaultBindTimeoutSeconds,
 			},
 		},
 		{

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -79,7 +79,8 @@ type KubeSchedulerConfiguration struct {
 	// at least "minFeasibleNodesToFind" feasible nodes no matter what the value of this flag is.
 	// Example: if the cluster size is 500 nodes and the value of this flag is 30,
 	// then scheduler stops finding further feasible nodes once it finds 150 feasible ones.
-	// When the value is 0, default percentage (50%) of the nodes will be scored.
+	// When the value is 0, default percentage (5%--50% based on the size of the cluster) of the
+	// nodes will be scored.
 	PercentageOfNodesToScore int32
 
 	// DEPRECATED.

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -81,11 +81,6 @@ func SetDefaults_KubeSchedulerConfiguration(obj *kubescedulerconfigv1alpha1.Kube
 		obj.LeaderElection.LockObjectName = kubescedulerconfigv1alpha1.SchedulerDefaultLockObjectName
 	}
 
-	if obj.PercentageOfNodesToScore == 0 {
-		// by default, stop finding feasible nodes once the number of feasible nodes is 50% of the cluster.
-		obj.PercentageOfNodesToScore = 50
-	}
-
 	if len(obj.FailureDomains) == 0 {
 		obj.FailureDomains = kubeletapis.DefaultFailureDomains
 	}

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -1483,3 +1483,56 @@ func TestPreempt(t *testing.T) {
 		})
 	}
 }
+
+func TestNumFeasibleNodesToFind(t *testing.T) {
+	tests := []struct {
+		name                     string
+		percentageOfNodesToScore int32
+		numAllNodes              int32
+		wantNumNodes             int32
+	}{
+		{
+			name:         "not set percentageOfNodesToScore and nodes number not more than 50",
+			numAllNodes:  10,
+			wantNumNodes: 10,
+		},
+		{
+			name:                     "set percentageOfNodesToScore and nodes number not more than 50",
+			percentageOfNodesToScore: 40,
+			numAllNodes:              10,
+			wantNumNodes:             10,
+		},
+		{
+			name:         "not set percentageOfNodesToScore and nodes number more than 50",
+			numAllNodes:  1000,
+			wantNumNodes: 420,
+		},
+		{
+			name:                     "set percentageOfNodesToScore and nodes number more than 50",
+			percentageOfNodesToScore: 40,
+			numAllNodes:              1000,
+			wantNumNodes:             400,
+		},
+		{
+			name:         "not set percentageOfNodesToScore and nodes number more than 50*125",
+			numAllNodes:  6000,
+			wantNumNodes: 300,
+		},
+		{
+			name:                     "set percentageOfNodesToScore and nodes number more than 50*125",
+			percentageOfNodesToScore: 40,
+			numAllNodes:              6000,
+			wantNumNodes:             2400,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &genericScheduler{
+				percentageOfNodesToScore: tt.percentageOfNodesToScore,
+			}
+			if gotNumNodes := g.numFeasibleNodesToFind(tt.numAllNodes); gotNumNodes != tt.wantNumNodes {
+				t.Errorf("genericScheduler.numFeasibleNodesToFind() = %v, want %v", gotNumNodes, tt.wantNumNodes)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
@@ -75,7 +75,8 @@ type KubeSchedulerConfiguration struct {
 	// at least "minFeasibleNodesToFind" feasible nodes no matter what the value of this flag is.
 	// Example: if the cluster size is 500 nodes and the value of this flag is 30,
 	// then scheduler stops finding further feasible nodes once it finds 150 feasible ones.
-	// When the value is 0, default percentage (50%) of the nodes will be scored.
+	// When the value is 0, default percentage (5%--50% based on the size of the cluster) of the
+	// nodes will be scored.
 	PercentageOfNodesToScore int32 `json:"percentageOfNodesToScore"`
 
 	// DEPRECATED.


### PR DESCRIPTION
… cluster size

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind feature
/sig scheduling

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72125

**Special notes for your reviewer**:
@bsalamat 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Set percentage of nodes scored in each cycle dynamically based on the cluster size.
```
