### PR TITLE
Bump dashboard version to v1.10.1

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -31,7 +31,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.0
+        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Bumping Dashboard version to v1.10.1

**Special notes for your reviewer**:
Dashboard release notes: https://github.com/kubernetes/dashboard/releases/tag/v1.10.1 

On till images are cut/pushed
/hold
/sig ui

**Does this PR introduce a user-facing change?**:
No.

```release-note
Bump Dashboard version to v1.10.1
```
