### PR TITLE
fix apiserver aggregator req.Host settings bug

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -142,6 +142,7 @@ func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	newReq := req.WithContext(context.Background())
 	newReq.Header = utilnet.CloneHeader(req.Header)
 	newReq.URL = location
+        newReq.Host = location.Host
 
 	if handlingInfo.proxyRoundTripper == nil {
 		proxyError(w, req, "", http.StatusNotFound)

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -142,7 +142,7 @@ func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	newReq := req.WithContext(context.Background())
 	newReq.Header = utilnet.CloneHeader(req.Header)
 	newReq.URL = location
-        newReq.Host = location.Host
+	newReq.Host = location.Host
 
 	if handlingInfo.proxyRoundTripper == nil {
 		proxyError(w, req, "", http.StatusNotFound)

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -245,8 +245,7 @@ func TestProxyHandler(t *testing.T) {
 				Name:   "username",
 				Groups: []string{"one", "two"},
 			},
-			path:            "/request/path",
-			serviceResolver: &mockedRouter{destinationHost: targetServer.Listener.Addr().String()},
+			path: "/request/path",
 			apiService: &apiregistration.APIService{
 				ObjectMeta: metav1.ObjectMeta{Name: "v1.foo"},
 				Spec: apiregistration.APIServiceSpec{

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -18,7 +18,6 @@ package apiserver
 
 import (
 	"crypto/tls"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -31,6 +30,7 @@ import (
 
 	"golang.org/x/net/websocket"
 
+	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -42,18 +42,21 @@ type targetHTTPHandler struct {
 	called  bool
 	headers map[string][]string
 	path    string
+	host    string
 }
 
 func (d *targetHTTPHandler) Reset() {
 	d.path = ""
 	d.called = false
 	d.headers = nil
+	d.host = ""
 }
 
 func (d *targetHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	d.path = r.URL.Path
 	d.called = true
 	d.headers = r.Header
+	d.host = r.Host
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -258,6 +261,38 @@ func TestProxyHandler(t *testing.T) {
 			},
 			expectedStatusCode: http.StatusServiceUnavailable,
 		},
+		"change aggregator http request host": {
+			user: &user.DefaultInfo{
+				Name:   "username",
+				Groups: []string{"one", "two"},
+			},
+			path: "/request/path",
+			apiService: &apiregistration.APIService{
+				ObjectMeta: metav1.ObjectMeta{Name: "v1.foo"},
+				Spec: apiregistration.APIServiceSpec{
+					Service:               &apiregistration.ServiceReference{},
+					Group:                 "foo",
+					Version:               "v1",
+					InsecureSkipTLSVerify: true,
+				},
+				Status: apiregistration.APIServiceStatus{
+					Conditions: []apiregistration.APIServiceCondition{
+						{Type: apiregistration.Available, Status: apiregistration.ConditionTrue},
+					},
+				},
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedCalled:     true,
+			expectedHeaders: map[string][]string{
+				"X-Forwarded-Proto": {"https"},
+				"X-Forwarded-Uri":   {"/request/path"},
+				"X-Forwarded-For":   {"127.0.0.1"},
+				"X-Remote-User":     {"username"},
+				"User-Agent":        {"Go-http-client/1.1"},
+				"Accept-Encoding":   {"gzip"},
+				"X-Remote-Group":    {"one", "two"},
+			},
+		},
 	}
 
 	for name, tc := range tests {
@@ -310,6 +345,10 @@ func TestProxyHandler(t *testing.T) {
 			// this varies every test
 			delete(target.headers, "X-Forwarded-Host")
 			if e, a := tc.expectedHeaders, target.headers; !reflect.DeepEqual(e, a) {
+				t.Errorf("%s: expected %v, got %v", name, e, a)
+				return
+			}
+			if e, a := targetServer.Listener.Addr().String(), target.host; tc.expectedCalled && !reflect.DeepEqual(e, a) {
 				t.Errorf("%s: expected %v, got %v", name, e, a)
 				return
 			}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -30,7 +31,6 @@ import (
 
 	"golang.org/x/net/websocket"
 
-	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -245,7 +245,8 @@ func TestProxyHandler(t *testing.T) {
 				Name:   "username",
 				Groups: []string{"one", "two"},
 			},
-			path: "/request/path",
+			path:            "/request/path",
+			serviceResolver: &mockedRouter{destinationHost: targetServer.Listener.Addr().String()},
 			apiService: &apiregistration.APIService{
 				ObjectMeta: metav1.ObjectMeta{Name: "v1.foo"},
 				Spec: apiregistration.APIServiceSpec{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
Many http proxy servers handle request forwarding through the http request header Host, such as nginx。if the aggregator accesses an external http service, the original request header HOST should be request.URL

**Which issue(s) this PR fixes**:
Fixes #71784 

**Special notes for your reviewer**:
@yliaog 

**Does this PR introduce a user-facing change?**:
NONE
