### PR TITLE
Roll forward #71456 with a check whether INSTANCE_GROUPS is empty.

### DIFF
--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -429,6 +429,30 @@ function dump_nodes_with_logexporter() {
   fi
 }
 
+function detect_node_failures() {
+  if ! [[ "${gcloud_supported_providers}" =~ "${KUBERNETES_PROVIDER}" ]]; then
+    return
+  fi
+
+  detect-node-names
+  for group in "${INSTANCE_GROUPS[@]}"; do
+    local creation_timestamp=$(gcloud compute instance-groups managed describe \
+                              "${group}" \
+                              --project "${PROJECT}" \
+                              --zone "${ZONE}" \
+                              --format='value(creationTimestamp)')
+    echo "Failures for ${group}"
+    gcloud logging read --order=asc \
+          --format='table(timestamp,jsonPayload.resource.name,jsonPayload.event_subtype)' \
+          --project "${PROJECT}" \
+          "resource.type=\"gce_instance\"
+           logName=\"projects/${PROJECT}/logs/compute.googleapis.com%2Factivity_log\"
+           (jsonPayload.event_subtype=\"compute.instances.hostError\" OR jsonPayload.event_subtype=\"compute.instances.automaticRestart\")
+           jsonPayload.resource.name:\"${group}\"
+           timestamp >= \"${creation_timestamp}\""
+  done
+}
+
 function main() {
   setup
   # Copy master logs to artifacts dir locally (through SSH).
@@ -447,6 +471,8 @@ function main() {
     echo "Dumping logs from nodes locally to '${report_dir}'"
     dump_nodes
   fi
+
+  detect_node_failures
 }
 
 main

--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -435,6 +435,9 @@ function detect_node_failures() {
   fi
 
   detect-node-names
+  if [ -z "$INSTANCE_GROUPS" ]; then
+    return
+  fi
   for group in "${INSTANCE_GROUPS[@]}"; do
     local creation_timestamp=$(gcloud compute instance-groups managed describe \
                               "${group}" \


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
When test finishes, check gce activity logs for hostError and automaticRestart. This is useful for debugging failed (flaky) test attempts.
This a second attempt to push  this change (first one #71456) has failed in gke provider where INSTANCE_GROUPS is empty (see https://github.com/kubernetes/kubernetes/pull/71456#issuecomment-443267397).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @wojtek-t 
