### PR TITLE
`kubectl get` should return a non-zero exit status for non-existent resources

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -18,6 +18,7 @@ package get
 
 import (
 	"context"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -575,7 +576,9 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 	}
 	w.Flush()
 	if nonEmptyObjCount == 0 && !o.IgnoreNotFound && len(allErrs) == 0 {
-		fmt.Fprintln(o.ErrOut, "No resources found.")
+		buf := bytes.NewBuffer(nil)
+		fmt.Fprintln(buf, "No resources found.")
+		return fmt.Errorf("%v", buf.String())
 	}
 	return utilerrors.NewAggregate(allErrs)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`kubectl get` should return a non-zero exit status when
 information is requested about resources that do not exist.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#557](https://github.com/kubernetes/kubectl/issues/557)

**Special notes for your reviewer**:

/sig cli
/area kubectl
/assign @soltysh @juanvallejo 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
$ kubectl get pods --namespace non-existent
error: No resources found.
$ echo $?
1
```
