### PR TITLE
Comment association to ConformanceIt block should be validated properly.

### DIFF
--- a/test/conformance/walk.go
+++ b/test/conformance/walk.go
@@ -161,8 +161,26 @@ func (v *visitor) failf(expr ast.Expr, format string, a ...interface{}) {
 func (v *visitor) comment(x *ast.BasicLit) string {
 	for _, comm := range v.cMap.Comments() {
 		testOffset := int(x.Pos()-comm.End()) - len("framework.ConformanceIt(\"")
-		if 0 < testOffset && testOffset < 3 {
-			return comm.Text()
+		//Cannot assume the offset is within three or four tabs from the test block itself.
+		//It is better to trim the newlines, tabs, etc and then we if the comment is followed
+		//by the test block itself so that we can associate the comment with it properly.
+		if 0 <= testOffset && testOffset <= 10 {
+			b1 := make([]byte, x.Pos()-comm.End())
+			//if we fail to open the file to compare the content we just assume the
+			//proximity of the comment and apply it.
+			myf, err := os.Open(v.FileSet.File(x.Pos()).Name())
+			if err == nil {
+				if _, err := myf.Seek(int64(comm.End()), 0); err == nil {
+					if _, err := myf.Read(b1); err == nil {
+						if strings.Compare(strings.Trim(string(b1), "\t \r\n"), "framework.ConformanceIt(\"") == 0 {
+							return comm.Text()
+						}
+					}
+				}
+			} else {
+				//comment section's end is noticed within 10 characters from framework.ConformanceIt block
+				return comm.Text()
+			}
 		}
 	}
 	return ""

--- a/test/conformance/walk_test.go
+++ b/test/conformance/walk_test.go
@@ -80,6 +80,18 @@ var _ = framework.KubeDescribe("Feature", func() {
 		Description: `By default the stdout and stderr from the process
 being executed in a pod MUST be sent to the pod's logs.` + "\n\n"}},
 	},
+	{"e2e/foo.go", `
+var _ = framework.KubeDescribe("Feature", func() {
+	Context("with context and extra spaces before It block should still pick up Testname", func() {
+		//					Testname: Test with spaces		
+		//Description: Should pick up testname even if it is not within 3 spaces
+		//even when executed from memory.
+		framework.ConformanceIt("should work", func() {})
+	})
+})`, []conformanceData{{URL: "https://github.com/kubernetes/kubernetes/tree/master/e2e/foo.go#L8", TestName: "Test with spaces",
+		Description: `Should pick up testname even if it is not within 3 spaces
+even when executed from memory.` + "\n\n"}},
+	},
 }
 
 func TestConformance(t *testing.T) {


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Original code would check if the ConformanceIt block is starting after the comment within 4 bytes and these bytes could be a newline, tab, etc.
With this fix we will make sure we trim non-printable characters such as \n \r \t from the end of the comment and look for ConformanceIt block that should follow the comment. This is associate the comment properly with the test irrespective of number of tabs or new lines in the code.

Fixes #72166

area/conformance  sig/architecture sig/testing  