### PR TITLE
Allow version field in the title to be changeable

### DIFF
--- a/test/conformance/cf_header.md
+++ b/test/conformance/cf_header.md
@@ -1,4 +1,4 @@
-# Kubernetes Conformance Test Suite - v1.9
+# Kubernetes Conformance Test Suite -  {{.Version}}
 
 ## **Summary**
 This document provides a summary of the tests included in the Kubernetes conformance test suite.
@@ -16,6 +16,7 @@ Example:
 ```
 /*
   Testname: Kubelet-OutputToLogs
+  Release: v1.9
   Description: By default the stdout and stderr from the process
            being executed in a pod MUST be sent to the pod's logs.
 */
@@ -30,6 +31,7 @@ documentation for that test.
 ### **Output:**
 ## [Kubelet-OutputToLogs](https://github.com/kubernetes/kubernetes/blob/release-1.9/test/e2e_node/kubelet_test.go#L42)
 
+### Release v1.9
 By default the stdout and stderr from the process
 being executed in a pod MUST be sent to the pod's logs.
 Note this test needs to be fixed to also test for stderr

--- a/test/conformance/walk.go
+++ b/test/conformance/walk.go
@@ -29,17 +29,18 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"text/template"
 )
 
 var (
 	baseURL                                           = flag.String("url", "https://github.com/kubernetes/kubernetes/tree/master/", "location of the current source")
 	confDoc                                           = flag.Bool("conformance", false, "write a conformance document")
+	version                                           = flag.String("version", "v1.9", "version of this conformance document")
 	totalConfTests, totalLegacyTests, missingComments int
 )
 
@@ -323,10 +324,16 @@ func main() {
 
 	if *confDoc {
 		// Note: this assumes that you're running from the root of the kube src repo
-		header, err := ioutil.ReadFile("test/conformance/cf_header.md")
-		if err == nil {
-			fmt.Printf("%s\n\n", header)
+		templ, err := template.ParseFiles("test/conformance/cf_header.md")
+		if err != nil {
+			fmt.Printf("Error reading the Header file information: %s\n\n", err)
 		}
+		data := struct {
+			Version string
+		}{
+			Version: *version,
+		}
+		templ.Execute(os.Stdout, data)
 	}
 
 	totalConfTests = 0


### PR DESCRIPTION
/kind bug

Currently Conformance Header is picked up from a static file. It requires templating to fill in at least release version for which the conformance document is generated.

Fixes #71627

