### PR TITLE
Make resourceVersion parameter semantics consistent across all storage.Interface implementations

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/BUILD
@@ -33,8 +33,10 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/storage",
     importpath = "k8s.io/apiserver/pkg/storage",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/validation/path:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -40,6 +40,10 @@ const (
 	// before terminating request and returning Timeout error with retry
 	// after suggestion.
 	blockTimeout = 3 * time.Second
+
+	// resourceVersionTooHighRetrySeconds is the seconds before a operation should be retried by the client
+	// after receiving a 'too high resource version' error.
+	resourceVersionTooHighRetrySeconds = 1
 )
 
 // watchCacheEvent is a single "watch event" that is send to users of
@@ -303,8 +307,8 @@ func (w *watchCache) waitUntilFreshAndBlock(resourceVersion uint64, trace *utilt
 	}
 	for w.resourceVersion < resourceVersion {
 		if w.clock.Since(startTime) >= blockTimeout {
-			// Timeout with retry after 1 second.
-			return errors.NewTimeoutError(fmt.Sprintf("Too large resource version: %v, current: %v", resourceVersion, w.resourceVersion), 1)
+			// Request that the client retry after 'resourceVersionTooHighRetrySeconds' seconds.
+			return storage.NewTooLargeResourceVersionError(resourceVersion, w.resourceVersion, resourceVersionTooHighRetrySeconds)
 		}
 		w.cond.Wait()
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -379,8 +379,11 @@ func TestWaitUntilFreshAndListTimeout(t *testing.T) {
 	}()
 
 	_, _, err := store.WaitUntilFreshAndList(5, nil)
-	if err == nil {
-		t.Fatalf("unexpected lack of timeout error")
+	if !errors.IsTimeout(err) {
+		t.Errorf("expected timeout error but got: %v", err)
+	}
+	if !storage.IsTooLargeResourceVersion(err) {
+		t.Errorf("expected 'Too large resource version' cause in error but got: %v", err)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/errors.go
@@ -19,6 +19,8 @@ package storage
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -167,4 +169,32 @@ func NewInternalError(reason string) InternalError {
 
 func NewInternalErrorf(format string, a ...interface{}) InternalError {
 	return InternalError{fmt.Sprintf(format, a...)}
+}
+
+var tooLargeResourceVersionCauseMsg = "Too large resource version"
+
+// NewTooLargeResourceVersionError returns a timeout error with the given retrySeconds for a request for
+// a minimum resource version that is larger than the largest currently available resource version for a requested resource.
+func NewTooLargeResourceVersionError(minimumResourceVersion, currentRevision uint64, retrySeconds int) error {
+	err := errors.NewTimeoutError(fmt.Sprintf("Too large resource version: %d, current: %d", minimumResourceVersion, currentRevision), retrySeconds)
+	err.ErrStatus.Details.Causes = []metav1.StatusCause{{Message: tooLargeResourceVersionCauseMsg}}
+	return err
+}
+
+// IsTooLargeResourceVersion returns true if the error is a TooLargeResourceVersion error.
+func IsTooLargeResourceVersion(err error) bool {
+	if !errors.IsTimeout(err) {
+		return false
+	}
+	switch t := err.(type) {
+	case errors.APIStatus:
+		if d := t.Status().Details; d != nil {
+			for _, cause := range d.Causes {
+				if cause.Message == tooLargeResourceVersionCauseMsg {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
-	"k8s.io/klog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -41,6 +40,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/etcd3/metrics"
 	"k8s.io/apiserver/pkg/storage/value"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog"
 	utiltrace "k8s.io/utils/trace"
 )
 
@@ -117,6 +117,9 @@ func (s *store) Get(ctx context.Context, key string, resourceVersion string, out
 	getResp, err := s.client.KV.Get(ctx, key, s.getOps...)
 	metrics.RecordEtcdRequestLatency("get", getTypeName(out), startTime)
 	if err != nil {
+		return err
+	}
+	if err = s.ensureMinimumResourceVersion(resourceVersion, uint64(getResp.Header.Revision)); err != nil {
 		return err
 	}
 
@@ -398,6 +401,9 @@ func (s *store) GetToList(ctx context.Context, key string, resourceVersion strin
 	if err != nil {
 		return err
 	}
+	if err = s.ensureMinimumResourceVersion(resourceVersion, uint64(getResp.Header.Revision)); err != nil {
+		return err
+	}
 
 	if len(getResp.Kvs) > 0 {
 		data, _, err := s.transformer.TransformFromStorage(getResp.Kvs[0].Value, authenticatedDataString(key))
@@ -559,17 +565,6 @@ func (s *store) List(ctx context.Context, key, resourceVersion string, pred stor
 		options = append(options, clientv3.WithRange(rangeEnd))
 
 	default:
-		if len(resourceVersion) > 0 {
-			fromRV, err := s.versioner.ParseResourceVersion(resourceVersion)
-			if err != nil {
-				return apierrors.NewBadRequest(fmt.Sprintf("invalid resource version: %v", err))
-			}
-			if fromRV > 0 {
-				options = append(options, clientv3.WithRev(int64(fromRV)))
-			}
-			returnedRV = int64(fromRV)
-		}
-
 		options = append(options, clientv3.WithPrefix())
 	}
 
@@ -583,6 +578,9 @@ func (s *store) List(ctx context.Context, key, resourceVersion string, pred stor
 		metrics.RecordEtcdRequestLatency("list", getTypeName(listPtr), startTime)
 		if err != nil {
 			return interpretListError(err, len(pred.Continue) > 0, continueKey, keyPrefix)
+		}
+		if err = s.ensureMinimumResourceVersion(resourceVersion, uint64(getResp.Header.Revision)); err != nil {
+			return err
 		}
 		hasMore = getResp.More
 
@@ -796,6 +794,24 @@ func (s *store) ttlOpts(ctx context.Context, ttl int64) ([]clientv3.OpOption, er
 		return nil, err
 	}
 	return []clientv3.OpOption{clientv3.WithLease(id)}, nil
+}
+
+// ensureMinimumResourceVersion returns a 'too large resource' version error when the provided minimumResourceVersion is
+// greater than the most recent actualRevision available from storage.
+func (s *store) ensureMinimumResourceVersion(minimumResourceVersion string, actualRevision uint64) error {
+	if minimumResourceVersion == "" {
+		return nil
+	}
+	minimumRV, err := s.versioner.ParseResourceVersion(minimumResourceVersion)
+	if err != nil {
+		return apierrors.NewBadRequest(fmt.Sprintf("invalid resource version: %v", err))
+	}
+	// Enforce the storage.Interface guarantee that the resource version of the returned data
+	// "will be at least 'resourceVersion'".
+	if minimumRV > actualRevision {
+		return storage.NewTooLargeResourceVersionError(minimumRV, actualRevision, 0)
+	}
+	return nil
 }
 
 // decode decodes value of bytes into object. It will also set the object resource version to rev.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -183,44 +183,87 @@ func TestCreateWithKeyExist(t *testing.T) {
 func TestGet(t *testing.T) {
 	ctx, store, cluster := testSetup(t)
 	defer cluster.Terminate(t)
+	// create an object to test
 	key, storedObj := testPropogateStore(ctx, t, store, &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
+	// create an additional object to increment the resource version for pods above the resource version of the foo object
+	lastUpdatedObj := &example.Pod{}
+	if err := store.Create(ctx, "bar", &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bar"}}, lastUpdatedObj, 0); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	currentRV, _ := strconv.Atoi(storedObj.ResourceVersion)
+	lastUpdatedCurrentRV, _ := strconv.Atoi(lastUpdatedObj.ResourceVersion)
 
 	tests := []struct {
+		name              string
 		key               string
 		ignoreNotFound    bool
 		expectNotFoundErr bool
+		expectRVTooLarge  bool
 		expectedOut       *example.Pod
+		rv                string
 	}{{ // test get on existing item
+		name:              "get existing",
 		key:               key,
 		ignoreNotFound:    false,
 		expectNotFoundErr: false,
 		expectedOut:       storedObj,
+	}, { // test get on existing item with minimum resource version set to 0
+		name:        "resource version 0",
+		key:         key,
+		expectedOut: storedObj,
+		rv:          "0",
+	}, { // test get on existing item with minimum resource version set to current resource version of the object
+		name:        "current object resource version",
+		key:         key,
+		expectedOut: storedObj,
+		rv:          fmt.Sprintf("%d", currentRV),
+	}, { // test get on existing item with minimum resource version set to latest pod resource version
+		name:        "latest resource version",
+		key:         key,
+		expectedOut: storedObj,
+		rv:          fmt.Sprintf("%d", lastUpdatedCurrentRV),
+	}, { // test get on existing item with minimum resource version set too high
+		name:             "too high resource version",
+		key:              key,
+		expectRVTooLarge: true,
+		rv:               fmt.Sprintf("%d", lastUpdatedCurrentRV+1),
 	}, { // test get on non-existing item with ignoreNotFound=false
+		name:              "get non-existing",
 		key:               "/non-existing",
 		ignoreNotFound:    false,
 		expectNotFoundErr: true,
 	}, { // test get on non-existing item with ignoreNotFound=true
+		name:              "get non-existing, ignore not found",
 		key:               "/non-existing",
 		ignoreNotFound:    true,
 		expectNotFoundErr: false,
 		expectedOut:       &example.Pod{},
 	}}
 
-	for i, tt := range tests {
-		out := &example.Pod{}
-		err := store.Get(ctx, tt.key, "", out, tt.ignoreNotFound)
-		if tt.expectNotFoundErr {
-			if err == nil || !storage.IsNotFound(err) {
-				t.Errorf("#%d: expecting not found error, but get: %s", i, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &example.Pod{}
+			err := store.Get(ctx, tt.key, tt.rv, out, tt.ignoreNotFound)
+			if tt.expectNotFoundErr {
+				if err == nil || !storage.IsNotFound(err) {
+					t.Errorf("expecting not found error, but get: %v", err)
+				}
+				return
 			}
-			continue
-		}
-		if err != nil {
-			t.Fatalf("Get failed: %v", err)
-		}
-		if !reflect.DeepEqual(tt.expectedOut, out) {
-			t.Errorf("#%d: pod want=%#v, get=%#v", i, tt.expectedOut, out)
-		}
+			if tt.expectRVTooLarge {
+				if err == nil || !storage.IsTooLargeResourceVersion(err) {
+					t.Errorf("expecting resource version too high error, but get: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Get failed: %v", err)
+			}
+			if !reflect.DeepEqual(tt.expectedOut, out) {
+				t.Errorf("pod want=%#v, get=%#v", tt.expectedOut, out)
+			}
+		})
 	}
 }
 
@@ -301,14 +344,34 @@ func TestGetToList(t *testing.T) {
 	defer cluster.Terminate(t)
 	key, storedObj := testPropogateStore(ctx, t, store, &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
 
+	currentRV, _ := strconv.Atoi(storedObj.ResourceVersion)
+
 	tests := []struct {
-		key         string
-		pred        storage.SelectionPredicate
-		expectedOut []*example.Pod
+		key              string
+		pred             storage.SelectionPredicate
+		expectedOut      []*example.Pod
+		rv               string
+		expectRVTooLarge bool
 	}{{ // test GetToList on existing key
 		key:         key,
 		pred:        storage.Everything,
 		expectedOut: []*example.Pod{storedObj},
+	}, { // test GetToList on existing key with minimum resource version set to 0
+		key:         key,
+		pred:        storage.Everything,
+		expectedOut: []*example.Pod{storedObj},
+		rv:          "0",
+	}, { // test GetToList on existing key with minimum resource version set to current resource version
+		key:         key,
+		pred:        storage.Everything,
+		expectedOut: []*example.Pod{storedObj},
+		rv:          fmt.Sprintf("%d", currentRV),
+	}, { // test GetToList on existing key with minimum resource version set too high
+		key:              key,
+		pred:             storage.Everything,
+		expectedOut:      []*example.Pod{storedObj},
+		rv:               fmt.Sprintf("%d", currentRV+1),
+		expectRVTooLarge: true,
 	}, { // test GetToList on non-existing key
 		key:         "/non-existing",
 		pred:        storage.Everything,
@@ -328,7 +391,15 @@ func TestGetToList(t *testing.T) {
 
 	for i, tt := range tests {
 		out := &example.PodList{}
-		err := store.GetToList(ctx, tt.key, "", tt.pred, out)
+		err := store.GetToList(ctx, tt.key, tt.rv, tt.pred, out)
+
+		if tt.expectRVTooLarge {
+			if err == nil || !storage.IsTooLargeResourceVersion(err) {
+				t.Errorf("#%d: expecting resource version too high error, but get: %s", i, err)
+			}
+			continue
+		}
+
 		if err != nil {
 			t.Fatalf("GetToList failed: %v", err)
 		}
@@ -838,6 +909,7 @@ func TestList(t *testing.T) {
 		expectContinue             bool
 		expectedRemainingItemCount *int64
 		expectError                bool
+		expectRVTooLarge           bool
 	}{
 		{
 			name:        "rejects invalid resource version",
@@ -859,10 +931,30 @@ func TestList(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name:             "rejects resource version set too high",
+			prefix:           "/",
+			rv:               fmt.Sprintf("%d", continueRV+1),
+			expectRVTooLarge: true,
+		},
+		{
 			name:        "test List on existing key",
 			prefix:      "/one-level/",
 			pred:        storage.Everything,
 			expectedOut: []*example.Pod{preset[0].storedObj},
+		},
+		{
+			name:        "test List on existing key with minimum resource version set to 0",
+			prefix:      "/one-level/",
+			pred:        storage.Everything,
+			expectedOut: []*example.Pod{preset[0].storedObj},
+			rv:          "0",
+		},
+		{
+			name:        "test List on existing key with minimum resource version set to current resource version",
+			prefix:      "/one-level/",
+			pred:        storage.Everything,
+			expectedOut: []*example.Pod{preset[0].storedObj},
+			rv:          list.ResourceVersion,
 		},
 		{
 			name:        "test List on non-existing key",
@@ -1054,6 +1146,13 @@ func TestList(t *testing.T) {
 		} else {
 			err = store.List(ctx, tt.prefix, tt.rv, tt.pred, out)
 		}
+		if tt.expectRVTooLarge {
+			if err == nil || !storage.IsTooLargeResourceVersion(err) {
+				t.Errorf("(%s): expecting resource version too high error, but get: %s", tt.name, err)
+			}
+			continue
+		}
+
 		if (err != nil) != tt.expectError {
 			t.Errorf("(%s): List failed: %v", tt.name, err)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
@@ -323,7 +323,9 @@ func TestList(t *testing.T) {
 	}
 }
 
-func TestInfiniteList(t *testing.T) {
+// TestTooLargeResourceVersionList ensures that a list request for a resource version higher than available
+// in the watch cache completes (does not wait indefinitely) and results in a ResourceVersionTooLarge error.
+func TestTooLargeResourceVersionList(t *testing.T) {
 	server, etcdStorage := newEtcdTestStorage(t, etcd3testing.PathPrefix())
 	defer server.Terminate(t)
 	cacher, v, err := newTestCacher(etcdStorage, 10)
@@ -346,6 +348,9 @@ func TestInfiniteList(t *testing.T) {
 	err = cacher.List(context.TODO(), "pods/ns", listRV, storage.Everything, result)
 	if !errors.IsTimeout(err) {
 		t.Errorf("Unexpected error: %v", err)
+	}
+	if !storage.IsTooLargeResourceVersion(err) {
+		t.Errorf("expected 'Too large resource version' cause in error but got: %v", err)
 	}
 }
 


### PR DESCRIPTION
_[This is part of effort to improve [Apiserver Resource Version Semantics](https://docs.google.com/document/d/1x3JXKwPTpum8S6bC-YXvoGS583iixuQSskEGukTAzcI/edit#) (as previously circulated with sig-apimachinery) and fix the ["stale read"](https://github.com/kubernetes/kubernetes/issues/59848) issue]_

Make the minimum `resourceVersion` semantics consistent across all `storage.Interface` implementations by:

- enforcing "minimum RV" constraints in the etcd3 storage implementation per the `storage.Interface` documentation
- modifying the etcd3 `List()` implementation to use "minimum RV" semantics instead of "exact RV" semantics when RV>0

**_Important: the watch cache is enabled by default on the kube-apiserver for all but a select few types (e.g. Events, CRDs) and so while API clients do not get to decide when they make requests what semantics they get, they typically will get the watch cache semantics._**

### Before:

|                 | Watch Cache (RV=0 & RV>0) | etcd3 RV=0                      | etcd RV>0 |
|--------------|--------------------|-----------------------------------|-----------------------------------|
| Get          | "min RV"        | quorum read, RV ignored | quorum read, RV ignored |
| List          | "min RV"        | quorum read, RV ignored | **"exact RV"**                   |
| GetToList | "min RV"        | quorum read, RV ignored | quorum read, RV ignored |
| Watch      | "min RV"        | "min RV"                           | "min RV" |

Note that "quorum read, RV ignored" behaves like "min RV" for all RVs that were retrieved from some previous operation on the store because quorum reads are guaranteed to be processed with the latest RV. So it appears from these semantics that "min RV" semantics are pervasive across both implementations and what we should converge to.

### After:

|                 | Watch Cache (RV=0 & RV>0) | etcd3 (RV=0 & RV>0) |
|--------------|--------------------|-----------------------------------|
| Get          | "min RV"        | "min RV"                           |
| List          | "min RV"        | "min RV"                           |
| GetToList | "min RV"        | "min RV"                           |
| Watch      | "min RV"        | "min RV"                           |

The change from "exact RV" to "min RV" for the `List` operation is the most notable change here. But given that the watch cache is enabled by default for all but a select few types, and that the semantics change here would only be visible if providing a non-zero RV, we don't expect this change to be particularly risky/visible. And we believe it to be lower risk than leaving the semantic inconsistent across implementations, esp. given that clients don't necessarily have any way of knowing if the watch cache is enabled and what semantics to expect.

As part of this change we're introducing a `ResourceVersionTooLargeError` type to the storage interface so that both the watch cache and etcd3 return the same error type if unable to serve a requested resource version because it's too high.  Previously the watch cache would return a timeout error in the case because it attempts to wait for 3 seconds to see if the "too high" resource version might appear if it waits a bit. I've done a quick review and it looks like this change is low risk, but if reviewers know of reasons why this might be breaking, please let me know.

```release-note
The resource version option, when passed to a list call, is now consistently interpreted as the minimum allowed resource version.  Previously when listing resources that had the watch cache disabled clients could retrieve a snapshot at that exact resource version.  If the client requests a resource version newer than the current state, a TimeoutError is returned suggesting the client retry in a few seconds.  This behavior is now consistent for both single item retrieval and list calls, and for when the watch cache is enabled or disabled.
```

cc @cheftako @lavalamp @wojtek-t @liggitt @smarterclayton 