### PR TITLE
Cleanup of disabled field handling

### DIFF
--- a/pkg/api/persistentvolumeclaim/util.go
+++ b/pkg/api/persistentvolumeclaim/util.go
@@ -24,8 +24,11 @@ import (
 
 // DropDisabledFields removes disabled fields from the pvc spec.
 // This should be called from PrepareForCreate/PrepareForUpdate for all resources containing a pvc spec.
-func DropDisabledFields(pvcSpec *core.PersistentVolumeClaimSpec) {
+func DropDisabledFields(pvcSpec, oldPVCSpec *core.PersistentVolumeClaimSpec) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.BlockVolume) {
 		pvcSpec.VolumeMode = nil
+		if oldPVCSpec != nil {
+			oldPVCSpec.VolumeMode = nil
+		}
 	}
 }

--- a/pkg/api/persistentvolumeclaim/util.go
+++ b/pkg/api/persistentvolumeclaim/util.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 )
 
-// DropDisabledAlphaFields removes disabled fields from the pvc spec.
+// DropDisabledFields removes disabled fields from the pvc spec.
 // This should be called from PrepareForCreate/PrepareForUpdate for all resources containing a pvc spec.
-func DropDisabledAlphaFields(pvcSpec *core.PersistentVolumeClaimSpec) {
+func DropDisabledFields(pvcSpec *core.PersistentVolumeClaimSpec) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.BlockVolume) {
 		pvcSpec.VolumeMode = nil
 	}

--- a/pkg/api/persistentvolumeclaim/util_test.go
+++ b/pkg/api/persistentvolumeclaim/util_test.go
@@ -39,7 +39,7 @@ func TestDropAlphaPVCVolumeMode(t *testing.T) {
 	// Enable alpha feature BlockVolume
 	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.BlockVolume, true)()
 	// now test dropping the fields - should not be dropped
-	DropDisabledAlphaFields(&pvc.Spec)
+	DropDisabledFields(&pvc.Spec)
 
 	// check to make sure VolumeDevices is still present
 	// if featureset is set to true
@@ -50,11 +50,11 @@ func TestDropAlphaPVCVolumeMode(t *testing.T) {
 	// Disable alpha feature BlockVolume
 	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.BlockVolume, false)()
 	// now test dropping the fields
-	DropDisabledAlphaFields(&pvc.Spec)
+	DropDisabledFields(&pvc.Spec)
 
 	// check to make sure VolumeDevices is nil
 	// if featureset is set to false
 	if pvc.Spec.VolumeMode != nil {
-		t.Error("DropDisabledAlphaFields VolumeMode for pvc.Spec failed")
+		t.Error("DropDisabledFields VolumeMode for pvc.Spec failed")
 	}
 }

--- a/pkg/api/persistentvolumeclaim/util_test.go
+++ b/pkg/api/persistentvolumeclaim/util_test.go
@@ -39,7 +39,7 @@ func TestDropAlphaPVCVolumeMode(t *testing.T) {
 	// Enable alpha feature BlockVolume
 	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.BlockVolume, true)()
 	// now test dropping the fields - should not be dropped
-	DropDisabledFields(&pvc.Spec)
+	DropDisabledFields(&pvc.Spec, nil)
 
 	// check to make sure VolumeDevices is still present
 	// if featureset is set to true
@@ -50,7 +50,7 @@ func TestDropAlphaPVCVolumeMode(t *testing.T) {
 	// Disable alpha feature BlockVolume
 	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.BlockVolume, false)()
 	// now test dropping the fields
-	DropDisabledFields(&pvc.Spec)
+	DropDisabledFields(&pvc.Spec, nil)
 
 	// check to make sure VolumeDevices is nil
 	// if featureset is set to false

--- a/pkg/api/podsecuritypolicy/util.go
+++ b/pkg/api/podsecuritypolicy/util.go
@@ -24,11 +24,17 @@ import (
 
 // DropDisabledFields removes disabled fields from the pod security policy spec.
 // This should be called from PrepareForCreate/PrepareForUpdate for all resources containing a od security policy spec.
-func DropDisabledFields(pspSpec *policy.PodSecurityPolicySpec) {
+func DropDisabledFields(pspSpec, oldPSPSpec *policy.PodSecurityPolicySpec) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.ProcMountType) {
 		pspSpec.AllowedProcMountTypes = nil
+		if oldPSPSpec != nil {
+			oldPSPSpec.AllowedProcMountTypes = nil
+		}
 	}
 	if !utilfeature.DefaultFeatureGate.Enabled(features.RunAsGroup) {
 		pspSpec.RunAsGroup = nil
+		if oldPSPSpec != nil {
+			oldPSPSpec.RunAsGroup = nil
+		}
 	}
 }

--- a/pkg/api/podsecuritypolicy/util.go
+++ b/pkg/api/podsecuritypolicy/util.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 )
 
-// DropDisabledAlphaFields removes disabled fields from the pod security policy spec.
+// DropDisabledFields removes disabled fields from the pod security policy spec.
 // This should be called from PrepareForCreate/PrepareForUpdate for all resources containing a od security policy spec.
-func DropDisabledAlphaFields(pspSpec *policy.PodSecurityPolicySpec) {
+func DropDisabledFields(pspSpec *policy.PodSecurityPolicySpec) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.ProcMountType) {
 		pspSpec.AllowedProcMountTypes = nil
 	}

--- a/pkg/api/podsecuritypolicy/util_test.go
+++ b/pkg/api/podsecuritypolicy/util_test.go
@@ -38,7 +38,7 @@ func TestDropAlphaProcMountType(t *testing.T) {
 	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ProcMountType, true)()
 
 	// now test dropping the fields - should not be dropped
-	DropDisabledFields(&psp.Spec)
+	DropDisabledFields(&psp.Spec, nil)
 
 	// check to make sure AllowedProcMountTypes is still present
 	// if featureset is set to true
@@ -52,7 +52,7 @@ func TestDropAlphaProcMountType(t *testing.T) {
 	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ProcMountType, false)()
 
 	// now test dropping the fields
-	DropDisabledFields(&psp.Spec)
+	DropDisabledFields(&psp.Spec, nil)
 
 	// check to make sure AllowedProcMountTypes is nil
 	// if featureset is set to false

--- a/pkg/api/podsecuritypolicy/util_test.go
+++ b/pkg/api/podsecuritypolicy/util_test.go
@@ -38,7 +38,7 @@ func TestDropAlphaProcMountType(t *testing.T) {
 	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ProcMountType, true)()
 
 	// now test dropping the fields - should not be dropped
-	DropDisabledAlphaFields(&psp.Spec)
+	DropDisabledFields(&psp.Spec)
 
 	// check to make sure AllowedProcMountTypes is still present
 	// if featureset is set to true
@@ -52,13 +52,13 @@ func TestDropAlphaProcMountType(t *testing.T) {
 	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ProcMountType, false)()
 
 	// now test dropping the fields
-	DropDisabledAlphaFields(&psp.Spec)
+	DropDisabledFields(&psp.Spec)
 
 	// check to make sure AllowedProcMountTypes is nil
 	// if featureset is set to false
 	if utilfeature.DefaultFeatureGate.Enabled(features.ProcMountType) {
 		if psp.Spec.AllowedProcMountTypes != nil {
-			t.Error("DropDisabledAlphaFields AllowedProcMountTypes for psp.Spec failed")
+			t.Error("DropDisabledFields AllowedProcMountTypes for psp.Spec failed")
 		}
 	}
 }

--- a/pkg/apis/storage/util/util.go
+++ b/pkg/apis/storage/util/util.go
@@ -22,8 +22,8 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 )
 
-// DropDisabledAlphaFields removes disabled fields from the StorageClass object.
-func DropDisabledAlphaFields(class *storage.StorageClass) {
+// DropDisabledFields removes disabled fields from the StorageClass object.
+func DropDisabledFields(class *storage.StorageClass) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.VolumeScheduling) {
 		class.VolumeBindingMode = nil
 		class.AllowedTopologies = nil

--- a/pkg/apis/storage/util/util.go
+++ b/pkg/apis/storage/util/util.go
@@ -23,9 +23,13 @@ import (
 )
 
 // DropDisabledFields removes disabled fields from the StorageClass object.
-func DropDisabledFields(class *storage.StorageClass) {
+func DropDisabledFields(class, oldClass *storage.StorageClass) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.VolumeScheduling) {
 		class.VolumeBindingMode = nil
 		class.AllowedTopologies = nil
+		if oldClass != nil {
+			oldClass.VolumeBindingMode = nil
+			oldClass.AllowedTopologies = nil
+		}
 	}
 }

--- a/pkg/apis/storage/util/util_test.go
+++ b/pkg/apis/storage/util/util_test.go
@@ -46,7 +46,7 @@ func TestDropAlphaFields(t *testing.T) {
 		VolumeBindingMode: &bindingMode,
 		AllowedTopologies: allowedTopologies,
 	}
-	DropDisabledFields(class)
+	DropDisabledFields(class, nil)
 	if class.VolumeBindingMode != nil {
 		t.Errorf("VolumeBindingMode field didn't get dropped: %+v", class.VolumeBindingMode)
 	}
@@ -60,7 +60,7 @@ func TestDropAlphaFields(t *testing.T) {
 		AllowedTopologies: allowedTopologies,
 	}
 	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeScheduling, true)()
-	DropDisabledFields(class)
+	DropDisabledFields(class, nil)
 	if class.VolumeBindingMode != &bindingMode {
 		t.Errorf("VolumeBindingMode field got unexpectantly modified: %+v", class.VolumeBindingMode)
 	}

--- a/pkg/apis/storage/util/util_test.go
+++ b/pkg/apis/storage/util/util_test.go
@@ -46,7 +46,7 @@ func TestDropAlphaFields(t *testing.T) {
 		VolumeBindingMode: &bindingMode,
 		AllowedTopologies: allowedTopologies,
 	}
-	DropDisabledAlphaFields(class)
+	DropDisabledFields(class)
 	if class.VolumeBindingMode != nil {
 		t.Errorf("VolumeBindingMode field didn't get dropped: %+v", class.VolumeBindingMode)
 	}
@@ -60,7 +60,7 @@ func TestDropAlphaFields(t *testing.T) {
 		AllowedTopologies: allowedTopologies,
 	}
 	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeScheduling, true)()
-	DropDisabledAlphaFields(class)
+	DropDisabledFields(class)
 	if class.VolumeBindingMode != &bindingMode {
 		t.Errorf("VolumeBindingMode field got unexpectantly modified: %+v", class.VolumeBindingMode)
 	}

--- a/pkg/registry/core/persistentvolumeclaim/strategy.go
+++ b/pkg/registry/core/persistentvolumeclaim/strategy.go
@@ -52,7 +52,7 @@ func (persistentvolumeclaimStrategy) PrepareForCreate(ctx context.Context, obj r
 	pvc := obj.(*api.PersistentVolumeClaim)
 	pvc.Status = api.PersistentVolumeClaimStatus{}
 
-	pvcutil.DropDisabledFields(&pvc.Spec)
+	pvcutil.DropDisabledFields(&pvc.Spec, nil)
 }
 
 func (persistentvolumeclaimStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
@@ -74,8 +74,7 @@ func (persistentvolumeclaimStrategy) PrepareForUpdate(ctx context.Context, obj, 
 	oldPvc := old.(*api.PersistentVolumeClaim)
 	newPvc.Status = oldPvc.Status
 
-	pvcutil.DropDisabledFields(&newPvc.Spec)
-	pvcutil.DropDisabledFields(&oldPvc.Spec)
+	pvcutil.DropDisabledFields(&newPvc.Spec, &oldPvc.Spec)
 }
 
 func (persistentvolumeclaimStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {

--- a/pkg/registry/core/persistentvolumeclaim/strategy.go
+++ b/pkg/registry/core/persistentvolumeclaim/strategy.go
@@ -52,7 +52,7 @@ func (persistentvolumeclaimStrategy) PrepareForCreate(ctx context.Context, obj r
 	pvc := obj.(*api.PersistentVolumeClaim)
 	pvc.Status = api.PersistentVolumeClaimStatus{}
 
-	pvcutil.DropDisabledAlphaFields(&pvc.Spec)
+	pvcutil.DropDisabledFields(&pvc.Spec)
 }
 
 func (persistentvolumeclaimStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
@@ -74,8 +74,8 @@ func (persistentvolumeclaimStrategy) PrepareForUpdate(ctx context.Context, obj, 
 	oldPvc := old.(*api.PersistentVolumeClaim)
 	newPvc.Status = oldPvc.Status
 
-	pvcutil.DropDisabledAlphaFields(&newPvc.Spec)
-	pvcutil.DropDisabledAlphaFields(&oldPvc.Spec)
+	pvcutil.DropDisabledFields(&newPvc.Spec)
+	pvcutil.DropDisabledFields(&oldPvc.Spec)
 }
 
 func (persistentvolumeclaimStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {

--- a/pkg/registry/policy/podsecuritypolicy/strategy.go
+++ b/pkg/registry/policy/podsecuritypolicy/strategy.go
@@ -58,15 +58,14 @@ func (strategy) AllowUnconditionalUpdate() bool {
 func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	psp := obj.(*policy.PodSecurityPolicy)
 
-	psputil.DropDisabledFields(&psp.Spec)
+	psputil.DropDisabledFields(&psp.Spec, nil)
 }
 
 func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	newPsp := obj.(*policy.PodSecurityPolicy)
 	oldPsp := old.(*policy.PodSecurityPolicy)
 
-	psputil.DropDisabledFields(&newPsp.Spec)
-	psputil.DropDisabledFields(&oldPsp.Spec)
+	psputil.DropDisabledFields(&newPsp.Spec, &oldPsp.Spec)
 }
 
 func (strategy) Canonicalize(obj runtime.Object) {

--- a/pkg/registry/policy/podsecuritypolicy/strategy.go
+++ b/pkg/registry/policy/podsecuritypolicy/strategy.go
@@ -58,15 +58,15 @@ func (strategy) AllowUnconditionalUpdate() bool {
 func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	psp := obj.(*policy.PodSecurityPolicy)
 
-	psputil.DropDisabledAlphaFields(&psp.Spec)
+	psputil.DropDisabledFields(&psp.Spec)
 }
 
 func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	newPsp := obj.(*policy.PodSecurityPolicy)
 	oldPsp := old.(*policy.PodSecurityPolicy)
 
-	psputil.DropDisabledAlphaFields(&newPsp.Spec)
-	psputil.DropDisabledAlphaFields(&oldPsp.Spec)
+	psputil.DropDisabledFields(&newPsp.Spec)
+	psputil.DropDisabledFields(&oldPsp.Spec)
 }
 
 func (strategy) Canonicalize(obj runtime.Object) {

--- a/pkg/registry/storage/storageclass/strategy.go
+++ b/pkg/registry/storage/storageclass/strategy.go
@@ -52,7 +52,7 @@ func (storageClassStrategy) PrepareForCreate(ctx context.Context, obj runtime.Ob
 		class.AllowVolumeExpansion = nil
 	}
 
-	storageutil.DropDisabledFields(class)
+	storageutil.DropDisabledFields(class, nil)
 }
 
 func (storageClassStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
@@ -77,8 +77,7 @@ func (storageClassStrategy) PrepareForUpdate(ctx context.Context, obj, old runti
 		newClass.AllowVolumeExpansion = nil
 		oldClass.AllowVolumeExpansion = nil
 	}
-	storageutil.DropDisabledFields(oldClass)
-	storageutil.DropDisabledFields(newClass)
+	storageutil.DropDisabledFields(oldClass, newClass)
 }
 
 func (storageClassStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {

--- a/pkg/registry/storage/storageclass/strategy.go
+++ b/pkg/registry/storage/storageclass/strategy.go
@@ -52,7 +52,7 @@ func (storageClassStrategy) PrepareForCreate(ctx context.Context, obj runtime.Ob
 		class.AllowVolumeExpansion = nil
 	}
 
-	storageutil.DropDisabledAlphaFields(class)
+	storageutil.DropDisabledFields(class)
 }
 
 func (storageClassStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
@@ -77,8 +77,8 @@ func (storageClassStrategy) PrepareForUpdate(ctx context.Context, obj, old runti
 		newClass.AllowVolumeExpansion = nil
 		oldClass.AllowVolumeExpansion = nil
 	}
-	storageutil.DropDisabledAlphaFields(oldClass)
-	storageutil.DropDisabledAlphaFields(newClass)
+	storageutil.DropDisabledFields(oldClass)
+	storageutil.DropDisabledFields(newClass)
 }
 
 func (storageClassStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {


### PR DESCRIPTION
xref https://github.com/kubernetes/kubernetes/issues/72169

This PR does not change behavior, but passes old and new objects to the function responsible for dropping disabled fields so that later PRs can make use of that information.

/sig api-machinery
/kind cleanup
/cc @msau42 

```release-note
NONE
```