### PR TITLE
make integration/verify script look for k8s under GOPATH

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -47,7 +47,7 @@ export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4
 export LOG_LEVEL=4
 
-cd /go/src/k8s.io/kubernetes
+cd "${GOPATH}/src/k8s.io/kubernetes"
 
 make generated_files
 go install ./cmd/...

--- a/hack/jenkins/verify-dockerized.sh
+++ b/hack/jenkins/verify-dockerized.sh
@@ -38,6 +38,6 @@ export ARTIFACTS_DIR=${WORKSPACE}/artifacts
 
 export LOG_LEVEL=4
 
-cd /go/src/k8s.io/kubernetes
+cd "${GOPATH}/src/k8s.io/kubernetes"
 
 make verify


### PR DESCRIPTION
$GOPATH for podutil is /home/prow/go instead of /go

https://gubernator.k8s.io/build/kubernetes-jenkins/pr-logs/pull/46662/pull-kubernetes-verify-podutil/2

/sig testing
/assign @ixdy @mikedanese 