### PR TITLE
OWNERS: add label:sig/network to a bunch of places

### DIFF
--- a/pkg/apis/networking/OWNERS
+++ b/pkg/apis/networking/OWNERS
@@ -3,3 +3,5 @@ reviewers:
 - cmluciano
 - danwinship
 - thockin
+labels:
+- sig/network

--- a/pkg/controller/endpoint/OWNERS
+++ b/pkg/controller/endpoint/OWNERS
@@ -8,3 +8,5 @@ reviewers:
 - MrHohn
 - thockin
 - matchstick
+labels:
+- sig/network

--- a/pkg/controller/nodeipam/OWNERS
+++ b/pkg/controller/nodeipam/OWNERS
@@ -7,3 +7,5 @@ reviewers:
 - ingvagabund
 - aveshagarwal
 - k82cn
+labels:
+- sig/network

--- a/pkg/controller/service/OWNERS
+++ b/pkg/controller/service/OWNERS
@@ -12,3 +12,5 @@ approvers:
 - matchstick
 - andrewsykim
 - cheftako
+labels:
+- sig/network

--- a/pkg/kubelet/dockershim/network/OWNERS
+++ b/pkg/kubelet/dockershim/network/OWNERS
@@ -6,4 +6,5 @@ approvers:
 - dcbw
 reviewers:
 - sig-network-reviewers
-
+labels:
+- sig/network

--- a/pkg/proxy/apis/config/OWNERS
+++ b/pkg/proxy/apis/config/OWNERS
@@ -2,3 +2,5 @@ approvers:
 - thockin
 reviewers:
 - sig-network-reviewers
+labels:
+- sig/network

--- a/pkg/proxy/config/OWNERS
+++ b/pkg/proxy/config/OWNERS
@@ -4,3 +4,5 @@ reviewers:
 - smarterclayton
 - brendandburns
 - freehan
+labels:
+- sig/network

--- a/pkg/proxy/iptables/OWNERS
+++ b/pkg/proxy/iptables/OWNERS
@@ -5,3 +5,5 @@ reviewers:
 - freehan
 - dcbw
 - danwinship
+labels:
+- sig/network

--- a/pkg/proxy/ipvs/OWNERS
+++ b/pkg/proxy/ipvs/OWNERS
@@ -7,3 +7,5 @@ approvers:
 - thockin
 - brendandburns
 - m1093782566
+labels:
+- sig/network

--- a/pkg/proxy/userspace/OWNERS
+++ b/pkg/proxy/userspace/OWNERS
@@ -3,3 +3,5 @@ reviewers:
 - lavalamp
 - smarterclayton
 - freehan
+labels:
+- sig/network

--- a/pkg/proxy/winkernel/OWNERS
+++ b/pkg/proxy/winkernel/OWNERS
@@ -6,3 +6,5 @@ reviewers:
 - dineshgovindasamy
 - madhanrm
 - feiskyer
+labels:
+- sig/network

--- a/pkg/util/ipset/OWNERS
+++ b/pkg/util/ipset/OWNERS
@@ -7,3 +7,5 @@ approvers:
   - thockin
   - brendandburns
   - m1093782566
+labels:
+- sig/network

--- a/pkg/util/iptables/OWNERS
+++ b/pkg/util/iptables/OWNERS
@@ -7,3 +7,5 @@ approvers:
   - dcbw
   - thockin
   - eparis
+labels:
+- sig/network

--- a/pkg/util/ipvs/OWNERS
+++ b/pkg/util/ipvs/OWNERS
@@ -4,4 +4,5 @@ reviewers:
 approvers:
   - thockin
   - m1093782566
-
+labels:
+- sig/network


### PR DESCRIPTION
Add label:sig/network to a bunch of places that should probably have it.

@thockin @bowei @freehan @danwinship 

```release-note
NONE
```
