### PR TITLE
Fix detect_node_failures for gke

### DIFF
--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -435,7 +435,7 @@ function detect_node_failures() {
   fi
 
   detect-node-names
-  if [ -z "$INSTANCE_GROUPS" ]; then
+  if [ -z "${INSTANCE_GROUPS:-}" ]; then
     return
   fi
   for group in "${INSTANCE_GROUPS[@]}"; do


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
log-dump.sh uses 'set -o nounset' which stops execution on using unbound value including the -z test which checks if the variable is unbound or empty.

**Which issue(s) this PR fixes**:
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE
```

/assign @wojtek-t 
