### PR TITLE
Clear the NodeSelector when loading checkpointed Pods from disk

### DIFF
--- a/pkg/kubelet/checkpoint/checkpoint.go
+++ b/pkg/kubelet/checkpoint/checkpoint.go
@@ -103,7 +103,7 @@ func LoadPods(cpm checkpointmanager.CheckpointManager) ([]*v1.Pod, error) {
 			klog.Errorf("Failed to retrieve checkpoint for pod %q: %v", key, err)
 			continue
 		}
-                // clear NodeSelector when restoring from checkpoint otherwise pod cannot be restarted
+		// clear NodeSelector when restoring from checkpoint otherwise pod cannot be restarted
 		// when there is no connection to api-server
 		var p *v1.Pod = checkpoint.GetPod()
 		p.Spec.NodeSelector = nil

--- a/pkg/kubelet/checkpoint/checkpoint.go
+++ b/pkg/kubelet/checkpoint/checkpoint.go
@@ -103,7 +103,11 @@ func LoadPods(cpm checkpointmanager.CheckpointManager) ([]*v1.Pod, error) {
 			klog.Errorf("Failed to retrieve checkpoint for pod %q: %v", key, err)
 			continue
 		}
-		pods = append(pods, checkpoint.GetPod())
+                // clear NodeSelector when restoring from checkpoint otherwise pod cannot be restarted
+		// when there is no connection to api-server
+		var p *v1.Pod = checkpoint.GetPod()
+		p.Spec.NodeSelector = nil
+		pods = append(pods, p)
 	}
 	return pods, nil
 }

--- a/pkg/kubelet/checkpoint/checkpoint_test.go
+++ b/pkg/kubelet/checkpoint/checkpoint_test.go
@@ -41,6 +41,9 @@ func TestWriteLoadDeletePods(t *testing.T) {
 					Annotations: map[string]string{core.BootstrapCheckpointAnnotationKey: "true"},
 					UID:         "1",
 				},
+				Spec: v1.PodSpec{
+					NodeSelector: map[string]string {"Name": "fake-name1", },
+				},
 			},
 			written: true,
 		},
@@ -51,6 +54,10 @@ func TestWriteLoadDeletePods(t *testing.T) {
 					Annotations: map[string]string{core.BootstrapCheckpointAnnotationKey: "true"},
 					UID:         "2",
 				},
+				Spec: v1.PodSpec{
+					NodeSelector: map[string]string {"Name": "fake-name2", },
+				},
+
 			},
 			written: true,
 		},
@@ -59,6 +66,9 @@ func TestWriteLoadDeletePods(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "Bar",
 					UID:  "3",
+				},
+				Spec: v1.PodSpec{
+					NodeSelector: map[string]string {"Name": "fake-name2", },
 				},
 			},
 			written: false,
@@ -98,6 +108,8 @@ func TestWriteLoadDeletePods(t *testing.T) {
 			}
 		}
 		if p.written {
+			// NodeSelector always reset when loaded
+			p.pod.Spec.NodeSelector = nil
 			if lpod != nil {
 				if !reflect.DeepEqual(p.pod, lpod) {
 					t.Errorf("expected %#v, \ngot %#v", p.pod, lpod)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
/sig node
**What type of PR is this?**
/kind bug
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR clears the NodeSelector field when restoring Pods from checkpoint files on disk. This ensures that the Pods can be started even if there is no connection to an api-server.

Without this PR, the Pods are not started because the labels required for node selection are not present.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #65153

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```