### PR TITLE
Change add-on manifests to apps/v1

### DIFF
--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -44,12 +44,11 @@ KUBECTL_PRUNE_WHITELIST=(
   core/v1/Service
   batch/v1/Job
   batch/v1beta1/CronJob
-  extensions/v1beta1/DaemonSet
-  extensions/v1beta1/Deployment
+  apps/v1/DaemonSet
+  apps/v1/Deployment
+  apps/v1/ReplicaSet
+  apps/v1/StatefulSet
   extensions/v1beta1/Ingress
-  extensions/v1beta1/ReplicaSet
-  apps/v1beta1/StatefulSet
-  apps/v1beta1/Deployment
 )
 
 ADDON_CHECK_INTERVAL_SEC=${TEST_ADDON_CHECK_INTERVAL_SEC:-60}

--- a/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system

--- a/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-deployment.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node-vertical-autoscaler
   namespace: kube-system
@@ -9,6 +9,9 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-node-autoscaler
   template:
     metadata:
       labels:

--- a/cluster/addons/calico-policy-controller/typha-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-typha
@@ -9,6 +9,9 @@ metadata:
     k8s-app: calico-typha
 spec:
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
   template:
     metadata:
       labels:

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-typha-horizontal-autoscaler
@@ -9,6 +9,9 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-typha-autoscaler
   template:
     metadata:
       labels:

--- a/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-deployment.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-typha-vertical-autoscaler
   namespace: kube-system
@@ -9,6 +9,9 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-typha-autoscaler
   template:
     metadata:
       labels:

--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -33,7 +33,7 @@ data:
     apiVersion: nannyconfig/v1alpha1
     kind: NannyConfiguration
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster-v1.6.0-beta.1

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -33,7 +33,7 @@ data:
     apiVersion: nannyconfig/v1alpha1
     kind: NannyConfiguration
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster-v1.6.0-beta.1

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -33,7 +33,7 @@ data:
     apiVersion: nannyconfig/v1alpha1
     kind: NannyConfiguration
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster-v1.6.0-beta.1

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: monitoring-influxdb-grafana-v4
   namespace: kube-system

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -20,7 +20,7 @@ data:
     apiVersion: nannyconfig/v1alpha1
     kind: NannyConfiguration
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster-v1.6.0-beta.1

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -20,7 +20,7 @@ data:
     apiVersion: nannyconfig/v1alpha1
     kind: NannyConfiguration
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster-v1.6.0-beta.1

--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -77,7 +77,7 @@ data:
         loadbalance
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coredns

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -77,7 +77,7 @@ data:
         loadbalance
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coredns

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -77,7 +77,7 @@ data:
         loadbalance
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coredns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -56,7 +56,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-dns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -56,7 +56,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-dns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -56,7 +56,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-dns

--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -26,7 +26,7 @@ subjects:
   name: event-exporter-sa
   namespace: kube-system
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: event-exporter-v0.2.3

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-gcp-{{ fluentd_gcp_yaml_version }}
@@ -9,6 +9,10 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     version: {{ fluentd_gcp_yaml_version }}
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-gcp
+      version: {{ fluentd_gcp_yaml_version }}
   updateStrategy:
     type: RollingUpdate
   template:

--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -9,7 +9,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 ---
 # https://github.com/kubernetes-incubator/ip-masq-agent/blob/v2.0.0/README.md
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ip-masq-agent
@@ -17,6 +17,10 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile  
 spec:
+  selector:
+    matchLabels:
+      labels:
+        k8s-app: ip-masq-agent
   template:
     metadata:
       labels:

--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -1,7 +1,7 @@
 # Please keep kube-proxy configuration in-sync with:
 # cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/cluster/addons/metadata-agent/stackdriver/metadata-agent.yaml
+++ b/cluster/addons/metadata-agent/stackdriver/metadata-agent.yaml
@@ -8,7 +8,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 ---
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   labels:
     app: metadata-agent
@@ -69,7 +69,7 @@ spec:
     type: RollingUpdate
 ---
 kind: Deployment
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   labels:
     app: metadata-agent-cluster-level

--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: metadata-proxy-v0.1
@@ -19,6 +19,10 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     version: v0.1
 spec:
+  selector:
+    matchLabels:
+      k8s-app: metadata-proxy
+      version: v0.1
   updateStrategy:
     type: RollingUpdate
   template:

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -20,7 +20,7 @@ data:
     apiVersion: nannyconfig/v1alpha1
     kind: NannyConfiguration
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server-v0.3.1

--- a/cluster/addons/node-problem-detector/npd.yaml
+++ b/cluster/addons/node-problem-detector/npd.yaml
@@ -23,7 +23,7 @@ subjects:
   name: node-problem-detector
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: npd-v0.4.1
@@ -34,6 +34,10 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  selector:
+    matchLabels:
+      k8s-app: node-problem-detector
+      version: v0.4.1
   template:
     metadata:
       labels:

--- a/cluster/addons/prometheus/alertmanager-deployment.yaml
+++ b/cluster/addons/prometheus/alertmanager-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: alertmanager

--- a/cluster/addons/prometheus/kube-state-metrics-deployment.yaml
+++ b/cluster/addons/prometheus/kube-state-metrics-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-state-metrics

--- a/cluster/addons/prometheus/node-exporter-ds.yml
+++ b/cluster/addons/prometheus/node-exporter-ds.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: node-exporter 

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -926,7 +926,7 @@ def launch_default_ingress_controller():
     if get_version('kubelet') < (1, 9):
         context['daemonset_api_version'] = 'extensions/v1beta1'
     else:
-        context['daemonset_api_version'] = 'apps/v1beta2'
+        context['daemonset_api_version'] = 'apps/v1'
     context['juju_application'] = hookenv.service_name()
     manifest = addon_path.format('ingress-daemon-set.yaml')
     render('ingress-daemon-set.yaml', manifest, context)

--- a/cluster/juju/layers/kubernetes-worker/templates/microbot-example.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/microbot-example.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cluster/juju/layers/kubernetes-worker/templates/nfs-provisioner.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/nfs-provisioner.yaml
@@ -7,11 +7,16 @@ metadata:
 provisioner: fuseim.pri/ifs
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: nfs-client-provisioner
+  labels:
+    app: nfs-client-provisioner
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: nfs-client-provisioner
   strategy:
     type: Recreate
   template:

--- a/cluster/log-dump/logexporter-daemonset.yaml
+++ b/cluster/log-dump/logexporter-daemonset.yaml
@@ -20,7 +20,7 @@ type: Opaque
 data:
   service-account.json: {{.ServiceAccountCredentials}}
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: logexporter


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Switches add-on manifests to apps/v1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref https://github.com/kubernetes/kubernetes/issues/43214

**Does this PR introduce a user-facing change?**:
```release-note
Add-on manifests now use the apps/v1 API for DaemonSets, Deployments, and ReplicaSets
```

@kubernetes/sig-apps-pr-reviews 

/cc @kow3ns 