### PR TITLE
Fix the unit test patch to not modify the node name

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/idempotency_test.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency_test.go
@@ -69,7 +69,9 @@ func TestPatchNodeNonErrorCases(t *testing.T) {
 				t.Fatalf("failed to create node to fake client: %v", err)
 			}
 			conditionFunction := apiclient.PatchNodeOnce(client, tc.lookupName, func(node *v1.Node) {
-				node.Name = "testNewNode"
+				node.Annotations = map[string]string{
+					"updatedBy": "test",
+				}
 			})
 			success, err := conditionFunction()
 			if err != nil {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/pull/70876#discussion_r243047547. Node's name is immutable.

Unblocking https://github.com/kubernetes/kubernetes/pull/70886.

/assign @neolit123 @chuckha
/kind bug
/sig cluster-lifecycle
/release-note-none