### PR TITLE
Clean up artifacts variables in hack scripts

### DIFF
--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -39,9 +39,9 @@ retry go get github.com/cespare/prettybench
 export KUBE_RACE=" "
 # Disable coverage report
 export KUBE_COVER="n"
-export ARTIFACTS_DIR=${WORKSPACE}/_artifacts
+export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}
 
-mkdir -p "${ARTIFACTS_DIR}"
+mkdir -p "${ARTIFACTS}"
 cd /go/src/k8s.io/kubernetes
 
 ./hack/install-etcd.sh
@@ -49,5 +49,5 @@ cd /go/src/k8s.io/kubernetes
 # Run the benchmark tests and pretty-print the results into a separate file.
 make test-integration WHAT="$*" KUBE_TEST_ARGS="-run='XXX' -bench=. -benchmem" \
   | tee \
-   >(prettybench -no-passthrough > ${ARTIFACTS_DIR}/BenchmarkResults.txt) \
-   >(go run test/integration/benchmark/jsonify/main.go ${ARTIFACTS_DIR}/BenchmarkResults_benchmark_$(date -u +%Y-%m-%dT%H:%M:%SZ).json || cat > /dev/null)
+   >(prettybench -no-passthrough > ${ARTIFACTS}/BenchmarkResults.txt) \
+   >(go run test/integration/benchmark/jsonify/main.go ${ARTIFACTS}/BenchmarkResults_benchmark_$(date -u +%Y-%m-%dT%H:%M:%SZ).json || cat > /dev/null)

--- a/hack/jenkins/gotest.sh
+++ b/hack/jenkins/gotest.sh
@@ -36,8 +36,10 @@ go get -u github.com/jstemmer/go-junit-report
 
 # Enable the Go race detector.
 export KUBE_RACE=-race
-# Produce a JUnit-style XML test report for Jenkins.
-export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/_artifacts
+# Set artifacts directory
+export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}
+# Produce a JUnit-style XML test report
+export KUBE_JUNIT_REPORT_DIR="${ARTIFACTS}"
 # Save the verbose stdout as well.
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 

--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -39,9 +39,10 @@ retry go get github.com/jstemmer/go-junit-report
 export KUBE_RACE=-race
 # Disable coverage report
 export KUBE_COVER="n"
-# Produce a JUnit-style XML test report for Jenkins.
-export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/artifacts
-export ARTIFACTS_DIR=${WORKSPACE}/artifacts
+# Set artifacts directory
+export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}
+# Produce a JUnit-style XML test report
+export KUBE_JUNIT_REPORT_DIR="${ARTIFACTS}"
 # Save the verbose stdout as well.
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4

--- a/hack/jenkins/verify-dockerized.sh
+++ b/hack/jenkins/verify-dockerized.sh
@@ -31,10 +31,10 @@ retry() {
 
 export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 
-# Produce a JUnit-style XML test report
-export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/artifacts
 # Set artifacts directory
-export ARTIFACTS_DIR=${WORKSPACE}/artifacts
+export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}
+# Produce a JUnit-style XML test report
+export KUBE_JUNIT_REPORT_DIR="${ARTIFACTS}"
 
 export LOG_LEVEL=4
 

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -70,8 +70,8 @@ kube::etcd::start() {
 
   # Start etcd
   ETCD_DIR=${ETCD_DIR:-$(mktemp -d 2>/dev/null || mktemp -d -t test-etcd.XXXXXX)}
-  if [[ -d "${ARTIFACTS_DIR:-}" ]]; then
-    ETCD_LOGFILE="${ARTIFACTS_DIR}/etcd.$(uname -n).$(id -un).log.DEBUG.$(date +%Y%m%d-%H%M%S).$$"
+  if [[ -d "${ARTIFACTS:-}" ]]; then
+    ETCD_LOGFILE="${ARTIFACTS}/etcd.$(uname -n).$(id -un).log.DEBUG.$(date +%Y%m%d-%H%M%S).$$"
   else
     ETCD_LOGFILE=${ETCD_LOGFILE:-"/dev/null"}
   fi

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -120,6 +120,10 @@ KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS:-${ALL_VERSIONS_CSV}}"
 # once we have multiple group supports
 # Create a junit-style XML test report in this directory if set.
 KUBE_JUNIT_REPORT_DIR=${KUBE_JUNIT_REPORT_DIR:-}
+# If KUBE_JUNIT_REPORT_DIR is unset, and ARTIFACTS is set, then have them match.
+if [[ -z "${KUBE_JUNIT_REPORT_DIR:-}" && -n "${ARTIFACTS:-}" ]]; then
+    export KUBE_JUNIT_REPORT_DIR="${ARTIFACTS}"
+fi
 # Set to 'y' to keep the verbose stdout from tests when KUBE_JUNIT_REPORT_DIR is
 # set.
 KUBE_KEEP_VERBOSE_TEST_OUTPUT=${KUBE_KEEP_VERBOSE_TEST_OUTPUT:-n}

--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -21,6 +21,11 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
+# If KUBE_JUNIT_REPORT_DIR is unset, and ARTIFACTS is set, then have them match.
+if [[ -z "${KUBE_JUNIT_REPORT_DIR:-}" && -n "${ARTIFACTS:-}" ]]; then
+    export KUBE_JUNIT_REPORT_DIR="${ARTIFACTS}"
+fi
+
 # include shell2junit library
 source "${KUBE_ROOT}/third_party/forked/shell2junit/sh2ju.sh"
 

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -94,9 +94,9 @@ pushd "${KUBE_ROOT}" > /dev/null 2>&1
     echo "(The above output can be saved as godepdiff.patch if you're not running this locally)" >&2
     echo "(The patch file should also be exported as a build artifact if run through CI)" >&2
     KEEP_TMP=true
-    if [[ -f godepdiff.patch && -d "${ARTIFACTS_DIR:-}" ]]; then
+    if [[ -f godepdiff.patch && -d "${ARTIFACTS:-}" ]]; then
       echo "Copying patch to artifacts.."
-      cp godepdiff.patch "${ARTIFACTS_DIR:-}/"
+      cp godepdiff.patch "${ARTIFACTS:-}/"
     fi
     ret=1
   fi
@@ -111,9 +111,9 @@ pushd "${KUBE_ROOT}" > /dev/null 2>&1
     echo "(The above output can be saved as godepdiff.patch if you're not running this locally)" >&2
     echo "(The patch file should also be exported as a build artifact if run through CI)" >&2
     KEEP_TMP=true
-    if [[ -f vendordiff.patch && -d "${ARTIFACTS_DIR:-}" ]]; then
+    if [[ -f vendordiff.patch && -d "${ARTIFACTS:-}" ]]; then
       echo "Copying patch to artifacts.."
-      cp vendordiff.patch "${ARTIFACTS_DIR:-}/"
+      cp vendordiff.patch "${ARTIFACTS:-}/"
     fi
     ret=1
   fi


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This cleans up our use of artifacts variables to standardize on two:
- `ARTIFACTS`: Any script that needs an artifacts directory should use this variable
- `KUBE_JUNIT_REPORT_DIR`: To maintain backwards compatibility, scripts that produce junit reports should use this, although if it is unset, and `ARTIFACTS` is set, then use `ARTIFACTS`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
