### PR TITLE
change azure disk host cache to ReadOnly by default

### DIFF
--- a/pkg/volume/azure_dd/azure_common.go
+++ b/pkg/volume/azure_dd/azure_common.go
@@ -40,7 +40,7 @@ import (
 const (
 	defaultStorageAccountType       = compute.StandardLRS
 	defaultAzureDiskKind            = v1.AzureManagedDisk
-	defaultAzureDataDiskCachingMode = v1.AzureDataDiskCachingNone
+	defaultAzureDataDiskCachingMode = v1.AzureDataDiskCachingReadOnly
 )
 
 type dataDisk struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
change azure disk host cache to `ReadOnly` by default
The default value `None` would lead to slow perf. And according to below doc: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage-performance#disk-caching

default host cache should be `ReadOnly`, the reason why we use “cachingMode: None” by default in k8s is that there is a critical disk bug due to this cachingMode setting(`ReadOnly` & `ReadWrite`) which would lead to disk i/o error, and this issue has been fixed in the middle of this year by azure disk team. 

I would also like to change the default value(from `ReadWrite` to `ReadOnly`) of caching mode in direct azure disk PV creation, there is one statement in the host cache doc:
```
Using ReadWrite cache with an application that does not handle persisting the required data can lead to data loss, if the VM crashes.
```
`ReadWrite` cache may lead to data loss when VM crashes according to below doc:
https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage-performance#disk-caching

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72228

**Special notes for your reviewer**:

**Release note**:
```
the azure disk persistent volume provisioner has changed the default host cache to ReadOnly, if `cachingmode` is not specified in the StorageClass parameters
```

/sig azure
/hold

hold this RP temporalily,  I will let azure disk team do final confirmation whether `ReadOnly` is the best default value.
From my side, I have verified that the [original issue](https://github.com/kubernetes/cloud-provider-azure/blob/master/docs/azuredisk-issues.md#2-disk-unavailable-after-attachdetach-a-data-disk-on-a-node) has been fixed in azure, we can move to use `ReadOnly` host cache now.