### PR TITLE
Stop using API server's `--insecure-port`

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -120,7 +120,6 @@ func CreateStaticPodFiles(manifestDir string, cfg *kubeadmapi.InitConfiguration,
 func getAPIServerCommand(cfg *kubeadmapi.InitConfiguration) []string {
 	defaultArguments := map[string]string{
 		"advertise-address":               cfg.LocalAPIEndpoint.AdvertiseAddress,
-		"insecure-port":                   "0",
 		"enable-admission-plugins":        "NodeRestriction",
 		"service-cluster-ip-range":        cfg.Networking.ServiceSubnet,
 		"service-account-key-file":        filepath.Join(cfg.CertificatesDir, kubeadmconstants.ServiceAccountPublicKeyName),

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -154,7 +154,6 @@ func TestGetAPIServerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-apiserver",
-				"--insecure-port=0",
 				"--enable-admission-plugins=NodeRestriction",
 				"--service-cluster-ip-range=bar",
 				"--service-account-key-file=" + testCertsDir + "/sa.pub",
@@ -193,7 +192,6 @@ func TestGetAPIServerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-apiserver",
-				"--insecure-port=0",
 				"--enable-admission-plugins=NodeRestriction",
 				"--service-cluster-ip-range=bar",
 				"--service-account-key-file=" + testCertsDir + "/sa.pub",
@@ -240,7 +238,6 @@ func TestGetAPIServerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-apiserver",
-				"--insecure-port=0",
 				"--enable-admission-plugins=NodeRestriction",
 				"--service-cluster-ip-range=bar",
 				"--service-account-key-file=" + testCertsDir + "/sa.pub",
@@ -284,7 +281,6 @@ func TestGetAPIServerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-apiserver",
-				"--insecure-port=0",
 				"--enable-admission-plugins=NodeRestriction",
 				"--service-cluster-ip-range=bar",
 				"--service-account-key-file=" + testCertsDir + "/sa.pub",
@@ -330,7 +326,6 @@ func TestGetAPIServerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-apiserver",
-				"--insecure-port=0",
 				"--enable-admission-plugins=NodeRestriction",
 				"--service-cluster-ip-range=baz",
 				"--service-account-key-file=" + testCertsDir + "/sa.pub",
@@ -378,7 +373,6 @@ func TestGetAPIServerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-apiserver",
-				"--insecure-port=0",
 				"--enable-admission-plugins=NodeRestriction",
 				"--service-cluster-ip-range=bar",
 				"--service-account-key-file=" + testCertsDir + "/sa.pub",
@@ -407,7 +401,7 @@ func TestGetAPIServerCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "insecure-port extra-args",
+			name: "secure-port extra-args",
 			cfg: &kubeadmapi.InitConfiguration{
 				LocalAPIEndpoint: kubeadmapi.APIEndpoint{BindPort: 123, AdvertiseAddress: "1.2.3.4"},
 				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
@@ -416,7 +410,7 @@ func TestGetAPIServerCommand(t *testing.T) {
 					APIServer: kubeadmapi.APIServer{
 						ControlPlaneComponent: kubeadmapi.ControlPlaneComponent{
 							ExtraArgs: map[string]string{
-								"insecure-port": "1234",
+								"secure-port": "123",
 							},
 						},
 					},
@@ -424,7 +418,6 @@ func TestGetAPIServerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-apiserver",
-				"--insecure-port=1234",
 				"--enable-admission-plugins=NodeRestriction",
 				"--service-cluster-ip-range=bar",
 				"--service-account-key-file=" + testCertsDir + "/sa.pub",
@@ -470,7 +463,6 @@ func TestGetAPIServerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-apiserver",
-				"--insecure-port=0",
 				"--enable-admission-plugins=NodeRestriction",
 				"--service-cluster-ip-range=bar",
 				"--service-account-key-file=" + testCertsDir + "/sa.pub",

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
@@ -54,7 +54,6 @@ spec:
     - --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt
     - --advertise-address=192.168.1.115
     - --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
-    - --insecure-port=0
     - --experimental-bootstrap-token-auth=true
     - --requestheader-username-headers=X-Remote-User
     - --requestheader-extra-headers-prefix=X-Remote-Extra-
@@ -136,7 +135,6 @@ spec:
         - --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt
         - --advertise-address=$(HOST_IP)
         - --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
-        - --insecure-port=0
         - --experimental-bootstrap-token-auth=true
         - --requestheader-username-headers=X-Remote-User
         - --requestheader-extra-headers-prefix=X-Remote-Extra-


### PR DESCRIPTION
depreciate  API server's `--insecure-port`
fixes https://github.com/kubernetes/kubeadm/issues/1283