### PR TITLE
[GCP] Update scaler-deployment.yaml CPU_LIMITS

### DIFF
--- a/cluster/addons/fluentd-gcp/scaler-deployment.yaml
+++ b/cluster/addons/fluentd-gcp/scaler-deployment.yaml
@@ -31,6 +31,6 @@ spec:
         - name: MEMORY_REQUEST
           value: 200Mi
         - name: CPU_LIMIT
-          value: 1000m
+          value: '1'
         - name: MEMORY_LIMIT
           value: 500Mi

--- a/cluster/addons/fluentd-gcp/scaler-deployment.yaml
+++ b/cluster/addons/fluentd-gcp/scaler-deployment.yaml
@@ -31,6 +31,6 @@ spec:
         - name: MEMORY_REQUEST
           value: 200Mi
         - name: CPU_LIMIT
-          value: '1'
+          value: "1"
         - name: MEMORY_LIMIT
           value: 500Mi


### PR DESCRIPTION
What this PR does / why we need it:
setting CPU_LIMITS to '1' fixes the following log appearing every 60 seconds:
Running: kubectl set resources -n kube-system ds fluentd-gcp-v3.1.0 -c fluentd-gcp --requests=cpu=100m,memory=200Mi --limits=cpu=1000m,memory=500Mi
error: info: {extensions v1beta1 daemonsets} "fluentd-gcp-v3.1.0" was not changed

this PR does not change scaler's behaviour, pods are scaled correctly despite error being logged


```release-note
[GCP] Remove confusing error log entry form fluentd scalers.
```

/assign @loburm 
/sig cluster-lifecycle  
/sig gcp