### PR TITLE
Add AWS Custom Endpoint capability #70588

### DIFF
--- a/pkg/cloudprovider/providers/aws/BUILD
+++ b/pkg/cloudprovider/providers/aws/BUILD
@@ -50,6 +50,7 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/credentials/stscreds:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/ec2metadata:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/endpoints:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/request:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/autoscaling:go_default_library",

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -609,32 +609,32 @@ func makeRegionEndpointSignature(serviceName, region string) string {
 }
 
 func parseOverrides(cfg *CloudConfig) error {
-	if len(cfg.Global.ServiceOverrides) > 0 {
-		if err := setOverridesDefaults(cfg); err != nil {
-			return err
-		}
-		overrides = make(map[string]CustomEndpoint)
-		for _, ovrd := range cfg.Global.ServiceOverrides {
-			tokens := strings.Split(ovrd, cfg.Global.OverrideSeparator)
-			if len(tokens) != 4 {
-				if len(tokens) > 0 {
-					return fmt.Errorf("4 parameters (service, region, url, signing region) are required for [%s] in %s",
-						tokens[0], ovrd)
-				}
-				return fmt.Errorf("4 parameters (service, region, url, signing region) are required in %s",
-					ovrd)
-			}
-			name := strings.TrimSpace(tokens[0])
-			region := strings.TrimSpace(tokens[1])
-			url := strings.TrimSpace(tokens[2])
-			signingRegion := strings.TrimSpace(tokens[3])
-			signature := makeRegionEndpointSignature(name, region)
-			overrides[signature] = CustomEndpoint{Endpoint: url, SigningRegion: signingRegion}
-		}
-		overridesActive = true
-	} else {
-		overridesActive = false
+	overridesActive = false
+	if len(cfg.Global.ServiceOverrides) == 0 {
+		return nil
 	}
+	if err := setOverridesDefaults(cfg); err != nil {
+		return err
+	}
+	overrides = make(map[string]CustomEndpoint)
+	for _, ovrd := range cfg.Global.ServiceOverrides {
+		tokens := strings.Split(ovrd, cfg.Global.OverrideSeparator)
+		if len(tokens) != 4 {
+			if len(tokens) > 0 {
+				return fmt.Errorf("4 parameters (service, region, url, signing region) are required for [%s] in %s",
+					tokens[0], ovrd)
+			}
+			return fmt.Errorf("4 parameters (service, region, url, signing region) are required in %s",
+				ovrd)
+		}
+		name := strings.TrimSpace(tokens[0])
+		region := strings.TrimSpace(tokens[1])
+		url := strings.TrimSpace(tokens[2])
+		signingRegion := strings.TrimSpace(tokens[3])
+		signature := makeRegionEndpointSignature(name, region)
+		overrides[signature] = CustomEndpoint{Endpoint: url, SigningRegion: signingRegion}
+	}
+	overridesActive = true
 	return nil
 }
 

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -643,20 +643,20 @@ func loadCustomResolver() func(service, region string, optFns ...func(*endpoints
 	defaultResolverFn := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 		return defaultResolver.EndpointFor(service, region, optFns...)
 	}
-	if overridesActive {
-		customResolverFn := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
-			signature := makeRegionEndpointSignature(service, region)
-			if ep, ok := overrides[signature]; ok {
-				return endpoints.ResolvedEndpoint{
-					URL:           ep.Endpoint,
-					SigningRegion: ep.SigningRegion,
-				}, nil
-			}
-			return defaultResolver.EndpointFor(service, region, optFns...)
-		}
-		return customResolverFn
+	if !overridesActive {
+		return defaultResolverFn
 	}
-	return defaultResolverFn
+	customResolverFn := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+		signature := makeRegionEndpointSignature(service, region)
+		if ep, ok := overrides[signature]; ok {
+			return endpoints.ResolvedEndpoint{
+				URL:           ep.Endpoint,
+				SigningRegion: ep.SigningRegion,
+			}, nil
+		}
+		return defaultResolver.EndpointFor(service, region, optFns...)
+	}
+	return customResolverFn
 }
 
 // awsSdkEC2 is an implementation of the EC2 interface, backed by aws-sdk-go

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -572,13 +572,13 @@ type CloudConfig struct {
 		DisableStrictZoneCheck bool
 	}
 	// [ServiceOverride "1"]
-	//  Name = s3
+	//  Service = s3
 	//  Region = region1
 	//  Url = https://s3.foo.bar
 	//  SigningRegion = signing_region
 	//
 	//  [ServiceOverride "2"]
-	//     Name = ec2
+	//     Service = ec2
 	//     Region = region2
 	//     Url = https://ec2.foo.bar
 	//     SigningRegion = signing_region

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -576,17 +576,20 @@ type CloudConfig struct {
 	//  Region = region1
 	//  URL = https://s3.foo.bar
 	//  SigningRegion = signing_region
+	//  SigningMethod = signing_method
 	//
 	//  [ServiceOverride "2"]
 	//     Service = ec2
 	//     Region = region2
 	//     URL = https://ec2.foo.bar
 	//     SigningRegion = signing_region
+	//     SigningMethod = signing_method
 	ServiceOverride map[string]*struct {
 		Service       string
 		Region        string
 		URL           string
 		SigningRegion string
+		SigningMethod string
 	}
 }
 
@@ -596,32 +599,39 @@ func (cfg *CloudConfig) validateOverrides() error {
 	}
 	set := make(map[string]bool)
 	for onum, ovrd := range cfg.ServiceOverride {
+		// Note: gcfg does not space trim, so we have to when comparing to empty string ""
 		name := strings.TrimSpace(ovrd.Service)
 		if name == "" {
 			return fmt.Errorf("service name is missing [Service is \"\"] in override %s", onum)
 		}
+		// insure the map service name is space trimmed
+		ovrd.Service = name
+
 		region := strings.TrimSpace(ovrd.Region)
 		if region == "" {
 			return fmt.Errorf("service region is missing [Region is \"\"] in override %s", onum)
 		}
+		// insure the map region is space trimmed
+		ovrd.Region = region
+
 		url := strings.TrimSpace(ovrd.URL)
-		if url == "" {
+		if url== "" {
 			return fmt.Errorf("url is missing [URL is \"\"] in override %s", onum)
 		}
 		signingRegion := strings.TrimSpace(ovrd.SigningRegion)
 		if signingRegion == "" {
 			return fmt.Errorf("signingRegion is missing [SigningRegion is \"\"] in override %s", onum)
 		}
-		if _, ok := set[name+"_"+region]; ok {
+		signature := name+"_"+region
+		if set[signature] {
 			return fmt.Errorf("duplicate entry found for service override [%s] (%s in %s)", onum, name, region)
 		}
-		set[name+"_"+region] = true
+		set[signature] = true
 	}
 	return nil
 }
 
-func (cfg *CloudConfig) getResolver() func(service, region string,
-	optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+func (cfg *CloudConfig) getResolver() endpoints.ResolverFunc {
 	defaultResolver := endpoints.DefaultResolver()
 	defaultResolverFn := func(service, region string,
 		optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
@@ -630,19 +640,20 @@ func (cfg *CloudConfig) getResolver() func(service, region string,
 	if len(cfg.ServiceOverride) == 0 {
 		return defaultResolverFn
 	}
-	customResolverFn := func(service, region string,
+
+	return func(service, region string,
 		optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 		for _, override := range cfg.ServiceOverride {
 			if override.Service == service && override.Region == region {
 				return endpoints.ResolvedEndpoint{
 					URL:           override.URL,
 					SigningRegion: override.SigningRegion,
+					SigningMethod: override.SigningMethod,
 				}, nil
 			}
 		}
 		return defaultResolver.EndpointFor(service, region, optFns...)
 	}
-	return customResolverFn
 }
 
 // awsSdkEC2 is an implementation of the EC2 interface, backed by aws-sdk-go
@@ -652,7 +663,7 @@ type awsSdkEC2 struct {
 
 // Interface to make the CloudConfig immutable for awsSDKProvider
 type awsCloudConfigProvider interface {
-	getResolver() func(string, string, ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error)
+	getResolver() endpoints.ResolverFunc
 }
 
 type awsSDKProvider struct {
@@ -732,7 +743,7 @@ func (p *awsSDKProvider) Compute(regionName string) (EC2, error) {
 		Credentials: p.creds,
 	}
 	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true).
-		WithEndpointResolver(endpoints.ResolverFunc(p.cfg.getResolver()))
+		WithEndpointResolver(p.cfg.getResolver())
 
 	sess, err := session.NewSession(awsConfig)
 	if err != nil {
@@ -754,7 +765,7 @@ func (p *awsSDKProvider) LoadBalancing(regionName string) (ELB, error) {
 		Credentials: p.creds,
 	}
 	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true).
-		WithEndpointResolver(endpoints.ResolverFunc(p.cfg.getResolver()))
+		WithEndpointResolver(p.cfg.getResolver())
 
 	sess, err := session.NewSession(awsConfig)
 	if err != nil {
@@ -772,7 +783,7 @@ func (p *awsSDKProvider) LoadBalancingV2(regionName string) (ELBV2, error) {
 		Credentials: p.creds,
 	}
 	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true).
-		WithEndpointResolver(endpoints.ResolverFunc(p.cfg.getResolver()))
+		WithEndpointResolver(p.cfg.getResolver())
 
 	sess, err := session.NewSession(awsConfig)
 	if err != nil {
@@ -791,7 +802,7 @@ func (p *awsSDKProvider) Autoscaling(regionName string) (ASG, error) {
 		Credentials: p.creds,
 	}
 	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true).
-		WithEndpointResolver(endpoints.ResolverFunc(p.cfg.getResolver()))
+		WithEndpointResolver(p.cfg.getResolver())
 
 	sess, err := session.NewSession(awsConfig)
 	if err != nil {
@@ -806,7 +817,7 @@ func (p *awsSDKProvider) Autoscaling(regionName string) (ASG, error) {
 
 func (p *awsSDKProvider) Metadata() (EC2Metadata, error) {
 	sess, err := session.NewSession(&aws.Config{
-		EndpointResolver: endpoints.ResolverFunc(p.cfg.getResolver()),
+		EndpointResolver: p.cfg.getResolver(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize AWS session: %v", err)
@@ -822,7 +833,7 @@ func (p *awsSDKProvider) KeyManagement(regionName string) (KMS, error) {
 		Credentials: p.creds,
 	}
 	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true).
-		WithEndpointResolver(endpoints.ResolverFunc(p.cfg.getResolver()))
+		WithEndpointResolver(p.cfg.getResolver())
 
 	sess, err := session.NewSession(awsConfig)
 	if err != nil {

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -574,18 +574,18 @@ type CloudConfig struct {
 	// [ServiceOverride "1"]
 	//  Service = s3
 	//  Region = region1
-	//  Url = https://s3.foo.bar
+	//  URL = https://s3.foo.bar
 	//  SigningRegion = signing_region
 	//
 	//  [ServiceOverride "2"]
 	//     Service = ec2
 	//     Region = region2
-	//     Url = https://ec2.foo.bar
+	//     URL = https://ec2.foo.bar
 	//     SigningRegion = signing_region
 	ServiceOverride map[string]*struct {
 		Service       string
 		Region        string
-		Url           string
+		URL           string
 		SigningRegion string
 	}
 }
@@ -604,9 +604,9 @@ func (cfg *CloudConfig) validateOverrides() error {
 		if region == "" {
 			return fmt.Errorf("service region is missing [Region is \"\"] in override %s", onum)
 		}
-		url := strings.TrimSpace(ovrd.Url)
+		url := strings.TrimSpace(ovrd.URL)
 		if url == "" {
-			return fmt.Errorf("url is missing [Url is \"\"] in override %s", onum)
+			return fmt.Errorf("url is missing [URL is \"\"] in override %s", onum)
 		}
 		signingRegion := strings.TrimSpace(ovrd.SigningRegion)
 		if signingRegion == "" {
@@ -614,9 +614,8 @@ func (cfg *CloudConfig) validateOverrides() error {
 		}
 		if _, ok := set[name+"_"+region]; ok {
 			return fmt.Errorf("duplicate entry found for service override [%s] (%s in %s)", onum, name, region)
-		} else {
-			set[name+"_"+region] = true
 		}
+		set[name+"_"+region] = true
 	}
 	return nil
 }
@@ -636,7 +635,7 @@ func (cfg *CloudConfig) getResolver() func(service, region string,
 		for _, override := range cfg.ServiceOverride {
 			if override.Service == service && override.Region == region {
 				return endpoints.ResolvedEndpoint{
-					URL:           override.Url,
+					URL:           override.URL,
 					SigningRegion: override.SigningRegion,
 				}, nil
 			}

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -615,14 +615,14 @@ func (cfg *CloudConfig) validateOverrides() error {
 		ovrd.Region = region
 
 		url := strings.TrimSpace(ovrd.URL)
-		if url== "" {
+		if url == "" {
 			return fmt.Errorf("url is missing [URL is \"\"] in override %s", onum)
 		}
 		signingRegion := strings.TrimSpace(ovrd.SigningRegion)
 		if signingRegion == "" {
 			return fmt.Errorf("signingRegion is missing [SigningRegion is \"\"] in override %s", onum)
 		}
-		signature := name+"_"+region
+		signature := name + "_" + region
 		if set[signature] {
 			return fmt.Errorf("duplicate entry found for service override [%s] (%s in %s)", onum, name, region)
 		}

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -590,6 +590,7 @@ type CloudConfig struct {
 		URL           string
 		SigningRegion string
 		SigningMethod string
+		SigningName   string
 	}
 }
 
@@ -649,6 +650,7 @@ func (cfg *CloudConfig) getResolver() endpoints.ResolverFunc {
 					URL:           override.URL,
 					SigningRegion: override.SigningRegion,
 					SigningMethod: override.SigningMethod,
+					SigningName:   override.SigningName,
 				}, nil
 			}
 		}

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -187,8 +187,8 @@ func TestReadAWSCloudConfig(t *testing.T) {
 }
 
 type ServiceDescriptor struct {
-	name   string
-	region string
+	name                         string
+	region                       string
 	signingRegion, signingMethod string
 }
 
@@ -309,7 +309,7 @@ func TestOverridesActiveConfig(t *testing.T) {
                   SigningMethod = v4`),
 			nil,
 			false, true,
-			[]ServiceDescriptor{{name:"s3", region: "sregion1", signingRegion: "sregion1", signingMethod: "v4"},
+			[]ServiceDescriptor{{name: "s3", region: "sregion1", signingRegion: "sregion1", signingMethod: "v4"},
 				{name: "ec2", region: "sregion2", signingRegion: "sregion2", signingMethod: "v4"}},
 		},
 		{
@@ -356,7 +356,7 @@ func TestOverridesActiveConfig(t *testing.T) {
 			nil,
 			false, true,
 			[]ServiceDescriptor{{name: "s3", region: "region1", signingRegion: "sregion1", signingMethod: ""},
-				{name:"ec2", region: "region2", signingRegion: "sregion", signingMethod: "v4"}},
+				{name: "ec2", region: "region2", signingRegion: "sregion", signingMethod: "v4"}},
 		},
 		{
 			"Multiple regions, Same Service",
@@ -380,8 +380,8 @@ func TestOverridesActiveConfig(t *testing.T) {
                  `),
 			nil,
 			false, true,
-			[]ServiceDescriptor{{name:"s3", region: "region1", signingRegion: "sregion1", signingMethod: "v3"},
-				{name:"s3", region: "region2", signingRegion: "sregion1", signingMethod: "v4"}},
+			[]ServiceDescriptor{{name: "s3", region: "region1", signingRegion: "sregion1", signingMethod: "v3"},
+				{name: "s3", region: "region2", signingRegion: "sregion1", signingMethod: "v4"}},
 		},
 	}
 

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -218,7 +218,7 @@ func TestOverridesActiveConfig(t *testing.T) {
 
                 [ServiceOverride "1"]
                  Region=sregion
-                 Url=https://s3.foo.bar
+                 URL=https://s3.foo.bar
                  SigningRegion=sregion
                 `),
 			nil,
@@ -232,7 +232,7 @@ func TestOverridesActiveConfig(t *testing.T) {
 
                 [ServiceOverride "1"]
                  Service=s3
-                 Url=https://s3.foo.bar
+                 URL=https://s3.foo.bar
                  SigningRegion=sregion
                  `),
 			nil,
@@ -261,7 +261,7 @@ func TestOverridesActiveConfig(t *testing.T) {
                 [ServiceOverride "1"]
                  Service=s3
                  Region=sregion
-                 Url=https://s3.foo.bar
+                 URL=https://s3.foo.bar
                  `),
 			nil,
 			true, false,
@@ -275,7 +275,7 @@ func TestOverridesActiveConfig(t *testing.T) {
                [ServiceOverride "1"]
                 Service = s3
                 Region = sregion
-                Url = https://s3.foo.bar
+                URL = https://s3.foo.bar
                 SigningRegion = sregion
                 `),
 			nil,
@@ -291,13 +291,13 @@ func TestOverridesActiveConfig(t *testing.T) {
 				[ServiceOverride "1"]
                   Service=s3
                   Region=sregion1
-                  Url=https://s3.foo.bar
+                  URL=https://s3.foo.bar
                   SigningRegion=sregion
 
 				[ServiceOverride "2"]
                   Service=ec2
                   Region=sregion2
-                  Url=https://ec2.foo.bar
+                  URL=https://ec2.foo.bar
                   SigningRegion=sregion`),
 			nil,
 			false, true,
@@ -312,13 +312,13 @@ func TestOverridesActiveConfig(t *testing.T) {
 				[ServiceOverride "1"]
                   Service=s3
                   Region=sregion1
-                  Url=https://s3.foo.bar
+                  URL=https://s3.foo.bar
                   SigningRegion=sregion
 
 				[ServiceOverride "2"]
                   Service=s3
                   Region=sregion1
-                  Url=https://s3.foo.bar
+                  URL=https://s3.foo.bar
                   SigningRegion=sregion`),
 			nil,
 			true, false,
@@ -332,13 +332,13 @@ func TestOverridesActiveConfig(t *testing.T) {
 				[ServiceOverride "1"]
                  Service=s3
                  Region=region1
-                 Url=https://s3.foo.bar
+                 URL=https://s3.foo.bar
                  SigningRegion=sregion
 
 				[ServiceOverride "2"]
                  Service=ec2
                  Region=region2
-                 Url=https://ec2.foo.bar
+                 URL=https://ec2.foo.bar
                  SigningRegion=sregion
                  `),
 			nil,
@@ -353,13 +353,13 @@ func TestOverridesActiveConfig(t *testing.T) {
 				[ServiceOverride "1"]
                 Service=s3
                 Region=region1
-                Url=https://s3.foo.bar
+                URL=https://s3.foo.bar
                 SigningRegion=sregion
 
 				[ServiceOverride "2"]
                  Service=s3
                  Region=region2
-                 Url=https://s3.foo.bar
+                 URL=https://s3.foo.bar
                  SigningRegion=sregion
                  `),
 			nil,
@@ -391,7 +391,7 @@ func TestOverridesActiveConfig(t *testing.T) {
 					var found *struct {
 						Service       string
 						Region        string
-						Url           string
+						URL           string
 						SigningRegion string
 					}
 					for _, v := range cfg.ServiceOverride {
@@ -409,9 +409,9 @@ func TestOverridesActiveConfig(t *testing.T) {
 								found.SigningRegion, test.name)
 						}
 						targetName := fmt.Sprintf("https://%s.foo.bar", sd.name)
-						if found.Url != targetName {
+						if found.URL != targetName {
 							t.Errorf("Expected Endpoint '%s', received '%s' for case %s",
-								targetName, found.Url, test.name)
+								targetName, found.URL, test.name)
 						}
 
 						fn := cfg.getResolver()

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -186,91 +186,77 @@ func TestReadAWSCloudConfig(t *testing.T) {
 	}
 }
 
+type ServiceDescriptor struct {
+	name string
+	region string
+}
+
 func TestOverridesActiveConfig(t *testing.T) {
 	tests := []struct {
 		name string
-
 
 		reader io.Reader
 		aws    Services
 
 		expectError        bool
 		active             bool
-		servicesOverridden []string
-		regions []string
+		servicesOverridden []ServiceDescriptor
 	}{
 		{
-			"No overrides in config",
-			strings.NewReader("[global]\nServiceOverrides=s3|sregion, https://s3.foo.bar, sregion"),
-			nil,
-			false, false,
-			[]string{}, []string{},
-		},
-		{
 			"Missing Servicename Separator",
-			strings.NewReader("[global]\nOverrideEndpoints=true\nServiceOverrides=s3sregion, https://s3.foo.bar, sregion"),
+			strings.NewReader("[global]\nServiceOverrides=s3sregion, https://s3.foo.bar, sregion"),
 			nil,
 			true, false,
-			[]string{}, []string{},
+			[]ServiceDescriptor{},
 		},
 		{
 			"Missing Service Region",
-			strings.NewReader("[global]\nOverrideEndpoints=true\nServiceOverrides=s3|https://s3.foo.bar, sregion"),
+			strings.NewReader("[global]\nServiceOverrides=s3, https://s3.foo.bar, sregion"),
 			nil,
 			true, false,
-			[]string{}, []string{},
+			[]ServiceDescriptor{},
 		},
 		{
-			"Semi-colon in service delimiter",
-			strings.NewReader("[global]\nOverrideEndpoints=true\nServiceDelimiter=;"),
+			"Semi-colon in override delimiter",
+			strings.NewReader("[global]\nOverrideSeparator=;\n" +
+				"ServiceOverrides=s3, https://s3.foo.bar, sregion"),
 			nil,
 			true, false,
-			[]string{}, []string{},
-		},
-		{
-			"Semi-colon in service name delimiter",
-			strings.NewReader("[global]\nOverrideEndpoints=true\nServicenameDelimiter=;"),
-			nil,
-			true, false,
-			[]string{}, []string{},
-		},
-		{
-			"Semi-colon in service name delimiter",
-			strings.NewReader("[global]\nOverrideEndpoints=true\nOverrideSeparator=;"),
-			nil,
-			true, false,
-			[]string{}, []string{},
+			[]ServiceDescriptor{},
 		},
 		{
 			"Active Overrides",
-			strings.NewReader("[global]\nOverrideEndpoints=true\nServiceOverrides=s3|sregion, https://s3.foo.bar, sregion"),
+			strings.NewReader("[global]\nServiceOverrides=s3, sregion, https://s3.foo.bar, sregion"),
 			nil,
 			false, true,
-			[]string{"s3"}, []string{"sregion"},
+			[]ServiceDescriptor{{name: "s3", region: "sregion"}},
 		},
 		{
 			"Multiple Overriden Services",
-			strings.NewReader("[global]\nOverrideEndpoints=true\n" +
-				"ServiceOverrides=s3|sregion, https://s3.foo.bar, sregion & ec2|sregion, https://ec2.foo.bar, sregion"),
+			strings.NewReader("[global]\n" +
+				"ServiceOverrides=s3, sregion1, https://s3.foo.bar, sregion\n" +
+				"ServiceOverrides=ec2, sregion2, https://ec2.foo.bar, sregion"),
 			nil,
 			false, true,
-			[]string{"s3", "ec2"}, []string{"sregion", "sregion"},
+			[]ServiceDescriptor{{"s3", "sregion1"}, {"ec2", "sregion2"}},
 		},
 		{
 			"Multiple Overriden Services in Multiple regions",
-			strings.NewReader("[global]\nOverrideEndpoints=true\n" +
-				"ServiceOverrides=s3|region1, https://s3.foo.bar, sregion & ec2|region2, https://ec2.foo.bar, sregion"),
+			strings.NewReader("[global]\n" +
+				"ServiceOverrides=s3, region1, https://s3.foo.bar, sregion\n" +
+				"ServiceOverrides=ec2, region2, https://ec2.foo.bar, sregion"),
 			nil,
 			false, true,
-			[]string{"s3", "ec2"}, []string{"region1", "region2"},
+			[]ServiceDescriptor{{"s3","region1"}, {"ec2", "region2"}},
 		},
 		{
 			"Multiple regions, Same Service",
-			strings.NewReader("[global]\nOverrideEndpoints=true\n" +
-				"ServiceOverrides=s3|region1, https://s3.foo.bar, sregion & s3|region2, https://s3.foo.bar, sregion"),
+			strings.NewReader("[global]\n" +
+				"ServiceOverrides=s3, region1, https://s3.foo.bar, sregion\n" +
+				"ServiceOverrides=s3, region2, https://s3.foo.bar, sregion"),
 			nil,
 			false, true,
-			[]string{"s3", "s3"}, []string{"region1", "region2"},
+			[]ServiceDescriptor{{"s3", "region1"}, {"s3", "region2"}},
 		},
 	}
 
@@ -278,59 +264,60 @@ func TestOverridesActiveConfig(t *testing.T) {
 		t.Logf("Running test case %s", test.name)
 		cfg, err := readAWSCloudConfig(test.reader)
 		if err == nil {
-			err = ParseOverrides(cfg)
+			err = parseOverrides(cfg)
 		}
 		if test.expectError {
 			if err == nil {
 				t.Errorf("Should error for case %s (cfg=%v)", test.name, cfg)
 			}
-			if IsOverridesActive() != test.active {
+			if overridesActive != test.active {
 				t.Errorf("Incorrect active flag (%v vs %v) for case: %s",
-					IsOverridesActive(), test.active, test.name)
+					overridesActive, test.active, test.name)
 			}
 		} else {
 			if err != nil {
 				t.Errorf("Should succeed for case: %s", test.name)
 			}
-			if IsOverridesActive() != test.active {
+			if overridesActive != test.active {
 				t.Errorf("Incorrect active flag (%v vs %v) for case: %s",
-					IsOverridesActive(), test.active, test.name)
-			}
-			if len(overrides) != len(test.servicesOverridden) {
-				t.Errorf("Expected %d overridden services, received %d for case %s",
-					len(test.servicesOverridden), len(overrides), test.name)
+					overridesActive, test.active, test.name)
 			} else {
-				for i, name := range test.servicesOverridden {
-					signature := MakeRegionEndpointSignature(name, test.regions[i])
-					ep, ok := overrides[signature]
-					if !ok {
-						t.Errorf("Missing override for service %s in case %s",
-							name, test.name)
-					} else {
-						if ep.SigningRegion != "sregion" {
-							t.Errorf("Expected signing region 'sregion', received '%s' for case %s",
-								ep.SigningRegion, test.name)
-						}
-						targetName := fmt.Sprintf("https://%s.foo.bar", name)
-						if ep.Endpoint != targetName {
-							t.Errorf("Expected Endpoint '%s', received '%s' for case %s",
-								targetName, ep.Endpoint, test.name)
-						}
-
-						fn := loadCustomResolver()
-						ep1, e := fn(name, test.regions[i], nil)
-						if e != nil {
-							t.Errorf("Expected a valid endpoint for %s in case %s",
-								name, test.name)
+				if len(overrides) != len(test.servicesOverridden) {
+					t.Errorf("Expected %d overridden services, received %d for case %s",
+						len(test.servicesOverridden), len(overrides), test.name)
+				} else {
+					for _, sd := range test.servicesOverridden {
+						signature := makeRegionEndpointSignature(sd.name, sd.region)
+						ep, ok := overrides[signature]
+						if !ok {
+							t.Errorf("Missing override for service %s in case %s",
+								sd.name, test.name)
 						} else {
-							targetName := fmt.Sprintf("https://%s.foo.bar", name)
-							if ep1.URL != targetName {
-								t.Errorf("Expected endpoint url: %s, received %s in case %s",
-									targetName, ep1.URL, test.name)
+							if ep.SigningRegion != "sregion" {
+								t.Errorf("Expected signing region 'sregion', received '%s' for case %s",
+									ep.SigningRegion, test.name)
 							}
-							if ep1.SigningRegion != "sregion" {
-								t.Errorf("Expected signing region 'sregion', received '%s' in case %s",
-									ep1.SigningRegion, test.name)
+							targetName := fmt.Sprintf("https://%s.foo.bar", sd.name)
+							if ep.Endpoint != targetName {
+								t.Errorf("Expected Endpoint '%s', received '%s' for case %s",
+									targetName, ep.Endpoint, test.name)
+							}
+
+							fn := loadCustomResolver()
+							ep1, e := fn(sd.name, sd.region, nil)
+							if e != nil {
+								t.Errorf("Expected a valid endpoint for %s in case %s",
+									sd.name, test.name)
+							} else {
+								targetName := fmt.Sprintf("https://%s.foo.bar", sd.name)
+								if ep1.URL != targetName {
+									t.Errorf("Expected endpoint url: %s, received %s in case %s",
+										targetName, ep1.URL, test.name)
+								}
+								if ep1.SigningRegion != "sregion" {
+									t.Errorf("Expected signing region 'sregion', received '%s' in case %s",
+										ep1.SigningRegion, test.name)
+								}
 							}
 						}
 					}
@@ -352,48 +339,22 @@ func TestOverridesDefaults(t *testing.T) {
 		defaults           []string
 	}{
 		{
-			"Bad Servicename Delimiter",
-			"[global]\nOverrideEndpoints=true\n" +
-				"ServiceOverrides=s3|sregion, https://s3.foo.bar,  sregion\n" +
-				"ServicenameDelimiter=?",
-			true, false,
-			[]string{},
-			[]string{";", "?", ","},
-		},
-		{
-			"Custom ServicenameDelimiter",
-			"[global]\nOverrideEndpoints=true\n" +
-				"ServiceOverrides=s3?sregion, https://s3.foo.bar,  sregion\n" +
-				"ServicenameDelimiter=?",
-			false, true,
-			[]string{"s3"},
-			[]string{"&", "?", ","},
-		},
-		{
 			"Custom OverrideSeparator",
-			"[global]\nOverrideEndpoints=true\n" +
-				"ServiceOverrides=s3|sregion + https://s3.foo.bar + sregion \n" +
+			"[global]\n" +
+				"ServiceOverrides=s3 + sregion + https://s3.foo.bar + sregion \n" +
 				"OverrideSeparator=+",
 			false, true,
 			[]string{"s3"},
-			[]string{"&", "|", "+"},
-		},
-		{
-			"Custom Services Delimiter",
-			"[global]\nOverrideEndpoints=true\n" +
-				"ServiceOverrides=s3|sregion, https://s3.foo.bar, sregion + ec2|sregion, https://ec2.foo.bar , sregion\n" +
-				"ServiceDelimiter=+",
-			false, true,
-			[]string{"s3", "ec2"},
-			[]string{"+", "|", ","},
+			[]string{"+"},
 		},
 		{
 			"Active Overrides",
-			"[global]\nOverrideEndpoints=true\n" +
-				"ServiceOverrides=s3|sregion, https://s3.foo.bar , sregion & ec2|sregion, https://ec2.foo.bar, sregion",
+			"[global]\n" +
+				"ServiceOverrides=s3, sregion, https://s3.foo.bar , sregion\n" +
+				"ServiceOverrides=ec2, sregion, https://ec2.foo.bar, sregion",
 			false, true,
 			[]string{"s3", "ec2"},
-			[]string{"&", "|", ","},
+			[]string{","},
 		},
 	}
 
@@ -401,71 +362,64 @@ func TestOverridesDefaults(t *testing.T) {
 		t.Logf("Running test case %s", test.name)
 		cfg, err := readAWSCloudConfig(strings.NewReader(test.configString))
 		if err == nil {
-			err = ParseOverrides(cfg)
+			err = parseOverrides(cfg)
 		}
 		if test.expectError {
 			if err == nil {
 				t.Errorf("Should error for case %s (cfg=%v)", test.name, cfg)
 			}
-			if IsOverridesActive() != test.active {
+			if overridesActive != test.active {
 				t.Errorf("Incorrect active flag (%v vs %v) for case: %s",
-					IsOverridesActive(), test.active, test.name)
+					overridesActive, test.active, test.name)
 			}
 		} else {
 			if err != nil {
 				t.Errorf("Should succeed for case: %s", test.name)
 			}
-			if IsOverridesActive() != test.active {
+			if overridesActive != test.active {
 				t.Errorf("Incorrect active flag (%v vs %v) for case: %s",
-					IsOverridesActive(), test.active, test.name)
-			}
-			if cfg.Global.ServiceDelimiter != test.defaults[0] {
-				t.Errorf("Incorrect ServiceDelimter (%s vs %s) for case %s",
-					cfg.Global.ServiceDelimiter, test.defaults[0], test.name)
-			}
-			if cfg.Global.ServicenameDelimiter != test.defaults[1] {
-				t.Errorf("Incorrect ServicenameDelimiter (%s vs %s) for case %s",
-					cfg.Global.ServicenameDelimiter, test.defaults[1], test.name)
-			}
-			if cfg.Global.OverrideSeparator != test.defaults[2] {
-				t.Errorf("Incorrect OverrideSeparator (%s vs %s) for case %s",
-					cfg.Global.OverrideSeparator, test.defaults[2], test.name)
-			}
-			if len(overrides) != len(test.servicesOverridden) {
-				t.Errorf("Expected %d overridden services, received %d for case %s",
-					len(test.servicesOverridden), len(overrides), test.name)
+					overridesActive, test.active, test.name)
 			} else {
-				for _, name := range test.servicesOverridden {
-					signature := MakeRegionEndpointSignature(name, "sregion")
-					ep, ok := overrides[signature]
-					if !ok {
-						t.Errorf("Missing override for service %s in case %s",
-							name, test.name)
-					} else {
-						if ep.SigningRegion != "sregion" {
-							t.Errorf("Expected signing region 'sregion', received '%s' for case %s",
-								ep.SigningRegion, test.name)
-						}
-						targetName := fmt.Sprintf("https://%s.foo.bar", name)
-						if ep.Endpoint != targetName {
-							t.Errorf("Expected Endpoint '%s', received '%s' for case %s",
-								targetName, ep.Endpoint, test.name)
-						}
-
-						fn := loadCustomResolver()
-						ep1, e := fn(name, "sregion", nil)
-						if e != nil {
-							t.Errorf("Expected a valid endpoint for %s in case %s",
+				if cfg.Global.OverrideSeparator != test.defaults[0] {
+					t.Errorf("Incorrect OverrideSeparator (%s vs %s) for case %s",
+						cfg.Global.OverrideSeparator, test.defaults[0], test.name)
+				}
+				if len(overrides) != len(test.servicesOverridden) {
+					t.Errorf("Expected %d overridden services, received %d for case %s",
+						len(test.servicesOverridden), len(overrides), test.name)
+				} else {
+					for _, name := range test.servicesOverridden {
+						signature := makeRegionEndpointSignature(name, "sregion")
+						ep, ok := overrides[signature]
+						if !ok {
+							t.Errorf("Missing override for service %s in case %s",
 								name, test.name)
 						} else {
-							targetName := fmt.Sprintf("https://%s.foo.bar", name)
-							if ep1.URL != targetName {
-								t.Errorf("Expected endpoint url: %s, received %s in case %s",
-									targetName, ep1.URL, test.name)
+							if ep.SigningRegion != "sregion" {
+								t.Errorf("Expected signing region 'sregion', received '%s' for case %s",
+									ep.SigningRegion, test.name)
 							}
-							if ep1.SigningRegion != "sregion" {
-								t.Errorf("Expected signing region 'sregion', received '%s' in case %s",
-									ep1.SigningRegion, test.name)
+							targetName := fmt.Sprintf("https://%s.foo.bar", name)
+							if ep.Endpoint != targetName {
+								t.Errorf("Expected Endpoint '%s', received '%s' for case %s",
+									targetName, ep.Endpoint, test.name)
+							}
+
+							fn := loadCustomResolver()
+							ep1, e := fn(name, "sregion", nil)
+							if e != nil {
+								t.Errorf("Expected a valid endpoint for %s in case %s",
+									name, test.name)
+							} else {
+								targetName := fmt.Sprintf("https://%s.foo.bar", name)
+								if ep1.URL != targetName {
+									t.Errorf("Expected endpoint url: %s, received %s in case %s",
+										targetName, ep1.URL, test.name)
+								}
+								if ep1.SigningRegion != "sregion" {
+									t.Errorf("Expected signing region 'sregion', received '%s' in case %s",
+										ep1.SigningRegion, test.name)
+								}
 							}
 						}
 					}

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -190,6 +190,7 @@ type ServiceDescriptor struct {
 	name                         string
 	region                       string
 	signingRegion, signingMethod string
+	signingName                  string
 }
 
 func TestOverridesActiveConfig(t *testing.T) {
@@ -376,12 +377,12 @@ func TestOverridesActiveConfig(t *testing.T) {
                  URL=https://s3.foo.bar
                  SigningRegion=sregion1
 				 SigningMethod = v4
-                 
+                 SigningName = "name"
                  `),
 			nil,
 			false, true,
 			[]ServiceDescriptor{{name: "s3", region: "region1", signingRegion: "sregion1", signingMethod: "v3"},
-				{name: "s3", region: "region2", signingRegion: "sregion1", signingMethod: "v4"}},
+				{name: "s3", region: "region2", signingRegion: "sregion1", signingMethod: "v4", signingName: "name"}},
 		},
 	}
 
@@ -411,6 +412,7 @@ func TestOverridesActiveConfig(t *testing.T) {
 						URL           string
 						SigningRegion string
 						SigningMethod string
+						SigningName   string
 					}
 					for _, v := range cfg.ServiceOverride {
 						if v.Service == sd.name && v.Region == sd.region {
@@ -434,6 +436,10 @@ func TestOverridesActiveConfig(t *testing.T) {
 						if found.URL != targetName {
 							t.Errorf("Expected Endpoint '%s', received '%s' for case %s",
 								targetName, found.URL, test.name)
+						}
+						if found.SigningName != sd.signingName {
+							t.Errorf("Expected signing name '%s', received '%s' for case %s",
+								sd.signingName, found.SigningName, test.name)
 						}
 
 						fn := cfg.getResolver()

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -207,8 +207,8 @@ func TestOverridesActiveConfig(t *testing.T) {
 			strings.NewReader(`
 				[global]
 				`),
-				nil,
-				false, false,
+			nil,
+			false, false,
 			[]ServiceDescriptor{},
 		},
 		{


### PR DESCRIPTION
Solves "Allow to override default AWS endpoint #70588"

Add several new properties to AWS CloudConfig to support custom endpoints.
Initialize/Parse on aws.go init() method which gets called when aws is loaded.
Allows overridden endpoints per servce and region. This allows functionality on air gapped networks.
This change is benign if services are not overridden in CloudConfig

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #70588 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds configuration for AWS endpoint fine control:
OverrideEndpoints bool Set to true to allow custom endpoints
ServiceDelimiter string Delimiter to use to separate overridden services (multiple services) Defaults to "&"
ServicenameDelimiter string Delimiter to use to separate servicename from its configuration parameters Defaults "|"
OverrideSeparator string Delimiter to use to separate region of occurrence, url and signing region for each override Defaults to ","
ServiceOverrides string example: s3|region1, https://s3.foo.bar, some signing_region & ec2|region2, https://ec2.foo.bar, signing_region

```
