### PR TITLE
[DO NOT MERGE] hack/ginkgo-e2e.sh: debugging EKS

### DIFF
--- a/cluster/eks/OWNERS
+++ b/cluster/eks/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- gyuho
+- shyamjvs
+reviewers:
+- gyuho
+- shyamjvs

--- a/cluster/eks/util.sh
+++ b/cluster/eks/util.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Perform preparations required to run e2e tests
+function prepare-e2e() {
+  echo "[DEBUG PREPARE 1] EKS provider doesn't need special preparations for e2e tests" 1>&2
+}
+
+# Configure parameters to talk to EKS control plane
+function detect-master {
+  export KUBE_MASTER_URL="https://82C1C3D0CA24715AA09034CB99C5A5AC.yl4.us-west-2.eks.amazonaws.com"
+  if [[ "${KUBE_MASTER_URL}" ]]; then
+    echo "[DEBUG PREPARE 2] Using KUBE_MASTER_URL: ${KUBE_MASTER_URL}"
+  else
+    echo "[DEBUG PREPARE 2] KUBE_MASTER_URL is not defined!"
+    # exit 255
+  fi
+}
+
+echo "[DEBUG PREPARE 3] KUBECTL before:" $(which kubectl)
+export KUBECTL="/tmp/aws-k8s-tester/kubectl --kubeconfig=/tmp/aws-k8s-tester/kubeconfig"
+echo "[DEBUG PREPARE 4] KUBECTL after:" ${KUBECTL}
+
+export KUBECTL_PATH="/tmp/aws-k8s-tester/kubectl"
+echo "[DEBUG PREPARE 5] KUBECTL_PATH:" ${KUBECTL_PATH}
+
+echo "HELLO"
+echo "[DEBUG PREPARE 6] env"
+env
+
+#export KUBECONFIG="/tmp/aws-k8s-tester/kubeconfig"
+#echo "KUBECONFIG:" ${KUBECONFIG}
+

--- a/cluster/kube-util.sh
+++ b/cluster/kube-util.sh
@@ -38,5 +38,6 @@ PROVIDER_VARS=""
 
 PROVIDER_UTILS="${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
 if [ -f ${PROVIDER_UTILS} ]; then
+    echo "[DEBUG] loading:" ${PROVIDER_UTILS}
     source "${PROVIDER_UTILS}"
 fi

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -18,6 +18,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+echo "[DEBUG 1] env"
+env
+
+echo "[DEBUG 2] starting ginkgo-e2e.sh"
+echo "[DEBUG 3] KUBECTL:" ${KUBECTL}
+
+export KUBECTL="/tmp/aws-k8s-tester/kubectl --kubeconfig=/tmp/aws-k8s-tester/kubeconfig"
+echo "[DEBUG 4] after set KUBECTL 1:" ${KUBECTL}
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/cluster/common.sh"
 source "${KUBE_ROOT}/hack/lib/init.sh"
@@ -42,8 +51,12 @@ GINKGO_TOLERATE_FLAKES=${GINKGO_TOLERATE_FLAKES:-n}
 : ${KUBE_CONFIG_FILE:="config-test.sh"}
 
 export KUBECTL KUBE_CONFIG_FILE
+echo "[DEBUG 5] after KUBECTL KUBE_CONFIG_FILE:" ${KUBECTL}
 
 source "${KUBE_ROOT}/cluster/kube-util.sh"
+
+export KUBECTL="/tmp/aws-k8s-tester/kubectl --kubeconfig=/tmp/aws-k8s-tester/kubeconfig"
+echo "[DEBUG 6] after set KUBECTL 2:" ${KUBECTL}
 
 function detect-master-from-kubeconfig() {
     export KUBECONFIG=${KUBECONFIG:-$DEFAULT_KUBECONFIG}

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -24,6 +24,7 @@ env
 echo "[DEBUG 2] starting ginkgo-e2e.sh"
 echo "[DEBUG 3] KUBECTL:" ${KUBECTL}
 
+export KUBECONFIG="/tmp/aws-k8s-tester/kubeconfig"
 export KUBECTL="/tmp/aws-k8s-tester/kubectl --kubeconfig=/tmp/aws-k8s-tester/kubeconfig"
 echo "[DEBUG 4] after set KUBECTL 1:" ${KUBECTL}
 
@@ -51,12 +52,14 @@ GINKGO_TOLERATE_FLAKES=${GINKGO_TOLERATE_FLAKES:-n}
 : ${KUBE_CONFIG_FILE:="config-test.sh"}
 
 export KUBECTL KUBE_CONFIG_FILE
-echo "[DEBUG 5] after KUBECTL KUBE_CONFIG_FILE:" ${KUBECTL}
 
+echo "[DEBUG 5-1] after cluster/kube-util"
 source "${KUBE_ROOT}/cluster/kube-util.sh"
+echo "[DEBUG 5-2] after cluster/kube-util"
 
+echo "[DEBUG 6-1] set KUBECTL:" ${KUBECTL}
 export KUBECTL="/tmp/aws-k8s-tester/kubectl --kubeconfig=/tmp/aws-k8s-tester/kubeconfig"
-echo "[DEBUG 6] after set KUBECTL 2:" ${KUBECTL}
+echo "[DEBUG 6-2] set KUBECTL:" ${KUBECTL}
 
 function detect-master-from-kubeconfig() {
     export KUBECONFIG=${KUBECONFIG:-$DEFAULT_KUBECONFIG}


### PR DESCRIPTION
**What type of PR is this?**

/hold

**What this PR does / why we need it**:

https://k8s-testgrid.appspot.com/sig-aws-eks-ci-kubernetes-e2e-1-10#ci-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance and others are still failing:

> error during ./hack/ginkgo-e2e.sh --ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8 --report-dir=/workspace/_artifacts --disable-log-dump=true: exit status 1

We want to create a test PR in kubernetes/kubernetes to debug around "hack/ginkgo-e2e.sh" script.
In order to do that, we have created `pull-kubernetes-e2e-aws-eks-1-11-prod-conformance` here https://github.com/kubernetes/test-infra/blob/445cfb0a00afcd4441d004dbd0eafa02425c3604/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presubmits.yaml#L5.

Ref. https://github.com/kubernetes/test-infra/pull/10387
Ref. https://github.com/kubernetes/test-infra/pull/10457

**Special notes for your reviewer**:

/hold

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
