### PR TITLE
Allow enabling/disabling specific extensions/v1beta1 resources

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -474,8 +474,6 @@ func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 	ret.EnableVersions(
 		admissionregistrationv1beta1.SchemeGroupVersion,
 		apiv1.SchemeGroupVersion,
-		appsv1beta1.SchemeGroupVersion,
-		appsv1beta2.SchemeGroupVersion,
 		appsv1.SchemeGroupVersion,
 		authenticationv1.SchemeGroupVersion,
 		authenticationv1beta1.SchemeGroupVersion,
@@ -498,6 +496,24 @@ func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 		storageapiv1.SchemeGroupVersion,
 		storageapiv1beta1.SchemeGroupVersion,
 		schedulingapiv1beta1.SchemeGroupVersion,
+	)
+	// enable non-deprecated beta resources in extensions/v1beta1 explicitly so we have a full list of what's possible to serve
+	ret.EnableResources(
+		extensionsapiv1beta1.SchemeGroupVersion.WithResource("ingresses"),
+	)
+	// enable deprecated beta resources in extensions/v1beta1 explicitly so we have a full list of what's possible to serve
+	ret.EnableResources(
+		extensionsapiv1beta1.SchemeGroupVersion.WithResource("daemonsets"),
+		extensionsapiv1beta1.SchemeGroupVersion.WithResource("deployments"),
+		extensionsapiv1beta1.SchemeGroupVersion.WithResource("networkpolicies"),
+		extensionsapiv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"),
+		extensionsapiv1beta1.SchemeGroupVersion.WithResource("replicasets"),
+		extensionsapiv1beta1.SchemeGroupVersion.WithResource("replicationcontrollers"),
+	)
+	// enable deprecated beta versions explicitly so we have a full list of what's possible to serve
+	ret.EnableVersions(
+		appsv1beta1.SchemeGroupVersion,
+		appsv1beta2.SchemeGroupVersion,
 	)
 	// disable alpha versions explicitly so we have a full list of what's possible to serve
 	ret.DisableVersions(

--- a/pkg/registry/extensions/rest/storage_extensions.go
+++ b/pkg/registry/extensions/rest/storage_extensions.go
@@ -52,39 +52,53 @@ func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorag
 
 	// This is a dummy replication controller for scale subresource purposes.
 	// TODO: figure out how to enable this only if needed as a part of scale subresource GA.
-	controllerStorage := expcontrollerstore.NewStorage(restOptionsGetter)
-	storage["replicationcontrollers"] = controllerStorage.ReplicationController
-	storage["replicationcontrollers/scale"] = controllerStorage.Scale
+	if apiResourceConfigSource.ResourceEnabled(extensionsapiv1beta1.SchemeGroupVersion.WithResource("replicationcontrollers")) {
+		controllerStorage := expcontrollerstore.NewStorage(restOptionsGetter)
+		storage["replicationcontrollers"] = controllerStorage.ReplicationController
+		storage["replicationcontrollers/scale"] = controllerStorage.Scale
+	}
 
 	// daemonsets
-	daemonSetStorage, daemonSetStatusStorage := daemonstore.NewREST(restOptionsGetter)
-	storage["daemonsets"] = daemonSetStorage.WithCategories(nil)
-	storage["daemonsets/status"] = daemonSetStatusStorage
+	if apiResourceConfigSource.ResourceEnabled(extensionsapiv1beta1.SchemeGroupVersion.WithResource("daemonsets")) {
+		daemonSetStorage, daemonSetStatusStorage := daemonstore.NewREST(restOptionsGetter)
+		storage["daemonsets"] = daemonSetStorage.WithCategories(nil)
+		storage["daemonsets/status"] = daemonSetStatusStorage
+	}
 
 	//deployments
-	deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
-	storage["deployments"] = deploymentStorage.Deployment.WithCategories(nil)
-	storage["deployments/status"] = deploymentStorage.Status
-	storage["deployments/rollback"] = deploymentStorage.Rollback
-	storage["deployments/scale"] = deploymentStorage.Scale
+	if apiResourceConfigSource.ResourceEnabled(extensionsapiv1beta1.SchemeGroupVersion.WithResource("deployments")) {
+		deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
+		storage["deployments"] = deploymentStorage.Deployment.WithCategories(nil)
+		storage["deployments/status"] = deploymentStorage.Status
+		storage["deployments/rollback"] = deploymentStorage.Rollback
+		storage["deployments/scale"] = deploymentStorage.Scale
+	}
 	// ingresses
-	ingressStorage, ingressStatusStorage := ingressstore.NewREST(restOptionsGetter)
-	storage["ingresses"] = ingressStorage
-	storage["ingresses/status"] = ingressStatusStorage
+	if apiResourceConfigSource.ResourceEnabled(extensionsapiv1beta1.SchemeGroupVersion.WithResource("ingresses")) {
+		ingressStorage, ingressStatusStorage := ingressstore.NewREST(restOptionsGetter)
+		storage["ingresses"] = ingressStorage
+		storage["ingresses/status"] = ingressStatusStorage
+	}
 
 	// podsecuritypolicy
-	podSecurityPolicyStorage := pspstore.NewREST(restOptionsGetter)
-	storage["podSecurityPolicies"] = podSecurityPolicyStorage
+	if apiResourceConfigSource.ResourceEnabled(extensionsapiv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies")) {
+		podSecurityPolicyStorage := pspstore.NewREST(restOptionsGetter)
+		storage["podSecurityPolicies"] = podSecurityPolicyStorage
+	}
 
 	// replicasets
-	replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
-	storage["replicasets"] = replicaSetStorage.ReplicaSet.WithCategories(nil)
-	storage["replicasets/status"] = replicaSetStorage.Status
-	storage["replicasets/scale"] = replicaSetStorage.Scale
+	if apiResourceConfigSource.ResourceEnabled(extensionsapiv1beta1.SchemeGroupVersion.WithResource("replicasets")) {
+		replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
+		storage["replicasets"] = replicaSetStorage.ReplicaSet.WithCategories(nil)
+		storage["replicasets/status"] = replicaSetStorage.Status
+		storage["replicasets/scale"] = replicaSetStorage.Scale
+	}
 
 	// networkpolicies
-	networkExtensionsStorage := networkpolicystore.NewREST(restOptionsGetter)
-	storage["networkpolicies"] = networkExtensionsStorage
+	if apiResourceConfigSource.ResourceEnabled(extensionsapiv1beta1.SchemeGroupVersion.WithResource("networkpolicies")) {
+		networkExtensionsStorage := networkpolicystore.NewREST(restOptionsGetter)
+		storage["networkpolicies"] = networkExtensionsStorage
+	}
 
 	return storage
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
@@ -23,6 +23,7 @@ import (
 // APIResourceConfigSource is the interface to determine which groups and versions are enabled
 type APIResourceConfigSource interface {
 	VersionEnabled(version schema.GroupVersion) bool
+	ResourceEnabled(resource schema.GroupVersionResource) bool
 	AnyVersionForGroupEnabled(group string) bool
 }
 
@@ -30,21 +31,28 @@ var _ APIResourceConfigSource = &ResourceConfig{}
 
 type ResourceConfig struct {
 	GroupVersionConfigs map[schema.GroupVersion]bool
+	ResourceConfigs     map[schema.GroupVersionResource]bool
 }
 
 func NewResourceConfig() *ResourceConfig {
-	return &ResourceConfig{GroupVersionConfigs: map[schema.GroupVersion]bool{}}
+	return &ResourceConfig{GroupVersionConfigs: map[schema.GroupVersion]bool{}, ResourceConfigs: map[schema.GroupVersionResource]bool{}}
 }
 
 func (o *ResourceConfig) DisableAll() {
 	for k := range o.GroupVersionConfigs {
 		o.GroupVersionConfigs[k] = false
 	}
+	for k := range o.ResourceConfigs {
+		o.ResourceConfigs[k] = false
+	}
 }
 
 func (o *ResourceConfig) EnableAll() {
 	for k := range o.GroupVersionConfigs {
 		o.GroupVersionConfigs[k] = true
+	}
+	for k := range o.ResourceConfigs {
+		o.ResourceConfigs[k] = true
 	}
 }
 
@@ -68,6 +76,29 @@ func (o *ResourceConfig) VersionEnabled(version schema.GroupVersion) bool {
 	}
 
 	return false
+}
+
+func (o *ResourceConfig) DisableResources(resources ...schema.GroupVersionResource) {
+	for _, resource := range resources {
+		o.ResourceConfigs[resource] = false
+	}
+}
+
+func (o *ResourceConfig) EnableResources(resources ...schema.GroupVersionResource) {
+	for _, resource := range resources {
+		o.ResourceConfigs[resource] = true
+	}
+}
+
+func (o *ResourceConfig) ResourceEnabled(resource schema.GroupVersionResource) bool {
+	if !o.VersionEnabled(resource.GroupVersion()) {
+		return false
+	}
+	resourceEnabled, explicitlySet := o.ResourceConfigs[resource]
+	if !explicitlySet {
+		return true
+	}
+	return resourceEnabled
 }
 
 func (o *ResourceConfig) AnyVersionForGroupEnabled(group string) bool {

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
@@ -43,6 +43,84 @@ func TestDisabledVersion(t *testing.T) {
 	}
 }
 
+func TestDisabledResource(t *testing.T) {
+	g1v1 := schema.GroupVersion{Group: "group1", Version: "version1"}
+	g1v1rUnspecified := g1v1.WithResource("unspecified")
+	g1v1rEnabled := g1v1.WithResource("enabled")
+	g1v1rDisabled := g1v1.WithResource("disabled")
+	g1v2 := schema.GroupVersion{Group: "group1", Version: "version2"}
+	g1v2rUnspecified := g1v2.WithResource("unspecified")
+	g1v2rEnabled := g1v2.WithResource("enabled")
+	g1v2rDisabled := g1v2.WithResource("disabled")
+	g2v1 := schema.GroupVersion{Group: "group2", Version: "version1"}
+	g2v1rUnspecified := g2v1.WithResource("unspecified")
+	g2v1rEnabled := g2v1.WithResource("enabled")
+	g2v1rDisabled := g2v1.WithResource("disabled")
+
+	config := NewResourceConfig()
+
+	config.DisableVersions(g1v1)
+	config.EnableVersions(g1v2, g2v1)
+
+	config.EnableResources(g1v1rEnabled, g1v2rEnabled, g2v1rEnabled)
+	config.DisableResources(g1v1rDisabled, g1v2rDisabled, g2v1rDisabled)
+
+	// all resources under g1v1 are disabled because the group-version is disabled
+	if config.ResourceEnabled(g1v1rUnspecified) {
+		t.Errorf("expected disabled for %v, from %v", g1v1rUnspecified, config)
+	}
+	if config.ResourceEnabled(g1v1rEnabled) {
+		t.Errorf("expected disabled for %v, from %v", g1v1rEnabled, config)
+	}
+	if config.ResourceEnabled(g1v1rDisabled) {
+		t.Errorf("expected disabled for %v, from %v", g1v1rDisabled, config)
+	}
+
+	// explicitly disabled resources in enabled group-versions are disabled
+	if config.ResourceEnabled(g1v2rDisabled) {
+		t.Errorf("expected disabled for %v, from %v", g1v2rDisabled, config)
+	}
+	if config.ResourceEnabled(g2v1rDisabled) {
+		t.Errorf("expected disabled for %v, from %v", g2v1rDisabled, config)
+	}
+
+	// unspecified and explicitly enabled resources in enabled group-versions are enabled
+	if !config.ResourceEnabled(g1v2rUnspecified) {
+		t.Errorf("expected enabled for %v, from %v", g1v2rUnspecified, config)
+	}
+	if !config.ResourceEnabled(g1v2rEnabled) {
+		t.Errorf("expected enabled for %v, from %v", g1v2rEnabled, config)
+	}
+	if !config.ResourceEnabled(g2v1rUnspecified) {
+		t.Errorf("expected enabled for %v, from %v", g2v1rUnspecified, config)
+	}
+	if !config.ResourceEnabled(g2v1rEnabled) {
+		t.Errorf("expected enabled for %v, from %v", g2v1rEnabled, config)
+	}
+
+	// Enable all enables specific resources
+	config.EnableAll()
+
+	// all resources under g1v1 are now enabled
+	if !config.ResourceEnabled(g1v1rUnspecified) {
+		t.Errorf("expected enabled for %v, from %v", g1v1rUnspecified, config)
+	}
+	if !config.ResourceEnabled(g1v1rEnabled) {
+		t.Errorf("expected enabled for %v, from %v", g1v1rEnabled, config)
+	}
+	if !config.ResourceEnabled(g1v1rDisabled) {
+		t.Errorf("expected enabled for %v, from %v", g1v1rDisabled, config)
+	}
+
+	// previously disabled resources are now enabled
+	if !config.ResourceEnabled(g1v2rDisabled) {
+		t.Errorf("expected enabled for %v, from %v", g1v2rDisabled, config)
+	}
+	if !config.ResourceEnabled(g2v1rDisabled) {
+		t.Errorf("expected enabled for %v, from %v", g2v1rDisabled, config)
+	}
+}
+
 func TestAnyVersionForGroupEnabled(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Re-enables `--runtime-config` to control specific resources in the extensions/v1beta1 API group. This is extracted from https://github.com/kubernetes/kubernetes/pull/70672 and will eventually be used to stop serving the deprecated resources in that group by default, while giving users a way to re-enable them for a few releases.

Note that [current documentation](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#enabling-resources-in-the-groups) still references this mechanism.

**Which issue(s) this PR fixes**:
Fixes #62044

**Does this PR introduce a user-facing change?**:
```release-note
kube-apiserver: `--runtime-config` can once again be used to enable/disable serving specific resources in the `extensions/v1beta1` API group. Note that specific resource enablement/disablement is only allowed for the `extensions/v1beta1` API group for legacy reasons. Attempts to enable/disable individual resources in other API groups will print a warning, and will return an error in future releases.
```

/cc @deads2k @lavalamp 
@kubernetes/sig-api-machinery-pr-reviews 