### PR TITLE
enable overrrides for certificate files

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -208,7 +208,9 @@ func getServerIdentificationPartialConfig(configAuthInfo clientcmdapi.AuthInfo, 
 	// configClusterInfo holds the information identify the server provided by .kubeconfig
 	configClientConfig := &restclient.Config{}
 	configClientConfig.CAFile = configClusterInfo.CertificateAuthority
-	configClientConfig.CAData = configClusterInfo.CertificateAuthorityData
+	if len(configClientConfig.CAFile) == 0 {
+		configClientConfig.CAData = configClusterInfo.CertificateAuthorityData
+	}
 	configClientConfig.Insecure = configClusterInfo.InsecureSkipTLSVerify
 	mergo.MergeWithOverwrite(mergedConfig, configClientConfig)
 
@@ -245,9 +247,13 @@ func (config *DirectClientConfig) getUserIdentificationPartialConfig(configAuthI
 	}
 	if len(configAuthInfo.ClientCertificate) > 0 || len(configAuthInfo.ClientCertificateData) > 0 {
 		mergedConfig.CertFile = configAuthInfo.ClientCertificate
-		mergedConfig.CertData = configAuthInfo.ClientCertificateData
+		if len(mergedConfig.CertFile) == 0 {
+			mergedConfig.CertData = configAuthInfo.ClientCertificateData
+		}
 		mergedConfig.KeyFile = configAuthInfo.ClientKey
-		mergedConfig.KeyData = configAuthInfo.ClientKeyData
+		if len(mergedConfig.KeyFile) == 0 {
+			mergedConfig.KeyData = configAuthInfo.ClientKeyData
+		}
 	}
 	if len(configAuthInfo.Username) > 0 || len(configAuthInfo.Password) > 0 {
 		mergedConfig.Username = configAuthInfo.Username

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
@@ -179,10 +179,6 @@ func validateClusterInfo(clusterName string, clusterInfo clientcmdapi.Cluster) [
 			validationErrors = append(validationErrors, fmt.Errorf("no server found for cluster %q", clusterName))
 		}
 	}
-	// Make sure CA data and CA file aren't both specified
-	if len(clusterInfo.CertificateAuthority) != 0 && len(clusterInfo.CertificateAuthorityData) != 0 {
-		validationErrors = append(validationErrors, fmt.Errorf("certificate-authority-data and certificate-authority are both specified for %v. certificate-authority-data will override.", clusterName))
-	}
 	if len(clusterInfo.CertificateAuthority) != 0 {
 		clientCertCA, err := os.Open(clusterInfo.CertificateAuthority)
 		defer clientCertCA.Close()
@@ -208,14 +204,6 @@ func validateAuthInfo(authInfoName string, authInfo clientcmdapi.AuthInfo) []err
 	}
 
 	if len(authInfo.ClientCertificate) != 0 || len(authInfo.ClientCertificateData) != 0 {
-		// Make sure cert data and file aren't both specified
-		if len(authInfo.ClientCertificate) != 0 && len(authInfo.ClientCertificateData) != 0 {
-			validationErrors = append(validationErrors, fmt.Errorf("client-cert-data and client-cert are both specified for %v. client-cert-data will override.", authInfoName))
-		}
-		// Make sure key data and file aren't both specified
-		if len(authInfo.ClientKey) != 0 && len(authInfo.ClientKeyData) != 0 {
-			validationErrors = append(validationErrors, fmt.Errorf("client-key-data and client-key are both specified for %v; client-key-data will override", authInfoName))
-		}
 		// Make sure a key is specified
 		if len(authInfo.ClientKey) == 0 && len(authInfo.ClientKeyData) == 0 {
 			validationErrors = append(validationErrors, fmt.Errorf("client-key-data or client-key must be specified for %v to use the clientCert authentication method.", authInfoName))


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

This PR enables overrides when specifying `certificate-authority` `client-cert` `client-key` options for kubectl

**Which issue(s) this PR fixes**:
Fixes #48767

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
