### PR TITLE
Add pods in the backoff queue to the list of pending pods

### DIFF
--- a/pkg/scheduler/internal/cache/debugger/comparer.go
+++ b/pkg/scheduler/internal/cache/debugger/comparer.go
@@ -54,13 +54,13 @@ func (c *CacheComparer) Compare() error {
 
 	snapshot := c.Cache.Snapshot()
 
-	waitingPods := c.PodQueue.WaitingPods()
+	pendingPods := c.PodQueue.PendingPods()
 
 	if missed, redundant := c.CompareNodes(nodes, snapshot.Nodes); len(missed)+len(redundant) != 0 {
 		klog.Warningf("cache mismatch: missed nodes: %s; redundant nodes: %s", missed, redundant)
 	}
 
-	if missed, redundant := c.ComparePods(pods, waitingPods, snapshot.Nodes); len(missed)+len(redundant) != 0 {
+	if missed, redundant := c.ComparePods(pods, pendingPods, snapshot.Nodes); len(missed)+len(redundant) != 0 {
 		klog.Warningf("cache mismatch: missed pods: %s; redundant pods: %s", missed, redundant)
 	}
 

--- a/pkg/scheduler/internal/cache/debugger/dumper.go
+++ b/pkg/scheduler/internal/cache/debugger/dumper.go
@@ -52,9 +52,9 @@ func (d *CacheDumper) dumpNodes() {
 
 // dumpSchedulingQueue writes pods in the scheduling queue to the scheduler logs.
 func (d *CacheDumper) dumpSchedulingQueue() {
-	waitingPods := d.podQueue.WaitingPods()
+	pendingPods := d.podQueue.PendingPods()
 	var podData strings.Builder
-	for _, p := range waitingPods {
+	for _, p := range pendingPods {
 		podData.WriteString(printPod(p))
 	}
 	klog.Infof("Dump of scheduling queue:\n%s", podData.String())

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -338,6 +338,22 @@ func TestPriorityQueue_WaitingPodsForNode(t *testing.T) {
 	}
 }
 
+func TestPriorityQueue_PendingPods(t *testing.T) {
+	q := NewPriorityQueue(nil)
+	q.Add(&medPriorityPod)
+	q.unschedulableQ.addOrUpdate(&unschedulablePod)
+	q.unschedulableQ.addOrUpdate(&highPriorityPod)
+	expectedList := []*v1.Pod{&medPriorityPod, &unschedulablePod, &highPriorityPod}
+	if !reflect.DeepEqual(expectedList, q.PendingPods()) {
+		t.Error("Unexpected list of pending Pods for node.")
+	}
+	// Move all to active queue. We should still see the same set of pods.
+	q.MoveAllToActiveQueue()
+	if !reflect.DeepEqual(expectedList, q.PendingPods()) {
+		t.Error("Unexpected list of pending Pods for node.")
+	}
+}
+
 func TestUnschedulablePodsMap(t *testing.T) {
 	var pods = []*v1.Pod{
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
After we added "backoff queue" to the scheduling queue, we didn't fix a function that returns all pending pods. That function is used only for debugging.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig scheduling