### PR TITLE
The release-1.12 branch requires bazel 0.17.1+ now

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -41,7 +41,7 @@ http_archive(
 
 load("@bazel_skylib//:lib.bzl", "versions")
 
-versions.check(minimum_bazel_version = "0.16.0")
+versions.check(minimum_bazel_version = "0.17.1")
 
 load("@io_bazel_rules_go//go:def.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_pull", "docker_repositories")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: in #71675 I inadvertently required a slightly newer bazel, as one of the attributes I was using was [first added in bazel 0.17.1](https://github.com/bazelbuild/bazel/commit/2c9c05b3960914b9120566bf680f2280c1857f82).

I've already updated the version of bazel we use for this branch on Prow in https://github.com/kubernetes/test-infra/pull/10350, but I keep getting bit by not using the right bazel version in other places. By updating this check, it becomes a little easier to debug.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @BenTheElder @feiskyer 