### PR TITLE
[WIP] Using size ranges for e2e storage drivers and tests

### DIFF
--- a/test/e2e/framework/volume_util.go
+++ b/test/e2e/framework/volume_util.go
@@ -74,6 +74,13 @@ const (
 	PodCleanupTimeout = 20 * time.Second
 )
 
+// SizeRange encapsulates a size range (along with its units) [min,max] that a storage driver supports.
+type SizeRange struct {
+	Max   float64 // Max size specified
+	Min   float64 // Min size specified
+	Units string  // The units in which Min and Max were specified
+}
+
 // Configuration of one tests. The test consist of:
 // - server pod - runs serverImage, exports ports[]
 // - client pod - does not need any special configuration

--- a/test/e2e/storage/drivers/base.go
+++ b/test/e2e/storage/drivers/base.go
@@ -92,6 +92,7 @@ type DriverInfo struct {
 	FeatureTag string // FeatureTag for the driver
 
 	MaxFileSize          int64               // Max file size to be tested for this driver
+	SupportedSizeRange   framework.SizeRange // The range of size supported by this driver
 	SupportedFsType      sets.String         // Map of string for supported fs type
 	SupportedMountOption sets.String         // Map of string for supported mount option
 	RequiredMountOption  sets.String         // Map of string for required mount option (Optional)

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -63,6 +63,11 @@ func InitHostPathCSIDriver() TestDriver {
 			Name:        "csi-hostpath",
 			FeatureTag:  "",
 			MaxFileSize: testpatterns.FileSizeMedium,
+			SupportedVolSize: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -152,6 +157,11 @@ func InitHostV0PathCSIDriver() TestDriver {
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
+			SupportedVolSize: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			Capabilities: map[Capability]bool{
 				CapPersistence: true,
 			},
@@ -235,6 +245,11 @@ func InitGcePDCSIDriver() TestDriver {
 			Name:        "pd.csi.storage.gke.io",
 			FeatureTag:  "[Serial]",
 			MaxFileSize: testpatterns.FileSizeMedium,
+			SupportedVolSize: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 				"ext2",
@@ -331,6 +346,11 @@ func InitGcePDExternalCSIDriver() TestDriver {
 				"ext4",
 				"xfs",
 			),
+			SupportedVolSize: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(1),
+				Units: "Gi",
+			},
 			Capabilities: map[Capability]bool{
 				CapPersistence: true,
 				CapFsGroup:     true,

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -88,6 +88,11 @@ func InitNFSDriver() TestDriver {
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
+			SupportedVolSize: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedMountOption: sets.NewString("proto=tcp", "relatime"),
 			RequiredMountOption:  sets.NewString("vers=4.1"),
 			Capabilities: map[Capability]bool{
@@ -233,6 +238,11 @@ func InitGlusterFSDriver() TestDriver {
 		driverInfo: DriverInfo{
 			Name:        "gluster",
 			MaxFileSize: testpatterns.FileSizeMedium,
+			SupportedVolSize: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -351,6 +361,11 @@ func InitISCSIDriver() TestDriver {
 			Name:        "iscsi",
 			FeatureTag:  "[Feature:Volumes]",
 			MaxFileSize: testpatterns.FileSizeMedium,
+			SupportedVolSize: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 				"ext2",
@@ -591,6 +606,11 @@ func InitCephFSDriver() TestDriver {
 			Name:        "ceph",
 			FeatureTag:  "[Feature:Volumes]",
 			MaxFileSize: testpatterns.FileSizeMedium,
+			SupportedSizeRange: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -691,6 +711,11 @@ func InitHostPathDriver() TestDriver {
 		driverInfo: DriverInfo{
 			Name:        "hostPath",
 			MaxFileSize: testpatterns.FileSizeMedium,
+			SupportedSizeRange: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -763,6 +788,11 @@ func InitHostPathSymlinkDriver() TestDriver {
 		driverInfo: DriverInfo{
 			Name:        "hostPathSymlink",
 			MaxFileSize: testpatterns.FileSizeMedium,
+			SupportedSizeRange: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -969,6 +999,11 @@ func InitCinderDriver() TestDriver {
 		driverInfo: DriverInfo{
 			Name:        "cinder",
 			MaxFileSize: testpatterns.FileSizeMedium,
+			SupportedSizeRange: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 				"ext3",
@@ -1132,6 +1167,11 @@ func InitGcePdDriver() TestDriver {
 				"ext4",
 				"xfs",
 			),
+			SupportedSizeRange: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedMountOption: sets.NewString("debug", "nouid32"),
 			Capabilities: map[Capability]bool{
 				CapPersistence: true,
@@ -1246,6 +1286,11 @@ func InitVSphereDriver() TestDriver {
 		driverInfo: DriverInfo{
 			Name:        "vSphere",
 			MaxFileSize: testpatterns.FileSizeMedium,
+			SupportedSizeRange: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 				"ext4",
@@ -1364,6 +1409,11 @@ func InitAzureDriver() TestDriver {
 		driverInfo: DriverInfo{
 			Name:        "azure",
 			MaxFileSize: testpatterns.FileSizeMedium,
+			SupportedSizeRange: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 				"ext4",
@@ -1479,6 +1529,11 @@ func InitAwsDriver() TestDriver {
 		driverInfo: DriverInfo{
 			Name:        "aws",
 			MaxFileSize: testpatterns.FileSizeMedium,
+			SupportedSizeRange: framework.SizeRange{
+				Min:   float64(1),
+				Max:   float64(3),
+				Units: "Gi",
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 				"ext3",

--- a/test/e2e/storage/testpatterns/testpattern.go
+++ b/test/e2e/storage/testpatterns/testpattern.go
@@ -47,11 +47,12 @@ var (
 
 // TestPattern represents a combination of parameters to be tested in a TestSuite
 type TestPattern struct {
-	Name       string                  // Name of TestPattern
-	FeatureTag string                  // featureTag for the TestSuite
-	VolType    TestVolType             // Volume type of the volume
-	FsType     string                  // Fstype of the volume
-	VolMode    v1.PersistentVolumeMode // PersistentVolumeMode of the volume
+	Name               string      // Name of TestPattern
+	FeatureTag         string      // featureTag for the TestSuite
+	VolType            TestVolType // Volume type of the volume
+	FsType             string      // Fstype of the volume
+	SupportedSizeRange Size
+	VolMode            v1.PersistentVolumeMode // PersistentVolumeMode of the volume
 }
 
 var (
@@ -61,16 +62,31 @@ var (
 	DefaultFsInlineVolume = TestPattern{
 		Name:    "Inline-volume (default fs)",
 		VolType: InlineVolume,
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 	// DefaultFsPreprovisionedPV is TestPattern for "Pre-provisioned PV (default fs)"
 	DefaultFsPreprovisionedPV = TestPattern{
 		Name:    "Pre-provisioned PV (default fs)",
 		VolType: PreprovisionedPV,
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 	// DefaultFsDynamicPV is TestPattern for "Dynamic PV (default fs)"
 	DefaultFsDynamicPV = TestPattern{
 		Name:    "Dynamic PV (default fs)",
 		VolType: DynamicPV,
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 
 	// Definitions for ext3
@@ -80,18 +96,33 @@ var (
 		Name:    "Inline-volume (ext3)",
 		VolType: InlineVolume,
 		FsType:  "ext3",
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 	// Ext3PreprovisionedPV is TestPattern for "Pre-provisioned PV (ext3)"
 	Ext3PreprovisionedPV = TestPattern{
 		Name:    "Pre-provisioned PV (ext3)",
 		VolType: PreprovisionedPV,
 		FsType:  "ext3",
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 	// Ext3DynamicPV is TestPattern for "Dynamic PV (ext3)"
 	Ext3DynamicPV = TestPattern{
 		Name:    "Dynamic PV (ext3)",
 		VolType: DynamicPV,
 		FsType:  "ext3",
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 
 	// Definitions for ext4
@@ -101,18 +132,33 @@ var (
 		Name:    "Inline-volume (ext4)",
 		VolType: InlineVolume,
 		FsType:  "ext4",
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 	// Ext4PreprovisionedPV is TestPattern for "Pre-provisioned PV (ext4)"
 	Ext4PreprovisionedPV = TestPattern{
 		Name:    "Pre-provisioned PV (ext4)",
 		VolType: PreprovisionedPV,
 		FsType:  "ext4",
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 	// Ext4DynamicPV is TestPattern for "Dynamic PV (ext4)"
 	Ext4DynamicPV = TestPattern{
 		Name:    "Dynamic PV (ext4)",
 		VolType: DynamicPV,
 		FsType:  "ext4",
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 
 	// Definitions for xfs
@@ -122,18 +168,33 @@ var (
 		Name:    "Inline-volume (xfs)",
 		VolType: InlineVolume,
 		FsType:  "xfs",
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 	// XfsPreprovisionedPV is TestPattern for "Pre-provisioned PV (xfs)"
 	XfsPreprovisionedPV = TestPattern{
 		Name:    "Pre-provisioned PV (xfs)",
 		VolType: PreprovisionedPV,
 		FsType:  "xfs",
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 	// XfsDynamicPV is TestPattern for "Dynamic PV (xfs)"
 	XfsDynamicPV = TestPattern{
 		Name:    "Dynamic PV (xfs)",
 		VolType: DynamicPV,
 		FsType:  "xfs",
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 
 	// Definitions for Filesystem volume mode
@@ -143,12 +204,22 @@ var (
 		Name:    "Pre-provisioned PV (filesystem volmode)",
 		VolType: PreprovisionedPV,
 		VolMode: v1.PersistentVolumeFilesystem,
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 	// FsVolModeDynamicPV is TestPattern for "Dynamic PV (filesystem)"
 	FsVolModeDynamicPV = TestPattern{
 		Name:    "Dynamic PV (filesystem volmode)",
 		VolType: DynamicPV,
 		VolMode: v1.PersistentVolumeFilesystem,
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 
 	// Definitions for block volume mode
@@ -158,11 +229,21 @@ var (
 		Name:    "Pre-provisioned PV (block volmode)",
 		VolType: PreprovisionedPV,
 		VolMode: v1.PersistentVolumeBlock,
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 	// BlockVolModeDynamicPV is TestPattern for "Dynamic PV (block)(immediate bind)"
 	BlockVolModeDynamicPV = TestPattern{
 		Name:    "Dynamic PV (block volmode)",
 		VolType: DynamicPV,
 		VolMode: v1.PersistentVolumeBlock,
+		SupportedSizeRange: framework.SizeRange{
+			Min:   float64(1),
+			Max:   float64(2),
+			Units: "Gi",
+		},
 	}
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
