### PR TITLE
call createValidation before rollback. Fixes #72256

### DIFF
--- a/pkg/registry/apps/deployment/storage/storage.go
+++ b/pkg/registry/apps/deployment/storage/storage.go
@@ -166,6 +166,12 @@ func (r *RollbackREST) Create(ctx context.Context, obj runtime.Object, createVal
 		return nil, errors.NewBadRequest(fmt.Sprintf("not a DeploymentRollback: %#v", obj))
 	}
 
+	if createValidation != nil {
+		if err := createValidation(obj.DeepCopyObject()); err != nil {
+			return nil, err
+		}
+	}
+
 	if errs := appsvalidation.ValidateDeploymentRollback(rollback); len(errs) != 0 {
 		return nil, errors.NewInvalid(apps.Kind("DeploymentRollback"), rollback.Name, errs)
 	}

--- a/pkg/registry/core/serviceaccount/storage/token.go
+++ b/pkg/registry/core/serviceaccount/storage/token.go
@@ -58,8 +58,10 @@ var gvk = schema.GroupVersionKind{
 }
 
 func (r *TokenREST) Create(ctx context.Context, name string, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
-	if err := createValidation(obj); err != nil {
-		return nil, err
+	if createValidation != nil {
+		if err := createValidation(obj.DeepCopyObject()); err != nil {
+			return nil, err
+		}
 	}
 
 	out := obj.(*authenticationapi.TokenRequest)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig apps
/sig api-machinery

**What this PR does / why we need it**:
Ensures validation for rollback requests

**Which issue(s) this PR fixes**:

Fixes #72256 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE 

```release-note
`deployments/rollback` is now passed through validation/admission controllers
```

