### PR TITLE
fix APIServer crashes on timeout

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/BUILD
@@ -17,6 +17,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
@@ -259,6 +259,9 @@ func WithRequestInfo(parent context.Context, info *RequestInfo) context.Context 
 
 // RequestInfoFrom returns the value of the RequestInfo key on the ctx
 func RequestInfoFrom(ctx context.Context) (*RequestInfo, bool) {
+	if ctx == nil {
+		return nil, false
+	}
 	info, ok := ctx.Value(requestInfoKey).(*RequestInfo)
 	return info, ok
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -262,4 +264,9 @@ func TestFieldSelectorParsing(t *testing.T) {
 			t.Errorf("%s: expected verb %v, actual %v", tc.name, e, a)
 		}
 	}
+}
+
+func TestNilContext(t *testing.T) {
+	_, ok := RequestInfoFrom(nil)
+	assert.False(t, ok)
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Check if the context is empty before trying to get RequestInfo from it

Change-Id: I4a8c233c83594ca4087037333643dff41351b95c

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72095

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
