### PR TITLE
[scheduler] Move predicate & priority registration to separate file

### DIFF
--- a/pkg/scheduler/algorithm/priorities/BUILD
+++ b/pkg/scheduler/algorithm/priorities/BUILD
@@ -18,6 +18,7 @@ go_library(
         "node_affinity.go",
         "node_label.go",
         "node_prefer_avoid_pods.go",
+        "priorities.go",
         "reduce.go",
         "requested_to_capacity_ratio.go",
         "resource_allocation.go",

--- a/pkg/scheduler/algorithm/priorities/priorities.go
+++ b/pkg/scheduler/algorithm/priorities/priorities.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package priorities
+
+const (
+	// EqualPriority defines the name of prioritizer function that gives an equal weight of one to all nodes.
+	EqualPriority = "EqualPriority"
+	// MostRequestedPriority defines the name of prioritizer function that gives used nodes higher priority.
+	MostRequestedPriority = "MostRequestedPriority"
+	// RequestedToCapacityRatioPriority defines the name of RequestedToCapacityRatioPriority.
+	RequestedToCapacityRatioPriority = "RequestedToCapacityRatioPriority"
+	// SelectorSpreadPriority defines the name of prioritizer function that spreads pods by minimizing
+	// the number of pods (belonging to the same service or replication controller) on the same node.
+	SelectorSpreadPriority = "SelectorSpreadPriority"
+	// ServiceSpreadingPriority is largely replaced by "SelectorSpreadPriority".
+	ServiceSpreadingPriority = "ServiceSpreadingPriority"
+	// InterPodAffinityPriority defines the name of prioritizer function that decides which pods should or
+	// should not be placed in the same topological domain as some other pods.
+	InterPodAffinityPriority = "InterPodAffinityPriority"
+	// LeastRequestedPriority defines the name of prioritizer function that prioritize nodes by least
+	// requested utilization.
+	LeastRequestedPriority = "LeastRequestedPriority"
+	// BalancedResourceAllocation defines the name of prioritizer function that prioritizes nodes
+	// to help achieve balanced resource usage.
+	BalancedResourceAllocation = "BalancedResourceAllocation"
+	// NodePreferAvoidPodsPriority defines the name of prioritizer function that priorities nodes according to
+	// the node annotation "scheduler.alpha.kubernetes.io/preferAvoidPods".
+	NodePreferAvoidPodsPriority = "NodePreferAvoidPodsPriority"
+	// NodeAffinityPriority defines the name of prioritizer function that prioritizes nodes which have labels
+	// matching NodeAffinity.
+	NodeAffinityPriority = "NodeAffinityPriority"
+	// TaintTolerationPriority defines the name of prioritizer function that prioritizes nodes that marked
+	// with taint which pod can tolerate.
+	TaintTolerationPriority = "TaintTolerationPriority"
+	// ImageLocalityPriority defines the name of prioritizer function that prioritizes nodes that have images
+	// requested by the pod present.
+	ImageLocalityPriority = "ImageLocalityPriority"
+	// ResourceLimitsPriority defines the nodes of prioritizer function ResourceLimitsPriority.
+	ResourceLimitsPriority = "ResourceLimitsPriority"
+)

--- a/pkg/scheduler/algorithmprovider/defaults/BUILD
+++ b/pkg/scheduler/algorithmprovider/defaults/BUILD
@@ -8,7 +8,11 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["defaults.go"],
+    srcs = [
+        "defaults.go",
+        "register_predicates.go",
+        "register_priorities.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/algorithmprovider/defaults",
     deps = [
         "//pkg/features:go_default_library",
@@ -29,6 +33,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/scheduler/algorithm/predicates:go_default_library",
+        "//pkg/scheduler/algorithm/priorities:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )

--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -23,10 +23,8 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/priorities"
-	"k8s.io/kubernetes/pkg/scheduler/core"
 	"k8s.io/kubernetes/pkg/scheduler/factory"
 )
 
@@ -36,139 +34,25 @@ const (
 )
 
 func init() {
-	// Register functions that extract metadata used by predicates and priorities computations.
-	factory.RegisterPredicateMetadataProducerFactory(
-		func(args factory.PluginFactoryArgs) predicates.PredicateMetadataProducer {
-			return predicates.NewPredicateMetadataFactory(args.PodLister)
-		})
-	factory.RegisterPriorityMetadataProducerFactory(
-		func(args factory.PluginFactoryArgs) algorithm.PriorityMetadataProducer {
-			return priorities.NewPriorityMetadataFactory(args.ServiceLister, args.ControllerLister, args.ReplicaSetLister, args.StatefulSetLister)
-		})
-
 	registerAlgorithmProvider(defaultPredicates(), defaultPriorities())
-
-	// IMPORTANT NOTES for predicate developers:
-	// Registers predicates and priorities that are not enabled by default, but user can pick when creating their
-	// own set of priorities/predicates.
-
-	// PodFitsPorts has been replaced by PodFitsHostPorts for better user understanding.
-	// For backwards compatibility with 1.0, PodFitsPorts is registered as well.
-	factory.RegisterFitPredicate("PodFitsPorts", predicates.PodFitsHostPorts)
-	// Fit is defined based on the absence of port conflicts.
-	// This predicate is actually a default predicate, because it is invoked from
-	// predicates.GeneralPredicates()
-	factory.RegisterFitPredicate(predicates.PodFitsHostPortsPred, predicates.PodFitsHostPorts)
-	// Fit is determined by resource availability.
-	// This predicate is actually a default predicate, because it is invoked from
-	// predicates.GeneralPredicates()
-	factory.RegisterFitPredicate(predicates.PodFitsResourcesPred, predicates.PodFitsResources)
-	// Fit is determined by the presence of the Host parameter and a string match
-	// This predicate is actually a default predicate, because it is invoked from
-	// predicates.GeneralPredicates()
-	factory.RegisterFitPredicate(predicates.HostNamePred, predicates.PodFitsHost)
-	// Fit is determined by node selector query.
-	factory.RegisterFitPredicate(predicates.MatchNodeSelectorPred, predicates.PodMatchNodeSelector)
-
-	// ServiceSpreadingPriority is a priority config factory that spreads pods by minimizing
-	// the number of pods (belonging to the same service) on the same node.
-	// Register the factory so that it's available, but do not include it as part of the default priorities
-	// Largely replaced by "SelectorSpreadPriority", but registered for backward compatibility with 1.0
-	factory.RegisterPriorityConfigFactory(
-		"ServiceSpreadingPriority",
-		factory.PriorityConfigFactory{
-			MapReduceFunction: func(args factory.PluginFactoryArgs) (algorithm.PriorityMapFunction, algorithm.PriorityReduceFunction) {
-				return priorities.NewSelectorSpreadPriority(args.ServiceLister, algorithm.EmptyControllerLister{}, algorithm.EmptyReplicaSetLister{}, algorithm.EmptyStatefulSetLister{})
-			},
-			Weight: 1,
-		},
-	)
-	// EqualPriority is a prioritizer function that gives an equal weight of one to all nodes
-	// Register the priority function so that its available
-	// but do not include it as part of the default priorities
-	factory.RegisterPriorityFunction2("EqualPriority", core.EqualPriorityMap, nil, 1)
-	// Optional, cluster-autoscaler friendly priority function - give used nodes higher priority.
-	factory.RegisterPriorityFunction2("MostRequestedPriority", priorities.MostRequestedPriorityMap, nil, 1)
-	factory.RegisterPriorityFunction2(
-		"RequestedToCapacityRatioPriority",
-		priorities.RequestedToCapacityRatioResourceAllocationPriorityDefault().PriorityMap,
-		nil,
-		1)
 }
 
 func defaultPredicates() sets.String {
 	return sets.NewString(
-		// Fit is determined by volume zone requirements.
-		factory.RegisterFitPredicateFactory(
-			predicates.NoVolumeZoneConflictPred,
-			func(args factory.PluginFactoryArgs) predicates.FitPredicate {
-				return predicates.NewVolumeZonePredicate(args.PVInfo, args.PVCInfo, args.StorageClassInfo)
-			},
-		),
-		// Fit is determined by whether or not there would be too many AWS EBS volumes attached to the node
-		factory.RegisterFitPredicateFactory(
-			predicates.MaxEBSVolumeCountPred,
-			func(args factory.PluginFactoryArgs) predicates.FitPredicate {
-				return predicates.NewMaxPDVolumeCountPredicate(predicates.EBSVolumeFilterType, args.PVInfo, args.PVCInfo)
-			},
-		),
-		// Fit is determined by whether or not there would be too many GCE PD volumes attached to the node
-		factory.RegisterFitPredicateFactory(
-			predicates.MaxGCEPDVolumeCountPred,
-			func(args factory.PluginFactoryArgs) predicates.FitPredicate {
-				return predicates.NewMaxPDVolumeCountPredicate(predicates.GCEPDVolumeFilterType, args.PVInfo, args.PVCInfo)
-			},
-		),
-		// Fit is determined by whether or not there would be too many Azure Disk volumes attached to the node
-		factory.RegisterFitPredicateFactory(
-			predicates.MaxAzureDiskVolumeCountPred,
-			func(args factory.PluginFactoryArgs) predicates.FitPredicate {
-				return predicates.NewMaxPDVolumeCountPredicate(predicates.AzureDiskVolumeFilterType, args.PVInfo, args.PVCInfo)
-			},
-		),
-		factory.RegisterFitPredicateFactory(
-			predicates.MaxCSIVolumeCountPred,
-			func(args factory.PluginFactoryArgs) predicates.FitPredicate {
-				return predicates.NewCSIMaxVolumeLimitPredicate(args.PVInfo, args.PVCInfo)
-			},
-		),
-		// Fit is determined by inter-pod affinity.
-		factory.RegisterFitPredicateFactory(
-			predicates.MatchInterPodAffinityPred,
-			func(args factory.PluginFactoryArgs) predicates.FitPredicate {
-				return predicates.NewPodAffinityPredicate(args.NodeInfo, args.PodLister)
-			},
-		),
-
-		// Fit is determined by non-conflicting disk volumes.
-		factory.RegisterFitPredicate(predicates.NoDiskConflictPred, predicates.NoDiskConflict),
-
-		// GeneralPredicates are the predicates that are enforced by all Kubernetes components
-		// (e.g. kubelet and all schedulers)
-		factory.RegisterFitPredicate(predicates.GeneralPred, predicates.GeneralPredicates),
-
-		// Fit is determined by node memory pressure condition.
-		factory.RegisterFitPredicate(predicates.CheckNodeMemoryPressurePred, predicates.CheckNodeMemoryPressurePredicate),
-
-		// Fit is determined by node disk pressure condition.
-		factory.RegisterFitPredicate(predicates.CheckNodeDiskPressurePred, predicates.CheckNodeDiskPressurePredicate),
-
-		// Fit is determined by node pid pressure condition.
-		factory.RegisterFitPredicate(predicates.CheckNodePIDPressurePred, predicates.CheckNodePIDPressurePredicate),
-
-		// Fit is determined by node conditions: not ready, network unavailable or out of disk.
-		factory.RegisterMandatoryFitPredicate(predicates.CheckNodeConditionPred, predicates.CheckNodeConditionPredicate),
-
-		// Fit is determined based on whether a pod can tolerate all of the node's taints
-		factory.RegisterFitPredicate(predicates.PodToleratesNodeTaintsPred, predicates.PodToleratesNodeTaints),
-
-		// Fit is determined by volume topology requirements.
-		factory.RegisterFitPredicateFactory(
-			predicates.CheckVolumeBindingPred,
-			func(args factory.PluginFactoryArgs) predicates.FitPredicate {
-				return predicates.NewVolumeBindingPredicate(args.VolumeBinder)
-			},
-		),
+		predicates.NoVolumeZoneConflictPred,
+		predicates.MaxEBSVolumeCountPred,
+		predicates.MaxGCEPDVolumeCountPred,
+		predicates.MaxAzureDiskVolumeCountPred,
+		predicates.MaxCSIVolumeCountPred,
+		predicates.MatchInterPodAffinityPred,
+		predicates.NoDiskConflictPred,
+		predicates.GeneralPred,
+		predicates.CheckNodeMemoryPressurePred,
+		predicates.CheckNodeDiskPressurePred,
+		predicates.CheckNodePIDPressurePred,
+		predicates.CheckNodeConditionPred,
+		predicates.PodToleratesNodeTaintsPred,
+		predicates.CheckVolumeBindingPred,
 	)
 }
 
@@ -206,9 +90,9 @@ func ApplyFeatureGates() {
 	// Prioritizes nodes that satisfy pod's resource limits
 	if utilfeature.DefaultFeatureGate.Enabled(features.ResourceLimitsPriorityFunction) {
 		klog.Infof("Registering resourcelimits priority function")
-		factory.RegisterPriorityFunction2("ResourceLimitsPriority", priorities.ResourceLimitsPriorityMap, nil, 1)
+		factory.RegisterPriorityFunction2(priorities.ResourceLimitsPriority, priorities.ResourceLimitsPriorityMap, nil, 1)
 		// Register the priority function to specific provider too.
-		factory.InsertPriorityKeyToAlgorithmProviderMap(factory.RegisterPriorityFunction2("ResourceLimitsPriority", priorities.ResourceLimitsPriorityMap, nil, 1))
+		factory.InsertPriorityKeyToAlgorithmProviderMap(factory.RegisterPriorityFunction2(priorities.ResourceLimitsPriority, priorities.ResourceLimitsPriorityMap, nil, 1))
 	}
 }
 
@@ -218,51 +102,19 @@ func registerAlgorithmProvider(predSet, priSet sets.String) {
 	factory.RegisterAlgorithmProvider(factory.DefaultProvider, predSet, priSet)
 	// Cluster autoscaler friendly scheduling algorithm.
 	factory.RegisterAlgorithmProvider(ClusterAutoscalerProvider, predSet,
-		copyAndReplace(priSet, "LeastRequestedPriority", "MostRequestedPriority"))
+		copyAndReplace(priSet, priorities.LeastRequestedPriority, priorities.MostRequestedPriority))
 }
 
 func defaultPriorities() sets.String {
 	return sets.NewString(
-		// spreads pods by minimizing the number of pods (belonging to the same service or replication controller) on the same node.
-		factory.RegisterPriorityConfigFactory(
-			"SelectorSpreadPriority",
-			factory.PriorityConfigFactory{
-				MapReduceFunction: func(args factory.PluginFactoryArgs) (algorithm.PriorityMapFunction, algorithm.PriorityReduceFunction) {
-					return priorities.NewSelectorSpreadPriority(args.ServiceLister, args.ControllerLister, args.ReplicaSetLister, args.StatefulSetLister)
-				},
-				Weight: 1,
-			},
-		),
-		// pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.)
-		// as some other pods, or, conversely, should not be placed in the same topological domain as some other pods.
-		factory.RegisterPriorityConfigFactory(
-			"InterPodAffinityPriority",
-			factory.PriorityConfigFactory{
-				Function: func(args factory.PluginFactoryArgs) algorithm.PriorityFunction {
-					return priorities.NewInterPodAffinityPriority(args.NodeInfo, args.NodeLister, args.PodLister, args.HardPodAffinitySymmetricWeight)
-				},
-				Weight: 1,
-			},
-		),
-
-		// Prioritize nodes by least requested utilization.
-		factory.RegisterPriorityFunction2("LeastRequestedPriority", priorities.LeastRequestedPriorityMap, nil, 1),
-
-		// Prioritizes nodes to help achieve balanced resource usage
-		factory.RegisterPriorityFunction2("BalancedResourceAllocation", priorities.BalancedResourceAllocationMap, nil, 1),
-
-		// Set this weight large enough to override all other priority functions.
-		// TODO: Figure out a better way to do this, maybe at same time as fixing #24720.
-		factory.RegisterPriorityFunction2("NodePreferAvoidPodsPriority", priorities.CalculateNodePreferAvoidPodsPriorityMap, nil, 10000),
-
-		// Prioritizes nodes that have labels matching NodeAffinity
-		factory.RegisterPriorityFunction2("NodeAffinityPriority", priorities.CalculateNodeAffinityPriorityMap, priorities.CalculateNodeAffinityPriorityReduce, 1),
-
-		// Prioritizes nodes that marked with taint which pod can tolerate.
-		factory.RegisterPriorityFunction2("TaintTolerationPriority", priorities.ComputeTaintTolerationPriorityMap, priorities.ComputeTaintTolerationPriorityReduce, 1),
-
-		// ImageLocalityPriority prioritizes nodes that have images requested by the pod present.
-		factory.RegisterPriorityFunction2("ImageLocalityPriority", priorities.ImageLocalityPriorityMap, nil, 1),
+		priorities.SelectorSpreadPriority,
+		priorities.InterPodAffinityPriority,
+		priorities.LeastRequestedPriority,
+		priorities.BalancedResourceAllocation,
+		priorities.NodePreferAvoidPodsPriority,
+		priorities.NodeAffinityPriority,
+		priorities.TaintTolerationPriority,
+		priorities.ImageLocalityPriority,
 	)
 }
 

--- a/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/priorities"
 )
 
 func TestCopyAndReplace(t *testing.T) {
@@ -53,14 +54,15 @@ func TestCopyAndReplace(t *testing.T) {
 
 func TestDefaultPriorities(t *testing.T) {
 	result := sets.NewString(
-		"SelectorSpreadPriority",
-		"InterPodAffinityPriority",
-		"LeastRequestedPriority",
-		"BalancedResourceAllocation",
-		"NodePreferAvoidPodsPriority",
-		"NodeAffinityPriority",
-		"TaintTolerationPriority",
-		"ImageLocalityPriority")
+		priorities.SelectorSpreadPriority,
+		priorities.InterPodAffinityPriority,
+		priorities.LeastRequestedPriority,
+		priorities.BalancedResourceAllocation,
+		priorities.NodePreferAvoidPodsPriority,
+		priorities.NodeAffinityPriority,
+		priorities.TaintTolerationPriority,
+		priorities.ImageLocalityPriority,
+	)
 	if expected := defaultPriorities(); !result.Equal(expected) {
 		t.Errorf("expected %v got %v", expected, result)
 	}

--- a/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaults
+
+import (
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	"k8s.io/kubernetes/pkg/scheduler/factory"
+)
+
+func init() {
+	// Register functions that extract metadata used by predicates computations.
+	factory.RegisterPredicateMetadataProducerFactory(
+		func(args factory.PluginFactoryArgs) predicates.PredicateMetadataProducer {
+			return predicates.NewPredicateMetadataFactory(args.PodLister)
+		})
+
+	// IMPORTANT NOTES for predicate developers:
+	// Registers predicates and priorities that are not enabled by default, but user can pick when creating their
+	// own set of priorities/predicates.
+
+	// PodFitsPorts has been replaced by PodFitsHostPorts for better user understanding.
+	// For backwards compatibility with 1.0, PodFitsPorts is registered as well.
+	factory.RegisterFitPredicate("PodFitsPorts", predicates.PodFitsHostPorts)
+	// Fit is defined based on the absence of port conflicts.
+	// This predicate is actually a default predicate, because it is invoked from
+	// predicates.GeneralPredicates()
+	factory.RegisterFitPredicate(predicates.PodFitsHostPortsPred, predicates.PodFitsHostPorts)
+	// Fit is determined by resource availability.
+	// This predicate is actually a default predicate, because it is invoked from
+	// predicates.GeneralPredicates()
+	factory.RegisterFitPredicate(predicates.PodFitsResourcesPred, predicates.PodFitsResources)
+	// Fit is determined by the presence of the Host parameter and a string match
+	// This predicate is actually a default predicate, because it is invoked from
+	// predicates.GeneralPredicates()
+	factory.RegisterFitPredicate(predicates.HostNamePred, predicates.PodFitsHost)
+	// Fit is determined by node selector query.
+	factory.RegisterFitPredicate(predicates.MatchNodeSelectorPred, predicates.PodMatchNodeSelector)
+
+	// Fit is determined by volume zone requirements.
+	factory.RegisterFitPredicateFactory(
+		predicates.NoVolumeZoneConflictPred,
+		func(args factory.PluginFactoryArgs) predicates.FitPredicate {
+			return predicates.NewVolumeZonePredicate(args.PVInfo, args.PVCInfo, args.StorageClassInfo)
+		},
+	)
+	// Fit is determined by whether or not there would be too many AWS EBS volumes attached to the node
+	factory.RegisterFitPredicateFactory(
+		predicates.MaxEBSVolumeCountPred,
+		func(args factory.PluginFactoryArgs) predicates.FitPredicate {
+			return predicates.NewMaxPDVolumeCountPredicate(predicates.EBSVolumeFilterType, args.PVInfo, args.PVCInfo)
+		},
+	)
+	// Fit is determined by whether or not there would be too many GCE PD volumes attached to the node
+	factory.RegisterFitPredicateFactory(
+		predicates.MaxGCEPDVolumeCountPred,
+		func(args factory.PluginFactoryArgs) predicates.FitPredicate {
+			return predicates.NewMaxPDVolumeCountPredicate(predicates.GCEPDVolumeFilterType, args.PVInfo, args.PVCInfo)
+		},
+	)
+	// Fit is determined by whether or not there would be too many Azure Disk volumes attached to the node
+	factory.RegisterFitPredicateFactory(
+		predicates.MaxAzureDiskVolumeCountPred,
+		func(args factory.PluginFactoryArgs) predicates.FitPredicate {
+			return predicates.NewMaxPDVolumeCountPredicate(predicates.AzureDiskVolumeFilterType, args.PVInfo, args.PVCInfo)
+		},
+	)
+	factory.RegisterFitPredicateFactory(
+		predicates.MaxCSIVolumeCountPred,
+		func(args factory.PluginFactoryArgs) predicates.FitPredicate {
+			return predicates.NewCSIMaxVolumeLimitPredicate(args.PVInfo, args.PVCInfo)
+		},
+	)
+	// Fit is determined by inter-pod affinity.
+	factory.RegisterFitPredicateFactory(
+		predicates.MatchInterPodAffinityPred,
+		func(args factory.PluginFactoryArgs) predicates.FitPredicate {
+			return predicates.NewPodAffinityPredicate(args.NodeInfo, args.PodLister)
+		},
+	)
+
+	// Fit is determined by non-conflicting disk volumes.
+	factory.RegisterFitPredicate(predicates.NoDiskConflictPred, predicates.NoDiskConflict)
+
+	// GeneralPredicates are the predicates that are enforced by all Kubernetes components
+	// (e.g. kubelet and all schedulers)
+	factory.RegisterFitPredicate(predicates.GeneralPred, predicates.GeneralPredicates)
+
+	// Fit is determined by node memory pressure condition.
+	factory.RegisterFitPredicate(predicates.CheckNodeMemoryPressurePred, predicates.CheckNodeMemoryPressurePredicate)
+
+	// Fit is determined by node disk pressure condition.
+	factory.RegisterFitPredicate(predicates.CheckNodeDiskPressurePred, predicates.CheckNodeDiskPressurePredicate)
+
+	// Fit is determined by node pid pressure condition.
+	factory.RegisterFitPredicate(predicates.CheckNodePIDPressurePred, predicates.CheckNodePIDPressurePredicate)
+
+	// Fit is determined by node conditions: not ready, network unavailable or out of disk.
+	factory.RegisterMandatoryFitPredicate(predicates.CheckNodeConditionPred, predicates.CheckNodeConditionPredicate)
+
+	// Fit is determined based on whether a pod can tolerate all of the node's taints
+	factory.RegisterFitPredicate(predicates.PodToleratesNodeTaintsPred, predicates.PodToleratesNodeTaints)
+
+	// Fit is determined by volume topology requirements.
+	factory.RegisterFitPredicateFactory(
+		predicates.CheckVolumeBindingPred,
+		func(args factory.PluginFactoryArgs) predicates.FitPredicate {
+			return predicates.NewVolumeBindingPredicate(args.VolumeBinder)
+		},
+	)
+}

--- a/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaults
+
+import (
+	"k8s.io/kubernetes/pkg/scheduler/algorithm"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/priorities"
+	"k8s.io/kubernetes/pkg/scheduler/core"
+	"k8s.io/kubernetes/pkg/scheduler/factory"
+)
+
+func init() {
+	// Register functions that extract metadata used by priorities computations.
+	factory.RegisterPriorityMetadataProducerFactory(
+		func(args factory.PluginFactoryArgs) algorithm.PriorityMetadataProducer {
+			return priorities.NewPriorityMetadataFactory(args.ServiceLister, args.ControllerLister, args.ReplicaSetLister, args.StatefulSetLister)
+		})
+
+	// ServiceSpreadingPriority is a priority config factory that spreads pods by minimizing
+	// the number of pods (belonging to the same service) on the same node.
+	// Register the factory so that it's available, but do not include it as part of the default priorities
+	// Largely replaced by "SelectorSpreadPriority", but registered for backward compatibility with 1.0
+	factory.RegisterPriorityConfigFactory(
+		priorities.ServiceSpreadingPriority,
+		factory.PriorityConfigFactory{
+			MapReduceFunction: func(args factory.PluginFactoryArgs) (algorithm.PriorityMapFunction, algorithm.PriorityReduceFunction) {
+				return priorities.NewSelectorSpreadPriority(args.ServiceLister, algorithm.EmptyControllerLister{}, algorithm.EmptyReplicaSetLister{}, algorithm.EmptyStatefulSetLister{})
+			},
+			Weight: 1,
+		},
+	)
+	// EqualPriority is a prioritizer function that gives an equal weight of one to all nodes
+	// Register the priority function so that its available
+	// but do not include it as part of the default priorities
+	factory.RegisterPriorityFunction2(priorities.EqualPriority, core.EqualPriorityMap, nil, 1)
+	// Optional, cluster-autoscaler friendly priority function - give used nodes higher priority.
+	factory.RegisterPriorityFunction2(priorities.MostRequestedPriority, priorities.MostRequestedPriorityMap, nil, 1)
+	factory.RegisterPriorityFunction2(
+		priorities.RequestedToCapacityRatioPriority,
+		priorities.RequestedToCapacityRatioResourceAllocationPriorityDefault().PriorityMap,
+		nil,
+		1)
+	// spreads pods by minimizing the number of pods (belonging to the same service or replication controller) on the same node.
+	factory.RegisterPriorityConfigFactory(
+		priorities.SelectorSpreadPriority,
+		factory.PriorityConfigFactory{
+			MapReduceFunction: func(args factory.PluginFactoryArgs) (algorithm.PriorityMapFunction, algorithm.PriorityReduceFunction) {
+				return priorities.NewSelectorSpreadPriority(args.ServiceLister, args.ControllerLister, args.ReplicaSetLister, args.StatefulSetLister)
+			},
+			Weight: 1,
+		},
+	)
+	// pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.)
+	// as some other pods, or, conversely, should not be placed in the same topological domain as some other pods.
+	factory.RegisterPriorityConfigFactory(
+		priorities.InterPodAffinityPriority,
+		factory.PriorityConfigFactory{
+			Function: func(args factory.PluginFactoryArgs) algorithm.PriorityFunction {
+				return priorities.NewInterPodAffinityPriority(args.NodeInfo, args.NodeLister, args.PodLister, args.HardPodAffinitySymmetricWeight)
+			},
+			Weight: 1,
+		},
+	)
+
+	// Prioritize nodes by least requested utilization.
+	factory.RegisterPriorityFunction2(priorities.LeastRequestedPriority, priorities.LeastRequestedPriorityMap, nil, 1)
+
+	// Prioritizes nodes to help achieve balanced resource usage
+	factory.RegisterPriorityFunction2(priorities.BalancedResourceAllocation, priorities.BalancedResourceAllocationMap, nil, 1)
+
+	// Set this weight large enough to override all other priority functions.
+	// TODO: Figure out a better way to do this, maybe at same time as fixing #24720.
+	factory.RegisterPriorityFunction2(priorities.NodePreferAvoidPodsPriority, priorities.CalculateNodePreferAvoidPodsPriorityMap, nil, 10000)
+
+	// Prioritizes nodes that have labels matching NodeAffinity
+	factory.RegisterPriorityFunction2(priorities.NodeAffinityPriority, priorities.CalculateNodeAffinityPriorityMap, priorities.CalculateNodeAffinityPriorityReduce, 1)
+
+	// Prioritizes nodes that marked with taint which pod can tolerate.
+	factory.RegisterPriorityFunction2(priorities.TaintTolerationPriority, priorities.ComputeTaintTolerationPriorityMap, priorities.ComputeTaintTolerationPriorityReduce, 1)
+
+	// ImageLocalityPriority prioritizes nodes that have images requested by the pod present.
+	factory.RegisterPriorityFunction2(priorities.ImageLocalityPriority, priorities.ImageLocalityPriorityMap, nil, 1)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
- Maintain list of default predicates and priorities in defaults.go
  and move the registration to separate files

**Which issue(s) this PR fixes**:
Fixes #71866 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig scheduling
/cc @misterikkit 