### PR TITLE
Disallow deployment on Fridays

### DIFF
--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -19,6 +19,7 @@ package deployment
 import (
 	"strconv"
 	"testing"
+	"time"
 
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
@@ -221,6 +222,7 @@ func (f *fixture) run_(deploymentName string, startInformers bool, expectError b
 		informers.Start(stopCh)
 	}
 
+	nowFn = func() time.Time { return time.Date(2018, 10, 20, 16, 59, 59, 0, time.UTC) }
 	err = c.syncDeployment(deploymentName)
 	if !expectError && err != nil {
 		f.t.Errorf("error syncing deployment: %v", err)

--- a/pkg/controller/deployment/rolling.go
+++ b/pkg/controller/deployment/rolling.go
@@ -66,6 +66,11 @@ func (dc *DeploymentController) rolloutRolling(d *apps.Deployment, rsList []*app
 }
 
 func (dc *DeploymentController) reconcileNewReplicaSet(allRSs []*apps.ReplicaSet, newRS *apps.ReplicaSet, deployment *apps.Deployment) (bool, error) {
+	isFriday := (nowFn().Weekday() == 5)
+	if isFriday {
+		return false, fmt.Errorf("No deploy Friday. Enjoy your weekend!")
+	}
+
 	if *(newRS.Spec.Replicas) == *(deployment.Spec.Replicas) {
 		// Scaling not required.
 		return false, nil


### PR DESCRIPTION
**Problem**: Many operators are complaining that Kubernetes is ruining their weekends and holidays. This is particularly problematic around holidays that merge with adjacent weekends, such as Christmas 2018.

**Solution**: As [voiced by many operators](https://twitter.com/hashtag/NoDeployFridays?src=hash), this patch disallows rolling updates on Fridays. The feature is deliberately hard-coded in the core of Kubernetes, specifically the Deployment controller. Alternatives, such as overriding "no deploy Fridays" via RBAC, Deployment spec or other means, were avoided to help operators with the temptation of disabling this safety check "just this one time".

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

See problem and solution above.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Merry Christmas!

**Does this PR introduce a user-facing change?**:

```release-note
* Kubernetes now disallows rolling updates on Friday. The feature is hard-coded and cannot be overwritten "just this one time".
```
