### PR TITLE
update apis modules docs with base-64 for []byte

### DIFF
--- a/pkg/apis/admission/types.go
+++ b/pkg/apis/admission/types.go
@@ -91,7 +91,7 @@ type AdmissionResponse struct {
 	// This field IS NOT consulted in any way if "Allowed" is "true".
 	// +optional
 	Result *metav1.Status
-	// Patch contains the actual patch. Currently we only support a response in the form of JSONPatch, RFC 6902.
+	// Patch contains the actual patch, base-64 encoded. Currently we only support a response in the form of JSONPatch, RFC 6902.
 	// +optional
 	Patch []byte
 	// PatchType indicates the form the Patch will take. Currently we only support "JSONPatch".

--- a/pkg/apis/admissionregistration/types.go
+++ b/pkg/apis/admissionregistration/types.go
@@ -328,7 +328,7 @@ type WebhookClientConfig struct {
 	// +optional
 	Service *ServiceReference
 
-	// `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
+	// `caBundle` is a PEM and base-64 encoded CA bundle which will be used to validate the webhook's server certificate.
 	// If unspecified, system trust roots on the apiserver are used.
 	// +optional
 	CABundle []byte

--- a/pkg/apis/auditregistration/types.go
+++ b/pkg/apis/auditregistration/types.go
@@ -173,7 +173,7 @@ type WebhookClientConfig struct {
 	// +optional
 	Service *ServiceReference
 
-	// `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
+	// `caBundle` is a PEM and base-64 encoded CA bundle which will be used to validate the webhook's server certificate.
 	// If unspecified, system trust roots on the apiserver are used.
 	// +optional
 	CABundle []byte

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -4706,7 +4706,7 @@ type RangeAllocation struct {
 	// port range "10000-30000". Range is not strongly schema'd here. The Range is expected to define
 	// a start and end unless there is an implicit end.
 	Range string
-	// A byte array representing the serialized state of a range allocation. Additional clarifiers on
+	// A byte array representing the base-64 encoded serialized state of a range allocation. Additional clarifiers on
 	// the type or format of data should be represented with annotations. For IP allocations, this is
 	// represented as a bit array starting at the base IP of the CIDR in Range, with each bit representing
 	// a single allocated address (the fifth bit on CIDR 10.0.0.0/8 is 10.0.0.4).


### PR DESCRIPTION
 /kind documentation
**What this PR does / why we need it**:
changing api documentation for []byte fields to indicate that it's base64-encoded
**Which issue(s) this PR fixes**:
Fixes #72158 
**Does this PR introduce a user-facing change?**:
NONE