### PR TITLE
kubeadm: add CurrentKubernetesVersion

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/kubelet.go
+++ b/cmd/kubeadm/app/cmd/alpha/kubelet.go
@@ -46,7 +46,7 @@ var (
 
 		# Downloads the kubelet configuration from the ConfigMap in the cluster. Uses a specific desired kubelet version.
 		kubeadm alpha phase kubelet config download --kubelet-version %s
-		`, constants.MinimumKubeletVersion))
+		`, constants.CurrentKubernetesVersion))
 
 	kubeletConfigEnableDynamicLongDesc = normalizer.LongDesc(`
 		Enables or updates dynamic kubelet configuration for a Node, against the kubelet-config-1.X ConfigMap in the cluster,
@@ -63,7 +63,7 @@ var (
 
 		WARNING: This feature is still experimental, and disabled by default. Enable only if you know what you are doing, as it
 		may have surprising side-effects at this stage.
-		`, constants.MinimumKubeletVersion))
+		`, constants.CurrentKubernetesVersion))
 )
 
 // newCmdKubeletUtility returns command for `kubeadm phase kubelet`

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -46,14 +46,14 @@ var (
 		what the _desired_ kubelet version is. Give 
 		`)
 
-	upgradeNodeConfigExample = normalizer.Examples(`
+	upgradeNodeConfigExample = normalizer.Examples(fmt.Sprintf(`
 		# Downloads the kubelet configuration from the ConfigMap in the cluster. Uses a specific desired kubelet version.
-		kubeadm upgrade node config --kubelet-version v1.13.0
+		kubeadm upgrade node config --kubelet-version %s
 
 		# Simulates the downloading of the kubelet configuration from the ConfigMap in the cluster with a specific desired
 		# version. Does not change any state locally on the node.
-		kubeadm upgrade node config --kubelet-version v1.13.0 --dry-run
-		`)
+		kubeadm upgrade node config --kubelet-version %[1]s --dry-run
+		`, constants.CurrentKubernetesVersion))
 )
 
 type nodeUpgradeFlags struct {

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -382,6 +382,9 @@ var (
 	// MinimumKubeletVersion specifies the minimum version of kubelet which kubeadm supports
 	MinimumKubeletVersion = version.MustParseSemantic("v1.12.0")
 
+	// CurrentKubernetesVersion specifies current Kubernetes version supported by kubeadm
+	CurrentKubernetesVersion = version.MustParseSemantic("v1.13.0")
+
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding Kubernetes releases
 	SupportedEtcdVersion = map[uint8]string{
 		10: "3.1.12",

--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -45,6 +45,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/constants:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/kubelet/apis/config:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/kubelet/config_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/config_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 )
 
@@ -35,7 +36,7 @@ func TestCreateConfigMap(t *testing.T) {
 	cfg := &kubeadmapi.InitConfiguration{
 		NodeRegistration: kubeadmapi.NodeRegistrationOptions{Name: nodeName},
 		ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-			KubernetesVersion: "v1.13.0",
+			KubernetesVersion: constants.CurrentKubernetesVersion.String(),
 			ComponentConfigs: kubeadmapi.ComponentConfigs{
 				Kubelet: &kubeletconfig.KubeletConfiguration{},
 			},

--- a/cmd/kubeadm/app/phases/upgrade/policy_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy_test.go
@@ -46,9 +46,9 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			vg: &fakeVersionGetter{
 				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
 				kubeletVersion: constants.MinimumControlPlaneVersion.WithPatch(2).String(),
-				kubeadmVersion: "v1.13.1",
+				kubeadmVersion: constants.CurrentKubernetesVersion.WithPatch(1).String(),
 			},
-			newK8sVersion: "v1.13.0",
+			newK8sVersion: constants.CurrentKubernetesVersion.String(),
 		},
 		{
 			name: "downgrade",
@@ -84,9 +84,9 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			vg: &fakeVersionGetter{
 				clusterVersion: "v1.11.3",
 				kubeletVersion: "v1.11.3",
-				kubeadmVersion: "v1.13.0",
+				kubeadmVersion: constants.CurrentKubernetesVersion.String(),
 			},
-			newK8sVersion:         "v1.13.0",
+			newK8sVersion:         constants.CurrentKubernetesVersion.String(),
 			expectedMandatoryErrs: 1, // can't upgrade two minor versions
 			expectedSkippableErrs: 1, // kubelet <-> apiserver skew too large
 		},
@@ -118,7 +118,7 @@ func TestEnforceVersionPolicies(t *testing.T) {
 				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
 				kubeadmVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
 			},
-			newK8sVersion:         "v1.13.0",
+			newK8sVersion:         constants.CurrentKubernetesVersion.String(),
 			expectedMandatoryErrs: 1,
 		},
 		{
@@ -126,9 +126,9 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			vg: &fakeVersionGetter{
 				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
 				kubeletVersion: "v1.11.8",
-				kubeadmVersion: "v1.13.0",
+				kubeadmVersion: constants.CurrentKubernetesVersion.String(),
 			},
-			newK8sVersion:         "v1.13.0",
+			newK8sVersion:         constants.CurrentKubernetesVersion.String(),
 			expectedSkippableErrs: 1,
 		},
 		{
@@ -136,9 +136,9 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			vg: &fakeVersionGetter{
 				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
 				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: "v1.13.0-beta.1",
+				kubeadmVersion: constants.CurrentKubernetesVersion.WithPreRelease("beta.1").String(),
 			},
-			newK8sVersion:     "v1.13.0-beta.1",
+			newK8sVersion:     constants.CurrentKubernetesVersion.WithPreRelease("beta.1").String(),
 			allowExperimental: true,
 		},
 		{
@@ -146,9 +146,9 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			vg: &fakeVersionGetter{
 				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
 				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: "v1.13.0-rc.1",
+				kubeadmVersion: constants.CurrentKubernetesVersion.WithPreRelease("rc.1").String(),
 			},
-			newK8sVersion: "v1.13.0-rc.1",
+			newK8sVersion: constants.CurrentKubernetesVersion.WithPreRelease("rc.1").String(),
 			allowRCs:      true,
 		},
 		{
@@ -156,9 +156,9 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			vg: &fakeVersionGetter{
 				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
 				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: "v1.13.0-rc.1",
+				kubeadmVersion: constants.CurrentKubernetesVersion.WithPreRelease("rc.1").String(),
 			},
-			newK8sVersion:     "v1.13.0-rc.1",
+			newK8sVersion:     constants.CurrentKubernetesVersion.WithPreRelease("rc.1").String(),
 			allowExperimental: true,
 		},
 		{
@@ -166,9 +166,9 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			vg: &fakeVersionGetter{
 				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
 				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: "v1.13.0-beta.1",
+				kubeadmVersion: constants.CurrentKubernetesVersion.WithPreRelease("beta.1").String(),
 			},
-			newK8sVersion:         "v1.13.0-beta.1",
+			newK8sVersion:         constants.CurrentKubernetesVersion.WithPreRelease("beta.1").String(),
 			allowRCs:              true,
 			expectedSkippableErrs: 1,
 		},
@@ -177,9 +177,9 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			vg: &fakeVersionGetter{
 				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
 				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: "v1.13.0-rc.1",
+				kubeadmVersion: constants.CurrentKubernetesVersion.WithPreRelease("rc.1").String(),
 			},
-			newK8sVersion:         "v1.13.0-rc.1",
+			newK8sVersion:         constants.CurrentKubernetesVersion.WithPreRelease("rc.1").String(),
 			expectedSkippableErrs: 1,
 		},
 		{
@@ -187,7 +187,7 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			vg: &fakeVersionGetter{
 				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
 				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: "v1.13.0",
+				kubeadmVersion: constants.CurrentKubernetesVersion.String(),
 			},
 			newK8sVersion:         constants.MinimumControlPlaneVersion.WithPatch(6).String(),
 			expectedSkippableErrs: 1, // can't upgrade old k8s with newer kubeadm

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -462,7 +462,7 @@ func TestStaticPodControlPlane(t *testing.T) {
 			t.Fatalf("couldn't read temp file: %v", err)
 		}
 
-		newcfg, err := getConfig("v1.13.0", tempCertsDir, tmpEtcdDataDir)
+		newcfg, err := getConfig(constants.CurrentKubernetesVersion.String(), tempCertsDir, tmpEtcdDataDir)
 		if err != nil {
 			t.Fatalf("couldn't create config: %v", err)
 		}

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -648,13 +648,13 @@ func TestKubeletVersionCheck(t *testing.T) {
 		expectErrors   bool
 		expectWarnings bool
 	}{
-		{"v1.13.2", "", false, false},       // check minimally supported version when there is no information about control plane
-		{"v1.11.3", "v1.11.8", true, false}, // too old kubelet (older than kubeadmconstants.MinimumKubeletVersion), should fail.
-		{"v" + constants.MinimumKubeletVersion.String(), constants.MinimumControlPlaneVersion.WithPatch(5).String(), false, false},              // kubelet within same major.minor as control plane
-		{"v" + constants.MinimumKubeletVersion.WithPatch(5).String(), constants.MinimumControlPlaneVersion.WithPatch(1).String(), false, false}, // kubelet is newer, but still within same major.minor as control plane
-		{"v" + constants.MinimumKubeletVersion.String(), "v1.13.1", false, false},                                                               // kubelet is lower than control plane, but newer than minimally supported
-		{"v1.13.0-alpha.1", constants.MinimumControlPlaneVersion.WithPatch(1).String(), true, false},                                            // kubelet is newer (development build) than control plane, should fail.
-		{"v1.13.0", constants.MinimumControlPlaneVersion.WithPatch(5).String(), true, false},                                                    // kubelet is newer (release) than control plane, should fail.
+		{"v" + constants.CurrentKubernetesVersion.WithPatch(2).String(), "", false, false},                                                                     // check minimally supported version when there is no information about control plane
+		{"v1.11.3", "v1.11.8", true, false},                                                                                                                    // too old kubelet (older than kubeadmconstants.MinimumKubeletVersion), should fail.
+		{"v" + constants.MinimumKubeletVersion.String(), constants.MinimumControlPlaneVersion.WithPatch(5).String(), false, false},                             // kubelet within same major.minor as control plane
+		{"v" + constants.MinimumKubeletVersion.WithPatch(5).String(), constants.MinimumControlPlaneVersion.WithPatch(1).String(), false, false},                // kubelet is newer, but still within same major.minor as control plane
+		{"v" + constants.MinimumKubeletVersion.String(), constants.CurrentKubernetesVersion.WithPatch(1).String(), false, false},                               // kubelet is lower than control plane, but newer than minimally supported
+		{"v" + constants.CurrentKubernetesVersion.WithPreRelease("alpha.1").String(), constants.MinimumControlPlaneVersion.WithPatch(1).String(), true, false}, // kubelet is newer (development build) than control plane, should fail.
+		{"v" + constants.CurrentKubernetesVersion.String(), constants.MinimumControlPlaneVersion.WithPatch(5).String(), true, false},                           // kubelet is newer (release) than control plane, should fail.
 	}
 
 	for _, tc := range cases {

--- a/cmd/kubeadm/test/cmd/BUILD
+++ b/cmd/kubeadm/test/cmd/BUILD
@@ -33,6 +33,7 @@ go_test(
         "skip",
     ],
     deps = [
+        "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/phases/certs:go_default_library",
         "//cmd/kubeadm/app/util/pkiutil:go_default_library",
         "//cmd/kubeadm/test:go_default_library",

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/renstrom/dedent"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
@@ -102,7 +103,7 @@ func TestCmdInitKubernetesVersion(t *testing.T) {
 		},
 		{
 			name:     "valid version is accepted",
-			args:     "--kubernetes-version=1.13.0",
+			args:     "--kubernetes-version=" + constants.CurrentKubernetesVersion.String(),
 			expected: true,
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Replaced hardcoded "v0.13.0" strings with CurrentKubernetesVersion variable.

This should help with a regular release version bumps.

**Special notes for your reviewer**:

This is a second step towards fixing kubernetes/kubeadm#1260

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```