### PR TITLE
[scheduler] update NodeInfo.taints when adding NotReady node to cache

### DIFF
--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -653,6 +653,17 @@ func (c *configFactory) addNodeToCache(obj interface{}) {
 		return
 	}
 
+	for _, cond := range node.Status.Conditions {
+		if cond.Type != v1.NodeReady {
+			continue
+		}
+		if cond.Status == v1.ConditionTrue {
+			break
+		}
+		klog.V(5).Infof("node %q is in NotReady status, hold off adding it to cache", node.Name)
+		return
+	}
+
 	if err := c.schedulerCache.AddNode(node); err != nil {
 		klog.Errorf("scheduler cache AddNode failed: %v", err)
 	}

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -653,17 +653,6 @@ func (c *configFactory) addNodeToCache(obj interface{}) {
 		return
 	}
 
-	for _, cond := range node.Status.Conditions {
-		if cond.Type != v1.NodeReady {
-			continue
-		}
-		if cond.Status == v1.ConditionTrue {
-			break
-		}
-		klog.V(5).Infof("node %q is in NotReady status, hold off adding it to cache", node.Name)
-		return
-	}
-
 	if err := c.schedulerCache.AddNode(node); err != nil {
 		klog.Errorf("scheduler cache AddNode failed: %v", err)
 	}

--- a/pkg/scheduler/internal/cache/BUILD
+++ b/pkg/scheduler/internal/cache/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/features:go_default_library",
         "//pkg/scheduler/algorithm:go_default_library",
+        "//pkg/scheduler/api:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #72129

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Prevent pods getting scheduled to a new node with NotReady status.
```

/sig scheduling