### PR TITLE
Add eks case to GetSigner()

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3660,7 +3660,7 @@ func GetSigner(provider string) (ssh.Signer, error) {
 		if keyfile == "" {
 			keyfile = "google_compute_engine"
 		}
-	case "aws":
+	case "aws", "eks":
 		keyfile = os.Getenv("AWS_SSH_KEY")
 		if keyfile == "" {
 			keyfile = "kube_aws_rsa"


### PR DESCRIPTION
e2e test in [this job](https://testgrid.k8s.io/sig-aws-eks-ci-kubernetes-e2e-latest#ci-kubernetes-e2e-latest-aws-eks-1-11-prod) seems to fail due to unable to SSH to node. Hope this fixes. 

/cc @gyuho 

```release-note
NONE
```
