### PR TITLE
Change docker metrics to conform metrics guidelines

### DIFF
--- a/pkg/kubelet/dockershim/libdocker/instrumented_client.go
+++ b/pkg/kubelet/dockershim/libdocker/instrumented_client.go
@@ -42,7 +42,9 @@ func NewInstrumentedInterface(dockerClient Interface) Interface {
 // recordOperation records the duration of the operation.
 func recordOperation(operation string, start time.Time) {
 	metrics.DockerOperations.WithLabelValues(operation).Inc()
-	metrics.DockerOperationsLatency.WithLabelValues(operation).Observe(metrics.SinceInMicroseconds(start))
+	metrics.DeprecatedDockerOperations.WithLabelValues(operation).Inc()
+	metrics.DockerOperationsLatency.WithLabelValues(operation).Observe(metrics.SinceInSeconds(start))
+	metrics.DeprecatedDockerOperationsLatency.WithLabelValues(operation).Observe(metrics.SinceInMicroseconds(start))
 }
 
 // recordError records error for metric if an error occurred.
@@ -50,9 +52,11 @@ func recordError(operation string, err error) {
 	if err != nil {
 		if _, ok := err.(operationTimeout); ok {
 			metrics.DockerOperationsTimeout.WithLabelValues(operation).Inc()
+			metrics.DeprecatedDockerOperationsTimeout.WithLabelValues(operation).Inc()
 		}
 		// Docker operation timeout error is also a docker error, so we don't add else here.
 		metrics.DockerOperationsErrors.WithLabelValues(operation).Inc()
+		metrics.DeprecatedDockerOperationsErrors.WithLabelValues(operation).Inc()
 	}
 }
 

--- a/pkg/kubelet/dockershim/metrics/metrics.go
+++ b/pkg/kubelet/dockershim/metrics/metrics.go
@@ -93,7 +93,7 @@ var (
 		prometheus.SummaryOpts{
 			Subsystem: kubeletSubsystem,
 			Name:      DeprecatedDockerOperationsLatencyKey,
-			Help:      "Latency in microseconds of Docker operations. Broken down by operation type.",
+			Help:      "(Deprecated) Latency in microseconds of Docker operations. Broken down by operation type.",
 		},
 		[]string{"operation_type"},
 	)
@@ -102,7 +102,7 @@ var (
 		prometheus.CounterOpts{
 			Subsystem: kubeletSubsystem,
 			Name:      DeprecatedDockerOperationsKey,
-			Help:      "Cumulative number of Docker operations by operation type.",
+			Help:      "(Deprecated) Cumulative number of Docker operations by operation type.",
 		},
 		[]string{"operation_type"},
 	)
@@ -112,7 +112,7 @@ var (
 		prometheus.CounterOpts{
 			Subsystem: kubeletSubsystem,
 			Name:      DeprecatedDockerOperationsErrorsKey,
-			Help:      "Cumulative number of Docker operation errors by operation type.",
+			Help:      "(Deprecated) Cumulative number of Docker operation errors by operation type.",
 		},
 		[]string{"operation_type"},
 	)
@@ -121,7 +121,7 @@ var (
 		prometheus.CounterOpts{
 			Subsystem: kubeletSubsystem,
 			Name:      DeprecatedDockerOperationsTimeoutKey,
-			Help:      "Cumulative number of Docker operation timeout by operation type.",
+			Help:      "(Deprecated) Cumulative number of Docker operation timeout by operation type.",
 		},
 		[]string{"operation_type"},
 	)

--- a/pkg/kubelet/dockershim/metrics/metrics.go
+++ b/pkg/kubelet/dockershim/metrics/metrics.go
@@ -25,13 +25,22 @@ import (
 
 const (
 	// DockerOperationsKey is the key for docker operation metrics.
-	DockerOperationsKey = "docker_operations"
+	DockerOperationsKey = "docker_operations_total"
 	// DockerOperationsLatencyKey is the key for the operation latency metrics.
-	DockerOperationsLatencyKey = "docker_operations_latency_microseconds"
+	DockerOperationsLatencyKey = "docker_operations_latency_seconds"
 	// DockerOperationsErrorsKey is the key for the operation error metrics.
-	DockerOperationsErrorsKey = "docker_operations_errors"
+	DockerOperationsErrorsKey = "docker_operations_errors_total"
 	// DockerOperationsTimeoutKey is the key for the operation timeout metrics.
-	DockerOperationsTimeoutKey = "docker_operations_timeout"
+	DockerOperationsTimeoutKey = "docker_operations_timeout_total"
+
+	// DeprecatedDockerOperationsKey is the deprecated key for docker operation metrics.
+	DeprecatedDockerOperationsKey = "docker_operations"
+	// DeprecatedDockerOperationsLatencyKey is the deprecated key for the operation latency metrics.
+	DeprecatedDockerOperationsLatencyKey = "docker_operations_latency_microseconds"
+	// DeprecatedDockerOperationsErrorsKey is the deprecated key for the operation error metrics.
+	DeprecatedDockerOperationsErrorsKey = "docker_operations_errors"
+	// DeprecatedDockerOperationsTimeoutKey is the deprecated key for the operation timeout metrics.
+	DeprecatedDockerOperationsTimeoutKey = "docker_operations_timeout"
 
 	// Keep the "kubelet" subsystem for backward compatibility.
 	kubeletSubsystem = "kubelet"
@@ -44,7 +53,7 @@ var (
 		prometheus.SummaryOpts{
 			Subsystem: kubeletSubsystem,
 			Name:      DockerOperationsLatencyKey,
-			Help:      "Latency in microseconds of Docker operations. Broken down by operation type.",
+			Help:      "Latency in seconds of Docker operations. Broken down by operation type.",
 		},
 		[]string{"operation_type"},
 	)
@@ -76,6 +85,45 @@ var (
 		},
 		[]string{"operation_type"},
 	)
+
+	// DeprecatedDockerOperationsLatency collects operation latency numbers by operation
+	// type.
+	DeprecatedDockerOperationsLatency = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Subsystem: kubeletSubsystem,
+			Name:      DeprecatedDockerOperationsLatencyKey,
+			Help:      "Latency in microseconds of Docker operations. Broken down by operation type.",
+		},
+		[]string{"operation_type"},
+	)
+	// DeprecatedDockerOperations collects operation counts by operation type.
+	DeprecatedDockerOperations = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: kubeletSubsystem,
+			Name:      DeprecatedDockerOperationsKey,
+			Help:      "Cumulative number of Docker operations by operation type.",
+		},
+		[]string{"operation_type"},
+	)
+	// DeprecatedDockerOperationsErrors collects operation errors by operation
+	// type.
+	DeprecatedDockerOperationsErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: kubeletSubsystem,
+			Name:      DeprecatedDockerOperationsErrorsKey,
+			Help:      "Cumulative number of Docker operation errors by operation type.",
+		},
+		[]string{"operation_type"},
+	)
+	// DeprecatedDockerOperationsTimeout collects operation timeouts by operation type.
+	DeprecatedDockerOperationsTimeout = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: kubeletSubsystem,
+			Name:      DeprecatedDockerOperationsTimeoutKey,
+			Help:      "Cumulative number of Docker operation timeout by operation type.",
+		},
+		[]string{"operation_type"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -87,10 +135,19 @@ func Register() {
 		prometheus.MustRegister(DockerOperations)
 		prometheus.MustRegister(DockerOperationsErrors)
 		prometheus.MustRegister(DockerOperationsTimeout)
+		prometheus.MustRegister(DeprecatedDockerOperationsLatency)
+		prometheus.MustRegister(DeprecatedDockerOperations)
+		prometheus.MustRegister(DeprecatedDockerOperationsErrors)
+		prometheus.MustRegister(DeprecatedDockerOperationsTimeout)
 	})
 }
 
 // SinceInMicroseconds gets the time since the specified start in microseconds.
 func SinceInMicroseconds(start time.Time) float64 {
 	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
+}
+
+// SinceInSeconds gets the time since the specified start in seconds.
+func SinceInSeconds(start time.Time) float64 {
+	return time.Since(start).Seconds()
 }

--- a/pkg/kubelet/dockershim/metrics/metrics.go
+++ b/pkg/kubelet/dockershim/metrics/metrics.go
@@ -49,11 +49,12 @@ const (
 var (
 	// DockerOperationsLatency collects operation latency numbers by operation
 	// type.
-	DockerOperationsLatency = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	DockerOperationsLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Subsystem: kubeletSubsystem,
 			Name:      DockerOperationsLatencyKey,
 			Help:      "Latency in seconds of Docker operations. Broken down by operation type.",
+			Buckets:   prometheus.DefBuckets,
 		},
 		[]string{"operation_type"},
 	)

--- a/pkg/kubelet/dockershim/network/metrics/metrics.go
+++ b/pkg/kubelet/dockershim/network/metrics/metrics.go
@@ -54,7 +54,7 @@ var (
 		prometheus.SummaryOpts{
 			Subsystem: kubeletSubsystem,
 			Name:      DeprecatedNetworkPluginOperationsLatencyKey,
-			Help:      "Latency in microseconds of network plugin operations. Broken down by operation type.",
+			Help:      "(Deprecated) Latency in microseconds of network plugin operations. Broken down by operation type.",
 		},
 		[]string{"operation_type"},
 	)

--- a/pkg/kubelet/dockershim/network/metrics/metrics.go
+++ b/pkg/kubelet/dockershim/network/metrics/metrics.go
@@ -38,11 +38,12 @@ const (
 var (
 	// NetworkPluginOperationsLatency collects operation latency numbers by operation
 	// type.
-	NetworkPluginOperationsLatency = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	NetworkPluginOperationsLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Subsystem: kubeletSubsystem,
 			Name:      NetworkPluginOperationsLatencyKey,
 			Help:      "Latency in seconds of network plugin operations. Broken down by operation type.",
+			Buckets:   prometheus.DefBuckets,
 		},
 		[]string{"operation_type"},
 	)

--- a/pkg/kubelet/dockershim/network/metrics/metrics.go
+++ b/pkg/kubelet/dockershim/network/metrics/metrics.go
@@ -27,7 +27,9 @@ const (
 	// NetworkPluginOperationsKey is the key for operation count metrics.
 	NetworkPluginOperationsKey = "network_plugin_operations"
 	// NetworkPluginOperationsLatencyKey is the key for the operation latency metrics.
-	NetworkPluginOperationsLatencyKey = "network_plugin_operations_latency_microseconds"
+	NetworkPluginOperationsLatencyKey = "network_plugin_operations_latency_seconds"
+	// DeprecatedNetworkPluginOperationsLatencyKey is the deprecated key for the operation latency metrics.
+	DeprecatedNetworkPluginOperationsLatencyKey = "network_plugin_operations_latency_microseconds"
 
 	// Keep the "kubelet" subsystem for backward compatibility.
 	kubeletSubsystem = "kubelet"
@@ -40,6 +42,17 @@ var (
 		prometheus.SummaryOpts{
 			Subsystem: kubeletSubsystem,
 			Name:      NetworkPluginOperationsLatencyKey,
+			Help:      "Latency in seconds of network plugin operations. Broken down by operation type.",
+		},
+		[]string{"operation_type"},
+	)
+
+	// DeprecatedNetworkPluginOperationsLatency collects operation latency numbers by operation
+	// type.
+	DeprecatedNetworkPluginOperationsLatency = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Subsystem: kubeletSubsystem,
+			Name:      DeprecatedNetworkPluginOperationsLatencyKey,
 			Help:      "Latency in microseconds of network plugin operations. Broken down by operation type.",
 		},
 		[]string{"operation_type"},
@@ -52,10 +65,16 @@ var registerMetrics sync.Once
 func Register() {
 	registerMetrics.Do(func() {
 		prometheus.MustRegister(NetworkPluginOperationsLatency)
+		prometheus.MustRegister(DeprecatedNetworkPluginOperationsLatency)
 	})
 }
 
 // SinceInMicroseconds gets the time since the specified start in microseconds.
 func SinceInMicroseconds(start time.Time) float64 {
 	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
+}
+
+// SinceInSeconds gets the time since the specified start in seconds.
+func SinceInSeconds(start time.Time) float64 {
+	return time.Since(start).Seconds()
 }

--- a/pkg/kubelet/dockershim/network/plugins.go
+++ b/pkg/kubelet/dockershim/network/plugins.go
@@ -351,7 +351,8 @@ func (pm *PluginManager) podUnlock(fullPodName string) {
 
 // recordOperation records operation and duration
 func recordOperation(operation string, start time.Time) {
-	metrics.NetworkPluginOperationsLatency.WithLabelValues(operation).Observe(metrics.SinceInMicroseconds(start))
+	metrics.NetworkPluginOperationsLatency.WithLabelValues(operation).Observe(metrics.SinceInSeconds(start))
+	metrics.DeprecatedNetworkPluginOperationsLatency.WithLabelValues(operation).Observe(metrics.SinceInMicroseconds(start))
 }
 
 func (pm *PluginManager) GetPodNetworkStatus(podNamespace, podName string, id kubecontainer.ContainerID) (*PodNetworkStatus, error) {

--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -169,7 +169,7 @@ var InterestingControllerManagerMetrics = []string{
 var InterestingKubeletMetrics = []string{
 	"kubelet_container_manager_latency_microseconds",
 	"kubelet_docker_errors",
-	"kubelet_docker_operations_latency_microseconds",
+	"kubelet_docker_operations_latency_seconds",
 	"kubelet_generate_pod_status_latency_microseconds",
 	"kubelet_pod_start_latency_microseconds",
 	"kubelet_pod_worker_latency_microseconds",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/sig instrumentation

**What this PR does / why we need it**:

1. As part of [kubernetes metrics overhaul](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md), change docker metrics to conform [Kubernetes metrics instrumentation guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/instrumentation.md).

2. Change docker metrics to histogram for better aggregation.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This patch does not remove the existing metrics but mark them as deprecated.
We need 2 releases for users to convert monitoring configuration.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Change docker metrics to conform metrics guidelines and using histogram for better aggregation.
The following metrics are deprecated, and will be removed in a future release:
* `docker_operations`
* `docker_operations_latency_microseconds`
* `docker_operations_errors`
* `docker_operations_timeout`
* `network_plugin_operations_latency_microseconds`
Please convert to the following metrics:
* `docker_operations_total`
* `docker_operations_latency_seconds`
* `docker_operations_errors_total`
* `docker_operations_timeout_total`
* `network_plugin_operations_latency_seconds`
```
