### PR TITLE
Change scheduler metrics to conform metrics guidelines

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -192,14 +192,16 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 			FailedPredicates: failedPredicateMap,
 		}
 	}
-	metrics.SchedulingAlgorithmPredicateEvaluationDuration.Observe(metrics.SinceInMicroseconds(startPredicateEvalTime))
+	metrics.SchedulingAlgorithmPredicateEvaluationDuration.Observe(metrics.SinceInSeconds(startPredicateEvalTime))
+	metrics.DeprecatedSchedulingAlgorithmPredicateEvaluationDuration.Observe(metrics.SinceInMicroseconds(startPredicateEvalTime))
 	metrics.SchedulingLatency.WithLabelValues(metrics.PredicateEvaluation).Observe(metrics.SinceInSeconds(startPredicateEvalTime))
 
 	trace.Step("Prioritizing")
 	startPriorityEvalTime := time.Now()
 	// When only one node after predicate, just use it.
 	if len(filteredNodes) == 1 {
-		metrics.SchedulingAlgorithmPriorityEvaluationDuration.Observe(metrics.SinceInMicroseconds(startPriorityEvalTime))
+		metrics.SchedulingAlgorithmPriorityEvaluationDuration.Observe(metrics.SinceInSeconds(startPriorityEvalTime))
+		metrics.DeprecatedSchedulingAlgorithmPriorityEvaluationDuration.Observe(metrics.SinceInMicroseconds(startPriorityEvalTime))
 		return ScheduleResult{
 			SuggestedHost:  filteredNodes[0].Name,
 			EvaluatedNodes: 1 + len(failedPredicateMap),
@@ -212,7 +214,8 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 	if err != nil {
 		return result, err
 	}
-	metrics.SchedulingAlgorithmPriorityEvaluationDuration.Observe(metrics.SinceInMicroseconds(startPriorityEvalTime))
+	metrics.SchedulingAlgorithmPriorityEvaluationDuration.Observe(metrics.SinceInSeconds(startPriorityEvalTime))
+	metrics.DeprecatedSchedulingAlgorithmPriorityEvaluationDuration.Observe(metrics.SinceInMicroseconds(startPriorityEvalTime))
 	metrics.SchedulingLatency.WithLabelValues(metrics.PriorityEvaluation).Observe(metrics.SinceInSeconds(startPriorityEvalTime))
 
 	trace.Step("Selecting host")

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -82,7 +82,7 @@ var (
 		prometheus.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "e2e_scheduling_latency_microseconds",
-			Help:      "E2e scheduling latency in microseconds (scheduling algorithm + binding)",
+			Help:      "(Deprecated) E2e scheduling latency in microseconds (scheduling algorithm + binding)",
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
@@ -98,7 +98,7 @@ var (
 		prometheus.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "scheduling_algorithm_latency_microseconds",
-			Help:      "Scheduling algorithm latency in microseconds",
+			Help:      "(Deprecated) Scheduling algorithm latency in microseconds",
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
@@ -114,7 +114,7 @@ var (
 		prometheus.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "scheduling_algorithm_predicate_evaluation",
-			Help:      "Scheduling algorithm predicate evaluation duration in microseconds",
+			Help:      "(Deprecated) Scheduling algorithm predicate evaluation duration in microseconds",
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
@@ -130,7 +130,7 @@ var (
 		prometheus.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "scheduling_algorithm_priority_evaluation",
-			Help:      "Scheduling algorithm priority evaluation duration in microseconds",
+			Help:      "(Deprecated) Scheduling algorithm priority evaluation duration in microseconds",
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
@@ -146,7 +146,7 @@ var (
 		prometheus.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "scheduling_algorithm_preemption_evaluation",
-			Help:      "Scheduling algorithm preemption evaluation duration in microseconds",
+			Help:      "(Deprecated) Scheduling algorithm preemption evaluation duration in microseconds",
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
@@ -162,7 +162,7 @@ var (
 		prometheus.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "binding_latency_microseconds",
-			Help:      "Binding latency in microseconds",
+			Help:      "(Deprecated) Binding latency in microseconds",
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -73,48 +73,96 @@ var (
 	E2eSchedulingLatency = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
+			Name:      "e2e_scheduling_latency_seconds",
+			Help:      "E2e scheduling latency in seconds (scheduling algorithm + binding)",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15),
+		},
+	)
+	DeprecatedE2eSchedulingLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Subsystem: SchedulerSubsystem,
 			Name:      "e2e_scheduling_latency_microseconds",
-			Help:      "E2e scheduling latency (scheduling algorithm + binding)",
+			Help:      "E2e scheduling latency in microseconds (scheduling algorithm + binding)",
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
 	SchedulingAlgorithmLatency = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
+			Name:      "scheduling_algorithm_latency_seconds",
+			Help:      "Scheduling algorithm latency in seconds",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15),
+		},
+	)
+	DeprecatedSchedulingAlgorithmLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Subsystem: SchedulerSubsystem,
 			Name:      "scheduling_algorithm_latency_microseconds",
-			Help:      "Scheduling algorithm latency",
+			Help:      "Scheduling algorithm latency in microseconds",
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
 	SchedulingAlgorithmPredicateEvaluationDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
+			Name:      "scheduling_algorithm_predicate_evaluation_seconds",
+			Help:      "Scheduling algorithm predicate evaluation duration in seconds",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15),
+		},
+	)
+	DeprecatedSchedulingAlgorithmPredicateEvaluationDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Subsystem: SchedulerSubsystem,
 			Name:      "scheduling_algorithm_predicate_evaluation",
-			Help:      "Scheduling algorithm predicate evaluation duration",
+			Help:      "Scheduling algorithm predicate evaluation duration in microseconds",
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
 	SchedulingAlgorithmPriorityEvaluationDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
+			Name:      "scheduling_algorithm_priority_evaluation_seconds",
+			Help:      "Scheduling algorithm priority evaluation duration in seconds",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15),
+		},
+	)
+	DeprecatedSchedulingAlgorithmPriorityEvaluationDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Subsystem: SchedulerSubsystem,
 			Name:      "scheduling_algorithm_priority_evaluation",
-			Help:      "Scheduling algorithm priority evaluation duration",
+			Help:      "Scheduling algorithm priority evaluation duration in microseconds",
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
 	SchedulingAlgorithmPremptionEvaluationDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
+			Name:      "scheduling_algorithm_preemption_evaluation_seconds",
+			Help:      "Scheduling algorithm preemption evaluation duration in seconds",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15),
+		},
+	)
+	DeprecatedSchedulingAlgorithmPremptionEvaluationDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Subsystem: SchedulerSubsystem,
 			Name:      "scheduling_algorithm_preemption_evaluation",
-			Help:      "Scheduling algorithm preemption evaluation duration",
+			Help:      "Scheduling algorithm preemption evaluation duration in microseconds",
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
 	BindingLatency = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
+			Name:      "binding_latency_seconds",
+			Help:      "Binding latency in seconds",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15),
+		},
+	)
+	DeprecatedBindingLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Subsystem: SchedulerSubsystem,
 			Name:      "binding_latency_microseconds",
-			Help:      "Binding latency",
+			Help:      "Binding latency in microseconds",
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
@@ -135,11 +183,17 @@ var (
 		scheduleAttempts,
 		SchedulingLatency,
 		E2eSchedulingLatency,
+		DeprecatedE2eSchedulingLatency,
 		SchedulingAlgorithmLatency,
+		DeprecatedSchedulingAlgorithmLatency,
 		BindingLatency,
+		DeprecatedBindingLatency,
 		SchedulingAlgorithmPredicateEvaluationDuration,
+		DeprecatedSchedulingAlgorithmPredicateEvaluationDuration,
 		SchedulingAlgorithmPriorityEvaluationDuration,
+		DeprecatedSchedulingAlgorithmPriorityEvaluationDuration,
 		SchedulingAlgorithmPremptionEvaluationDuration,
+		DeprecatedSchedulingAlgorithmPremptionEvaluationDuration,
 		PreemptionVictims,
 		PreemptionAttempts,
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -444,7 +444,8 @@ func (sched *Scheduler) bind(assumed *v1.Pod, b *v1.Binding) error {
 		return err
 	}
 
-	metrics.BindingLatency.Observe(metrics.SinceInMicroseconds(bindingStart))
+	metrics.BindingLatency.Observe(metrics.SinceInSeconds(bindingStart))
+	metrics.DeprecatedBindingLatency.Observe(metrics.SinceInMicroseconds(bindingStart))
 	metrics.SchedulingLatency.WithLabelValues(metrics.Binding).Observe(metrics.SinceInSeconds(bindingStart))
 	sched.config.Recorder.Eventf(assumed, v1.EventTypeNormal, "Scheduled", "Successfully assigned %v/%v to %v", assumed.Namespace, assumed.Name, b.Target.Name)
 	return nil
@@ -487,7 +488,8 @@ func (sched *Scheduler) scheduleOne() {
 				preemptionStartTime := time.Now()
 				sched.preempt(pod, fitError)
 				metrics.PreemptionAttempts.Inc()
-				metrics.SchedulingAlgorithmPremptionEvaluationDuration.Observe(metrics.SinceInMicroseconds(preemptionStartTime))
+				metrics.SchedulingAlgorithmPremptionEvaluationDuration.Observe(metrics.SinceInSeconds(preemptionStartTime))
+				metrics.DeprecatedSchedulingAlgorithmPremptionEvaluationDuration.Observe(metrics.SinceInMicroseconds(preemptionStartTime))
 				metrics.SchedulingLatency.WithLabelValues(metrics.PreemptionEvaluation).Observe(metrics.SinceInSeconds(preemptionStartTime))
 			}
 			// Pod did not fit anywhere, so it is counted as a failure. If preemption
@@ -500,7 +502,8 @@ func (sched *Scheduler) scheduleOne() {
 		}
 		return
 	}
-	metrics.SchedulingAlgorithmLatency.Observe(metrics.SinceInMicroseconds(start))
+	metrics.SchedulingAlgorithmLatency.Observe(metrics.SinceInSeconds(start))
+	metrics.DeprecatedSchedulingAlgorithmLatency.Observe(metrics.SinceInMicroseconds(start))
 	// Tell the cache to assume that a pod now is running on a given node, even though it hasn't been bound yet.
 	// This allows us to keep scheduling without waiting on binding to occur.
 	assumedPod := pod.DeepCopy()
@@ -579,7 +582,8 @@ func (sched *Scheduler) scheduleOne() {
 				Name: scheduleResult.SuggestedHost,
 			},
 		})
-		metrics.E2eSchedulingLatency.Observe(metrics.SinceInMicroseconds(start))
+		metrics.E2eSchedulingLatency.Observe(metrics.SinceInSeconds(start))
+		metrics.DeprecatedE2eSchedulingLatency.Observe(metrics.SinceInMicroseconds(start))
 		if err != nil {
 			klog.Errorf("error binding pod: %v", err)
 			metrics.PodScheduleErrors.Inc()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/sig instrumentation

**What this PR does / why we need it**:

As part of [kubernetes metrics overhaul](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md), change scheduler metrics to conform [Kubernetes metrics instrumentation guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/instrumentation.md).

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This patch does not remove the existing metrics but mark them as deprecated.
We need 2 releases for users to convert monitoring configuration.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Change scheduler metrics to conform metrics guidelines.
The following metrics are deprecated, and will be removed in a future release:
* `e2e_scheduling_latency_microseconds`
* `scheduling_algorithm_latency_microseconds`
* `scheduling_algorithm_predicate_evaluation`
* `scheduling_algorithm_priority_evaluation`
* `scheduling_algorithm_preemption_evaluation`
* `binding_latency_microseconds`
Please convert to the following metrics:
* `e2e_scheduling_latency_seconds`
* `scheduling_algorithm_latency_seconds`
* `scheduling_algorithm_predicate_evaluation_seconds`
* `scheduling_algorithm_priority_evaluation_seconds`
* `scheduling_algorithm_preemption_evaluation_seconds`
* `binding_latency_seconds`
```
