### PR TITLE
Change apiserver metrics to conform metrics guidelines

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -57,7 +57,7 @@ var (
 	deprecatedRequestCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "apiserver_request_count",
-			Help: "Counter of apiserver requests broken out for each verb, group, version, resource, scope, component, client, and HTTP response contentType and code.",
+			Help: "(Deprecated) Counter of apiserver requests broken out for each verb, group, version, resource, scope, component, client, and HTTP response contentType and code.",
 		},
 		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component", "client", "contentType", "code"},
 	)
@@ -77,20 +77,10 @@ var (
 		},
 		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component"},
 	)
-	requestLatenciesSummary = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Name: "apiserver_request_latency_seconds_summary",
-			Help: "Response latency summary in seconds for each verb, group, version, resource, subresource, scope and component.",
-			// Make the sliding window of 5h.
-			// TODO: The value for this should be based on our SLI definition (medium term).
-			MaxAge: 5 * time.Hour,
-		},
-		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component"},
-	)
 	deprecatedRequestLatencies = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "apiserver_request_latencies",
-			Help: "Response latency distribution in microseconds for each verb, group, version, resource, subresource, scope and component.",
+			Help: "(Deprecated) Response latency distribution in microseconds for each verb, group, version, resource, subresource, scope and component.",
 			// Use buckets ranging from 125 ms to 8 seconds.
 			Buckets: prometheus.ExponentialBuckets(125000, 2.0, 7),
 		},
@@ -99,7 +89,7 @@ var (
 	deprecatedRequestLatenciesSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name: "apiserver_request_latencies_summary",
-			Help: "Response latency summary in microseconds for each verb, group, version, resource, subresource, scope and component.",
+			Help: "(Deprecated) Response latency summary in microseconds for each verb, group, version, resource, subresource, scope and component.",
 			// Make the sliding window of 5h.
 			// TODO: The value for this should be based on our SLI definition (medium term).
 			MaxAge: 5 * time.Hour,
@@ -126,7 +116,7 @@ var (
 	DeprecatedDroppedRequests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "apiserver_dropped_requests",
-			Help: "Number of requests dropped with 'Try again later' response",
+			Help: "(Deprecated) Number of requests dropped with 'Try again later' response",
 		},
 		[]string{"requestKind"},
 	)
@@ -154,7 +144,6 @@ var (
 		deprecatedRequestCounter,
 		longRunningRequestGauge,
 		requestLatencies,
-		requestLatenciesSummary,
 		deprecatedRequestLatencies,
 		deprecatedRequestLatenciesSummary,
 		responseSizes,
@@ -240,7 +229,6 @@ func MonitorRequest(req *http.Request, verb, group, version, resource, subresour
 	deprecatedRequestCounter.WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component, client, contentType, codeToString(httpCode)).Inc()
 	requestLatencies.WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component).Observe(elapsedSeconds)
 	deprecatedRequestLatencies.WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component).Observe(elapsedMicroseconds)
-	requestLatenciesSummary.WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component).Observe(elapsedSeconds)
 	deprecatedRequestLatenciesSummary.WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component).Observe(elapsedMicroseconds)
 	// We are only interested in response sizes of read requests.
 	if verb == "GET" || verb == "LIST" {

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
@@ -163,8 +163,10 @@ func WithMaxInFlightLimit(
 				// We need to split this data between buckets used for throttling.
 				if isMutatingRequest {
 					metrics.DroppedRequests.WithLabelValues(metrics.MutatingKind).Inc()
+					metrics.DeprecatedDroppedRequests.WithLabelValues(metrics.MutatingKind).Inc()
 				} else {
 					metrics.DroppedRequests.WithLabelValues(metrics.ReadOnlyKind).Inc()
+					metrics.DeprecatedDroppedRequests.WithLabelValues(metrics.ReadOnlyKind).Inc()
 				}
 				// at this point we're about to return a 429, BUT not all actors should be rate limited.  A system:master is so powerful
 				// that they should always get an answer.  It's a super-admin or a loopback connection.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/metrics/metrics.go
@@ -40,22 +40,22 @@ var (
 			"because two concurrent threads can miss the cache and generate the same entry twice.",
 	}
 	cacheEntryCounter = prometheus.NewCounter(cacheEntryCounterOpts)
-	cacheGetLatency   = prometheus.NewSummary(
-		prometheus.SummaryOpts{
+	cacheGetLatency   = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
 			Name: "etcd_request_cache_get_latency_seconds",
 			Help: "Latency in seconds of getting an object from etcd cache",
 		},
 	)
-	cacheAddLatency = prometheus.NewSummary(
-		prometheus.SummaryOpts{
+	cacheAddLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
 			Name: "etcd_request_cache_add_latency_seconds",
 			Help: "Latency in seconds of adding an object to etcd cache",
 		},
 	)
-	etcdRequestLatenciesSummary = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	etcdRequestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Name: "etcd_request_latency_seconds",
-			Help: "Etcd request latency summary in seconds for each operation and object type.",
+			Help: "Etcd request latency in seconds for each operation and object type.",
 		},
 		[]string{"operation", "type"},
 	)
@@ -69,36 +69,36 @@ var (
 
 	deprecatedCacheHitCounterOpts = prometheus.CounterOpts{
 		Name: "etcd_helper_cache_hit_count",
-		Help: "Counter of etcd helper cache hits.",
+		Help: "(Deprecated) Counter of etcd helper cache hits.",
 	}
 	deprecatedCacheHitCounter      = prometheus.NewCounter(deprecatedCacheHitCounterOpts)
 	deprecatedCacheMissCounterOpts = prometheus.CounterOpts{
 		Name: "etcd_helper_cache_miss_count",
-		Help: "Counter of etcd helper cache miss.",
+		Help: "(Deprecated) Counter of etcd helper cache miss.",
 	}
 	deprecatedCacheMissCounter      = prometheus.NewCounter(deprecatedCacheMissCounterOpts)
 	deprecatedCacheEntryCounterOpts = prometheus.CounterOpts{
 		Name: "etcd_helper_cache_entry_count",
-		Help: "Counter of etcd helper cache entries. This can be different from etcd_helper_cache_miss_count " +
+		Help: "(Deprecated) Counter of etcd helper cache entries. This can be different from etcd_helper_cache_miss_count " +
 			"because two concurrent threads can miss the cache and generate the same entry twice.",
 	}
 	deprecatedCacheEntryCounter = prometheus.NewCounter(deprecatedCacheEntryCounterOpts)
 	deprecatedCacheGetLatency   = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Name: "etcd_request_cache_get_latencies_summary",
-			Help: "Latency in microseconds of getting an object from etcd cache",
+			Help: "(Deprecated) Latency in microseconds of getting an object from etcd cache",
 		},
 	)
 	deprecatedCacheAddLatency = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Name: "etcd_request_cache_add_latencies_summary",
-			Help: "Latency in microseconds of adding an object to etcd cache",
+			Help: "(Deprecated) Latency in microseconds of adding an object to etcd cache",
 		},
 	)
 	deprecatedEtcdRequestLatenciesSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name: "etcd_request_latencies_summary",
-			Help: "Etcd request latency summary in microseconds for each operation and object type.",
+			Help: "(Deprecated) Etcd request latency summary in microseconds for each operation and object type.",
 		},
 		[]string{"operation", "type"},
 	)
@@ -115,7 +115,7 @@ func Register() {
 		prometheus.MustRegister(cacheEntryCounter)
 		prometheus.MustRegister(cacheAddLatency)
 		prometheus.MustRegister(cacheGetLatency)
-		prometheus.MustRegister(etcdRequestLatenciesSummary)
+		prometheus.MustRegister(etcdRequestLatency)
 		prometheus.MustRegister(objectCounts)
 
 		// TODO(danielqsj): Remove the following metrics, they are deprecated
@@ -133,7 +133,7 @@ func UpdateObjectCount(resourcePrefix string, count int64) {
 }
 
 func RecordEtcdRequestLatency(verb, resource string, startTime time.Time) {
-	etcdRequestLatenciesSummary.WithLabelValues(verb, resource).Observe(sinceInSeconds(startTime))
+	etcdRequestLatency.WithLabelValues(verb, resource).Observe(sinceInSeconds(startTime))
 	deprecatedEtcdRequestLatenciesSummary.WithLabelValues(verb, resource).Observe(sinceInMicroseconds(startTime))
 }
 
@@ -168,7 +168,7 @@ func Reset() {
 	cacheEntryCounter = prometheus.NewCounter(cacheEntryCounterOpts)
 	// TODO: Reset cacheAddLatency.
 	// TODO: Reset cacheGetLatency.
-	etcdRequestLatenciesSummary.Reset()
+	etcdRequestLatency.Reset()
 
 	deprecatedCacheHitCounter = prometheus.NewCounter(deprecatedCacheHitCounterOpts)
 	deprecatedCacheMissCounter = prometheus.NewCounter(deprecatedCacheMissCounterOpts)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/metrics/metrics.go
@@ -25,37 +25,37 @@ import (
 
 var (
 	cacheHitCounterOpts = prometheus.CounterOpts{
-		Name: "etcd_helper_cache_hit_count",
+		Name: "etcd_helper_cache_hit_total",
 		Help: "Counter of etcd helper cache hits.",
 	}
 	cacheHitCounter      = prometheus.NewCounter(cacheHitCounterOpts)
 	cacheMissCounterOpts = prometheus.CounterOpts{
-		Name: "etcd_helper_cache_miss_count",
+		Name: "etcd_helper_cache_miss_total",
 		Help: "Counter of etcd helper cache miss.",
 	}
 	cacheMissCounter      = prometheus.NewCounter(cacheMissCounterOpts)
 	cacheEntryCounterOpts = prometheus.CounterOpts{
-		Name: "etcd_helper_cache_entry_count",
+		Name: "etcd_helper_cache_entry_total",
 		Help: "Counter of etcd helper cache entries. This can be different from etcd_helper_cache_miss_count " +
 			"because two concurrent threads can miss the cache and generate the same entry twice.",
 	}
 	cacheEntryCounter = prometheus.NewCounter(cacheEntryCounterOpts)
 	cacheGetLatency   = prometheus.NewSummary(
 		prometheus.SummaryOpts{
-			Name: "etcd_request_cache_get_latencies_summary",
-			Help: "Latency in microseconds of getting an object from etcd cache",
+			Name: "etcd_request_cache_get_latency_seconds",
+			Help: "Latency in seconds of getting an object from etcd cache",
 		},
 	)
 	cacheAddLatency = prometheus.NewSummary(
 		prometheus.SummaryOpts{
-			Name: "etcd_request_cache_add_latencies_summary",
-			Help: "Latency in microseconds of adding an object to etcd cache",
+			Name: "etcd_request_cache_add_latency_seconds",
+			Help: "Latency in seconds of adding an object to etcd cache",
 		},
 	)
 	etcdRequestLatenciesSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Name: "etcd_request_latencies_summary",
-			Help: "Etcd request latency summary in microseconds for each operation and object type.",
+			Name: "etcd_request_latency_seconds",
+			Help: "Etcd request latency summary in seconds for each operation and object type.",
 		},
 		[]string{"operation", "type"},
 	)
@@ -65,6 +65,42 @@ var (
 			Help: "Number of stored objects at the time of last check split by kind.",
 		},
 		[]string{"resource"},
+	)
+
+	deprecatedCacheHitCounterOpts = prometheus.CounterOpts{
+		Name: "etcd_helper_cache_hit_count",
+		Help: "Counter of etcd helper cache hits.",
+	}
+	deprecatedCacheHitCounter      = prometheus.NewCounter(deprecatedCacheHitCounterOpts)
+	deprecatedCacheMissCounterOpts = prometheus.CounterOpts{
+		Name: "etcd_helper_cache_miss_count",
+		Help: "Counter of etcd helper cache miss.",
+	}
+	deprecatedCacheMissCounter      = prometheus.NewCounter(deprecatedCacheMissCounterOpts)
+	deprecatedCacheEntryCounterOpts = prometheus.CounterOpts{
+		Name: "etcd_helper_cache_entry_count",
+		Help: "Counter of etcd helper cache entries. This can be different from etcd_helper_cache_miss_count " +
+			"because two concurrent threads can miss the cache and generate the same entry twice.",
+	}
+	deprecatedCacheEntryCounter = prometheus.NewCounter(deprecatedCacheEntryCounterOpts)
+	deprecatedCacheGetLatency   = prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Name: "etcd_request_cache_get_latencies_summary",
+			Help: "Latency in microseconds of getting an object from etcd cache",
+		},
+	)
+	deprecatedCacheAddLatency = prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Name: "etcd_request_cache_add_latencies_summary",
+			Help: "Latency in microseconds of adding an object to etcd cache",
+		},
+	)
+	deprecatedEtcdRequestLatenciesSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "etcd_request_latencies_summary",
+			Help: "Etcd request latency summary in microseconds for each operation and object type.",
+		},
+		[]string{"operation", "type"},
 	)
 )
 
@@ -81,6 +117,14 @@ func Register() {
 		prometheus.MustRegister(cacheGetLatency)
 		prometheus.MustRegister(etcdRequestLatenciesSummary)
 		prometheus.MustRegister(objectCounts)
+
+		// TODO(danielqsj): Remove the following metrics, they are deprecated
+		prometheus.MustRegister(deprecatedCacheHitCounter)
+		prometheus.MustRegister(deprecatedCacheMissCounter)
+		prometheus.MustRegister(deprecatedCacheEntryCounter)
+		prometheus.MustRegister(deprecatedCacheAddLatency)
+		prometheus.MustRegister(deprecatedCacheGetLatency)
+		prometheus.MustRegister(deprecatedEtcdRequestLatenciesSummary)
 	})
 }
 
@@ -89,27 +133,33 @@ func UpdateObjectCount(resourcePrefix string, count int64) {
 }
 
 func RecordEtcdRequestLatency(verb, resource string, startTime time.Time) {
-	etcdRequestLatenciesSummary.WithLabelValues(verb, resource).Observe(float64(time.Since(startTime) / time.Microsecond))
+	etcdRequestLatenciesSummary.WithLabelValues(verb, resource).Observe(sinceInSeconds(startTime))
+	deprecatedEtcdRequestLatenciesSummary.WithLabelValues(verb, resource).Observe(sinceInMicroseconds(startTime))
 }
 
 func ObserveGetCache(startTime time.Time) {
-	cacheGetLatency.Observe(float64(time.Since(startTime) / time.Microsecond))
+	cacheGetLatency.Observe(sinceInSeconds(startTime))
+	deprecatedCacheGetLatency.Observe(sinceInMicroseconds(startTime))
 }
 
 func ObserveAddCache(startTime time.Time) {
-	cacheAddLatency.Observe(float64(time.Since(startTime) / time.Microsecond))
+	cacheAddLatency.Observe(sinceInSeconds(startTime))
+	deprecatedCacheAddLatency.Observe(sinceInMicroseconds(startTime))
 }
 
 func ObserveCacheHit() {
 	cacheHitCounter.Inc()
+	deprecatedCacheHitCounter.Inc()
 }
 
 func ObserveCacheMiss() {
 	cacheMissCounter.Inc()
+	deprecatedCacheMissCounter.Inc()
 }
 
 func ObserveNewEntry() {
 	cacheEntryCounter.Inc()
+	deprecatedCacheEntryCounter.Inc()
 }
 
 func Reset() {
@@ -119,4 +169,19 @@ func Reset() {
 	// TODO: Reset cacheAddLatency.
 	// TODO: Reset cacheGetLatency.
 	etcdRequestLatenciesSummary.Reset()
+
+	deprecatedCacheHitCounter = prometheus.NewCounter(deprecatedCacheHitCounterOpts)
+	deprecatedCacheMissCounter = prometheus.NewCounter(deprecatedCacheMissCounterOpts)
+	deprecatedCacheEntryCounter = prometheus.NewCounter(deprecatedCacheEntryCounterOpts)
+	deprecatedEtcdRequestLatenciesSummary.Reset()
+}
+
+// sinceInMicroseconds gets the time since the specified start in microseconds.
+func sinceInMicroseconds(start time.Time) float64 {
+	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
+}
+
+// sinceInSeconds gets the time since the specified start in seconds.
+func sinceInSeconds(start time.Time) float64 {
+	return time.Since(start).Seconds()
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
@@ -46,7 +46,7 @@ var (
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "transformation_latencies_microseconds",
-			Help:      "Latencies in microseconds of value transformation operations.",
+			Help:      "(Deprecated) Latencies in microseconds of value transformation operations.",
 			// In-process transformations (ex. AES CBC) complete on the order of 20 microseconds. However, when
 			// external KMS is involved latencies may climb into milliseconds.
 			Buckets: prometheus.ExponentialBuckets(5, 2, 14),
@@ -86,7 +86,7 @@ var (
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "data_key_generation_latencies_microseconds",
-			Help:      "Latencies in microseconds of data encryption key(DEK) generation operations.",
+			Help:      "(Deprecated) Latencies in microseconds of data encryption key(DEK) generation operations.",
 			Buckets:   prometheus.ExponentialBuckets(5, 2, 14),
 		},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
@@ -33,6 +33,18 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
+			Name:      "transformation_latencies_seconds",
+			Help:      "Latencies in seconds of value transformation operations.",
+			// In-process transformations (ex. AES CBC) complete on the order of 20 microseconds. However, when
+			// external KMS is involved latencies may climb into milliseconds.
+			Buckets: prometheus.ExponentialBuckets(5e-6, 2, 14),
+		},
+		[]string{"transformation_type"},
+	)
+	deprecatedTransformerLatencies = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
 			Name:      "transformation_latencies_microseconds",
 			Help:      "Latencies in microseconds of value transformation operations.",
 			// In-process transformations (ex. AES CBC) complete on the order of 20 microseconds. However, when
@@ -64,6 +76,15 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
+			Name:      "data_key_generation_latencies_seconds",
+			Help:      "Latencies in seconds of data encryption key(DEK) generation operations.",
+			Buckets:   prometheus.ExponentialBuckets(5e-6, 2, 14),
+		},
+	)
+	deprecatedDataKeyGenerationLatencies = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
 			Name:      "data_key_generation_latencies_microseconds",
 			Help:      "Latencies in microseconds of data encryption key(DEK) generation operations.",
 			Buckets:   prometheus.ExponentialBuckets(5, 2, 14),
@@ -84,9 +105,11 @@ var registerMetrics sync.Once
 func RegisterMetrics() {
 	registerMetrics.Do(func() {
 		prometheus.MustRegister(transformerLatencies)
+		prometheus.MustRegister(deprecatedTransformerLatencies)
 		prometheus.MustRegister(transformerFailuresTotal)
 		prometheus.MustRegister(envelopeTransformationCacheMissTotal)
 		prometheus.MustRegister(dataKeyGenerationLatencies)
+		prometheus.MustRegister(deprecatedDataKeyGenerationLatencies)
 		prometheus.MustRegister(dataKeyGenerationFailuresTotal)
 	})
 }
@@ -98,8 +121,8 @@ func RecordTransformation(transformationType string, start time.Time, err error)
 		return
 	}
 
-	since := sinceInMicroseconds(start)
-	transformerLatencies.WithLabelValues(transformationType).Observe(float64(since))
+	transformerLatencies.WithLabelValues(transformationType).Observe(sinceInSeconds(start))
+	deprecatedTransformerLatencies.WithLabelValues(transformationType).Observe(sinceInMicroseconds(start))
 }
 
 // RecordCacheMiss records a miss on Key Encryption Key(KEK) - call to KMS was required to decrypt KEK.
@@ -114,11 +137,16 @@ func RecordDataKeyGeneration(start time.Time, err error) {
 		return
 	}
 
-	since := sinceInMicroseconds(start)
-	dataKeyGenerationLatencies.Observe(float64(since))
+	dataKeyGenerationLatencies.Observe(sinceInSeconds(start))
+	deprecatedDataKeyGenerationLatencies.Observe(sinceInMicroseconds(start))
 }
 
-func sinceInMicroseconds(start time.Time) int64 {
-	elapsedNanoseconds := time.Since(start).Nanoseconds()
-	return elapsedNanoseconds / int64(time.Microsecond)
+// sinceInMicroseconds gets the time since the specified start in microseconds.
+func sinceInMicroseconds(start time.Time) float64 {
+	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
+}
+
+// sinceInSeconds gets the time since the specified start in seconds.
+func sinceInSeconds(start time.Time) float64 {
+	return time.Since(start).Seconds()
 }

--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -136,14 +136,14 @@ func (m *MetricsForE2E) SummaryKind() string {
 var SchedulingLatencyMetricName = model.LabelValue(schedulermetric.SchedulerSubsystem + "_" + schedulermetric.SchedulingLatencyName)
 
 var InterestingApiServerMetrics = []string{
-	"apiserver_request_count",
-	"apiserver_request_latencies_summary",
-	"etcd_helper_cache_entry_count",
-	"etcd_helper_cache_hit_count",
-	"etcd_helper_cache_miss_count",
-	"etcd_request_cache_add_latencies_summary",
-	"etcd_request_cache_get_latencies_summary",
-	"etcd_request_latencies_summary",
+	"apiserver_request_total",
+	"apiserver_request_latency_seconds_summary",
+	"etcd_helper_cache_entry_total",
+	"etcd_helper_cache_hit_total",
+	"etcd_helper_cache_miss_total",
+	"etcd_request_cache_add_latency_seconds",
+	"etcd_request_cache_get_latency_seconds",
+	"etcd_request_latency_seconds",
 }
 
 var InterestingControllerManagerMetrics = []string{
@@ -475,10 +475,10 @@ func readLatencyMetrics(c clientset.Interface) (*APIResponsiveness, error) {
 
 	for _, sample := range samples {
 		// Example line:
-		// apiserver_request_latencies_summary{resource="namespaces",verb="LIST",quantile="0.99"} 908
-		// apiserver_request_count{resource="pods",verb="LIST",client="kubectl",code="200",contentType="json"} 233
-		if sample.Metric[model.MetricNameLabel] != "apiserver_request_latencies_summary" &&
-			sample.Metric[model.MetricNameLabel] != "apiserver_request_count" {
+		// apiserver_request_latency_seconds_summary{resource="namespaces",verb="LIST",quantile="0.99"} 0.000908
+		// apiserver_request_total{resource="pods",verb="LIST",client="kubectl",code="200",contentType="json"} 233
+		if sample.Metric[model.MetricNameLabel] != "apiserver_request_latency_seconds_summary" &&
+			sample.Metric[model.MetricNameLabel] != "apiserver_request_total" {
 			continue
 		}
 
@@ -491,14 +491,14 @@ func readLatencyMetrics(c clientset.Interface) (*APIResponsiveness, error) {
 		}
 
 		switch sample.Metric[model.MetricNameLabel] {
-		case "apiserver_request_latencies_summary":
+		case "apiserver_request_latency_seconds_summary":
 			latency := sample.Value
 			quantile, err := strconv.ParseFloat(string(sample.Metric[model.QuantileLabel]), 64)
 			if err != nil {
 				return nil, err
 			}
-			a.addMetricRequestLatency(resource, subresource, verb, scope, quantile, time.Duration(int64(latency))*time.Microsecond)
-		case "apiserver_request_count":
+			a.addMetricRequestLatency(resource, subresource, verb, scope, quantile, time.Duration(int64(latency))*time.Second)
+		case "apiserver_request_total":
 			count := sample.Value
 			a.addMetricRequestCount(resource, subresource, verb, scope, int(count))
 

--- a/test/integration/metrics/metrics_test.go
+++ b/test/integration/metrics/metrics_test.go
@@ -120,7 +120,7 @@ func TestApiserverMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkForExpectedMetrics(t, metrics, []string{
-		"apiserver_request_count",
-		"apiserver_request_latencies",
+		"apiserver_request_total",
+		"apiserver_request_latency_seconds",
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/sig instrumentation

**What this PR does / why we need it**:

1. As part of [kubernetes metrics overhaul](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md), change apiserver metrics to conform [Kubernetes metrics instrumentation guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/instrumentation.md).
2. Change etcd latency metrics to histogram for better aggregation.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This patch does not remove the existing metrics but mark them as deprecated.
We need 2 releases for users to convert monitoring configuration.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Change apiserver metrics to conform metrics guidelines.
The following metrics are deprecated, and will be removed in a future release:
* `apiserver_request_count`
* `apiserver_request_latencies`
* `apiserver_request_latencies_summary`
* `apiserver_dropped_requests`
* `etcd_helper_cache_hit_count`
* `etcd_helper_cache_miss_count`
* `etcd_helper_cache_entry_count`
* `etcd_request_cache_get_latencies_summary`
* `etcd_request_cache_add_latencies_summary`
* `etcd_request_latencies_summary`
* `transformation_latencies_microseconds `
* `data_key_generation_latencies_microseconds`
Please convert to the following metrics:
* `apiserver_request_total`
* `apiserver_request_latency_seconds`
* `apiserver_dropped_requests_total`
* `etcd_helper_cache_hit_total`
* `etcd_helper_cache_miss_total`
* `etcd_helper_cache_entry_total`
* `etcd_request_cache_get_latency_seconds`
* `etcd_request_cache_add_latency_seconds`
* `etcd_request_latency_seconds`
* `transformation_latencies_seconds`
* `data_key_generation_latencies_seconds`
```