### PR TITLE
kubelet: fixes cadvisor internal error

### DIFF
--- a/pkg/kubelet/cadvisor/helpers_linux.go
+++ b/pkg/kubelet/cadvisor/helpers_linux.go
@@ -42,7 +42,7 @@ func (i *imageFsInfoProvider) ImageFsInfoLabel() (string, error) {
 		// This is a temporary workaround to get stats for cri-o from cadvisor
 		// and should be removed.
 		// Related to https://github.com/kubernetes/kubernetes/issues/51798
-		if i.runtimeEndpoint == CrioSocket {
+		if i.runtimeEndpoint == CrioSocket || i.runtimeEndpoint == "unix://"+CrioSocket {
 			return cadvisorfs.LabelCrioImages, nil
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When kubelet is set `--container-runtime-endpoint=unix:///var/run/crio/crio.sock`, cadvisor in kubelet returns `Internal Error: failed to get imageFs stats: failed to get imageFs info: no imagefs label for configured runtime` because `runtimeEndpoint` is not assumed "unix://" prefix for CrioSocket.

**Does this PR introduce a user-facing change?**:
```release-note
kubelet: fixes cadvisor internal error when "--container-runtime-endpoint" is set to "unix:///var/run/crio/crio.sock".
```