### PR TITLE
Fix admission metrics in true units

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -153,19 +153,31 @@ func (m *AdmissionMetrics) ObserveWebhook(elapsed time.Duration, rejected bool, 
 }
 
 type metricSet struct {
-	latencies        *prometheus.HistogramVec
-	latenciesSummary *prometheus.SummaryVec
+	latencies                  *prometheus.HistogramVec
+	deprecatedLatencies        *prometheus.HistogramVec
+	latenciesSummary           *prometheus.SummaryVec
+	deprecatedLatenciesSummary *prometheus.SummaryVec
 }
 
 func newMetricSet(name string, labels []string, helpTemplate string, hasSummary bool) *metricSet {
-	var summary *prometheus.SummaryVec
+	var summary, deprecatedSummary *prometheus.SummaryVec
 	if hasSummary {
 		summary = prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
 				Namespace: namespace,
 				Subsystem: subsystem,
 				Name:      fmt.Sprintf("%s_admission_latencies_seconds_summary", name),
-				Help:      fmt.Sprintf(helpTemplate, "latency summary"),
+				Help:      fmt.Sprintf(helpTemplate, "latency summary in seconds"),
+				MaxAge:    latencySummaryMaxAge,
+			},
+			labels,
+		)
+		deprecatedSummary = prometheus.NewSummaryVec(
+			prometheus.SummaryOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      fmt.Sprintf("%s_admission_latencies_milliseconds_summary", name),
+				Help:      fmt.Sprintf("(Deprecated) "+helpTemplate, "latency summary in milliseconds"),
 				MaxAge:    latencySummaryMaxAge,
 			},
 			labels,
@@ -178,37 +190,61 @@ func newMetricSet(name string, labels []string, helpTemplate string, hasSummary 
 				Namespace: namespace,
 				Subsystem: subsystem,
 				Name:      fmt.Sprintf("%s_admission_latencies_seconds", name),
-				Help:      fmt.Sprintf(helpTemplate, "latency histogram"),
+				Help:      fmt.Sprintf(helpTemplate, "latency histogram in seconds"),
+				Buckets:   latencyBuckets,
+			},
+			labels,
+		),
+		deprecatedLatencies: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      fmt.Sprintf("%s_admission_latencies_milliseconds", name),
+				Help:      fmt.Sprintf("(Deprecated) "+helpTemplate, "latency histogram in milliseconds"),
 				Buckets:   latencyBuckets,
 			},
 			labels,
 		),
 
-		latenciesSummary: summary,
+		latenciesSummary:           summary,
+		deprecatedLatenciesSummary: deprecatedSummary,
 	}
 }
 
 // MustRegister registers all the prometheus metrics in the metricSet.
 func (m *metricSet) mustRegister() {
 	prometheus.MustRegister(m.latencies)
+	prometheus.MustRegister(m.deprecatedLatencies)
 	if m.latenciesSummary != nil {
 		prometheus.MustRegister(m.latenciesSummary)
+	}
+	if m.deprecatedLatenciesSummary != nil {
+		prometheus.MustRegister(m.deprecatedLatenciesSummary)
 	}
 }
 
 // Reset resets all the prometheus metrics in the metricSet.
 func (m *metricSet) reset() {
 	m.latencies.Reset()
+	m.deprecatedLatencies.Reset()
 	if m.latenciesSummary != nil {
 		m.latenciesSummary.Reset()
+	}
+	if m.deprecatedLatenciesSummary != nil {
+		m.deprecatedLatenciesSummary.Reset()
 	}
 }
 
 // Observe records an observed admission event to all metrics in the metricSet.
 func (m *metricSet) observe(elapsed time.Duration, labels ...string) {
 	elapsedSeconds := elapsed.Seconds()
+	elapsedMicroseconds := float64(elapsed / time.Microsecond)
 	m.latencies.WithLabelValues(labels...).Observe(elapsedSeconds)
+	m.deprecatedLatencies.WithLabelValues(labels...).Observe(elapsedMicroseconds)
 	if m.latenciesSummary != nil {
 		m.latenciesSummary.WithLabelValues(labels...).Observe(elapsedSeconds)
+	}
+	if m.deprecatedLatenciesSummary != nil {
+		m.deprecatedLatenciesSummary.WithLabelValues(labels...).Observe(elapsedMicroseconds)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -206,9 +206,9 @@ func (m *metricSet) reset() {
 
 // Observe records an observed admission event to all metrics in the metricSet.
 func (m *metricSet) observe(elapsed time.Duration, labels ...string) {
-	elapsedMicroseconds := float64(elapsed / time.Microsecond)
-	m.latencies.WithLabelValues(labels...).Observe(elapsedMicroseconds)
+	elapsedSeconds := elapsed.Seconds()
+	m.latencies.WithLabelValues(labels...).Observe(elapsedSeconds)
 	if m.latenciesSummary != nil {
-		m.latenciesSummary.WithLabelValues(labels...).Observe(elapsedMicroseconds)
+		m.latenciesSummary.WithLabelValues(labels...).Observe(elapsedSeconds)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Admission metrics name is `*_admission_latencies_seconds` and `*_admission_latencies_seconds_summary`, the units from metrics name are `seconds`, but actually the return metrics are in `microseconds`, this PR aims to fix these metrics in `seconds`.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72342

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix admission metrics in seconds.
Add metrics `*_admission_latencies_milliseconds` and `*_admission_latencies_milliseconds_summary` for backward compatible, but will be removed in a future release.
```
