### PR TITLE
Fix create secret docker-registry compatibility

### DIFF
--- a/pkg/kubectl/generate/versioned/secret_for_docker_registry.go
+++ b/pkg/kubectl/generate/versioned/secret_for_docker_registry.go
@@ -17,6 +17,7 @@ limitations under the License.
 package versioned
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -152,6 +153,7 @@ func handleDockerCfgJSONContent(username, password, email, server string) ([]byt
 		Username: username,
 		Password: password,
 		Email:    email,
+		Auth:     encodeDockerConfigFieldAuth(username, password),
 	}
 
 	dockerCfgJSON := DockerConfigJSON{
@@ -159,6 +161,11 @@ func handleDockerCfgJSONContent(username, password, email, server string) ([]byt
 	}
 
 	return json.Marshal(dockerCfgJSON)
+}
+
+func encodeDockerConfigFieldAuth(username, password string) string {
+	fieldValue := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(fieldValue))
 }
 
 // DockerConfigJSON represents a local docker auth config file
@@ -175,7 +182,8 @@ type DockerConfigJSON struct {
 type DockerConfig map[string]DockerConfigEntry
 
 type DockerConfigEntry struct {
-	Username string
-	Password string
-	Email    string
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Email    string `json:"email,omitempty"`
+	Auth     string `json:"auth,omitempty"`
 }

--- a/pkg/kubectl/generate/versioned/secret_for_docker_registry_test.go
+++ b/pkg/kubectl/generate/versioned/secret_for_docker_registry_test.go
@@ -73,7 +73,7 @@ func TestSecretForDockerRegistryGenerate(t *testing.T) {
 			},
 			expected: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo-7566tc6mgc",
+					Name: "foo-548cm7fgdh",
 				},
 				Data: map[string][]byte{
 					v1.DockerConfigJsonKey: secretData,

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -739,7 +739,7 @@ run_secrets_test() {
   # Post-condition: secret exists and has expected values
   kube::test::get_object_assert 'secret/test-secret --namespace=test-secrets' "{{$id_field}}" 'test-secret'
   kube::test::get_object_assert 'secret/test-secret --namespace=test-secrets' "{{$secret_type}}" 'kubernetes.io/dockerconfigjson'
-  [[ "$(kubectl get secret/test-secret --namespace=test-secrets -o yaml "${kube_flags[@]}" | grep '.dockerconfigjson:')" ]]
+  [[ "$(kubectl get secret/test-secret --namespace=test-secrets -o yaml "${kube_flags[@]}" | grep '.dockerconfigjson: eyJhdXRocyI6eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsidXNlcm5hbWUiOiJ0ZXN0LXVzZXIiLCJwYXNzd29yZCI6InRlc3QtcGFzc3dvcmQiLCJlbWFpbCI6InRlc3QtdXNlckB0ZXN0LmNvbSIsImF1dGgiOiJkR1Z6ZEMxMWMyVnlPblJsYzNRdGNHRnpjM2R2Y21RPSJ9fX0=')" ]]
   # Clean-up
   kubectl delete secret test-secret --namespace=test-secrets
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes the secrets produced by `kubectl create secret docker-registry` to restore auth segment and produce the correct case.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/571

**Special notes for your reviewer**:

https://github.com/kubernetes/kubernetes/pull/68441 didn't preserve the json marshaling behavior of the original struct

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes `kubectl create secret docker-registry` compatibility
```

/assign @smarterclayton 
/sig cli