### PR TITLE
Fixup apps/v1 addon manifests

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -38,6 +38,10 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: event-exporter
+      version: v0.2.3
   template:
     metadata:
       labels:

--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -19,8 +19,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      labels:
-        k8s-app: ip-masq-agent
+      k8s-app: ip-masq-agent
   template:
     metadata:
       labels:

--- a/cluster/addons/prometheus/node-exporter-ds.yml
+++ b/cluster/addons/prometheus/node-exporter-ds.yml
@@ -9,6 +9,10 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     version: v0.15.2
 spec:
+  selector:
+    matchLabels:
+      k8s-app: node-exporter 
+      version: v0.15.2
   updateStrategy:
     type: OnDelete
   template:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Follow up to https://github.com/kubernetes/kubernetes/pull/72203, corrected a couple manifests that were missing selectors. Manually created each manifest touched by #72203 and verified it was created correctly.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```


/assign @dims 