### PR TITLE
Fix for kubectl go-template 'eq' & 'lt' not working with integers.

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/printers/BUILD
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/printers/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/client-go/util/jsonpath:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/printers/template.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/printers/template.go
@@ -18,13 +18,13 @@ package printers
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
 	"text/template"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
 )
 
 // GoTemplatePrinter is an implementation of ResourcePrinter which formats data with a Go Template.

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/printers/template_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/printers/template_test.go
@@ -52,6 +52,14 @@ func TestTemplate(t *testing.T) {
 				return "a base64 decode error", matched
 			},
 		},
+		{
+			name:     "template 'eq' should not throw error for numbers",
+			template: "{{ eq .count 1}}",
+			obj: &v1.Event{
+				Count: 1,
+			},
+			expectOut: "true",
+		},
 	}
 	for _, test := range testCase {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: This PR fixes kubectl go-template 'eq' & 'lt' not working with integers issue.  '[encoding/json](https://golang.org/pkg/encoding/json/#Unmarshal)' unmarshal stores float64 for JSON numbers which causing incompatible type comparison [error](https://github.com/golang/go/blob/master/src/text/template/funcs.go#L407).  Changed from 'encoding/json' to '[util/json](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/json/json.go)' which preserving numbers.

**Which issue(s) this PR fixes**: Fixes https://github.com/kubernetes/kubectl/issues/505

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```
