### PR TITLE
kubeadm: use T.Run API in test/cmd

### DIFF
--- a/cmd/kubeadm/test/cmd/completion_test.go
+++ b/cmd/kubeadm/test/cmd/completion_test.go
@@ -27,23 +27,26 @@ func TestCmdCompletion(t *testing.T) {
 	}
 
 	var tests = []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"", false},    // shell not specified
-		{"foo", false}, // unsupported shell type
+		{"shell not expected", "", false},
+		{"unsupported shell type", "foo", false},
 	}
 
 	for _, rt := range tests {
-		_, _, actual := RunCmd(kubeadmPath, "completion", rt.args)
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdCompletion running 'kubeadm completion %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, actual := RunCmd(kubeadmPath, "completion", rt.args)
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed CmdCompletion running 'kubeadm completion %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+					rt.args,
+					actual,
+					rt.expected,
+					(actual == nil),
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/test/cmd/join_test.go
+++ b/cmd/kubeadm/test/cmd/join_test.go
@@ -32,26 +32,29 @@ func TestCmdJoinConfig(t *testing.T) {
 	}
 
 	var initTest = []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"--config=foobar", false},
-		{"--config=/does/not/exist/foo/bar", false},
+		{"config", "--config=foobar", false},
+		{"config path", "--config=/does/not/exist/foo/bar", false},
 	}
 
 	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdJoinConfig running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed CmdJoinConfig running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+					rt.args,
+					actual,
+					rt.expected,
+					(actual == nil),
+				)
+			}
+			kubeadmReset()
+		})
 	}
 }
 
@@ -62,26 +65,29 @@ func TestCmdJoinDiscoveryFile(t *testing.T) {
 	}
 
 	var initTest = []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"--discovery-file=foobar", false},
-		{"--discovery-file=file:wrong", false},
+		{"valid discovery file", "--discovery-file=foobar", false},
+		{"invalid discovery file", "--discovery-file=file:wrong", false},
 	}
 
 	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdJoinDiscoveryFile running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed CmdJoinDiscoveryFile running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+					rt.args,
+					actual,
+					rt.expected,
+					(actual == nil),
+				)
+			}
+			kubeadmReset()
+		})
 	}
 }
 
@@ -92,26 +98,29 @@ func TestCmdJoinDiscoveryToken(t *testing.T) {
 	}
 
 	var initTest = []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"--discovery-token=foobar", false},
-		{"--discovery-token=token://asdf:asdf", false},
+		{"valid discovery token", "--discovery-token=foobar", false},
+		{"valid discovery token url", "--discovery-token=token://asdf:asdf", false},
 	}
 
 	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdJoinDiscoveryToken running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed CmdJoinDiscoveryToken running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+					rt.args,
+					actual,
+					rt.expected,
+					(actual == nil),
+				)
+			}
+			kubeadmReset()
+		})
 	}
 }
 
@@ -122,25 +131,28 @@ func TestCmdJoinNodeName(t *testing.T) {
 	}
 
 	var initTest = []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"--node-name=foobar", false},
+		{"valid node name", "--node-name=foobar", false},
 	}
 
 	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdJoinNodeName running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed CmdJoinNodeName running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+					rt.args,
+					actual,
+					rt.expected,
+					(actual == nil),
+				)
+			}
+			kubeadmReset()
+		})
 	}
 }
 
@@ -151,26 +163,29 @@ func TestCmdJoinTLSBootstrapToken(t *testing.T) {
 	}
 
 	var initTest = []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"--tls-bootstrap-token=foobar", false},
-		{"--tls-bootstrap-token=token://asdf:asdf", false},
+		{"valid bootstrap token", "--tls-bootstrap-token=foobar", false},
+		{"valid bootstrap token url", "--tls-bootstrap-token=token://asdf:asdf", false},
 	}
 
 	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdJoinTLSBootstrapToken running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed CmdJoinTLSBootstrapToken running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+					rt.args,
+					actual,
+					rt.expected,
+					(actual == nil),
+				)
+			}
+			kubeadmReset()
+		})
 	}
 }
 
@@ -181,26 +196,29 @@ func TestCmdJoinToken(t *testing.T) {
 	}
 
 	var initTest = []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"--token=foobar", false},
-		{"--token=token://asdf:asdf", false},
+		{"valid token", "--token=foobar", false},
+		{"valid token url", "--token=token://asdf:asdf", false},
 	}
 
 	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdJoinToken running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed CmdJoinToken running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+					rt.args,
+					actual,
+					rt.expected,
+					(actual == nil),
+				)
+			}
+			kubeadmReset()
+		})
 	}
 }
 
@@ -212,25 +230,28 @@ func TestCmdJoinBadArgs(t *testing.T) {
 
 	kubeadmPath := getKubeadmPath()
 	var initTest = []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"--discovery-token=abcdef.1234567890123456 --discovery-file=file:///tmp/foo.bar", false}, // DiscoveryToken, DiscoveryFile can't both be set
-		{"", false}, // DiscoveryToken or DiscoveryFile must be set
+		{"discovery-token and discovery-file can't both be set", "--discovery-token=abcdef.1234567890123456 --discovery-file=file:///tmp/foo.bar", false}, // DiscoveryToken, DiscoveryFile can't both be set
+		{"discovery-token or discovery-file must be set", "", false},                                                                                      // DiscoveryToken or DiscoveryFile must be set
 	}
 
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdJoinBadArgs 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed CmdJoinBadArgs 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+					rt.args,
+					actual,
+					rt.expected,
+					(actual == nil),
+				)
+			}
+			kubeadmReset()
+		})
 	}
 }
 
@@ -241,24 +262,27 @@ func TestCmdJoinArgsMixed(t *testing.T) {
 	}
 
 	var initTest = []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"--discovery-token=abcdef.1234567890abcdef --config=/etc/kubernetes/kubeadm.config", false},
+		{"discovery-token and config", "--discovery-token=abcdef.1234567890abcdef --config=/etc/kubernetes/kubeadm.config", false},
 	}
 
 	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdJoinArgsMixed running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed CmdJoinArgsMixed running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+					rt.args,
+					actual,
+					rt.expected,
+					(actual == nil),
+				)
+			}
+			kubeadmReset()
+		})
 	}
 }

--- a/cmd/kubeadm/test/cmd/token_test.go
+++ b/cmd/kubeadm/test/cmd/token_test.go
@@ -90,25 +90,28 @@ func TestCmdTokenDelete(t *testing.T) {
 	}
 
 	var tests = []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"", false},       // no token provided
-		{"foobar", false}, // invalid token
+		{"no token provided", "", false},
+		{"invalid token", "foobar", false},
 	}
 
 	kubeadmPath := getKubeadmPath()
 	for _, rt := range tests {
-		_, _, actual := RunCmd(kubeadmPath, "token", "delete", rt.args)
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdTokenDelete running 'kubeadm token %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, actual := RunCmd(kubeadmPath, "token", "delete", rt.args)
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed CmdTokenDelete running 'kubeadm token %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+					rt.args,
+					actual,
+					rt.expected,
+					(actual == nil),
+				)
+			}
+			kubeadmReset()
+		})
 	}
 }

--- a/cmd/kubeadm/test/cmd/version_test.go
+++ b/cmd/kubeadm/test/cmd/version_test.go
@@ -40,37 +40,40 @@ func TestCmdVersion(t *testing.T) {
 	}
 
 	var versionTest = []struct {
+		name     string
 		args     string
 		regex    string
 		expected bool
 	}{
-		{"--output=valid", "", false},
-		{"--output=short", ShortExpectedRegex, true},
-		{"", NormalExpectedRegex, true},
+		{"invalid output option", "--output=valid", "", false},
+		{"short output", "--output=short", ShortExpectedRegex, true},
+		{"default output", "", NormalExpectedRegex, true},
 	}
 
 	kubeadmPath := getKubeadmPath()
 	for _, rt := range versionTest {
-		stdout, _, actual := RunCmd(kubeadmPath, "version", rt.args)
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdVersion running 'kubeadm version %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			stdout, _, actual := RunCmd(kubeadmPath, "version", rt.args)
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed CmdVersion running 'kubeadm version %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+					rt.args,
+					actual,
+					rt.expected,
+					(actual == nil),
+				)
+			}
 
-		if rt.expected {
-			matched, err := regexp.MatchString(rt.regex, stdout)
-			if err != nil {
-				t.Fatalf("encountered an error while trying to match 'kubeadm version %s' stdout: %v", rt.args, err)
+			if rt.expected {
+				matched, err := regexp.MatchString(rt.regex, stdout)
+				if err != nil {
+					t.Fatalf("encountered an error while trying to match 'kubeadm version %s' stdout: %v", rt.args, err)
+				}
+				if !matched {
+					t.Errorf("'kubeadm version %s' stdout did not match expected regex; wanted: [%q], got: [%s]", rt.args, rt.regex, stdout)
+				}
 			}
-			if !matched {
-				t.Errorf("'kubeadm version %s' stdout did not match expected regex; wanted: [%q], got: [%s]", rt.args, rt.regex, stdout)
-			}
-		}
+		})
 	}
 }
 
@@ -81,52 +84,55 @@ func TestCmdVersionOutputJsonOrYaml(t *testing.T) {
 	}
 
 	var versionTest = []struct {
+		name     string
 		args     string
 		format   string
 		expected bool
 	}{
-		{"--output=json", "json", true},
-		{"--output=yaml", "yaml", true},
+		{"json output", "--output=json", "json", true},
+		{"yaml output", "--output=yaml", "yaml", true},
 	}
 
 	kubeadmPath := getKubeadmPath()
 	for _, rt := range versionTest {
-		stdout, _, actual := RunCmd(kubeadmPath, "version", rt.args)
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdVersion running 'kubeadm version %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-
-		if rt.expected {
-			var obj interface{}
-			switch rt.format {
-			case "json":
-				err := json.Unmarshal([]byte(stdout), &obj)
-				if err != nil {
-					t.Errorf("failed to parse json from 'kubeadm version %s': %s", rt.args, err)
-				}
-			case "yaml":
-				err := yaml.Unmarshal([]byte(stdout), &obj)
-				if err != nil {
-					t.Errorf("failed to parse yaml from 'kubeadm version %s': %s", rt.args, err)
-				}
+		t.Run(rt.name, func(t *testing.T) {
+			stdout, _, actual := RunCmd(kubeadmPath, "version", rt.args)
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed CmdVersion running 'kubeadm version %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+					rt.args,
+					actual,
+					rt.expected,
+					(actual == nil),
+				)
 			}
 
-			m := obj.(map[string]interface{})
-			if m["clientVersion"] == nil {
-				t.Errorf("failed to get the information of clientVersion from 'kubeadm version %s'", rt.args)
-			}
-			info := m["clientVersion"].(map[string]interface{})
-			for _, key := range VersionInfo {
-				if len(info[key].(string)) == 0 {
-					t.Errorf("failed to get the information of %s from 'kubeadm version %s'", key, rt.args)
+			if rt.expected {
+				var obj interface{}
+				switch rt.format {
+				case "json":
+					err := json.Unmarshal([]byte(stdout), &obj)
+					if err != nil {
+						t.Errorf("failed to parse json from 'kubeadm version %s': %s", rt.args, err)
+					}
+				case "yaml":
+					err := yaml.Unmarshal([]byte(stdout), &obj)
+					if err != nil {
+						t.Errorf("failed to parse yaml from 'kubeadm version %s': %s", rt.args, err)
+					}
+				}
+
+				m := obj.(map[string]interface{})
+				if m["clientVersion"] == nil {
+					t.Errorf("failed to get the information of clientVersion from 'kubeadm version %s'", rt.args)
+				}
+				info := m["clientVersion"].(map[string]interface{})
+				for _, key := range VersionInfo {
+					if len(info[key].(string)) == 0 {
+						t.Errorf("failed to get the information of %s from 'kubeadm version %s'", key, rt.args)
+					}
 				}
 			}
-		}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Used [T.Run API](https://golang.org/pkg/testing/#T.Run) for kubeadm tests in cmd/kubeadm/test/cmd/

This should improve testing output and make it more visible
which test is doing what.

**Special notes for your reviewer**:

This is a first PR of a series aiming to usage of [T.Run API](https://golang.org/pkg/testing/#T.Run)  in all kubeadm tests. If this is accepted I'll send more PRs of this kind. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```