### PR TITLE
kubeadm: fix golint warnings for redundant ifs

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/controlplane.go
@@ -149,9 +149,6 @@ func runControlPlaneSubPhase(component string) func(c workflow.RunData) error {
 		cfg := data.Cfg()
 
 		fmt.Printf("[control-plane] Creating static Pod manifest for %q\n", component)
-		if err := controlplane.CreateStaticPodFiles(data.ManifestDir(), cfg, component); err != nil {
-			return err
-		}
-		return nil
+		return controlplane.CreateStaticPodFiles(data.ManifestDir(), cfg, component)
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/markcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/markcontrolplane.go
@@ -69,9 +69,5 @@ func runMarkControlPlane(c workflow.RunData) error {
 	}
 
 	nodeRegistration := data.Cfg().NodeRegistration
-	if err := markcontrolplanephase.MarkControlPlane(client, nodeRegistration.Name, nodeRegistration.Taints); err != nil {
-		return err
-	}
-
-	return nil
+	return markcontrolplanephase.MarkControlPlane(client, nodeRegistration.Name, nodeRegistration.Taints)
 }

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -239,10 +239,7 @@ func removeContainers(execer utilsexec.Interface, criSocketPath string) error {
 	if err != nil {
 		return err
 	}
-	if err := containerRuntime.RemoveContainers(containers); err != nil {
-		return err
-	}
-	return nil
+	return containerRuntime.RemoveContainers(containers)
 }
 
 // cleanDir removes everything in a directory, but not the directory itself

--- a/cmd/kubeadm/app/componentconfigs/registrations.go
+++ b/cmd/kubeadm/app/componentconfigs/registrations.go
@@ -74,10 +74,7 @@ func (r Registration) Unmarshal(fileContent []byte) (runtime.Object, error) {
 
 func unmarshalObject(obj runtime.Object, fileContent []byte) error {
 	// Decode the file content  using the componentconfig Codecs that knows about all APIs
-	if err := runtime.DecodeInto(Codecs.UniversalDecoder(), fileContent, obj); err != nil {
-		return err
-	}
-	return nil
+	return runtime.DecodeInto(Codecs.UniversalDecoder(), fileContent, obj)
 }
 
 const (

--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -59,11 +59,7 @@ func CreatePKIAssets(cfg *kubeadmapi.InitConfiguration) error {
 	fmt.Printf("[certs] valid certificates and keys now exist in %q\n", cfg.CertificatesDir)
 
 	// Service accounts are not x509 certs, so handled separately
-	if err := CreateServiceAccountKeyAndPublicKeyFiles(cfg); err != nil {
-		return err
-	}
-
-	return nil
+	return CreateServiceAccountKeyAndPublicKeyFiles(cfg)
 }
 
 // CreateServiceAccountKeyAndPublicKeyFiles create a new public/private key files for signing service account users.

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -54,10 +54,7 @@ func SetInitDynamicDefaults(cfg *kubeadmapi.InitConfiguration) error {
 	if err := SetAPIEndpointDynamicDefaults(&cfg.LocalAPIEndpoint); err != nil {
 		return err
 	}
-	if err := SetClusterDynamicDefaults(&cfg.ClusterConfiguration, cfg.LocalAPIEndpoint.AdvertiseAddress, cfg.LocalAPIEndpoint.BindPort); err != nil {
-		return err
-	}
-	return nil
+	return SetClusterDynamicDefaults(&cfg.ClusterConfiguration, cfg.LocalAPIEndpoint.AdvertiseAddress, cfg.LocalAPIEndpoint.BindPort)
 }
 
 // SetBootstrapTokensDynamicDefaults checks and sets configuration values for the BootstrapTokens object

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -41,11 +41,7 @@ func SetJoinDynamicDefaults(cfg *kubeadmapi.JoinConfiguration) error {
 		return err
 	}
 
-	if err := SetJoinControlPlaneDefaults(cfg.ControlPlane); err != nil {
-		return err
-	}
-
-	return nil
+	return SetJoinControlPlaneDefaults(cfg.ControlPlane)
 }
 
 // SetJoinControlPlaneDefaults checks and sets configuration values for the JoinControlPlane object


### PR DESCRIPTION
**What this PR does / why we need it**:

When golint is run against kubeadm it reports several warnings like

    redundant if ...; err != nil check, just return error instead.

Fix the warnings by just returning error.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
