### PR TITLE
Filter resources logged by e2e ns debugging

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1325,6 +1325,7 @@ func hasRemainingContent(c clientset.Interface, dynamicClient dynamic.Interface,
 	if err != nil {
 		return false, err
 	}
+	resources = discovery.FilteredBy(discovery.SupportsAllVerbs{Verbs: []string{"list", "delete"}}, resources)
 	groupVersionResources, err := discovery.GroupVersionResources(resources)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
stops interrogating resources unrelated to namespace deletion as part of debugging namespace cleanup failure

Seen in [triage reports](https://storage.googleapis.com/k8s-gubernator/triage/index.html?pr=1&text=0-length%20response) while debugging https://github.com/kubernetes/kubernetes/issues/71696

```release-note
NONE
```

/cc @dims 