### PR TITLE
fail faster for readiness checks

### DIFF
--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -45,6 +45,7 @@
         "port": 8080,
         "path": "/healthz"
       },
+      "periodSeconds": 1,
       "timeoutSeconds": 15
     },
     "ports":[


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Our readiness checks should fail prior to our liveness checks, since that would allow us to optimally take advantage of the readiness information in HA situations. This PR adjusts GCE configurations such that readiness probes execute more frequently and also to fail faster. 

**Does this PR introduce a user-facing change?**:

NONE