### PR TITLE
Deprecate mount.IsNotMountPoint in favor of mounter.IsNotMountPoint

### DIFF
--- a/pkg/util/mount/exec_mount_unsupported.go
+++ b/pkg/util/mount/exec_mount_unsupported.go
@@ -48,7 +48,7 @@ func (mounter *execMounter) IsMountPointMatch(mp MountPoint, dir string) bool {
 }
 
 func (mounter *execMounter) IsNotMountPoint(dir string) (bool, error) {
-	return IsNotMountPoint(mounter, dir)
+	return isNotMountPoint(mounter, dir)
 }
 
 func (mounter *execMounter) IsLikelyNotMountPoint(file string) (bool, error) {

--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -137,7 +137,7 @@ func (f *FakeMounter) IsMountPointMatch(mp MountPoint, dir string) bool {
 }
 
 func (f *FakeMounter) IsNotMountPoint(dir string) (bool, error) {
-	return IsNotMountPoint(f, dir)
+	return isNotMountPoint(f, dir)
 }
 
 func (f *FakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -245,12 +245,9 @@ func GetDeviceNameFromMount(mounter Interface, mountPath string) (string, int, e
 	return device, refCount, nil
 }
 
-// IsNotMountPoint determines if a directory is a mountpoint.
-// It should return ErrNotExist when the directory does not exist.
-// This method uses the List() of all mountpoints
-// It is more extensive than IsLikelyNotMountPoint
-// and it detects bind mounts in linux
-func IsNotMountPoint(mounter Interface, file string) (bool, error) {
+// isNotMountPoint implements Mounter.IsNotMountPoint and is shared by mounter
+// implementations.
+func isNotMountPoint(mounter Interface, file string) (bool, error) {
 	// IsLikelyNotMountPoint provides a quick check
 	// to determine whether file IS A mountpoint
 	notMnt, notMntErr := mounter.IsLikelyNotMountPoint(file)

--- a/pkg/util/mount/mount_helper.go
+++ b/pkg/util/mount/mount_helper.go
@@ -56,7 +56,7 @@ func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPoin
 		var notMnt bool
 		var err error
 		if extensiveMountPointCheck {
-			notMnt, err = IsNotMountPoint(mounter, mountPath)
+			notMnt, err = mounter.IsNotMountPoint(mountPath)
 		} else {
 			notMnt, err = mounter.IsLikelyNotMountPoint(mountPath)
 		}

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -229,7 +229,7 @@ func (mounter *Mounter) IsMountPointMatch(mp MountPoint, dir string) bool {
 }
 
 func (mounter *Mounter) IsNotMountPoint(dir string) (bool, error) {
-	return IsNotMountPoint(mounter, dir)
+	return isNotMountPoint(mounter, dir)
 }
 
 // IsLikelyNotMountPoint determines if a directory is not a mountpoint.
@@ -757,7 +757,7 @@ func safeOpenSubPath(mounter Interface, subpath Subpath) (int, error) {
 func prepareSubpathTarget(mounter Interface, subpath Subpath) (bool, string, error) {
 	// Early check for already bind-mounted subpath.
 	bindPathTarget := getSubpathBindTarget(subpath)
-	notMount, err := IsNotMountPoint(mounter, bindPathTarget)
+	notMount, err := mounter.IsNotMountPoint(bindPathTarget)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return false, "", fmt.Errorf("error checking path %s for mount: %s", bindPathTarget, err)

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -55,7 +55,7 @@ func (mounter *Mounter) IsMountPointMatch(mp MountPoint, dir string) bool {
 }
 
 func (mounter *Mounter) IsNotMountPoint(dir string) (bool, error) {
-	return IsNotMountPoint(mounter, dir)
+	return isNotMountPoint(mounter, dir)
 }
 
 func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -132,7 +132,7 @@ func (mounter *Mounter) IsMountPointMatch(mp MountPoint, dir string) bool {
 
 // IsNotMountPoint determines if a directory is a mountpoint.
 func (mounter *Mounter) IsNotMountPoint(dir string) (bool, error) {
-	return IsNotMountPoint(mounter, dir)
+	return isNotMountPoint(mounter, dir)
 }
 
 // IsLikelyNotMountPoint determines if a directory is not a mountpoint.

--- a/pkg/util/mount/nsenter_mount.go
+++ b/pkg/util/mount/nsenter_mount.go
@@ -145,7 +145,7 @@ func (*NsenterMounter) List() ([]MountPoint, error) {
 }
 
 func (m *NsenterMounter) IsNotMountPoint(dir string) (bool, error) {
-	return IsNotMountPoint(m, dir)
+	return isNotMountPoint(m, dir)
 }
 
 func (*NsenterMounter) IsMountPointMatch(mp MountPoint, dir string) bool {

--- a/pkg/util/mount/nsenter_mount_unsupported.go
+++ b/pkg/util/mount/nsenter_mount_unsupported.go
@@ -46,7 +46,7 @@ func (*NsenterMounter) List() ([]MountPoint, error) {
 }
 
 func (m *NsenterMounter) IsNotMountPoint(dir string) (bool, error) {
-	return IsNotMountPoint(m, dir)
+	return isNotMountPoint(m, dir)
 }
 
 func (*NsenterMounter) IsMountPointMatch(mp MountPoint, dir string) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Deprecate mount.IsNotMountPoint in favor of mounter.IsNotMountPoint.

For better code.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72387

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
