### PR TITLE
Register plugins with the scheduling framework properly

### DIFF
--- a/pkg/scheduler/plugins/registrar.go
+++ b/pkg/scheduler/plugins/registrar.go
@@ -58,7 +58,7 @@ func NewDefaultPluginSet(ctx *plugins.PluginContext, schedulerCache *cache.Cache
 	return &defaultRegistrar
 }
 
-func (r DefaultPluginSet) registerReservePlugins() {
+func (r *DefaultPluginSet) registerReservePlugins() {
 	r.reservePlugins = []plugins.ReservePlugin{
 		// Init functions of all reserve plugins go here. They are called in the
 		// same order that they are registered.
@@ -67,7 +67,7 @@ func (r DefaultPluginSet) registerReservePlugins() {
 	}
 }
 
-func (r DefaultPluginSet) registerPrebindPlugins() {
+func (r *DefaultPluginSet) registerPrebindPlugins() {
 	r.prebindPlugins = []plugins.PrebindPlugin{
 		// Init functions of all prebind plugins go here. They are called in the
 		// same order that they are registered.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Currently the functions for plugin registration are in the passing-by-value. In my understanding, we should pass references here not to discard the changes at the end of the function scope.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix registration for scheduling framework plugins with the default plugin set
```

/sig scheduling