### PR TITLE
Remove old aws security role on service port changes

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -885,21 +885,21 @@ func (c *Cloud) updateInstanceSecurityGroupsForNLB(mappings []nlbPortMapping, in
 
 		// Add desired groups to actual groups if it is not already so, in order to remove old security rules also
 		// from the desired groups
-		for _, desiredGroupId := range desiredGroupIds {
+		for _, desiredGroupID := range desiredGroupIds {
 
-			founded := false
+			found := false
 			for _, actualGroup := range actualGroups {
-				actualGroupId := aws.StringValue(actualGroup.GroupId)
-				if desiredGroupId == actualGroupId {
-					founded = true
+				actualGroupID := aws.StringValue(actualGroup.GroupId)
+				if desiredGroupID == actualGroupID {
+					found = true
 					break
 				}
 			}
 
-			if !founded {
-				missingGroup, err := c.findSecurityGroup(desiredGroupId)
+			if !found {
+				missingGroup, err := c.findSecurityGroup(desiredGroupID)
 				if err != nil {
-					return fmt.Errorf("error finding security group with id %s: %q", desiredGroupId, err)
+					return fmt.Errorf("error finding security group with id %s: %q", desiredGroupID, err)
 				}
 				actualGroups = append(actualGroups, missingGroup)
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Remove old security role from aws security groups when changing service port using aws nlb

**Which issue(s) this PR fixes**:
Fixes #70421

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig aws