### PR TITLE
Speedup listers for empty selectors

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/listers.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listers.go
@@ -31,7 +31,14 @@ import (
 type AppendFunc func(interface{})
 
 func ListAll(store Store, selector labels.Selector, appendFn AppendFunc) error {
+	selectAll := selector.Empty()
 	for _, m := range store.List() {
+		if selectAll {
+			// Avoid computing labels of the objects to speed up common flows
+			// of listing all objects.
+			appendFn(m)
+			continue
+		}
 		metadata, err := meta.Accessor(m)
 		if err != nil {
 			return err
@@ -44,8 +51,15 @@ func ListAll(store Store, selector labels.Selector, appendFn AppendFunc) error {
 }
 
 func ListAllByNamespace(indexer Indexer, namespace string, selector labels.Selector, appendFn AppendFunc) error {
+	selectAll := selector.Empty()
 	if namespace == metav1.NamespaceAll {
 		for _, m := range indexer.List() {
+			if selectAll {
+				// Avoid computing labels of the objects to speed up common flows
+				// of listing all objects.
+				appendFn(m)
+				continue
+			}
 			metadata, err := meta.Accessor(m)
 			if err != nil {
 				return err
@@ -74,6 +88,12 @@ func ListAllByNamespace(indexer Indexer, namespace string, selector labels.Selec
 		return nil
 	}
 	for _, m := range items {
+		if selectAll {
+			// Avoid computing labels of the objects to speed up common flows
+			// of listing all objects.
+			appendFn(m)
+			continue
+		}
 		metadata, err := meta.Accessor(m)
 		if err != nil {
 			return err


### PR DESCRIPTION
Listing all objects from local cache is pretty common usecase in k8s components.
Profiles show that when listing all objects, up to 2/3rd of time is spent on getting labels (which are then ignored for empty selectors).

This trivial change is optimizing this flow.