### PR TITLE
e2e/storage: reset driver config in the test suite

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -127,20 +127,23 @@ var _ = utils.SIGDescribe("CSI Volumes", func() {
 
 	for _, initDriver := range csiTestDrivers {
 		curDriver := initDriver(config)
+		curConfig := curDriver.GetDriverInfo().Config
 		Context(testsuites.GetDriverNameWithFeatureTags(curDriver), func() {
-			driver := curDriver
-
 			BeforeEach(func() {
+				// Reset config. The driver might have modified its copy
+				// in a previous test.
+				curDriver.GetDriverInfo().Config = curConfig
+
 				// setupDriver
-				driver.CreateDriver()
+				curDriver.CreateDriver()
 			})
 
 			AfterEach(func() {
 				// Cleanup driver
-				driver.CleanupDriver()
+				curDriver.CleanupDriver()
 			})
 
-			testsuites.RunTestSuite(f, driver, csiTestSuites, csiTunePattern)
+			testsuites.RunTestSuite(f, curDriver, csiTestSuites, csiTunePattern)
 		})
 	}
 

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -151,9 +151,6 @@ func (n *nfsDriver) CreateDriver() {
 	ns := f.Namespace
 	n.externalPluginName = fmt.Sprintf("example.com/nfs-%s", ns.Name)
 
-	// Reset config. It might have been modified by a previous CreateVolume call.
-	n.driverInfo.Config.ServerConfig = nil
-
 	// TODO(mkimuram): cluster-admin gives too much right but system:persistent-volume-provisioner
 	// is not enough. We should create new clusterrole for testing.
 	framework.BindClusterRole(cs.RbacV1beta1(), "cluster-admin", ns.Name,
@@ -298,8 +295,6 @@ func (g *glusterFSDriver) GetPersistentVolumeSource(readOnly bool, fsType string
 }
 
 func (g *glusterFSDriver) CreateDriver() {
-	// Reset config. It might have been modified by a previous CreateVolume call.
-	g.driverInfo.Config.ServerConfig = nil
 }
 
 func (g *glusterFSDriver) CleanupDriver() {
@@ -429,8 +424,6 @@ func (i *iSCSIDriver) GetPersistentVolumeSource(readOnly bool, fsType string, te
 }
 
 func (i *iSCSIDriver) CreateDriver() {
-	// Reset config. It might have been modified by a previous CreateVolume call.
-	i.driverInfo.Config.ServerConfig = nil
 }
 
 func (i *iSCSIDriver) CleanupDriver() {
@@ -556,8 +549,6 @@ func (r *rbdDriver) GetPersistentVolumeSource(readOnly bool, fsType string, test
 }
 
 func (r *rbdDriver) CreateDriver() {
-	// Reset config. It might have been modified by a previous CreateVolume call.
-	r.driverInfo.Config.ServerConfig = nil
 }
 
 func (r *rbdDriver) CleanupDriver() {
@@ -670,8 +661,6 @@ func (c *cephFSDriver) GetPersistentVolumeSource(readOnly bool, fsType string, t
 }
 
 func (c *cephFSDriver) CreateDriver() {
-	// Reset config. It might have been modified by a previous CreateVolume call.
-	c.driverInfo.Config.ServerConfig = nil
 }
 
 func (c *cephFSDriver) CleanupDriver() {

--- a/test/e2e/storage/in_tree_volumes.go
+++ b/test/e2e/storage/in_tree_volumes.go
@@ -69,20 +69,23 @@ var _ = utils.SIGDescribe("In-tree Volumes", func() {
 
 	for _, initDriver := range testDrivers {
 		curDriver := initDriver(config)
+		curConfig := curDriver.GetDriverInfo().Config
 		Context(testsuites.GetDriverNameWithFeatureTags(curDriver), func() {
-			driver := curDriver
-
 			BeforeEach(func() {
+				// Reset config. The driver might have modified its copy
+				// in a previous test.
+				curDriver.GetDriverInfo().Config = curConfig
+
 				// setupDriver
-				driver.CreateDriver()
+				curDriver.CreateDriver()
 			})
 
 			AfterEach(func() {
 				// Cleanup driver
-				driver.CleanupDriver()
+				curDriver.CleanupDriver()
 			})
 
-			testsuites.RunTestSuite(f, driver, testSuites, intreeTunePattern)
+			testsuites.RunTestSuite(f, curDriver, testSuites, intreeTunePattern)
 		})
 	}
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

PR #70862 made each driver responsible for resetting its config, but
as it turned out, one place was missed in that PR: the in-tree gcepd
sets a node selector. Not resetting that caused other tests to fail
randomly depending on test execution order.
    
Now the test suite resets the config by taking a copy after setting up
the driver and restoring that copy before each test.
    
Long term the intention is to separate the entire test config from the
static driver info (https://github.com/kubernetes/kubernetes/issues/72288),
but for now resetting the config is the fastest way to fix the test flake.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72378 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
