### PR TITLE
log api proposal: adding preamble option.

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3869,6 +3869,8 @@ type PodLogOptions struct {
 	// log output. This may not display a complete final line of logging, and may return
 	// slightly more or slightly less than the specified limit.
 	LimitBytes *int64
+	// If non empty, the log string would yield preamble before sending out any log
+	Preamble string
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/kubelet/kuberuntime/logs/logs.go
+++ b/pkg/kubelet/kuberuntime/logs/logs.go
@@ -88,6 +88,7 @@ type LogOptions struct {
 	since     time.Time
 	follow    bool
 	timestamp bool
+	preamble  string
 }
 
 // NewLogOptions convert the v1.PodLogOptions to CRI internal LogOptions.
@@ -97,6 +98,7 @@ func NewLogOptions(apiOpts *v1.PodLogOptions, now time.Time) *LogOptions {
 		bytes:     -1, // -1 by default which means read all logs.
 		follow:    apiOpts.Follow,
 		timestamp: apiOpts.Timestamps,
+		preamble:  apiOpts.Preamble,
 	}
 	if apiOpts.TailLines != nil {
 		opts.tail = *apiOpts.TailLines
@@ -289,6 +291,10 @@ func ReadLogs(ctx context.Context, path, containerID string, opts *LogOptions, r
 	var watcher *fsnotify.Watcher
 	var parse parseFunc
 	var stop bool
+	// write back the preamble if set
+	if opts.preamble != "" {
+		stdout.Write([]byte(opts.preamble + "\n"))
+	}
 	writer := newLogWriter(stdout, stderr, opts)
 	msg := &logMessage{}
 	for {

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -382,6 +382,9 @@ func LogLocation(
 	if opts.LimitBytes != nil {
 		params.Add("limitBytes", strconv.FormatInt(*opts.LimitBytes, 10))
 	}
+	if opts.Preamble != "" {
+		params.Add("preamble", opts.Preamble)
+	}
 	loc := &url.URL{
 		Scheme:   nodeInfo.Scheme,
 		Host:     net.JoinHostPort(nodeInfo.Hostname, nodeInfo.Port),

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4348,6 +4348,9 @@ type PodLogOptions struct {
 	// slightly more or slightly less than the specified limit.
 	// +optional
 	LimitBytes *int64 `json:"limitBytes,omitempty" protobuf:"varint,8,opt,name=limitBytes"`
+	// The preamble string if set would be send back before any container logs.
+	// +optional
+	Preamble string `json:"preamble,omitempty" protobuf:"bytes,9,opt,name=preamble"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
 /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR add a preamble option to logs api. When client request logs with a preamble parameter, the server would send back the preamble string before any container logs.
The reason for this option is that  when starting a live log stream with follow set to true, some k8s client, in my caes kubernetes-python, needs at least 1 byte received from response body to return a responsive object(HTTPResponse) for further polling. But if there is no pod log yield yet, the client would block there waiting for the first byte. This make writing a async client very hard with those existing client library. With this option, client would make sure that at least 1 byte is send back by setting preamble to some specific string, e.g.
> # kubectl get --raw '/api/v1/namespaces/ingress-nginx/pods/default-http-backend-68f657df97-j2ncr/log?follow=True&preamble=>>>>>'
> >>>>>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72397
https://github.com/kubernetes-client/python/issues/716
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add preamble option in logs api, if set, the preamble would be send back before the real log stream. 
```
