### PR TITLE
Add request.memory to  kube-apiserver, kube-controller-manager, kube-scheduler static pod

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -58,7 +58,7 @@ func GetStaticPodSpecs(cfg *kubeadmapi.InitConfiguration, k8sVersion *version.Ve
 			Command:         getAPIServerCommand(cfg),
 			VolumeMounts:    staticpodutil.VolumeMountMapToSlice(mounts.GetVolumeMounts(kubeadmconstants.KubeAPIServer)),
 			LivenessProbe:   staticpodutil.ComponentProbe(cfg, kubeadmconstants.KubeAPIServer, int(cfg.LocalAPIEndpoint.BindPort), "/healthz", v1.URISchemeHTTPS),
-			Resources:       staticpodutil.ComponentResources("250m"),
+			Resources:       staticpodutil.ComponentResources("250m", "250Mi"),
 			Env:             getProxyEnvVars(),
 		}, mounts.GetVolumes(kubeadmconstants.KubeAPIServer)),
 		kubeadmconstants.KubeControllerManager: staticpodutil.ComponentPod(v1.Container{
@@ -68,7 +68,7 @@ func GetStaticPodSpecs(cfg *kubeadmapi.InitConfiguration, k8sVersion *version.Ve
 			Command:         getControllerManagerCommand(cfg, k8sVersion),
 			VolumeMounts:    staticpodutil.VolumeMountMapToSlice(mounts.GetVolumeMounts(kubeadmconstants.KubeControllerManager)),
 			LivenessProbe:   staticpodutil.ComponentProbe(cfg, kubeadmconstants.KubeControllerManager, 10252, "/healthz", v1.URISchemeHTTP),
-			Resources:       staticpodutil.ComponentResources("200m"),
+			Resources:       staticpodutil.ComponentResources("200m", "250Mi"),
 			Env:             getProxyEnvVars(),
 		}, mounts.GetVolumes(kubeadmconstants.KubeControllerManager)),
 		kubeadmconstants.KubeScheduler: staticpodutil.ComponentPod(v1.Container{
@@ -78,7 +78,7 @@ func GetStaticPodSpecs(cfg *kubeadmapi.InitConfiguration, k8sVersion *version.Ve
 			Command:         getSchedulerCommand(cfg),
 			VolumeMounts:    staticpodutil.VolumeMountMapToSlice(mounts.GetVolumeMounts(kubeadmconstants.KubeScheduler)),
 			LivenessProbe:   staticpodutil.ComponentProbe(cfg, kubeadmconstants.KubeScheduler, 10251, "/healthz", v1.URISchemeHTTP),
-			Resources:       staticpodutil.ComponentResources("100m"),
+			Resources:       staticpodutil.ComponentResources("100m", "250Mi"),
 			Env:             getProxyEnvVars(),
 		}, mounts.GetVolumes(kubeadmconstants.KubeScheduler)),
 	}

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -74,10 +74,11 @@ func ComponentPod(container v1.Container, volumes map[string]v1.Volume) v1.Pod {
 }
 
 // ComponentResources returns the v1.ResourceRequirements object needed for allocating a specified amount of the CPU
-func ComponentResources(cpu string) v1.ResourceRequirements {
+func ComponentResources(cpu, mem string) v1.ResourceRequirements {
 	return v1.ResourceRequirements{
 		Requests: v1.ResourceList{
-			v1.ResourceName(v1.ResourceCPU): resource.MustParse(cpu),
+			v1.ResourceName(v1.ResourceCPU):    resource.MustParse(cpu),
+			v1.ResourceName(v1.ResourceMemory): resource.MustParse(mem),
 		},
 	}
 }

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -34,10 +34,10 @@ import (
 )
 
 func TestComponentResources(t *testing.T) {
-	a := ComponentResources("250m")
+	a := ComponentResources("250m", "250Mi")
 	if a.Requests == nil {
 		t.Errorf(
-			"failed componentResources, return value was nil",
+			"failed componentResources, returned requests value was nil",
 		)
 	}
 }


### PR DESCRIPTION
Make kube-apiserver, kube-controller-manager, kube-scheduler static pod with qos class Garanteed

Signed-off-by: Lei Gong <lgong@alauda.io>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
recently my kube-apiserver keeps restarting. I found that this was due to lack of disk space and was expelled by evict manager along with other normal pod. Then I found that the qos class of kube-apiserver is Bursted, in which case will be evicted by kubelet firstly. So may be we should specify both the limits and requests in spec.resources of the static pod so that the Qos could be Garanteed.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: Add requests.memory for static pod so that they will not evicted firstly when lacking of resource.
```