### PR TITLE
kubeadm: use T.Run API in app/util

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/init_dryrun_test.go
+++ b/cmd/kubeadm/app/util/apiclient/init_dryrun_test.go
@@ -32,54 +32,63 @@ func TestHandleGetAction(t *testing.T) {
 	idr := NewInitDryRunGetter(masterName, serviceSubnet)
 
 	var tests = []struct {
+		name               string
 		action             core.GetActionImpl
 		expectedHandled    bool
 		expectedObjectJSON []byte
 		expectedErr        bool
 	}{
 		{
+			name:               "get default services",
 			action:             core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "services"}, "default", "kubernetes"),
 			expectedHandled:    true,
 			expectedObjectJSON: []byte(`{"metadata":{"name":"kubernetes","namespace":"default","creationTimestamp":null,"labels":{"component":"apiserver","provider":"kubernetes"}},"spec":{"ports":[{"name":"https","port":443,"targetPort":6443}],"clusterIP":"10.96.0.1"},"status":{"loadBalancer":{}}}`),
 			expectedErr:        false,
 		},
 		{
+			name:               "get nodes",
 			action:             core.NewRootGetAction(schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, masterName),
 			expectedHandled:    true,
 			expectedObjectJSON: []byte(`{"metadata":{"name":"master-foo","creationTimestamp":null,"labels":{"kubernetes.io/hostname":"master-foo"}},"spec":{},"status":{"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"","osImage":"","containerRuntimeVersion":"","kubeletVersion":"","kubeProxyVersion":"","operatingSystem":"","architecture":""}}}`),
 			expectedErr:        false,
 		},
 		{
+			name:               "get clusterrolebinings",
 			action:             core.NewRootGetAction(schema.GroupVersionResource{Group: rbac.GroupName, Version: rbac.SchemeGroupVersion.Version, Resource: "clusterrolebindings"}, "system:node"),
 			expectedHandled:    true,
 			expectedObjectJSON: []byte(``),
 			expectedErr:        true, // we expect a NotFound error here
 		},
 		{
+			name:               "get kube-system secret bootstrap-token-abcdef",
 			action:             core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "secrets"}, "kube-system", "bootstrap-token-abcdef"),
 			expectedHandled:    true,
 			expectedObjectJSON: []byte(``),
 			expectedErr:        true, // we expect a NotFound error here
 		},
 		{ // an ask for a kubernetes service in the _kube-system_ ns should not be answered
+			name:               "get kube-system services",
 			action:             core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "services"}, "kube-system", "kubernetes"),
 			expectedHandled:    false,
 			expectedObjectJSON: []byte(``),
 			expectedErr:        false,
 		},
 		{ // an ask for an other service than kubernetes should not be answered
+			name:               "get default my-other-service",
 			action:             core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "services"}, "default", "my-other-service"),
 			expectedHandled:    false,
 			expectedObjectJSON: []byte(``),
 			expectedErr:        false,
 		},
 		{ // an ask for an other node than the master should not be answered
+			name:               "get other-node",
 			action:             core.NewRootGetAction(schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, "other-node"),
 			expectedHandled:    false,
 			expectedObjectJSON: []byte(``),
 			expectedErr:        false,
 		},
 		{ // an ask for a secret in any other ns than kube-system should not be answered
+			name:               "get default secret bootstrap-token-abcdef",
 			action:             core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "secrets"}, "default", "bootstrap-token-abcdef"),
 			expectedHandled:    false,
 			expectedObjectJSON: []byte(``),
@@ -87,40 +96,42 @@ func TestHandleGetAction(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		handled, obj, actualErr := idr.HandleGetAction(rt.action)
-		objBytes := []byte(``)
-		if obj != nil {
-			var err error
-			objBytes, err = json.Marshal(obj)
-			if err != nil {
-				t.Fatalf("couldn't marshal returned object")
+		t.Run(rt.name, func(t *testing.T) {
+			handled, obj, actualErr := idr.HandleGetAction(rt.action)
+			objBytes := []byte(``)
+			if obj != nil {
+				var err error
+				objBytes, err = json.Marshal(obj)
+				if err != nil {
+					t.Fatalf("couldn't marshal returned object")
+				}
 			}
-		}
 
-		if handled != rt.expectedHandled {
-			t.Errorf(
-				"failed HandleGetAction:\n\texpected handled: %t\n\t  actual: %t %v",
-				rt.expectedHandled,
-				handled,
-				rt.action,
-			)
-		}
+			if handled != rt.expectedHandled {
+				t.Errorf(
+					"failed HandleGetAction:\n\texpected handled: %t\n\t  actual: %t %v",
+					rt.expectedHandled,
+					handled,
+					rt.action,
+				)
+			}
 
-		if !bytes.Equal(objBytes, rt.expectedObjectJSON) {
-			t.Errorf(
-				"failed HandleGetAction:\n\texpected object: %q\n\t  actual: %q",
-				rt.expectedObjectJSON,
-				objBytes,
-			)
-		}
+			if !bytes.Equal(objBytes, rt.expectedObjectJSON) {
+				t.Errorf(
+					"failed HandleGetAction:\n\texpected object: %q\n\t  actual: %q",
+					rt.expectedObjectJSON,
+					objBytes,
+				)
+			}
 
-		if (actualErr != nil) != rt.expectedErr {
-			t.Errorf(
-				"failed HandleGetAction:\n\texpected error: %t\n\t  actual: %t %v",
-				rt.expectedErr,
-				(actualErr != nil),
-				rt.action,
-			)
-		}
+			if (actualErr != nil) != rt.expectedErr {
+				t.Errorf(
+					"failed HandleGetAction:\n\texpected error: %t\n\t  actual: %t %v",
+					rt.expectedErr,
+					(actualErr != nil),
+					rt.action,
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/util/arguments_test.go
+++ b/cmd/kubeadm/app/util/arguments_test.go
@@ -24,11 +24,13 @@ import (
 
 func TestBuildArgumentListFromMap(t *testing.T) {
 	var tests = []struct {
+		name      string
 		base      map[string]string
 		overrides map[string]string
 		expected  []string
 	}{
-		{ // override an argument from the base
+		{
+			name: "override an argument from the base",
 			base: map[string]string{
 				"admission-control":     "NamespaceLifecycle",
 				"insecure-bind-address": "127.0.0.1",
@@ -43,7 +45,8 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 				"--insecure-bind-address=127.0.0.1",
 			},
 		},
-		{ // add an argument that is not in base
+		{
+			name: "add an argument that is not in base",
 			base: map[string]string{
 				"insecure-bind-address": "127.0.0.1",
 				"allow-privileged":      "true",
@@ -57,7 +60,8 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 				"--insecure-bind-address=127.0.0.1",
 			},
 		},
-		{ // allow empty strings in base
+		{
+			name: "allow empty strings in base",
 			base: map[string]string{
 				"insecure-bind-address":              "127.0.0.1",
 				"allow-privileged":                   "true",
@@ -73,7 +77,8 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 				"--something-that-allows-empty-string=",
 			},
 		},
-		{ // allow empty strings in overrides
+		{
+			name: "allow empty strings in overrides",
 			base: map[string]string{
 				"insecure-bind-address":              "127.0.0.1",
 				"allow-privileged":                   "true",
@@ -93,20 +98,23 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actual := BuildArgumentListFromMap(rt.base, rt.overrides)
-		if !reflect.DeepEqual(actual, rt.expected) {
-			t.Errorf("failed BuildArgumentListFromMap:\nexpected:\n%v\nsaw:\n%v", rt.expected, actual)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actual := BuildArgumentListFromMap(rt.base, rt.overrides)
+			if !reflect.DeepEqual(actual, rt.expected) {
+				t.Errorf("failed BuildArgumentListFromMap:\nexpected:\n%v\nsaw:\n%v", rt.expected, actual)
+			}
+		})
 	}
 }
 
 func TestParseArgumentListToMap(t *testing.T) {
 	var tests = []struct {
+		name        string
 		args        []string
 		expectedMap map[string]string
 	}{
 		{
-			// normal case
+			name: "normal case",
 			args: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--insecure-bind-address=127.0.0.1",
@@ -119,7 +127,7 @@ func TestParseArgumentListToMap(t *testing.T) {
 			},
 		},
 		{
-			// test that feature-gates is working
+			name: "test that feature-gates is working",
 			args: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--insecure-bind-address=127.0.0.1",
@@ -134,7 +142,7 @@ func TestParseArgumentListToMap(t *testing.T) {
 			},
 		},
 		{
-			// test that a binary can be the first arg
+			name: "test that a binary can be the first arg",
 			args: []string{
 				"kube-apiserver",
 				"--admission-control=NamespaceLifecycle,LimitRanger",
@@ -152,21 +160,24 @@ func TestParseArgumentListToMap(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actualMap := ParseArgumentListToMap(rt.args)
-		if !reflect.DeepEqual(actualMap, rt.expectedMap) {
-			t.Errorf("failed ParseArgumentListToMap:\nexpected:\n%v\nsaw:\n%v", rt.expectedMap, actualMap)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actualMap := ParseArgumentListToMap(rt.args)
+			if !reflect.DeepEqual(actualMap, rt.expectedMap) {
+				t.Errorf("failed ParseArgumentListToMap:\nexpected:\n%v\nsaw:\n%v", rt.expectedMap, actualMap)
+			}
+		})
 	}
 }
 
 func TestReplaceArgument(t *testing.T) {
 	var tests = []struct {
+		name         string
 		args         []string
 		mutateFunc   func(map[string]string) map[string]string
 		expectedArgs []string
 	}{
 		{
-			// normal case
+			name: "normal case",
 			args: []string{
 				"kube-apiserver",
 				"--admission-control=NamespaceLifecycle,LimitRanger",
@@ -185,7 +196,7 @@ func TestReplaceArgument(t *testing.T) {
 			},
 		},
 		{
-			// normal case
+			name: "another normal case",
 			args: []string{
 				"kube-apiserver",
 				"--admission-control=NamespaceLifecycle,LimitRanger",
@@ -207,21 +218,24 @@ func TestReplaceArgument(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actualArgs := ReplaceArgument(rt.args, rt.mutateFunc)
-		sort.Strings(actualArgs)
-		sort.Strings(rt.expectedArgs)
-		if !reflect.DeepEqual(actualArgs, rt.expectedArgs) {
-			t.Errorf("failed ReplaceArgument:\nexpected:\n%v\nsaw:\n%v", rt.expectedArgs, actualArgs)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actualArgs := ReplaceArgument(rt.args, rt.mutateFunc)
+			sort.Strings(actualArgs)
+			sort.Strings(rt.expectedArgs)
+			if !reflect.DeepEqual(actualArgs, rt.expectedArgs) {
+				t.Errorf("failed ReplaceArgument:\nexpected:\n%v\nsaw:\n%v", rt.expectedArgs, actualArgs)
+			}
+		})
 	}
 }
 
 func TestRoundtrip(t *testing.T) {
 	var tests = []struct {
+		name string
 		args []string
 	}{
 		{
-			// normal case
+			name: "normal case",
 			args: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--insecure-bind-address=127.0.0.1",
@@ -229,7 +243,7 @@ func TestRoundtrip(t *testing.T) {
 			},
 		},
 		{
-			// test that feature-gates is working
+			name: "test that feature-gates is working",
 			args: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--insecure-bind-address=127.0.0.1",
@@ -240,86 +254,89 @@ func TestRoundtrip(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		// These two methods should be each other's opposite functions, test that by chaining the methods and see if you get the same result back
-		actual := BuildArgumentListFromMap(ParseArgumentListToMap(rt.args), map[string]string{})
-		sort.Strings(actual)
-		sort.Strings(rt.args)
+		t.Run(rt.name, func(t *testing.T) {
+			// These two methods should be each other's opposite functions, test that by chaining the methods and see if you get the same result back
+			actual := BuildArgumentListFromMap(ParseArgumentListToMap(rt.args), map[string]string{})
+			sort.Strings(actual)
+			sort.Strings(rt.args)
 
-		if !reflect.DeepEqual(actual, rt.args) {
-			t.Errorf("failed TestRoundtrip:\nexpected:\n%v\nsaw:\n%v", rt.args, actual)
-		}
+			if !reflect.DeepEqual(actual, rt.args) {
+				t.Errorf("failed TestRoundtrip:\nexpected:\n%v\nsaw:\n%v", rt.args, actual)
+			}
+		})
 	}
 }
 
 func TestParseArgument(t *testing.T) {
 	var tests = []struct {
+		name        string
 		arg         string
 		expectedKey string
 		expectedVal string
 		expectedErr bool
 	}{
 		{
-			// cannot be empty
+			name:        "arg cannot be empty",
 			arg:         "",
 			expectedErr: true,
 		},
 		{
-			// must contain -- and =
+			name:        "arg must contain -- and =",
 			arg:         "a",
 			expectedErr: true,
 		},
 		{
-			// must contain -- and =
+			name:        "arg must contain -- and =",
 			arg:         "a-z",
 			expectedErr: true,
 		},
 		{
-			// must contain --
+			name:        "arg must contain --",
 			arg:         "a=b",
 			expectedErr: true,
 		},
 		{
-			// must contain a key
+			name:        "arg must contain a key",
 			arg:         "--=b",
 			expectedErr: true,
 		},
 		{
-			// can contain key but no value
+			name:        "arg can contain key but no value",
 			arg:         "--a=",
 			expectedKey: "a",
 			expectedVal: "",
 			expectedErr: false,
 		},
 		{
-			// simple case
+			name:        "simple case",
 			arg:         "--a=b",
 			expectedKey: "a",
 			expectedVal: "b",
 			expectedErr: false,
 		},
 		{
-			// keys/values with '-' should be supported
+			name:        "keys/values with '-' should be supported",
 			arg:         "--very-long-flag-name=some-value",
 			expectedKey: "very-long-flag-name",
 			expectedVal: "some-value",
 			expectedErr: false,
 		},
 		{
-			// numbers should be handled correctly
+			name:        "numbers should be handled correctly",
 			arg:         "--some-number=0.2",
 			expectedKey: "some-number",
 			expectedVal: "0.2",
 			expectedErr: false,
 		},
 		{
-			// lists should be handled correctly
+			name:        "lists should be handled correctly",
 			arg:         "--admission-control=foo,bar,baz",
 			expectedKey: "admission-control",
 			expectedVal: "foo,bar,baz",
 			expectedErr: false,
 		},
 		{
-			// more than one '=' should be allowed
+			name:        "more than one '=' should be allowed",
 			arg:         "--feature-gates=EnableFoo=true,EnableBar=false",
 			expectedKey: "feature-gates",
 			expectedVal: "EnableFoo=true,EnableBar=false",
@@ -328,12 +345,14 @@ func TestParseArgument(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		key, val, actual := parseArgument(rt.arg)
-		if (actual != nil) != rt.expectedErr {
-			t.Errorf("failed parseArgument:\nexpected error:\n%t\nsaw error:\n%v", rt.expectedErr, actual)
-		}
-		if (key != rt.expectedKey) || (val != rt.expectedVal) {
-			t.Errorf("failed parseArgument:\nexpected key: %s\nsaw key: %s\nexpected value: %s\nsaw value: %s", rt.expectedKey, key, rt.expectedVal, val)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			key, val, actual := parseArgument(rt.arg)
+			if (actual != nil) != rt.expectedErr {
+				t.Errorf("failed parseArgument:\nexpected error:\n%t\nsaw error:\n%v", rt.expectedErr, actual)
+			}
+			if (key != rt.expectedKey) || (val != rt.expectedVal) {
+				t.Errorf("failed parseArgument:\nexpected key: %s\nsaw key: %s\nexpected value: %s\nsaw value: %s", rt.expectedKey, key, rt.expectedVal, val)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/util/endpoint_test.go
+++ b/cmd/kubeadm/app/util/endpoint_test.go
@@ -197,19 +197,21 @@ func TestGetMasterEndpoint(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actualEndpoint, actualError := GetMasterEndpoint(rt.cfg)
+		t.Run(rt.name, func(t *testing.T) {
+			actualEndpoint, actualError := GetMasterEndpoint(rt.cfg)
 
-		if (actualError != nil) && !rt.expectedError {
-			t.Errorf("%s unexpected failure: %v", rt.name, actualError)
-			continue
-		} else if (actualError == nil) && rt.expectedError {
-			t.Errorf("%s passed when expected to fail", rt.name)
-			continue
-		}
+			if (actualError != nil) && !rt.expectedError {
+				t.Errorf("%s unexpected failure: %v", rt.name, actualError)
+				return
+			} else if (actualError == nil) && rt.expectedError {
+				t.Errorf("%s passed when expected to fail", rt.name)
+				return
+			}
 
-		if actualEndpoint != rt.expectedEndpoint {
-			t.Errorf("%s returned invalid endpoint %s, expected %s", rt.name, actualEndpoint, rt.expectedEndpoint)
-		}
+			if actualEndpoint != rt.expectedEndpoint {
+				t.Errorf("%s returned invalid endpoint %s, expected %s", rt.name, actualEndpoint, rt.expectedEndpoint)
+			}
+		})
 	}
 }
 
@@ -316,24 +318,26 @@ func TestParseHostPort(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actualHost, actualPort, actualError := ParseHostPort(rt.hostport)
+		t.Run(rt.name, func(t *testing.T) {
+			actualHost, actualPort, actualError := ParseHostPort(rt.hostport)
 
-		if (actualError != nil) && !rt.expectedError {
-			t.Errorf("%s unexpected failure: %v", rt.name, actualError)
-			continue
-		} else if (actualError == nil) && rt.expectedError {
-			t.Errorf("%s passed when expected to fail", rt.name)
-			continue
-		}
+			if (actualError != nil) && !rt.expectedError {
+				t.Errorf("%s unexpected failure: %v", rt.name, actualError)
+				return
+			} else if (actualError == nil) && rt.expectedError {
+				t.Errorf("%s passed when expected to fail", rt.name)
+				return
+			}
 
-		if actualHost != rt.expectedHost {
-			t.Errorf("%s returned invalid host %s, expected %s", rt.name, actualHost, rt.expectedHost)
-			continue
-		}
+			if actualHost != rt.expectedHost {
+				t.Errorf("%s returned invalid host %s, expected %s", rt.name, actualHost, rt.expectedHost)
+				return
+			}
 
-		if actualPort != rt.expectedPort {
-			t.Errorf("%s returned invalid port %s, expected %s", rt.name, actualPort, rt.expectedPort)
-		}
+			if actualPort != rt.expectedPort {
+				t.Errorf("%s returned invalid port %s, expected %s", rt.name, actualPort, rt.expectedPort)
+			}
+		})
 	}
 }
 
@@ -368,18 +372,20 @@ func TestParsePort(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actualPort, actualError := ParsePort(rt.port)
+		t.Run(rt.name, func(t *testing.T) {
+			actualPort, actualError := ParsePort(rt.port)
 
-		if (actualError != nil) && !rt.expectedError {
-			t.Errorf("%s unexpected failure: %v", rt.name, actualError)
-			continue
-		} else if (actualError == nil) && rt.expectedError {
-			t.Errorf("%s passed when expected to fail", rt.name)
-			continue
-		}
+			if (actualError != nil) && !rt.expectedError {
+				t.Errorf("%s unexpected failure: %v", rt.name, actualError)
+				return
+			} else if (actualError == nil) && rt.expectedError {
+				t.Errorf("%s passed when expected to fail", rt.name)
+				return
+			}
 
-		if actualPort != rt.expectedPort {
-			t.Errorf("%s returned invalid port %d, expected %d", rt.name, actualPort, rt.expectedPort)
-		}
+			if actualPort != rt.expectedPort {
+				t.Errorf("%s returned invalid port %d, expected %d", rt.name, actualPort, rt.expectedPort)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/util/error_test.go
+++ b/cmd/kubeadm/app/util/error_test.go
@@ -31,25 +31,28 @@ func TestCheckErr(t *testing.T) {
 		codeReturned = code
 	}
 
-	var tokenTest = []struct {
+	var tests = []struct {
+		name     string
 		e        error
 		expected int
 	}{
-		{nil, 0},
-		{errors.New(""), DefaultErrorExitCode},
-		{&pferror{}, PreFlightExitCode},
+		{"error is nil", nil, 0},
+		{"empty error", errors.New(""), DefaultErrorExitCode},
+		{"preflight error", &pferror{}, PreFlightExitCode},
 	}
 
-	for _, rt := range tokenTest {
-		codeReturned = 0
-		checkErr(rt.e, errHandle)
-		if codeReturned != rt.expected {
-			t.Errorf(
-				"failed checkErr:\n\texpected: %d\n\t  actual: %d",
-				rt.expected,
-				codeReturned,
-			)
-		}
+	for _, rt := range tests {
+		t.Run(rt.name, func(t *testing.T) {
+			codeReturned = 0
+			checkErr(rt.e, errHandle)
+			if codeReturned != rt.expected {
+				t.Errorf(
+					"failed checkErr:\n\texpected: %d\n\t  actual: %d",
+					rt.expected,
+					codeReturned,
+				)
+			}
+		})
 	}
 }
 
@@ -58,10 +61,12 @@ func TestFormatErrMsg(t *testing.T) {
 	errMsg2 := "specified version to upgrade to v1.9.0-alpha.3 is higher than the kubeadm version v1.9.0-alpha.1.3121+84178212527295-dirty. Upgrade kubeadm first using the tool you used to install kubeadm"
 
 	testCases := []struct {
+		name   string
 		errs   []error
 		expect string
 	}{
 		{
+			name: "two errors",
 			errs: []error{
 				errors.New(errMsg1),
 				errors.New(errMsg2),
@@ -69,6 +74,7 @@ func TestFormatErrMsg(t *testing.T) {
 			expect: "\t- " + errMsg1 + "\n" + "\t- " + errMsg2 + "\n",
 		},
 		{
+			name: "one error",
 			errs: []error{
 				errors.New(errMsg1),
 			},
@@ -77,9 +83,11 @@ func TestFormatErrMsg(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		got := FormatErrMsg(testCase.errs)
-		if got != testCase.expect {
-			t.Errorf("FormatErrMsg error, expect: %v, got: %v", testCase.expect, got)
-		}
+		t.Run(testCase.name, func(t *testing.T) {
+			got := FormatErrMsg(testCase.errs)
+			if got != testCase.expect {
+				t.Errorf("FormatErrMsg error, expect: %v, got: %v", testCase.expect, got)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig_test.go
@@ -81,56 +81,62 @@ type configClientWithToken struct {
 
 func TestCreateWithCerts(t *testing.T) {
 	var createBasicTest = []struct {
+		name        string
 		cc          configClient
 		ccWithCerts configClientWithCerts
 		expected    string
 	}{
-		{configClient{}, configClientWithCerts{}, ""},
-		{configClient{clusterName: "kubernetes"}, configClientWithCerts{}, ""},
+		{"empty config", configClient{}, configClientWithCerts{}, ""},
+		{"clusterName kubernetes", configClient{clusterName: "kubernetes"}, configClientWithCerts{}, ""},
 	}
 	for _, rt := range createBasicTest {
-		cwc := CreateWithCerts(
-			rt.cc.serverURL,
-			rt.cc.clusterName,
-			rt.cc.userName,
-			rt.cc.caCert,
-			rt.ccWithCerts.clientKey,
-			rt.ccWithCerts.clientCert,
-		)
-		if cwc.Kind != rt.expected {
-			t.Errorf(
-				"failed CreateWithCerts:\n\texpected: %s\n\t  actual: %s",
-				rt.expected,
-				cwc.Kind,
+		t.Run(rt.name, func(t *testing.T) {
+			cwc := CreateWithCerts(
+				rt.cc.serverURL,
+				rt.cc.clusterName,
+				rt.cc.userName,
+				rt.cc.caCert,
+				rt.ccWithCerts.clientKey,
+				rt.ccWithCerts.clientCert,
 			)
-		}
+			if cwc.Kind != rt.expected {
+				t.Errorf(
+					"failed CreateWithCerts:\n\texpected: %s\n\t  actual: %s",
+					rt.expected,
+					cwc.Kind,
+				)
+			}
+		})
 	}
 }
 
 func TestCreateWithToken(t *testing.T) {
 	var createBasicTest = []struct {
+		name        string
 		cc          configClient
 		ccWithToken configClientWithToken
 		expected    string
 	}{
-		{configClient{}, configClientWithToken{}, ""},
-		{configClient{clusterName: "kubernetes"}, configClientWithToken{}, ""},
+		{"empty config", configClient{}, configClientWithToken{}, ""},
+		{"clusterName kubernetes", configClient{clusterName: "kubernetes"}, configClientWithToken{}, ""},
 	}
 	for _, rt := range createBasicTest {
-		cwc := CreateWithToken(
-			rt.cc.serverURL,
-			rt.cc.clusterName,
-			rt.cc.userName,
-			rt.cc.caCert,
-			rt.ccWithToken.token,
-		)
-		if cwc.Kind != rt.expected {
-			t.Errorf(
-				"failed CreateWithToken:\n\texpected: %s\n\t  actual: %s",
-				rt.expected,
-				cwc.Kind,
+		t.Run(rt.name, func(t *testing.T) {
+			cwc := CreateWithToken(
+				rt.cc.serverURL,
+				rt.cc.clusterName,
+				rt.cc.userName,
+				rt.cc.caCert,
+				rt.ccWithToken.token,
 			)
-		}
+			if cwc.Kind != rt.expected {
+				t.Errorf(
+					"failed CreateWithToken:\n\texpected: %s\n\t  actual: %s",
+					rt.expected,
+					cwc.Kind,
+				)
+			}
+		})
 	}
 }
 
@@ -152,29 +158,31 @@ func TestWriteKubeconfigToDisk(t *testing.T) {
 		{"test2", configClient{clusterName: "kubernetes", userName: "user2", serverURL: "localhost:8080"}, configClientWithToken{token: "cba"}, nil, []byte(configOut2)},
 	}
 	for _, rt := range writeConfig {
-		c := CreateWithToken(
-			rt.cc.serverURL,
-			rt.cc.clusterName,
-			rt.cc.userName,
-			rt.cc.caCert,
-			rt.ccWithToken.token,
-		)
-		configPath := fmt.Sprintf("%s/etc/kubernetes/%s.conf", tmpdir, rt.name)
-		err := WriteToDisk(configPath, c)
-		if err != rt.expected {
-			t.Errorf(
-				"failed WriteToDisk with an error:\n\texpected: %s\n\t  actual: %s",
-				rt.expected,
-				err,
+		t.Run(rt.name, func(t *testing.T) {
+			c := CreateWithToken(
+				rt.cc.serverURL,
+				rt.cc.clusterName,
+				rt.cc.userName,
+				rt.cc.caCert,
+				rt.ccWithToken.token,
 			)
-		}
-		newFile, _ := ioutil.ReadFile(configPath)
-		if !bytes.Equal(newFile, rt.file) {
-			t.Errorf(
-				"failed WriteToDisk config write:\n\texpected: %s\n\t  actual: %s",
-				rt.file,
-				newFile,
-			)
-		}
+			configPath := fmt.Sprintf("%s/etc/kubernetes/%s.conf", tmpdir, rt.name)
+			err := WriteToDisk(configPath, c)
+			if err != rt.expected {
+				t.Errorf(
+					"failed WriteToDisk with an error:\n\texpected: %s\n\t  actual: %s",
+					rt.expected,
+					err,
+				)
+			}
+			newFile, _ := ioutil.ReadFile(configPath)
+			if !bytes.Equal(newFile, rt.file) {
+				t.Errorf(
+					"failed WriteToDisk config write:\n\texpected: %s\n\t  actual: %s",
+					rt.file,
+					newFile,
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
@@ -70,40 +70,43 @@ func TestNewCertificateAuthority(t *testing.T) {
 
 func TestNewCertAndKey(t *testing.T) {
 	var tests = []struct {
+		name      string
 		caKeySize int
 		expected  bool
 	}{
 		{
-			// RSA key too small
+			name:      "RSA key too small",
 			caKeySize: 128,
 			expected:  false,
 		},
 		{
-			// Should succeed
+			name:      "Should succeed",
 			caKeySize: 2048,
 			expected:  true,
 		},
 	}
 
 	for _, rt := range tests {
-		caKey, err := rsa.GenerateKey(rand.Reader, rt.caKeySize)
-		if err != nil {
-			t.Fatalf("Couldn't create rsa Private Key")
-		}
-		caCert := &x509.Certificate{}
-		config := &certutil.Config{
-			CommonName:   "test",
-			Organization: []string{"test"},
-			Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-		}
-		_, _, actual := NewCertAndKey(caCert, caKey, config)
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed NewCertAndKey:\n\texpected: %t\n\t  actual: %t",
-				rt.expected,
-				(actual == nil),
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			caKey, err := rsa.GenerateKey(rand.Reader, rt.caKeySize)
+			if err != nil {
+				t.Fatalf("Couldn't create rsa Private Key")
+			}
+			caCert := &x509.Certificate{}
+			config := &certutil.Config{
+				CommonName:   "test",
+				Organization: []string{"test"},
+				Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			}
+			_, _, actual := NewCertAndKey(caCert, caKey, config)
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed NewCertAndKey:\n\texpected: %t\n\t  actual: %t",
+					rt.expected,
+					(actual == nil),
+				)
+			}
+		})
 	}
 }
 
@@ -111,10 +114,12 @@ func TestHasServerAuth(t *testing.T) {
 	caCert, caKey, _ := NewCertificateAuthority(&certutil.Config{CommonName: "kubernetes"})
 
 	var tests = []struct {
+		name     string
 		config   certutil.Config
 		expected bool
 	}{
 		{
+			name: "has ServerAuth",
 			config: certutil.Config{
 				CommonName: "test",
 				Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
@@ -122,6 +127,7 @@ func TestHasServerAuth(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "doesn't have ServerAuth",
 			config: certutil.Config{
 				CommonName: "test",
 				Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
@@ -131,18 +137,20 @@ func TestHasServerAuth(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		cert, _, err := NewCertAndKey(caCert, caKey, &rt.config)
-		if err != nil {
-			t.Fatalf("Couldn't create cert: %v", err)
-		}
-		actual := HasServerAuth(cert)
-		if actual != rt.expected {
-			t.Errorf(
-				"failed HasServerAuth:\n\texpected: %t\n\t  actual: %t",
-				rt.expected,
-				actual,
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			cert, _, err := NewCertAndKey(caCert, caKey, &rt.config)
+			if err != nil {
+				t.Fatalf("Couldn't create cert: %v", err)
+			}
+			actual := HasServerAuth(cert)
+			if actual != rt.expected {
+				t.Errorf(
+					"failed HasServerAuth:\n\texpected: %t\n\t  actual: %t",
+					rt.expected,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -245,30 +253,35 @@ func TestCertOrKeyExist(t *testing.T) {
 	}
 
 	var tests = []struct {
+		desc     string
 		path     string
 		name     string
 		expected bool
 	}{
 		{
+			desc:     "empty path and name",
 			path:     "",
 			name:     "",
 			expected: false,
 		},
 		{
+			desc:     "valid path and name",
 			path:     tmpdir,
 			name:     "foo",
 			expected: true,
 		},
 	}
 	for _, rt := range tests {
-		actual := CertOrKeyExist(rt.path, rt.name)
-		if actual != rt.expected {
-			t.Errorf(
-				"failed CertOrKeyExist:\n\texpected: %t\n\t  actual: %t",
-				rt.expected,
-				actual,
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actual := CertOrKeyExist(rt.path, rt.name)
+			if actual != rt.expected {
+				t.Errorf(
+					"failed CertOrKeyExist:\n\texpected: %t\n\t  actual: %t",
+					rt.expected,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -295,30 +308,35 @@ func TestTryLoadCertAndKeyFromDisk(t *testing.T) {
 	}
 
 	var tests = []struct {
+		desc     string
 		path     string
 		name     string
 		expected bool
 	}{
 		{
+			desc:     "empty path and name",
 			path:     "",
 			name:     "",
 			expected: false,
 		},
 		{
+			desc:     "valid path and name",
 			path:     tmpdir,
 			name:     "foo",
 			expected: true,
 		},
 	}
 	for _, rt := range tests {
-		_, _, actual := TryLoadCertAndKeyFromDisk(rt.path, rt.name)
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed TryLoadCertAndKeyFromDisk:\n\texpected: %t\n\t  actual: %t",
-				rt.expected,
-				(actual == nil),
-			)
-		}
+		t.Run(rt.desc, func(t *testing.T) {
+			_, _, actual := TryLoadCertAndKeyFromDisk(rt.path, rt.name)
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed TryLoadCertAndKeyFromDisk:\n\texpected: %t\n\t  actual: %t",
+					rt.expected,
+					(actual == nil),
+				)
+			}
+		})
 	}
 }
 
@@ -345,30 +363,35 @@ func TestTryLoadCertFromDisk(t *testing.T) {
 	}
 
 	var tests = []struct {
+		desc     string
 		path     string
 		name     string
 		expected bool
 	}{
 		{
+			desc:     "empty path and name",
 			path:     "",
 			name:     "",
 			expected: false,
 		},
 		{
+			desc:     "valid path and name",
 			path:     tmpdir,
 			name:     "foo",
 			expected: true,
 		},
 	}
 	for _, rt := range tests {
-		_, actual := TryLoadCertFromDisk(rt.path, rt.name)
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed TryLoadCertAndKeyFromDisk:\n\texpected: %t\n\t  actual: %t",
-				rt.expected,
-				(actual == nil),
-			)
-		}
+		t.Run(rt.desc, func(t *testing.T) {
+			_, actual := TryLoadCertFromDisk(rt.path, rt.name)
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed TryLoadCertAndKeyFromDisk:\n\texpected: %t\n\t  actual: %t",
+					rt.expected,
+					(actual == nil),
+				)
+			}
+		})
 	}
 }
 
@@ -395,30 +418,35 @@ func TestTryLoadKeyFromDisk(t *testing.T) {
 	}
 
 	var tests = []struct {
+		desc     string
 		path     string
 		name     string
 		expected bool
 	}{
 		{
+			desc:     "empty path and name",
 			path:     "",
 			name:     "",
 			expected: false,
 		},
 		{
+			desc:     "valid path and name",
 			path:     tmpdir,
 			name:     "foo",
 			expected: true,
 		},
 	}
 	for _, rt := range tests {
-		_, actual := TryLoadKeyFromDisk(rt.path, rt.name)
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed TryLoadCertAndKeyFromDisk:\n\texpected: %t\n\t  actual: %t",
-				rt.expected,
-				(actual == nil),
-			)
-		}
+		t.Run(rt.desc, func(t *testing.T) {
+			_, actual := TryLoadKeyFromDisk(rt.path, rt.name)
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed TryLoadCertAndKeyFromDisk:\n\texpected: %t\n\t  actual: %t",
+					rt.expected,
+					(actual == nil),
+				)
+			}
+		})
 	}
 }
 
@@ -463,12 +491,14 @@ func TestPathForCSR(t *testing.T) {
 func TestGetAPIServerAltNames(t *testing.T) {
 
 	var tests = []struct {
+		desc                string
 		name                string
 		cfg                 *kubeadmapi.InitConfiguration
 		expectedDNSNames    []string
 		expectedIPAddresses []string
 	}{
 		{
+			desc: "empty name",
 			name: "",
 			cfg: &kubeadmapi.InitConfiguration{
 				LocalAPIEndpoint: kubeadmapi.APIEndpoint{AdvertiseAddress: "1.2.3.4"},
@@ -485,6 +515,7 @@ func TestGetAPIServerAltNames(t *testing.T) {
 			expectedIPAddresses: []string{"10.96.0.1", "1.2.3.4", "10.1.245.94", "10.1.245.95"},
 		},
 		{
+			desc: "ControlPlaneEndpoint IP",
 			name: "ControlPlaneEndpoint IP",
 			cfg: &kubeadmapi.InitConfiguration{
 				LocalAPIEndpoint: kubeadmapi.APIEndpoint{AdvertiseAddress: "1.2.3.4"},
@@ -503,38 +534,40 @@ func TestGetAPIServerAltNames(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		altNames, err := GetAPIServerAltNames(rt.cfg)
-		if err != nil {
-			t.Fatalf("failed calling GetAPIServerAltNames: %s: %v", rt.name, err)
-		}
+		t.Run(rt.desc, func(t *testing.T) {
+			altNames, err := GetAPIServerAltNames(rt.cfg)
+			if err != nil {
+				t.Fatalf("failed calling GetAPIServerAltNames: %s: %v", rt.name, err)
+			}
 
-		for _, DNSName := range rt.expectedDNSNames {
-			found := false
-			for _, val := range altNames.DNSNames {
-				if val == DNSName {
-					found = true
-					break
+			for _, DNSName := range rt.expectedDNSNames {
+				found := false
+				for _, val := range altNames.DNSNames {
+					if val == DNSName {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					t.Errorf("%s: altNames does not contain DNSName %s but %v", rt.name, DNSName, altNames.DNSNames)
 				}
 			}
 
-			if !found {
-				t.Errorf("%s: altNames does not contain DNSName %s but %v", rt.name, DNSName, altNames.DNSNames)
-			}
-		}
+			for _, IPAddress := range rt.expectedIPAddresses {
+				found := false
+				for _, val := range altNames.IPs {
+					if val.Equal(net.ParseIP(IPAddress)) {
+						found = true
+						break
+					}
+				}
 
-		for _, IPAddress := range rt.expectedIPAddresses {
-			found := false
-			for _, val := range altNames.IPs {
-				if val.Equal(net.ParseIP(IPAddress)) {
-					found = true
-					break
+				if !found {
+					t.Errorf("%s: altNames does not contain IPAddress %s but %v", rt.name, IPAddress, altNames.IPs)
 				}
 			}
-
-			if !found {
-				t.Errorf("%s: altNames does not contain IPAddress %s but %v", rt.name, IPAddress, altNames.IPs)
-			}
-		}
+		})
 	}
 }
 
@@ -569,32 +602,36 @@ func TestGetEtcdAltNames(t *testing.T) {
 
 	expectedDNSNames := []string{"myNode", "localhost", proxy}
 	for _, DNSName := range expectedDNSNames {
-		found := false
-		for _, val := range altNames.DNSNames {
-			if val == DNSName {
-				found = true
-				break
+		t.Run(DNSName, func(t *testing.T) {
+			found := false
+			for _, val := range altNames.DNSNames {
+				if val == DNSName {
+					found = true
+					break
+				}
 			}
-		}
 
-		if !found {
-			t.Errorf("altNames does not contain DNSName %s", DNSName)
-		}
+			if !found {
+				t.Errorf("altNames does not contain DNSName %s", DNSName)
+			}
+		})
 	}
 
 	expectedIPAddresses := []string{"1.2.3.4", "127.0.0.1", net.IPv6loopback.String(), proxyIP}
 	for _, IPAddress := range expectedIPAddresses {
-		found := false
-		for _, val := range altNames.IPs {
-			if val.Equal(net.ParseIP(IPAddress)) {
-				found = true
-				break
+		t.Run(IPAddress, func(t *testing.T) {
+			found := false
+			for _, val := range altNames.IPs {
+				if val.Equal(net.ParseIP(IPAddress)) {
+					found = true
+					break
+				}
 			}
-		}
 
-		if !found {
-			t.Errorf("altNames does not contain IPAddress %s", IPAddress)
-		}
+			if !found {
+				t.Errorf("altNames does not contain IPAddress %s", IPAddress)
+			}
+		})
 	}
 }
 
@@ -627,31 +664,33 @@ func TestGetEtcdPeerAltNames(t *testing.T) {
 
 	expectedDNSNames := []string{hostname, proxy}
 	for _, DNSName := range expectedDNSNames {
-		found := false
-		for _, val := range altNames.DNSNames {
-			if val == DNSName {
-				found = true
-				break
+		t.Run(DNSName, func(t *testing.T) {
+			found := false
+			for _, val := range altNames.DNSNames {
+				if val == DNSName {
+					found = true
+					break
+				}
 			}
-		}
 
-		if !found {
-			t.Errorf("altNames does not contain DNSName %s", DNSName)
-		}
-	}
-
-	expectedIPAddresses := []string{advertiseIP, proxyIP}
-	for _, IPAddress := range expectedIPAddresses {
-		found := false
-		for _, val := range altNames.IPs {
-			if val.Equal(net.ParseIP(IPAddress)) {
-				found = true
-				break
+			if !found {
+				t.Errorf("altNames does not contain DNSName %s", DNSName)
 			}
-		}
 
-		if !found {
-			t.Errorf("altNames does not contain IPAddress %s", IPAddress)
-		}
+			expectedIPAddresses := []string{advertiseIP, proxyIP}
+			for _, IPAddress := range expectedIPAddresses {
+				found := false
+				for _, val := range altNames.IPs {
+					if val.Equal(net.ParseIP(IPAddress)) {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					t.Errorf("altNames does not contain IPAddress %s", IPAddress)
+				}
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -166,27 +166,29 @@ func TestComponentProbe(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		actual := ComponentProbe(rt.cfg, rt.component, rt.port, rt.path, rt.scheme)
-		if actual.Handler.HTTPGet.Host != rt.expected {
-			t.Errorf("%s test case failed:\n\texpected: %s\n\t  actual: %s",
-				rt.name, rt.expected,
-				actual.Handler.HTTPGet.Host)
-		}
-		if actual.Handler.HTTPGet.Port != intstr.FromInt(rt.port) {
-			t.Errorf("%s test case failed:\n\texpected: %v\n\t  actual: %v",
-				rt.name, rt.port,
-				actual.Handler.HTTPGet.Port)
-		}
-		if actual.Handler.HTTPGet.Path != rt.path {
-			t.Errorf("%s test case failed:\n\texpected: %s\n\t  actual: %s",
-				rt.name, rt.path,
-				actual.Handler.HTTPGet.Path)
-		}
-		if actual.Handler.HTTPGet.Scheme != rt.scheme {
-			t.Errorf("%s test case failed:\n\texpected: %v\n\t  actual: %v",
-				rt.name, rt.scheme,
-				actual.Handler.HTTPGet.Scheme)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actual := ComponentProbe(rt.cfg, rt.component, rt.port, rt.path, rt.scheme)
+			if actual.Handler.HTTPGet.Host != rt.expected {
+				t.Errorf("%s test case failed:\n\texpected: %s\n\t  actual: %s",
+					rt.name, rt.expected,
+					actual.Handler.HTTPGet.Host)
+			}
+			if actual.Handler.HTTPGet.Port != intstr.FromInt(rt.port) {
+				t.Errorf("%s test case failed:\n\texpected: %v\n\t  actual: %v",
+					rt.name, rt.port,
+					actual.Handler.HTTPGet.Port)
+			}
+			if actual.Handler.HTTPGet.Path != rt.path {
+				t.Errorf("%s test case failed:\n\texpected: %s\n\t  actual: %s",
+					rt.name, rt.path,
+					actual.Handler.HTTPGet.Path)
+			}
+			if actual.Handler.HTTPGet.Scheme != rt.scheme {
+				t.Errorf("%s test case failed:\n\texpected: %v\n\t  actual: %v",
+					rt.name, rt.scheme,
+					actual.Handler.HTTPGet.Scheme)
+			}
+		})
 	}
 }
 
@@ -330,16 +332,18 @@ func TestEtcdProbe(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		// TODO: Make EtcdProbe accept a ClusterConfiguration object instead of InitConfiguration
-		initcfg := &kubeadmapi.InitConfiguration{
-			ClusterConfiguration: *rt.cfg,
-		}
-		actual := EtcdProbe(initcfg, rt.component, rt.port, rt.certsDir, rt.cacert, rt.cert, rt.key)
-		if actual.Handler.Exec.Command[2] != rt.expected {
-			t.Errorf("%s test case failed:\n\texpected: %s\n\t  actual: %s",
-				rt.name, rt.expected,
-				actual.Handler.Exec.Command[2])
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			// TODO: Make EtcdProbe accept a ClusterConfiguration object instead of InitConfiguration
+			initcfg := &kubeadmapi.InitConfiguration{
+				ClusterConfiguration: *rt.cfg,
+			}
+			actual := EtcdProbe(initcfg, rt.component, rt.port, rt.certsDir, rt.cacert, rt.cert, rt.key)
+			if actual.Handler.Exec.Command[2] != rt.expected {
+				t.Errorf("%s test case failed:\n\texpected: %s\n\t  actual: %s",
+					rt.name, rt.expected,
+					actual.Handler.Exec.Command[2])
+			}
+		})
 	}
 }
 
@@ -376,15 +380,17 @@ func TestComponentPod(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		c := v1.Container{Name: rt.name}
-		actual := ComponentPod(c, map[string]v1.Volume{})
-		if !reflect.DeepEqual(rt.expected, actual) {
-			t.Errorf(
-				"failed componentPod:\n\texpected: %v\n\t  actual: %v",
-				rt.expected,
-				actual,
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			c := v1.Container{Name: rt.name}
+			actual := ComponentPod(c, map[string]v1.Volume{})
+			if !reflect.DeepEqual(rt.expected, actual) {
+				t.Errorf(
+					"failed componentPod:\n\texpected: %v\n\t  actual: %v",
+					rt.expected,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -413,14 +419,16 @@ func TestNewVolume(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actual := NewVolume(rt.name, rt.path, rt.pathType)
-		if !reflect.DeepEqual(actual, rt.expected) {
-			t.Errorf(
-				"failed newVolume:\n\texpected: %v\n\t  actual: %v",
-				rt.expected,
-				actual,
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actual := NewVolume(rt.name, rt.path, rt.pathType)
+			if !reflect.DeepEqual(actual, rt.expected) {
+				t.Errorf(
+					"failed newVolume:\n\texpected: %v\n\t  actual: %v",
+					rt.expected,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -454,14 +462,16 @@ func TestNewVolumeMount(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actual := NewVolumeMount(rt.name, rt.path, rt.ro)
-		if !reflect.DeepEqual(actual, rt.expected) {
-			t.Errorf(
-				"failed newVolumeMount:\n\texpected: %v\n\t  actual: %v",
-				rt.expected,
-				actual,
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actual := NewVolumeMount(rt.name, rt.path, rt.ro)
+			if !reflect.DeepEqual(actual, rt.expected) {
+				t.Errorf(
+					"failed newVolumeMount:\n\texpected: %v\n\t  actual: %v",
+					rt.expected,
+					actual,
+				)
+			}
+		})
 	}
 }
 func TestVolumeMapToSlice(t *testing.T) {
@@ -508,11 +518,13 @@ func TestVolumeMountMapToSlice(t *testing.T) {
 
 func TestGetExtraParameters(t *testing.T) {
 	var tests = []struct {
+		name      string
 		overrides map[string]string
 		defaults  map[string]string
 		expected  []string
 	}{
 		{
+			name: "with admission-control default NamespaceLifecycle",
 			overrides: map[string]string{
 				"admission-control": "NamespaceLifecycle,LimitRanger",
 			},
@@ -528,6 +540,7 @@ func TestGetExtraParameters(t *testing.T) {
 			},
 		},
 		{
+			name: "without admission-control default",
 			overrides: map[string]string{
 				"admission-control": "NamespaceLifecycle,LimitRanger",
 			},
@@ -544,12 +557,14 @@ func TestGetExtraParameters(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actual := GetExtraParameters(rt.overrides, rt.defaults)
-		sort.Strings(actual)
-		sort.Strings(rt.expected)
-		if !reflect.DeepEqual(actual, rt.expected) {
-			t.Errorf("failed getExtraParameters:\nexpected:\n%v\nsaw:\n%v", rt.expected, actual)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actual := GetExtraParameters(rt.overrides, rt.defaults)
+			sort.Strings(actual)
+			sort.Strings(rt.expected)
+			if !reflect.DeepEqual(actual, rt.expected) {
+				t.Errorf("failed getExtraParameters:\nexpected:\n%v\nsaw:\n%v", rt.expected, actual)
+			}
+		})
 	}
 }
 
@@ -599,27 +614,29 @@ func TestReadStaticPodFromDisk(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		tmpdir := testutil.SetupTempDir(t)
-		defer os.RemoveAll(tmpdir)
+		t.Run(rt.description, func(t *testing.T) {
+			tmpdir := testutil.SetupTempDir(t)
+			defer os.RemoveAll(tmpdir)
 
-		manifestPath := filepath.Join(tmpdir, "pod.yaml")
-		if rt.writeManifest {
-			err := ioutil.WriteFile(manifestPath, []byte(rt.podYaml), 0644)
-			if err != nil {
-				t.Fatalf("Failed to write pod manifest\n%s\n\tfatal error: %v", rt.description, err)
+			manifestPath := filepath.Join(tmpdir, "pod.yaml")
+			if rt.writeManifest {
+				err := ioutil.WriteFile(manifestPath, []byte(rt.podYaml), 0644)
+				if err != nil {
+					t.Fatalf("Failed to write pod manifest\n%s\n\tfatal error: %v", rt.description, err)
+				}
 			}
-		}
 
-		_, actualErr := ReadStaticPodFromDisk(manifestPath)
-		if (actualErr != nil) != rt.expectErr {
-			t.Errorf(
-				"ReadStaticPodFromDisk failed\n%s\n\texpected error: %t\n\tgot: %t\n\tactual error: %v",
-				rt.description,
-				rt.expectErr,
-				(actualErr != nil),
-				actualErr,
-			)
-		}
+			_, actualErr := ReadStaticPodFromDisk(manifestPath)
+			if (actualErr != nil) != rt.expectErr {
+				t.Errorf(
+					"ReadStaticPodFromDisk failed\n%s\n\texpected error: %t\n\tgot: %t\n\tactual error: %v",
+					rt.description,
+					rt.expectErr,
+					(actualErr != nil),
+					actualErr,
+				)
+			}
+		})
 	}
 }
 
@@ -657,38 +674,40 @@ func TestManifestFilesAreEqual(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		tmpdir := testutil.SetupTempDir(t)
-		defer os.RemoveAll(tmpdir)
+		t.Run(rt.description, func(t *testing.T) {
+			tmpdir := testutil.SetupTempDir(t)
+			defer os.RemoveAll(tmpdir)
 
-		// write 2 manifests
-		for i := 0; i < 2; i++ {
-			if rt.podYamls[i] != "" {
-				manifestPath := filepath.Join(tmpdir, strconv.Itoa(i)+".yaml")
-				err := ioutil.WriteFile(manifestPath, []byte(rt.podYamls[i]), 0644)
-				if err != nil {
-					t.Fatalf("Failed to write manifest file\n%s\n\tfatal error: %v", rt.description, err)
+			// write 2 manifests
+			for i := 0; i < 2; i++ {
+				if rt.podYamls[i] != "" {
+					manifestPath := filepath.Join(tmpdir, strconv.Itoa(i)+".yaml")
+					err := ioutil.WriteFile(manifestPath, []byte(rt.podYamls[i]), 0644)
+					if err != nil {
+						t.Fatalf("Failed to write manifest file\n%s\n\tfatal error: %v", rt.description, err)
+					}
 				}
 			}
-		}
 
-		// compare them
-		result, actualErr := ManifestFilesAreEqual(filepath.Join(tmpdir, "0.yaml"), filepath.Join(tmpdir, "1.yaml"))
-		if result != rt.expectedResult {
-			t.Errorf(
-				"ManifestFilesAreEqual failed\n%s\nexpected result: %t\nactual result: %t",
-				rt.description,
-				rt.expectedResult,
-				result,
-			)
-		}
-		if (actualErr != nil) != rt.expectErr {
-			t.Errorf(
-				"ManifestFilesAreEqual failed\n%s\n\texpected error: %t\n\tgot: %t\n\tactual error: %v",
-				rt.description,
-				rt.expectErr,
-				(actualErr != nil),
-				actualErr,
-			)
-		}
+			// compare them
+			result, actualErr := ManifestFilesAreEqual(filepath.Join(tmpdir, "0.yaml"), filepath.Join(tmpdir, "1.yaml"))
+			if result != rt.expectedResult {
+				t.Errorf(
+					"ManifestFilesAreEqual failed\n%s\nexpected result: %t\nactual result: %t",
+					rt.description,
+					rt.expectedResult,
+					result,
+				)
+			}
+			if (actualErr != nil) != rt.expectErr {
+				t.Errorf(
+					"ManifestFilesAreEqual failed\n%s\n\texpected error: %t\n\tgot: %t\n\tactual error: %v",
+					rt.description,
+					rt.expectErr,
+					(actualErr != nil),
+					actualErr,
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/util/template_test.go
+++ b/cmd/kubeadm/app/util/template_test.go
@@ -30,13 +30,14 @@ const (
 
 func TestParseTemplate(t *testing.T) {
 	var tmplTests = []struct {
+		name        string
 		template    string
 		data        interface{}
 		output      string
 		errExpected bool
 	}{
-		// should parse a valid template and set the right values
 		{
+			name:     "should parse a valid template and set the right values",
 			template: validTmpl,
 			data: struct{ ImageRepository, Arch string }{
 				ImageRepository: "k8s.gcr.io",
@@ -45,8 +46,8 @@ func TestParseTemplate(t *testing.T) {
 			output:      validTmplOut,
 			errExpected: false,
 		},
-		// should noop if there aren't any {{ .foo }} present
 		{
+			name:     "should noop if there aren't any {{ .foo }} present",
 			template: doNothing,
 			data: struct{ ImageRepository, Arch string }{
 				ImageRepository: "k8s.gcr.io",
@@ -55,15 +56,15 @@ func TestParseTemplate(t *testing.T) {
 			output:      doNothing,
 			errExpected: false,
 		},
-		// invalid syntax, passing nil
 		{
+			name:        "invalid syntax, passing nil",
 			template:    invalidTmpl1,
 			data:        nil,
 			output:      "",
 			errExpected: true,
 		},
-		// invalid syntax
 		{
+			name:        "invalid syntax",
 			template:    invalidTmpl2,
 			data:        struct{}{},
 			output:      "",
@@ -71,20 +72,22 @@ func TestParseTemplate(t *testing.T) {
 		},
 	}
 	for _, tt := range tmplTests {
-		outbytes, err := ParseTemplate(tt.template, tt.data)
-		if tt.errExpected != (err != nil) {
-			t.Errorf(
-				"failed TestParseTemplate:\n\texpected err: %t\n\t  actual: %s",
-				tt.errExpected,
-				err,
-			)
-		}
-		if tt.output != string(outbytes) {
-			t.Errorf(
-				"failed TestParseTemplate:\n\texpected bytes: %s\n\t  actual: %s",
-				tt.output,
-				outbytes,
-			)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			outbytes, err := ParseTemplate(tt.template, tt.data)
+			if tt.errExpected != (err != nil) {
+				t.Errorf(
+					"failed TestParseTemplate:\n\texpected err: %t\n\t  actual: %s",
+					tt.errExpected,
+					err,
+				)
+			}
+			if tt.output != string(outbytes) {
+				t.Errorf(
+					"failed TestParseTemplate:\n\texpected bytes: %s\n\t  actual: %s",
+					tt.output,
+					outbytes,
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -48,14 +49,16 @@ func TestValidVersion(t *testing.T) {
 		"v1.6.1+coreos.0",
 	}
 	for _, s := range validVersions {
-		ver, err := KubernetesReleaseVersion(s)
-		t.Log("Valid: ", s, ver, err)
-		if err != nil {
-			t.Errorf("KubernetesReleaseVersion unexpected error for version %q: %v", s, err)
-		}
-		if ver != s {
-			t.Errorf("KubernetesReleaseVersion should return same valid version string. %q != %q", s, ver)
-		}
+		t.Run(s, func(t *testing.T) {
+			ver, err := KubernetesReleaseVersion(s)
+			t.Log("Valid: ", s, ver, err)
+			if err != nil {
+				t.Errorf("KubernetesReleaseVersion unexpected error for version %q: %v", s, err)
+			}
+			if ver != s {
+				t.Errorf("KubernetesReleaseVersion should return same valid version string. %q != %q", s, ver)
+			}
+		})
 	}
 }
 
@@ -68,14 +71,16 @@ func TestInvalidVersion(t *testing.T) {
 		"something1.2",
 	}
 	for _, s := range invalidVersions {
-		ver, err := KubernetesReleaseVersion(s)
-		t.Log("Invalid: ", s, ver, err)
-		if err == nil {
-			t.Errorf("KubernetesReleaseVersion error expected for version %q, but returned successfully", s)
-		}
-		if ver != "" {
-			t.Errorf("KubernetesReleaseVersion should return empty string in case of error. Returned %q for version %q", ver, s)
-		}
+		t.Run(s, func(t *testing.T) {
+			ver, err := KubernetesReleaseVersion(s)
+			t.Log("Invalid: ", s, ver, err)
+			if err == nil {
+				t.Errorf("KubernetesReleaseVersion error expected for version %q, but returned successfully", s)
+			}
+			if ver != "" {
+				t.Errorf("KubernetesReleaseVersion should return empty string in case of error. Returned %q for version %q", ver, s)
+			}
+		})
 	}
 }
 
@@ -86,14 +91,16 @@ func TestValidConvenientForUserVersion(t *testing.T) {
 		"1.6.1_coreos.0",
 	}
 	for _, s := range validVersions {
-		ver, err := KubernetesReleaseVersion(s)
-		t.Log("Valid: ", s, ver, err)
-		if err != nil {
-			t.Errorf("KubernetesReleaseVersion unexpected error for version %q: %v", s, err)
-		}
-		if ver != "v"+s {
-			t.Errorf("KubernetesReleaseVersion should return semantic version string. %q vs. %q", s, ver)
-		}
+		t.Run(s, func(t *testing.T) {
+			ver, err := KubernetesReleaseVersion(s)
+			t.Log("Valid: ", s, ver, err)
+			if err != nil {
+				t.Errorf("KubernetesReleaseVersion unexpected error for version %q: %v", s, err)
+			}
+			if ver != "v"+s {
+				t.Errorf("KubernetesReleaseVersion should return semantic version string. %q vs. %q", s, ver)
+			}
+		})
 	}
 }
 
@@ -128,16 +135,18 @@ func TestVersionFromNetwork(t *testing.T) {
 	kubeReleaseBucketURL = server.URL
 
 	for k, v := range cases {
-		ver, err := KubernetesReleaseVersion(k)
-		t.Logf("Key: %q. Result: %q, Error: %v", k, ver, err)
-		switch {
-		case err != nil && !v.ErrorExpected:
-			t.Errorf("KubernetesReleaseVersion: unexpected error for %q. Error: %+v", k, err)
-		case err == nil && v.ErrorExpected:
-			t.Errorf("KubernetesReleaseVersion: error expected for key %q, but result is %q", k, ver)
-		case ver != v.Expected:
-			t.Errorf("KubernetesReleaseVersion: unexpected result for key %q. Expected: %q Actual: %q", k, v.Expected, ver)
-		}
+		t.Run(k, func(t *testing.T) {
+			ver, err := KubernetesReleaseVersion(k)
+			t.Logf("Key: %q. Result: %q, Error: %v", k, ver, err)
+			switch {
+			case err != nil && !v.ErrorExpected:
+				t.Errorf("KubernetesReleaseVersion: unexpected error for %q. Error: %+v", k, err)
+			case err == nil && v.ErrorExpected:
+				t.Errorf("KubernetesReleaseVersion: error expected for key %q, but result is %q", k, ver)
+			case ver != v.Expected:
+				t.Errorf("KubernetesReleaseVersion: unexpected result for key %q. Expected: %q Actual: %q", k, v.Expected, ver)
+			}
+		})
 	}
 }
 
@@ -158,11 +167,13 @@ func TestVersionToTag(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tag := KubernetesVersionToImageTag(tc.input)
-		t.Logf("KubernetesVersionToImageTag: Input: %q. Result: %q. Expected: %q", tc.input, tag, tc.expected)
-		if tag != tc.expected {
-			t.Errorf("failed KubernetesVersionToImageTag: Input: %q. Result: %q. Expected: %q", tc.input, tag, tc.expected)
-		}
+		t.Run(fmt.Sprintf("input:%s/expected:%s", tc.input, tc.expected), func(t *testing.T) {
+			tag := KubernetesVersionToImageTag(tc.input)
+			t.Logf("KubernetesVersionToImageTag: Input: %q. Result: %q. Expected: %q", tc.input, tag, tc.expected)
+			if tag != tc.expected {
+				t.Errorf("failed KubernetesVersionToImageTag: Input: %q. Result: %q. Expected: %q", tc.input, tag, tc.expected)
+			}
+		})
 	}
 }
 
@@ -194,18 +205,19 @@ func TestSplitVersion(t *testing.T) {
 	kubeReleaseBucketURL = "https://dl.k8s.io"
 
 	for _, tc := range cases {
-		bucket, label, err := splitVersion(tc.input)
-		switch {
-		case err != nil && tc.valid:
-			t.Errorf("splitVersion: unexpected error for %q. Error: %v", tc.input, err)
-		case err == nil && !tc.valid:
-			t.Errorf("splitVersion: error expected for key %q, but result is %q, %q", tc.input, bucket, label)
-		case bucket != tc.bucket:
-			t.Errorf("splitVersion: unexpected bucket result for key %q. Expected: %q Actual: %q", tc.input, tc.bucket, bucket)
-		case label != tc.label:
-			t.Errorf("splitVersion: unexpected label result for key %q. Expected: %q Actual: %q", tc.input, tc.label, label)
-		}
-
+		t.Run(fmt.Sprintf("input:%s/label:%s", tc.input, tc.label), func(t *testing.T) {
+			bucket, label, err := splitVersion(tc.input)
+			switch {
+			case err != nil && tc.valid:
+				t.Errorf("splitVersion: unexpected error for %q. Error: %v", tc.input, err)
+			case err == nil && !tc.valid:
+				t.Errorf("splitVersion: error expected for key %q, but result is %q, %q", tc.input, bucket, label)
+			case bucket != tc.bucket:
+				t.Errorf("splitVersion: unexpected bucket result for key %q. Expected: %q Actual: %q", tc.input, tc.bucket, bucket)
+			case label != tc.label:
+				t.Errorf("splitVersion: unexpected label result for key %q. Expected: %q Actual: %q", tc.input, tc.label, label)
+			}
+		})
 	}
 }
 
@@ -227,13 +239,14 @@ func TestKubernetesIsCIVersion(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		result := KubernetesIsCIVersion(tc.input)
-		t.Logf("KubernetesIsCIVersion: Input: %q. Result: %v. Expected: %v", tc.input, result, tc.expected)
-		if result != tc.expected {
-			t.Errorf("failed KubernetesIsCIVersion: Input: %q. Result: %v. Expected: %v", tc.input, result, tc.expected)
-		}
+		t.Run(fmt.Sprintf("input:%s/expected:%t", tc.input, tc.expected), func(t *testing.T) {
+			result := KubernetesIsCIVersion(tc.input)
+			t.Logf("KubernetesIsCIVersion: Input: %q. Result: %v. Expected: %v", tc.input, result, tc.expected)
+			if result != tc.expected {
+				t.Errorf("failed KubernetesIsCIVersion: Input: %q. Result: %v. Expected: %v", tc.input, result, tc.expected)
+			}
+		})
 	}
-
 }
 
 // Validate KubernetesReleaseVersion but with bucket prefixes
@@ -258,16 +271,18 @@ func TestCIBuildVersion(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		ver, err := KubernetesReleaseVersion(tc.input)
-		t.Logf("Input: %q. Result: %q, Error: %v", tc.input, ver, err)
-		switch {
-		case err != nil && tc.valid:
-			t.Errorf("KubernetesReleaseVersion: unexpected error for input %q. Error: %v", tc.input, err)
-		case err == nil && !tc.valid:
-			t.Errorf("KubernetesReleaseVersion: error expected for input %q, but result is %q", tc.input, ver)
-		case ver != tc.expected:
-			t.Errorf("KubernetesReleaseVersion: unexpected result for input %q. Expected: %q Actual: %q", tc.input, tc.expected, ver)
-		}
+		t.Run(fmt.Sprintf("input:%s/expected:%s", tc.input, tc.expected), func(t *testing.T) {
+			ver, err := KubernetesReleaseVersion(tc.input)
+			t.Logf("Input: %q. Result: %q, Error: %v", tc.input, ver, err)
+			switch {
+			case err != nil && tc.valid:
+				t.Errorf("KubernetesReleaseVersion: unexpected error for input %q. Error: %v", tc.input, err)
+			case err == nil && !tc.valid:
+				t.Errorf("KubernetesReleaseVersion: error expected for input %q, but result is %q", tc.input, ver)
+			case ver != tc.expected:
+				t.Errorf("KubernetesReleaseVersion: unexpected result for input %q. Expected: %q Actual: %q", tc.input, tc.expected, ver)
+			}
+		})
 	}
 }
 
@@ -284,10 +299,12 @@ func TestNormalizedBuildVersionVersion(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		output := normalizedBuildVersion(tc.input)
-		if output != tc.expected {
-			t.Errorf("normalizedBuildVersion: unexpected output %q for input %q. Expected: %q", output, tc.input, tc.expected)
-		}
+		t.Run(fmt.Sprintf("input:%s/expected:%s", tc.input, tc.expected), func(t *testing.T) {
+			output := normalizedBuildVersion(tc.input)
+			if output != tc.expected {
+				t.Errorf("normalizedBuildVersion: unexpected output %q for input %q. Expected: %q", output, tc.input, tc.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Used [T.Run API](https://golang.org/pkg/testing/#T.Run) for kubeadm tests in the rest of app/util code

This should improve testing output and make it more visible
which test is doing what.

**Special notes for your reviewer**:

This is a third PR of a series aiming to usage of [T.Run API](https://golang.org/pkg/testing/#T.Run)  in all kubeadm tests. If this is accepted I'll send more PRs of this kind. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```