### PR TITLE
Shorten re-read period for token files to work with ProjectedTokenVolumeSource

### DIFF
--- a/staging/src/k8s.io/client-go/transport/token_source.go
+++ b/staging/src/k8s.io/client-go/transport/token_source.go
@@ -47,14 +47,14 @@ func TokenSourceWrapTransport(ts oauth2.TokenSource) func(http.RoundTripper) htt
 func NewCachedFileTokenSource(path string) oauth2.TokenSource {
 	return &cachingTokenSource{
 		now:    time.Now,
-		leeway: 1 * time.Minute,
+		leeway: 10 * time.Second,
 		base: &fileTokenSource{
 			path: path,
-			// This period was picked because it is half of the minimum validity
-			// duration for a token provisioned by they TokenRequest API. This is
-			// unsophisticated and should induce rotation at a frequency that should
-			// work with the token volume source.
-			period: 5 * time.Minute,
+			// This period was picked because it is half of the duration between when the kubelet
+			// refreshes a projected service account token and when the original token expires.
+			// Default token lifetime is 10 minutes, and the kubelet starts refreshing at 80% of lifetime.
+			// This should induce re-reading at a frequency that works with the token volume source.
+			period: time.Minute,
 		},
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes the token file cache period to be short enough to observe refreshed service account tokens before the original expires.

The original 5 minute window (actually 4 minutes because of the 1 minute leeway) could prevent reading a token refreshed 1 second after the last read and expiring 2 minutes later.

**Does this PR introduce a user-facing change?**:
```release-note
client-go: shortens refresh period for token files to 1 minute to ensure auto-rotated projected service account tokens are read frequently enough.
```

/cc @mikedanese 
/sig auth