### PR TITLE
annotate errors in apps/job e2e tests

### DIFF
--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -41,11 +41,11 @@ var _ = SIGDescribe("Job", func() {
 		By("Creating a job")
 		job := framework.NewTestJob("succeed", "all-succeed", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
 
 		By("Ensuring job reaches completions")
 		err = framework.WaitForJobComplete(f.ClientSet, f.Namespace.Name, job.Name, completions)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to ensure job completion in namespace: %s", f.Namespace.Name)
 	})
 
 	// Pods sometimes fail, but eventually succeed.
@@ -60,11 +60,11 @@ var _ = SIGDescribe("Job", func() {
 		// test timeout.
 		job := framework.NewTestJob("failOnce", "fail-once-local", v1.RestartPolicyOnFailure, parallelism, completions, nil, backoffLimit)
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
 
 		By("Ensuring job reaches completions")
 		err = framework.WaitForJobComplete(f.ClientSet, f.Namespace.Name, job.Name, completions)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to ensure job completion in namespace: %s", f.Namespace.Name)
 	})
 
 	// Pods sometimes fail, but eventually succeed, after pod restarts
@@ -81,11 +81,11 @@ var _ = SIGDescribe("Job", func() {
 		// test less flaky, for now.
 		job := framework.NewTestJob("randomlySucceedOrFail", "rand-non-local", v1.RestartPolicyNever, parallelism, 3, nil, 999)
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
 
 		By("Ensuring job reaches completions")
 		err = framework.WaitForJobComplete(f.ClientSet, f.Namespace.Name, job.Name, *job.Spec.Completions)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to ensure job completion in namespace: %s", f.Namespace.Name)
 	})
 
 	It("should exceed active deadline", func() {
@@ -93,28 +93,28 @@ var _ = SIGDescribe("Job", func() {
 		var activeDeadlineSeconds int64 = 1
 		job := framework.NewTestJob("notTerminate", "exceed-active-deadline", v1.RestartPolicyNever, parallelism, completions, &activeDeadlineSeconds, backoffLimit)
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
 		By("Ensuring job past active deadline")
 		err = framework.WaitForJobFailure(f.ClientSet, f.Namespace.Name, job.Name, time.Duration(activeDeadlineSeconds+10)*time.Second, "DeadlineExceeded")
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to ensure job past active deadline in namespace: %s", f.Namespace.Name)
 	})
 
 	It("should delete a job", func() {
 		By("Creating a job")
 		job := framework.NewTestJob("notTerminate", "foo", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
 
 		By("Ensuring active pods == parallelism")
 		err = framework.WaitForAllJobPodsRunning(f.ClientSet, f.Namespace.Name, job.Name, parallelism)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to ensure active pods == parallelism in namespace: %s", f.Namespace.Name)
 
 		By("delete a job")
 		framework.ExpectNoError(framework.DeleteResourceAndWaitForGC(f.ClientSet, batchinternal.Kind("Job"), f.Namespace.Name, job.Name))
 
 		By("Ensuring job was deleted")
 		_, err = framework.GetJob(f.ClientSet, f.Namespace.Name, job.Name)
-		Expect(err).To(HaveOccurred())
+		Expect(err).To(HaveOccurred(), "failed to get Job %s in namespace: %s", job.Name, f.Namespace.Name)
 		Expect(errors.IsNotFound(err)).To(BeTrue())
 	})
 
@@ -125,16 +125,16 @@ var _ = SIGDescribe("Job", func() {
 		// Save Kind since it won't be populated in the returned job.
 		kind := job.Kind
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
 		job.Kind = kind
 
 		By("Ensuring active pods == parallelism")
 		err = framework.WaitForAllJobPodsRunning(f.ClientSet, f.Namespace.Name, job.Name, parallelism)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to ensure active pods == parallelism in namespace: %s", f.Namespace.Name)
 
 		By("Orphaning one of the Job's Pods")
 		pods, err := framework.GetJobPods(f.ClientSet, f.Namespace.Name, job.Name)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to get PodList for job %s in namespace: %s", job.Name, f.Namespace.Name)
 		Expect(pods.Items).To(HaveLen(int(parallelism)))
 		pod := pods.Items[0]
 		f.PodClient().Update(pod.Name, func(pod *v1.Pod) {
@@ -177,15 +177,15 @@ var _ = SIGDescribe("Job", func() {
 		backoff := 1
 		job := framework.NewTestJob("fail", "backofflimit", v1.RestartPolicyNever, 1, 1, nil, int32(backoff))
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
 		By("Ensuring job exceed backofflimit")
 
 		err = framework.WaitForJobFailure(f.ClientSet, f.Namespace.Name, job.Name, framework.JobTimeout, "BackoffLimitExceeded")
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to ensure job exceed backofflimit in namespace: %s", f.Namespace.Name)
 
 		By(fmt.Sprintf("Checking that %d pod created and status is failed", backoff+1))
 		pods, err := framework.GetJobPods(f.ClientSet, f.Namespace.Name, job.Name)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to get PodList for job %s in namespace: %s", job.Name, f.Namespace.Name)
 		// Expect(pods.Items).To(HaveLen(backoff + 1))
 		// due to NumRequeus not being stable enough, especially with failed status
 		// updates we need to allow more than backoff+1

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -41,7 +41,7 @@ var _ = SIGDescribe("Job", func() {
 		By("Creating a job")
 		job := framework.NewTestJob("succeed", "all-succeed", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to create job in namespace: %s", f.Namespace.Name)
 
 		By("Ensuring job reaches completions")
 		err = framework.WaitForJobComplete(f.ClientSet, f.Namespace.Name, job.Name, completions)
@@ -60,7 +60,7 @@ var _ = SIGDescribe("Job", func() {
 		// test timeout.
 		job := framework.NewTestJob("failOnce", "fail-once-local", v1.RestartPolicyOnFailure, parallelism, completions, nil, backoffLimit)
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to create job in namespace: %s", f.Namespace.Name)
 
 		By("Ensuring job reaches completions")
 		err = framework.WaitForJobComplete(f.ClientSet, f.Namespace.Name, job.Name, completions)
@@ -81,7 +81,7 @@ var _ = SIGDescribe("Job", func() {
 		// test less flaky, for now.
 		job := framework.NewTestJob("randomlySucceedOrFail", "rand-non-local", v1.RestartPolicyNever, parallelism, 3, nil, 999)
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to create job in namespace: %s", f.Namespace.Name)
 
 		By("Ensuring job reaches completions")
 		err = framework.WaitForJobComplete(f.ClientSet, f.Namespace.Name, job.Name, *job.Spec.Completions)
@@ -93,7 +93,7 @@ var _ = SIGDescribe("Job", func() {
 		var activeDeadlineSeconds int64 = 1
 		job := framework.NewTestJob("notTerminate", "exceed-active-deadline", v1.RestartPolicyNever, parallelism, completions, &activeDeadlineSeconds, backoffLimit)
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to create job in namespace: %s", f.Namespace.Name)
 		By("Ensuring job past active deadline")
 		err = framework.WaitForJobFailure(f.ClientSet, f.Namespace.Name, job.Name, time.Duration(activeDeadlineSeconds+10)*time.Second, "DeadlineExceeded")
 		Expect(err).NotTo(HaveOccurred(), "failed to ensure job past active deadline in namespace: %s", f.Namespace.Name)
@@ -103,7 +103,7 @@ var _ = SIGDescribe("Job", func() {
 		By("Creating a job")
 		job := framework.NewTestJob("notTerminate", "foo", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to create job in namespace: %s", f.Namespace.Name)
 
 		By("Ensuring active pods == parallelism")
 		err = framework.WaitForAllJobPodsRunning(f.ClientSet, f.Namespace.Name, job.Name, parallelism)
@@ -114,7 +114,7 @@ var _ = SIGDescribe("Job", func() {
 
 		By("Ensuring job was deleted")
 		_, err = framework.GetJob(f.ClientSet, f.Namespace.Name, job.Name)
-		Expect(err).To(HaveOccurred(), "failed to get Job %s in namespace: %s", job.Name, f.Namespace.Name)
+		Expect(err).To(HaveOccurred(), "failed to ensure job %s was deleted in namespace: %s", job.Name, f.Namespace.Name)
 		Expect(errors.IsNotFound(err)).To(BeTrue())
 	})
 
@@ -125,7 +125,7 @@ var _ = SIGDescribe("Job", func() {
 		// Save Kind since it won't be populated in the returned job.
 		kind := job.Kind
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to create job in namespace: %s", f.Namespace.Name)
 		job.Kind = kind
 
 		By("Ensuring active pods == parallelism")
@@ -177,7 +177,7 @@ var _ = SIGDescribe("Job", func() {
 		backoff := 1
 		job := framework.NewTestJob("fail", "backofflimit", v1.RestartPolicyNever, 1, 1, nil, int32(backoff))
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred(), "failed to create Job in namespace: %s", f.Namespace.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to create job in namespace: %s", f.Namespace.Name)
 		By("Ensuring job exceed backofflimit")
 
 		err = framework.WaitForJobFailure(f.ClientSet, f.Namespace.Name, job.Name, framework.JobTimeout, "BackoffLimitExceeded")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug  

/kind cleanup  

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR annotates the errors in apps/job e2e tests providing more context.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
WIP for #34059

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
