### PR TITLE
Moved token related flags to constants.

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/v1beta1:go_default_library",
+        "//cmd/kubeadm/app/cmd/options:go_default_library",
         "//cmd/kubeadm/app/componentconfigs:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/features:go_default_library",

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -34,6 +34,7 @@ import (
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
+	kubeadmcmdoptions "k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
@@ -146,7 +147,7 @@ func ValidateDiscoveryBootstrapToken(b *kubeadm.BootstrapTokenDiscovery, fldPath
 		allErrs = append(allErrs, field.Invalid(fldPath, "", "using token-based discovery without caCertHashes can be unsafe. Set unsafeSkipCAVerification to continue"))
 	}
 
-	allErrs = append(allErrs, ValidateToken(b.Token, fldPath.Child("token"))...)
+	allErrs = append(allErrs, ValidateToken(b.Token, fldPath.Child(kubeadmcmdoptions.TokenStr))...)
 	allErrs = append(allErrs, ValidateDiscoveryTokenAPIServer(b.APIServerEndpoint, fldPath.Child("apiServerEndpoints"))...)
 
 	return allErrs
@@ -199,9 +200,9 @@ func ValidateBootstrapTokens(bts []kubeadm.BootstrapToken, fldPath *field.Path) 
 	allErrs := field.ErrorList{}
 	for i, bt := range bts {
 		btPath := fldPath.Child(fmt.Sprintf("%d", i))
-		allErrs = append(allErrs, ValidateToken(bt.Token.String(), btPath.Child("token"))...)
-		allErrs = append(allErrs, ValidateTokenUsages(bt.Usages, btPath.Child("usages"))...)
-		allErrs = append(allErrs, ValidateTokenGroups(bt.Usages, bt.Groups, btPath.Child("groups"))...)
+		allErrs = append(allErrs, ValidateToken(bt.Token.String(), btPath.Child(kubeadmcmdoptions.TokenStr))...)
+		allErrs = append(allErrs, ValidateTokenUsages(bt.Usages, btPath.Child(kubeadmcmdoptions.TokenUsages))...)
+		allErrs = append(allErrs, ValidateTokenGroups(bt.Usages, bt.Groups, btPath.Child(kubeadmcmdoptions.TokenGroups))...)
 
 		if bt.Expires != nil && bt.TTL != nil {
 			allErrs = append(allErrs, field.Invalid(btPath, "", "the BootstrapToken .TTL and .Expires fields are mutually exclusive"))

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -84,3 +84,18 @@ const CSROnly = "csr-only"
 
 // CSRDir flag sets the location for CSRs and flags to be output
 const CSRDir = "csr-dir"
+
+// TokenStr flag sets the token
+const TokenStr = "token"
+
+// TokenTTL flag sets the time to live for token
+const TokenTTL = "token-ttl"
+
+// TokenUsages flag sets the usages of the token
+const TokenUsages = "usages"
+
+// TokenGroups flag sets the authentication groups of the token
+const TokenGroups = "groups"
+
+// TokenDescription flag sets the description of the token
+const TokenDescription = "description"

--- a/cmd/kubeadm/app/cmd/options/token.go
+++ b/cmd/kubeadm/app/cmd/options/token.go
@@ -45,14 +45,14 @@ type BootstrapTokenOptions struct {
 // AddTokenFlag adds the --token flag to the given flagset
 func (bto *BootstrapTokenOptions) AddTokenFlag(fs *pflag.FlagSet) {
 	fs.StringVar(
-		&bto.TokenStr, "token", "",
+		&bto.TokenStr, TokenStr, "",
 		"The token to use for establishing bidirectional trust between nodes and masters. The format is [a-z0-9]{6}\\.[a-z0-9]{16} - e.g. abcdef.0123456789abcdef",
 	)
 }
 
 // AddTTLFlag adds the --token-ttl flag to the given flagset
 func (bto *BootstrapTokenOptions) AddTTLFlag(fs *pflag.FlagSet) {
-	bto.AddTTLFlagWithName(fs, "token-ttl")
+	bto.AddTTLFlagWithName(fs, TokenTTL)
 }
 
 // AddTTLFlagWithName adds the --token-ttl flag with a custom flag name given flagset
@@ -66,7 +66,7 @@ func (bto *BootstrapTokenOptions) AddTTLFlagWithName(fs *pflag.FlagSet, flagName
 // AddUsagesFlag adds the --usages flag to the given flagset
 func (bto *BootstrapTokenOptions) AddUsagesFlag(fs *pflag.FlagSet) {
 	fs.StringSliceVar(
-		&bto.Usages, "usages", bto.Usages,
+		&bto.Usages, TokenUsages, bto.Usages,
 		fmt.Sprintf("Describes the ways in which this token can be used. You can pass --usages multiple times or provide a comma separated list of options. Valid options: [%s]", strings.Join(kubeadmconstants.DefaultTokenUsages, ",")),
 	)
 }
@@ -74,7 +74,7 @@ func (bto *BootstrapTokenOptions) AddUsagesFlag(fs *pflag.FlagSet) {
 // AddGroupsFlag adds the --groups flag to the given flagset
 func (bto *BootstrapTokenOptions) AddGroupsFlag(fs *pflag.FlagSet) {
 	fs.StringSliceVar(
-		&bto.Groups, "groups", bto.Groups,
+		&bto.Groups, TokenGroups, bto.Groups,
 		fmt.Sprintf("Extra groups that this token will authenticate as when used for authentication. Must match %q", bootstrapapi.BootstrapGroupPattern),
 	)
 }
@@ -82,7 +82,7 @@ func (bto *BootstrapTokenOptions) AddGroupsFlag(fs *pflag.FlagSet) {
 // AddDescriptionFlag adds the --description flag to the given flagset
 func (bto *BootstrapTokenOptions) AddDescriptionFlag(fs *pflag.FlagSet) {
 	fs.StringVar(
-		&bto.Description, "description", bto.Description,
+		&bto.Description, TokenDescription, bto.Description,
 		"A human friendly description of how this token is used.",
 	)
 }


### PR DESCRIPTION
**What type of PR is this?**

 /kind cleanup


**What this PR does / why we need it**:
This PR refactors kubeadm token related flags into constants

**Which issue(s) this PR fixes**:
https://github.com/kubernetes/kubeadm/issues/1333

**Special notes for your reviewer**:

/sig cluster-lifecycle
/assign @kubernetes/sig-cluster-lifecycle-pr-reviews

**Does this PR introduce a user-facing change?**:

`NONE`
