### PR TITLE
kubeadm: use T.Run API in app/apis/kubeadm

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/bootstraptokenhelpers_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/bootstraptokenhelpers_test.go
@@ -64,14 +64,16 @@ func TestToSecret(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		actual := rt.bt.ToSecret()
-		if !reflect.DeepEqual(actual, rt.secret) {
-			t.Errorf(
-				"failed BootstrapToken.ToSecret():\n\texpected: %v\n\t  actual: %v",
-				rt.secret,
-				actual,
-			)
-		}
+		t.Run(rt.bt.Token.ID, func(t *testing.T) {
+			actual := rt.bt.ToSecret()
+			if !reflect.DeepEqual(actual, rt.secret) {
+				t.Errorf(
+					"failed BootstrapToken.ToSecret():\n\texpected: %v\n\t  actual: %v",
+					rt.secret,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -92,27 +94,31 @@ func TestBootstrapTokenToSecretRoundtrip(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		actual, err := BootstrapTokenFromSecret(rt.bt.ToSecret())
-		if err != nil {
-			t.Errorf("failed BootstrapToken to Secret roundtrip with error: %v", err)
-		}
-		if !reflect.DeepEqual(actual, rt.bt) {
-			t.Errorf(
-				"failed BootstrapToken to Secret roundtrip:\n\texpected: %v\n\t  actual: %v",
-				rt.bt,
-				actual,
-			)
-		}
+		t.Run(rt.bt.Token.ID, func(t *testing.T) {
+			actual, err := BootstrapTokenFromSecret(rt.bt.ToSecret())
+			if err != nil {
+				t.Errorf("failed BootstrapToken to Secret roundtrip with error: %v", err)
+			}
+			if !reflect.DeepEqual(actual, rt.bt) {
+				t.Errorf(
+					"failed BootstrapToken to Secret roundtrip:\n\texpected: %v\n\t  actual: %v",
+					rt.bt,
+					actual,
+				)
+			}
+		})
 	}
 }
 
 func TestEncodeTokenSecretData(t *testing.T) {
 	var tests = []struct {
+		name string
 		bt   *BootstrapToken
 		data map[string][]byte
 	}{
 		{
-			&BootstrapToken{ // the minimum amount of information needed to be specified
+			"the minimum amount of information needed to be specified",
+			&BootstrapToken{
 				Token: &BootstrapTokenString{ID: "abcdef", Secret: "abcdef0123456789"},
 			},
 			map[string][]byte{
@@ -121,7 +127,8 @@ func TestEncodeTokenSecretData(t *testing.T) {
 			},
 		},
 		{
-			&BootstrapToken{ // adds description
+			"adds description",
+			&BootstrapToken{
 				Token:       &BootstrapTokenString{ID: "abcdef", Secret: "abcdef0123456789"},
 				Description: "foo",
 			},
@@ -132,7 +139,8 @@ func TestEncodeTokenSecretData(t *testing.T) {
 			},
 		},
 		{
-			&BootstrapToken{ // adds ttl
+			"adds ttl",
+			&BootstrapToken{
 				Token: &BootstrapTokenString{ID: "abcdef", Secret: "abcdef0123456789"},
 				TTL: &metav1.Duration{
 					Duration: mustParseDuration("2h", t),
@@ -145,7 +153,8 @@ func TestEncodeTokenSecretData(t *testing.T) {
 			},
 		},
 		{
-			&BootstrapToken{ // adds expiration
+			"adds expiration",
+			&BootstrapToken{
 				Token: &BootstrapTokenString{ID: "abcdef", Secret: "abcdef0123456789"},
 				Expires: &metav1.Time{
 					Time: refTime,
@@ -158,7 +167,8 @@ func TestEncodeTokenSecretData(t *testing.T) {
 			},
 		},
 		{
-			&BootstrapToken{ // adds ttl and expiration, should favor expiration
+			"adds ttl and expiration, should favor expiration",
+			&BootstrapToken{
 				Token: &BootstrapTokenString{ID: "abcdef", Secret: "abcdef0123456789"},
 				TTL: &metav1.Duration{
 					Duration: mustParseDuration("2h", t),
@@ -174,7 +184,8 @@ func TestEncodeTokenSecretData(t *testing.T) {
 			},
 		},
 		{
-			&BootstrapToken{ // adds usages
+			"adds usages",
+			&BootstrapToken{
 				Token:  &BootstrapTokenString{ID: "abcdef", Secret: "abcdef0123456789"},
 				Usages: []string{"authentication", "signing"},
 			},
@@ -186,7 +197,8 @@ func TestEncodeTokenSecretData(t *testing.T) {
 			},
 		},
 		{
-			&BootstrapToken{ // adds groups
+			"adds groups",
+			&BootstrapToken{
 				Token:  &BootstrapTokenString{ID: "abcdef", Secret: "abcdef0123456789"},
 				Groups: []string{"system:bootstrappers", "system:bootstrappers:foo"},
 			},
@@ -197,7 +209,8 @@ func TestEncodeTokenSecretData(t *testing.T) {
 			},
 		},
 		{
-			&BootstrapToken{ // all together
+			"all together",
+			&BootstrapToken{
 				Token:       &BootstrapTokenString{ID: "abcdef", Secret: "abcdef0123456789"},
 				Description: "foo",
 				TTL: &metav1.Duration{
@@ -221,14 +234,16 @@ func TestEncodeTokenSecretData(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		actual := encodeTokenSecretData(rt.bt, refTime)
-		if !reflect.DeepEqual(actual, rt.data) {
-			t.Errorf(
-				"failed encodeTokenSecretData:\n\texpected: %v\n\t  actual: %v",
-				rt.data,
-				actual,
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actual := encodeTokenSecretData(rt.bt, refTime)
+			if !reflect.DeepEqual(actual, rt.data) {
+				t.Errorf(
+					"failed encodeTokenSecretData:\n\texpected: %v\n\t  actual: %v",
+					rt.data,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -242,12 +257,14 @@ func mustParseDuration(durationStr string, t *testing.T) time.Duration {
 
 func TestBootstrapTokenFromSecret(t *testing.T) {
 	var tests = []struct {
+		desc          string
 		name          string
 		data          map[string][]byte
 		bt            *BootstrapToken
 		expectedError bool
 	}{
-		{ // minimum information
+		{
+			"minimum information",
 			"bootstrap-token-abcdef",
 			map[string][]byte{
 				"token-id":     []byte("abcdef"),
@@ -258,7 +275,8 @@ func TestBootstrapTokenFromSecret(t *testing.T) {
 			},
 			false,
 		},
-		{ // invalid token id
+		{
+			"invalid token id",
 			"bootstrap-token-abcdef",
 			map[string][]byte{
 				"token-id":     []byte("abcdeF"),
@@ -267,7 +285,8 @@ func TestBootstrapTokenFromSecret(t *testing.T) {
 			nil,
 			true,
 		},
-		{ // invalid secret naming
+		{
+			"invalid secret naming",
 			"foo",
 			map[string][]byte{
 				"token-id":     []byte("abcdef"),
@@ -276,7 +295,8 @@ func TestBootstrapTokenFromSecret(t *testing.T) {
 			nil,
 			true,
 		},
-		{ // invalid token secret
+		{
+			"invalid token secret",
 			"bootstrap-token-abcdef",
 			map[string][]byte{
 				"token-id":     []byte("abcdef"),
@@ -285,7 +305,8 @@ func TestBootstrapTokenFromSecret(t *testing.T) {
 			nil,
 			true,
 		},
-		{ // adds description
+		{
+			"adds description",
 			"bootstrap-token-abcdef",
 			map[string][]byte{
 				"token-id":     []byte("abcdef"),
@@ -298,7 +319,8 @@ func TestBootstrapTokenFromSecret(t *testing.T) {
 			},
 			false,
 		},
-		{ // adds expiration
+		{
+			"adds expiration",
 			"bootstrap-token-abcdef",
 			map[string][]byte{
 				"token-id":     []byte("abcdef"),
@@ -313,7 +335,8 @@ func TestBootstrapTokenFromSecret(t *testing.T) {
 			},
 			false,
 		},
-		{ // invalid expiration
+		{
+			"invalid expiration",
 			"bootstrap-token-abcdef",
 			map[string][]byte{
 				"token-id":     []byte("abcdef"),
@@ -323,7 +346,8 @@ func TestBootstrapTokenFromSecret(t *testing.T) {
 			nil,
 			true,
 		},
-		{ // adds usages
+		{
+			"adds usages",
 			"bootstrap-token-abcdef",
 			map[string][]byte{
 				"token-id":                       []byte("abcdef"),
@@ -337,7 +361,8 @@ func TestBootstrapTokenFromSecret(t *testing.T) {
 			},
 			false,
 		},
-		{ // should ignore usages that aren't set to true
+		{
+			"should ignore usages that aren't set to true",
 			"bootstrap-token-abcdef",
 			map[string][]byte{
 				"token-id":                       []byte("abcdef"),
@@ -353,7 +378,8 @@ func TestBootstrapTokenFromSecret(t *testing.T) {
 			},
 			false,
 		},
-		{ // adds groups
+		{
+			"adds groups",
 			"bootstrap-token-abcdef",
 			map[string][]byte{
 				"token-id":          []byte("abcdef"),
@@ -366,7 +392,8 @@ func TestBootstrapTokenFromSecret(t *testing.T) {
 			},
 			false,
 		},
-		{ // all fields set
+		{
+			"all fields set",
 			"bootstrap-token-abcdef",
 			map[string][]byte{
 				"token-id":                       []byte("abcdef"),
@@ -390,34 +417,36 @@ func TestBootstrapTokenFromSecret(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		actual, err := BootstrapTokenFromSecret(&v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      rt.name,
-				Namespace: "kube-system",
-			},
-			Type: v1.SecretType("bootstrap.kubernetes.io/token"),
-			Data: rt.data,
-		})
-		if (err != nil) != rt.expectedError {
-			t.Errorf(
-				"failed BootstrapTokenFromSecret\n\texpected error: %t\n\t  actual error: %v",
-				rt.expectedError,
-				err,
-			)
-		} else {
-			if actual == nil && rt.bt == nil {
-				// if both pointers are nil, it's okay, just continue
-				continue
-			}
-			// If one of the pointers is defined but the other isn't, throw error. If both pointers are defined but unequal, throw error
-			if (actual == nil && rt.bt != nil) || (actual != nil && rt.bt == nil) || !reflect.DeepEqual(*actual, *rt.bt) {
+		t.Run(rt.desc, func(t *testing.T) {
+			actual, err := BootstrapTokenFromSecret(&v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      rt.name,
+					Namespace: "kube-system",
+				},
+				Type: v1.SecretType("bootstrap.kubernetes.io/token"),
+				Data: rt.data,
+			})
+			if (err != nil) != rt.expectedError {
 				t.Errorf(
-					"failed BootstrapTokenFromSecret\n\texpected: %s\n\t  actual: %s",
-					jsonMarshal(rt.bt),
-					jsonMarshal(actual),
+					"failed BootstrapTokenFromSecret\n\texpected error: %t\n\t  actual error: %v",
+					rt.expectedError,
+					err,
 				)
+			} else {
+				if actual == nil && rt.bt == nil {
+					// if both pointers are nil, it's okay, just continue
+					return
+				}
+				// If one of the pointers is defined but the other isn't, throw error. If both pointers are defined but unequal, throw error
+				if (actual == nil && rt.bt != nil) || (actual != nil && rt.bt == nil) || !reflect.DeepEqual(*actual, *rt.bt) {
+					t.Errorf(
+						"failed BootstrapTokenFromSecret\n\texpected: %s\n\t  actual: %s",
+						jsonMarshal(rt.bt),
+						jsonMarshal(actual),
+					)
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -428,11 +457,13 @@ func jsonMarshal(bt *BootstrapToken) string {
 
 func TestGetSecretString(t *testing.T) {
 	var tests = []struct {
+		name        string
 		secret      *v1.Secret
 		key         string
 		expectedVal string
 	}{
 		{
+			name: "existing key",
 			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Data: map[string][]byte{
@@ -443,6 +474,7 @@ func TestGetSecretString(t *testing.T) {
 			expectedVal: "bar",
 		},
 		{
+			name: "non-existing key",
 			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Data: map[string][]byte{
@@ -453,6 +485,7 @@ func TestGetSecretString(t *testing.T) {
 			expectedVal: "",
 		},
 		{
+			name: "no data",
 			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 			},
@@ -461,13 +494,15 @@ func TestGetSecretString(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		actual := getSecretString(rt.secret, rt.key)
-		if actual != rt.expectedVal {
-			t.Errorf(
-				"failed getSecretString:\n\texpected: %s\n\t  actual: %s",
-				rt.expectedVal,
-				actual,
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actual := getSecretString(rt.secret, rt.key)
+			if actual != rt.expectedVal {
+				t.Errorf(
+					"failed getSecretString:\n\texpected: %s\n\t  actual: %s",
+					rt.expectedVal,
+					actual,
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/bootstraptokenstring_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/bootstraptokenstring_test.go
@@ -34,17 +34,19 @@ func TestMarshalJSON(t *testing.T) {
 		{BootstrapTokenString{ID: "h", Secret: "b"}, `"h.b"`},
 	}
 	for _, rt := range tests {
-		b, err := json.Marshal(rt.bts)
-		if err != nil {
-			t.Fatalf("json.Marshal returned an unexpected error: %v", err)
-		}
-		if string(b) != rt.expected {
-			t.Errorf(
-				"failed BootstrapTokenString.MarshalJSON:\n\texpected: %s\n\t  actual: %s",
-				rt.expected,
-				string(b),
-			)
-		}
+		t.Run(rt.bts.ID, func(t *testing.T) {
+			b, err := json.Marshal(rt.bts)
+			if err != nil {
+				t.Fatalf("json.Marshal returned an unexpected error: %v", err)
+			}
+			if string(b) != rt.expected {
+				t.Errorf(
+					"failed BootstrapTokenString.MarshalJSON:\n\texpected: %s\n\t  actual: %s",
+					rt.expected,
+					string(b),
+				)
+			}
+		})
 	}
 }
 
@@ -64,17 +66,19 @@ func TestUnmarshalJSON(t *testing.T) {
 		{`"123456.aabbccddeeffgghh"`, &BootstrapTokenString{ID: "123456", Secret: "aabbccddeeffgghh"}, false},
 	}
 	for _, rt := range tests {
-		newbts := &BootstrapTokenString{}
-		err := json.Unmarshal([]byte(rt.input), newbts)
-		if (err != nil) != rt.expectedError {
-			t.Errorf("failed BootstrapTokenString.UnmarshalJSON:\n\texpected error: %t\n\t  actual error: %v", rt.expectedError, err)
-		} else if !reflect.DeepEqual(rt.bts, newbts) {
-			t.Errorf(
-				"failed BootstrapTokenString.UnmarshalJSON:\n\texpected: %v\n\t  actual: %v",
-				rt.bts,
-				newbts,
-			)
-		}
+		t.Run(rt.input, func(t *testing.T) {
+			newbts := &BootstrapTokenString{}
+			err := json.Unmarshal([]byte(rt.input), newbts)
+			if (err != nil) != rt.expectedError {
+				t.Errorf("failed BootstrapTokenString.UnmarshalJSON:\n\texpected error: %t\n\t  actual error: %v", rt.expectedError, err)
+			} else if !reflect.DeepEqual(rt.bts, newbts) {
+				t.Errorf(
+					"failed BootstrapTokenString.UnmarshalJSON:\n\texpected: %v\n\t  actual: %v",
+					rt.bts,
+					newbts,
+				)
+			}
+		})
 	}
 }
 
@@ -87,9 +91,11 @@ func TestJSONRoundtrip(t *testing.T) {
 		{"", &BootstrapTokenString{ID: "abcdef", Secret: "abcdef0123456789"}},
 	}
 	for _, rt := range tests {
-		if err := roundtrip(rt.input, rt.bts); err != nil {
-			t.Errorf("failed BootstrapTokenString JSON roundtrip with error: %v", err)
-		}
+		t.Run(rt.input, func(t *testing.T) {
+			if err := roundtrip(rt.input, rt.bts); err != nil {
+				t.Errorf("failed BootstrapTokenString JSON roundtrip with error: %v", err)
+			}
+		})
 	}
 }
 
@@ -140,14 +146,16 @@ func TestTokenFromIDAndSecret(t *testing.T) {
 		{BootstrapTokenString{ID: "h", Secret: "b"}, "h.b"},
 	}
 	for _, rt := range tests {
-		actual := rt.bts.String()
-		if actual != rt.expected {
-			t.Errorf(
-				"failed BootstrapTokenString.String():\n\texpected: %s\n\t  actual: %s",
-				rt.expected,
-				actual,
-			)
-		}
+		t.Run(rt.bts.ID, func(t *testing.T) {
+			actual := rt.bts.String()
+			if actual != rt.expected {
+				t.Errorf(
+					"failed BootstrapTokenString.String():\n\texpected: %s\n\t  actual: %s",
+					rt.expected,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -175,22 +183,24 @@ func TestNewBootstrapTokenString(t *testing.T) {
 		{token: "123456.1234560123456789", expectedError: false, bts: &BootstrapTokenString{ID: "123456", Secret: "1234560123456789"}},
 	}
 	for _, rt := range tests {
-		actual, err := NewBootstrapTokenString(rt.token)
-		if (err != nil) != rt.expectedError {
-			t.Errorf(
-				"failed NewBootstrapTokenString for the token %q\n\texpected error: %t\n\t  actual error: %v",
-				rt.token,
-				rt.expectedError,
-				err,
-			)
-		} else if !reflect.DeepEqual(actual, rt.bts) {
-			t.Errorf(
-				"failed NewBootstrapTokenString for the token %q\n\texpected: %v\n\t  actual: %v",
-				rt.token,
-				rt.bts,
-				actual,
-			)
-		}
+		t.Run(rt.token, func(t *testing.T) {
+			actual, err := NewBootstrapTokenString(rt.token)
+			if (err != nil) != rt.expectedError {
+				t.Errorf(
+					"failed NewBootstrapTokenString for the token %q\n\texpected error: %t\n\t  actual error: %v",
+					rt.token,
+					rt.expectedError,
+					err,
+				)
+			} else if !reflect.DeepEqual(actual, rt.bts) {
+				t.Errorf(
+					"failed NewBootstrapTokenString for the token %q\n\texpected: %v\n\t  actual: %v",
+					rt.token,
+					rt.bts,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -215,23 +225,25 @@ func TestNewBootstrapTokenStringFromIDAndSecret(t *testing.T) {
 		{id: "123456", secret: "1234560123456789", expectedError: false, bts: &BootstrapTokenString{ID: "123456", Secret: "1234560123456789"}},
 	}
 	for _, rt := range tests {
-		actual, err := NewBootstrapTokenStringFromIDAndSecret(rt.id, rt.secret)
-		if (err != nil) != rt.expectedError {
-			t.Errorf(
-				"failed NewBootstrapTokenStringFromIDAndSecret for the token with id %q and secret %q\n\texpected error: %t\n\t  actual error: %v",
-				rt.id,
-				rt.secret,
-				rt.expectedError,
-				err,
-			)
-		} else if !reflect.DeepEqual(actual, rt.bts) {
-			t.Errorf(
-				"failed NewBootstrapTokenStringFromIDAndSecret for the token with id %q and secret %q\n\texpected: %v\n\t  actual: %v",
-				rt.id,
-				rt.secret,
-				rt.bts,
-				actual,
-			)
-		}
+		t.Run(rt.id, func(t *testing.T) {
+			actual, err := NewBootstrapTokenStringFromIDAndSecret(rt.id, rt.secret)
+			if (err != nil) != rt.expectedError {
+				t.Errorf(
+					"failed NewBootstrapTokenStringFromIDAndSecret for the token with id %q and secret %q\n\texpected error: %t\n\t  actual error: %v",
+					rt.id,
+					rt.secret,
+					rt.expectedError,
+					err,
+				)
+			} else if !reflect.DeepEqual(actual, rt.bts) {
+				t.Errorf(
+					"failed NewBootstrapTokenStringFromIDAndSecret for the token with id %q and secret %q\n\texpected: %v\n\t  actual: %v",
+					rt.id,
+					rt.secret,
+					rt.bts,
+					actual,
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/bootstraptokenstring_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/bootstraptokenstring_test.go
@@ -34,17 +34,19 @@ func TestMarshalJSON(t *testing.T) {
 		{BootstrapTokenString{ID: "h", Secret: "b"}, `"h.b"`},
 	}
 	for _, rt := range tests {
-		b, err := json.Marshal(rt.bts)
-		if err != nil {
-			t.Fatalf("json.Marshal returned an unexpected error: %v", err)
-		}
-		if string(b) != rt.expected {
-			t.Errorf(
-				"failed BootstrapTokenString.MarshalJSON:\n\texpected: %s\n\t  actual: %s",
-				rt.expected,
-				string(b),
-			)
-		}
+		t.Run(rt.bts.ID, func(t *testing.T) {
+			b, err := json.Marshal(rt.bts)
+			if err != nil {
+				t.Fatalf("json.Marshal returned an unexpected error: %v", err)
+			}
+			if string(b) != rt.expected {
+				t.Errorf(
+					"failed BootstrapTokenString.MarshalJSON:\n\texpected: %s\n\t  actual: %s",
+					rt.expected,
+					string(b),
+				)
+			}
+		})
 	}
 }
 
@@ -64,17 +66,19 @@ func TestUnmarshalJSON(t *testing.T) {
 		{`"123456.aabbccddeeffgghh"`, &BootstrapTokenString{ID: "123456", Secret: "aabbccddeeffgghh"}, false},
 	}
 	for _, rt := range tests {
-		newbts := &BootstrapTokenString{}
-		err := json.Unmarshal([]byte(rt.input), newbts)
-		if (err != nil) != rt.expectedError {
-			t.Errorf("failed BootstrapTokenString.UnmarshalJSON:\n\texpected error: %t\n\t  actual error: %v", rt.expectedError, err)
-		} else if !reflect.DeepEqual(rt.bts, newbts) {
-			t.Errorf(
-				"failed BootstrapTokenString.UnmarshalJSON:\n\texpected: %v\n\t  actual: %v",
-				rt.bts,
-				newbts,
-			)
-		}
+		t.Run(rt.input, func(t *testing.T) {
+			newbts := &BootstrapTokenString{}
+			err := json.Unmarshal([]byte(rt.input), newbts)
+			if (err != nil) != rt.expectedError {
+				t.Errorf("failed BootstrapTokenString.UnmarshalJSON:\n\texpected error: %t\n\t  actual error: %v", rt.expectedError, err)
+			} else if !reflect.DeepEqual(rt.bts, newbts) {
+				t.Errorf(
+					"failed BootstrapTokenString.UnmarshalJSON:\n\texpected: %v\n\t  actual: %v",
+					rt.bts,
+					newbts,
+				)
+			}
+		})
 	}
 }
 
@@ -87,9 +91,11 @@ func TestJSONRoundtrip(t *testing.T) {
 		{"", &BootstrapTokenString{ID: "abcdef", Secret: "abcdef0123456789"}},
 	}
 	for _, rt := range tests {
-		if err := roundtrip(rt.input, rt.bts); err != nil {
-			t.Errorf("failed BootstrapTokenString JSON roundtrip with error: %v", err)
-		}
+		t.Run(rt.input, func(t *testing.T) {
+			if err := roundtrip(rt.input, rt.bts); err != nil {
+				t.Errorf("failed BootstrapTokenString JSON roundtrip with error: %v", err)
+			}
+		})
 	}
 }
 
@@ -140,14 +146,16 @@ func TestTokenFromIDAndSecret(t *testing.T) {
 		{BootstrapTokenString{ID: "h", Secret: "b"}, "h.b"},
 	}
 	for _, rt := range tests {
-		actual := rt.bts.String()
-		if actual != rt.expected {
-			t.Errorf(
-				"failed BootstrapTokenString.String():\n\texpected: %s\n\t  actual: %s",
-				rt.expected,
-				actual,
-			)
-		}
+		t.Run(rt.bts.ID, func(t *testing.T) {
+			actual := rt.bts.String()
+			if actual != rt.expected {
+				t.Errorf(
+					"failed BootstrapTokenString.String():\n\texpected: %s\n\t  actual: %s",
+					rt.expected,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -175,22 +183,24 @@ func TestNewBootstrapTokenString(t *testing.T) {
 		{token: "123456.1234560123456789", expectedError: false, bts: &BootstrapTokenString{ID: "123456", Secret: "1234560123456789"}},
 	}
 	for _, rt := range tests {
-		actual, err := NewBootstrapTokenString(rt.token)
-		if (err != nil) != rt.expectedError {
-			t.Errorf(
-				"failed NewBootstrapTokenString for the token %q\n\texpected error: %t\n\t  actual error: %v",
-				rt.token,
-				rt.expectedError,
-				err,
-			)
-		} else if !reflect.DeepEqual(actual, rt.bts) {
-			t.Errorf(
-				"failed NewBootstrapTokenString for the token %q\n\texpected: %v\n\t  actual: %v",
-				rt.token,
-				rt.bts,
-				actual,
-			)
-		}
+		t.Run(rt.token, func(t *testing.T) {
+			actual, err := NewBootstrapTokenString(rt.token)
+			if (err != nil) != rt.expectedError {
+				t.Errorf(
+					"failed NewBootstrapTokenString for the token %q\n\texpected error: %t\n\t  actual error: %v",
+					rt.token,
+					rt.expectedError,
+					err,
+				)
+			} else if !reflect.DeepEqual(actual, rt.bts) {
+				t.Errorf(
+					"failed NewBootstrapTokenString for the token %q\n\texpected: %v\n\t  actual: %v",
+					rt.token,
+					rt.bts,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -215,23 +225,25 @@ func TestNewBootstrapTokenStringFromIDAndSecret(t *testing.T) {
 		{id: "123456", secret: "1234560123456789", expectedError: false, bts: &BootstrapTokenString{ID: "123456", Secret: "1234560123456789"}},
 	}
 	for _, rt := range tests {
-		actual, err := NewBootstrapTokenStringFromIDAndSecret(rt.id, rt.secret)
-		if (err != nil) != rt.expectedError {
-			t.Errorf(
-				"failed NewBootstrapTokenStringFromIDAndSecret for the token with id %q and secret %q\n\texpected error: %t\n\t  actual error: %v",
-				rt.id,
-				rt.secret,
-				rt.expectedError,
-				err,
-			)
-		} else if !reflect.DeepEqual(actual, rt.bts) {
-			t.Errorf(
-				"failed NewBootstrapTokenStringFromIDAndSecret for the token with id %q and secret %q\n\texpected: %v\n\t  actual: %v",
-				rt.id,
-				rt.secret,
-				rt.bts,
-				actual,
-			)
-		}
+		t.Run(rt.id, func(t *testing.T) {
+			actual, err := NewBootstrapTokenStringFromIDAndSecret(rt.id, rt.secret)
+			if (err != nil) != rt.expectedError {
+				t.Errorf(
+					"failed NewBootstrapTokenStringFromIDAndSecret for the token with id %q and secret %q\n\texpected error: %t\n\t  actual error: %v",
+					rt.id,
+					rt.secret,
+					rt.expectedError,
+					err,
+				)
+			} else if !reflect.DeepEqual(actual, rt.bts) {
+				t.Errorf(
+					"failed NewBootstrapTokenStringFromIDAndSecret for the token with id %q and secret %q\n\texpected: %v\n\t  actual: %v",
+					rt.id,
+					rt.secret,
+					rt.bts,
+					actual,
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/conversion_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/conversion_test.go
@@ -46,13 +46,15 @@ func TestJoinConfigurationConversion(t *testing.T) {
 			expectedError: true,
 		},
 	}
-	for _, tc := range testcases {
-		internal := &kubeadm.JoinConfiguration{}
-		err := Convert_v1alpha3_JoinConfiguration_To_kubeadm_JoinConfiguration(tc.old, internal, nil)
-		if (err != nil) != tc.expectedError {
-			t.Errorf("ImageToImageMeta returned unexpected error: %v, saw: %v", tc.expectedError, (err != nil))
-			return
-		}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			internal := &kubeadm.JoinConfiguration{}
+			err := Convert_v1alpha3_JoinConfiguration_To_kubeadm_JoinConfiguration(tc.old, internal, nil)
+			if (err != nil) != tc.expectedError {
+				t.Errorf("ImageToImageMeta returned unexpected error: %v, saw: %v", tc.expectedError, (err != nil))
+				return
+			}
+		})
 	}
 }
 
@@ -76,12 +78,14 @@ func TestInitConfigurationConversion(t *testing.T) {
 			expectedErr: true,
 		},
 	}
-	for _, tc := range testcases {
-		internal := &kubeadm.InitConfiguration{}
-		err := Convert_v1alpha3_InitConfiguration_To_kubeadm_InitConfiguration(tc.old, internal, nil)
-		if (err != nil) != tc.expectedErr {
-			t.Errorf("no error was expected but '%s' was found", err)
-		}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			internal := &kubeadm.InitConfiguration{}
+			err := Convert_v1alpha3_InitConfiguration_To_kubeadm_InitConfiguration(tc.old, internal, nil)
+			if (err != nil) != tc.expectedErr {
+				t.Errorf("no error was expected but '%s' was found", err)
+			}
+		})
 	}
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/bootstraptokenstring_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/bootstraptokenstring_test.go
@@ -34,17 +34,19 @@ func TestMarshalJSON(t *testing.T) {
 		{BootstrapTokenString{ID: "h", Secret: "b"}, `"h.b"`},
 	}
 	for _, rt := range tests {
-		b, err := json.Marshal(rt.bts)
-		if err != nil {
-			t.Fatalf("json.Marshal returned an unexpected error: %v", err)
-		}
-		if string(b) != rt.expected {
-			t.Errorf(
-				"failed BootstrapTokenString.MarshalJSON:\n\texpected: %s\n\t  actual: %s",
-				rt.expected,
-				string(b),
-			)
-		}
+		t.Run(rt.bts.ID, func(t *testing.T) {
+			b, err := json.Marshal(rt.bts)
+			if err != nil {
+				t.Fatalf("json.Marshal returned an unexpected error: %v", err)
+			}
+			if string(b) != rt.expected {
+				t.Errorf(
+					"failed BootstrapTokenString.MarshalJSON:\n\texpected: %s\n\t  actual: %s",
+					rt.expected,
+					string(b),
+				)
+			}
+		})
 	}
 }
 
@@ -64,17 +66,19 @@ func TestUnmarshalJSON(t *testing.T) {
 		{`"123456.aabbccddeeffgghh"`, &BootstrapTokenString{ID: "123456", Secret: "aabbccddeeffgghh"}, false},
 	}
 	for _, rt := range tests {
-		newbts := &BootstrapTokenString{}
-		err := json.Unmarshal([]byte(rt.input), newbts)
-		if (err != nil) != rt.expectedError {
-			t.Errorf("failed BootstrapTokenString.UnmarshalJSON:\n\texpected error: %t\n\t  actual error: %v", rt.expectedError, err)
-		} else if !reflect.DeepEqual(rt.bts, newbts) {
-			t.Errorf(
-				"failed BootstrapTokenString.UnmarshalJSON:\n\texpected: %v\n\t  actual: %v",
-				rt.bts,
-				newbts,
-			)
-		}
+		t.Run(rt.input, func(t *testing.T) {
+			newbts := &BootstrapTokenString{}
+			err := json.Unmarshal([]byte(rt.input), newbts)
+			if (err != nil) != rt.expectedError {
+				t.Errorf("failed BootstrapTokenString.UnmarshalJSON:\n\texpected error: %t\n\t  actual error: %v", rt.expectedError, err)
+			} else if !reflect.DeepEqual(rt.bts, newbts) {
+				t.Errorf(
+					"failed BootstrapTokenString.UnmarshalJSON:\n\texpected: %v\n\t  actual: %v",
+					rt.bts,
+					newbts,
+				)
+			}
+		})
 	}
 }
 
@@ -87,9 +91,11 @@ func TestJSONRoundtrip(t *testing.T) {
 		{"", &BootstrapTokenString{ID: "abcdef", Secret: "abcdef0123456789"}},
 	}
 	for _, rt := range tests {
-		if err := roundtrip(rt.input, rt.bts); err != nil {
-			t.Errorf("failed BootstrapTokenString JSON roundtrip with error: %v", err)
-		}
+		t.Run(rt.input, func(t *testing.T) {
+			if err := roundtrip(rt.input, rt.bts); err != nil {
+				t.Errorf("failed BootstrapTokenString JSON roundtrip with error: %v", err)
+			}
+		})
 	}
 }
 
@@ -140,14 +146,16 @@ func TestTokenFromIDAndSecret(t *testing.T) {
 		{BootstrapTokenString{ID: "h", Secret: "b"}, "h.b"},
 	}
 	for _, rt := range tests {
-		actual := rt.bts.String()
-		if actual != rt.expected {
-			t.Errorf(
-				"failed BootstrapTokenString.String():\n\texpected: %s\n\t  actual: %s",
-				rt.expected,
-				actual,
-			)
-		}
+		t.Run(rt.bts.ID, func(t *testing.T) {
+			actual := rt.bts.String()
+			if actual != rt.expected {
+				t.Errorf(
+					"failed BootstrapTokenString.String():\n\texpected: %s\n\t  actual: %s",
+					rt.expected,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -175,22 +183,24 @@ func TestNewBootstrapTokenString(t *testing.T) {
 		{token: "123456.1234560123456789", expectedError: false, bts: &BootstrapTokenString{ID: "123456", Secret: "1234560123456789"}},
 	}
 	for _, rt := range tests {
-		actual, err := NewBootstrapTokenString(rt.token)
-		if (err != nil) != rt.expectedError {
-			t.Errorf(
-				"failed NewBootstrapTokenString for the token %q\n\texpected error: %t\n\t  actual error: %v",
-				rt.token,
-				rt.expectedError,
-				err,
-			)
-		} else if !reflect.DeepEqual(actual, rt.bts) {
-			t.Errorf(
-				"failed NewBootstrapTokenString for the token %q\n\texpected: %v\n\t  actual: %v",
-				rt.token,
-				rt.bts,
-				actual,
-			)
-		}
+		t.Run(rt.token, func(t *testing.T) {
+			actual, err := NewBootstrapTokenString(rt.token)
+			if (err != nil) != rt.expectedError {
+				t.Errorf(
+					"failed NewBootstrapTokenString for the token %q\n\texpected error: %t\n\t  actual error: %v",
+					rt.token,
+					rt.expectedError,
+					err,
+				)
+			} else if !reflect.DeepEqual(actual, rt.bts) {
+				t.Errorf(
+					"failed NewBootstrapTokenString for the token %q\n\texpected: %v\n\t  actual: %v",
+					rt.token,
+					rt.bts,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -215,23 +225,25 @@ func TestNewBootstrapTokenStringFromIDAndSecret(t *testing.T) {
 		{id: "123456", secret: "1234560123456789", expectedError: false, bts: &BootstrapTokenString{ID: "123456", Secret: "1234560123456789"}},
 	}
 	for _, rt := range tests {
-		actual, err := NewBootstrapTokenStringFromIDAndSecret(rt.id, rt.secret)
-		if (err != nil) != rt.expectedError {
-			t.Errorf(
-				"failed NewBootstrapTokenStringFromIDAndSecret for the token with id %q and secret %q\n\texpected error: %t\n\t  actual error: %v",
-				rt.id,
-				rt.secret,
-				rt.expectedError,
-				err,
-			)
-		} else if !reflect.DeepEqual(actual, rt.bts) {
-			t.Errorf(
-				"failed NewBootstrapTokenStringFromIDAndSecret for the token with id %q and secret %q\n\texpected: %v\n\t  actual: %v",
-				rt.id,
-				rt.secret,
-				rt.bts,
-				actual,
-			)
-		}
+		t.Run(rt.id, func(t *testing.T) {
+			actual, err := NewBootstrapTokenStringFromIDAndSecret(rt.id, rt.secret)
+			if (err != nil) != rt.expectedError {
+				t.Errorf(
+					"failed NewBootstrapTokenStringFromIDAndSecret for the token with id %q and secret %q\n\texpected error: %t\n\t  actual error: %v",
+					rt.id,
+					rt.secret,
+					rt.expectedError,
+					err,
+				)
+			} else if !reflect.DeepEqual(actual, rt.bts) {
+				t.Errorf(
+					"failed NewBootstrapTokenStringFromIDAndSecret for the token with id %q and secret %q\n\texpected: %v\n\t  actual: %v",
+					rt.id,
+					rt.secret,
+					rt.bts,
+					actual,
+				)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Used [T.Run API](https://golang.org/pkg/testing/#T.Run) for kubeadm tests in app/apis/kubeadm

This should improve testing output and make it more visible
which test is doing what.

**Special notes for your reviewer**:

This is a fourth PR of a series aiming to usage of [T.Run API](https://golang.org/pkg/testing/#T.Run)  in all kubeadm tests. If this is accepted I'll send more PRs of this kind. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```