### PR TITLE
Print additional columns for RuntimeClass CRD

### DIFF
--- a/cluster/addons/runtimeclass/runtimeclass_crd.yaml
+++ b/cluster/addons/runtimeclass/runtimeclass_crd.yaml
@@ -15,6 +15,13 @@ spec:
     plural:   runtimeclasses
     singular: runtimeclass
     kind:     RuntimeClass
+  additionalPrinterColumns:
+  - name: Runtime-Handler
+    type: string
+    JSONPath: .spec.runtimeHandler
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
   scope: Cluster
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Without this PR, runtimeclass obj is printed with name and age columns:

```console
$ k get runtimeclass
NAME         AGE
containerd   16h
```

After leveraging `additionalPrinterColumns` feature of CRD (since 1.11), more meaningful columns can be printed out:

```console
$ k apply -f runtimeclass-crd.yaml
customresourcedefinition.apiextensions.k8s.io/runtimeclasses.node.k8s.io configured
$ k get runtimeclass
NAME         RUNTIME-HANDLER   AGE
containerd   runc              16h
```

**Does this PR introduce a user-facing change?**:

```release-note
RuntimeClass is now printed with extra `RUNTIME-HANDLER` column.
```

/sig node
/assign @tallclair 
