### PR TITLE
Fix wrong completion for kubectl attach

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -248,11 +248,11 @@ __custom_func() {
             __kubectl_get_resource
             return
             ;;
-        kubectl_logs | kubectl_attach)
+        kubectl_logs)
             __kubectl_require_pod_and_container
             return
             ;;
-        kubectl_exec | kubectl_port-forward | kubectl_top_pod)
+        kubectl_exec | kubectl_port-forward | kubectl_top_pod | kubectl_attach)
             __kubectl_get_resource_pod
             return
             ;;


### PR DESCRIPTION
Although `kubectl attach POD_NAME <tab>` completes container name,
kubectl attach needs `-c` option so the command causes error as:

```
$ kubectl attach nginx-7cdbd8cdc9-b5rhr nginx
error: the server doesn't have a resource type "nginx-7cdbd8cdc9-b5rhr"
```

This patch changes the completion to the same way as `kubectl exec`.

**What type of PR is this?**
 /kind flake

```release-note
NONE
```
/sig cli
