### PR TITLE
Fix completion loop by kubectl {exec,port-foward,top_pod} POD_NAME <tab>

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -263,7 +263,9 @@ __custom_func() {
             return
             ;;
         kubectl_cordon | kubectl_uncordon | kubectl_drain | kubectl_top_node)
-            __kubectl_get_resource_node
+            if [[ ${#nouns[@]} -eq 0 ]]; then
+                __kubectl_get_resource_node
+            fi;
             return
             ;;
         kubectl_config_use-context | kubectl_config_rename-context)

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -253,7 +253,9 @@ __custom_func() {
             return
             ;;
         kubectl_exec | kubectl_port-forward | kubectl_top_pod | kubectl_attach)
-            __kubectl_get_resource_pod
+            if [[ ${#nouns[@]} -eq 0 ]]; then
+                __kubectl_get_resource_pod
+            fi;
             return
             ;;
         kubectl_rolling-update)


### PR DESCRIPTION
When `kubectl exec POD_NAME <tab>`, kubectl completes pod name forever
even though `kubectl {exec,port-foward,top_pod}` handles only one pod.

e.g
```
$ kubectl exec nginx-7cdbd8cdc9-b5rhr nginx-7cdbd8cdc9-b5rhr <continue tab>
// continue to complete pod name forever.
```

This patch changes the completion to stop after one pod name was
completed.

**What type of PR is this?**

/kind bug

```release-note
NONE
```

/sig cli
