### PR TITLE
Remove deprecated kubectl_rolling-update

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -166,11 +166,6 @@ __kubectl_get_resource_pod()
     __kubectl_parse_get "pod"
 }
 
-__kubectl_get_resource_rc()
-{
-    __kubectl_parse_get "rc"
-}
-
 __kubectl_get_resource_node()
 {
     __kubectl_parse_get "node"
@@ -254,10 +249,6 @@ __custom_func() {
             ;;
         kubectl_exec | kubectl_port-forward | kubectl_top_pod)
             __kubectl_get_resource_pod
-            return
-            ;;
-        kubectl_rolling-update)
-            __kubectl_get_resource_rc
             return
             ;;
         kubectl_cordon | kubectl_uncordon | kubectl_drain | kubectl_top_node)


### PR DESCRIPTION
kubectl rolling-update is already dprecated and
function `kubectl_rolling-update` does not exist anymore.

This patch removes unused functions`kubectl_rolling-update` and
`__kubectl_get_resource_rc` from completion script.


**What type of PR is this?**

/kind flake

```release-note
NONE
```

/sig cli
