### PR TITLE
Remove SERIAL tag from DaemonSet for conformance tests

### DIFF
--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -62,7 +62,7 @@ var NamespaceNodeSelectors = []string{"scheduler.alpha.kubernetes.io/node-select
 // happen.  In the future, running in parallel may work if we have an eviction
 // model which lets the DS controller kick out other pods to make room.
 // See http://issues.k8s.io/21767 for more details
-var _ = SIGDescribe("Daemon set [Serial]", func() {
+var _ = SIGDescribe("Daemon set", func() {
 	var f *framework.Framework
 
 	AfterEach(func() {

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR to resolve the issue #62161,
Serial tag removed from DaemonSet tests that do not modify node labels. 

**Which issue(s) this PR fixes**: #62161

Fixes #
Serial / Flaky / Slow tests should not be marked [Conformance] should not include DaemonSet tests with SERIAL tag as they do not modify the node labels.

**Special notes for your reviewer**:
As per the #62161 SERIAL tags needs to be removed from Conformance tests for DaemonSet as they are not modifying the node labels. The SERIAL tag for these tests were introduced as per #21767.

**Does this PR introduce a user-facing change?**: NONE

/area conformance

cc @spiffxp

