### PR TITLE
kubeadm: add final fallback to constants.CurrentKubernetesVersion

### DIFF
--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -29,6 +29,7 @@ import (
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	pkgversion "k8s.io/kubernetes/pkg/version"
 )
 
@@ -92,13 +93,20 @@ func KubernetesReleaseVersion(version string) (string, error) {
 			if body != "" {
 				return "", err
 			}
-			// Handle air-gapped environments by falling back to the client version.
-			klog.Infof("could not fetch a Kubernetes version from the internet: %v", err)
-			klog.Infof("falling back to the local client version: %s", clientVersion)
-			return KubernetesReleaseVersion(clientVersion)
+			if clientVersionErr == nil {
+				// Handle air-gapped environments by falling back to the client version.
+				klog.Warningf("could not fetch a Kubernetes version from the internet: %v", err)
+				klog.Warningf("falling back to the local client version: %s", clientVersion)
+				return KubernetesReleaseVersion(clientVersion)
+			}
 		}
 
 		if clientVersionErr != nil {
+			if err != nil {
+				klog.Warningf("could not obtain neither client nor remote version; fall back to: %s", constants.CurrentKubernetesVersion)
+				return KubernetesReleaseVersion(constants.CurrentKubernetesVersion.String())
+			}
+
 			klog.Warningf("could not obtain client version; using remote version: %s", body)
 			return KubernetesReleaseVersion(body)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

It may happen that both the git version and the remote version
are broken/inaccessible. In this case the broken remote version
would be used.

To overcome this situation fall back to the constant CurrentKubernetesVersion.

The alternative could be os.Exit(1).

Also this change fixes bazel-based unit tests in air-gapped environment.

**What type of PR is this?**
> /kind cleanup
> /kind failing-test

**Does this PR introduce a user-facing change?**:
```release-note
In case kubeadm can't access the current Kubernetes version remotely and fails to parse
the git-based version it falls back to a static predefined value of
k8s.io/kubernetes/cmd/kubeadm/app/constants.CurrentKubernetesVersion.
```
