### PR TITLE
68907 added the slow spec threshold option to ginkgo

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -162,6 +162,7 @@ export PATH=$(dirname "${e2e_test}"):"${PATH}"
   --cluster-monitoring-mode="${KUBE_ENABLE_CLUSTER_MONITORING:-standalone}" \
   --prometheus-monitoring="${KUBE_ENABLE_PROMETHEUS_MONITORING:-false}" \
   --dns-domain="${KUBE_DNS_DOMAIN:-cluster.local}" \
+  --ginkgo.slowSpecThreshold="${GINKGO_SLOW_SPEC_THRESHOLD:-300}" \
   ${KUBE_CONTAINER_RUNTIME:+"--container-runtime=${KUBE_CONTAINER_RUNTIME}"} \
   ${MASTER_OS_DISTRIBUTION:+"--master-os-distro=${MASTER_OS_DISTRIBUTION}"} \
   ${NODE_OS_DISTRIBUTION:+"--node-os-distro=${NODE_OS_DISTRIBUTION}"} \


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

It adds the slow-spec-threshold to be configurable for e2e tests using ginkgo

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/68907

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```