### PR TITLE
kubeadm: use T.Run API in app/cmd

### DIFF
--- a/cmd/kubeadm/app/cmd/completion_test.go
+++ b/cmd/kubeadm/app/cmd/completion_test.go
@@ -88,8 +88,10 @@ func TestRunCompletion(t *testing.T) {
 	parentCmd.AddCommand(cmd)
 
 	for _, tc := range testCases {
-		if err := RunCompletion(&out, "", cmd, tc.args); (err != nil) != tc.expectedError {
-			t.Errorf("Test case %q: TestRunCompletion expected error: %v, saw: %v", tc.name, tc.expectedError, (err != nil))
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if err := RunCompletion(&out, "", cmd, tc.args); (err != nil) != tc.expectedError {
+				t.Errorf("Test case %q: TestRunCompletion expected error: %v, saw: %v", tc.name, tc.expectedError, (err != nil))
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/cmd/upgrade/apply_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply_test.go
@@ -28,11 +28,13 @@ import (
 
 func TestSetImplicitFlags(t *testing.T) {
 	var tests = []struct {
+		name          string
 		flags         *applyFlags
 		expectedFlags applyFlags
 		errExpected   bool
 	}{
-		{ // if not dryRun or force is set; the nonInteractiveMode field should not be touched
+		{
+			name: "if not dryRun or force is set; the nonInteractiveMode field should not be touched",
 			flags: &applyFlags{
 				newK8sVersionStr:   "v1.8.0",
 				dryRun:             false,
@@ -46,7 +48,8 @@ func TestSetImplicitFlags(t *testing.T) {
 				nonInteractiveMode: false,
 			},
 		},
-		{ // if not dryRun or force is set; the nonInteractiveMode field should not be touched
+		{
+			name: "if not dryRun or force is set; the nonInteractiveMode field should not be touched",
 			flags: &applyFlags{
 				newK8sVersionStr:   "v1.8.0",
 				dryRun:             false,
@@ -60,7 +63,8 @@ func TestSetImplicitFlags(t *testing.T) {
 				nonInteractiveMode: true,
 			},
 		},
-		{ // if dryRun or force is set; the nonInteractiveMode field should be set to true
+		{
+			name: "if dryRun or force is set; the nonInteractiveMode field should be set to true",
 			flags: &applyFlags{
 				newK8sVersionStr:   "v1.8.0",
 				dryRun:             true,
@@ -74,7 +78,8 @@ func TestSetImplicitFlags(t *testing.T) {
 				nonInteractiveMode: true,
 			},
 		},
-		{ // if dryRun or force is set; the nonInteractiveMode field should be set to true
+		{
+			name: "if dryRun or force is set; the nonInteractiveMode field should be set to true",
 			flags: &applyFlags{
 				newK8sVersionStr:   "v1.8.0",
 				dryRun:             false,
@@ -88,7 +93,8 @@ func TestSetImplicitFlags(t *testing.T) {
 				nonInteractiveMode: true,
 			},
 		},
-		{ // if dryRun or force is set; the nonInteractiveMode field should be set to true
+		{
+			name: "if dryRun or force is set; the nonInteractiveMode field should be set to true",
 			flags: &applyFlags{
 				newK8sVersionStr:   "v1.8.0",
 				dryRun:             true,
@@ -102,7 +108,8 @@ func TestSetImplicitFlags(t *testing.T) {
 				nonInteractiveMode: true,
 			},
 		},
-		{ // if dryRun or force is set; the nonInteractiveMode field should be set to true
+		{
+			name: "if dryRun or force is set; the nonInteractiveMode field should be set to true",
 			flags: &applyFlags{
 				newK8sVersionStr:   "v1.8.0",
 				dryRun:             true,
@@ -116,7 +123,8 @@ func TestSetImplicitFlags(t *testing.T) {
 				nonInteractiveMode: true,
 			},
 		},
-		{ // if the new version is empty; it should error out
+		{
+			name: "if the new version is empty; it should error out",
 			flags: &applyFlags{
 				newK8sVersionStr: "",
 			},
@@ -127,27 +135,29 @@ func TestSetImplicitFlags(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		actualErr := SetImplicitFlags(rt.flags)
+		t.Run(rt.name, func(t *testing.T) {
+			actualErr := SetImplicitFlags(rt.flags)
 
-		// If an error was returned; make newK8sVersion nil so it's easy to match using reflect.DeepEqual later (instead of a random pointer)
-		if actualErr != nil {
-			rt.flags.newK8sVersion = nil
-		}
+			// If an error was returned; make newK8sVersion nil so it's easy to match using reflect.DeepEqual later (instead of a random pointer)
+			if actualErr != nil {
+				rt.flags.newK8sVersion = nil
+			}
 
-		if !reflect.DeepEqual(*rt.flags, rt.expectedFlags) {
-			t.Errorf(
-				"failed SetImplicitFlags:\n\texpected flags: %v\n\t  actual: %v",
-				rt.expectedFlags,
-				*rt.flags,
-			)
-		}
-		if (actualErr != nil) != rt.errExpected {
-			t.Errorf(
-				"failed SetImplicitFlags:\n\texpected error: %t\n\t  actual: %t",
-				rt.errExpected,
-				(actualErr != nil),
-			)
-		}
+			if !reflect.DeepEqual(*rt.flags, rt.expectedFlags) {
+				t.Errorf(
+					"failed SetImplicitFlags:\n\texpected flags: %v\n\t  actual: %v",
+					rt.expectedFlags,
+					*rt.flags,
+				)
+			}
+			if (actualErr != nil) != rt.errExpected {
+				t.Errorf(
+					"failed SetImplicitFlags:\n\texpected error: %t\n\t  actual: %t",
+					rt.errExpected,
+					(actualErr != nil),
+				)
+			}
+		})
 	}
 }
 

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -25,15 +25,18 @@ import (
 
 func TestPrintConfiguration(t *testing.T) {
 	var tests = []struct {
+		name          string
 		cfg           *kubeadmapi.ClusterConfiguration
 		buf           *bytes.Buffer
 		expectedBytes []byte
 	}{
 		{
+			name:          "config is nil",
 			cfg:           nil,
 			expectedBytes: []byte(""),
 		},
 		{
+			name: "cluster config with local Etcd",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				KubernetesVersion: "v1.7.1",
 				Etcd: kubeadmapi.Etcd{
@@ -67,6 +70,7 @@ func TestPrintConfiguration(t *testing.T) {
 `),
 		},
 		{
+			name: "cluster config with ServiceSubnet and external Etcd",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				KubernetesVersion: "v1.7.1",
 				Networking: kubeadmapi.Networking{
@@ -108,15 +112,17 @@ func TestPrintConfiguration(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		rt.buf = bytes.NewBufferString("")
-		printConfiguration(rt.cfg, rt.buf)
-		actualBytes := rt.buf.Bytes()
-		if !bytes.Equal(actualBytes, rt.expectedBytes) {
-			t.Errorf(
-				"failed PrintConfiguration:\n\texpected: %q\n\t  actual: %q",
-				string(rt.expectedBytes),
-				string(actualBytes),
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			rt.buf = bytes.NewBufferString("")
+			printConfiguration(rt.cfg, rt.buf)
+			actualBytes := rt.buf.Bytes()
+			if !bytes.Equal(actualBytes, rt.expectedBytes) {
+				t.Errorf(
+					"failed PrintConfiguration:\n\texpected: %q\n\t  actual: %q",
+					string(rt.expectedBytes),
+					string(actualBytes),
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/cmd/upgrade/plan_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan_test.go
@@ -27,35 +27,42 @@ import (
 
 func TestSortedSliceFromStringIntMap(t *testing.T) {
 	var tests = []struct {
+		name          string
 		strMap        map[string]uint16
 		expectedSlice []string
-	}{ // The returned slice should be alphabetically sorted based on the string keys in the map
+	}{
 		{
+			name:          "the returned slice should be alphabetically sorted based on the string keys in the map",
 			strMap:        map[string]uint16{"foo": 1, "bar": 2},
 			expectedSlice: []string{"bar", "foo"},
 		},
-		{ // The int value should not affect this func
+		{
+			name:          "the int value should not affect this func",
 			strMap:        map[string]uint16{"foo": 2, "bar": 1},
 			expectedSlice: []string{"bar", "foo"},
 		},
 		{
+			name:          "slice with 4 keys and different values",
 			strMap:        map[string]uint16{"b": 2, "a": 1, "cb": 0, "ca": 1000},
 			expectedSlice: []string{"a", "b", "ca", "cb"},
 		},
-		{ // This should work for version numbers as well; and the lowest version should come first
+		{
+			name:          "this should work for version numbers as well; and the lowest version should come first",
 			strMap:        map[string]uint16{"v1.7.0": 1, "v1.6.1": 1, "v1.6.2": 1, "v1.8.0": 1, "v1.8.0-alpha.1": 1},
 			expectedSlice: []string{"v1.6.1", "v1.6.2", "v1.7.0", "v1.8.0", "v1.8.0-alpha.1"},
 		},
 	}
 	for _, rt := range tests {
-		actualSlice := sortedSliceFromStringIntMap(rt.strMap)
-		if !reflect.DeepEqual(actualSlice, rt.expectedSlice) {
-			t.Errorf(
-				"failed SortedSliceFromStringIntMap:\n\texpected: %v\n\t  actual: %v",
-				rt.expectedSlice,
-				actualSlice,
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actualSlice := sortedSliceFromStringIntMap(rt.strMap)
+			if !reflect.DeepEqual(actualSlice, rt.expectedSlice) {
+				t.Errorf(
+					"failed SortedSliceFromStringIntMap:\n\texpected: %v\n\t  actual: %v",
+					rt.expectedSlice,
+					actualSlice,
+				)
+			}
+		})
 	}
 }
 

--- a/cmd/kubeadm/app/cmd/util/cmdutil_test.go
+++ b/cmd/kubeadm/app/cmd/util/cmdutil_test.go
@@ -22,43 +22,51 @@ import (
 
 func TestValidateExactArgNumber(t *testing.T) {
 	var tests = []struct {
+		name                string
 		args, supportedArgs []string
 		expectedErr         bool
 	}{
-		{ // one arg given and one arg expected
+		{
+			name:          "one arg given and one arg expected",
 			args:          []string{"my-node-1234"},
 			supportedArgs: []string{"node-name"},
 			expectedErr:   false,
 		},
-		{ // two args given and two args expected
+		{
+			name:          "two args given and two args expected",
 			args:          []string{"my-node-1234", "foo"},
 			supportedArgs: []string{"node-name", "second-toplevel-arg"},
 			expectedErr:   false,
 		},
-		{ // too few supplied args
+		{
+			name:          "too few supplied args",
 			args:          []string{},
 			supportedArgs: []string{"node-name"},
 			expectedErr:   true,
 		},
-		{ // too few non-empty args
+		{
+			name:          "too few non-empty args",
 			args:          []string{""},
 			supportedArgs: []string{"node-name"},
 			expectedErr:   true,
 		},
-		{ // too many args
+		{
+			name:          "too many args",
 			args:          []string{"my-node-1234", "foo"},
 			supportedArgs: []string{"node-name"},
 			expectedErr:   true,
 		},
 	}
 	for _, rt := range tests {
-		actual := ValidateExactArgNumber(rt.args, rt.supportedArgs)
-		if (actual != nil) != rt.expectedErr {
-			t.Errorf(
-				"failed ValidateExactArgNumber:\n\texpected error: %t\n\t  actual error: %t",
-				rt.expectedErr,
-				(actual != nil),
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actual := ValidateExactArgNumber(rt.args, rt.supportedArgs)
+			if (actual != nil) != rt.expectedErr {
+				t.Errorf(
+					"failed ValidateExactArgNumber:\n\texpected error: %t\n\t  actual error: %t",
+					rt.expectedErr,
+					(actual != nil),
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/cmd/version_test.go
+++ b/cmd/kubeadm/app/cmd/version_test.go
@@ -69,28 +69,30 @@ func TestRunVersion(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		var err error
-		if len(tc.flag) > 0 {
-			if err = cmd.Flags().Set(flagNameOutput, tc.flag); err != nil {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			if len(tc.flag) > 0 {
+				if err = cmd.Flags().Set(flagNameOutput, tc.flag); err != nil {
+					goto error
+				}
+			}
+			buf.Reset()
+			if err = RunVersion(&buf, cmd); err != nil {
 				goto error
 			}
-		}
-		buf.Reset()
-		if err = RunVersion(&buf, cmd); err != nil {
-			goto error
-		}
-		if buf.String() == "" {
-			err = errors.New("empty output")
-			goto error
-		}
-		if tc.shouldBeValidYAML {
-			err = yaml.Unmarshal(buf.Bytes(), &iface)
-		} else if tc.shouldBeValidJSON {
-			err = json.Unmarshal(buf.Bytes(), &iface)
-		}
-	error:
-		if (err != nil) != tc.expectedError {
-			t.Errorf("Test case %q: RunVersion expected error: %v, saw: %v; %v", tc.name, tc.expectedError, err != nil, err)
-		}
+			if buf.String() == "" {
+				err = errors.New("empty output")
+				goto error
+			}
+			if tc.shouldBeValidYAML {
+				err = yaml.Unmarshal(buf.Bytes(), &iface)
+			} else if tc.shouldBeValidJSON {
+				err = json.Unmarshal(buf.Bytes(), &iface)
+			}
+		error:
+			if (err != nil) != tc.expectedError {
+				t.Errorf("Test case %q: RunVersion expected error: %v, saw: %v; %v", tc.name, tc.expectedError, err != nil, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Used [T.Run API](https://golang.org/pkg/testing/#T.Run) for kubeadm tests in app/cmd

This should improve testing output and make it more visible
which test is doing what.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```