### PR TITLE
Add configmap get to system:kube-scheduler

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -421,7 +421,8 @@ func ClusterRoles() []rbacv1.ClusterRole {
 				// TODO: scope this to the kube-system namespace
 				rbacv1helpers.NewRule("create").Groups(legacyGroup).Resources("endpoints").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "update", "patch", "delete").Groups(legacyGroup).Resources("endpoints").Names("kube-scheduler").RuleOrDie(),
-
+				// extension-apiserver-authentication
+				rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("configmaps").RuleOrDie(),
 				// fundamental resources
 				rbacv1helpers.NewRule(Read...).Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list", "watch", "delete").Groups(legacyGroup).Resources("pods").RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -725,6 +725,12 @@ items:
   - apiGroups:
     - ""
     resources:
+    - configmaps
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    resources:
     - nodes
     verbs:
     - get


### PR DESCRIPTION
kube-scheduler tries to get the `extension-apiserver-authentication` ConfigMap by default (unless `--authentication-skip-lookup=true`). Fix the `system:kube-scheduler` ClusterRole to allow kube-scheduler to use a ServiceAccount bound to the role to get the configmap by default.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Add permission for startup for a self-hosted kube-scheduler
 
**Which issue(s) this PR fixes**:

Fixes #72473

**Special notes for your reviewer**:

* Analogous to https://github.com/kubernetes/kubernetes/pull/69062
* This fix could be cherry-picked to v1.12 if someone finds it needed

```release-note
Add permission for startup for a self-hosted kube-scheduler
```
