### PR TITLE
kubeadm: add required etcd certs to selfhosting api-server

### DIFF
--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,6 +129,40 @@ func apiServerCertificatesVolumeSource() v1.VolumeSource {
 						},
 					},
 				},
+				{
+					Secret: &v1.SecretProjection{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: strings.Replace(kubeadmconstants.EtcdCACertAndKeyBaseName, "/", "-", -1),
+						},
+						Items: []v1.KeyToPath{
+							{
+								Key:  v1.TLSCertKey,
+								Path: kubeadmconstants.EtcdCACertName,
+							},
+							{
+								Key:  v1.TLSPrivateKeyKey,
+								Path: kubeadmconstants.EtcdCAKeyName,
+							},
+						},
+					},
+				},
+				{
+					Secret: &v1.SecretProjection{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: kubeadmconstants.APIServerEtcdClientCertAndKeyBaseName,
+						},
+						Items: []v1.KeyToPath{
+							{
+								Key:  v1.TLSCertKey,
+								Path: kubeadmconstants.APIServerEtcdClientCertName,
+							},
+							{
+								Key:  v1.TLSPrivateKeyKey,
+								Path: kubeadmconstants.APIServerEtcdClientKeyName,
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -175,7 +210,7 @@ func controllerManagerCertificatesVolumeSource() v1.VolumeSource {
 func kubeConfigVolumeSource(kubeconfigSecretName string) v1.VolumeSource {
 	return v1.VolumeSource{
 		Secret: &v1.SecretVolumeSource{
-			SecretName: kubeconfigSecretName,
+			SecretName: strings.Replace(kubeconfigSecretName, "/", "-", -1),
 		},
 	}
 }
@@ -293,6 +328,16 @@ func getTLSKeyPairs() []*tlsKeyPair {
 			name: kubeadmconstants.FrontProxyClientCertAndKeyBaseName,
 			cert: kubeadmconstants.FrontProxyClientCertName,
 			key:  kubeadmconstants.FrontProxyClientKeyName,
+		},
+		{
+			name: strings.Replace(kubeadmconstants.EtcdCACertAndKeyBaseName, "/", "-", -1),
+			cert: kubeadmconstants.EtcdCACertName,
+			key:  kubeadmconstants.EtcdCAKeyName,
+		},
+		{
+			name: kubeadmconstants.APIServerEtcdClientCertAndKeyBaseName,
+			cert: kubeadmconstants.APIServerEtcdClientCertName,
+			key:  kubeadmconstants.APIServerEtcdClientKeyName,
 		},
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Selfhosting pivoting fails when using --store-certs-in-secrets
as api-server fails to start because of missing etcd/ca and
apiserver-etcd-client certificates:
```
   F1227 16:01:52.237352 1 storage_decorator.go:57] Unable to create storage backend:
   config (&{ /registry [https://127.0.0.1:2379]
              /etc/kubernetes/pki/apiserver-etcd-client.key
              /etc/kubernetes/pki/apiserver-etcd-client.crt
              /etc/kubernetes/pki/etcd/ca.crt true 0xc000884120 <nil> 5m0s 1m0s}),
   err (open /etc/kubernetes/pki/apiserver-etcd-client.crt: no such file or directory)
```

Added required certificates to fix this.

Secret name for etc/ca certifcate has been converted to conform RFC-1123 subdomain
naming conventions to prevent this TLS secret creation failure:
```
    unable to create secret: Secret "etcd/ca" is invalid: metadata.name:
    Invalid value: "etcd/ca": a DNS-1123 subdomain must consist of lower
    case alphanumeric characters, '-' or '.', and must start and end with an
    alphanumeric character (e.g. 'example.com', regex used for validation is
    '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

Related issue: kubernetes/kubeadm#1281

**Special notes for your reviewer**:
This is a first commit of a series aiming to fix kubernetes/kubeadm#1281

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: fixed storing of etcd certificates in secrets required by kube-apiserver selfhosting pivoting
```