### PR TITLE
kubeadm: use T.Run API in app/

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/validation_test.go
+++ b/cmd/kubeadm/app/componentconfigs/validation_test.go
@@ -31,11 +31,13 @@ import (
 
 func TestValidateKubeProxyConfiguration(t *testing.T) {
 	var tests = []struct {
+		name          string
 		clusterConfig *kubeadm.ClusterConfiguration
 		msg           string
 		expectErr     bool
 	}{
 		{
+			name: "valid config",
 			clusterConfig: &kubeadm.ClusterConfiguration{
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
@@ -67,6 +69,7 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name: "invalid BindAddress",
 			clusterConfig: &kubeadm.ClusterConfiguration{
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
@@ -100,6 +103,7 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "invalid HealthzBindAddress",
 			clusterConfig: &kubeadm.ClusterConfiguration{
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
@@ -133,6 +137,7 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "invalid MetricsBindAddress",
 			clusterConfig: &kubeadm.ClusterConfiguration{
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
@@ -166,6 +171,7 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "invalid ClusterCIDR",
 			clusterConfig: &kubeadm.ClusterConfiguration{
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
@@ -199,6 +205,7 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "invalid UDPIdleTimeout",
 			clusterConfig: &kubeadm.ClusterConfiguration{
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
@@ -232,6 +239,7 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "invalid ConfigSyncPeriod",
 			clusterConfig: &kubeadm.ClusterConfiguration{
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
@@ -266,22 +274,26 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 		},
 	}
 	for i, rt := range tests {
-		err := ValidateKubeProxyConfiguration(rt.clusterConfig, nil).ToAggregate()
-		if (err != nil) != rt.expectErr {
-			t.Errorf("%d failed ValidateKubeProxyConfiguration: expected error %t, got error %t", i, rt.expectErr, err != nil)
-		}
-		if err != nil && !strings.Contains(err.Error(), rt.msg) {
-			t.Errorf("%d failed ValidateKubeProxyConfiguration: unexpected error: %v, expected: %s", i, err, rt.msg)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			err := ValidateKubeProxyConfiguration(rt.clusterConfig, nil).ToAggregate()
+			if (err != nil) != rt.expectErr {
+				t.Errorf("%d failed ValidateKubeProxyConfiguration: expected error %t, got error %t", i, rt.expectErr, err != nil)
+			}
+			if err != nil && !strings.Contains(err.Error(), rt.msg) {
+				t.Errorf("%d failed ValidateKubeProxyConfiguration: unexpected error: %v, expected: %s", i, err, rt.msg)
+			}
+		})
 	}
 }
 
 func TestValidateKubeletConfiguration(t *testing.T) {
 	var tests = []struct {
+		name          string
 		clusterConfig *kubeadm.ClusterConfiguration
 		expectErr     bool
 	}{
 		{
+			name: "valid configuration",
 			clusterConfig: &kubeadm.ClusterConfiguration{
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					Kubelet: &kubeletconfig.KubeletConfiguration{
@@ -314,6 +326,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name: "invalid configuration",
 			clusterConfig: &kubeadm.ClusterConfiguration{
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					Kubelet: &kubeletconfig.KubeletConfiguration{
@@ -345,9 +358,11 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		},
 	}
 	for i, rt := range tests {
-		err := ValidateKubeletConfiguration(rt.clusterConfig, nil).ToAggregate()
-		if (err != nil) != rt.expectErr {
-			t.Errorf("%d failed ValidateKubeletConfiguration: expected error %t, got error %t", i, rt.expectErr, err != nil)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			err := ValidateKubeletConfiguration(rt.clusterConfig, nil).ToAggregate()
+			if (err != nil) != rt.expectErr {
+				t.Errorf("%d failed ValidateKubeletConfiguration: expected error %t, got error %t", i, rt.expectErr, err != nil)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/constants/constants_test.go
+++ b/cmd/kubeadm/app/constants/constants_test.go
@@ -100,14 +100,16 @@ func TestGetStaticPodFilepath(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		actual := GetStaticPodFilepath(rt.componentName, rt.manifestsDir)
-		if actual != rt.expected {
-			t.Errorf(
-				"failed GetStaticPodFilepath:\n\texpected: %s\n\t  actual: %s",
-				rt.expected,
-				actual,
-			)
-		}
+		t.Run(rt.componentName, func(t *testing.T) {
+			actual := GetStaticPodFilepath(rt.componentName, rt.manifestsDir)
+			if actual != rt.expected {
+				t.Errorf(
+					"failed GetStaticPodFilepath:\n\texpected: %s\n\t  actual: %s",
+					rt.expected,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -133,14 +135,16 @@ func TestAddSelfHostedPrefix(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		actual := AddSelfHostedPrefix(rt.componentName)
-		if actual != rt.expected {
-			t.Errorf(
-				"failed AddSelfHostedPrefix:\n\texpected: %s\n\t  actual: %s",
-				rt.expected,
-				actual,
-			)
-		}
+		t.Run(rt.componentName, func(t *testing.T) {
+			actual := AddSelfHostedPrefix(rt.componentName)
+			if actual != rt.expected {
+				t.Errorf(
+					"failed AddSelfHostedPrefix:\n\texpected: %s\n\t  actual: %s",
+					rt.expected,
+					actual,
+				)
+			}
+		})
 	}
 }
 
@@ -182,28 +186,30 @@ func TestEtcdSupportedVersion(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		actualVersion, actualError := EtcdSupportedVersion(rt.kubernetesVersion)
-		if actualError != nil {
-			if rt.expectedError == nil {
-				t.Errorf("failed EtcdSupportedVersion:\n\texpected no error, but got: %v", actualError)
-			} else if actualError.Error() != rt.expectedError.Error() {
-				t.Errorf(
-					"failed EtcdSupportedVersion:\n\texpected error: %v\n\t  actual error: %v",
-					rt.expectedError,
-					actualError,
-				)
+		t.Run(rt.kubernetesVersion, func(t *testing.T) {
+			actualVersion, actualError := EtcdSupportedVersion(rt.kubernetesVersion)
+			if actualError != nil {
+				if rt.expectedError == nil {
+					t.Errorf("failed EtcdSupportedVersion:\n\texpected no error, but got: %v", actualError)
+				} else if actualError.Error() != rt.expectedError.Error() {
+					t.Errorf(
+						"failed EtcdSupportedVersion:\n\texpected error: %v\n\t  actual error: %v",
+						rt.expectedError,
+						actualError,
+					)
+				}
+			} else {
+				if rt.expectedError != nil {
+					t.Errorf("failed EtcdSupportedVersion:\n\texpected error: %v, but got no error", rt.expectedError)
+				} else if strings.Compare(actualVersion.String(), rt.expectedVersion.String()) != 0 {
+					t.Errorf(
+						"failed EtcdSupportedVersion:\n\texpected version: %s\n\t  actual version: %s",
+						rt.expectedVersion.String(),
+						actualVersion.String(),
+					)
+				}
 			}
-		} else {
-			if rt.expectedError != nil {
-				t.Errorf("failed EtcdSupportedVersion:\n\texpected error: %v, but got no error", rt.expectedError)
-			} else if strings.Compare(actualVersion.String(), rt.expectedVersion.String()) != 0 {
-				t.Errorf(
-					"failed EtcdSupportedVersion:\n\texpected version: %s\n\t  actual version: %s",
-					rt.expectedVersion.String(),
-					actualVersion.String(),
-				)
-			}
-		}
+		})
 	}
 }
 
@@ -222,13 +228,15 @@ func TestGetKubeDNSVersion(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		actualDNSVersion := GetDNSVersion(rt.dns)
-		if actualDNSVersion != rt.expected {
-			t.Errorf(
-				"failed GetDNSVersion:\n\texpected: %s\n\t  actual: %s",
-				rt.expected,
-				actualDNSVersion,
-			)
-		}
+		t.Run(string(rt.dns), func(t *testing.T) {
+			actualDNSVersion := GetDNSVersion(rt.dns)
+			if actualDNSVersion != rt.expected {
+				t.Errorf(
+					"failed GetDNSVersion:\n\texpected: %s\n\t  actual: %s",
+					rt.expected,
+					actualDNSVersion,
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/discovery/discovery_test.go
+++ b/cmd/kubeadm/app/discovery/discovery_test.go
@@ -24,11 +24,17 @@ import (
 
 func TestFor(t *testing.T) {
 	tests := []struct {
+		name   string
 		d      kubeadm.JoinConfiguration
 		expect bool
 	}{
-		{d: kubeadm.JoinConfiguration{}, expect: false},
 		{
+			name:   "default Discovery",
+			d:      kubeadm.JoinConfiguration{},
+			expect: false,
+		},
+		{
+			name: "file Discovery with a path",
 			d: kubeadm.JoinConfiguration{
 				Discovery: kubeadm.Discovery{
 					File: &kubeadm.FileDiscovery{
@@ -39,6 +45,7 @@ func TestFor(t *testing.T) {
 			expect: false,
 		},
 		{
+			name: "file Discovery with an url",
 			d: kubeadm.JoinConfiguration{
 				Discovery: kubeadm.Discovery{
 					File: &kubeadm.FileDiscovery{
@@ -49,6 +56,7 @@ func TestFor(t *testing.T) {
 			expect: false,
 		},
 		{
+			name: "BootstrapTokenDiscovery",
 			d: kubeadm.JoinConfiguration{
 				Discovery: kubeadm.Discovery{
 					BootstrapToken: &kubeadm.BootstrapTokenDiscovery{
@@ -60,13 +68,15 @@ func TestFor(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		_, actual := For(&rt.d)
-		if (actual == nil) != rt.expect {
-			t.Errorf(
-				"failed For:\n\texpected: %t\n\t  actual: %t",
-				rt.expect,
-				(actual == nil),
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			_, actual := For(&rt.d)
+			if (actual == nil) != rt.expect {
+				t.Errorf(
+					"failed For:\n\texpected: %t\n\t  actual: %t",
+					rt.expect,
+					(actual == nil),
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/features/features_test.go
+++ b/cmd/kubeadm/app/features/features_test.go
@@ -108,20 +108,21 @@ func TestNewFeatureGate(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		t.Run(test.value, func(t *testing.T) {
+			r, err := NewFeatureGate(&someFeatures, test.value)
 
-		r, err := NewFeatureGate(&someFeatures, test.value)
+			if !test.expectedError && err != nil {
+				t.Errorf("NewFeatureGate failed when not expected: %v", err)
+				return
+			} else if test.expectedError && err == nil {
+				t.Error("NewFeatureGate didn't failed when expected")
+				return
+			}
 
-		if !test.expectedError && err != nil {
-			t.Errorf("NewFeatureGate failed when not expected: %v", err)
-			continue
-		} else if test.expectedError && err == nil {
-			t.Error("NewFeatureGate didn't failed when expected")
-			continue
-		}
-
-		if !reflect.DeepEqual(r, test.expectedFeaturesGate) {
-			t.Errorf("NewFeatureGate returned a unexpected value")
-		}
+			if !reflect.DeepEqual(r, test.expectedFeaturesGate) {
+				t.Errorf("NewFeatureGate returned a unexpected value")
+			}
+		})
 	}
 }
 
@@ -132,20 +133,24 @@ func TestValidateVersion(t *testing.T) {
 	}
 
 	var tests = []struct {
+		name              string
 		requestedVersion  string
 		requestedFeatures map[string]bool
 		expectedError     bool
 	}{
-		{ //no min version
+		{
+			name:              "no min version",
 			requestedFeatures: map[string]bool{"feature1": true},
 			expectedError:     false,
 		},
-		{ //min version but correct value given
+		{
+			name:              "min version but correct value given",
 			requestedFeatures: map[string]bool{"feature2": true},
 			requestedVersion:  constants.MinimumControlPlaneVersion.String(),
 			expectedError:     false,
 		},
-		{ //min version and incorrect value given
+		{
+			name:              "min version and incorrect value given",
 			requestedFeatures: map[string]bool{"feature2": true},
 			requestedVersion:  "v1.11.2",
 			expectedError:     true,
@@ -153,14 +158,16 @@ func TestValidateVersion(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := ValidateVersion(someFeatures, test.requestedFeatures, test.requestedVersion)
-		if !test.expectedError && err != nil {
-			t.Errorf("ValidateVersion failed when not expected: %v", err)
-			continue
-		} else if test.expectedError && err == nil {
-			t.Error("ValidateVersion didn't failed when expected")
-			continue
-		}
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateVersion(someFeatures, test.requestedFeatures, test.requestedVersion)
+			if !test.expectedError && err != nil {
+				t.Errorf("ValidateVersion failed when not expected: %v", err)
+				return
+			} else if test.expectedError && err == nil {
+				t.Error("ValidateVersion didn't failed when expected")
+				return
+			}
+		})
 	}
 }
 
@@ -185,23 +192,28 @@ func TestCheckDeprecatedFlags(t *testing.T) {
 	}
 
 	var tests = []struct {
+		name        string
 		features    map[string]bool
 		expectedMsg map[string]string
 	}{
-		{ // feature deprecated
+		{
+			name:        "deprecated feature",
 			features:    map[string]bool{"deprecated": true},
 			expectedMsg: map[string]string{"deprecated": dummyMessage},
 		},
-		{ // valid feature
+		{
+			name:        "valid feature",
 			features:    map[string]bool{"feature1": true},
 			expectedMsg: map[string]string{},
 		},
 	}
 
 	for _, test := range tests {
-		msg := CheckDeprecatedFlags(&someFeatures, test.features)
-		if !reflect.DeepEqual(test.expectedMsg, msg) {
-			t.Error("CheckDeprecatedFlags didn't returned expected message")
-		}
+		t.Run(test.name, func(t *testing.T) {
+			msg := CheckDeprecatedFlags(&someFeatures, test.features)
+			if !reflect.DeepEqual(test.expectedMsg, msg) {
+				t.Error("CheckDeprecatedFlags didn't returned expected message")
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/preflight/utils_test.go
+++ b/cmd/kubeadm/app/preflight/utils_test.go
@@ -40,26 +40,26 @@ func TestGetKubeletVersion(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		fcmd := fakeexec.FakeCmd{
-			CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
-				func() ([]byte, error) { return []byte(tc.output), tc.err },
-			},
-		}
-		fexec := &fakeexec.FakeExec{
-			CommandScript: []fakeexec.FakeCommandAction{
-				func(cmd string, args ...string) utilsexec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
-			},
-		}
-		ver, err := GetKubeletVersion(fexec)
-		switch {
-		case err != nil && tc.valid:
-			t.Errorf("GetKubeletVersion: unexpected error for %q. Error: %v", tc.output, err)
-		case err == nil && !tc.valid:
-			t.Errorf("GetKubeletVersion: error expected for key %q, but result is %q", tc.output, ver)
-		case ver != nil && ver.String() != tc.expected:
-			t.Errorf("GetKubeletVersion: unexpected version result for key %q. Expected: %q Actual: %q", tc.output, tc.expected, ver)
-		}
-
+		t.Run(tc.output, func(t *testing.T) {
+			fcmd := fakeexec.FakeCmd{
+				CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
+					func() ([]byte, error) { return []byte(tc.output), tc.err },
+				},
+			}
+			fexec := &fakeexec.FakeExec{
+				CommandScript: []fakeexec.FakeCommandAction{
+					func(cmd string, args ...string) utilsexec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+				},
+			}
+			ver, err := GetKubeletVersion(fexec)
+			switch {
+			case err != nil && tc.valid:
+				t.Errorf("GetKubeletVersion: unexpected error for %q. Error: %v", tc.output, err)
+			case err == nil && !tc.valid:
+				t.Errorf("GetKubeletVersion: error expected for key %q, but result is %q", tc.output, ver)
+			case ver != nil && ver.String() != tc.expected:
+				t.Errorf("GetKubeletVersion: unexpected version result for key %q. Expected: %q Actual: %q", tc.output, tc.expected, ver)
+			}
+		})
 	}
-
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Used [T.Run API](https://golang.org/pkg/testing/#T.Run) for kubeadm tests in app/

This should improve testing output and make it more visible
which test is doing what.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```