### PR TITLE
Bump dashboard to v1.10.1

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -31,7 +31,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.0
+        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
Picks up dashboard v1.10.1 to address CVE-2018-18264

See https://github.com/kubernetes/dashboard/pull/3400

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change?**:
```release-note
Updates the kubernetes dashboard add-on to v1.10.1. Skipping dashboard login is no longer enabled by default.
```