### PR TITLE
Automated cherry pick of #72495: Bump dashboard to v1.10.1 for CVE-2018-18264

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -31,7 +31,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.0
+        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
Cherry pick of #72495 on release-1.13.

#72495: Bump dashboard to v1.10.1 for CVE-2018-18264