### PR TITLE
kubeadm: imports cleanup

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/selfhosting.go
+++ b/cmd/kubeadm/app/cmd/alpha/selfhosting.go
@@ -18,11 +18,11 @@ package alpha
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"

--- a/cmd/kubeadm/app/cmd/phases/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/controlplane.go
@@ -17,8 +17,9 @@ limitations under the License.
 package phases
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"

--- a/cmd/kubeadm/app/cmd/phases/workflow/doc_test.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/doc_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package workflow
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -225,7 +225,7 @@ func getEtcdDataDir(manifestPath string, client clientset.Interface) (string, er
 		}
 	}
 	if dataDir == "" {
-		return dataDir, fmt.Errorf("invalid etcd pod manifest")
+		return dataDir, errors.New("invalid etcd pod manifest")
 	}
 	return dataDir, nil
 }

--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -97,7 +97,7 @@ func TestRunCreateToken(t *testing.T) {
 	var buf bytes.Buffer
 	fakeClient := &fake.Clientset{}
 	fakeClient.AddReactor("get", "secrets", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		return true, nil, errors.NewNotFound(v1.Resource("secrets"), "foo")
+		return true, nil, apierrors.NewNotFound(v1.Resource("secrets"), "foo")
 	})
 
 	testCases := []struct {

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/cmd/kubeadm/app/discovery/file/file.go
+++ b/cmd/kubeadm/app/discovery/file/file.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 
 	"github.com/pkg/errors"
+
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/mholt/caddy/caddyfile"
 	"github.com/pkg/errors"
+
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"

--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -130,7 +130,7 @@ func CreateCACertAndKeyFiles(certSpec *KubeadmCert, cfg *kubeadmapi.InitConfigur
 func NewCSR(certSpec *KubeadmCert, cfg *kubeadmapi.InitConfiguration) (*x509.CertificateRequest, *rsa.PrivateKey, error) {
 	certConfig, err := certSpec.GetConfig(cfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to retrieve cert configuration: %v", err)
+		return nil, nil, errors.Wrap(err, "failed to retrieve cert configuration")
 	}
 
 	return pkiutil.NewCSRAndKey(certConfig)

--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -54,6 +54,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
 	"k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -18,11 +18,12 @@ package kubelet
 
 import (
 	"context"
-	"errors"
 	"io"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"k8s.io/api/core/v1"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -23,10 +23,11 @@ import (
 	"path/filepath"
 	"time"
 
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/errors"
+	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	certutil "k8s.io/client-go/util/cert"
@@ -61,7 +62,7 @@ func PerformPostUpgradeTasks(client clientset.Interface, cfg *kubeadmapi.InitCon
 
 	// Create the new, version-branched kubelet ComponentConfig ConfigMap
 	if err := kubeletphase.CreateConfigMap(cfg, client); err != nil {
-		errs = append(errs, pkgerrors.Wrap(err, "error creating kubelet configuration ConfigMap"))
+		errs = append(errs, errors.Wrap(err, "error creating kubelet configuration ConfigMap"))
 	}
 
 	// Write the new kubelet config down to disk and the env file if needed
@@ -73,7 +74,7 @@ func PerformPostUpgradeTasks(client clientset.Interface, cfg *kubeadmapi.InitCon
 	// --cri-socket.
 	// TODO: In the future we want to use something more official like NodeStatus or similar for detecting this properly
 	if err := patchnodephase.AnnotateCRISocket(client, cfg.NodeRegistration.Name, cfg.NodeRegistration.CRISocket); err != nil {
-		errs = append(errs, pkgerrors.Wrap(err, "error uploading crisocket"))
+		errs = append(errs, errors.Wrap(err, "error uploading crisocket"))
 	}
 
 	// Create/update RBAC rules that makes the bootstrap tokens able to post CSRs
@@ -118,7 +119,7 @@ func PerformPostUpgradeTasks(client clientset.Interface, cfg *kubeadmapi.InitCon
 	if err := proxy.EnsureProxyAddon(cfg, client); err != nil {
 		errs = append(errs, err)
 	}
-	return errors.NewAggregate(errs)
+	return errorsutil.NewAggregate(errs)
 }
 
 func removeOldDNSDeploymentIfAnotherDNSIsUsed(cfg *kubeadmapi.InitConfiguration, client clientset.Interface, dryRun bool) error {
@@ -138,7 +139,7 @@ func removeOldDNSDeploymentIfAnotherDNSIsUsed(cfg *kubeadmapi.InitConfiguration,
 				return err
 			}
 			if dnsDeployment.Status.ReadyReplicas == 0 {
-				return pkgerrors.New("the DNS deployment isn't ready yet")
+				return errors.New("the DNS deployment isn't ready yet")
 			}
 		}
 
@@ -158,7 +159,7 @@ func BackupAPIServerCertIfNeeded(cfg *kubeadmapi.InitConfiguration, dryRun bool)
 	shouldBackup, err := shouldBackupAPIServerCertAndKey(certAndKeyDir)
 	if err != nil {
 		// Don't fail the upgrade phase if failing to determine to backup kube-apiserver cert and key.
-		return pkgerrors.Wrap(err, "[postupgrade] WARNING: failed to determine to backup kube-apiserver cert and key")
+		return errors.Wrap(err, "[postupgrade] WARNING: failed to determine to backup kube-apiserver cert and key")
 	}
 
 	if !shouldBackup {
@@ -196,7 +197,7 @@ func writeKubeletConfigFiles(client clientset.Interface, cfg *kubeadmapi.InitCon
 		// *would* post the new kubelet-config-1.X configmap that doesn't exist now when we're trying to download it
 		// again.
 		if !(apierrors.IsNotFound(err) && dryRun) {
-			errs = append(errs, pkgerrors.Wrap(err, "error downloading kubelet configuration from the ConfigMap"))
+			errs = append(errs, errors.Wrap(err, "error downloading kubelet configuration from the ConfigMap"))
 		}
 	}
 
@@ -210,14 +211,14 @@ func writeKubeletConfigFiles(client clientset.Interface, cfg *kubeadmapi.InitCon
 		// as we handle that ourselves in the markmaster phase
 		// TODO: Maybe we want to do that some time in the future, in order to remove some logic from the markmaster phase?
 		if err := kubeletphase.WriteKubeletDynamicEnvFile(cfg, false, kubeletDir); err != nil {
-			errs = append(errs, pkgerrors.Wrap(err, "error writing a dynamic environment file for the kubelet"))
+			errs = append(errs, errors.Wrap(err, "error writing a dynamic environment file for the kubelet"))
 		}
 
 		if dryRun { // Print what contents would be written
 			dryrunutil.PrintDryRunFile(kubeadmconstants.KubeletEnvFileName, kubeletDir, kubeadmconstants.KubeletRunDirectory, os.Stdout)
 		}
 	}
-	return errors.NewAggregate(errs)
+	return errorsutil.NewAggregate(errs)
 }
 
 // getKubeletDir gets the kubelet directory based on whether the user is dry-running this command or not.
@@ -233,7 +234,7 @@ func getKubeletDir(dryRun bool) (string, error) {
 func backupAPIServerCertAndKey(certAndKeyDir string) error {
 	subDir := filepath.Join(certAndKeyDir, "expired")
 	if err := os.Mkdir(subDir, 0766); err != nil {
-		return pkgerrors.Wrapf(err, "failed to created backup directory %s", subDir)
+		return errors.Wrapf(err, "failed to created backup directory %s", subDir)
 	}
 
 	filesToMove := map[string]string{
@@ -263,7 +264,7 @@ func rollbackFiles(files map[string]string, originalErr error) error {
 			errs = append(errs, err)
 		}
 	}
-	return pkgerrors.Errorf("couldn't move these files: %v. Got errors: %v", files, errors.NewAggregate(errs))
+	return errors.Errorf("couldn't move these files: %v. Got errors: %v", files, errorsutil.NewAggregate(errs))
 }
 
 // shouldBackupAPIServerCertAndKey checks if the cert of kube-apiserver will be expired in 180 days.
@@ -271,10 +272,10 @@ func shouldBackupAPIServerCertAndKey(certAndKeyDir string) (bool, error) {
 	apiServerCert := filepath.Join(certAndKeyDir, kubeadmconstants.APIServerCertName)
 	certs, err := certutil.CertsFromFile(apiServerCert)
 	if err != nil {
-		return false, pkgerrors.Wrapf(err, "couldn't load the certificate file %s", apiServerCert)
+		return false, errors.Wrapf(err, "couldn't load the certificate file %s", apiServerCert)
 	}
 	if len(certs) == 0 {
-		return false, pkgerrors.New("no certificate data found")
+		return false, errors.New("no certificate data found")
 	}
 
 	if time.Now().Sub(certs[0].NotBefore) > expiry {

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package upgrade
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"

--- a/cmd/kubeadm/app/util/apiclient/clientbacked_dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/clientbacked_dryrun.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,8 +31,6 @@ import (
 	"k8s.io/client-go/rest"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
-
-	"github.com/pkg/errors"
 )
 
 // ClientBackedDryRunGetter implements the DryRunGetter interface for use in NewDryRunClient() and proxies all GET and LIST requests to the backing API server reachable via rest.Config

--- a/cmd/kubeadm/app/util/apiclient/idempotency.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/kubeadm/app/util/config/cluster.go
+++ b/cmd/kubeadm/app/util/config/cluster.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/cmd/kubeadm/app/util/dryrun/dryrun.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/errors"
+	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 )
@@ -76,7 +76,7 @@ func PrintDryRunFiles(files []FileToPrint, w io.Writer) error {
 		fmt.Fprintf(w, "[dryrun] Would write file %q with content:\n", outputFilePath)
 		apiclient.PrintBytesWithLinePrefix(w, fileBytes, "\t")
 	}
-	return errors.NewAggregate(errs)
+	return errorsutil.NewAggregate(errs)
 }
 
 // Waiter is an implementation of apiclient.Waiter that should be used for dry-running

--- a/cmd/kubeadm/app/util/error.go
+++ b/cmd/kubeadm/app/util/error.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"strings"
 
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 )
 
 const (
@@ -69,7 +69,7 @@ func checkErr(err error, handleErr func(string, int)) {
 		return
 	case preflightError:
 		handleErr(err.Error(), PreFlightExitCode)
-	case utilerrors.Aggregate:
+	case errorsutil.Aggregate:
 		handleErr(err.Error(), ValidationExitCode)
 
 	default:

--- a/cmd/kubeadm/app/util/marshal.go
+++ b/cmd/kubeadm/app/util/marshal.go
@@ -21,13 +21,13 @@ import (
 	"bytes"
 	"io"
 
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/util/errors"
+	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -45,7 +45,7 @@ func MarshalToYamlForCodecs(obj runtime.Object, gv schema.GroupVersion, codecs s
 	mediaType := "application/yaml"
 	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), mediaType)
 	if !ok {
-		return []byte{}, pkgerrors.Errorf("unsupported media type %q", mediaType)
+		return []byte{}, errors.Errorf("unsupported media type %q", mediaType)
 	}
 
 	encoder := codecs.EncoderForVersion(info.Serializer, gv)
@@ -64,7 +64,7 @@ func UnmarshalFromYamlForCodecs(buffer []byte, gv schema.GroupVersion, codecs se
 	mediaType := "application/yaml"
 	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), mediaType)
 	if !ok {
-		return nil, pkgerrors.Errorf("unsupported media type %q", mediaType)
+		return nil, errors.Errorf("unsupported media type %q", mediaType)
 	}
 
 	decoder := codecs.DecoderToVersion(info.Serializer, gv)
@@ -97,12 +97,12 @@ func SplitYAMLDocuments(yamlBytes []byte) (map[schema.GroupVersionKind][]byte, e
 		}
 		// Require TypeMeta information to be present
 		if len(typeMetaInfo.APIVersion) == 0 || len(typeMetaInfo.Kind) == 0 {
-			errs = append(errs, pkgerrors.New("invalid configuration: kind and apiVersion is mandatory information that needs to be specified in all YAML documents"))
+			errs = append(errs, errors.New("invalid configuration: kind and apiVersion is mandatory information that needs to be specified in all YAML documents"))
 			continue
 		}
 		// Check whether the kind has been registered before. If it has, throw an error
 		if known := knownKinds[typeMetaInfo.Kind]; known {
-			errs = append(errs, pkgerrors.Errorf("invalid configuration: kind %q is specified twice in YAML file", typeMetaInfo.Kind))
+			errs = append(errs, errors.Errorf("invalid configuration: kind %q is specified twice in YAML file", typeMetaInfo.Kind))
 			continue
 		}
 		knownKinds[typeMetaInfo.Kind] = true
@@ -110,7 +110,7 @@ func SplitYAMLDocuments(yamlBytes []byte) (map[schema.GroupVersionKind][]byte, e
 		// Build a GroupVersionKind object from the deserialized TypeMeta object
 		gv, err := schema.ParseGroupVersion(typeMetaInfo.APIVersion)
 		if err != nil {
-			errs = append(errs, pkgerrors.Wrap(err, "unable to parse apiVersion"))
+			errs = append(errs, errors.Wrap(err, "unable to parse apiVersion"))
 			continue
 		}
 		gvk := gv.WithKind(typeMetaInfo.Kind)
@@ -118,7 +118,7 @@ func SplitYAMLDocuments(yamlBytes []byte) (map[schema.GroupVersionKind][]byte, e
 		// Save the mapping between the gvk and the bytes that object consists of
 		gvkmap[gvk] = b
 	}
-	if err := errors.NewAggregate(errs); err != nil {
+	if err := errorsutil.NewAggregate(errs); err != nil {
 		return nil, err
 	}
 	return gvkmap, nil

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
@@ -459,12 +459,12 @@ func EncodeCSRPEM(csr *x509.CertificateRequest) []byte {
 func parseCSRPEM(pemCSR []byte) (*x509.CertificateRequest, error) {
 	block, _ := pem.Decode(pemCSR)
 	if block == nil {
-		return nil, fmt.Errorf("data doesn't contain a valid certificate request")
+		return nil, errors.New("data doesn't contain a valid certificate request")
 	}
 
 	if block.Type != certutil.CertificateRequestBlockType {
 		var block *pem.Block
-		return nil, fmt.Errorf("expected block type %q, but PEM had type %v", certutil.CertificateRequestBlockType, block.Type)
+		return nil, errors.Errorf("expected block type %q, but PEM had type %v", certutil.CertificateRequestBlockType, block.Type)
 	}
 
 	return x509.ParseCertificateRequest(block.Bytes)
@@ -480,7 +480,7 @@ func CertificateRequestFromFile(file string) (*x509.CertificateRequest, error) {
 
 	csr, err := parseCSRPEM(pemBlock)
 	if err != nil {
-		return nil, fmt.Errorf("error reading certificate request file %s: %v", file, err)
+		return nil, errors.Wrapf(err, "error reading certificate request file %s", file)
 	}
 	return csr, nil
 }

--- a/cmd/kubeadm/app/util/system/validators.go
+++ b/cmd/kubeadm/app/util/system/validators.go
@@ -18,7 +18,8 @@ package system
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/errors"
+
+	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // Validator is the interface for all validators.
@@ -46,7 +47,7 @@ func Validate(spec SysSpec, validators []Validator) (error, error) {
 		errs = append(errs, err)
 		warns = append(warns, warn)
 	}
-	return errors.NewAggregate(warns), errors.NewAggregate(errs)
+	return errorsutil.NewAggregate(warns), errorsutil.NewAggregate(errs)
 }
 
 // ValidateSpec uses all default validators to validate the system and writes to stdout.

--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -25,7 +24,8 @@ import (
 	"strings"
 	"time"
 
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
+
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog"
@@ -111,7 +111,7 @@ func KubernetesReleaseVersion(version string) (string, error) {
 		// Re-validate received version and return.
 		return KubernetesReleaseVersion(body)
 	}
-	return "", pkgerrors.Errorf("version %q doesn't match patterns for neither semantic version nor labels (stable, latest, ...)", version)
+	return "", errors.Errorf("version %q doesn't match patterns for neither semantic version nor labels (stable, latest, ...)", version)
 }
 
 // KubernetesVersionToImageTag is helper function that replaces all
@@ -152,7 +152,7 @@ func splitVersion(version string) (string, string, error) {
 	var urlSuffix string
 	subs := kubeBucketPrefixes.FindAllStringSubmatch(version, 1)
 	if len(subs) != 1 || len(subs[0]) != 4 {
-		return "", "", pkgerrors.Errorf("invalid version %q", version)
+		return "", "", errors.Errorf("invalid version %q", version)
 	}
 
 	switch {
@@ -172,12 +172,12 @@ func fetchFromURL(url string, timeout time.Duration) (string, error) {
 	client := &http.Client{Timeout: timeout, Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
 	resp, err := client.Get(url)
 	if err != nil {
-		return "", pkgerrors.Errorf("unable to get URL %q: %s", url, err.Error())
+		return "", errors.Errorf("unable to get URL %q: %s", url, err.Error())
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", pkgerrors.Errorf("unable to read content of URL %q: %s", url, err.Error())
+		return "", errors.Errorf("unable to read content of URL %q: %s", url, err.Error())
 	}
 	bodyString := strings.TrimSpace(string(body))
 
@@ -192,7 +192,7 @@ func fetchFromURL(url string, timeout time.Duration) (string, error) {
 func kubeadmVersion(info string) (string, error) {
 	v, err := versionutil.ParseSemantic(info)
 	if err != nil {
-		return "", pkgerrors.Wrap(err, "kubeadm version error")
+		return "", errors.Wrap(err, "kubeadm version error")
 	}
 	// There is no utility in versionutil to get the version without the metadata,
 	// so this needs some manual formatting.
@@ -226,11 +226,11 @@ func kubeadmVersion(info string) (string, error) {
 func validateStableVersion(remoteVersion, clientVersion string) (string, error) {
 	verRemote, err := versionutil.ParseGeneric(remoteVersion)
 	if err != nil {
-		return "", pkgerrors.Wrap(err, "remote version error")
+		return "", errors.Wrap(err, "remote version error")
 	}
 	verClient, err := versionutil.ParseGeneric(clientVersion)
 	if err != nil {
-		return "", pkgerrors.Wrap(err, "client version error")
+		return "", errors.Wrap(err, "client version error")
 	}
 	// If the remote Major version is bigger or if the Major versions are the same,
 	// but the remote Minor is bigger use the client version release. This handles Major bumps too.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR fixes few ´fmt.Errorf`/`errors`(from standard library) left overs and make consistent import alias for error management across the kubeadm codebase:
- `"github.com/pkg/errors"` (alway without alias)
- `errorsutil "k8s.io/apimachinery/pkg/util/errors"`
- `apierrors "k8s.io/apimachinery/pkg/api/errors"`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cluster-lifecycle
/priority backlog
@kubernetes/sig-cluster-lifecycle-pr-reviews