### PR TITLE
kubeadm selfhosting: fix pod spec mutation for controller-manager

### DIFF
--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
@@ -159,7 +159,14 @@ func setSelfHostedVolumesForControllerManager(podSpec *v1.PodSpec) {
 	// This is not a problem with hostPath mounts as hostPath supports mounting one file only, instead of always a full directory. Secrets and Projected Volumes
 	// don't support that.
 	podSpec.Containers[0].Command = kubeadmutil.ReplaceArgument(podSpec.Containers[0].Command, func(argMap map[string]string) map[string]string {
-		argMap["kubeconfig"] = filepath.Join(selfHostedKubeConfigDir, kubeadmconstants.ControllerManagerKubeConfigFileName)
+		controllerManagerKubeConfigPath := filepath.Join(selfHostedKubeConfigDir, kubeadmconstants.ControllerManagerKubeConfigFileName)
+		argMap["kubeconfig"] = controllerManagerKubeConfigPath
+		if _, ok := argMap["authentication-kubeconfig"]; ok {
+			argMap["authentication-kubeconfig"] = controllerManagerKubeConfigPath
+		}
+		if _, ok := argMap["authorization-kubeconfig"]; ok {
+			argMap["authorization-kubeconfig"] = controllerManagerKubeConfigPath
+		}
 		return argMap
 	})
 }

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
@@ -414,6 +414,8 @@ func TestSetSelfHostedVolumesForControllerManager(t *testing.T) {
 						},
 						Command: []string{
 							"--kubeconfig=/etc/kubernetes/controller-manager.conf",
+							"--authentication-kubeconfig=/etc/kubernetes/controller-manager.conf",
+							"--authorization-kubeconfig=/etc/kubernetes/controller-manager.conf",
 							"--foo=bar",
 						},
 					},
@@ -467,6 +469,8 @@ func TestSetSelfHostedVolumesForControllerManager(t *testing.T) {
 						},
 						Command: []string{
 							"--kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.conf",
+							"--authentication-kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.conf",
+							"--authorization-kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.conf",
 							"--foo=bar",
 						},
 					},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Modified command line options --authentication-kubeconfig and
--authorization-kubeconfig to point out to the correct location
of the controller-manager.conf

This should fix this controller-manager crash:
```
    failed to get delegated authentication kubeconfig: failed to get
    delegated authentication kubeconfig: stat
    /etc/kubernetes/controller-manager.conf: no such file or directory
```

Related issue: kubernetes/kubeadm#1281

**Special notes for your reviewer**:

This is a second commit of a series related to kubernetes/kubeadm#1281

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: fixed incorrect controller manager pod mutations during selfhosting pivoting
```