### PR TITLE
Ensure we set a content-type for healthz

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -185,6 +185,8 @@ func handleRootHealthz(checks ...HealthzChecker) http.HandlerFunc {
 			return
 		}
 
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
 		if _, found := r.URL.Query()["verbose"]; !found {
 			fmt.Fprint(w, "ok")
 			return

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
@@ -40,6 +40,10 @@ func TestInstallHandler(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("expected %v, got %v", http.StatusOK, w.Code)
 	}
+	c := w.Header().Get("Content-Type")
+	if c != "text/plain; charset=utf-8" {
+		t.Errorf("expected %v, got %v", "text/plain", c)
+	}
 	if w.Body.String() != "ok" {
 		t.Errorf("expected %v, got %v", "ok", w.Body.String())
 	}
@@ -58,6 +62,10 @@ func TestInstallPathHandler(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("expected %v, got %v", http.StatusOK, w.Code)
 	}
+	c := w.Header().Get("Content-Type")
+	if c != "text/plain; charset=utf-8" {
+		t.Errorf("expected %v, got %v", "text/plain", c)
+	}
 	if w.Body.String() != "ok" {
 		t.Errorf("expected %v, got %v", "ok", w.Body.String())
 	}
@@ -70,6 +78,10 @@ func TestInstallPathHandler(t *testing.T) {
 	mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Errorf("expected %v, got %v", http.StatusOK, w.Code)
+	}
+	c = w.Header().Get("Content-Type")
+	if c != "text/plain; charset=utf-8" {
+		t.Errorf("expected %v, got %v", "text/plain", c)
 	}
 	if w.Body.String() != "ok" {
 		t.Errorf("expected %v, got %v", "ok", w.Body.String())
@@ -119,6 +131,10 @@ func testMultipleChecks(path string, t *testing.T) {
 		mux.ServeHTTP(w, req)
 		if w.Code != test.expectedStatus {
 			t.Errorf("case[%d] Expected: %v, got: %v", i, test.expectedStatus, w.Code)
+		}
+		c := w.Header().Get("Content-Type")
+		if c != "text/plain; charset=utf-8" {
+			t.Errorf("case[%d] Expected: %v, got: %v", i, "text/plain", c)
 		}
 		if w.Body.String() != test.expectedResponse {
 			t.Errorf("case[%d] Expected:\n%v\ngot:\n%v\n", i, test.expectedResponse, w.Body.String())


### PR DESCRIPTION
Change-Id: I453b1433c69bf26c28da873dbdd1ac25006b8d60

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

`/healthz` spits out plain text, so make sure we tell http clients that the body is plain text

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
