### PR TITLE
Ensure we capture http and trace related logs

### DIFF
--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -17,10 +17,12 @@ limitations under the License.
 package framework
 
 import (
+	"flag"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/go-openapi/spec"
@@ -111,6 +113,13 @@ func (h *MasterHolder) SetMaster(m *master.Master) {
 func startMasterOrDie(masterConfig *master.Config, incomingServer *httptest.Server, masterReceiver MasterReceiver) (*master.Master, *httptest.Server, CloseFunc) {
 	var m *master.Master
 	var s *httptest.Server
+
+	// Ensure we log at least level 4
+	v := flag.Lookup("v").Value
+	level, _ := strconv.Atoi(v.String())
+	if level < 4 {
+		v.Set("4")
+	}
 
 	if incomingServer != nil {
 		s = incomingServer


### PR DESCRIPTION

Change-Id: I64a30029778615e679b244ddba801833218d1573

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When we are running apiserver related code, we do not currently capture
the logs from `httplog.NewLogged` and `trace.LogIfLong` since the
default log verbosity is not set. So just make sure we have a minimum
verbosity set in these circumstance.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
