### PR TITLE
kubeadm: use t.Run in selfhosting and update phases

### DIFF
--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
@@ -27,11 +27,13 @@ import (
 
 func TestMutatePodSpec(t *testing.T) {
 	var tests = []struct {
+		name      string
 		component string
 		podSpec   *v1.PodSpec
 		expected  v1.PodSpec
 	}{
 		{
+			name:      "mutate api server podspec",
 			component: kubeadmconstants.KubeAPIServer,
 			podSpec: &v1.PodSpec{
 				Containers: []v1.Container{
@@ -73,6 +75,7 @@ func TestMutatePodSpec(t *testing.T) {
 			},
 		},
 		{
+			name:      "mutate controller manager podspec",
 			component: kubeadmconstants.KubeControllerManager,
 			podSpec:   &v1.PodSpec{},
 			expected: v1.PodSpec{
@@ -86,6 +89,7 @@ func TestMutatePodSpec(t *testing.T) {
 			},
 		},
 		{
+			name:      "mutate scheduler podspec",
 			component: kubeadmconstants.KubeScheduler,
 			podSpec:   &v1.PodSpec{},
 			expected: v1.PodSpec{
@@ -101,20 +105,24 @@ func TestMutatePodSpec(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		mutatePodSpec(GetDefaultMutators(), rt.component, rt.podSpec)
+		t.Run(rt.name, func(t *testing.T) {
+			mutatePodSpec(GetDefaultMutators(), rt.component, rt.podSpec)
 
-		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
-			t.Errorf("failed mutatePodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
-		}
+			if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
+				t.Errorf("failed mutatePodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
+			}
+		})
 	}
 }
 
 func TestAddNodeSelectorToPodSpec(t *testing.T) {
 	var tests = []struct {
+		name     string
 		podSpec  *v1.PodSpec
 		expected v1.PodSpec
 	}{
 		{
+			name:    "empty podspec",
 			podSpec: &v1.PodSpec{},
 			expected: v1.PodSpec{
 				NodeSelector: map[string]string{
@@ -123,6 +131,7 @@ func TestAddNodeSelectorToPodSpec(t *testing.T) {
 			},
 		},
 		{
+			name: "podspec with a valid node selector",
 			podSpec: &v1.PodSpec{
 				NodeSelector: map[string]string{
 					"foo": "bar",
@@ -138,20 +147,24 @@ func TestAddNodeSelectorToPodSpec(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		addNodeSelectorToPodSpec(rt.podSpec)
+		t.Run(rt.name, func(t *testing.T) {
+			addNodeSelectorToPodSpec(rt.podSpec)
 
-		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
-			t.Errorf("failed addNodeSelectorToPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
-		}
+			if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
+				t.Errorf("failed addNodeSelectorToPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
+			}
+		})
 	}
 }
 
 func TestSetMasterTolerationOnPodSpec(t *testing.T) {
 	var tests = []struct {
+		name     string
 		podSpec  *v1.PodSpec
 		expected v1.PodSpec
 	}{
 		{
+			name:    "empty podspec",
 			podSpec: &v1.PodSpec{},
 			expected: v1.PodSpec{
 				Tolerations: []v1.Toleration{
@@ -160,6 +173,7 @@ func TestSetMasterTolerationOnPodSpec(t *testing.T) {
 			},
 		},
 		{
+			name: "podspec with a valid toleration",
 			podSpec: &v1.PodSpec{
 				Tolerations: []v1.Toleration{
 					{Key: "foo", Value: "bar"},
@@ -175,26 +189,31 @@ func TestSetMasterTolerationOnPodSpec(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		setMasterTolerationOnPodSpec(rt.podSpec)
+		t.Run(rt.name, func(t *testing.T) {
+			setMasterTolerationOnPodSpec(rt.podSpec)
 
-		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
-			t.Errorf("failed setMasterTolerationOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
-		}
+			if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
+				t.Errorf("failed setMasterTolerationOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
+			}
+		})
 	}
 }
 
 func TestSetRightDNSPolicyOnPodSpec(t *testing.T) {
 	var tests = []struct {
+		name     string
 		podSpec  *v1.PodSpec
 		expected v1.PodSpec
 	}{
 		{
+			name:    "empty podspec",
 			podSpec: &v1.PodSpec{},
 			expected: v1.PodSpec{
 				DNSPolicy: v1.DNSClusterFirstWithHostNet,
 			},
 		},
 		{
+			name: "podspec with a v1.DNSClusterFirst policy",
 			podSpec: &v1.PodSpec{
 				DNSPolicy: v1.DNSClusterFirst,
 			},
@@ -205,20 +224,24 @@ func TestSetRightDNSPolicyOnPodSpec(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		setRightDNSPolicyOnPodSpec(rt.podSpec)
+		t.Run(rt.name, func(t *testing.T) {
+			setRightDNSPolicyOnPodSpec(rt.podSpec)
 
-		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
-			t.Errorf("failed setRightDNSPolicyOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
-		}
+			if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
+				t.Errorf("failed setRightDNSPolicyOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
+			}
+		})
 	}
 }
 
 func TestSetHostIPOnPodSpec(t *testing.T) {
 	var tests = []struct {
+		name     string
 		podSpec  *v1.PodSpec
 		expected v1.PodSpec
 	}{
 		{
+			name: "set HOST_IP env var on a podspec",
 			podSpec: &v1.PodSpec{
 				Containers: []v1.Container{
 					{
@@ -254,21 +277,25 @@ func TestSetHostIPOnPodSpec(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		setHostIPOnPodSpec(rt.podSpec)
+		t.Run(rt.name, func(t *testing.T) {
+			setHostIPOnPodSpec(rt.podSpec)
 
-		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
-			t.Errorf("failed setHostIPOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
-		}
+			if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
+				t.Errorf("failed setHostIPOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
+			}
+		})
 	}
 }
 
 func TestSetSelfHostedVolumesForAPIServer(t *testing.T) {
 	hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
 	var tests = []struct {
+		name     string
 		podSpec  *v1.PodSpec
 		expected v1.PodSpec
 	}{
 		{
+			name: "set selfhosted volumes for api server",
 			podSpec: &v1.PodSpec{
 				Containers: []v1.Container{
 					{
@@ -346,13 +373,15 @@ func TestSetSelfHostedVolumesForAPIServer(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		setSelfHostedVolumesForAPIServer(rt.podSpec)
-		sort.Strings(rt.podSpec.Containers[0].Command)
-		sort.Strings(rt.expected.Containers[0].Command)
+		t.Run(rt.name, func(t *testing.T) {
+			setSelfHostedVolumesForAPIServer(rt.podSpec)
+			sort.Strings(rt.podSpec.Containers[0].Command)
+			sort.Strings(rt.expected.Containers[0].Command)
 
-		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
-			t.Errorf("failed setSelfHostedVolumesForAPIServer:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
-		}
+			if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
+				t.Errorf("failed setSelfHostedVolumesForAPIServer:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
+			}
+		})
 	}
 }
 
@@ -360,10 +389,12 @@ func TestSetSelfHostedVolumesForControllerManager(t *testing.T) {
 	hostPathFileOrCreate := v1.HostPathFileOrCreate
 	hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
 	var tests = []struct {
+		name     string
 		podSpec  *v1.PodSpec
 		expected v1.PodSpec
 	}{
 		{
+			name: "set selfhosted volumes for controller mananger",
 			podSpec: &v1.PodSpec{
 				Containers: []v1.Container{
 					{
@@ -464,23 +495,27 @@ func TestSetSelfHostedVolumesForControllerManager(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		setSelfHostedVolumesForControllerManager(rt.podSpec)
-		sort.Strings(rt.podSpec.Containers[0].Command)
-		sort.Strings(rt.expected.Containers[0].Command)
+		t.Run(rt.name, func(t *testing.T) {
+			setSelfHostedVolumesForControllerManager(rt.podSpec)
+			sort.Strings(rt.podSpec.Containers[0].Command)
+			sort.Strings(rt.expected.Containers[0].Command)
 
-		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
-			t.Errorf("failed setSelfHostedVolumesForControllerManager:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
-		}
+			if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
+				t.Errorf("failed setSelfHostedVolumesForControllerManager:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
+			}
+		})
 	}
 }
 
 func TestSetSelfHostedVolumesForScheduler(t *testing.T) {
 	hostPathFileOrCreate := v1.HostPathFileOrCreate
 	var tests = []struct {
+		name     string
 		podSpec  *v1.PodSpec
 		expected v1.PodSpec
 	}{
 		{
+			name: "set selfhosted volumes for scheduler",
 			podSpec: &v1.PodSpec{
 				Containers: []v1.Container{
 					{
@@ -534,12 +569,14 @@ func TestSetSelfHostedVolumesForScheduler(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		setSelfHostedVolumesForScheduler(rt.podSpec)
-		sort.Strings(rt.podSpec.Containers[0].Command)
-		sort.Strings(rt.expected.Containers[0].Command)
+		t.Run(rt.name, func(t *testing.T) {
+			setSelfHostedVolumesForScheduler(rt.podSpec)
+			sort.Strings(rt.podSpec.Containers[0].Command)
+			sort.Strings(rt.expected.Containers[0].Command)
 
-		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
-			t.Errorf("failed setSelfHostedVolumesForScheduler:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
-		}
+			if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
+				t.Errorf("failed setSelfHostedVolumesForScheduler:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
@@ -488,41 +488,44 @@ func TestBuildDaemonSet(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		tempFile, err := createTempFileWithContent(rt.podBytes)
-		if err != nil {
-			t.Errorf("error creating tempfile with content:%v", err)
-		}
-		defer os.Remove(tempFile)
+		t.Run(rt.component, func(t *testing.T) {
+			tempFile, err := createTempFileWithContent(rt.podBytes)
+			if err != nil {
+				t.Errorf("error creating tempfile with content:%v", err)
+			}
+			defer os.Remove(tempFile)
 
-		podSpec, err := loadPodSpecFromFile(tempFile)
-		if err != nil {
-			t.Fatalf("couldn't load the specified Pod Spec")
-		}
+			podSpec, err := loadPodSpecFromFile(tempFile)
+			if err != nil {
+				t.Fatalf("couldn't load the specified Pod Spec")
+			}
 
-		ds := BuildDaemonSet(rt.component, podSpec, GetDefaultMutators())
-		dsBytes, err := util.MarshalToYaml(ds, apps.SchemeGroupVersion)
-		if err != nil {
-			t.Fatalf("failed to marshal daemonset to YAML: %v", err)
-		}
+			ds := BuildDaemonSet(rt.component, podSpec, GetDefaultMutators())
+			dsBytes, err := util.MarshalToYaml(ds, apps.SchemeGroupVersion)
+			if err != nil {
+				t.Fatalf("failed to marshal daemonset to YAML: %v", err)
+			}
 
-		if !bytes.Equal(dsBytes, rt.dsBytes) {
-			t.Errorf("failed TestBuildDaemonSet:\nexpected:\n%s\nsaw:\n%s", rt.dsBytes, dsBytes)
-		}
+			if !bytes.Equal(dsBytes, rt.dsBytes) {
+				t.Errorf("failed TestBuildDaemonSet:\nexpected:\n%s\nsaw:\n%s", rt.dsBytes, dsBytes)
+			}
+		})
 	}
 }
 
 func TestLoadPodSpecFromFile(t *testing.T) {
 	tests := []struct {
+		name        string
 		content     string
 		expectError bool
 	}{
 		{
-			// No content
+			name:        "no content",
 			content:     "",
 			expectError: true,
 		},
 		{
-			// Good YAML
+			name: "valid YAML",
 			content: `
 apiVersion: v1
 kind: Pod
@@ -535,7 +538,7 @@ spec:
 			expectError: false,
 		},
 		{
-			// Good JSON
+			name: "valid JSON",
 			content: `
 {
   "apiVersion": "v1",
@@ -554,7 +557,7 @@ spec:
 			expectError: false,
 		},
 		{
-			// Bad PodSpec
+			name: "incorrect PodSpec",
 			content: `
 apiVersion: v1
 kind: Pod
@@ -568,22 +571,26 @@ spec:
 	}
 
 	for _, rt := range tests {
-		tempFile, err := createTempFileWithContent([]byte(rt.content))
-		if err != nil {
-			t.Errorf("error creating tempfile with content:%v", err)
-		}
-		defer os.Remove(tempFile)
+		t.Run(rt.name, func(t *testing.T) {
+			tempFile, err := createTempFileWithContent([]byte(rt.content))
+			if err != nil {
+				t.Errorf("error creating tempfile with content:%v", err)
+			}
+			defer os.Remove(tempFile)
 
-		_, err = loadPodSpecFromFile(tempFile)
-		if (err != nil) != rt.expectError {
-			t.Errorf("failed TestLoadPodSpecFromFile:\nexpected error:\n%t\nsaw:\n%v", rt.expectError, err)
-		}
+			_, err = loadPodSpecFromFile(tempFile)
+			if (err != nil) != rt.expectError {
+				t.Errorf("failed TestLoadPodSpecFromFile:\nexpected error:\n%t\nsaw:\n%v", rt.expectError, err)
+			}
+		})
 	}
 
-	_, err := loadPodSpecFromFile("")
-	if err == nil {
-		t.Error("unexpected success: loadPodSpecFromFile should return error when no file is given")
-	}
+	t.Run("empty file name", func(t *testing.T) {
+		_, err := loadPodSpecFromFile("")
+		if err == nil {
+			t.Error("unexpected success: loadPodSpecFromFile should return error when no file is given")
+		}
+	})
 }
 
 func createTempFileWithContent(content []byte) (string, error) {

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -781,18 +781,21 @@ func TestGetAvailableUpgrades(t *testing.T) {
 
 func TestKubeletUpgrade(t *testing.T) {
 	tests := []struct {
+		name     string
 		before   map[string]uint16
 		after    string
 		expected bool
 	}{
-		{ // upgrade available
+		{
+			name: "upgrade from v1.10.1 to v1.10.3 is available",
 			before: map[string]uint16{
 				"v1.10.1": 1,
 			},
 			after:    "v1.10.3",
 			expected: true,
 		},
-		{ // upgrade available
+		{
+			name: "upgrade from v1.10.1 and v1.10.3/100 to v1.10.3 is available",
 			before: map[string]uint16{
 				"v1.10.1": 1,
 				"v1.10.3": 100,
@@ -800,21 +803,24 @@ func TestKubeletUpgrade(t *testing.T) {
 			after:    "v1.10.3",
 			expected: true,
 		},
-		{ // upgrade not available
+		{
+			name: "upgrade from v1.10.3 to v1.10.3 is not available",
 			before: map[string]uint16{
 				"v1.10.3": 1,
 			},
 			after:    "v1.10.3",
 			expected: false,
 		},
-		{ // upgrade not available
+		{
+			name: "upgrade from v1.10.3/100 to v1.10.3 is not available",
 			before: map[string]uint16{
 				"v1.10.3": 100,
 			},
 			after:    "v1.10.3",
 			expected: false,
 		},
-		{ // upgrade not available if we don't know anything about the earlier state
+		{
+			name:     "upgrade is not available if we don't know anything about the earlier state",
 			before:   map[string]uint16{},
 			after:    "v1.10.3",
 			expected: false,
@@ -822,19 +828,20 @@ func TestKubeletUpgrade(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-
-		upgrade := Upgrade{
-			Before: ClusterState{
-				KubeletVersions: rt.before,
-			},
-			After: ClusterState{
-				KubeVersion: rt.after,
-			},
-		}
-		actual := upgrade.CanUpgradeKubelets()
-		if actual != rt.expected {
-			t.Errorf("failed TestKubeletUpgrade\n\texpected: %t\n\tgot: %t\n\ttest object: %v", rt.expected, actual, upgrade)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			upgrade := Upgrade{
+				Before: ClusterState{
+					KubeletVersions: rt.before,
+				},
+				After: ClusterState{
+					KubeVersion: rt.after,
+				},
+			}
+			actual := upgrade.CanUpgradeKubelets()
+			if actual != rt.expected {
+				t.Errorf("failed TestKubeletUpgrade\n\texpected: %t\n\tgot: %t\n\ttest object: %v", rt.expected, actual, upgrade)
+			}
+		})
 	}
 }
 
@@ -883,10 +890,11 @@ func TestGetBranchFromVersion(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		v := getBranchFromVersion(tc.version)
-		if v != tc.expectedVersion {
-			t.Errorf("expected version %s, got %s", tc.expectedVersion, v)
-		}
+		t.Run(tc.version, func(t *testing.T) {
+			v := getBranchFromVersion(tc.version)
+			if v != tc.expectedVersion {
+				t.Errorf("expected version %s, got %s", tc.expectedVersion, v)
+			}
+		})
 	}
-
 }

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
@@ -150,35 +150,37 @@ func TestShouldBackupAPIServerCertAndKey(t *testing.T) {
 			expected:       true,
 		},
 	} {
-		tmpdir := testutil.SetupTempDir(t)
-		defer os.RemoveAll(tmpdir)
-		cfg.CertificatesDir = tmpdir
+		t.Run(desc, func(t *testing.T) {
+			tmpdir := testutil.SetupTempDir(t)
+			defer os.RemoveAll(tmpdir)
+			cfg.CertificatesDir = tmpdir
 
-		caCert, caKey, err := certsphase.KubeadmCertRootCA.CreateAsCA(cfg)
-		if err != nil {
-			t.Fatalf("failed creation of ca cert and key: %v", err)
-		}
-		caCert.NotBefore = caCert.NotBefore.Add(-test.adjustedExpiry).UTC()
-
-		err = certsphase.KubeadmCertAPIServer.CreateFromCA(cfg, caCert, caKey)
-		if err != nil {
-			t.Fatalf("Test %s: failed creation of cert and key: %v", desc, err)
-		}
-
-		certAndKey := []string{filepath.Join(tmpdir, constants.APIServerCertName), filepath.Join(tmpdir, constants.APIServerKeyName)}
-		for _, path := range certAndKey {
-			if _, err := os.Stat(path); os.IsNotExist(err) {
-				t.Fatalf("Test %s: %s not exist: %v", desc, path, err)
+			caCert, caKey, err := certsphase.KubeadmCertRootCA.CreateAsCA(cfg)
+			if err != nil {
+				t.Fatalf("failed creation of ca cert and key: %v", err)
 			}
-		}
+			caCert.NotBefore = caCert.NotBefore.Add(-test.adjustedExpiry).UTC()
 
-		shouldBackup, err := shouldBackupAPIServerCertAndKey(tmpdir)
-		if err != nil {
-			t.Fatalf("Test %s: failed to check shouldBackupAPIServerCertAndKey: %v", desc, err)
-		}
+			err = certsphase.KubeadmCertAPIServer.CreateFromCA(cfg, caCert, caKey)
+			if err != nil {
+				t.Fatalf("Test %s: failed creation of cert and key: %v", desc, err)
+			}
 
-		if shouldBackup != test.expected {
-			t.Fatalf("Test %s: shouldBackupAPIServerCertAndKey expected %v, got %v", desc, test.expected, shouldBackup)
-		}
+			certAndKey := []string{filepath.Join(tmpdir, constants.APIServerCertName), filepath.Join(tmpdir, constants.APIServerKeyName)}
+			for _, path := range certAndKey {
+				if _, err := os.Stat(path); os.IsNotExist(err) {
+					t.Fatalf("Test %s: %s not exist: %v", desc, path, err)
+				}
+			}
+
+			shouldBackup, err := shouldBackupAPIServerCertAndKey(tmpdir)
+			if err != nil {
+				t.Fatalf("Test %s: failed to check shouldBackupAPIServerCertAndKey: %v", desc, err)
+			}
+
+			if shouldBackup != test.expected {
+				t.Fatalf("Test %s: shouldBackupAPIServerCertAndKey expected %v, got %v", desc, test.expected, shouldBackup)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/phases/upgrade/prepull_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/prepull_test.go
@@ -108,26 +108,31 @@ func (p *goodPrepuller) DeleteFunc(component string) error {
 
 func TestPrepullImagesInParallel(t *testing.T) {
 	tests := []struct {
+		name        string
 		p           Prepuller
 		timeout     time.Duration
 		expectedErr bool
 	}{
-		{ // should error out; create failed
+		{
+			name:        "should error out; create failed",
 			p:           NewFailedCreatePrepuller(),
 			timeout:     10 * time.Second,
 			expectedErr: true,
 		},
-		{ // should error out; timeout exceeded
+		{
+			name:        "should error out; timeout exceeded",
 			p:           NewForeverWaitPrepuller(),
 			timeout:     10 * time.Second,
 			expectedErr: true,
 		},
-		{ // should error out; delete failed
+		{
+			name:        "should error out; delete failed",
 			p:           NewFailedDeletePrepuller(),
 			timeout:     10 * time.Second,
 			expectedErr: true,
 		},
-		{ // should work just fine
+		{
+			name:        "should work just fine",
 			p:           NewGoodPrepuller(),
 			timeout:     10 * time.Second,
 			expectedErr: false,
@@ -135,14 +140,15 @@ func TestPrepullImagesInParallel(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-
-		actualErr := PrepullImagesInParallel(rt.p, rt.timeout, append(constants.MasterComponents, constants.Etcd))
-		if (actualErr != nil) != rt.expectedErr {
-			t.Errorf(
-				"failed TestPrepullImagesInParallel\n\texpected error: %t\n\tgot: %t",
-				rt.expectedErr,
-				(actualErr != nil),
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			actualErr := PrepullImagesInParallel(rt.p, rt.timeout, append(constants.MasterComponents, constants.Etcd))
+			if (actualErr != nil) != rt.expectedErr {
+				t.Errorf(
+					"failed TestPrepullImagesInParallel\n\texpected error: %t\n\tgot: %t",
+					rt.expectedErr,
+					(actualErr != nil),
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -412,116 +412,117 @@ func TestStaticPodControlPlane(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		waiter := NewFakeStaticPodWaiter(rt.waitErrsToReturn)
-		pathMgr, err := NewFakeStaticPodPathManager(rt.moveFileFunc)
-		if err != nil {
-			t.Fatalf("couldn't run NewFakeStaticPodPathManager: %v", err)
-		}
-		defer os.RemoveAll(pathMgr.(*fakeStaticPodPathManager).KubernetesDir())
-		constants.KubernetesDir = pathMgr.(*fakeStaticPodPathManager).KubernetesDir()
-
-		tempCertsDir, err := ioutil.TempDir("", "kubeadm-certs")
-		if err != nil {
-			t.Fatalf("couldn't create temporary certificates directory: %v", err)
-		}
-		defer os.RemoveAll(tempCertsDir)
-		tmpEtcdDataDir, err := ioutil.TempDir("", "kubeadm-etcd-data")
-		if err != nil {
-			t.Fatalf("couldn't create temporary etcd data directory: %v", err)
-		}
-		defer os.RemoveAll(tmpEtcdDataDir)
-
-		oldcfg, err := getConfig(constants.MinimumControlPlaneVersion.String(), tempCertsDir, tmpEtcdDataDir)
-		if err != nil {
-			t.Fatalf("couldn't create config: %v", err)
-		}
-
-		tree, err := certsphase.GetCertsWithoutEtcd().AsMap().CertTree()
-		if err != nil {
-			t.Fatalf("couldn't get cert tree: %v", err)
-		}
-
-		if err := tree.CreateTree(oldcfg); err != nil {
-			t.Fatalf("couldn't get create cert tree: %v", err)
-		}
-
-		t.Logf("Wrote certs to %s\n", oldcfg.CertificatesDir)
-
-		// Initialize the directory with v1.7 manifests; should then be upgraded to v1.8 using the method
-		err = controlplanephase.CreateInitStaticPodManifestFiles(pathMgr.RealManifestDir(), oldcfg)
-		if err != nil {
-			t.Fatalf("couldn't run CreateInitStaticPodManifestFiles: %v", err)
-		}
-		err = etcdphase.CreateLocalEtcdStaticPodManifestFile(pathMgr.RealManifestDir(), oldcfg)
-		if err != nil {
-			t.Fatalf("couldn't run CreateLocalEtcdStaticPodManifestFile: %v", err)
-		}
-		// Get a hash of the v1.7 API server manifest to compare later (was the file re-written)
-		oldHash, err := getAPIServerHash(pathMgr.RealManifestDir())
-		if err != nil {
-			t.Fatalf("couldn't read temp file: %v", err)
-		}
-
-		newcfg, err := getConfig(constants.CurrentKubernetesVersion.String(), tempCertsDir, tmpEtcdDataDir)
-		if err != nil {
-			t.Fatalf("couldn't create config: %v", err)
-		}
-
-		// create the kubeadm etcd certs
-		caCert, caKey, err := certsphase.KubeadmCertEtcdCA.CreateAsCA(newcfg)
-		if err != nil {
-			t.Fatalf("couldn't create new CA certificate: %v", err)
-		}
-		for _, cert := range []*certsphase.KubeadmCert{
-			&certsphase.KubeadmCertEtcdServer,
-			&certsphase.KubeadmCertEtcdPeer,
-			&certsphase.KubeadmCertEtcdHealthcheck,
-			&certsphase.KubeadmCertEtcdAPIClient,
-		} {
-			if err := cert.CreateFromCA(newcfg, caCert, caKey); err != nil {
-				t.Fatalf("couldn't create certificate %s: %v", cert.Name, err)
+		t.Run(rt.description, func(t *testing.T) {
+			waiter := NewFakeStaticPodWaiter(rt.waitErrsToReturn)
+			pathMgr, err := NewFakeStaticPodPathManager(rt.moveFileFunc)
+			if err != nil {
+				t.Fatalf("couldn't run NewFakeStaticPodPathManager: %v", err)
 			}
-		}
+			defer os.RemoveAll(pathMgr.(*fakeStaticPodPathManager).KubernetesDir())
+			constants.KubernetesDir = pathMgr.(*fakeStaticPodPathManager).KubernetesDir()
 
-		actualErr := StaticPodControlPlane(
-			nil,
-			waiter,
-			pathMgr,
-			newcfg,
-			true,
-			fakeTLSEtcdClient{
-				TLS: false,
-			},
-			fakePodManifestEtcdClient{
-				ManifestDir:     pathMgr.RealManifestDir(),
-				CertificatesDir: newcfg.CertificatesDir,
-			},
-		)
-		if (actualErr != nil) != rt.expectedErr {
-			t.Errorf(
-				"failed UpgradeStaticPodControlPlane\n%s\n\texpected error: %t\n\tgot: %t\n\tactual error: %v",
-				rt.description,
-				rt.expectedErr,
-				(actualErr != nil),
-				actualErr,
+			tempCertsDir, err := ioutil.TempDir("", "kubeadm-certs")
+			if err != nil {
+				t.Fatalf("couldn't create temporary certificates directory: %v", err)
+			}
+			defer os.RemoveAll(tempCertsDir)
+			tmpEtcdDataDir, err := ioutil.TempDir("", "kubeadm-etcd-data")
+			if err != nil {
+				t.Fatalf("couldn't create temporary etcd data directory: %v", err)
+			}
+			defer os.RemoveAll(tmpEtcdDataDir)
+
+			oldcfg, err := getConfig(constants.MinimumControlPlaneVersion.String(), tempCertsDir, tmpEtcdDataDir)
+			if err != nil {
+				t.Fatalf("couldn't create config: %v", err)
+			}
+
+			tree, err := certsphase.GetCertsWithoutEtcd().AsMap().CertTree()
+			if err != nil {
+				t.Fatalf("couldn't get cert tree: %v", err)
+			}
+
+			if err := tree.CreateTree(oldcfg); err != nil {
+				t.Fatalf("couldn't get create cert tree: %v", err)
+			}
+
+			t.Logf("Wrote certs to %s\n", oldcfg.CertificatesDir)
+
+			// Initialize the directory with v1.7 manifests; should then be upgraded to v1.8 using the method
+			err = controlplanephase.CreateInitStaticPodManifestFiles(pathMgr.RealManifestDir(), oldcfg)
+			if err != nil {
+				t.Fatalf("couldn't run CreateInitStaticPodManifestFiles: %v", err)
+			}
+			err = etcdphase.CreateLocalEtcdStaticPodManifestFile(pathMgr.RealManifestDir(), oldcfg)
+			if err != nil {
+				t.Fatalf("couldn't run CreateLocalEtcdStaticPodManifestFile: %v", err)
+			}
+			// Get a hash of the v1.7 API server manifest to compare later (was the file re-written)
+			oldHash, err := getAPIServerHash(pathMgr.RealManifestDir())
+			if err != nil {
+				t.Fatalf("couldn't read temp file: %v", err)
+			}
+
+			newcfg, err := getConfig(constants.CurrentKubernetesVersion.String(), tempCertsDir, tmpEtcdDataDir)
+			if err != nil {
+				t.Fatalf("couldn't create config: %v", err)
+			}
+
+			// create the kubeadm etcd certs
+			caCert, caKey, err := certsphase.KubeadmCertEtcdCA.CreateAsCA(newcfg)
+			if err != nil {
+				t.Fatalf("couldn't create new CA certificate: %v", err)
+			}
+			for _, cert := range []*certsphase.KubeadmCert{
+				&certsphase.KubeadmCertEtcdServer,
+				&certsphase.KubeadmCertEtcdPeer,
+				&certsphase.KubeadmCertEtcdHealthcheck,
+				&certsphase.KubeadmCertEtcdAPIClient,
+			} {
+				if err := cert.CreateFromCA(newcfg, caCert, caKey); err != nil {
+					t.Fatalf("couldn't create certificate %s: %v", cert.Name, err)
+				}
+			}
+
+			actualErr := StaticPodControlPlane(
+				nil,
+				waiter,
+				pathMgr,
+				newcfg,
+				true,
+				fakeTLSEtcdClient{
+					TLS: false,
+				},
+				fakePodManifestEtcdClient{
+					ManifestDir:     pathMgr.RealManifestDir(),
+					CertificatesDir: newcfg.CertificatesDir,
+				},
 			)
-		}
+			if (actualErr != nil) != rt.expectedErr {
+				t.Errorf(
+					"failed UpgradeStaticPodControlPlane\n%s\n\texpected error: %t\n\tgot: %t\n\tactual error: %v",
+					rt.description,
+					rt.expectedErr,
+					(actualErr != nil),
+					actualErr,
+				)
+			}
 
-		newHash, err := getAPIServerHash(pathMgr.RealManifestDir())
-		if err != nil {
-			t.Fatalf("couldn't read temp file: %v", err)
-		}
+			newHash, err := getAPIServerHash(pathMgr.RealManifestDir())
+			if err != nil {
+				t.Fatalf("couldn't read temp file: %v", err)
+			}
 
-		if (oldHash != newHash) != rt.manifestShouldChange {
-			t.Errorf(
-				"failed StaticPodControlPlane\n%s\n\texpected manifest change: %t\n\tgot: %t\n\tnewHash: %v",
-				rt.description,
-				rt.manifestShouldChange,
-				(oldHash != newHash),
-				newHash,
-			)
-		}
-		return
+			if (oldHash != newHash) != rt.manifestShouldChange {
+				t.Errorf(
+					"failed StaticPodControlPlane\n%s\n\texpected manifest change: %t\n\tgot: %t\n\tnewHash: %v",
+					rt.description,
+					rt.manifestShouldChange,
+					(oldHash != newHash),
+					newHash,
+				)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Used T.Run API for kubeadm tests in app/phases/selfhosting and
app/phases/update directories

This should improve testing output and make it more visible
which test is doing what.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
