### PR TITLE
Use overridden context when determining if default namespace came from config

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
@@ -150,7 +150,12 @@ func (config *DeferredLoadingClientConfig) Namespace() (string, bool, error) {
 
 		// if we got a default namespace, determine whether it was explicit or implicit
 		if raw, err := mergedKubeConfig.RawConfig(); err == nil {
-			if context := raw.Contexts[raw.CurrentContext]; context != nil && len(context.Namespace) > 0 {
+			// determine the current context
+			currentContext := raw.CurrentContext
+			if config.overrides != nil && len(config.overrides.CurrentContext) > 0 {
+				currentContext = config.overrides.CurrentContext
+			}
+			if context := raw.Contexts[currentContext]; context != nil && len(context.Namespace) > 0 {
 				return ns, false, nil
 			}
 		}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go
@@ -38,6 +38,7 @@ func (l *testLoader) Load() (*clientcmdapi.Config, error) {
 }
 
 type testClientConfig struct {
+	rawconfig          *clientcmdapi.Config
 	config             *restclient.Config
 	namespace          string
 	namespaceSpecified bool
@@ -45,7 +46,10 @@ type testClientConfig struct {
 }
 
 func (c *testClientConfig) RawConfig() (clientcmdapi.Config, error) {
-	return clientcmdapi.Config{}, fmt.Errorf("unexpected call")
+	if c.rawconfig == nil {
+		return clientcmdapi.Config{}, fmt.Errorf("unexpected call")
+	}
+	return *c.rawconfig, nil
 }
 func (c *testClientConfig) ClientConfig() (*restclient.Config, error) {
 	return c.config, c.err
@@ -224,10 +228,11 @@ func TestInClusterConfigNamespace(t *testing.T) {
 	testCases := map[string]struct {
 		clientConfig *testClientConfig
 		icc          *testICC
+		overrides    *ConfigOverrides
 
 		checkedICC bool
 		result     string
-		ok         bool
+		overridden bool
 		err        error
 	}{
 		"in-cluster checked on empty error": {
@@ -256,8 +261,8 @@ func TestInClusterConfigNamespace(t *testing.T) {
 			clientConfig: &testClientConfig{namespace: "test", namespaceSpecified: true},
 			icc:          &testICC{},
 
-			result: "test",
-			ok:     true,
+			result:     "test",
+			overridden: true,
 		},
 
 		"in-cluster checked when namespace is not specified, but is defaulted": {
@@ -266,7 +271,7 @@ func TestInClusterConfigNamespace(t *testing.T) {
 
 			checkedICC: true,
 			result:     "test",
-			ok:         false,
+			overridden: false,
 		},
 
 		"in-cluster error returned when config is empty": {
@@ -294,7 +299,7 @@ func TestInClusterConfigNamespace(t *testing.T) {
 
 			checkedICC: true,
 			result:     "test",
-			ok:         true,
+			overridden: true,
 		},
 
 		"in-cluster config returned when config is empty and namespace is defaulted but not explicitly set": {
@@ -309,20 +314,41 @@ func TestInClusterConfigNamespace(t *testing.T) {
 
 			checkedICC: true,
 			result:     "test",
-			ok:         false,
+			overridden: false,
+		},
+
+		"overridden context used to verify explicit namespace in config": {
+			clientConfig: &testClientConfig{
+				namespace:          "default",
+				namespaceSpecified: false, // a namespace that comes from a context is not considered overridden
+				rawconfig:          &clientcmdapi.Config{Contexts: map[string]*clientcmdapi.Context{"overridden-context": {Namespace: "default"}}},
+			},
+			overrides: &ConfigOverrides{CurrentContext: "overridden-context"},
+			icc: &testICC{
+				possible: true,
+				testClientConfig: testClientConfig{
+					namespace:          "icc",
+					namespaceSpecified: false, // a namespace that comes from icc is not considered overridden
+				},
+			},
+			checkedICC: true,
+			result:     "default",
+			overridden: false, // a namespace that comes from a context is not considered overridden
 		},
 	}
 
 	for name, test := range testCases {
-		c := &DeferredLoadingClientConfig{icc: test.icc}
-		c.clientConfig = test.clientConfig
+		t.Run(name, func(t *testing.T) {
+			c := &DeferredLoadingClientConfig{icc: test.icc, overrides: test.overrides}
+			c.clientConfig = test.clientConfig
 
-		ns, ok, err := c.Namespace()
-		if test.icc.called != test.checkedICC {
-			t.Errorf("%s: unexpected in-cluster-config call %t", name, test.icc.called)
-		}
-		if err != test.err || ns != test.result || ok != test.ok {
-			t.Errorf("%s: unexpected result: %v %s %t", name, err, ns, ok)
-		}
+			ns, overridden, err := c.Namespace()
+			if test.icc.called != test.checkedICC {
+				t.Errorf("%s: unexpected in-cluster-config call %t", name, test.icc.called)
+			}
+			if err != test.err || ns != test.result || overridden != test.overridden {
+				t.Errorf("%s: unexpected result: %v %s %t", name, err, ns, overridden)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
Fixes #72524

**Does this PR introduce a user-facing change?**:
```release-note
kubectl: fixes a bug determining the correct namespace while running in a pod when the `--context` flag is explicitly specified, and the referenced context specifies the namespace `default`
```

/sig cli
/cc @soltysh 