### PR TITLE
kube-proxy: Fix bug in rejecting 0 endpoint svc

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -374,12 +374,7 @@ var iptablesJumpChains = []iptablesJumpChain{
 	{utiliptables.TableFilter, kubeForwardChain, utiliptables.ChainForward, "kubernetes forwarding rules", nil},
 }
 
-var iptablesCleanupOnlyChains = []iptablesJumpChain{
-	// Present in kube 1.6 - 1.9. Removed by #56164 in favor of kubeExternalServicesChain
-	{utiliptables.TableFilter, kubeServicesChain, utiliptables.ChainInput, "kubernetes service portals", nil},
-	// Present in kube <= 1.9. Removed by #60306 in favor of rule with extraArgs
-	{utiliptables.TableFilter, kubeServicesChain, utiliptables.ChainOutput, "kubernetes service portals", nil},
-}
+var iptablesCleanupOnlyChains = []iptablesJumpChain{}
 
 // CleanupLeftovers removes all iptables rules and chains created by the Proxier
 // It returns true if an error was encountered. Errors are logged.

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -367,11 +367,12 @@ type iptablesJumpChain struct {
 
 var iptablesJumpChains = []iptablesJumpChain{
 	{utiliptables.TableFilter, kubeExternalServicesChain, utiliptables.ChainInput, "kubernetes externally-visible service portals", []string{"-m", "conntrack", "--ctstate", "NEW"}},
+	{utiliptables.TableFilter, kubeServicesChain, utiliptables.ChainForward, "kubernetes service portals", []string{"-m", "conntrack", "--ctstate", "NEW"}},
 	{utiliptables.TableFilter, kubeServicesChain, utiliptables.ChainOutput, "kubernetes service portals", []string{"-m", "conntrack", "--ctstate", "NEW"}},
+	{utiliptables.TableFilter, kubeForwardChain, utiliptables.ChainForward, "kubernetes forwarding rules", nil},
 	{utiliptables.TableNAT, kubeServicesChain, utiliptables.ChainOutput, "kubernetes service portals", nil},
 	{utiliptables.TableNAT, kubeServicesChain, utiliptables.ChainPrerouting, "kubernetes service portals", nil},
 	{utiliptables.TableNAT, kubePostroutingChain, utiliptables.ChainPostrouting, "kubernetes postrouting rules", nil},
-	{utiliptables.TableFilter, kubeForwardChain, utiliptables.ChainForward, "kubernetes forwarding rules", nil},
 }
 
 var iptablesCleanupOnlyChains = []iptablesJumpChain{}

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -385,12 +385,12 @@ var iptablesCleanupOnlyChains = []iptablesJumpChain{
 // It returns true if an error was encountered. Errors are logged.
 func CleanupLeftovers(ipt utiliptables.Interface) (encounteredError bool) {
 	// Unlink our chains
-	for _, chain := range append(iptablesJumpChains, iptablesCleanupOnlyChains...) {
-		args := append(chain.extraArgs,
-			"-m", "comment", "--comment", chain.comment,
-			"-j", string(chain.dstChain),
+	for _, jump := range append(iptablesJumpChains, iptablesCleanupOnlyChains...) {
+		args := append(jump.extraArgs,
+			"-m", "comment", "--comment", jump.comment,
+			"-j", string(jump.dstChain),
 		)
-		if err := ipt.DeleteRule(chain.table, chain.sourceChain, args...); err != nil {
+		if err := ipt.DeleteRule(jump.table, jump.sourceChain, args...); err != nil {
 			if !utiliptables.IsNotFoundError(err) {
 				klog.Errorf("Error removing pure-iptables proxy rule: %v", err)
 				encounteredError = true
@@ -670,17 +670,17 @@ func (proxier *Proxier) syncProxyRules() {
 	klog.V(3).Info("Syncing iptables rules")
 
 	// Create and link the kube chains.
-	for _, chain := range iptablesJumpChains {
-		if _, err := proxier.iptables.EnsureChain(chain.table, chain.dstChain); err != nil {
-			klog.Errorf("Failed to ensure that %s chain %s exists: %v", chain.table, kubeServicesChain, err)
+	for _, jump := range iptablesJumpChains {
+		if _, err := proxier.iptables.EnsureChain(jump.table, jump.dstChain); err != nil {
+			klog.Errorf("Failed to ensure that %s chain %s exists: %v", jump.table, jump.dstChain, err)
 			return
 		}
-		args := append(chain.extraArgs,
-			"-m", "comment", "--comment", chain.comment,
-			"-j", string(chain.dstChain),
+		args := append(jump.extraArgs,
+			"-m", "comment", "--comment", jump.comment,
+			"-j", string(jump.dstChain),
 		)
-		if _, err := proxier.iptables.EnsureRule(utiliptables.Prepend, chain.table, chain.sourceChain, args...); err != nil {
-			klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", chain.table, chain.sourceChain, chain.dstChain, err)
+		if _, err := proxier.iptables.EnsureRule(utiliptables.Prepend, jump.table, jump.sourceChain, args...); err != nil {
+			klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", jump.table, jump.sourceChain, jump.dstChain, err)
 			return
 		}
 	}

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -358,11 +358,11 @@ func NewProxier(ipt utiliptables.Interface,
 }
 
 type iptablesJumpChain struct {
-	table       utiliptables.Table
-	dstChain    utiliptables.Chain
-	sourceChain utiliptables.Chain
-	comment     string
-	extraArgs   []string
+	table     utiliptables.Table
+	dstChain  utiliptables.Chain
+	srcChain  utiliptables.Chain
+	comment   string
+	extraArgs []string
 }
 
 var iptablesJumpChains = []iptablesJumpChain{
@@ -390,7 +390,7 @@ func CleanupLeftovers(ipt utiliptables.Interface) (encounteredError bool) {
 			"-m", "comment", "--comment", jump.comment,
 			"-j", string(jump.dstChain),
 		)
-		if err := ipt.DeleteRule(jump.table, jump.sourceChain, args...); err != nil {
+		if err := ipt.DeleteRule(jump.table, jump.srcChain, args...); err != nil {
 			if !utiliptables.IsNotFoundError(err) {
 				klog.Errorf("Error removing pure-iptables proxy rule: %v", err)
 				encounteredError = true
@@ -679,8 +679,8 @@ func (proxier *Proxier) syncProxyRules() {
 			"-m", "comment", "--comment", jump.comment,
 			"-j", string(jump.dstChain),
 		)
-		if _, err := proxier.iptables.EnsureRule(utiliptables.Prepend, jump.table, jump.sourceChain, args...); err != nil {
-			klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", jump.table, jump.sourceChain, jump.dstChain, err)
+		if _, err := proxier.iptables.EnsureRule(utiliptables.Prepend, jump.table, jump.srcChain, args...); err != nil {
+			klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", jump.table, jump.srcChain, jump.dstChain, err)
 			return
 		}
 	}

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -359,7 +359,7 @@ func NewProxier(ipt utiliptables.Interface,
 
 type iptablesJumpChain struct {
 	table       utiliptables.Table
-	chain       utiliptables.Chain
+	dstChain    utiliptables.Chain
 	sourceChain utiliptables.Chain
 	comment     string
 	extraArgs   []string
@@ -388,7 +388,7 @@ func CleanupLeftovers(ipt utiliptables.Interface) (encounteredError bool) {
 	for _, chain := range append(iptablesJumpChains, iptablesCleanupOnlyChains...) {
 		args := append(chain.extraArgs,
 			"-m", "comment", "--comment", chain.comment,
-			"-j", string(chain.chain),
+			"-j", string(chain.dstChain),
 		)
 		if err := ipt.DeleteRule(chain.table, chain.sourceChain, args...); err != nil {
 			if !utiliptables.IsNotFoundError(err) {
@@ -671,16 +671,16 @@ func (proxier *Proxier) syncProxyRules() {
 
 	// Create and link the kube chains.
 	for _, chain := range iptablesJumpChains {
-		if _, err := proxier.iptables.EnsureChain(chain.table, chain.chain); err != nil {
+		if _, err := proxier.iptables.EnsureChain(chain.table, chain.dstChain); err != nil {
 			klog.Errorf("Failed to ensure that %s chain %s exists: %v", chain.table, kubeServicesChain, err)
 			return
 		}
 		args := append(chain.extraArgs,
 			"-m", "comment", "--comment", chain.comment,
-			"-j", string(chain.chain),
+			"-j", string(chain.dstChain),
 		)
 		if _, err := proxier.iptables.EnsureRule(utiliptables.Prepend, chain.table, chain.sourceChain, args...); err != nil {
-			klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", chain.table, chain.sourceChain, chain.chain, err)
+			klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", chain.table, chain.sourceChain, chain.dstChain, err)
 			return
 		}
 	}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

As cited in #20767 (thanks @vllry), we do not REJECT when we should (I think).

**Which issue(s) this PR fixes**:

xref #20767
xref #19576

**Special notes for your reviewer**:

I can't find any reasons NOT to do this, butthat doesn't mean they don't exist.

```release-note

Connections from Pods to Services with 0 endpoints will now ICMP reject immediately, rather than blackhole and timeout.

```

@m1093782566 Please cross-check with IPVS mode for similar changes?