### PR TITLE
Always set content-type & nosniff

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -552,6 +552,8 @@ func (s *ProxyServer) Run() error {
 		proxyMux := mux.NewPathRecorderMux("kube-proxy")
 		healthz.InstallHandler(proxyMux)
 		proxyMux.HandleFunc("/proxyMode", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
 			fmt.Fprintf(w, "%s", s.ProxyMode)
 		})
 		proxyMux.Handle("/metrics", legacyregistry.Handler())

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -299,6 +299,8 @@ func installMetricHandler(pathRecorderMux *mux.PathRecorderMux) {
 	pathRecorderMux.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == "DELETE" {
 			metrics.Reset()
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
 			io.WriteString(w, "metrics reset\n")
 			return
 		}

--- a/pkg/controller/garbagecollector/dump.go
+++ b/pkg/controller/garbagecollector/dump.go
@@ -273,6 +273,8 @@ func (h *debugHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("Content-Type", "text/vnd.graphviz")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Write(data)
 	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/proxy/healthcheck/healthcheck.go
+++ b/pkg/proxy/healthcheck/healthcheck.go
@@ -210,6 +210,7 @@ func (h hcHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	h.hcs.lock.RUnlock()
 
 	resp.Header().Set("Content-Type", "application/json")
+	resp.Header().Set("X-Content-Type-Options", "nosniff")
 	if count == 0 {
 		resp.WriteHeader(http.StatusServiceUnavailable)
 	} else {
@@ -338,6 +339,7 @@ func (h healthzHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	currentTime := h.hs.clock.Now()
 
 	resp.Header().Set("Content-Type", "application/json")
+	resp.Header().Set("X-Content-Type-Options", "nosniff")
 	if !lastUpdated.IsZero() && currentTime.After(lastUpdated.Add(h.hs.healthTimeout)) {
 		resp.WriteHeader(http.StatusServiceUnavailable)
 	} else {

--- a/pkg/util/configz/configz.go
+++ b/pkg/util/configz/configz.go
@@ -118,6 +118,7 @@ func write(w http.ResponseWriter) error {
 		return fmt.Errorf("error marshaling json: %v", err)
 	}
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	_, err = w.Write(b)
 	return err
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/flags.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/flags.go
@@ -121,6 +121,7 @@ func StringFlagPutHandler(setter StringFlagSetterFunc) http.HandlerFunc {
 // writePlainText renders a simple string response.
 func writePlainText(statusCode int, text string, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(statusCode)
 	fmt.Fprintln(w, text)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

HTTP responses should always set a content-type header, and `nosniff` option to prevent certain types of XSS or mime attacks.

Follow-up to https://github.com/kubernetes/kubernetes/pull/72520 to fix a few more cases.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @dims 