### PR TITLE
Fix flaking evictions test

### DIFF
--- a/test/integration/evictions/evictions_test.go
+++ b/test/integration/evictions/evictions_test.go
@@ -86,7 +86,7 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 		}
 	}
 
-	waitToObservePods(t, informers.Core().V1().Pods().Informer(), numOfEvictions)
+	waitToObservePods(t, informers.Core().V1().Pods().Informer(), numOfEvictions, v1.PodRunning)
 
 	pdb := newPDB()
 	if _, err := clientSet.Policy().PodDisruptionBudgets(ns.Name).Create(pdb); err != nil {
@@ -193,17 +193,20 @@ func TestTerminalPodEviction(t *testing.T) {
 	if _, err := clientSet.CoreV1().Pods(ns.Name).Create(pod); err != nil {
 		t.Errorf("Failed to create pod: %v", err)
 	}
+
 	addPodConditionSucceeded(pod)
 	if _, err := clientSet.CoreV1().Pods(ns.Name).UpdateStatus(pod); err != nil {
 		t.Fatal(err)
 	}
 
-	waitToObservePods(t, informers.Core().V1().Pods().Informer(), 1)
+	waitToObservePods(t, informers.Core().V1().Pods().Informer(), 1, v1.PodSucceeded)
 
 	pdb := newPDB()
 	if _, err := clientSet.Policy().PodDisruptionBudgets(ns.Name).Create(pdb); err != nil {
 		t.Errorf("Failed to create PodDisruptionBudget: %v", err)
 	}
+
+	waitPDBStable(t, clientSet, 1, ns.Name, pdb.Name)
 
 	pdbList, err := clientSet.Policy().PodDisruptionBudgets(ns.Name).List(metav1.ListOptions{})
 	if err != nil {
@@ -341,13 +344,19 @@ func rmSetup(t *testing.T) (*httptest.Server, framework.CloseFunc, *disruption.D
 // wait for the podInformer to observe the pods. Call this function before
 // running the RS controller to prevent the rc manager from creating new pods
 // rather than adopting the existing ones.
-func waitToObservePods(t *testing.T, podInformer cache.SharedIndexInformer, podNum int) {
+func waitToObservePods(t *testing.T, podInformer cache.SharedIndexInformer, podNum int, phase v1.PodPhase) {
 	if err := wait.PollImmediate(2*time.Second, 60*time.Second, func() (bool, error) {
 		objects := podInformer.GetIndexer().List()
-		if len(objects) == podNum {
-			return true, nil
+		if len(objects) != podNum {
+			return false, nil
 		}
-		return false, nil
+		for _, obj := range objects {
+			pod := obj.(*v1.Pod)
+			if pod.Status.Phase != phase {
+				return false, nil
+			}
+		}
+		return true, nil
 	}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
`TestTerminalPodEviction` is flaking as discussed in #70180. This should fix this by addressing to races in the test. 
First, it makes sure that the DisruptionController observe the newly created PDB and the pod which is covered by the PDB before doing the eviction. Without this change, there is a chance that the controller reconciles the state while the eviction is happening, which will cause the test to fail because the ObservedGeneration differs between the new and old version of the PDB.
Second, it makes sure that the updated pod condition is observed before creating the PDB.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
