### PR TITLE
Refactored cloud controller manager flogs into constants

### DIFF
--- a/cmd/cloud-controller-manager/app/options/BUILD
+++ b/cmd/cloud-controller-manager/app/options/BUILD
@@ -8,7 +8,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["options.go"],
+    srcs = [
+        "options.go",
+        "constant.go"
+    ],
     importpath = "k8s.io/kubernetes/cmd/cloud-controller-manager/app/options",
     deps = [
         "//cmd/cloud-controller-manager/app/apis/config:go_default_library",

--- a/cmd/cloud-controller-manager/app/options/constant.go
+++ b/cmd/cloud-controller-manager/app/options/constant.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+const (
+	// cloudControllerManagerUserAgent is the userAgent name when starting cloud-controller managers.
+	cloudControllerManagerUserAgent = "cloud-controller-manager"
+
+	// DefaultInsecureCloudControllerManagerPort is the default insecure cloud-controller manager port.
+	DefaultInsecureCloudControllerManagerPort = 0
+
+	// CloudControllerManagerServiceController cloud controller manager service controller name.
+	CloudControllerManagerServiceController = "service controller"
+
+	// CloudControllerManagerSecureServing cloud controller manager secure serving option value.
+	CloudControllerManagerSecureServing = "secure serving"
+
+	// CloudControllerManagerInsecureServing cloud controller manager insecure serving option value.
+	CloudControllerManagerInsecureServing = "insecure serving"
+
+	// CloudControllerManagerAuthentication flag sets authentication headers.
+	CloudControllerManagerAuthentication = "authentication"
+
+	// CloudControllerManagerAuthorization  flag sets authentication headers.
+	CloudControllerManagerAuthorization = "authorization"
+
+	// CloudControllerManagerMisc initiate misc/additional flags.
+	CloudControllerManagerMisc = "misc"
+
+	// CloudControllerManagerMaster flag sets the address of the Kubernetes API server.
+	CloudControllerManagerMaster = "master"
+
+	// CloudControllerManagerKubeConfig flag sets Path to kubeconfig file with authorization and master location information.
+	CloudControllerManagerKubeConfig = "kubeconfig"
+
+	// CloudControllerManagerNodeStatusUpdateFrequency flag sets specifies how often the controller updates nodes' status.
+	CloudControllerManagerNodeStatusUpdateFrequency = "node-status-update-frequency"
+
+	// CloudControllerManagerInsecureServingNetworkProtocol defines the default insecure serving network protocol
+	CloudControllerManagerInsecureServingNetworkProtocol = "tcp"
+)

--- a/cmd/controller-manager/app/options/cloudprovider.go
+++ b/cmd/controller-manager/app/options/cloudprovider.go
@@ -36,10 +36,10 @@ func (s *CloudProviderOptions) Validate() []error {
 
 // AddFlags adds flags related to cloudprovider for controller manager to the specified FlagSet.
 func (s *CloudProviderOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&s.Name, "cloud-provider", s.Name,
+	fs.StringVar(&s.Name, ControllerManagerCloudProvider, s.Name,
 		"The provider for cloud services. Empty string for no provider.")
 
-	fs.StringVar(&s.CloudConfigFile, "cloud-config", s.CloudConfigFile,
+	fs.StringVar(&s.CloudConfigFile, ControllerManagerCloudConfig, s.CloudConfigFile,
 		"The path to the cloud provider configuration file. Empty string for no configuration file.")
 }
 

--- a/cmd/controller-manager/app/options/constant.go
+++ b/cmd/controller-manager/app/options/constant.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+const (
+	// ControllerManagerGeneric flag sets generic cloud controller manager option.
+	ControllerManagerGeneric = "generic"
+
+	// ControllerManagerHiddenMark sets hidden flag.
+	ControllerManagerHiddenMark = "controllers"
+
+	// ControllerManagerCloudProvider sets the provider for cloud services.
+	ControllerManagerCloudProvider = "cloud-provider"
+
+	// ControllerManagerCloudConfig sets the path to the cloud provider configuration file.
+	ControllerManagerCloudConfig = "cloud-config"
+
+	// ControllerManagerProfiling enable profiling via web interface host:port/debug/pprof/.
+	ControllerManagerProfiling = "profiling"
+
+	// ControllerManagerContentionProfiling enable lock contention profiling, if profiling is enabled.
+	ControllerManagerContentionProfiling = "contention-profiling"
+
+	// ControllerManagerDebugging enable debugging mod.
+	ControllerManagerDebugging = "debugging"
+
+	// ControllerManagerMinimumResyncPeriod sets the resync period in reflectors.
+	ControllerManagerMinimumResyncPeriod = "min-resync-period"
+
+	// ControllerManagerKubeApiContentType sets content type of requests sent to apiserver.
+	ControllerManagerKubeApiContentType = "kube-api-content-type"
+
+	// ControllerManagerKubeApiQps sets QPS to use while talking with kubernetes apiserver.
+	ControllerManagerKubeApiQps = "kube-api-qps"
+
+	// ControllerManagerKubeApiBurst sets burst to use while talking with kubernetes apiserver.
+	ControllerManagerKubeApiBurst = "kube-api-burst"
+
+	// ControllerManagerControllerStartInterval sets interval between starting controller managers.
+	ControllerManagerControllerStartInterval = "controller-start-interval"
+
+	// ControllerManagerCloudProviderGceLbSrcCidrs sets google compute emgine cloud provider load balancer cidrs.
+	ControllerManagerCloudProviderGceLbSrcCidrs = "cloud-provider-gce-lb-src-cidrs"
+
+	// ControllerManagerExternalCloudVolumeProvider sets the plugin to use when cloud provider is set to external.
+	ControllerManagerExternalCloudVolumeProvider = "external-cloud-volume-plugin"
+
+	// ControllerManagerUseServiceAccountCredentials if true, use individual service account credentials for each controller.
+	ControllerManagerUseServiceAccountCredentials = "use-service-account-credentials"
+
+	// ControllerManagerAllowUntaggedCloud allow the cluster to run without the cluster-id on cloud instances.
+	ControllerManagerAllowUntaggedCloud = "allow-untagged-cloud"
+
+	// ControllerManagerRouteReconciliationPeriod sets the period for reconciling routes created for Nodes by cloud provider.
+	ControllerManagerRouteReconciliationPeriod = "route-reconciliation-period"
+
+	// ControllerManagerNodeMonitorPeriod sets the period for syncing NodeStatus in NodeController.
+	ControllerManagerNodeMonitorPeriod = "node-monitor-period"
+
+	// ControllerManagerClusterName sets the instance prefix for the cluster.
+	ControllerManagerClusterName = "cluster-name"
+
+	// ControllerManagerClusterCidr sets CIDR Range for Pods in cluster.
+	ControllerManagerClusterCidr = "cluster-cidr"
+
+	// ControllerManagerAllocateNodeCidrs defines should CIDRs for Pods be allocated and set on the cloud provider.
+	ControllerManagerAllocateNodeCidrs = "allocate-node-cidrs"
+
+	// ControllerManagerCidrAllocatorType sets type of CIDR allocator to use.
+	ControllerManagerCidrAllocatorType = "cidr-allocator-type"
+
+	// ControllerManagerCidrAllocatorType value for range allocator type.
+	ControllerManagerRangeAllocatorType = "RangeAllocator"
+
+	// ControllerManagerConfigureCloudRoutes defines should CIDRs allocated by allocate-node-cidrs be configured on the cloud provider.
+	ControllerManagerConfigureCloudRoutes = "configure-cloud-routes"
+
+	// ControllerManagerNodeSyncPeriod this flag is deprecated and will be removed in future releases.
+	ControllerManagerNodeSyncPeriod = "node-sync-period"
+
+	// ControllerManagerNodeSyncPeriod sets the number of services that are allowed to sync concurrently.
+	ControllerManagerConcurrentServiceSyncs = "concurrent-service-syncs"
+)

--- a/cmd/controller-manager/app/options/debugging.go
+++ b/cmd/controller-manager/app/options/debugging.go
@@ -34,9 +34,9 @@ func (o *DebuggingOptions) AddFlags(fs *pflag.FlagSet) {
 		return
 	}
 
-	fs.BoolVar(&o.EnableProfiling, "profiling", o.EnableProfiling,
+	fs.BoolVar(&o.EnableProfiling, ControllerManagerProfiling, o.EnableProfiling,
 		"Enable profiling via web interface host:port/debug/pprof/")
-	fs.BoolVar(&o.EnableContentionProfiling, "contention-profiling", o.EnableContentionProfiling,
+	fs.BoolVar(&o.EnableContentionProfiling, ControllerManagerContentionProfiling, o.EnableContentionProfiling,
 		"Enable lock contention profiling, if profiling is enabled")
 }
 

--- a/cmd/controller-manager/app/options/generic.go
+++ b/cmd/controller-manager/app/options/generic.go
@@ -65,15 +65,15 @@ func (o *GenericControllerManagerConfigurationOptions) AddFlags(fss *apiserverfl
 		return
 	}
 
-	o.Debugging.AddFlags(fss.FlagSet("debugging"))
-	genericfs := fss.FlagSet("generic")
-	genericfs.DurationVar(&o.MinResyncPeriod.Duration, "min-resync-period", o.MinResyncPeriod.Duration, "The resync period in reflectors will be random between MinResyncPeriod and 2*MinResyncPeriod.")
-	genericfs.StringVar(&o.ClientConnection.ContentType, "kube-api-content-type", o.ClientConnection.ContentType, "Content type of requests sent to apiserver.")
-	genericfs.Float32Var(&o.ClientConnection.QPS, "kube-api-qps", o.ClientConnection.QPS, "QPS to use while talking with kubernetes apiserver.")
-	genericfs.Int32Var(&o.ClientConnection.Burst, "kube-api-burst", o.ClientConnection.Burst, "Burst to use while talking with kubernetes apiserver.")
-	genericfs.DurationVar(&o.ControllerStartInterval.Duration, "controller-start-interval", o.ControllerStartInterval.Duration, "Interval between starting controller managers.")
+	o.Debugging.AddFlags(fss.FlagSet(ControllerManagerDebugging))
+	genericfs := fss.FlagSet(ControllerManagerGeneric)
+	genericfs.DurationVar(&o.MinResyncPeriod.Duration, ControllerManagerMinimumResyncPeriod, o.MinResyncPeriod.Duration, "The resync period in reflectors will be random between MinResyncPeriod and 2*MinResyncPeriod.")
+	genericfs.StringVar(&o.ClientConnection.ContentType, ControllerManagerKubeApiContentType, o.ClientConnection.ContentType, "Content type of requests sent to apiserver.")
+	genericfs.Float32Var(&o.ClientConnection.QPS, ControllerManagerKubeApiQps, o.ClientConnection.QPS, "QPS to use while talking with kubernetes apiserver.")
+	genericfs.Int32Var(&o.ClientConnection.Burst, ControllerManagerKubeApiBurst, o.ClientConnection.Burst, "Burst to use while talking with kubernetes apiserver.")
+	genericfs.DurationVar(&o.ControllerStartInterval.Duration, ControllerManagerControllerStartInterval, o.ControllerStartInterval.Duration, "Interval between starting controller managers.")
 	// TODO: complete the work of the cloud-controller-manager (and possibly other consumers of this code) respecting the --controllers flag
-	genericfs.StringSliceVar(&o.Controllers, "controllers", o.Controllers, fmt.Sprintf(""+
+	genericfs.StringSliceVar(&o.Controllers, ControllerManagerHiddenMark, o.Controllers, fmt.Sprintf(""+
 		"A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller "+
 		"named 'foo', '-foo' disables the controller named 'foo'.\nAll controllers: %s\nDisabled-by-default controllers: %s",
 		strings.Join(allControllers, ", "), strings.Join(disabledByDefaultControllers, ", ")))

--- a/cmd/controller-manager/app/options/globalflags.go
+++ b/cmd/controller-manager/app/options/globalflags.go
@@ -31,5 +31,5 @@ import (
 func AddCustomGlobalFlags(fs *pflag.FlagSet) {
 	// lookup flags in global flag set and re-register the values with our flagset
 	// adds flags from k8s.io/kubernetes/pkg/cloudprovider/providers
-	globalflag.Register(fs, "cloud-provider-gce-lb-src-cidrs")
+	globalflag.Register(fs, ControllerManagerCloudProviderGceLbSrcCidrs)
 }

--- a/cmd/controller-manager/app/options/globalflags_test.go
+++ b/cmd/controller-manager/app/options/globalflags_test.go
@@ -34,7 +34,7 @@ func TestAddCustomGlobalFlags(t *testing.T) {
 	// Note that we will register all flags (including klog flags) into the same
 	// flag set. This allows us to test against all global flags from
 	// flags.CommandLine.
-	nfs := namedFlagSets.FlagSet("generic")
+	nfs := namedFlagSets.FlagSet(ControllerManagerGeneric)
 	globalflag.AddGlobalFlags(nfs, "test-cmd")
 	AddCustomGlobalFlags(nfs)
 

--- a/cmd/controller-manager/app/options/kubecloudshared.go
+++ b/cmd/controller-manager/app/options/kubecloudshared.go
@@ -64,23 +64,23 @@ func (o *KubeCloudSharedOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 
 	o.CloudProvider.AddFlags(fs)
-	fs.StringVar(&o.ExternalCloudVolumePlugin, "external-cloud-volume-plugin", o.ExternalCloudVolumePlugin, "The plugin to use when cloud provider is set to external. Can be empty, should only be set when cloud-provider is external. Currently used to allow node and volume controllers to work for in tree cloud providers.")
-	fs.BoolVar(&o.UseServiceAccountCredentials, "use-service-account-credentials", o.UseServiceAccountCredentials, "If true, use individual service account credentials for each controller.")
-	fs.BoolVar(&o.AllowUntaggedCloud, "allow-untagged-cloud", false, "Allow the cluster to run without the cluster-id on cloud instances. This is a legacy mode of operation and a cluster-id will be required in the future.")
-	fs.MarkDeprecated("allow-untagged-cloud", "This flag is deprecated and will be removed in a future release. A cluster-id will be required on cloud instances.")
-	fs.DurationVar(&o.RouteReconciliationPeriod.Duration, "route-reconciliation-period", o.RouteReconciliationPeriod.Duration, "The period for reconciling routes created for Nodes by cloud provider.")
-	fs.DurationVar(&o.NodeMonitorPeriod.Duration, "node-monitor-period", o.NodeMonitorPeriod.Duration,
+	fs.StringVar(&o.ExternalCloudVolumePlugin, ControllerManagerExternalCloudVolumeProvider, o.ExternalCloudVolumePlugin, "The plugin to use when cloud provider is set to external. Can be empty, should only be set when cloud-provider is external. Currently used to allow node and volume controllers to work for in tree cloud providers.")
+	fs.BoolVar(&o.UseServiceAccountCredentials, ControllerManagerUseServiceAccountCredentials, o.UseServiceAccountCredentials, "If true, use individual service account credentials for each controller.")
+	fs.BoolVar(&o.AllowUntaggedCloud, ControllerManagerAllowUntaggedCloud, false, "Allow the cluster to run without the cluster-id on cloud instances. This is a legacy mode of operation and a cluster-id will be required in the future.")
+	fs.MarkDeprecated(ControllerManagerAllowUntaggedCloud, "This flag is deprecated and will be removed in a future release. A cluster-id will be required on cloud instances.")
+	fs.DurationVar(&o.RouteReconciliationPeriod.Duration, ControllerManagerRouteReconciliationPeriod, o.RouteReconciliationPeriod.Duration, "The period for reconciling routes created for Nodes by cloud provider.")
+	fs.DurationVar(&o.NodeMonitorPeriod.Duration, ControllerManagerNodeMonitorPeriod, o.NodeMonitorPeriod.Duration,
 		"The period for syncing NodeStatus in NodeController.")
-	fs.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "The instance prefix for the cluster.")
-	fs.StringVar(&o.ClusterCIDR, "cluster-cidr", o.ClusterCIDR, "CIDR Range for Pods in cluster. Requires --allocate-node-cidrs to be true")
-	fs.BoolVar(&o.AllocateNodeCIDRs, "allocate-node-cidrs", false, "Should CIDRs for Pods be allocated and set on the cloud provider.")
-	fs.StringVar(&o.CIDRAllocatorType, "cidr-allocator-type", "RangeAllocator", "Type of CIDR allocator to use")
-	fs.BoolVar(&o.ConfigureCloudRoutes, "configure-cloud-routes", true, "Should CIDRs allocated by allocate-node-cidrs be configured on the cloud provider.")
+	fs.StringVar(&o.ClusterName, ControllerManagerClusterName, o.ClusterName, "The instance prefix for the cluster.")
+	fs.StringVar(&o.ClusterCIDR, ControllerManagerClusterCidr, o.ClusterCIDR, "CIDR Range for Pods in cluster. Requires --allocate-node-cidrs to be true")
+	fs.BoolVar(&o.AllocateNodeCIDRs, ControllerManagerAllocateNodeCidrs, false, "Should CIDRs for Pods be allocated and set on the cloud provider.")
+	fs.StringVar(&o.CIDRAllocatorType, ControllerManagerCidrAllocatorType, ControllerManagerRangeAllocatorType, "Type of CIDR allocator to use")
+	fs.BoolVar(&o.ConfigureCloudRoutes, ControllerManagerConfigureCloudRoutes, true, "Should CIDRs allocated by allocate-node-cidrs be configured on the cloud provider.")
 
-	fs.DurationVar(&o.NodeSyncPeriod.Duration, "node-sync-period", 0, ""+
+	fs.DurationVar(&o.NodeSyncPeriod.Duration, ControllerManagerNodeSyncPeriod, 0, ""+
 		"This flag is deprecated and will be removed in future releases. See node-monitor-period for Node health checking or "+
 		"route-reconciliation-period for cloud provider's route configuration settings.")
-	fs.MarkDeprecated("node-sync-period", "This flag is currently no-op and will be deleted.")
+	fs.MarkDeprecated(ControllerManagerNodeSyncPeriod, "This flag is currently no-op and will be deleted.")
 }
 
 // ApplyTo fills up KubeCloudShared config with options.

--- a/cmd/controller-manager/app/options/servicecontroller.go
+++ b/cmd/controller-manager/app/options/servicecontroller.go
@@ -33,7 +33,7 @@ func (o *ServiceControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		return
 	}
 
-	fs.Int32Var(&o.ConcurrentServiceSyncs, "concurrent-service-syncs", o.ConcurrentServiceSyncs, "The number of services that are allowed to sync concurrently. Larger number = more responsive service management, but more CPU (and network) load")
+	fs.Int32Var(&o.ConcurrentServiceSyncs, ControllerManagerConcurrentServiceSyncs, o.ConcurrentServiceSyncs, "The number of services that are allowed to sync concurrently. Larger number = more responsive service management, but more CPU (and network) load")
 }
 
 // ApplyTo fills up ServiceController config with options.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Refactored cloud controller manager options flags into constants.
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/1336

**Special notes for your reviewer**:

1) Please take a carefull look at constants description, honestly not sure about some flags.
2) Should we also move to constants, hardcode like this https://github.com/kubernetes/kubeadm/issues/1336 ?

**Does this PR introduce a user-facing change?**:

`NONE`
