### PR TITLE
Move CacheDebugger signal handling into the package.

### DIFF
--- a/pkg/scheduler/factory/BUILD
+++ b/pkg/scheduler/factory/BUILD
@@ -5,8 +5,6 @@ go_library(
     srcs = [
         "factory.go",
         "plugins.go",
-        "signal.go",
-        "signal_windows.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/factory",
     visibility = ["//visibility:public"],

--- a/pkg/scheduler/internal/cache/debugger/BUILD
+++ b/pkg/scheduler/internal/cache/debugger/BUILD
@@ -6,6 +6,8 @@ go_library(
         "comparer.go",
         "debugger.go",
         "dumper.go",
+        "signal.go",
+        "signal_windows.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/internal/cache/debugger",
     visibility = ["//pkg/scheduler:__subpackages__"],

--- a/pkg/scheduler/internal/cache/debugger/signal.go
+++ b/pkg/scheduler/internal/cache/debugger/signal.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 /*
 Copyright 2018 The Kubernetes Authors.
 
@@ -14,10 +16,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factory
+package debugger
 
-import "os"
+import "syscall"
 
-// compareSignal is the signal to trigger cache compare. For windows,
-// it's SIGINT.
-var compareSignal = os.Interrupt
+// compareSignal is the signal to trigger cache compare. For non-windows
+// environment it's SIGUSR2.
+var compareSignal = syscall.SIGUSR2

--- a/pkg/scheduler/internal/cache/debugger/signal_windows.go
+++ b/pkg/scheduler/internal/cache/debugger/signal_windows.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
 Copyright 2018 The Kubernetes Authors.
 
@@ -16,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factory
+package debugger
 
-import "syscall"
+import "os"
 
-// compareSignal is the signal to trigger cache compare. For non-windows
-// environment it's SIGUSR2.
-var compareSignal = syscall.SIGUSR2
+// compareSignal is the signal to trigger cache compare. For windows,
+// it's SIGINT.
+var compareSignal = os.Interrupt


### PR DESCRIPTION

**What this PR does / why we need it**:

This moves the signal handling for CacheDebugger from the factory
package into the CacheDebugger's package. That makes it easier to reuse
from packages other than factory.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/72543

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
