### PR TITLE
Delete non-existent cloud provider nodes with Ready condition Unknown

### DIFF
--- a/pkg/controller/cloud/node_lifecycle_controller.go
+++ b/pkg/controller/cloud/node_lifecycle_controller.go
@@ -146,18 +146,6 @@ func (c *CloudNodeLifecycleController) MonitorNodes() {
 			continue
 		}
 
-		// node condition is unknown so we should not try to update it
-		if status == v1.ConditionUnknown {
-			continue
-		}
-
-		// status for NodeReady should be false at this point, this check
-		// is here as a fail safe in the case a new node condition is added
-		// without consideration of this controller
-		if status != v1.ConditionFalse {
-			continue
-		}
-
 		// we need to check this first to get taint working in similar in all cloudproviders
 		// current problem is that shutdown nodes are not working in similar way ie. all cloudproviders
 		// does not delete node from kubernetes cluster when instance it is shutdown see issue #46442

--- a/pkg/controller/cloud/node_lifecycle_controller_test.go
+++ b/pkg/controller/cloud/node_lifecycle_controller_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -164,7 +165,9 @@ func Test_NodesDeleted(t *testing.T) {
 			fakeCloud: &fakecloud.FakeCloud{
 				ExistsByProviderID: false,
 			},
-			deleteNodes: []*v1.Node{},
+			deleteNodes: []*v1.Node{
+				testutil.NewNode("node0"),
+			},
 		},
 		{
 			name: "node ready condition is unknown, node exists",
@@ -191,7 +194,11 @@ func Test_NodesDeleted(t *testing.T) {
 				Clientset:    fake.NewSimpleClientset(),
 			},
 			fakeCloud: &fakecloud.FakeCloud{
+				NodeShutdown:       false,
 				ExistsByProviderID: true,
+				ExtID: map[types.NodeName]string{
+					types.NodeName("node0"): "foo://12345",
+				},
 			},
 			deleteNodes: []*v1.Node{},
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Also deletes nodes with Ready condition `Unknown` if the node does not exist in the cloud provider. This was introduced in https://github.com/kubernetes/kubernetes/pull/70344 because we assumed that deleted nodes report Ready condition as `False` instead of `Unknown`. This PR changes the logic to delete any node that has a Ready condition that is not `True` and does not exist in the cloud provider (consistent with what we already had prior to merging https://github.com/kubernetes/kubernetes/pull/70344).

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes/kubernetes/issues/72499

**Special notes for your reviewer**:
@mtaufen I'm not sure if we should be expecting this condition to be `Unknown`, but I've opened this PR to bring things back to what they were prior to https://github.com/kubernetes/kubernetes/pull/70344. Let me know if you prefer another solution. 

**Does this PR introduce a user-facing change?**:
```release-note
Nodes deleted in the cloud provider with Ready condition `Unknown` should also be deleted on the API server. 
```

/assign @mtaufen 
/sig cloud-provider node