### PR TITLE
Add labels in the github template metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug Report
 about: Report a bug encountered while operating Kubernetes
+labels: kind/bug
 
 ---
 
@@ -22,6 +23,3 @@ about: Report a bug encountered while operating Kubernetes
 - Kernel (e.g. `uname -a`):
 - Install tools:
 - Others:
-
-<!-- DO NOT EDIT BELOW THIS LINE -->
-/kind bug

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,6 +1,7 @@
 ---
 name: Enhancement Request
 about: Suggest an enhancement to the Kubernetes project
+labels: kind/feature
 
 ---
 <!-- Please only use this template for submitting enhancement requests -->
@@ -8,6 +9,3 @@ about: Suggest an enhancement to the Kubernetes project
 **What would you like to be added**:
 
 **Why is this needed**:
-
-<!-- DO NOT EDIT BELOW THIS LINE -->
-/kind feature

--- a/.github/ISSUE_TEMPLATE/failing-test.md
+++ b/.github/ISSUE_TEMPLATE/failing-test.md
@@ -1,6 +1,7 @@
 ---
 name: Failing Test
 about: Report test failures in Kubernetes CI jobs
+labels: kind/failing-test
 
 ---
 
@@ -17,6 +18,3 @@ about: Report test failures in Kubernetes CI jobs
 **Reason for failure**:
 
 **Anything else we need to know**:
-
-<!-- DO NOT EDIT BELOW THIS LINE -->
-/kind failing-test

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,6 +1,7 @@
 ---
 name: Support Request
 about: Support request or question relating to Kubernetes
+labels: triage/support
 
 ---
 
@@ -15,8 +16,3 @@ You can also post your question on the [Kubernetes Slack](http://slack.k8s.io/) 
 
 If the matter is security related, please disclose it privately via https://kubernetes.io/security/.
 -->
-
-<!-- DO NOT EDIT BELOW THIS LINE -->
-
-/triage support
-


### PR DESCRIPTION
GitHub now allows you to specify labels by default as a part of the template. This PR updates our templates to use this.

Ref: https://help.github.com/articles/creating-issue-templates-for-your-repository/

Similar PR for kubernetes/org: https://github.com/kubernetes/org/pull/329

/assign @cblecker 


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
