### PR TITLE
Add e2e test for services with no endpoints

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -1748,6 +1749,62 @@ var _ = SIGDescribe("Services", func() {
 		By("verifying service-disabled is still not up")
 		framework.ExpectNoError(framework.VerifyServeHostnameServiceDown(cs, host, svcDisabledIP, servicePort))
 	})
+
+	It("should be rejected when no endpoints exist", func() {
+		namespace := f.Namespace.Name
+		serviceName := "no-pods"
+		jig := framework.NewServiceTestJig(cs, serviceName)
+		nodes := jig.GetNodes(framework.MaxNodesForEndpointsTests)
+		labels := map[string]string{
+			"nopods": "nopods",
+		}
+		ports := []v1.ServicePort{{
+			Port:       80,
+			TargetPort: intstr.FromInt(80),
+		}}
+
+		By("creating a service with no endpoints")
+		svc, err := jig.CreateServiceWithServicePort(labels, namespace, ports)
+		if err != nil {
+			framework.Failf("Failed to create service: %v", err)
+		}
+
+		port := strconv.Itoa(int(svc.Spec.Ports[0].Port))
+		servicePort := net.JoinHostPort(serviceName, port)
+		nodeName := nodes.Items[0].Name
+		podName := "execpod-noendpoints"
+
+		By(fmt.Sprintf("creating %v on node %v", podName, nodeName))
+		execPodName := framework.CreateExecPodOrFail(f.ClientSet, namespace, podName, func(pod *v1.Pod) {
+			pod.Spec.NodeName = nodeName
+		})
+		execPod, err := f.ClientSet.CoreV1().Pods(namespace).Get(execPodName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+
+		framework.Logf("waiting up to %v wget %v", framework.KubeProxyEndpointLagTimeout, servicePort)
+		cmd := fmt.Sprintf(`wget -T 10 -qO- %v`, servicePort)
+
+		By(fmt.Sprintf("hitting service %v from pod %v on node %v", servicePort, podName, nodeName))
+		expectedErr := "connection refused"
+		if pollErr := wait.PollImmediate(framework.Poll, framework.KubeProxyEndpointLagTimeout, func() (bool, error) {
+			_, err := framework.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
+
+			if err != nil {
+				if strings.Contains(strings.ToLower(err.Error()), expectedErr) {
+					framework.Logf("error contained '%s', as expected: %s", expectedErr, err.Error())
+					return true, nil
+				} else {
+					framework.Logf("error didn't contain '%s', keep trying: %s", expectedErr, err.Error())
+					return false, nil
+				}
+			} else {
+				return true, errors.New("expected wget call to fail")
+			}
+		}); pollErr != nil {
+			Expect(pollErr).NotTo(HaveOccurred())
+		}
+	})
+
 })
 
 // TODO: Get rid of [DisabledForLargeClusters] tag when issue #56138 is fixed.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds an e2e test for services that have no endpoints. Expected behaviour is a rejected connection.

master is currently broken, with requests timing out rather than being rejected. There is a fix for the regression in #72534

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20767

**Special notes for your reviewer**:
This test loops until it receives a success (fail, it shouldn't), receives the expected failure, or times out.

* I'm not certain if `framework.KubeProxyEndpointLagTimeout` is the correct timeout to use.
* Is wget string-searching acceptable? Should it be strengthened?
* I opted to print the received error each loop for clarity, but this might be too noisy.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```