### PR TITLE
Fix apimachinery/pkg/api/errors.APIStatus.Status() interface

### DIFF
--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -65,7 +65,7 @@ func AddSourceToErr(verb string, source string, err error) error {
 		if statusError, ok := err.(kerrors.APIStatus); ok {
 			status := statusError.Status()
 			status.Message = fmt.Sprintf("error when %s %q: %v", verb, source, status.Message)
-			return &kerrors.StatusError{ErrStatus: status}
+			return &kerrors.StatusError{ErrStatus: *status}
 		}
 		return fmt.Errorf("error when %s %q: %v", verb, source, err)
 	}

--- a/staging/src/k8s.io/api/Godeps/Godeps.json
+++ b/staging/src/k8s.io/api/Godeps/Godeps.json
@@ -107,6 +107,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/meta",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -38,7 +38,7 @@ const (
 // APIStatus is exposed by errors that can be converted to an api.Status object
 // for finer grained details.
 type APIStatus interface {
-	Status() metav1.Status
+	Status() *metav1.Status
 }
 
 // StatusError is an error intended for consumption by a REST API server; it can also be
@@ -54,8 +54,8 @@ func (e *StatusError) Error() string {
 
 // Status allows access to e's status without having to know the detailed workings
 // of StatusError.
-func (e *StatusError) Status() metav1.Status {
-	return e.ErrStatus
+func (e *StatusError) Status() *metav1.Status {
+	return &e.ErrStatus
 }
 
 // DebugError reports extended info about the error to debug output.

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -35,19 +35,17 @@ const (
 	StatusTooManyRequests = 429
 )
 
-// StatusError is an error intended for consumption by a REST API server; it can also be
-// reconstructed by clients from a REST response. Public to allow easy type switches.
-type StatusError struct {
-	ErrStatus metav1.Status
-}
-
 // APIStatus is exposed by errors that can be converted to an api.Status object
 // for finer grained details.
 type APIStatus interface {
 	Status() metav1.Status
 }
 
-var _ error = &StatusError{}
+// StatusError is an error intended for consumption by a REST API server; it can also be
+// reconstructed by clients from a REST response. Public to allow easy type switches.
+type StatusError struct {
+	ErrStatus metav1.Status
+}
 
 // Error implements the Error interface.
 func (e *StatusError) Error() string {
@@ -67,6 +65,9 @@ func (e *StatusError) DebugError() (string, []interface{}) {
 	}
 	return "server response object: %#v", []interface{}{e.ErrStatus}
 }
+
+var _ error = &StatusError{}
+var _ APIStatus = &StatusError{}
 
 // UnexpectedObjectError can be returned by FromObject if it's passed a non-status object.
 type UnexpectedObjectError struct {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/BUILD
@@ -14,6 +14,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
     importpath = "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
@@ -53,8 +53,8 @@ func (e errNotMarshalable) Error() string {
 	return fmt.Sprintf("object %v does not implement the protobuf marshalling interface and cannot be encoded to a protobuf message", e.t)
 }
 
-func (e errNotMarshalable) Status() metav1.Status {
-	return metav1.Status{
+func (e errNotMarshalable) Status() *metav1.Status {
+	return &metav1.Status{
 		Status:  metav1.StatusFailure,
 		Code:    http.StatusNotAcceptable,
 		Reason:  metav1.StatusReason("NotAcceptable"),

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -60,6 +61,9 @@ func (e errNotMarshalable) Status() metav1.Status {
 		Message: e.Error(),
 	}
 }
+
+var _ error = &errNotMarshalable{}
+var _ apierrors.APIStatus = &errNotMarshalable{}
 
 func IsNotMarshalable(err error) bool {
 	_, ok := err.(errNotMarshalable)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/namespace/matcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/namespace/matcher.go
@@ -103,7 +103,7 @@ func (m *Matcher) MatchNamespaceSelector(h *v1beta1.Webhook, attr admission.Attr
 		if !ok {
 			return false, apierrors.NewInternalError(err)
 		}
-		return false, &apierrors.StatusError{status.Status()}
+		return false, &apierrors.StatusError{ErrStatus: *status.Status()}
 	}
 	if err != nil {
 		return false, apierrors.NewInternalError(err)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = ["negotiate_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
@@ -26,6 +27,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers/negotiation",
     importpath = "k8s.io/apiserver/pkg/endpoints/handlers/negotiation",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/errors.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -46,6 +47,9 @@ func (e errNotAcceptable) Status() metav1.Status {
 	}
 }
 
+var _ error = &errNotAcceptable{}
+var _ apierrors.APIStatus = &errNotAcceptable{}
+
 // errUnsupportedMediaType indicates Content-Type is not recognized
 type errUnsupportedMediaType struct {
 	accepted []string
@@ -67,3 +71,6 @@ func (e errUnsupportedMediaType) Status() metav1.Status {
 		Message: e.Error(),
 	}
 }
+
+var _ error = &errUnsupportedMediaType{}
+var _ apierrors.APIStatus = &errUnsupportedMediaType{}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/errors.go
@@ -38,8 +38,8 @@ func (e errNotAcceptable) Error() string {
 	return fmt.Sprintf("only the following media types are accepted: %v", strings.Join(e.accepted, ", "))
 }
 
-func (e errNotAcceptable) Status() metav1.Status {
-	return metav1.Status{
+func (e errNotAcceptable) Status() *metav1.Status {
+	return &metav1.Status{
 		Status:  metav1.StatusFailure,
 		Code:    http.StatusNotAcceptable,
 		Reason:  metav1.StatusReasonNotAcceptable,
@@ -63,8 +63,8 @@ func (e errUnsupportedMediaType) Error() string {
 	return fmt.Sprintf("the body of the request was in an unknown format - accepted media types include: %v", strings.Join(e.accepted, ", "))
 }
 
-func (e errUnsupportedMediaType) Status() metav1.Status {
-	return metav1.Status{
+func (e errUnsupportedMediaType) Status() *metav1.Status {
+	return &metav1.Status{
 		Status:  metav1.StatusFailure,
 		Code:    http.StatusUnsupportedMediaType,
 		Reason:  metav1.StatusReasonUnsupportedMediaType,

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate_test.go
@@ -21,14 +21,10 @@ import (
 	"net/url"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
-
-// statusError is an object that can be converted into an metav1.Status
-type statusError interface {
-	Status() metav1.Status
-}
 
 type fakeNegotiater struct {
 	serializer, streamSerializer runtime.Serializer
@@ -243,9 +239,9 @@ func TestNegotiate(t *testing.T) {
 			if !test.errFn(err) {
 				t.Errorf("%d: failed: %v", i, err)
 			}
-			status, ok := err.(statusError)
+			status, ok := err.(apierrors.APIStatus)
 			if !ok {
-				t.Errorf("%d: failed, error should be statusError: %v", i, err)
+				t.Errorf("%d: failed, error should be apierrors.APIStatus: %v", i, err)
 				continue
 			}
 			if status.Status().Status != metav1.StatusFailure || status.Status().Code != http.StatusNotAcceptable {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response.go
@@ -121,8 +121,8 @@ func (e errNotAcceptable) Error() string {
 	return e.message
 }
 
-func (e errNotAcceptable) Status() metav1.Status {
-	return metav1.Status{
+func (e errNotAcceptable) Status() *metav1.Status {
+	return &metav1.Status{
 		Status:  metav1.StatusFailure,
 		Code:    http.StatusNotAcceptable,
 		Reason:  metav1.StatusReason("NotAcceptable"),

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response.go
@@ -130,6 +130,9 @@ func (e errNotAcceptable) Status() metav1.Status {
 	}
 }
 
+var _ error = &errNotAcceptable{}
+var _ errors.APIStatus = &errNotAcceptable{}
+
 func asV1Beta1Table(ctx context.Context, result runtime.Object, opts *metav1beta1.TableOptions, scope RequestScope) (runtime.Object, error) {
 	trace := scope.Trace
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
@@ -45,7 +45,7 @@ func ErrorToAPIStatus(err error) *metav1.Status {
 		status.Kind = "Status"
 		status.APIVersion = "v1"
 		//TODO: check for invalid responses
-		return &status
+		return status
 	default:
 		status := http.StatusInternalServerError
 		switch {
@@ -57,7 +57,7 @@ func ErrorToAPIStatus(err error) *metav1.Status {
 		// by REST storage - these typically indicate programmer
 		// error by not using pkg/api/errors, or unexpected failure
 		// cases.
-		runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %#+v", err))
+		runtime.HandleError(fmt.Errorf("apiserver received an error that is not an *metav1.Status: %#+v", err))
 		return &metav1.Status{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Status",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
@@ -20,20 +20,16 @@ import (
 	"fmt"
 	"net/http"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/storage"
 )
 
-// statusError is an object that can be converted into an metav1.Status
-type statusError interface {
-	Status() metav1.Status
-}
-
 // ErrorToAPIStatus converts an error to an metav1.Status object.
 func ErrorToAPIStatus(err error) *metav1.Status {
 	switch t := err.(type) {
-	case statusError:
+	case apierrors.APIStatus:
 		status := t.Status()
 		if len(status.Status) == 0 {
 			status.Status = metav1.StatusFailure

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -604,7 +604,7 @@ func TestWatchHTTPErrors(t *testing.T) {
 	client := http.Client{}
 	resp, err := client.Do(req)
 	errStatus := errors.NewInternalError(fmt.Errorf("we got an error")).Status()
-	watcher.Error(&errStatus)
+	watcher.Error(errStatus)
 	watcher.Stop()
 
 	// Make sure we can actually watch an endpoint
@@ -666,7 +666,7 @@ func TestWatchHTTPDynamicClientErrors(t *testing.T) {
 	}
 
 	errStatus := errors.NewInternalError(fmt.Errorf("we got an error")).Status()
-	watcher.Error(&errStatus)
+	watcher.Error(errStatus)
 	watcher.Stop()
 
 	got := <-w.ResultChan()

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/table.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/table.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
@@ -97,3 +98,6 @@ func (e errNotAcceptable) Status() metav1.Status {
 		Message: e.Error(),
 	}
 }
+
+var _ error = &errNotAcceptable{}
+var _ apierrors.APIStatus = &errNotAcceptable{}

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/table.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/table.go
@@ -90,8 +90,8 @@ func (e errNotAcceptable) Error() string {
 	return fmt.Sprintf("the resource %s does not support being converted to a Table", e.resource)
 }
 
-func (e errNotAcceptable) Status() metav1.Status {
-	return metav1.Status{
+func (e errNotAcceptable) Status() *metav1.Status {
+	return &metav1.Status{
 		Status:  metav1.StatusFailure,
 		Code:    http.StatusNotAcceptable,
 		Reason:  metav1.StatusReason("NotAcceptable"),

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -326,7 +326,7 @@ func transformErrorToEvent(err error) *watch.Event {
 	status := err.(apierrs.APIStatus).Status()
 	return &watch.Event{
 		Type:   watch.Error,
-		Object: &status,
+		Object: status,
 	}
 }
 

--- a/staging/src/k8s.io/client-go/rest/client_test.go
+++ b/staging/src/k8s.io/client-go/rest/client_test.go
@@ -115,8 +115,8 @@ func TestDoRequestFailed(t *testing.T) {
 		t.Errorf("unexpected error type %v", err)
 	}
 	actual := ss.Status()
-	if !reflect.DeepEqual(status, &actual) {
-		t.Errorf("Unexpected mis-match: %s", diff.ObjectReflectDiff(status, &actual))
+	if !reflect.DeepEqual(status, actual) {
+		t.Errorf("Unexpected mis-match: %s", diff.ObjectReflectDiff(status, actual))
 	}
 }
 
@@ -155,8 +155,8 @@ func TestDoRawRequestFailed(t *testing.T) {
 		t.Errorf("unexpected error type %v", err)
 	}
 	actual := ss.Status()
-	if !reflect.DeepEqual(status, &actual) {
-		t.Errorf("Unexpected mis-match: %s", diff.ObjectReflectDiff(status, &actual))
+	if !reflect.DeepEqual(status, actual) {
+		t.Errorf("Unexpected mis-match: %s", diff.ObjectReflectDiff(status, actual))
 	}
 }
 

--- a/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
+++ b/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
@@ -169,7 +169,7 @@ func ensureCompatible(new, orig *certificates.CertificateSigningRequest, private
 // a single argument format string, and returns the wrapped error.
 func formatError(format string, err error) error {
 	if s, ok := err.(errors.APIStatus); ok {
-		se := &errors.StatusError{ErrStatus: s.Status()}
+		se := &errors.StatusError{ErrStatus: *s.Status()}
 		se.ErrStatus.Message = fmt.Sprintf(format, se.ErrStatus.Message)
 		return se
 	}


### PR DESCRIPTION
Fix apimachinery/pkg/api/errors.APIStatus.Status() interface to return object fulfilling runtime.Object interface.


**What this PR does / why we need it**:

Currently the Status method return `metav1.Status` which doesn't fulfil `runtime.Object` interface because it's method use pointer receiver.

Also while it looks like it returns a copy of the status (by value) it is only a shallow copy.

Converting the `Status()` method to return a pointer (`*metav1.Status`) makes it clear it's not a copy and also the resulting object fulfils `runtime.Object` interface.

**Release note**:
```release-note
NONE
```

/kind cleanup

@kubernetes/sig-api-machinery-pr-reviews 
