### PR TITLE
Flush headers before streaming logs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -101,6 +101,10 @@ func StreamObject(statusCode int, gv schema.GroupVersion, s runtime.NegotiatedSe
 	}
 	w.Header().Set("Content-Type", contentType)
 	w.WriteHeader(statusCode)
+	// Flush headers, if possible
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
 	writer := w.(io.Writer)
 	if flush {
 		writer = flushwriter.Wrap(w)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

A request to get logs does not return http headers from the apiserver until the first byte of log data 
is returned.

**Which issue(s) this PR fixes**:
xref #72397

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery
