### PR TITLE
Strengthen ErrorToAPIStatus against bad input

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
@@ -38,11 +38,18 @@ func ErrorToAPIStatus(err error) *metav1.Status {
 		if len(status.Status) == 0 {
 			status.Status = metav1.StatusFailure
 		}
-		if status.Code == 0 {
-			switch status.Status {
-			case metav1.StatusSuccess:
+		switch status.Status {
+		case metav1.StatusSuccess:
+			if status.Code == 0 {
 				status.Code = http.StatusOK
-			case metav1.StatusFailure:
+			}
+		case metav1.StatusFailure:
+			if status.Code == 0 {
+				status.Code = http.StatusInternalServerError
+			}
+		default:
+			runtime.HandleError(fmt.Errorf("apiserver received an error with wrong status field : %#+v", err))
+			if status.Code == 0 {
 				status.Code = http.StatusInternalServerError
 			}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status_test.go
@@ -27,6 +27,19 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+func TestBadStatusErrorToAPIStatus(t *testing.T) {
+	err := errors.StatusError{}
+	actual := ErrorToAPIStatus(&err)
+	expected := &metav1.Status{
+		TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+		Status:   metav1.StatusFailure,
+		Code:     500,
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("%s: Expected %#v, Got %#v", actual, expected, actual)
+	}
+}
+
 func TestAPIStatus(t *testing.T) {
 	cases := map[error]metav1.Status{
 		errors.NewNotFound(schema.GroupResource{Group: "legacy.kubernetes.io", Resource: "foos"}, "bar"): {


### PR DESCRIPTION
Change-Id: Id44a59f56c074901257760ff4e40ce29820c6c50

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Trying to eliminate `ErrorToAPIStatus` as a possible culprit for us ending up with `0` as the http status by ensuring that we use `500` as default in `metav1.Status`
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
