### PR TITLE
Cluster Autoscaler 1.3.5

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.4",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.5",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Note: This is not a cherry-pick, Cluster Autoscaler versions are specific to Kubernetes versions (ie. 1.11, 1.12, 1.13 each use a different version). 

```release-note
Update Cluster Autoscaler to version 1.3.5. Release notes: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.3.5
```