### PR TITLE
preserve prior behavior of ignoring invalid --runtime-config keys

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	serverstore "k8s.io/apiserver/pkg/server/storage"
 	utilflag "k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/klog"
 )
 
 // GroupVersionRegistry provides access to registered group versions.
@@ -106,7 +107,8 @@ func MergeAPIResourceConfigs(
 		// individual resource enablement/disablement is only supported in the extensions/v1beta1 API group for legacy reasons.
 		// all other API groups are expected to contain coherent sets of resources that are enabled/disabled together.
 		if len(tokens) > 2 && (groupVersion != schema.GroupVersion{Group: "extensions", Version: "v1beta1"}) {
-			return nil, fmt.Errorf("invalid key %s, individual resource enablement/disablement is not supported in %s", key, groupVersion.String())
+			klog.Warningf("ignoring invalid key %s, individual resource enablement/disablement is not supported in %s, and will prevent starting in future releases", key, groupVersion.String())
+			continue
 		}
 
 		// Exclude group not registered into the registry.

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
@@ -117,11 +117,6 @@ func TestParseRuntimeConfig(t *testing.T) {
 			expectedAPIConfig: func() *serverstore.ResourceConfig {
 				config := newFakeAPIResourceConfigSource()
 				config.EnableVersions(scheme.PrioritizedVersionsAllGroups()...)
-				config.EnableResources(
-					extensionsapiv1beta1.SchemeGroupVersion.WithResource("deployments"),
-					extensionsapiv1beta1.SchemeGroupVersion.WithResource("replicasets"),
-					extensionsapiv1beta1.SchemeGroupVersion.WithResource("daemonsets"),
-				)
 				return config
 			},
 			err: false,
@@ -138,7 +133,6 @@ func TestParseRuntimeConfig(t *testing.T) {
 			expectedAPIConfig: func() *serverstore.ResourceConfig {
 				config := newFakeAPIResourceConfigSource()
 				config.DisableVersions(extensionsapiv1beta1.SchemeGroupVersion)
-				config.DisableResources(extensionsapiv1beta1.SchemeGroupVersion.WithResource("ingresses"))
 				return config
 			},
 			err: false,
@@ -197,11 +191,9 @@ func TestParseRuntimeConfig(t *testing.T) {
 				return newFakeAPIResourceConfigSource()
 			},
 			expectedAPIConfig: func() *serverstore.ResourceConfig {
-				config := newFakeAPIResourceConfigSource()
-				config.DisableVersions(extensionsapiv1beta1.SchemeGroupVersion)
-				return config
+				return newFakeAPIResourceConfigSource()
 			},
-			err: true,
+			err: false, // no error for backwards compatibility
 		},
 	}
 	for index, test := range testCases {

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
@@ -38,21 +38,17 @@ func NewResourceConfig() *ResourceConfig {
 	return &ResourceConfig{GroupVersionConfigs: map[schema.GroupVersion]bool{}, ResourceConfigs: map[schema.GroupVersionResource]bool{}}
 }
 
+// DisableAll disables all group/versions. It does not modify individual resource enablement/disablement.
 func (o *ResourceConfig) DisableAll() {
 	for k := range o.GroupVersionConfigs {
 		o.GroupVersionConfigs[k] = false
 	}
-	for k := range o.ResourceConfigs {
-		o.ResourceConfigs[k] = false
-	}
 }
 
+// EnableAll enables all group/versions. It does not modify individual resource enablement/disablement.
 func (o *ResourceConfig) EnableAll() {
 	for k := range o.GroupVersionConfigs {
 		o.GroupVersionConfigs[k] = true
-	}
-	for k := range o.ResourceConfigs {
-		o.ResourceConfigs[k] = true
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
@@ -98,26 +98,59 @@ func TestDisabledResource(t *testing.T) {
 		t.Errorf("expected enabled for %v, from %v", g2v1rEnabled, config)
 	}
 
-	// Enable all enables specific resources
+	// DisableAll() only disables to the group/version level for compatibility
+	// corresponds to --runtime-config=api/all=false
+	config.DisableAll()
+	if config.ResourceEnabled(g1v1rEnabled) {
+		t.Errorf("expected disabled for %v, from %v", g1v1rEnabled, config)
+	}
+	if config.ResourceEnabled(g1v2rEnabled) {
+		t.Errorf("expected disabled for %v, from %v", g1v2rEnabled, config)
+	}
+	if config.ResourceEnabled(g2v1rEnabled) {
+		t.Errorf("expected disabled for %v, from %v", g2v1rEnabled, config)
+	}
+
+	// DisableAll() only disables to the group/version level for compatibility
+	// corresponds to --runtime-config=api/all=false,g1/v1=true
+	config.DisableAll()
+	config.EnableVersions(g1v1)
+	if !config.ResourceEnabled(g1v1rEnabled) {
+		t.Errorf("expected enabled for %v, from %v", g1v1rEnabled, config)
+	}
+
+	// EnableAll() only enables to the group/version level for compatibility
 	config.EnableAll()
 
-	// all resources under g1v1 are now enabled
+	// all unspecified or enabled resources under all groups now enabled
 	if !config.ResourceEnabled(g1v1rUnspecified) {
 		t.Errorf("expected enabled for %v, from %v", g1v1rUnspecified, config)
 	}
 	if !config.ResourceEnabled(g1v1rEnabled) {
 		t.Errorf("expected enabled for %v, from %v", g1v1rEnabled, config)
 	}
-	if !config.ResourceEnabled(g1v1rDisabled) {
-		t.Errorf("expected enabled for %v, from %v", g1v1rDisabled, config)
+	if !config.ResourceEnabled(g1v2rUnspecified) {
+		t.Errorf("expected enabled for %v, from %v", g1v2rUnspecified, config)
+	}
+	if !config.ResourceEnabled(g1v2rEnabled) {
+		t.Errorf("expected enabled for %v, from %v", g1v2rEnabled, config)
+	}
+	if !config.ResourceEnabled(g2v1rUnspecified) {
+		t.Errorf("expected enabled for %v, from %v", g2v1rUnspecified, config)
+	}
+	if !config.ResourceEnabled(g2v1rEnabled) {
+		t.Errorf("expected enabled for %v, from %v", g2v1rEnabled, config)
 	}
 
-	// previously disabled resources are now enabled
-	if !config.ResourceEnabled(g1v2rDisabled) {
-		t.Errorf("expected enabled for %v, from %v", g1v2rDisabled, config)
+	// previously disabled resources are still disabled
+	if config.ResourceEnabled(g1v1rDisabled) {
+		t.Errorf("expected disabled for %v, from %v", g1v1rDisabled, config)
 	}
-	if !config.ResourceEnabled(g2v1rDisabled) {
-		t.Errorf("expected enabled for %v, from %v", g2v1rDisabled, config)
+	if config.ResourceEnabled(g1v2rDisabled) {
+		t.Errorf("expected disabled for %v, from %v", g1v2rDisabled, config)
+	}
+	if config.ResourceEnabled(g2v1rDisabled) {
+		t.Errorf("expected disabled for %v, from %v", g2v1rDisabled, config)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/pull/72249 made two changes to `--runtime-config`:
* allowed individual resource enablement/disablement in the extensions/v1beta1 API group, returning errors for attempts to enable/disable specific resources outside that API group. Prior to that PR, those attempts were silently ignored.
* added knowledge of specific resources under `extensions/v1beta1` and made `api/all=false` and `api/all=true` enable/disable both the versions *and the known individual resources*. Prior to that PR, `api/all=false` and `api/all=true` only disabled/enabled to the version level.

These changes would cause problems for the following existing uses:
* clusters that were unknowingly passing previously ignored `<group>/<version>/<resource>=[true|false]` options. This PR switches the error back to a warning, to match pre-1.14 behavior of skipping those keys. Will release note the stricter behavior and promote to an error in a future release.
* clusters that explicitly enumerated their enabled group/versions by doing `api/all=false,api/v1=true,apps/v1=true,...,...,...`. This PR switches `api/all=[true|false]` back to only enabling/disabling to the version level.

fixes https://github.com/kubernetes/kubernetes/issues/72541

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
