### PR TITLE
add a content-type filter to apiserver filters to autoset nosniff

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/BUILD
@@ -10,6 +10,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "compression_test.go",
+        "content_type_test.go",
         "cors_test.go",
         "maxinflight_test.go",
         "timeout_test.go",
@@ -32,6 +33,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "compression.go",
+        "content_type.go",
         "cors.go",
         "doc.go",
         "longrunning.go",

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/content_type.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/content_type.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import "net/http"
+
+// WithContentType sets both the Content-Type and the X-Content-Type-Options (nosniff) header
+func WithContentType(handler http.Handler, contentType string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		handler.ServeHTTP(w, r)
+	})
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/content_type_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/content_type_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func noopHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// noop
+	})
+}
+
+func TestWithContentType(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.Handle("/text", WithContentType(noopHandler(), "text/plain"))
+	mux.Handle("/json", WithContentType(noopHandler(), "application/json"))
+	tests := []struct {
+		description      string
+		path             string
+		expectedMimeType string
+	}{
+		{"/text should return a plain text response", "/text", "text/plain"},
+		{"/json should return a json response", "/json", "application/json"},
+	}
+	for _, test := range tests {
+		path := "http://example.com" + test.path
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequest("GET", path, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			if nosniffHeader := w.Header().Get("X-Content-Type-Options"); nosniffHeader != "nosniff" {
+				t.Errorf("expected nosniff header to be set, got %v", nosniffHeader)
+			}
+			if mimeTypeHeader := w.Header().Get("Content-Type"); mimeTypeHeader != test.expectedMimeType {
+				t.Errorf("expected %v, got %v", test.expectedMimeType, mimeTypeHeader)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds a utility filter for autosetting the nosniff header when we set the content type. This filter should not be added to the handler chain, since we do not always know ahead of time what the mime-type will be. However, in cases where we do know the mime-type ahead of time, we should use this filter for the path handler.

**Special notes for your reviewer**:

This change can be used in conjunction with the changes in these PRs (#72520, #72535).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery
