### PR TITLE
[WIP] Set nominated node name of pods and kill preemption victims asynchronously 

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -493,7 +493,7 @@ func (p *PriorityQueue) Update(oldPod, newPod *v1.Pod) error {
 			return err
 		}
 
-		// If the pod is in the backoff queue, update it there.
+		// If the pod is in the backoff queue, move the updated version to the activeQ.
 		if _, exists, _ := p.podBackoffQ.Get(oldPod); exists {
 			p.nominatedPods.update(oldPod, newPod)
 			p.podBackoffQ.Delete(newPod)


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug
/kind cleanup

This is essentially an optimization, but we don't have a better type for it.

**What this PR does / why we need it**:
It should improve performance of the scheduler when it performs preemption.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig scheduling
