### PR TITLE
Improve portforward command's description 

### DIFF
--- a/pkg/kubectl/cmd/portforward/portforward.go
+++ b/pkg/kubectl/cmd/portforward/portforward.go
@@ -59,7 +59,7 @@ type PortForwardOptions struct {
 
 var (
 	portforwardLong = templates.LongDesc(i18n.T(`
-                Forward one or more local ports to a pod.
+                Forward one or more local ports to a pod. This command requires the node to have 'socat' installed.
 
                 Use resource type/name such as deployment/mydeployment to select a pod. Resource type defaults to 'pod' if omitted.
 


### PR DESCRIPTION


> /kind documentation


**What this PR does / why we need it**:
When execute kubectl port-forward command, it may trigger error when node has no 'socat' command installed, it looks like:
`an error occurred forwarding 80 -> 80: error forwarding port 80 to pod def05a827d0b2a68586e183ac2ce8e77cdc1afc7bca0c5956fe75a1f5e0651c8, uid : unable to do port forwarding: socat not found.`

This patch adds a hint about this.


```release-note
NONE
```
