### PR TITLE
Apply go-junit-report/pull/83 so we can capture better log output

### DIFF
--- a/hack/jenkins/gotest.sh
+++ b/hack/jenkins/gotest.sh
@@ -34,6 +34,13 @@ export PATH=${GOPATH}/bin:${HOME}/third_party/etcd:/usr/local/go/bin:$PATH
 command -v etcd &>/dev/null || ./hack/install-etcd.sh
 go get -u github.com/jstemmer/go-junit-report
 
+# Apply patch in https://github.com/jstemmer/go-junit-report/pull/83 to better
+# capture test output in junit xml.
+pushd ${GOPATH}/src/github.com/jstemmer/go-junit-report
+(curl https://patch-diff.githubusercontent.com/raw/jstemmer/go-junit-report/pull/83.patch | patch -p1 --forward --batch) || true
+go install .
+popd
+
 # Enable the Go race detector.
 export KUBE_RACE=-race
 # Set artifacts directory

--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -35,6 +35,13 @@ export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 
 retry go get github.com/jstemmer/go-junit-report
 
+# Apply patch in https://github.com/jstemmer/go-junit-report/pull/83 to better
+# capture test output in junit xml.
+pushd ${GOPATH}/src/github.com/jstemmer/go-junit-report
+(curl https://patch-diff.githubusercontent.com/raw/jstemmer/go-junit-report/pull/83.patch | patch -p1 --forward --batch) || true
+go install .
+popd
+
 # Enable the Go race detector.
 export KUBE_RACE=-race
 # Disable coverage report


### PR DESCRIPTION
Change-Id: I1e4c1b83533c1e534b01bdaab3583fdd3ca9e15c

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Patch up what we use until https://github.com/jstemmer/go-junit-report/pull/83 merges

Added some defensive steps so we don't keel over when the PR merges.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
