### PR TITLE
Automated cherry pick of #72229

### DIFF
--- a/pkg/volume/azure_dd/azure_common.go
+++ b/pkg/volume/azure_dd/azure_common.go
@@ -40,7 +40,7 @@ import (
 const (
 	defaultStorageAccountType       = compute.StandardLRS
 	defaultAzureDiskKind            = v1.AzureManagedDisk
-	defaultAzureDataDiskCachingMode = v1.AzureDataDiskCachingNone
+	defaultAzureDataDiskCachingMode = v1.AzureDataDiskCachingReadOnly
 )
 
 type dataDisk struct {


### PR DESCRIPTION
Cherry pick of #72229 on release-1.13.

#72229: change azure disk host cache to ReadOnly by default