### PR TITLE
Move getNextPod to closure

### DIFF
--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -901,9 +901,7 @@ func (c *configFactory) CreateFromKeys(predicateKeys, priorityKeys sets.String, 
 		WaitForCacheSync: func() bool {
 			return cache.WaitForCacheSync(c.StopEverything, c.scheduledPodsHasSynced)
 		},
-		NextPod: func() *v1.Pod {
-			return c.getNextPod()
-		},
+		NextPod:         internalqueue.MakeNextPodFunc(c.podQueue),
 		Error:           c.MakeDefaultErrorFunc(podBackoff, c.podQueue),
 		StopEverything:  c.StopEverything,
 		VolumeBinder:    c.volumeBinder,
@@ -970,16 +968,6 @@ func (c *configFactory) getPluginArgs() (*PluginFactoryArgs, error) {
 		VolumeBinder:                   c.volumeBinder,
 		HardPodAffinitySymmetricWeight: c.hardPodAffinitySymmetricWeight,
 	}, nil
-}
-
-func (c *configFactory) getNextPod() *v1.Pod {
-	pod, err := c.podQueue.Pop()
-	if err == nil {
-		klog.V(4).Infof("About to try and schedule pod %v/%v", pod.Namespace, pod.Name)
-		return pod
-	}
-	klog.Errorf("Error while retrieving next pod from scheduling queue: %v", err)
-	return nil
 }
 
 // assignedPod selects pods that are assigned (scheduled and running).

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -809,6 +809,8 @@ func newNominatedPodMap() *nominatedPodMap {
 	}
 }
 
+// MakeNextPodFunc returns a function to retrieve the next pod from a given
+// scheduling queue
 func MakeNextPodFunc(queue SchedulingQueue) func() *v1.Pod {
 	return func() *v1.Pod {
 		pod, err := queue.Pop()

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -808,3 +808,15 @@ func newNominatedPodMap() *nominatedPodMap {
 		nominatedPodToNode: make(map[ktypes.UID]string),
 	}
 }
+
+func MakeNextPodFunc(queue SchedulingQueue) func() *v1.Pod {
+	return func() *v1.Pod {
+		pod, err := queue.Pop()
+		if err == nil {
+			klog.V(4).Infof("About to try and schedule pod %v/%v", pod.Namespace, pod.Name)
+			return pod
+		}
+		klog.Errorf("Error while retrieving next pod from scheduling queue: %v", err)
+		return nil
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/sig scheduling
/kind cleanup

**What this PR does / why we need it**:
The `getNextPod` method of `configFactory` is a simple wrapper around `SchedulingQueue.Pop`. It should be converted into a simple closure instead of being a method.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72546

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
