### PR TITLE
WIP: add debug response writer wrapper to catch zero-length responses

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/BUILD
@@ -50,6 +50,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flushwriter:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/wsstream:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -328,6 +328,10 @@ func (r *ResponseWriterDelegator) ContentLength() int {
 	return int(r.written)
 }
 
+func (r *ResponseWriterDelegator) WroteHeader() bool {
+	return r.wroteHeader
+}
+
 type fancyResponseWriterDelegator struct {
 	*ResponseWriterDelegator
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
adds instrumentation to catch code paths that exit WriteObjectNegotiated without calling Write or WriteHeader on the response. Not intended to merge as-is.

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/kubernetes/issues/71696

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

cc @dims