### PR TITLE
Remove newline from kernel version on windows node

### DIFF
--- a/pkg/kubelet/winstats/version.go
+++ b/pkg/kubelet/winstats/version.go
@@ -101,7 +101,7 @@ func getKernelVersion() (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%d.%d.%s.%d\n", majorVersionNumber[0], minorVersionNumber[0], buildNumber, revision), nil
+	return fmt.Sprintf("%d.%d.%s.%d", majorVersionNumber[0], minorVersionNumber[0], buildNumber, revision), nil
 }
 
 // getOSImageVersion gets the osImage name and version.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes json returned from `kubectl get nodes -l "beta.kubernetes.io/os=windows" -o json` remove the new line.  When chaining calls together with tools like jq it can throw errors parsing because the json returned has the new line.

As well as the output from `kubectl get nodes -o wide` as is formated in correctly because the new line is the kernel version (the container runtime ends up on second line):

```
NAME                       STATUS    ROLES     AGE       VERSION   INTERNAL-IP   EXTERNAL-IP    OS-IMAGE                    KERNEL-VERSION   CONTAINER-RUNTIME
3456k8s000                 Ready     agent     11d       v1.13.1                            Windows Server Datacenter   10.0.17763.194
                           containerd://Unknown
k8s-linuxpool-34728241-0   Ready     agent     11d       v1.13.0-alpha.2                   <none>    Ubuntu 16.04.5 LTS   4.15.0-1036-azure   docker://3.0.2
k8s-master-34728241-0      Ready     master    11d       v1.13.0-alpha.2                <none>    Ubuntu 16.04.5 LTS   4.15.0-1036-azure   docker://3.0.2
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
removes newline from json output for windows nodes #72657
```
