### PR TITLE
Update OWNERS so it isn't single threaded.

### DIFF
--- a/cluster/addons/dashboard/OWNERS
+++ b/cluster/addons/dashboard/OWNERS
@@ -1,12 +1,13 @@
 approvers:
 - bryk
+- floreks
+- jeefy
+- maciaszczykm
 reviewers:
 - cheld
 - cupofcat
 - danielromlein
-- floreks
 - ianlewis
 - konryd
-- maciaszczykm
 - mhenc
 - rf232


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig ui

**What this PR does / why we need it**:
Moves @maciaszczykm and @floreks and myself up as Approvers. :tada:

We shouldn't be single threaded through @bryk in case we need quick turn around. (example: https://github.com/kubernetes/kubernetes/pull/72496/files) 

```release-note
NONE
```