### PR TITLE
Automated cherry pick of #72437: Shorten re-read period for token files to work with

### DIFF
--- a/staging/src/k8s.io/client-go/transport/token_source.go
+++ b/staging/src/k8s.io/client-go/transport/token_source.go
@@ -47,14 +47,14 @@ func TokenSourceWrapTransport(ts oauth2.TokenSource) func(http.RoundTripper) htt
 func NewCachedFileTokenSource(path string) oauth2.TokenSource {
 	return &cachingTokenSource{
 		now:    time.Now,
-		leeway: 1 * time.Minute,
+		leeway: 10 * time.Second,
 		base: &fileTokenSource{
 			path: path,
-			// This period was picked because it is half of the minimum validity
-			// duration for a token provisioned by they TokenRequest API. This is
-			// unsophisticated and should induce rotation at a frequency that should
-			// work with the token volume source.
-			period: 5 * time.Minute,
+			// This period was picked because it is half of the duration between when the kubelet
+			// refreshes a projected service account token and when the original token expires.
+			// Default token lifetime is 10 minutes, and the kubelet starts refreshing at 80% of lifetime.
+			// This should induce re-reading at a frequency that works with the token volume source.
+			period: time.Minute,
 		},
 	}
 }


### PR DESCRIPTION
Cherry pick of #72437 on release-1.13.

#72437: Shorten re-read period for token files to work with