### PR TITLE
Mark deprecated in related workqueue metrics

### DIFF
--- a/pkg/util/workqueue/prometheus/prometheus.go
+++ b/pkg/util/workqueue/prometheus/prometheus.go
@@ -131,7 +131,7 @@ func (prometheusMetricsProvider) NewDeprecatedDepthMetric(name string) workqueue
 	depth := prometheus.NewGauge(prometheus.GaugeOpts{
 		Subsystem: name,
 		Name:      "depth",
-		Help:      "Current depth of workqueue: " + name,
+		Help:      "(Deprecated) Current depth of workqueue: " + name,
 	})
 	prometheus.Register(depth)
 	return depth
@@ -141,7 +141,7 @@ func (prometheusMetricsProvider) NewDeprecatedAddsMetric(name string) workqueue.
 	adds := prometheus.NewCounter(prometheus.CounterOpts{
 		Subsystem: name,
 		Name:      "adds",
-		Help:      "Total number of adds handled by workqueue: " + name,
+		Help:      "(Deprecated) Total number of adds handled by workqueue: " + name,
 	})
 	prometheus.Register(adds)
 	return adds
@@ -151,7 +151,7 @@ func (prometheusMetricsProvider) NewDeprecatedLatencyMetric(name string) workque
 	latency := prometheus.NewSummary(prometheus.SummaryOpts{
 		Subsystem: name,
 		Name:      "queue_latency",
-		Help:      "How long an item stays in workqueue" + name + " before being requested.",
+		Help:      "(Deprecated) How long an item stays in workqueue" + name + " before being requested.",
 	})
 	prometheus.Register(latency)
 	return latency
@@ -161,7 +161,7 @@ func (prometheusMetricsProvider) NewDeprecatedWorkDurationMetric(name string) wo
 	workDuration := prometheus.NewSummary(prometheus.SummaryOpts{
 		Subsystem: name,
 		Name:      "work_duration",
-		Help:      "How long processing an item from workqueue" + name + " takes.",
+		Help:      "(Deprecated) How long processing an item from workqueue" + name + " takes.",
 	})
 	prometheus.Register(workDuration)
 	return workDuration
@@ -171,7 +171,7 @@ func (prometheusMetricsProvider) NewDeprecatedUnfinishedWorkSecondsMetric(name s
 	unfinished := prometheus.NewGauge(prometheus.GaugeOpts{
 		Subsystem: name,
 		Name:      "unfinished_work_seconds",
-		Help: "How many seconds of work " + name + " has done that " +
+		Help: "(Deprecated) How many seconds of work " + name + " has done that " +
 			"is in progress and hasn't been observed by work_duration. Large " +
 			"values indicate stuck threads. One can deduce the number of stuck " +
 			"threads by observing the rate at which this increases.",
@@ -184,7 +184,7 @@ func (prometheusMetricsProvider) NewDeprecatedLongestRunningProcessorMicrosecond
 	unfinished := prometheus.NewGauge(prometheus.GaugeOpts{
 		Subsystem: name,
 		Name:      "longest_running_processor_microseconds",
-		Help: "How many microseconds has the longest running " +
+		Help: "(Deprecated) How many microseconds has the longest running " +
 			"processor for " + name + " been running.",
 	})
 	prometheus.Register(unfinished)
@@ -195,7 +195,7 @@ func (prometheusMetricsProvider) NewDeprecatedRetriesMetric(name string) workque
 	retries := prometheus.NewCounter(prometheus.CounterOpts{
 		Subsystem: name,
 		Name:      "retries",
-		Help:      "Total number of retries handled by workqueue: " + name,
+		Help:      "(Deprecated) Total number of retries handled by workqueue: " + name,
 	})
 	prometheus.Register(retries)
 	return retries


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/sig instrumentation

**What this PR does / why we need it**:

As discussed [here](https://github.com/kubernetes/kubernetes/pull/72332#issuecomment-451964891), need to add `Deprecated` in the description of deprecated metrics.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
