### PR TITLE
golint fixes in pkg/kubectl/cmd/annotate #68026

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -135,7 +135,6 @@ pkg/kubeapiserver
 pkg/kubeapiserver/options
 pkg/kubectl
 pkg/kubectl/apps
-pkg/kubectl/cmd/annotate
 pkg/kubectl/cmd/apply
 pkg/kubectl/cmd/attach
 pkg/kubectl/cmd/autoscale

--- a/pkg/kubectl/cmd/annotate/annotate.go
+++ b/pkg/kubectl/cmd/annotate/annotate.go
@@ -41,8 +41,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
 )
 
-// AnnotateOptions have the data required to perform the annotate operation
-type AnnotateOptions struct {
+// Options have the data required to perform the annotate operation
+type Options struct {
 	PrintFlags *genericclioptions.PrintFlags
 	PrintObj   printers.ResourcePrinterFunc
 
@@ -109,9 +109,9 @@ var (
     kubectl annotate pods foo description-`))
 )
 
-// NewAnnotateOptions creates the options for annotate
-func NewAnnotateOptions(ioStreams genericclioptions.IOStreams) *AnnotateOptions {
-	return &AnnotateOptions{
+// NewOptions creates the options for annotate
+func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
+	return &Options{
 		PrintFlags: genericclioptions.NewPrintFlags("annotated").WithTypeSetter(scheme.Scheme),
 
 		RecordFlags: genericclioptions.NewRecordFlags(),
@@ -122,7 +122,7 @@ func NewAnnotateOptions(ioStreams genericclioptions.IOStreams) *AnnotateOptions 
 
 // NewCmdAnnotate creates the `annotate` command
 func NewCmdAnnotate(parent string, f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
-	o := NewAnnotateOptions(ioStreams)
+	o := NewOptions(ioStreams)
 
 	cmd := &cobra.Command{
 		Use:                   "annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]",
@@ -156,7 +156,7 @@ func NewCmdAnnotate(parent string, f cmdutil.Factory, ioStreams genericclioption
 }
 
 // Complete adapts from the command line args and factory to the data required.
-func (o *AnnotateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	var err error
 
 	o.RecordFlags.Complete(cmd)
@@ -203,7 +203,7 @@ func (o *AnnotateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 }
 
 // Validate checks to the AnnotateOptions to see if there is sufficient information run the command.
-func (o AnnotateOptions) Validate() error {
+func (o Options) Validate() error {
 	if o.all && len(o.selector) > 0 {
 		return fmt.Errorf("cannot set --all and --selector at the same time")
 	}
@@ -220,7 +220,7 @@ func (o AnnotateOptions) Validate() error {
 }
 
 // RunAnnotate does the work
-func (o AnnotateOptions) RunAnnotate() error {
+func (o Options) RunAnnotate() error {
 	b := o.builder.
 		Unstructured().
 		LocalParam(o.local).
@@ -354,7 +354,7 @@ func validateNoAnnotationOverwrites(accessor metav1.Object, annotations map[stri
 }
 
 // updateAnnotations updates annotations of obj
-func (o AnnotateOptions) updateAnnotations(obj runtime.Object) error {
+func (o Options) updateAnnotations(obj runtime.Object) error {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return err

--- a/pkg/kubectl/cmd/annotate/annotate_test.go
+++ b/pkg/kubectl/cmd/annotate/annotate_test.go
@@ -356,7 +356,7 @@ func TestUpdateAnnotations(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		options := &AnnotateOptions{
+		options := &Options{
 			overwrite:         test.overwrite,
 			newAnnotations:    test.annotations,
 			removeAnnotations: test.remove,
@@ -430,7 +430,7 @@ func TestAnnotateErrors(t *testing.T) {
 			for k, v := range testCase.flags {
 				cmd.Flags().Set(k, v)
 			}
-			options := NewAnnotateOptions(iostreams)
+			options := NewOptions(iostreams)
 			err := options.Complete(tf, cmd, testCase.args)
 			if err == nil {
 				err = options.Validate()
@@ -489,7 +489,7 @@ func TestAnnotateObject(t *testing.T) {
 	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 	cmd.SetOutput(bufOut)
-	options := NewAnnotateOptions(iostreams)
+	options := NewOptions(iostreams)
 	args := []string{"pods/foo", "a=b", "c-"}
 	if err := options.Complete(tf, cmd, args); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -542,7 +542,7 @@ func TestAnnotateObjectFromFile(t *testing.T) {
 	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 	cmd.SetOutput(bufOut)
-	options := NewAnnotateOptions(iostreams)
+	options := NewOptions(iostreams)
 	options.Filenames = []string{"../../../../test/e2e/testing-manifests/statefulset/cassandra/controller.yaml"}
 	args := []string{"a=b", "c-"}
 	if err := options.Complete(tf, cmd, args); err != nil {
@@ -572,7 +572,7 @@ func TestAnnotateLocal(t *testing.T) {
 
 	iostreams, _, _, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
-	options := NewAnnotateOptions(iostreams)
+	options := NewOptions(iostreams)
 	options.local = true
 	options.Filenames = []string{"../../../../test/e2e/testing-manifests/statefulset/cassandra/controller.yaml"}
 	args := []string{"a=b"}
@@ -628,7 +628,7 @@ func TestAnnotateMultipleObjects(t *testing.T) {
 	iostreams, _, _, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 	cmd.SetOutput(iostreams.Out)
-	options := NewAnnotateOptions(iostreams)
+	options := NewOptions(iostreams)
 	options.all = true
 	args := []string{"pods", "a=b", "c-"}
 	if err := options.Complete(tf, cmd, args); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Removes the following golint error from pkg/kubectl/cmd/annotate

```
Errors from golint:
pkg/kubectl/cmd/annotate/annotate.go:45:6: type name will be used as annotate.AnnotateOptions by other packages, and that stutters; consider calling this Options
```

**Which issue(s) this PR fixes**:

Part of #68026

**Special notes for your reviewer**:

hack/verify-golint.sh returns successful now
Ran hack/update-bazel.sh and hack/update-gofmt.sh afterwards.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
