### PR TITLE
Remove extra newline from one expected message

### DIFF
--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -172,7 +172,7 @@ while true; do sleep 1; done
 						TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 					},
 					phase:   v1.PodFailed,
-					message: Equal("DONE\n"),
+					message: Equal("DONE"),
 				},
 
 				{


### PR DESCRIPTION
**What type of PR is this?**
Bug (This bug is found while debugging #70990.)

**What this PR does / why we need it**:
This PR removes an extra newline from one expected message to fix the broken e2e test.
Note: so far the broken tests never get run because a bug in the test code (this explains why pull-kubernetes-node-e2e never fails on our PRs), which should be fixed by #72793 .