### PR TITLE
cluster-bootstrap: expose helper functions for generating token IDs and Secrets

### DIFF
--- a/staging/src/k8s.io/cluster-bootstrap/token/util/helpers.go
+++ b/staging/src/k8s.io/cluster-bootstrap/token/util/helpers.go
@@ -41,17 +41,27 @@ var (
 
 // GenerateBootstrapToken generates a new, random Bootstrap Token.
 func GenerateBootstrapToken() (string, error) {
-	tokenID, err := randBytes(api.BootstrapTokenIDBytes)
+	tokenID, err := GenerateBootstrapTokenID()
 	if err != nil {
 		return "", err
 	}
 
-	tokenSecret, err := randBytes(api.BootstrapTokenSecretBytes)
+	tokenSecret, err := GenerateBootstrapTokenSecret()
 	if err != nil {
 		return "", err
 	}
 
 	return TokenFromIDAndSecret(tokenID, tokenSecret), nil
+}
+
+// GenerateBootstrapTokenID generates a new, random Bootstrap Token ID
+func GenerateBootstrapTokenID() (string, error) {
+	return randBytes(api.BootstrapTokenIDBytes)
+}
+
+// GenerateBootstrapTokenSecret generates a new, random Bootstrap Token ID
+func GenerateBootstrapTokenSecret() (string, error) {
+	return randBytes(api.BootstrapTokenSecretBytes)
 }
 
 // randBytes returns a random string consisting of the characters in


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:

This PR exposes functionality in the bootstrap-cluster APIs to generate bootstrap token IDs and Secrets separately. The motivation for this is so bootstrap tokens can be created out-of-band from `kubeadm`, where most of the logic currently resides instead of `client-go`. Workaround for now is just call `GenerateBootstrapToken()` and parse out the ID and Secret parts manually, then call `BootstrapTokenSecretName(tokenID)` from there. With these changes, it's a bit easier to generate the ID and Secret parts separately. The existing functionality of `GenerateBootstrapToken()` remains as-is.

**Special notes for your reviewer**: N/A

**Does this PR introduce a user-facing change?**:

```release-note
cluster-bootstrap: expose helper functions for generating token IDs and Secrets
```
