### PR TITLE
Refactored kube-apiserver options flags into constants

### DIFF
--- a/cmd/kube-apiserver/app/options/BUILD
+++ b/cmd/kube-apiserver/app/options/BUILD
@@ -9,6 +9,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "constant.go",
         "globalflags.go",
         "options.go",
         "validation.go",

--- a/cmd/kube-apiserver/app/options/constant.go
+++ b/cmd/kube-apiserver/app/options/constant.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+const (
+	// KubeApiServerCloudProviderGceLbSrcCidrs sets google compute engine load balancer cidrs source.
+	KubeApiServerCloudProviderGceLbSrcCidrs = "cloud-provider-gce-lb-src-cidrs"
+
+	// KubeApiServerDefaultNotReadyTolerationSeconds sets default not ready toleration seconds.
+	KubeApiServerDefaultNotReadyTolerationSeconds = "default-not-ready-toleration-seconds"
+
+	// KubeApiServerDefaultUnreachableTolerationSeconds sets default unreachable toleration seconds.
+	KubeApiServerDefaultUnreachableTolerationSeconds = "default-unreachable-toleration-seconds"
+
+	// KubeApiServerGeneric sets generic kube apiserver options.
+	KubeApiServerGeneric = "generic"
+
+	// KubeApiServerEtcd sets etcd options.
+	KubeApiServerEtcd = "etcd"
+
+	// KubeApiServerSecureServing defines secure serving.
+	KubeApiServerSecureServing = "secure serving"
+
+	// KubeApiServerInsecureServing defines secure serving.
+	KubeApiServerInsecureServing = "insecure serving"
+
+	// KubeApiServerAuditing sets auditing option.
+	KubeApiServerAuditing = "auditing"
+
+	// KubeApiServerFeatures sets features.
+	KubeApiServerFeatures = "features"
+
+	// KubeApiServerAuthentication sets authentication parameters.
+	KubeApiServerAuthentication = "authentication"
+
+	// KubeApiServerAuthorization sets authorization parameters.
+	KubeApiServerAuthorization = "authorization"
+
+	// KubeApiServerCloudProvider sets cloud provider.
+	KubeApiServerCloudProvider = "cloud provider"
+
+	// KubeApiServerStorage sets storage.
+	KubeApiServerStorage = "storage"
+
+	// KubeApiServerApiEnablement sets api enablement status.
+	KubeApiServerApiEnablement = "api enablement"
+
+	// KubeApiServerAdmission sets admission options.
+	KubeApiServerAdmission = "admission"
+
+	// KubeApiServerMisc sets misc options.
+	KubeApiServerMisc = "misc"
+
+	// KubeApiServerEventTtl sets amount of time to retain events.
+	KubeApiServerEventTtl = "event-ttl"
+
+	// KubeApiServerAllowPrivileged if true, allow privileged containers.
+	KubeApiServerAllowPrivileged = "allow-privileged"
+
+	// KubeApiServerEnableLogsHandler if true, install a /logs handler for the apiserver logs.
+	KubeApiServerEnableLogsHandler = "enable-logs-handler"
+
+	// KubeApiServerSshUser if non-empty, use secure SSH proxy to the nodes, using this user name.
+	KubeApiServerSshUser = "ssh-user"
+
+	// KubeApiServerSshKeyFile if non-empty, use secure SSH proxy to the nodes, using this user keyfile.
+	KubeApiServerSshKeyFile = "ssh-keyfile"
+
+	// KubeApiServerMaxConnectionBytesPerSec if non-zero, throttle each user connection to this number of bytes/sec.
+	KubeApiServerMaxConnectionBytesPerSec = "max-connection-bytes-per-sec"
+
+	// KubeApiServerCount sets the number of apiservers running in the cluster, must be a positive number.
+	KubeApiServerCount = "apiserver-count"
+
+	// KubeApiServerEndpointReconcilerType defines if should use an endpoint reconciler.
+	KubeApiServerEndpointReconcilerType = "endpoint-reconciler-type"
+
+	// KubeApiServerKubernetesServiceNodePort defines default kubernetes service node port.
+	KubeApiServerKubernetesServiceNodePort = "kubernetes-service-node-port"
+
+	// KubeApiServerServiceClusterIpRange sets service cluster ip range.
+	KubeApiServerServiceClusterIpRange = "service-cluster-ip-range"
+
+	// KubeApiServerServiceNodePortRange sets service node port range.
+	KubeApiServerServiceNodePortRange = "service-node-port-range"
+
+	// KubeApiServerKubeletHttps difines if should use https for kubelet connections.
+	KubeApiServerKubeletHttps = "kubelet-https"
+
+	// KubeApiServerKubeletPreferredAddressTypes sets kubelet preferred address types.
+	KubeApiServerKubeletPreferredAddressTypes = "kubelet-preferred-address-types"
+
+	// KubeApiServerKubeletPort sets kubelet port.
+	KubeApiServerKubeletPort = "kubelet-port"
+
+	// KubeApiServerKubeletReadOnlyPort sets kubelet read only port.
+	KubeApiServerKubeletReadOnlyPort = "kubelet-read-only-port"
+
+	// KubeApiServerKubeletTimeout sets kubelet timeout.
+	KubeApiServerKubeletTimeout = "kubelet-timeout"
+
+	// KubeApiServerKubeletClientCertificate sets kubelet client certificate.
+	KubeApiServerKubeletClientCertificate = "kubelet-client-certificate"
+
+	// KubeApiServerKubeletClientKey sets kubelet client key.
+	KubeApiServerKubeletClientKey = "kubelet-client-key"
+
+	// KubeApiServerKubeletCertificateAuthority sets kubelet certificate authority.
+	KubeApiServerKubeletCertificateAuthority = "kubelet-certificate-authority"
+
+	// KubeApiServerRepairMalformedUpdates deprecated.
+	KubeApiServerRepairMalformedUpdates = "repair-malformed-updates"
+
+	// KubeApiServerProxyClientCertFile sets proxy client cert file.
+	KubeApiServerProxyClientCertFile = "proxy-client-cert-file"
+
+	// KubeApiServerProxyClientKeyFile sets proxy client key file.
+	KubeApiServerProxyClientKeyFile = "proxy-client-key-file"
+
+	// KubeApiServerEnableAggregatorRouting defines if aggregator routing is enabled.
+	KubeApiServerEnableAggregatorRouting = "enable-aggregator-routing"
+
+	// KubeApiServerServiceAccountSigningKeyFile sets service account signing key file.
+	KubeApiServerServiceAccountSigningKeyFile = "service-account-signing-key-file"
+)

--- a/cmd/kube-apiserver/app/options/globalflags.go
+++ b/cmd/kube-apiserver/app/options/globalflags.go
@@ -33,9 +33,9 @@ func AddCustomGlobalFlags(fs *pflag.FlagSet) {
 	// Lookup flags in global flag set and re-register the values with our flagset.
 
 	// Adds flags from k8s.io/kubernetes/pkg/cloudprovider/providers.
-	globalflag.Register(fs, "cloud-provider-gce-lb-src-cidrs")
+	globalflag.Register(fs, KubeApiServerCloudProviderGceLbSrcCidrs)
 
 	// Adds flags from k8s.io/apiserver/pkg/admission.
-	globalflag.Register(fs, "default-not-ready-toleration-seconds")
-	globalflag.Register(fs, "default-unreachable-toleration-seconds")
+	globalflag.Register(fs, KubeApiServerDefaultNotReadyTolerationSeconds)
+	globalflag.Register(fs, KubeApiServerDefaultUnreachableTolerationSeconds)
 }

--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -78,17 +78,17 @@ type ServerRunOptions struct {
 func NewServerRunOptions() *ServerRunOptions {
 	s := ServerRunOptions{
 		GenericServerRunOptions: genericoptions.NewServerRunOptions(),
-		Etcd:                    genericoptions.NewEtcdOptions(storagebackend.NewDefaultConfig(kubeoptions.DefaultEtcdPathPrefix, nil)),
-		SecureServing:           kubeoptions.NewSecureServingOptions(),
-		InsecureServing:         kubeoptions.NewInsecureServingOptions(),
-		Audit:                   genericoptions.NewAuditOptions(),
-		Features:                genericoptions.NewFeatureOptions(),
-		Admission:               kubeoptions.NewAdmissionOptions(),
-		Authentication:          kubeoptions.NewBuiltInAuthenticationOptions().WithAll(),
-		Authorization:           kubeoptions.NewBuiltInAuthorizationOptions(),
-		CloudProvider:           kubeoptions.NewCloudProviderOptions(),
-		StorageSerialization:    kubeoptions.NewStorageSerializationOptions(),
-		APIEnablement:           genericoptions.NewAPIEnablementOptions(),
+		Etcd:                 genericoptions.NewEtcdOptions(storagebackend.NewDefaultConfig(kubeoptions.DefaultEtcdPathPrefix, nil)),
+		SecureServing:        kubeoptions.NewSecureServingOptions(),
+		InsecureServing:      kubeoptions.NewInsecureServingOptions(),
+		Audit:                genericoptions.NewAuditOptions(),
+		Features:             genericoptions.NewFeatureOptions(),
+		Admission:            kubeoptions.NewAdmissionOptions(),
+		Authentication:       kubeoptions.NewBuiltInAuthenticationOptions().WithAll(),
+		Authorization:        kubeoptions.NewBuiltInAuthorizationOptions(),
+		CloudProvider:        kubeoptions.NewCloudProviderOptions(),
+		StorageSerialization: kubeoptions.NewStorageSerializationOptions(),
+		APIEnablement:        genericoptions.NewAPIEnablementOptions(),
 
 		EnableLogsHandler:      true,
 		EventTTL:               1 * time.Hour,
@@ -125,99 +125,99 @@ func NewServerRunOptions() *ServerRunOptions {
 // Flags returns flags for a specific APIServer by section name
 func (s *ServerRunOptions) Flags() (fss apiserverflag.NamedFlagSets) {
 	// Add the generic flags.
-	s.GenericServerRunOptions.AddUniversalFlags(fss.FlagSet("generic"))
-	s.Etcd.AddFlags(fss.FlagSet("etcd"))
-	s.SecureServing.AddFlags(fss.FlagSet("secure serving"))
-	s.InsecureServing.AddFlags(fss.FlagSet("insecure serving"))
-	s.InsecureServing.AddUnqualifiedFlags(fss.FlagSet("insecure serving")) // TODO: remove it until kops stops using `--address`
-	s.Audit.AddFlags(fss.FlagSet("auditing"))
-	s.Features.AddFlags(fss.FlagSet("features"))
-	s.Authentication.AddFlags(fss.FlagSet("authentication"))
-	s.Authorization.AddFlags(fss.FlagSet("authorization"))
-	s.CloudProvider.AddFlags(fss.FlagSet("cloud provider"))
-	s.StorageSerialization.AddFlags(fss.FlagSet("storage"))
-	s.APIEnablement.AddFlags(fss.FlagSet("api enablement"))
-	s.Admission.AddFlags(fss.FlagSet("admission"))
+	s.GenericServerRunOptions.AddUniversalFlags(fss.FlagSet(KubeApiServerGeneric))
+	s.Etcd.AddFlags(fss.FlagSet(KubeApiServerEtcd))
+	s.SecureServing.AddFlags(fss.FlagSet(KubeApiServerSecureServing))
+	s.InsecureServing.AddFlags(fss.FlagSet(KubeApiServerInsecureServing))
+	s.InsecureServing.AddUnqualifiedFlags(fss.FlagSet(KubeApiServerInsecureServing)) // TODO: remove it until kops stops using `--address`
+	s.Audit.AddFlags(fss.FlagSet(KubeApiServerAuditing))
+	s.Features.AddFlags(fss.FlagSet(KubeApiServerFeatures))
+	s.Authentication.AddFlags(fss.FlagSet(KubeApiServerAuthentication))
+	s.Authorization.AddFlags(fss.FlagSet(KubeApiServerAuthorization))
+	s.CloudProvider.AddFlags(fss.FlagSet(KubeApiServerCloudProvider))
+	s.StorageSerialization.AddFlags(fss.FlagSet(KubeApiServerStorage))
+	s.APIEnablement.AddFlags(fss.FlagSet(KubeApiServerApiEnablement))
+	s.Admission.AddFlags(fss.FlagSet(KubeApiServerAdmission))
 
 	// Note: the weird ""+ in below lines seems to be the only way to get gofmt to
 	// arrange these text blocks sensibly. Grrr.
-	fs := fss.FlagSet("misc")
-	fs.DurationVar(&s.EventTTL, "event-ttl", s.EventTTL,
+	fs := fss.FlagSet(KubeApiServerMisc)
+	fs.DurationVar(&s.EventTTL, KubeApiServerEventTtl, s.EventTTL,
 		"Amount of time to retain events.")
 
-	fs.BoolVar(&s.AllowPrivileged, "allow-privileged", s.AllowPrivileged,
+	fs.BoolVar(&s.AllowPrivileged, KubeApiServerAllowPrivileged, s.AllowPrivileged,
 		"If true, allow privileged containers. [default=false]")
 
-	fs.BoolVar(&s.EnableLogsHandler, "enable-logs-handler", s.EnableLogsHandler,
+	fs.BoolVar(&s.EnableLogsHandler, KubeApiServerEnableLogsHandler, s.EnableLogsHandler,
 		"If true, install a /logs handler for the apiserver logs.")
 
 	// Deprecated in release 1.9
-	fs.StringVar(&s.SSHUser, "ssh-user", s.SSHUser,
+	fs.StringVar(&s.SSHUser, KubeApiServerSshUser, s.SSHUser,
 		"If non-empty, use secure SSH proxy to the nodes, using this user name")
-	fs.MarkDeprecated("ssh-user", "This flag will be removed in a future version.")
+	fs.MarkDeprecated(KubeApiServerSshUser, "This flag will be removed in a future version.")
 
 	// Deprecated in release 1.9
-	fs.StringVar(&s.SSHKeyfile, "ssh-keyfile", s.SSHKeyfile,
+	fs.StringVar(&s.SSHKeyfile, KubeApiServerSshKeyFile, s.SSHKeyfile,
 		"If non-empty, use secure SSH proxy to the nodes, using this user keyfile")
-	fs.MarkDeprecated("ssh-keyfile", "This flag will be removed in a future version.")
+	fs.MarkDeprecated(KubeApiServerSshKeyFile, "This flag will be removed in a future version.")
 
-	fs.Int64Var(&s.MaxConnectionBytesPerSec, "max-connection-bytes-per-sec", s.MaxConnectionBytesPerSec, ""+
+	fs.Int64Var(&s.MaxConnectionBytesPerSec, KubeApiServerMaxConnectionBytesPerSec, s.MaxConnectionBytesPerSec, ""+
 		"If non-zero, throttle each user connection to this number of bytes/sec. "+
 		"Currently only applies to long-running requests.")
 
-	fs.IntVar(&s.MasterCount, "apiserver-count", s.MasterCount,
+	fs.IntVar(&s.MasterCount, KubeApiServerCount, s.MasterCount,
 		"The number of apiservers running in the cluster, must be a positive number. (In use when --endpoint-reconciler-type=master-count is enabled.)")
 
-	fs.StringVar(&s.EndpointReconcilerType, "endpoint-reconciler-type", string(s.EndpointReconcilerType),
+	fs.StringVar(&s.EndpointReconcilerType, KubeApiServerEndpointReconcilerType, string(s.EndpointReconcilerType),
 		"Use an endpoint reconciler ("+strings.Join(reconcilers.AllTypes.Names(), ", ")+")")
 
 	// See #14282 for details on how to test/try this option out.
 	// TODO: remove this comment once this option is tested in CI.
-	fs.IntVar(&s.KubernetesServiceNodePort, "kubernetes-service-node-port", s.KubernetesServiceNodePort, ""+
+	fs.IntVar(&s.KubernetesServiceNodePort, KubeApiServerKubernetesServiceNodePort, s.KubernetesServiceNodePort, ""+
 		"If non-zero, the Kubernetes master service (which apiserver creates/maintains) will be "+
 		"of type NodePort, using this as the value of the port. If zero, the Kubernetes master "+
 		"service will be of type ClusterIP.")
 
-	fs.IPNetVar(&s.ServiceClusterIPRange, "service-cluster-ip-range", s.ServiceClusterIPRange, ""+
+	fs.IPNetVar(&s.ServiceClusterIPRange, KubeApiServerServiceClusterIpRange, s.ServiceClusterIPRange, ""+
 		"A CIDR notation IP range from which to assign service cluster IPs. This must not "+
 		"overlap with any IP ranges assigned to nodes for pods.")
 
-	fs.Var(&s.ServiceNodePortRange, "service-node-port-range", ""+
+	fs.Var(&s.ServiceNodePortRange, KubeApiServerServiceNodePortRange, ""+
 		"A port range to reserve for services with NodePort visibility. "+
 		"Example: '30000-32767'. Inclusive at both ends of the range.")
 
 	// Kubelet related flags:
-	fs.BoolVar(&s.KubeletConfig.EnableHttps, "kubelet-https", s.KubeletConfig.EnableHttps,
+	fs.BoolVar(&s.KubeletConfig.EnableHttps, KubeApiServerKubeletHttps, s.KubeletConfig.EnableHttps,
 		"Use https for kubelet connections.")
 
-	fs.StringSliceVar(&s.KubeletConfig.PreferredAddressTypes, "kubelet-preferred-address-types", s.KubeletConfig.PreferredAddressTypes,
+	fs.StringSliceVar(&s.KubeletConfig.PreferredAddressTypes, KubeApiServerKubeletPreferredAddressTypes, s.KubeletConfig.PreferredAddressTypes,
 		"List of the preferred NodeAddressTypes to use for kubelet connections.")
 
-	fs.UintVar(&s.KubeletConfig.Port, "kubelet-port", s.KubeletConfig.Port,
+	fs.UintVar(&s.KubeletConfig.Port, KubeApiServerKubeletPort, s.KubeletConfig.Port,
 		"DEPRECATED: kubelet port.")
-	fs.MarkDeprecated("kubelet-port", "kubelet-port is deprecated and will be removed.")
+	fs.MarkDeprecated(KubeApiServerKubeletPort, "kubelet-port is deprecated and will be removed.")
 
-	fs.UintVar(&s.KubeletConfig.ReadOnlyPort, "kubelet-read-only-port", s.KubeletConfig.ReadOnlyPort,
+	fs.UintVar(&s.KubeletConfig.ReadOnlyPort, KubeApiServerKubeletReadOnlyPort, s.KubeletConfig.ReadOnlyPort,
 		"DEPRECATED: kubelet port.")
 
-	fs.DurationVar(&s.KubeletConfig.HTTPTimeout, "kubelet-timeout", s.KubeletConfig.HTTPTimeout,
+	fs.DurationVar(&s.KubeletConfig.HTTPTimeout, KubeApiServerKubeletTimeout, s.KubeletConfig.HTTPTimeout,
 		"Timeout for kubelet operations.")
 
-	fs.StringVar(&s.KubeletConfig.CertFile, "kubelet-client-certificate", s.KubeletConfig.CertFile,
+	fs.StringVar(&s.KubeletConfig.CertFile, KubeApiServerKubeletClientCertificate, s.KubeletConfig.CertFile,
 		"Path to a client cert file for TLS.")
 
-	fs.StringVar(&s.KubeletConfig.KeyFile, "kubelet-client-key", s.KubeletConfig.KeyFile,
+	fs.StringVar(&s.KubeletConfig.KeyFile, KubeApiServerKubeletClientKey, s.KubeletConfig.KeyFile,
 		"Path to a client key file for TLS.")
 
-	fs.StringVar(&s.KubeletConfig.CAFile, "kubelet-certificate-authority", s.KubeletConfig.CAFile,
+	fs.StringVar(&s.KubeletConfig.CAFile, KubeApiServerKubeletCertificateAuthority, s.KubeletConfig.CAFile,
 		"Path to a cert file for the certificate authority.")
 
 	// TODO: delete this flag in 1.13
 	repair := false
-	fs.BoolVar(&repair, "repair-malformed-updates", false, "deprecated")
-	fs.MarkDeprecated("repair-malformed-updates", "This flag will be removed in a future version")
+	fs.BoolVar(&repair, KubeApiServerRepairMalformedUpdates, false, "deprecated")
+	fs.MarkDeprecated(KubeApiServerRepairMalformedUpdates, "This flag will be removed in a future version")
 
-	fs.StringVar(&s.ProxyClientCertFile, "proxy-client-cert-file", s.ProxyClientCertFile, ""+
+	fs.StringVar(&s.ProxyClientCertFile, KubeApiServerProxyClientCertFile, s.ProxyClientCertFile, ""+
 		"Client certificate used to prove the identity of the aggregator or kube-apiserver "+
 		"when it must call out during a request. This includes proxying requests to a user "+
 		"api-server and calling out to webhook admission plugins. It is expected that this "+
@@ -225,15 +225,15 @@ func (s *ServerRunOptions) Flags() (fss apiserverflag.NamedFlagSets) {
 		"That CA is published in the 'extension-apiserver-authentication' configmap in "+
 		"the kube-system namespace. Components receiving calls from kube-aggregator should "+
 		"use that CA to perform their half of the mutual TLS verification.")
-	fs.StringVar(&s.ProxyClientKeyFile, "proxy-client-key-file", s.ProxyClientKeyFile, ""+
+	fs.StringVar(&s.ProxyClientKeyFile, KubeApiServerProxyClientKeyFile, s.ProxyClientKeyFile, ""+
 		"Private key for the client certificate used to prove the identity of the aggregator or kube-apiserver "+
 		"when it must call out during a request. This includes proxying requests to a user "+
 		"api-server and calling out to webhook admission plugins.")
 
-	fs.BoolVar(&s.EnableAggregatorRouting, "enable-aggregator-routing", s.EnableAggregatorRouting,
+	fs.BoolVar(&s.EnableAggregatorRouting, KubeApiServerEnableAggregatorRouting, s.EnableAggregatorRouting,
 		"Turns on aggregator routing requests to endpoints IP rather than cluster IP.")
 
-	fs.StringVar(&s.ServiceAccountSigningKeyFile, "service-account-signing-key-file", s.ServiceAccountSigningKeyFile, ""+
+	fs.StringVar(&s.ServiceAccountSigningKeyFile, KubeApiServerServiceAccountSigningKeyFile, s.ServiceAccountSigningKeyFile, ""+
 		"Path to the file that contains the current private key of the service account token issuer. The issuer will sign issued ID tokens with this private key. (Requires the 'TokenRequest' feature gate.)")
 
 	return fss


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Refactoring for kube-apiserver options flags, move them all to constants file

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/72702

**Special notes for your reviewer**:

Open questions:
We have few Todo's in this package, like https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/app/options/options.go#L132 or https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/app/options/options.go#L175 can we resolve them?
We have a lot of hardcodes here https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/app/aggregator.go#L242 should we do something to them?

**Does this PR introduce a user-facing change?**:

`"NONE"`
