### PR TITLE
Storage test framework log message fix, bump nfs-provisioner version

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2469,8 +2469,8 @@ func (f *Framework) MatchContainerOutput(
 		return fmt.Errorf("expected pod %q success: %v", createdPod.Name, podErr)
 	}
 
-	Logf("Trying to get logs from node %s pod %s container %s: %v",
-		podStatus.Spec.NodeName, podStatus.Name, containerName, err)
+	Logf("Trying to get logs from node %s pod %s container %s",
+		podStatus.Spec.NodeName, podStatus.Name, containerName)
 
 	// Sometimes the actual containers take a second to get started, try to get logs for 60s
 	logs, err := GetPodLogs(f.ClientSet, ns, podStatus.Name, containerName)

--- a/test/e2e/storage/utils/utils.go
+++ b/test/e2e/storage/utils/utils.go
@@ -338,7 +338,7 @@ func StartExternalProvisioner(c clientset.Interface, ns string, externalPluginNa
 			Containers: []v1.Container{
 				{
 					Name:  "nfs-provisioner",
-					Image: "quay.io/kubernetes_incubator/nfs-provisioner:v2.2.0-k8s1.12",
+					Image: "quay.io/kubernetes_incubator/nfs-provisioner:v2.2.1-k8s1.12",
 					SecurityContext: &v1.SecurityContext{
 						Capabilities: &v1.Capabilities{
 							Add: []v1.Capability{"DAC_READ_SEARCH"},


### PR DESCRIPTION
Just some random little fixes made while debugging related tests.

/kind cleanup
/sig storage

```release-note
NONE
```