### PR TITLE
kubeadm: add front-proxy CA certificate to selfhosting controller-manager

### DIFF
--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
@@ -225,6 +225,7 @@ spec:
     - --cluster-signing-key-file=/etc/kubernetes/pki/ca.key
     - --bind-address=127.0.0.1
     - --use-service-account-credentials=true
+    - --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
     image: k8s.gcr.io/kube-controller-manager-amd64:v1.7.4
     livenessProbe:
       failureThreshold: 8
@@ -300,6 +301,7 @@ spec:
         - --cluster-signing-key-file=/etc/kubernetes/pki/ca.key
         - --bind-address=127.0.0.1
         - --use-service-account-credentials=true
+        - --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
         image: k8s.gcr.io/kube-controller-manager-amd64:v1.7.4
         livenessProbe:
           failureThreshold: 8

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
@@ -202,6 +202,19 @@ func controllerManagerCertificatesVolumeSource() v1.VolumeSource {
 						},
 					},
 				},
+				{
+					Secret: &v1.SecretProjection{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: kubeadmconstants.FrontProxyCACertAndKeyBaseName,
+						},
+						Items: []v1.KeyToPath{
+							{
+								Key:  v1.TLSCertKey,
+								Path: kubeadmconstants.FrontProxyCACertName,
+							},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Selfhosting pivoting fails when using --store-certs-in-secrets
as controller-manager fails to start because of missing front-proxy CA
certificate:
```
    unable to load client CA file: unable to load client CA file: open
    /etc/kubernetes/pki/front-proxy-ca.crt: no such file or directory
```

Added required certificate to fix this.

**Which issue(s) this PR fixes**:

Fixes kubernetes/kubeadm#1281

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: fixed storing of front-proxy certificate in secrets required by kube-controller-manager selfhosting pivoting
```