### PR TITLE
Deprecate DenyEscalatingExec and DenyExecOnPrivileged admission plugins

### DIFF
--- a/plugin/pkg/admission/exec/BUILD
+++ b/plugin/pkg/admission/exec/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/plugin/pkg/admission/exec/admission.go
+++ b/plugin/pkg/admission/exec/admission.go
@@ -25,25 +25,33 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
 )
 
 const (
 	// DenyEscalatingExec indicates name of admission plugin.
+	// Deprecated, will be removed in v1.18.
+	// Use of PodSecurityPolicy or a custom admission plugin to limit creation of pods is recommended instead.
 	DenyEscalatingExec = "DenyEscalatingExec"
 	// DenyExecOnPrivileged indicates name of admission plugin.
-	// Deprecated, should use DenyEscalatingExec instead.
+	// Deprecated, will be removed in v1.18.
+	// Use of PodSecurityPolicy or a custom admission plugin to limit creation of pods is recommended instead.
 	DenyExecOnPrivileged = "DenyExecOnPrivileged"
 )
 
 // Register registers a plugin
 func Register(plugins *admission.Plugins) {
 	plugins.Register(DenyEscalatingExec, func(config io.Reader) (admission.Interface, error) {
+		klog.Warningf("the %s admission plugin is deprecated and will be removed in v1.18", DenyEscalatingExec)
+		klog.Warningf("use of PodSecurityPolicy or a custom admission plugin to limit creation of pods is recommended instead")
 		return NewDenyEscalatingExec(), nil
 	})
 
 	// This is for legacy support of the DenyExecOnPrivileged admission controller.  Most
 	// of the time DenyEscalatingExec should be preferred.
 	plugins.Register(DenyExecOnPrivileged, func(config io.Reader) (admission.Interface, error) {
+		klog.Warningf("the %s admission plugin is deprecated and will be removed in v1.18", DenyExecOnPrivileged)
+		klog.Warningf("use of PodSecurityPolicy or a custom admission plugin to limit creation of pods is recommended instead")
 		return NewDenyExecOnPrivileged(), nil
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Deprecates the DenyEscalatingExec and DenyExecOnPrivileged admission plugins. These do not protect creation of privileged pods, and do not allow for any differentiation between users. Use of a policy-based admission plugin (like PodSecurityPolicy or a custom admission plugin) which can be targeted at specific users or namespaces, and also protects against creation of overly privileged pods is recommended instead.

**Which issue(s) this PR fixes**:
Fixes #65408

**Does this PR introduce a user-facing change?**:
```release-note
The DenyEscalatingExec and DenyExecOnPrivileged admission plugins are deprecated and will be removed in v1.18. Use of `PodSecurityPolicy` or a custom admission plugin to limit creation of pods is recommended instead.
```

@kubernetes/sig-auth-pr-reviews 