### PR TITLE
int tests: stop special casing KUBE_TEST_ARGS

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -93,12 +93,6 @@ checkEtcdOnPath
 # Run cleanup to stop etcd on interrupt or other kill signal.
 trap cleanup EXIT
 
-# If a test case is specified, just run once with v1 API version and exit
-if [[ -n "${KUBE_TEST_ARGS}" ]]; then
-  runTests v1
-  exit 0
-fi
-
 # Convert the CSV to an array of API versions to test
 IFS=';' read -a apiVersions <<< "${KUBE_TEST_API_VERSIONS}"
 for apiVersion in "${apiVersions[@]}"; do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Stop special casing KUBE_TEST_ARGS and limiting the API
group/version settings to "v1" when running the tests. This was
helpful in the past when we used to test multiple values for
KUBE_TEST_API_VERSIONS - if you were specifying KUBE_TEST_ARGS to run a
single test case, you probably didn't want to have it tested for
multiple values of KUBE_TEST_API_VERSIONS.

Now, however, KUBE_TEST_API_VERSIONS comes from
KUBE_AVAILABLE_GROUP_VERSIONS by default, which is a single list instead
of multiple, so we shouldn't need to special case KUBE_TEST_ARGS any
more. This is especially necessary because certain tests that are using
testapi break if KUBE_TEST_API_VERSIONS is just "v1".

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

The original logic was added in https://github.com/kubernetes/kubernetes/pull/26032. cc @pmorie 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig testing