### PR TITLE
Automated cherry pick of #68422: Fix AWS NLB security group updates

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -564,12 +564,17 @@ func filterForIPRangeDescription(securityGroups []*ec2.SecurityGroup, lbName str
 	response := []*ec2.SecurityGroup{}
 	clientRule := fmt.Sprintf("%s=%s", NLBClientRuleDescription, lbName)
 	healthRule := fmt.Sprintf("%s=%s", NLBHealthCheckRuleDescription, lbName)
+	alreadyAdded := sets.NewString()
 	for i := range securityGroups {
 		for j := range securityGroups[i].IpPermissions {
 			for k := range securityGroups[i].IpPermissions[j].IpRanges {
 				description := aws.StringValue(securityGroups[i].IpPermissions[j].IpRanges[k].Description)
 				if description == clientRule || description == healthRule {
-					response = append(response, securityGroups[i])
+					sgIDString := aws.StringValue(securityGroups[i].GroupId)
+					if !alreadyAdded.Has(sgIDString) {
+						response = append(response, securityGroups[i])
+						alreadyAdded.Insert(sgIDString)
+					}
 				}
 			}
 		}
@@ -594,6 +599,7 @@ func (c *Cloud) getVpcCidrBlock() (*string, error) {
 // if clientTraffic is false, then only update HealthCheck rules
 func (c *Cloud) updateInstanceSecurityGroupsForNLBTraffic(actualGroups []*ec2.SecurityGroup, desiredSgIds []string, ports []int64, lbName string, clientCidrs []string, clientTraffic bool) error {
 
+	glog.V(8).Infof("updateInstanceSecurityGroupsForNLBTraffic: actualGroups=%v, desiredSgIds=%v, ports=%v, clientTraffic=%v", actualGroups, desiredSgIds, ports, clientTraffic)
 	// Map containing the groups we want to make changes on; the ports to make
 	// changes on; and whether to add or remove it. true to add, false to remove
 	portChanges := map[string]map[int64]bool{}
@@ -648,16 +654,16 @@ func (c *Cloud) updateInstanceSecurityGroupsForNLBTraffic(actualGroups []*ec2.Se
 			if add {
 				if clientTraffic {
 					glog.V(2).Infof("Adding rule for client MTU discovery from the network load balancer (%s) to instances (%s)", clientCidrs, instanceSecurityGroupID)
-					glog.V(2).Infof("Adding rule for client traffic from the network load balancer (%s) to instances (%s)", clientCidrs, instanceSecurityGroupID)
+					glog.V(2).Infof("Adding rule for client traffic from the network load balancer (%s) to instances (%s), port (%v)", clientCidrs, instanceSecurityGroupID, port)
 				} else {
-					glog.V(2).Infof("Adding rule for health check traffic from the network load balancer (%s) to instances (%s)", clientCidrs, instanceSecurityGroupID)
+					glog.V(2).Infof("Adding rule for health check traffic from the network load balancer (%s) to instances (%s), port (%v)", clientCidrs, instanceSecurityGroupID, port)
 				}
 			} else {
 				if clientTraffic {
 					glog.V(2).Infof("Removing rule for client MTU discovery from the network load balancer (%s) to instances (%s)", clientCidrs, instanceSecurityGroupID)
-					glog.V(2).Infof("Removing rule for client traffic from the network load balancer (%s) to instance (%s)", clientCidrs, instanceSecurityGroupID)
+					glog.V(2).Infof("Removing rule for client traffic from the network load balancer (%s) to instance (%s), port (%v)", clientCidrs, instanceSecurityGroupID, port)
 				}
-				glog.V(2).Infof("Removing rule for health check traffic from the network load balancer (%s) to instance (%s)", clientCidrs, instanceSecurityGroupID)
+				glog.V(2).Infof("Removing rule for health check traffic from the network load balancer (%s) to instance (%s), port (%v)", clientCidrs, instanceSecurityGroupID, port)
 			}
 
 			if clientTraffic {

--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package aws
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
+	"fmt"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 func TestElbProtocolsAreEqual(t *testing.T) {
@@ -158,4 +161,64 @@ func TestIsNLB(t *testing.T) {
 			t.Errorf("Incorrect value for isNLB() case %s. Got %t, expected %t.", test.name, got, test.want)
 		}
 	}
+}
+
+func TestSecurityGroupFiltering(t *testing.T) {
+	grid := []struct {
+		in          []*ec2.SecurityGroup
+		name        string
+		expected    int
+		description string
+	}{
+		{
+			in: []*ec2.SecurityGroup{
+				{
+					IpPermissions: []*ec2.IpPermission{
+						{
+							IpRanges: []*ec2.IpRange{
+								{
+									Description: aws.String("an unmanaged"),
+								},
+							},
+						},
+					},
+				},
+			},
+			name:        "unmanaged",
+			expected:    0,
+			description: "An environment without managed LBs should have %d, but found %d SecurityGroups",
+		},
+		{
+			in: []*ec2.SecurityGroup{
+				{
+					IpPermissions: []*ec2.IpPermission{
+						{
+							IpRanges: []*ec2.IpRange{
+								{
+									Description: aws.String("an unmanaged"),
+								},
+								{
+									Description: aws.String(fmt.Sprintf("%s=%s", NLBClientRuleDescription, "managedlb")),
+								},
+								{
+									Description: aws.String(fmt.Sprintf("%s=%s", NLBHealthCheckRuleDescription, "managedlb")),
+								},
+							},
+						},
+					},
+				},
+			},
+			name:        "managedlb",
+			expected:    1,
+			description: "Found %d, but should have %d Security Groups",
+		},
+	}
+
+	for _, g := range grid {
+		actual := len(filterForIPRangeDescription(g.in, g.name))
+		if actual != g.expected {
+			t.Errorf(g.description, actual, g.expected)
+		}
+	}
+
 }


### PR DESCRIPTION
Cherry pick of #68422 on release-1.12.

#68422: Fix AWS NLB security group updates

Tests done:
1. created an kops cluster with [binaries built by this PR](https://storage.googleapis.com/kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws/v1.12.5-beta.0.82+8063abb5de1b08)
2. verified the original issue as described in #68422 is gone.