### PR TITLE
Remove Sysctls feature gate from validation

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -310,6 +310,12 @@ func dropDisabledFields(
 		podSpec.ReadinessGates = nil
 	}
 
+	if !utilfeature.DefaultFeatureGate.Enabled(features.Sysctls) && !sysctlsInUse(oldPodSpec) {
+		if podSpec.SecurityContext != nil {
+			podSpec.SecurityContext.Sysctls = nil
+		}
+	}
+
 	if !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) && !emptyDirSizeLimitInUse(oldPodSpec) {
 		for i := range podSpec.Volumes {
 			if podSpec.Volumes[i].EmptyDir != nil {
@@ -491,6 +497,16 @@ func podReadinessGatesInUse(podSpec *api.PodSpec) bool {
 		return false
 	}
 	if podSpec.ReadinessGates != nil {
+		return true
+	}
+	return false
+}
+
+func sysctlsInUse(podSpec *api.PodSpec) bool {
+	if podSpec == nil {
+		return false
+	}
+	if podSpec.SecurityContext != nil && podSpec.SecurityContext.Sysctls != nil {
 		return true
 	}
 	return false

--- a/pkg/api/podsecuritypolicy/util.go
+++ b/pkg/api/podsecuritypolicy/util.go
@@ -31,6 +31,10 @@ func DropDisabledFields(pspSpec, oldPSPSpec *policy.PodSecurityPolicySpec) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.RunAsGroup) && (oldPSPSpec == nil || oldPSPSpec.RunAsGroup == nil) {
 		pspSpec.RunAsGroup = nil
 	}
+	if !utilfeature.DefaultFeatureGate.Enabled(features.Sysctls) && !sysctlsInUse(oldPSPSpec) {
+		pspSpec.AllowedUnsafeSysctls = nil
+		pspSpec.ForbiddenSysctls = nil
+	}
 }
 
 func allowedProcMountTypesInUse(oldPSPSpec *policy.PodSecurityPolicySpec) bool {
@@ -44,4 +48,14 @@ func allowedProcMountTypesInUse(oldPSPSpec *policy.PodSecurityPolicySpec) bool {
 
 	return false
 
+}
+
+func sysctlsInUse(oldPSPSpec *policy.PodSecurityPolicySpec) bool {
+	if oldPSPSpec == nil {
+		return false
+	}
+	if oldPSPSpec.AllowedUnsafeSysctls != nil || oldPSPSpec.ForbiddenSysctls != nil {
+		return true
+	}
+	return false
 }

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3436,11 +3436,7 @@ func ValidatePodSecurityContext(securityContext *core.PodSecurityContext, spec *
 		}
 
 		if len(securityContext.Sysctls) != 0 {
-			if utilfeature.DefaultFeatureGate.Enabled(features.Sysctls) {
-				allErrs = append(allErrs, validateSysctls(securityContext.Sysctls, fldPath.Child("sysctls"))...)
-			} else {
-				allErrs = append(allErrs, field.Forbidden(fldPath.Child("sysctls"), "Sysctls are disabled by Sysctls feature-gate"))
-			}
+			allErrs = append(allErrs, validateSysctls(securityContext.Sysctls, fldPath.Child("sysctls"))...)
 		}
 	}
 

--- a/pkg/apis/policy/validation/BUILD
+++ b/pkg/apis/policy/validation/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/validation:go_default_library",
         "//pkg/apis/policy:go_default_library",
-        "//pkg/features:go_default_library",
         "//pkg/security/apparmor:go_default_library",
         "//pkg/security/podsecuritypolicy/seccomp:go_default_library",
         "//pkg/security/podsecuritypolicy/util:go_default_library",
@@ -23,7 +22,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/apis/policy/validation/validation.go
+++ b/pkg/apis/policy/validation/validation.go
@@ -31,12 +31,9 @@ import (
 	core "k8s.io/kubernetes/pkg/apis/core"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/apis/policy"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/security/apparmor"
 	"k8s.io/kubernetes/pkg/security/podsecuritypolicy/seccomp"
 	psputil "k8s.io/kubernetes/pkg/security/podsecuritypolicy/util"
-
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 func ValidatePodDisruptionBudget(pdb *policy.PodDisruptionBudget) field.ErrorList {
@@ -399,10 +396,6 @@ func validatePodSecurityPolicySysctls(fldPath *field.Path, sysctls []string) fie
 
 	if len(sysctls) == 0 {
 		return allErrs
-	}
-
-	if !utilfeature.DefaultFeatureGate.Enabled(features.Sysctls) {
-		return append(allErrs, field.Forbidden(fldPath, "Sysctls are disabled by Sysctls feature-gate"))
 	}
 
 	coversAll := false


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change
/kind bug

**What this PR does / why we need it**:
Moves feature gate checking of Sysctls out of validation into strategy utility methods, and avoids dropping data on update if the existing pod spec and podsecuritypolicy already uses Sysctls. Adds unit test for the strategy utility methods and removes feature gate from validations.

**Which issue(s) this PR fixes**:
xref #72651 

**Does this PR introduce a user-facing change?**:
```release-note
The `spec.SecurityContext.Sysctls` field is now dropped during creation of `Pod` objects unless the `Sysctls` feature gate is enabled.

The `spec.AllowedUnsafeSysctls` and `spec.ForbiddenSysctls` fields are now dropped during creation of `PodSecurityPolicy` objects unless the `Sysctls` feature gate is enabled.
```

/sig api-machinery