### PR TITLE
etcd check: use url.Parse to parse server list

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -287,11 +287,9 @@ func CreateKubeAPIServerConfig(
 		return
 	}
 
-	if _, port, err := net.SplitHostPort(s.Etcd.StorageConfig.Transport.ServerList[0]); err == nil && port != "0" && len(port) != 0 {
-		if err := utilwait.PollImmediate(etcdRetryInterval, etcdRetryLimit*etcdRetryInterval, preflight.EtcdConnection{ServerList: s.Etcd.StorageConfig.Transport.ServerList}.CheckEtcdServers); err != nil {
-			lastErr = fmt.Errorf("error waiting for etcd connection: %v", err)
-			return
-		}
+	if err := utilwait.PollImmediate(etcdRetryInterval, etcdRetryLimit*etcdRetryInterval, preflight.EtcdConnection{ServerList: s.Etcd.StorageConfig.Transport.ServerList}.CheckEtcdServers); err != nil {
+		lastErr = fmt.Errorf("error waiting for etcd connection: %v", err)
+		return
 	}
 
 	capabilities.Initialize(capabilities.Capabilities{

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -19,6 +19,7 @@ package options
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -83,6 +84,14 @@ func (s *EtcdOptions) Validate() []error {
 	allErrors := []error{}
 	if len(s.StorageConfig.Transport.ServerList) == 0 {
 		allErrors = append(allErrors, fmt.Errorf("--etcd-servers must be specified"))
+	}
+
+	for _, server := range s.StorageConfig.Transport.ServerList {
+		_, err := url.Parse(server)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Errorf("--etcd-servers is invalid, %s is not a valid url", server))
+			break
+		}
 	}
 
 	if s.StorageConfig.Type != storagebackend.StorageTypeUnset && !storageTypes.Has(s.StorageConfig.Type) {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -57,6 +57,30 @@ func TestEtcdOptionsValidate(t *testing.T) {
 			expectErr: "--etcd-servers must be specified",
 		},
 		{
+			name: "test when ServerList is invalid",
+			testOptions: &EtcdOptions{
+				StorageConfig: storagebackend.Config{
+					Type:   "etcd3",
+					Prefix: "/registry",
+					Transport: storagebackend.TransportConfig{
+						ServerList: []string{"127.0.0.1:4001"},
+						KeyFile:    "/var/run/kubernetes/etcd.key",
+						CAFile:     "/var/run/kubernetes/etcdca.crt",
+						CertFile:   "/var/run/kubernetes/etcdce.crt",
+					},
+					CompactionInterval:    storagebackend.DefaultCompactInterval,
+					CountMetricPollPeriod: time.Minute,
+				},
+				DefaultStorageMediaType: "application/vnd.kubernetes.protobuf",
+				DeleteCollectionWorkers: 1,
+				EnableGarbageCollection: true,
+				EnableWatchCache:        true,
+				DefaultWatchCacheSize:   100,
+				EtcdServersOverrides:    []string{"/events#http://127.0.0.1:4002"},
+			},
+			expectErr: "--etcd-servers is invalid, 127.0.0.1:4001 is not a valid url",
+		},
+		{
 			name: "test when storage-backend is invalid",
 			testOptions: &EtcdOptions{
 				StorageConfig: storagebackend.Config{


### PR DESCRIPTION
Previously, net.SplitHostPort does not work with urls, and as a
result, the preflight check may never run.

/kind bug
/sig apimachinery

```release-note
NONE
```