### PR TITLE
Fix kube-proxy PodSecurityPolicy RoleBinding namespace

### DIFF
--- a/cluster/gce/addons/podsecuritypolicies/kube-proxy-binding.yaml
+++ b/cluster/gce/addons/podsecuritypolicies/kube-proxy-binding.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: gce:podsecuritypolicy:kube-proxy
+  namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
kube-proxy's PodSecurityPolicy binding was accidentally created in the default namespace rather than `kube-system`

**Does this PR introduce a user-facing change?**:
```release-note
Fix kube-proxy PodSecurityPolicy binding on GCE & GKE. This was only an issue when running kube-proxy as a DaemonSet, with PodSecurityPolicy enabled.
```

/sig gce
/priority important-soon