### PR TITLE
Use node-controller cluster role for node-lifecycle and cloud-node-lifecycle controller

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -225,7 +225,8 @@ func startControllers(c *cloudcontrollerconfig.CompletedConfig, stop <-chan stru
 	// Start the CloudNodeController
 	nodeController := cloudcontrollers.NewCloudNodeController(
 		c.SharedInformers.Core().V1().Nodes(),
-		client("cloud-node-controller"), cloud,
+		// cloud node controller uses existing cluster role from node-controller
+		client("node-controller"), cloud,
 		c.ComponentConfig.NodeStatusUpdateFrequency.Duration)
 
 	go nodeController.Run(stop)
@@ -233,7 +234,8 @@ func startControllers(c *cloudcontrollerconfig.CompletedConfig, stop <-chan stru
 
 	cloudNodeLifecycleController, err := cloudcontrollers.NewCloudNodeLifecycleController(
 		c.SharedInformers.Core().V1().Nodes(),
-		client("cloud-node-lifecycle-controller"), cloud,
+		// cloud node lifecycle controller uses existing cluster role from node-controller
+		client("node-controller"), cloud,
 		c.ComponentConfig.KubeCloudShared.NodeMonitorPeriod.Duration,
 	)
 	if err != nil {

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -126,6 +126,7 @@ func startNodeLifecycleController(ctx ControllerContext) (http.Handler, bool, er
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.InformerFactory.Core().V1().Nodes(),
 		ctx.InformerFactory.Apps().V1().DaemonSets(),
+		// node lifecycle controller uses existing cluster role from node-controller
 		ctx.ClientBuilder.ClientOrDie("node-controller"),
 		ctx.ComponentConfig.KubeCloudShared.NodeMonitorPeriod.Duration,
 		ctx.ComponentConfig.NodeLifecycleController.NodeStartupGracePeriod.Duration,
@@ -149,7 +150,8 @@ func startNodeLifecycleController(ctx ControllerContext) (http.Handler, bool, er
 func startCloudNodeLifecycleController(ctx ControllerContext) (http.Handler, bool, error) {
 	cloudNodeLifecycleController, err := cloudcontroller.NewCloudNodeLifecycleController(
 		ctx.InformerFactory.Core().V1().Nodes(),
-		ctx.ClientBuilder.ClientOrDie("cloud-node-lifecycle-controller"),
+		// cloud node lifecycle controller uses existing cluster role from node-controller
+		ctx.ClientBuilder.ClientOrDie("node-controller"),
 		ctx.Cloud,
 		ctx.ComponentConfig.KubeCloudShared.NodeMonitorPeriod.Duration,
 	)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In https://github.com/kubernetes/kubernetes/pull/70344 we split `node-lifecycle-controller` into two separate controllers: `node-lifecycle-controller` and `cloud-node-lifecycle` controller (see the PR for reasons). As a follow up we should have separate controller roles. This also fixes a bug (https://github.com/kubernetes/kubernetes/issues/72499) where nodes that do not exist are not deleted in the API server if `--use-service-account-credentials` is set. 

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes/kubernetes/issues/72499

**Special notes for your reviewer**:
This change also removes the need for the `node-controller` service account & role. Is there a deprecation process for bootstrap policies or a mechanism to clean them up?

**Does this PR introduce a user-facing change?**:
```release-note
Add bootstrap service account & cluster roles for node-lifecycle-controller, cloud-node-lifecycle-controller, and cloud-node-controller.  
```

/assign @mtaufen @liggitt 
