### PR TITLE
[Mitigate KCM CrashLooping] Add test for ResourceQuotaController Init.

### DIFF
--- a/cmd/kube-controller-manager/app/BUILD
+++ b/cmd/kube-controller-manager/app/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -139,6 +139,21 @@ go_library(
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["core_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/discovery:go_default_library",
+        "//staging/src/k8s.io/client-go/discovery/fake:go_default_library",
+        "//staging/src/k8s.io/client-go/informers:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//staging/src/k8s.io/client-go/rest:go_default_library",
     ],
 )
 

--- a/cmd/kube-controller-manager/app/core_test.go
+++ b/cmd/kube-controller-manager/app/core_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	restclient "k8s.io/client-go/rest"
+)
+
+// TestClientBuilder inherits ClientBuilder and can accept a given fake clientset.
+type TestClientBuilder struct {
+	clientset clientset.Interface
+}
+
+func (TestClientBuilder) Config(name string) (*restclient.Config, error)  { return nil, nil }
+func (TestClientBuilder) ConfigOrDie(name string) *restclient.Config      { return nil }
+func (TestClientBuilder) Client(name string) (clientset.Interface, error) { return nil, nil }
+func (m TestClientBuilder) ClientOrDie(name string) clientset.Interface {
+	return m.clientset
+}
+
+// FakeDiscoveryWithError inherits DiscoveryInterface(via FakeDiscovery) with some methods accepting testing data.
+type FakeDiscoveryWithError struct {
+	fakediscovery.FakeDiscovery
+	PossibleResources []*metav1.APIResourceList
+	Err               error
+}
+
+func (d FakeDiscoveryWithError) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return d.PossibleResources, d.Err
+}
+
+// FakeDiscoveryWithError inherits Clientset(via FakeClientset) with overridden Discovery method.
+type FakeClientSet struct {
+	fakeclientset.Clientset
+	DiscoveryObj *FakeDiscoveryWithError
+}
+
+func (c *FakeClientSet) Discovery() discovery.DiscoveryInterface {
+	return c.DiscoveryObj
+}
+
+// Create a fake Clientset with its Discovery method overridden.
+func NewFakeClientset(fakeDiscovery FakeDiscoveryWithError) *FakeClientSet {
+	cs := &FakeClientSet{}
+	cs.DiscoveryObj = &fakeDiscovery
+	return cs
+}
+
+func TestStartResourceQuotaController_DiscoveryError(t *testing.T) {
+	tcs := map[string]struct {
+		discoveryError    error
+		expectedErr       bool
+		possibleResources []*metav1.APIResourceList
+	}{
+		"No Discovery Error": {
+			discoveryError:    nil,
+			possibleResources: nil,
+			expectedErr:       false,
+		},
+		"Discovery Calls Partially Failed": {
+			discoveryError: new(discovery.ErrGroupDiscoveryFailed),
+			possibleResources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "create/v1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "jobs",
+							Verbs:      []string{"create", "list", "watch", "delete"},
+							ShortNames: []string{"jz"},
+							Categories: []string{"all"},
+						},
+					},
+				},
+			},
+			expectedErr: false,
+		},
+	}
+	for name, test := range tcs {
+		testDiscovery := FakeDiscoveryWithError{Err: test.discoveryError, PossibleResources: test.possibleResources}
+		testClientset := NewFakeClientset(testDiscovery)
+		testClientBuilder := TestClientBuilder{clientset: testClientset}
+		ctx := ControllerContext{
+			ClientBuilder:    testClientBuilder,
+			InformerFactory:  informers.NewSharedInformerFactoryWithOptions(testClientset, time.Duration(1)),
+			InformersStarted: make(chan struct{}),
+		}
+		_, _, err := startResourceQuotaController(ctx)
+		if test.expectedErr != (err != nil) {
+			t.Errorf("test failed for use case: %v", name)
+		}
+	}
+}


### PR DESCRIPTION
ResourceQuotaController calls Discovery to get available resources. When this step fails, it doesn't necessarily indicate a ResourceQuotaController failure. THis test guarantees no error is raised in the ResourceController Initialization step when the Discovery call is partially failed.

Why Discovery failure may cause KCM crash looping: If the discovery failure results in a ResourceQuotaController Initialization breakage (returns error), the kube-controller-manager(KCM) will exit immediately and leaving some controllers unstarted. When the KCM is restarted, it will exit again for the same cause.

Test:
* make test
* Specifically: make test WHAT=./cmd/kube-controller-manager/app/ KUBE_TEST_ARGS="-run TestStartResourceQuotaController_DiscoveryError"

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

/kind documentation

> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
ResourceQuotaController calls Discovery to get available resources. When this step fails, it doesn't necessarily indicate a ResourceQuotaController failure. This test guarantees no error is raised in the ResourceController Initialization step when the Discovery call is partially failed.

Why Discovery failure may cause KCM crash looping: If the discovery failure results in a ResourceQuotaController Initialization breakage (returns error), the kube-controller-manager(KCM) will exit immediately and leaving some controllers unstarted. When the KCM is restarted, it will exit again for the same cause.

**Which issue(s) this PR fixes**:

Fixes #55271

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
None
```
