### PR TITLE
Bug fix: ./hack/install-etcd.sh is not work on Arm64 platform

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -105,11 +105,16 @@ kube::etcd::cleanup() {
 kube::etcd::install() {
   (
     local os
+    local arch
+
+    os=$(kube::util::host_os)
+    arch=$(kube::util::host_arch)
+
     cd "${KUBE_ROOT}/third_party"
-    os=$(uname | tr "[:upper:]" "[:lower:]")
     if [[ $(readlink etcd) == etcd-v${ETCD_VERSION}-${os}-* ]]; then
       return  # already installed
     fi
+
     if [[ ${os} == "darwin" ]]; then
       download_file="etcd-v${ETCD_VERSION}-darwin-amd64.zip"
       url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/${download_file}"
@@ -118,11 +123,11 @@ kube::etcd::install() {
       ln -fns "etcd-v${ETCD_VERSION}-darwin-amd64" etcd
       rm "${download_file}"
     else
-      url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz"
-      download_file="etcd-v${ETCD_VERSION}-linux-amd64.tar.gz"
+      url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-${arch}.tar.gz"
+      download_file="etcd-v${ETCD_VERSION}-linux-${arch}.tar.gz"
       kube::util::download_file "${url}" "${download_file}"
       tar xzf "${download_file}"
-      ln -fns "etcd-v${ETCD_VERSION}-linux-amd64" etcd
+      ln -fns "etcd-v${ETCD_VERSION}-linux-${arch}" etcd
       rm "${download_file}"
     fi
     kube::log::info "etcd v${ETCD_VERSION} installed. To use:"


### PR DESCRIPTION
Signed-off-by: Bin Lu <bin.lu@arm.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We need to fix it so that we can install etcd on Arm64 platform.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
We can use it to install etcd for e2e test on Arm64 platform.

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```