### PR TITLE
Adds test which pulls dockerhub Windows image

### DIFF
--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -19,6 +19,7 @@ package common
 import (
 	"fmt"
 	"path"
+	"strings"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -272,15 +273,21 @@ while true; do sleep 1; done
 					waiting:     true,
 				},
 				{
+					// TODO(claudiub): Add a Windows equivalent test.
 					description: "should be able to pull image from gcr.io [LinuxOnly]",
 					image:       "gcr.io/google-containers/debian-base:0.4.1",
 					phase:       v1.PodRunning,
 					waiting:     false,
 				},
 				{
-					// TODO(claudiub): Remove the [LinuxOnly] tag when a Windows-friendly image is used instead of alpine.
 					description: "should be able to pull image from docker hub [LinuxOnly]",
 					image:       "alpine:3.7",
+					phase:       v1.PodRunning,
+					waiting:     false,
+				},
+				{
+					description: "should be able to pull image from docker hub [WindowsOnly]",
+					image:       "e2eteam/busybox:1.29",
 					phase:       v1.PodRunning,
 					waiting:     false,
 				},
@@ -300,6 +307,9 @@ while true; do sleep 1; done
 			} {
 				testCase := testCase
 				It(testCase.description+" [NodeConformance]", func() {
+					if strings.Contains(testCase.description, "[WindowsOnly]") {
+						framework.SkipUnlessNodeOSDistroIs("windows")
+					}
 					name := "image-pull-test"
 					command := []string{"/bin/sh", "-c", "while true; do sleep 1; done"}
 					container := ConformanceContainer{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test
/sig testing
/sig windows

**What this PR does / why we need it**:

Updates the test "should be able to pull image from docker hub" to pull
the golang image instead of alpine, which can also be used on Windows,
allowing the test to pass on both OSes.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related: #69871

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
