### PR TITLE
followup of #72364, slightly improve the comment

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -864,7 +864,12 @@ func TestGarbageCollectorSync(t *testing.T) {
 	//            gc.resyncMonitors()
 	//            controller.WaitForCacheSync() loops with `syncedPollPeriod` (hardcoded to 100ms), until either its stop channel is closed after `period`, or all caches synced.
 	//
-	// Setting the period to 200ms allows the WaitForCacheSync() to check for cache sync ~2 times in every wait.PollImmediateUntil() loop.
+	// Setting the period to 200ms allows the WaitForCacheSync() to check
+	// for cache sync ~2 times in every wait.PollImmediateUntil() loop.
+	//
+	// The 1s sleep in the test allows GetDelableResources and
+	// gc.resyncMoitors to run ~5 times to ensure the changes to the
+	// fakeDiscoveryClient are picked up.
 	go gc.Sync(fakeDiscoveryClient, 200*time.Millisecond, stopCh)
 
 	// Wait until the sync discovers the initial resources


### PR DESCRIPTION
See discussion [here](https://github.com/kubernetes/kubernetes/pull/72364#discussion_r246667887).

/sig api-machinery
/assign @kdada 
/kind cleanup
/release-note-none