### PR TITLE
Only collect metrics for cgroups required by the summary API

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -616,9 +616,34 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 		kubeDeps.Auth = auth
 	}
 
+	var cgroupRoots []string
+
+	cgroupRoots = append(cgroupRoots, cm.NodeAllocatableRoot(s.CgroupRoot, s.CgroupDriver))
+	kubeletCgroup, err := cm.GetKubeletContainer(s.KubeletCgroups)
+	if err != nil {
+		return fmt.Errorf("failed to get the kubelet's cgroup: %v", err)
+	}
+	if kubeletCgroup != "" {
+		cgroupRoots = append(cgroupRoots, kubeletCgroup)
+	}
+
+	runtimeCgroup, err := cm.GetRuntimeContainer(s.ContainerRuntime, s.RuntimeCgroups)
+	if err != nil {
+		return fmt.Errorf("failed to get the container runtime's cgroup: %v", err)
+	}
+	if runtimeCgroup != "" {
+		// RuntimeCgroups is optional, so ignore if it isn't specified
+		cgroupRoots = append(cgroupRoots, runtimeCgroup)
+	}
+
+	if s.SystemCgroups != "" {
+		// SystemCgroups is optional, so ignore if it isn't specified
+		cgroupRoots = append(cgroupRoots, s.SystemCgroups)
+	}
+
 	if kubeDeps.CAdvisorInterface == nil {
 		imageFsInfoProvider := cadvisor.NewImageFsInfoProvider(s.ContainerRuntime, s.RemoteRuntimeEndpoint)
-		kubeDeps.CAdvisorInterface, err = cadvisor.New(imageFsInfoProvider, s.RootDirectory, cadvisor.UsingLegacyCadvisorStats(s.ContainerRuntime, s.RemoteRuntimeEndpoint))
+		kubeDeps.CAdvisorInterface, err = cadvisor.New(imageFsInfoProvider, s.RootDirectory, cgroupRoots, cadvisor.UsingLegacyCadvisorStats(s.ContainerRuntime, s.RemoteRuntimeEndpoint))
 		if err != nil {
 			return err
 		}

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -82,7 +82,7 @@ func init() {
 	}
 }
 
-func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, usingLegacyStats bool) (Interface, error) {
+func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots []string, usingLegacyStats bool) (Interface, error) {
 	sysFs := sysfs.NewRealSysFs()
 
 	includedMetrics := cadvisormetrics.MetricSet{
@@ -98,10 +98,8 @@ func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, usingLegacySt
 		includedMetrics[cadvisormetrics.DiskUsageMetrics] = struct{}{}
 	}
 
-	// collect metrics for all cgroups
-	rawContainerCgroupPathPrefixWhiteList := []string{"/"}
 	// Create and start the cAdvisor container manager.
-	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs, maxHousekeepingInterval, allowDynamicHousekeeping, includedMetrics, http.DefaultClient, rawContainerCgroupPathPrefixWhiteList)
+	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs, maxHousekeepingInterval, allowDynamicHousekeeping, includedMetrics, http.DefaultClient, cgroupRoots)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/cadvisor/cadvisor_unsupported.go
+++ b/pkg/kubelet/cadvisor/cadvisor_unsupported.go
@@ -31,7 +31,7 @@ type cadvisorUnsupported struct {
 
 var _ Interface = new(cadvisorUnsupported)
 
-func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, usingLegacyStats bool) (Interface, error) {
+func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupsRoots []string, usingLegacyStats bool) (Interface, error) {
 	return &cadvisorUnsupported{}, nil
 }
 

--- a/pkg/kubelet/cadvisor/cadvisor_windows.go
+++ b/pkg/kubelet/cadvisor/cadvisor_windows.go
@@ -33,7 +33,7 @@ type cadvisorClient struct {
 var _ Interface = new(cadvisorClient)
 
 // New creates a cAdvisor and exports its API on the specified port if port > 0.
-func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, usingLegacyStats bool) (Interface, error) {
+func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots []string, usingLegacyStats bool) (Interface, error) {
 	client, err := winstats.NewPerfCounterClient()
 	return &cadvisorClient{
 		rootPath:       rootPath,

--- a/pkg/kubelet/cm/helpers_unsupported.go
+++ b/pkg/kubelet/cm/helpers_unsupported.go
@@ -59,3 +59,18 @@ func getCgroupProcs(dir string) ([]int, error) {
 func GetPodCgroupNameSuffix(podUID types.UID) string {
 	return ""
 }
+
+// NodeAllocatableRoot returns the literal cgroup path for the node allocatable cgroup
+func NodeAllocatableRoot(cgroupRoot, cgroupDriver string) string {
+	return ""
+}
+
+// GetKubeletContainer returns the cgroup the kubelet will use
+func GetKubeletContainer(kubeletCgroups string) (string, error) {
+	return "", nil
+}
+
+// GetRuntimeContainer returns the cgroup used by the container runtime
+func GetRuntimeContainer(containerRuntime, runtimeCgroups string) (string, error) {
+	return "", nil
+}

--- a/test/e2e_node/environment/conformance.go
+++ b/test/e2e_node/environment/conformance.go
@@ -99,7 +99,7 @@ func containerRuntime() error {
 	}
 
 	// Setup cadvisor to check the container environment
-	c, err := cadvisor.New(cadvisor.NewImageFsInfoProvider("docker", ""), "/var/lib/kubelet", false)
+	c, err := cadvisor.New(cadvisor.NewImageFsInfoProvider("docker", ""), "/var/lib/kubelet", []string{"/"}, false)
 	if err != nil {
 		return printError("Container Runtime Check: %s Could not start cadvisor %v", failed, err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This makes the kubelet more efficient, as it only collects metrics for cgroups within:
* The runtime cgroup
* The kubelet cgroup
* The system (misc) cgroup
* The allocatable (/kubepods) cgroup

This includes all pod and container cgroups, as those are within the allocatable cgroup.  The node cgroup is always collected.

**Which issue(s) this PR fixes**:
Fixes https://github.com/google/cadvisor/issues/2129

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
The kubelet only collects metrics for the node, container runtime, kubelet, pods, and containers.
```
