### PR TITLE
[feature branch] skip conversion to same version

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/versionconverter.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/versionconverter.go
@@ -59,6 +59,11 @@ func (v *versionConverter) Convert(object typed.TypedValue, version fieldpath.AP
 		return object, err
 	}
 
+	// If attempting to convert to the same version as we already have, just return it.
+	if objectToConvert.GetObjectKind().GroupVersionKind().GroupVersion() == groupVersion {
+		return object, nil
+	}
+
 	// Convert to internal
 	internalObject, err := v.objectConvertor.ConvertToVersion(objectToConvert, v.hubVersion)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig api-machinery
/cc @apelisse 
/priority important-longterm

**What this PR does / why we need it**:
When converting to the same version we already have, don't attempt to go through the hub version
This could be further optimized to also skip going to a runtime.Object if typed.TypedValue exposed the fieldpath.APIVersion it corresponds to

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```