### PR TITLE
Update ubuntu image used for e2e node test

### DIFF
--- a/test/e2e_node/jenkins/image-config-serial.yaml
+++ b/test/e2e_node/jenkins/image-config-serial.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
+    image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
     project: ubuntu-os-gke-cloud
   coreos-alpha:
     image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
+    image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
     project: ubuntu-os-gke-cloud
   coreos-alpha:
     image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
the ubuntu image used in the node-e2e test `ubuntu-gke-1604-xenial-v20170420-1` is broken.

**Which issue(s) this PR fixes**:
Fixes #70990

**Does this PR introduce a user-facing change?**:
no

/assign @yguo0905
