### PR TITLE
Bug fix: ./hack/local-up-cluster.sh is not work on Arm64 platform

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -697,6 +697,15 @@ function kube::util::ensure-cfssl {
     return 0
   fi
 
+  host_arch=$(kube::util::host_arch)
+
+  if [[ "${host_arch}" != "amd64" ]]; then
+    echo "Cannot download cfssl on non-amd64 hosts and cfssl does not appear to be installed."
+    echo "Please install cfssl and cfssljson and verify they are in \$PATH."
+    echo "Hint: export PATH=\$PATH:\$GOPATH/bin; go get -u github.com/cloudflare/cfssl/cmd/..."
+    exit 1
+  fi
+
   # Create a temp dir for cfssl if no directory was given
   local cfssldir=${1:-}
   if [[ -z "${cfssldir}" ]]; then


### PR DESCRIPTION
Signed-off-by: Bin Lu <bin.lu@arm.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We need to fix it so that we can run e2e test on Arm64 platform.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
We can use it to run a local k8s cluster on Arm64 platform.

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```