### PR TITLE
fix typo "udp" -> "UDP"

### DIFF
--- a/pkg/kubectl/cmd/expose/expose.go
+++ b/pkg/kubectl/cmd/expose/expose.go
@@ -74,7 +74,7 @@ var (
 		kubectl expose service nginx --port=443 --target-port=8443 --name=nginx-https
 
 		# Create a service for a replicated streaming application on port 4100 balancing UDP traffic and named 'video-stream'.
-		kubectl expose rc streamer --port=4100 --protocol=udp --name=video-stream
+		kubectl expose rc streamer --port=4100 --protocol=UDP --name=video-stream
 
 		# Create a service for a replicated nginx using replica set, which serves on port 80 and connects to the containers on port 8000.
 		kubectl expose rs nginx --port=80 --target-port=8000


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
fix a typo
```
kubectl expose deploy test1 --port=4100 --protocol=udp --name=video-stream
The Service "video-stream" is invalid: spec.ports[0].protocol: Unsupported value: "udp": supported values: "SCTP", "TCP", "UDP"
```
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
