### PR TITLE
Delete predicates.PodToleratesNodeTaintsPred from defaultPredicates

### DIFF
--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -51,7 +51,6 @@ func defaultPredicates() sets.String {
 		predicates.CheckNodeDiskPressurePred,
 		predicates.CheckNodePIDPressurePred,
 		predicates.CheckNodeConditionPred,
-		predicates.PodToleratesNodeTaintsPred,
 		predicates.CheckVolumeBindingPred,
 	)
 }

--- a/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
@@ -82,7 +82,6 @@ func TestDefaultPredicates(t *testing.T) {
 		predicates.CheckNodeDiskPressurePred,
 		predicates.CheckNodePIDPressurePred,
 		predicates.CheckNodeConditionPred,
-		predicates.PodToleratesNodeTaintsPred,
 		predicates.CheckVolumeBindingPred,
 	)
 

--- a/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
@@ -111,9 +111,6 @@ func init() {
 	// Fit is determined by node conditions: not ready, network unavailable or out of disk.
 	factory.RegisterMandatoryFitPredicate(predicates.CheckNodeConditionPred, predicates.CheckNodeConditionPredicate)
 
-	// Fit is determined based on whether a pod can tolerate all of the node's taints
-	factory.RegisterFitPredicate(predicates.PodToleratesNodeTaintsPred, predicates.PodToleratesNodeTaints)
-
 	// Fit is determined by volume topology requirements.
 	factory.RegisterFitPredicateFactory(
 		predicates.CheckVolumeBindingPred,


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
I think predicates.PodToleratesNodeTaintsPred should be controlled by features.TaintNodesByCondition, and it should be deleted from defaultPredicates.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

/release-note-none
/priority backlog
