### PR TITLE
Added --all flag to rollout undo ctl

### DIFF
--- a/pkg/kubectl/cmd/rollout/BUILD
+++ b/pkg/kubectl/cmd/rollout/BUILD
@@ -64,10 +64,14 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["rollout_pause_test.go"],
+    srcs = [
+        "rollout_pause_test.go",
+        "rollout_undo_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/kubectl/cmd/testing:go_default_library",
+        "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/scheme:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/kubectl/cmd/rollout/rollout_undo_test.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rollout
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+func TestResourceErrors(t *testing.T) {
+	testCases := map[string]struct {
+		args    []string
+		errFn   func(string) bool
+		allFlag string
+		file    string
+	}{
+		"no args": {
+			args: []string{},
+			errFn: func(err string) bool {
+				return (strings.Contains(err, "required resource not specified") ||
+					strings.Contains(err, "You must provide one or more resources by argument or filename"))
+			},
+		},
+		"resource with all flag": {
+			args: []string{""},
+			errFn: func(err string) bool {
+				return (strings.Contains(err, "cannot set --all and --filename at the same time") ||
+					strings.Contains(err, "the path \"/test.yaml\" does not exist"))
+			},
+			allFlag: "true",
+			file:    "/test.yaml",
+		},
+	}
+
+	for k, testCase := range testCases {
+		t.Run(k, func(t *testing.T) {
+			cmdutil.BehaviorOnFatal(func(str string, code int) {
+				if !testCase.errFn(str) {
+					t.Errorf("%s: unexpected error: %v", k, str)
+					return
+				}
+			})
+			tf := cmdtesting.NewTestFactory().WithNamespace("test")
+			defer tf.Cleanup()
+
+			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+			streams, _, _, _ := genericclioptions.NewTestIOStreams()
+			cmd := NewCmdRolloutUndo(tf, streams)
+			if testCase.allFlag != "" {
+				cmd.Flags().Set("all", testCase.allFlag)
+			}
+			if testCase.file != "" {
+				cmd.Flags().Set("filename", testCase.file)
+			}
+			cmd.Run(cmd, testCase.args)
+		})
+	}
+}

--- a/test/cmd/apps.sh
+++ b/test/cmd/apps.sh
@@ -65,7 +65,7 @@ run_daemonset_history_tests() {
   kubectl apply -f hack/testdata/rollingupdate-daemonset.yaml --record "${kube_flags[@]}"
   kube::test::wait_object_assert controllerrevisions "{{range.items}}{{$annotations_field}}:{{end}}" ".*rollingupdate-daemonset.yaml --record.*"
   # Rollback to revision 1 - should be no-op
-  kubectl rollout undo daemonset --to-revision=1 "${kube_flags[@]}"
+  kubectl rollout undo daemonset --all --to-revision=1 "${kube_flags[@]}"
   kube::test::get_object_assert daemonset "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_PAUSE_V2}:"
   kube::test::get_object_assert daemonset "{{range.items}}{{$container_len}}{{end}}" "1"
   # Update the DaemonSet (revision 2)
@@ -75,21 +75,21 @@ run_daemonset_history_tests() {
   kube::test::get_object_assert daemonset "{{range.items}}{{$container_len}}{{end}}" "2"
   kube::test::wait_object_assert controllerrevisions "{{range.items}}{{$annotations_field}}:{{end}}" ".*rollingupdate-daemonset-rv2.yaml --record.*"
   # Rollback to revision 1 with dry-run - should be no-op
-  kubectl rollout undo daemonset --dry-run=true "${kube_flags[@]}"
+  kubectl rollout undo daemonset --all --dry-run=true "${kube_flags[@]}"
   kube::test::get_object_assert daemonset "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_DAEMONSET_R2}:"
   kube::test::get_object_assert daemonset "{{range.items}}{{$image_field1}}:{{end}}" "${IMAGE_DAEMONSET_R2_2}:"
   kube::test::get_object_assert daemonset "{{range.items}}{{$container_len}}{{end}}" "2"
   # Rollback to revision 1
-  kubectl rollout undo daemonset --to-revision=1 "${kube_flags[@]}"
+  kubectl rollout undo daemonset --all --to-revision=1 "${kube_flags[@]}"
   kube::test::wait_object_assert daemonset "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_PAUSE_V2}:"
   kube::test::get_object_assert daemonset "{{range.items}}{{$container_len}}{{end}}" "1"
   # Rollback to revision 1000000 - should fail
-  output_message=$(! kubectl rollout undo daemonset --to-revision=1000000 "${kube_flags[@]}" 2>&1)
+  output_message=$(! kubectl rollout undo daemonset --all --to-revision=1000000 "${kube_flags[@]}" 2>&1)
   kube::test::if_has_string "${output_message}" "unable to find specified revision"
   kube::test::get_object_assert daemonset "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_PAUSE_V2}:"
   kube::test::get_object_assert daemonset "{{range.items}}{{$container_len}}{{end}}" "1"
   # Rollback to last revision
-  kubectl rollout undo daemonset "${kube_flags[@]}"
+  kubectl rollout undo daemonset --all "${kube_flags[@]}"
   kube::test::wait_object_assert daemonset "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_DAEMONSET_R2}:"
   kube::test::wait_object_assert daemonset "{{range.items}}{{$image_field1}}:{{end}}" "${IMAGE_DAEMONSET_R2_2}:"
   kube::test::get_object_assert daemonset "{{range.items}}{{$container_len}}{{end}}" "2"
@@ -416,7 +416,7 @@ run_statefulset_history_tests() {
   kubectl apply -f hack/testdata/rollingupdate-statefulset.yaml --record "${kube_flags[@]}"
   kube::test::wait_object_assert controllerrevisions "{{range.items}}{{$annotations_field}}:{{end}}" ".*rollingupdate-statefulset.yaml --record.*"
   # Rollback to revision 1 - should be no-op
-  kubectl rollout undo statefulset --to-revision=1 "${kube_flags[@]}"
+  kubectl rollout undo statefulset --all --to-revision=1 "${kube_flags[@]}"
   kube::test::get_object_assert statefulset "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_STATEFULSET_R1}:"
   kube::test::get_object_assert statefulset "{{range.items}}{{$container_len}}{{end}}" "1"
   # Update the statefulset (revision 2)
@@ -426,12 +426,12 @@ run_statefulset_history_tests() {
   kube::test::get_object_assert statefulset "{{range.items}}{{$container_len}}{{end}}" "2"
   kube::test::wait_object_assert controllerrevisions "{{range.items}}{{$annotations_field}}:{{end}}" ".*rollingupdate-statefulset-rv2.yaml --record.*"
   # Rollback to revision 1 with dry-run - should be no-op
-  kubectl rollout undo statefulset --dry-run=true "${kube_flags[@]}"
+  kubectl rollout undo statefulset --all --dry-run=true "${kube_flags[@]}"
   kube::test::get_object_assert statefulset "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_STATEFULSET_R2}:"
   kube::test::get_object_assert statefulset "{{range.items}}{{$image_field1}}:{{end}}" "${IMAGE_PAUSE_V2}:"
   kube::test::get_object_assert statefulset "{{range.items}}{{$container_len}}{{end}}" "2"
   # Rollback to revision 1
-  kubectl rollout undo statefulset --to-revision=1 "${kube_flags[@]}"
+  kubectl rollout undo statefulset --all --to-revision=1 "${kube_flags[@]}"
   kube::test::wait_object_assert statefulset "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_STATEFULSET_R1}:"
   kube::test::get_object_assert statefulset "{{range.items}}{{$container_len}}{{end}}" "1"
   # Rollback to revision 1000000 - should fail
@@ -440,7 +440,7 @@ run_statefulset_history_tests() {
   kube::test::get_object_assert statefulset "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_STATEFULSET_R1}:"
   kube::test::get_object_assert statefulset "{{range.items}}{{$container_len}}{{end}}" "1"
   # Rollback to last revision
-  kubectl rollout undo statefulset "${kube_flags[@]}"
+  kubectl rollout undo statefulset --all "${kube_flags[@]}"
   kube::test::wait_object_assert statefulset "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_STATEFULSET_R2}:"
   kube::test::wait_object_assert statefulset "{{range.items}}{{$image_field1}}:{{end}}" "${IMAGE_PAUSE_V2}:"
   kube::test::get_object_assert statefulset "{{range.items}}{{$container_len}}{{end}}" "2"


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature

**What this PR does / why we need it**:

Added `--all` flag to `rollout undo` ctl
Added unit-test for new flag

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/72747
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
The "--all" flag was added to "rollout undo" command, "rollout undo deployment" cannot be used anymore and will return error, now user is obligate to specify resource name or use the --all flag.

```

