### PR TITLE
Bump Docker supported version to 18.09

### DIFF
--- a/cmd/kubeadm/app/util/system/docker_validator.go
+++ b/cmd/kubeadm/app/util/system/docker_validator.go
@@ -38,7 +38,7 @@ func (d *DockerValidator) Name() string {
 
 const (
 	dockerConfigPrefix           = "DOCKER_"
-	latestValidatedDockerVersion = "18.06"
+	latestValidatedDockerVersion = "18.09"
 )
 
 // TODO(random-liu): Add more validating items.

--- a/cmd/kubeadm/app/util/system/docker_validator_test.go
+++ b/cmd/kubeadm/app/util/system/docker_validator_test.go
@@ -92,8 +92,14 @@ func TestValidateDockerInfo(t *testing.T) {
 			warn: false,
 		},
 		{
-			name: "Docker version 18.09.0 is not in the list of validated versions",
-			info: types.Info{Driver: "driver_2", ServerVersion: "18.09.0"},
+			name: "valid Docker version 18.09.1-ce",
+			info: types.Info{Driver: "driver_2", ServerVersion: "18.09.1-ce"},
+			err:  false,
+			warn: false,
+		},
+		{
+			name: "Docker version 19.01.0 is not in the list of validated versions",
+			info: types.Info{Driver: "driver_2", ServerVersion: "19.01.0"},
 			err:  false,
 			warn: true,
 		},

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -103,6 +103,8 @@ build() {
 }
 
 docker_version_check() {
+  # The reason for this version check is even though "docker manifest" command is available in 18.03, it does
+  # not work properly in that version. So we insist on 18.06.0 or higher.
   docker_version=$(docker version --format '{{.Client.Version}}' | cut -d"-" -f1)
   if [[ ${docker_version} != 18.06.0 && ${docker_version} < 18.06.0 ]]; then
     echo "Minimum docker version 18.06.0 is required for creating and pushing manifest images[found: ${docker_version}]"


### PR DESCRIPTION
For 1.14, let's support Docker 18.09 for kubeadm

Change-Id: Ib8d4d9dd3cb51cf4780623389a4bcb101d3c8fa7

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow users to use Docker 18.09 with kubeadm
```
