### PR TITLE
add an env to skip readonly-packages check

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -54,6 +54,13 @@ if [[ ${EXCLUDE_GODEP:-} =~ ^[yY]$ ]]; then
     )
 fi
 
+# Exclude readonly package check in certain cases, aka, in periodic jobs we don't care and a readonly package won't be touched
+if [[ ${EXCLUDE_READONLY_PACKAGE:-} =~ ^[yY]$ ]]; then
+  EXCLUDED_PATTERNS+=(
+    "verify-readonly-packages.sh"  # skip in CI, if env is set
+    )
+fi
+
 # Only run whitelisted fast checks in quick mode.
 # These run in <10s each on enisoc's workstation, assuming that
 # `make` and `hack/godep-restore.sh` had already been run.


### PR DESCRIPTION
In order to move CI verify job onto podutils, ref https://github.com/kubernetes/test-infra/pull/10679#discussion_r246911603

/assign @ixdy @BenTheElder @cblecker 

/sig testing
/kind cleanup
/release-note none
/priority critical-urgent