### PR TITLE
Fix PidPressure, and add fork-bomb e2e-node test

### DIFF
--- a/pkg/kubelet/eviction/api/types.go
+++ b/pkg/kubelet/eviction/api/types.go
@@ -63,6 +63,7 @@ var OpForSignal = map[Signal]ThresholdOperator{
 	SignalNodeFsInodesFree:  OpLessThan,
 	SignalImageFsAvailable:  OpLessThan,
 	SignalImageFsInodesFree: OpLessThan,
+	SignalPIDAvailable:      OpLessThan,
 }
 
 // ThresholdValue is a value holder that abstracts literal versus percentage based quantity

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -157,7 +157,7 @@ func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAd
 	return lifecycle.PodAdmitResult{
 		Admit:   false,
 		Reason:  Reason,
-		Message: fmt.Sprintf(nodeLowMessageFmt, m.nodeConditions),
+		Message: fmt.Sprintf(nodeConditionMessageFmt, m.nodeConditions),
 	}
 }
 

--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -40,6 +40,8 @@ const (
 	Reason = "Evicted"
 	// nodeLowMessageFmt is the message for evictions due to resource pressure.
 	nodeLowMessageFmt = "The node was low on resource: %v. "
+	// nodeConditionMessageFmt is the message for evictions due to resource pressure.
+	nodeConditionMessageFmt = "The node had condition: %v. "
 	// containerMessageFmt provides additional information for containers exceeding requests
 	containerMessageFmt = "Container %s was using %s, which exceeds its request of %s. "
 	// containerEphemeralStorageMessageFmt provides additional information for containers which have exceeded their ES limit
@@ -50,6 +52,8 @@ const (
 	emptyDirMessageFmt = "Usage of EmptyDir volume %q exceeds the limit %q. "
 	// inodes, number. internal to this module, used to account for local disk inode consumption.
 	resourceInodes v1.ResourceName = "inodes"
+	// resourcePids, number. internal to this module, used to account for local pid consumption.
+	resourcePids v1.ResourceName = "pids"
 	// OffendingContainersKey is the key in eviction event annotations for the list of container names which exceeded their requests
 	OffendingContainersKey = "offending_containers"
 	// OffendingContainersUsageKey is the key in eviction event annotations for the list of usage of containers which exceeded their requests
@@ -84,6 +88,7 @@ func init() {
 	signalToResource[evictionapi.SignalImageFsInodesFree] = resourceInodes
 	signalToResource[evictionapi.SignalNodeFsAvailable] = v1.ResourceEphemeralStorage
 	signalToResource[evictionapi.SignalNodeFsInodesFree] = resourceInodes
+	signalToResource[evictionapi.SignalPIDAvailable] = resourcePids
 }
 
 // validSignal returns true if the signal is supported.
@@ -674,6 +679,11 @@ func rankMemoryPressure(pods []*v1.Pod, stats statsFunc) {
 	orderedBy(exceedMemoryRequests(stats), priority, memory(stats)).Sort(pods)
 }
 
+// rankPIDPressure orders the input pods by priority in response to PID pressure.
+func rankPIDPressure(pods []*v1.Pod, stats statsFunc) {
+	orderedBy(priority).Sort(pods)
+}
+
 // rankDiskPressureFunc returns a rankFunc that measures the specified fs stats.
 func rankDiskPressureFunc(fsStatsToMeasure []fsStatsType, diskResource v1.ResourceName) rankFunc {
 	return func(pods []*v1.Pod, stats statsFunc) {
@@ -987,6 +997,7 @@ func buildSignalToRankFunc(withImageFs bool) map[evictionapi.Signal]rankFunc {
 	signalToRankFunc := map[evictionapi.Signal]rankFunc{
 		evictionapi.SignalMemoryAvailable:            rankMemoryPressure,
 		evictionapi.SignalAllocatableMemoryAvailable: rankMemoryPressure,
+		evictionapi.SignalPIDAvailable:               rankPIDPressure,
 	}
 	// usage of an imagefs is optional
 	if withImageFs {

--- a/pkg/kubelet/eviction/helpers_test.go
+++ b/pkg/kubelet/eviction/helpers_test.go
@@ -943,13 +943,13 @@ func TestSortByEvictionPriority(t *testing.T) {
 			expected:   []evictionapi.Threshold{},
 		},
 		{
-			name: "memory first, PID last",
+			name: "memory first",
 			thresholds: []evictionapi.Threshold{
 				{
-					Signal: evictionapi.SignalPIDAvailable,
+					Signal: evictionapi.SignalNodeFsAvailable,
 				},
 				{
-					Signal: evictionapi.SignalNodeFsAvailable,
+					Signal: evictionapi.SignalPIDAvailable,
 				},
 				{
 					Signal: evictionapi.SignalMemoryAvailable,
@@ -968,13 +968,13 @@ func TestSortByEvictionPriority(t *testing.T) {
 			},
 		},
 		{
-			name: "allocatable memory first, PID last",
+			name: "allocatable memory first",
 			thresholds: []evictionapi.Threshold{
 				{
-					Signal: evictionapi.SignalPIDAvailable,
+					Signal: evictionapi.SignalNodeFsAvailable,
 				},
 				{
-					Signal: evictionapi.SignalNodeFsAvailable,
+					Signal: evictionapi.SignalPIDAvailable,
 				},
 				{
 					Signal: evictionapi.SignalAllocatableMemoryAvailable,

--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -122,6 +122,7 @@ go_test(
         "//pkg/kubelet/cm/cpuset:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/eviction:go_default_library",
+        "//pkg/kubelet/eviction/api:go_default_library",
         "//pkg/kubelet/images:go_default_library",
         "//pkg/kubelet/kubeletconfig:go_default_library",
         "//pkg/kubelet/kubeletconfig/status:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As @derekwaynecarr noted at sig-node, the PidPressure condition hasn't been functional for some time now.  This fixes the PidPressure condition by adding PidPressure to the relevant maps in the eviction manager, including `OpForSignal`, `signalToResource`, and `signalToRankFunc`.  `signalToRankFunc` is only required to enable eviction for PidPressure.  `OpForSignal` and `signalToResource` are required for PidPressure to surface at all.

As we don't have easily available process metrics, this PR uses *only priority* as the way to rank pods for eviction in response to PidPressure.  While this isn't ideal, it is better than no eviction at all IMO.  We can iterate on this if needed.

The e2e node test sets the eviction threshold such that with 10k additional processes the eviction threshold will be crossed, and the fork-bomb container creates 12k processes.

This PR also makes a minor change to the message when a pod fails admission due to pressure, changing the message from "The node was low on resource: [Diskpressure]" to "The node had condition: [DiskPressure]".

It also changes eviction tests to use constants from the eviction api, such as `SignalNodeFsAvailable` instead of `nodefs.available`.

**Which issue(s) this PR fixes**:
Fixes #72654 

**Does this PR introduce a user-facing change?**:
```release-note
PidPressure evicts pods from lowest priority to highest priority
```

/assign @dims @derekwaynecarr 