### PR TITLE
WIP: Fallback to first type if having candidates

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
@@ -282,6 +282,12 @@ func NegotiateMediaTypeOptions(header string, accepted []AcceptedMediaType, endp
 		}
 	}
 
+	if len(accepted) > 0 {
+		return MediaTypeOptions{
+			Accepted: &accepted[0],
+		}, true
+	}
+
 	return MediaTypeOptions{}, false
 }
 


### PR DESCRIPTION
**TODO**
- need unit test
- verify this works fine for integration tests

**What type of PR is this?**
/kind bug
/kind failing-test
/kind flake

**What this PR does / why we need it**:

Before giving up to get the most appropriate content type,
this makes the method returns the first type if having some
candidates.

**Which issue(s) this PR fixes**:
Fixes #71696
