### PR TITLE
.github: add nikhita as reviewer

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -2,6 +2,7 @@ reviewers:
   - castrojo
   - cblecker
   - grodrigues3
+  - nikhita
   - parispittman
   - Phillels
 approvers:
@@ -10,3 +11,5 @@ approvers:
   - grodrigues3
   - parispittman
   - Phillels
+labels:
+  - sig/contributor-experience


### PR DESCRIPTION
Also automatically apply the `sig/contributor-experience` label for any changes to `.github/`.

I would like to help with reviews related to changes in files in `.github`. :)
Previously, I have reviewed https://github.com/kubernetes/kubernetes/pull/68774 (which was a major overhaul of our issue templates) and authored https://github.com/kubernetes/kubernetes/pull/72560.

/assign @cblecker @parispittman @Phillels @castrojo 
/sig contributor-experience
/kind cleanup

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
