### PR TITLE
Fix nil panic propagation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -190,9 +190,9 @@ func finishRequest(timeout time.Duration, fn resultFunc) (result runtime.Object,
 				buf := make([]byte, size)
 				buf = buf[:goruntime.Stack(buf, false)]
 				panicReason = strings.TrimSuffix(fmt.Sprintf("%v\n%s", panicReason, string(buf)), "\n")
+				// Propagate to parent goroutine
+				panicCh <- panicReason
 			}
-			// Propagate to parent goroutine
-			panicCh <- panicReason
 		}()
 
 		if result, err := fn(); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/pull/71076/files#diff-390e9c6b4af51b3a3723c78f40b0e134 introduced a bug in which nil could be sent to the rest panic-propagating channel.

When the response actually did panic, this code worked properly.

When the response did not panic, it would send nil, racing the err and result channels. When the panic-propagating channel won the race, a nil panic would be thrown. This would short-circuit all response writing, resulting in no content type and no status code, but maddeningly, would not be logged (because the object sent to panic was `nil`).

**Which issue(s) this PR fixes**:
Fixes #71696 

**Special notes for your reviewer**:
@dims is a hero for tracking this down.

**Does this PR introduce a user-facing change?**:
```release-note
Fixes spurious 0-length API responses.
```

/assign @dims @sttts 
/sig api-machinery
/kind bug
/priority critical-urgent