### PR TITLE
Fix Kubelet hostAliases should write entries to /etc/hosts test

### DIFF
--- a/test/e2e/common/kubelet.go
+++ b/test/e2e/common/kubelet.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -175,11 +175,14 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 				buf.ReadFrom(rc)
 				hostsFileContent := buf.String()
 
-				if !strings.Contains(hostsFileContent, "123.45.67.89\tfoo\tbar") {
-					return fmt.Errorf("expected hosts file to contain entries from HostAliases. Got:\n%+v", hostsFileContent)
+				if strings.Contains(hostsFileContent, "123.45.67.89\tfoo\tbar") ||
+					(strings.Contains(hostsFileContent, "123.45.67.89\tfoo") &&
+						strings.Contains(hostsFileContent, "123.45.67.89\tbar")) {
+					return nil
 				}
 
-				return nil
+				return fmt.Errorf("expected hosts file to contain entries from HostAliases. Got:\n%+v", hostsFileContent)
+
 			}, time.Minute, time.Second*4).Should(BeNil())
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label

4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
When running a pod with HostAliases and checking whether hosts file contains specified hostnames, conformance test checks for:
```
123.45.67.89   foo bar
```
but this version is also valid:
```
123.45.67.89   foo
123.45.67.89   bar
```

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
