### PR TITLE
Kubeadm/HA: pull images during join for control-plane

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -419,6 +419,10 @@ func (j *joinData) Run() error {
 		fmt.Printf("[join] Running pre-flight checks before initializing the new control plane instance\n")
 		preflight.RunInitMasterChecks(utilsexec.New(), initCfg, j.ignorePreflightErrors)
 
+		fmt.Println("[join] Pulling control-plane images")
+		if err := preflight.RunPullImagesCheck(utilsexec.New(), initCfg, j.ignorePreflightErrors); err != nil {
+			return err
+		}
 		// Prepares the node for hosting a new control plane instance by writing necessary
 		// kubeconfig files, and static pod manifests
 		if err := j.PrepareForHostingControlPlane(initCfg); err != nil {


### PR DESCRIPTION
> /kind feature

**What this PR does / why we need it**:


Kubeadm/HA: pull images during join for control-plane

**Which issue(s) this PR fixes**:

Fixes kubernetes/kubeadm#1341

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: pull images when joining a new control plane instance
```
