### PR TITLE
Implement a dedicated serializer package for ComponentConfigs

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/error.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/error.go
@@ -120,3 +120,77 @@ func IsMissingVersion(err error) bool {
 	_, ok := err.(*missingVersionErr)
 	return ok
 }
+
+// StrictDecoderError is a base error type that is returned by a strict Decoder such
+// as UniversalStrictDecoder.
+type StrictDecoderError struct {
+	message      string
+	gvk          schema.GroupVersionKind
+	originalData []byte
+}
+
+// UnknownFieldError is an error type that is returned in cases where the input
+// JSON or YAML contains unknown fields.
+// UnknownFieldError embeds StrictDecoderError.
+type UnknownFieldError struct {
+	StrictDecoderError
+}
+
+// DuplicateFieldError is an error type that is returned in cases where the input
+// JSON or YAML contains duplicate fields under the same parent field.
+// DuplicateFieldError embeds StrictDecoderError.
+type DuplicateFieldError struct {
+	StrictDecoderError
+}
+
+// NewStrictDecoderError creates a new NewStrictDecoderError object
+func NewStrictDecoderError(message string, gvk schema.GroupVersionKind, originalData []byte) *StrictDecoderError {
+	return &StrictDecoderError{
+		message:      message,
+		gvk:          gvk,
+		originalData: originalData,
+	}
+}
+
+func (e *StrictDecoderError) Error() string {
+	return fmt.Sprintf("strict decoder error for %#v: %s", e.gvk, e.message)
+}
+
+// GVK returns the GVK that was extacted when Decoding using a strict Decoder.
+func (e *StrictDecoderError) GVK() schema.GroupVersionKind {
+	return e.gvk
+}
+
+// OriginalData returns the original byte slice input that was passed to a strict Decoder.
+func (e *StrictDecoderError) OriginalData() []byte {
+	return e.originalData
+}
+
+// IsStrictDecoderError returns true if the error is a result of a strict Decoder.
+func IsStrictDecoderError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*StrictDecoderError)
+	return ok
+}
+
+// IsUnknownFieldError returns true if the error is a result of a strict Decoder failing
+// due to a unknown field.
+func IsUnknownFieldError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*UnknownFieldError)
+	return ok
+}
+
+// IsDuplicateFieldError returns true if the error is a result of a strict Decoder failing
+// due to a duplicate field.
+func IsDuplicateFieldError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*DuplicateFieldError)
+	return ok
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
@@ -59,8 +59,22 @@ type DecodableSpec struct {
 func (d *testDecodable) GetObjectKind() schema.ObjectKind                { return d }
 func (d *testDecodable) SetGroupVersionKind(gvk schema.GroupVersionKind) { d.gvk = gvk }
 func (d *testDecodable) GroupVersionKind() schema.GroupVersionKind       { return d.gvk }
-func (d *testDecodable) DeepCopyObject() runtime.Object {
-	panic("testDecodable does not support DeepCopy")
+func (in *testDecodable) DeepCopyObject() runtime.Object {
+	if in == nil {
+		return nil
+	}
+	out := new(testDecodable)
+	in.DeepCopyInto(out)
+	return out
+}
+func (in *testDecodable) DeepCopyInto(out *testDecodable) {
+	*out = *in
+	out.Other = in.Other
+	out.Value = in.Value
+	out.Spec = in.Spec
+	out.Interface = in.Interface
+	out.gvk = in.gvk
+	return
 }
 
 func TestDecode(t *testing.T) {
@@ -69,6 +83,7 @@ func TestDecode(t *testing.T) {
 		typer   runtime.ObjectTyper
 		yaml    bool
 		pretty  bool
+		strict  bool
 
 		data       []byte
 		defaultGVK *schema.GroupVersionKind
@@ -274,14 +289,146 @@ func TestDecode(t *testing.T) {
 				Spec: DecodableSpec{A: 1, H: 3},
 			},
 		},
+		// Unknown fields should return an error from the strict JSON deserializer.
+		{
+			data:        []byte(`{"unknown": 1}`),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "unknown field")
+			},
+			strict: true,
+		},
+		// Unknown fields should return an error from the strict YAML deserializer.
+		{
+			data:        []byte("unknown: 1\n"),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "unknown field")
+			},
+			yaml:   true,
+			strict: true,
+		},
+		// Duplicate fields should return an error from the strict JSON deserializer.
+		{
+			data:        []byte(`{"value":1,"value":1}`),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "already set in map")
+			},
+			strict: true,
+		},
+		// Duplicate fields should return an error from the strict YAML deserializer.
+		{
+			data: []byte("value: 1\n" +
+				"value: 1\n"),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "already set in map")
+			},
+			yaml:   true,
+			strict: true,
+		},
+		// Strict JSON decode should fail for untagged fields.
+		{
+			data:        []byte(`{"kind":"Test","apiVersion":"other/blah","value":1,"Other":"test"}`),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "unknown field")
+			},
+			strict: true,
+		},
+		// Strict YAML decode should fail for untagged fields.
+		{
+			data: []byte("kind: Test\n" +
+				"apiVersion: other/blah\n" +
+				"value: 1\n" +
+				"Other: test\n"),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "unknown field")
+			},
+			yaml:   true,
+			strict: true,
+		},
+		// Strict JSON decode into unregistered objects directly.
+		{
+			data:        []byte(`{"kind":"Test","apiVersion":"other/blah","value":1,"Other":"test"}`),
+			into:        &testDecodable{},
+			typer:       &mockTyper{err: runtime.NewNotRegisteredErrForKind("mock", schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"})},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			expectedObject: &testDecodable{
+				Other: "test",
+				Value: 1,
+			},
+			strict: true,
+		},
+		// Strict YAML decode into unregistered objects directly.
+		{
+			data: []byte("kind: Test\n" +
+				"apiVersion: other/blah\n" +
+				"value: 1\n" +
+				"Other: test\n"),
+			into:        &testDecodable{},
+			typer:       &mockTyper{err: runtime.NewNotRegisteredErrForKind("mock", schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"})},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			expectedObject: &testDecodable{
+				Other: "test",
+				Value: 1,
+			},
+			yaml:   true,
+			strict: true,
+		},
+		// Valid strict JSON decode without GVK.
+		{
+			data:        []byte(`{"value":1234}`),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			expectedObject: &testDecodable{
+				Value: 1234,
+			},
+			strict: true,
+		},
+		// Valid strict YAML decode without GVK.
+		{
+			data:        []byte("value: 1234\n"),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			expectedObject: &testDecodable{
+				Value: 1234,
+			},
+			yaml:   true,
+			strict: true,
+		},
 	}
 
 	for i, test := range testCases {
 		var s runtime.Serializer
 		if test.yaml {
-			s = json.NewYAMLSerializer(json.DefaultMetaFactory, test.creater, test.typer)
+			if !test.strict {
+				s = json.NewYAMLSerializer(json.DefaultMetaFactory, test.creater, test.typer)
+			} else {
+				s = json.NewStrictYAMLSerializer(json.DefaultMetaFactory, test.creater, test.typer)
+			}
 		} else {
-			s = json.NewSerializer(json.DefaultMetaFactory, test.creater, test.typer, test.pretty)
+			if !test.strict {
+				s = json.NewSerializer(json.DefaultMetaFactory, test.creater, test.typer, test.pretty)
+			} else {
+				s = json.NewStrictSerializer(json.DefaultMetaFactory, test.creater, test.typer)
+			}
 		}
 		obj, gvk, err := s.Decode([]byte(test.data), test.defaultGVK, test.into)
 

--- a/staging/src/k8s.io/component-base/Godeps/Godeps.json
+++ b/staging/src/k8s.io/component-base/Godeps/Godeps.json
@@ -19,6 +19,18 @@
 			"Rev": "44d81051d367757e1c7c6a5a86423ece9afcf63c"
 		},
 		{
+			"ImportPath": "github.com/json-iterator/go",
+			"Rev": "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
+		},
+		{
+			"ImportPath": "github.com/modern-go/concurrent",
+			"Rev": "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
+		},
+		{
+			"ImportPath": "github.com/modern-go/reflect2",
+			"Rev": "94122c33edd36123c84d5368cfb2b69df93a0ec8"
+		},
+		{
 			"ImportPath": "golang.org/x/net/http2",
 			"Rev": "0ed95abb35c445290478a5348a7b38bb154135fd"
 		},
@@ -55,11 +67,19 @@
 			"Rev": "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
 		},
 		{
+			"ImportPath": "gopkg.in/yaml.v2",
+			"Rev": "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
@@ -87,6 +107,30 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/json",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/testing",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/selection",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
@@ -96,6 +140,10 @@
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/framer",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
@@ -131,6 +179,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/watch",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
@@ -145,6 +197,10 @@
 		{
 			"ImportPath": "k8s.io/utils/pointer",
 			"Rev": "8e7ff06bf0e2d3289061230af203e430a15b6dcc"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/yaml",
+			"Rev": "fd68e9863619f6ec2fdd8625fe1f02e7c877e480"
 		}
 	]
 }

--- a/staging/src/k8s.io/component-base/config/BUILD
+++ b/staging/src/k8s.io/component-base/config/BUILD
@@ -24,6 +24,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//staging/src/k8s.io/component-base/config/serializer:all-srcs",
         "//staging/src/k8s.io/component-base/config/v1alpha1:all-srcs",
         "//staging/src/k8s.io/component-base/config/validation:all-srcs",
     ],

--- a/staging/src/k8s.io/component-base/config/serializer/BUILD
+++ b/staging/src/k8s.io/component-base/config/serializer/BUILD
@@ -1,0 +1,45 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "encode.go",
+        "error.go",
+    ],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/component-base/config/serializer",
+    importpath = "k8s.io/component-base/config/serializer",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["encode_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/conversion:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/testing:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/component-base/config/serializer/encode.go
+++ b/staging/src/k8s.io/component-base/config/serializer/encode.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serializer
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+)
+
+// EncodingFormat is a high-level, typed constant configuring how an object should be encoded
+type EncodingFormat string
+
+const (
+	// YAML encodes a config file in the YAML format
+	YAML EncodingFormat = "YAML"
+	// JSON encodes a config file in compact JSON format
+	JSON EncodingFormat = "JSON"
+)
+
+// NewConfigSerializer creates a new implementation of the ConfigSerializer interface
+func NewConfigSerializer(scheme *runtime.Scheme, codecs *serializer.CodecFactory) ConfigSerializer {
+	// Store a map of known encoders, indexed by EncodingFormat
+	encoderMap := map[EncodingFormat]runtime.Encoder{}
+	for _, serializerInfo := range codecs.SupportedMediaTypes() {
+		switch serializerInfo.MediaType {
+		case "application/json":
+			encoderMap[JSON] = serializerInfo.Serializer
+		case "application/yaml":
+			encoderMap[YAML] = serializerInfo.Serializer
+		}
+	}
+
+	// Create the strict deserializer, and later the
+	yamlStrictSerializer := json.NewStrictYAMLSerializer(json.DefaultMetaFactory, scheme, scheme)
+	universalDecoder := codecs.CodecForVersions(nil, yamlStrictSerializer, nil, runtime.InternalGroupVersioner)
+
+	return &configSerializer{scheme, codecs, encoderMap, universalDecoder}
+}
+
+// ConfigSerializer provides encoding/decoding for a configuration file
+type ConfigSerializer interface {
+	DecodeInto([]byte, runtime.Object) error
+	Encode(EncodingFormat, schema.GroupVersion, runtime.Object) ([]byte, error)
+}
+
+// configSerializer implements the ConfigSerializer interface
+var _ ConfigSerializer = &configSerializer{}
+
+type configSerializer struct {
+	scheme     *runtime.Scheme
+	codecs     *serializer.CodecFactory
+	encoderMap map[EncodingFormat]runtime.Encoder
+	decoder    runtime.Decoder
+}
+
+// DecodeInto decodes bytes into a pointer of the desired type
+func (cs *configSerializer) DecodeInto(data []byte, into runtime.Object) error {
+	out, gvk, err := cs.decoder.Decode(data, nil, into)
+	// Return a structured error if the group was registered with the scheme but the version was unrecognized
+	if gvk != nil && err != nil {
+		if cs.scheme.IsGroupRegistered(gvk.Group) && !cs.scheme.IsVersionRegistered(gvk.GroupVersion()) {
+			return NewUnrecognizedVersionError("please specify a correct API version", *gvk, data)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if out != into {
+		return fmt.Errorf("unable to decode %s into %v", gvk, reflect.TypeOf(into))
+	}
+	return nil
+}
+
+// Encode encodes the object into a byte slice for the specific format and version
+func (cs *configSerializer) Encode(format EncodingFormat, gv schema.GroupVersion, obj runtime.Object) ([]byte, error) {
+	encoder, ok := cs.encoderMap[format]
+	if !ok {
+		return []byte{}, fmt.Errorf("encoding format not supported: %s", format)
+	}
+	// versionSpecificEncoder writes out YAML bytes for exactly this group version
+	versionSpecificEncoder := cs.codecs.EncoderForVersion(encoder, gv)
+	// Encode the object to YAML for the given version
+	return runtime.Encode(versionSpecificEncoder, obj)
+}

--- a/staging/src/k8s.io/component-base/config/serializer/encode_test.go
+++ b/staging/src/k8s.io/component-base/config/serializer/encode_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serializer
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	runtimetest "k8s.io/apimachinery/pkg/runtime/testing"
+)
+
+var (
+	scheme        = runtime.NewScheme()
+	codecs        = serializer.NewCodecFactory(scheme)
+	cfgserializer = NewConfigSerializer(scheme, &codecs)
+
+	intsb = runtime.NewSchemeBuilder(addInternalTypes)
+	extsb = runtime.NewSchemeBuilder(registerConversions, addExternalTypes)
+
+	groupname = "foogroup"
+	intgv     = schema.GroupVersion{Group: groupname, Version: runtime.APIVersionInternal}
+	extgv     = schema.GroupVersion{Group: groupname, Version: "v1alpha1"}
+)
+
+func registerConversions(s *runtime.Scheme) error {
+	if err := s.AddGeneratedConversionFunc((*runtimetest.ExternalSimple)(nil), (*runtimetest.InternalSimple)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return autoConvertExternalSimpleToInternalSimple(a.(*runtimetest.ExternalSimple), b.(*runtimetest.InternalSimple), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddGeneratedConversionFunc((*runtimetest.InternalSimple)(nil), (*runtimetest.ExternalSimple)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return autoConvertInternalSimpleToExternalSimple(a.(*runtimetest.InternalSimple), b.(*runtimetest.ExternalSimple), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddGeneratedConversionFunc((*runtimetest.ExternalComplex)(nil), (*runtimetest.InternalComplex)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return autoConvertExternalComplexToInternalComplex(a.(*runtimetest.ExternalComplex), b.(*runtimetest.InternalComplex), scope)
+	}); err != nil {
+		return err
+	}
+	return s.AddGeneratedConversionFunc((*runtimetest.InternalComplex)(nil), (*runtimetest.ExternalComplex)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return autoConvertInternalComplexToExternalComplex(a.(*runtimetest.InternalComplex), b.(*runtimetest.ExternalComplex), scope)
+	})
+}
+
+func autoConvertExternalSimpleToInternalSimple(in *runtimetest.ExternalSimple, out *runtimetest.InternalSimple, s conversion.Scope) error {
+	out.TestString = in.TestString
+	return nil
+}
+
+func autoConvertInternalSimpleToExternalSimple(in *runtimetest.InternalSimple, out *runtimetest.ExternalSimple, s conversion.Scope) error {
+	out.TestString = in.TestString
+	return nil
+}
+
+func autoConvertExternalComplexToInternalComplex(in *runtimetest.ExternalComplex, out *runtimetest.InternalComplex, s conversion.Scope) error {
+	out.String = in.String
+	out.Integer = in.Integer
+	out.Integer64 = in.Integer64
+	out.Int64 = in.Int64
+	out.Bool = in.Bool
+	return nil
+}
+
+func autoConvertInternalComplexToExternalComplex(in *runtimetest.InternalComplex, out *runtimetest.ExternalComplex, s conversion.Scope) error {
+	out.String = in.String
+	out.Integer = in.Integer
+	out.Integer64 = in.Integer64
+	out.Int64 = in.Int64
+	out.Bool = in.Bool
+	return nil
+}
+
+func addInternalTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypeWithName(intgv.WithKind("Simple"), &runtimetest.InternalSimple{})
+	scheme.AddKnownTypeWithName(intgv.WithKind("Complex"), &runtimetest.InternalComplex{})
+	return nil
+}
+
+func addExternalTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypeWithName(extgv.WithKind("Simple"), &runtimetest.ExternalSimple{})
+	scheme.AddKnownTypeWithName(extgv.WithKind("Complex"), &runtimetest.ExternalComplex{})
+	return nil
+}
+
+func init() {
+	intsb.AddToScheme(scheme)
+	extsb.AddToScheme(scheme)
+}
+
+var (
+	oneSimple = []byte(`apiVersion: foogroup/v1alpha1
+kind: Simple
+testString: foo
+`)
+	simpleUnknownField = []byte(`apiVersion: foogroup/v1alpha1
+kind: Simple
+testString: foo
+unknownField: bar
+`)
+	simpleDuplicateField = []byte(`apiVersion: foogroup/v1alpha1
+kind: Simple
+testString: foo
+testString: bar
+`)
+	unrecognizedVersion = []byte(`apiVersion: foogroup/v1alpha0
+kind: Simple
+testString: foo
+`)
+	oneComplex = []byte(`Int64: 0
+apiVersion: foogroup/v1alpha1
+bool: false
+int: 0
+kind: Complex
+string: bar
+`)
+	simpleJSON = []byte(`{"apiVersion":"foogroup/v1alpha1","kind":"Simple","testString":"foo"}
+`)
+	complexJSON = []byte(`{"apiVersion":"foogroup/v1alpha1","kind":"Complex","string":"bar","int":0,"Int64":0,"bool":false}
+`)
+)
+
+func TestEncode(t *testing.T) {
+	simpleObj := &runtimetest.InternalSimple{TestString: "foo"}
+	complexObj := &runtimetest.InternalComplex{String: "bar"}
+	tests := []struct {
+		name        string
+		format      EncodingFormat
+		gv          schema.GroupVersion
+		obj         runtime.Object
+		expected    []byte
+		expectedErr bool
+	}{
+		{"simple yaml", YAML, extgv, simpleObj, oneSimple, false},
+		{"complex yaml", YAML, extgv, complexObj, oneComplex, false},
+		{"simple json", JSON, extgv, simpleObj, simpleJSON, false},
+		{"complex json", JSON, extgv, complexObj, complexJSON, false},
+		{"no-conversion simple", JSON, extgv, &runtimetest.ExternalSimple{TestString: "foo"}, simpleJSON, false},
+		{"support internal", JSON, intgv, simpleObj, []byte(`{"testString":"foo"}` + "\n"), false},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t2 *testing.T) {
+			actual, actualErr := cfgserializer.Encode(rt.format, rt.gv, rt.obj)
+			if (actualErr != nil) != rt.expectedErr {
+				t2.Errorf("expected error %t but actual %t", rt.expectedErr, actualErr != nil)
+			}
+			if !bytes.Equal(actual, rt.expected) {
+				t2.Errorf("expected %q but actual %q", string(rt.expected), string(actual))
+			}
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	simpleMeta := runtime.TypeMeta{APIVersion: "foogroup/v1alpha1", Kind: "Simple"}
+	complexMeta := runtime.TypeMeta{APIVersion: "foogroup/v1alpha1", Kind: "Complex"}
+	tests := []struct {
+		name        string
+		data        []byte
+		obj         runtime.Object
+		expected    runtime.Object
+		expectedErr bool
+	}{
+		{"simple internal", oneSimple, &runtimetest.InternalSimple{}, &runtimetest.InternalSimple{TestString: "foo"}, false},
+		{"complex internal", oneComplex, &runtimetest.InternalComplex{}, &runtimetest.InternalComplex{String: "bar"}, false},
+		{"simple external", oneSimple, &runtimetest.ExternalSimple{}, &runtimetest.ExternalSimple{TypeMeta: simpleMeta, TestString: "foo"}, false},
+		{"complex external", oneComplex, &runtimetest.ExternalComplex{}, &runtimetest.ExternalComplex{TypeMeta: complexMeta, String: "bar"}, false},
+		{"no unknown fields", simpleUnknownField, &runtimetest.InternalSimple{}, nil, true},
+		{"no duplicate fields", simpleDuplicateField, &runtimetest.InternalSimple{}, nil, true},
+		{"no unrecognized API version", unrecognizedVersion, &runtimetest.InternalSimple{}, nil, true},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t2 *testing.T) {
+			actual := cfgserializer.DecodeInto(rt.data, rt.obj)
+			if (actual != nil) != rt.expectedErr {
+				t2.Errorf("expected error %t but actual %t", rt.expectedErr, actual != nil)
+			}
+			if rt.expected != nil && !reflect.DeepEqual(rt.obj, rt.expected) {
+				t2.Errorf("expected %#v but actual %#v", rt.expected, rt.obj)
+			}
+		})
+	}
+}
+
+func TestRoundtrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   []byte
+		format EncodingFormat
+		gv     schema.GroupVersion
+		obj    runtime.Object
+	}{
+		{"simple yaml", oneSimple, YAML, extgv, &runtimetest.InternalSimple{}},
+		{"complex yaml", oneComplex, YAML, extgv, &runtimetest.InternalComplex{}},
+		{"simple json", simpleJSON, JSON, extgv, &runtimetest.InternalSimple{}},
+		{"complex json", complexJSON, JSON, extgv, &runtimetest.InternalComplex{}},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t2 *testing.T) {
+			err := cfgserializer.DecodeInto(rt.data, rt.obj)
+			if err != nil {
+				t2.Errorf("unexpected decode error: %v", err)
+			}
+			actual, err := cfgserializer.Encode(rt.format, rt.gv, rt.obj)
+			if err != nil {
+				t2.Errorf("unexpected encode error: %v", err)
+			}
+			if !bytes.Equal(actual, rt.data) {
+				t2.Errorf("expected %q but actual %q", string(rt.data), string(actual))
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/component-base/config/serializer/error.go
+++ b/staging/src/k8s.io/component-base/config/serializer/error.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serializer
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Error implements the error interface
+var _ error = &UnrecognizedVersionError{}
+
+// UnrecognizedVersionError is a base error type that is returned when decoding bytes that
+// use a too old API version.
+type UnrecognizedVersionError struct {
+	message      string
+	gvk          schema.GroupVersionKind
+	originalData []byte
+}
+
+// NewUnrecognizedVersionError creates a new UnrecognizedVersionError object
+func NewUnrecognizedVersionError(message string, gvk schema.GroupVersionKind, originalData []byte) *UnrecognizedVersionError {
+	return &UnrecognizedVersionError{
+		message:      message,
+		gvk:          gvk,
+		originalData: originalData,
+	}
+}
+
+// Error implements the error interface
+func (e *UnrecognizedVersionError) Error() string {
+	return fmt.Sprintf("unrecognized version %s in known group %s for kind %v: %s", e.gvk.Version, e.gvk.Group, e.gvk, e.message)
+}
+
+// GVK returns the GroupVersionKind for this error
+func (e *UnrecognizedVersionError) GVK() schema.GroupVersionKind {
+	return e.gvk
+}
+
+// OriginalData returns the original byte slice input.
+func (e *UnrecognizedVersionError) OriginalData() []byte {
+	return e.originalData
+}
+
+// IsUnrecognizedVersionError returns true if the error...
+func IsUnrecognizedVersionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*UnrecognizedVersionError)
+	return ok
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
>
> /kind flake

/kind feature

**What this PR does / why we need it**:

Builds on top of: https://github.com/kubernetes/kubernetes/pull/71589

This PR is a PoC of how a generic code could be written that implements the semantics we want for ComponentConfigs (e.g. using a strict codec, reading one or many kinds from multiple sources, support multiple YAML documents per file, etc.)

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/assign @neolit123 @sttts @mtaufen 