### PR TITLE
kubeadm: reduce visibility of funcs and vars to the code they are relevant to

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -114,7 +114,7 @@ func NewCmdApply(apf *applyPlanFlags) *cobra.Command {
 			err = SetImplicitFlags(flags)
 			kubeadmutil.CheckErr(err)
 
-			err = RunApply(flags)
+			err = runApply(flags)
 			kubeadmutil.CheckErr(err)
 		},
 	}
@@ -132,7 +132,7 @@ func NewCmdApply(apf *applyPlanFlags) *cobra.Command {
 	return cmd
 }
 
-// RunApply takes care of the actual upgrade functionality
+// runApply takes care of the actual upgrade functionality
 // It does the following things:
 // - Checks if the cluster is healthy
 // - Gets the configuration from the kubeadm-config ConfigMap in the cluster
@@ -144,7 +144,7 @@ func NewCmdApply(apf *applyPlanFlags) *cobra.Command {
 //   - Creating the RBAC rules for the bootstrap tokens and the cluster-info ConfigMap
 //   - Applying new kube-dns and kube-proxy manifests
 //   - Uploads the newly used configuration to the cluster ConfigMap
-func RunApply(flags *applyFlags) error {
+func runApply(flags *applyFlags) error {
 
 	// Start with the basics, verify that the cluster is healthy and get the configuration from the cluster (using the ConfigMap)
 	klog.V(1).Infof("[upgrade/apply] verifying health of cluster")

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -75,7 +75,7 @@ func NewCmdPlan(apf *applyPlanFlags) *cobra.Command {
 				flags.newK8sVersionStr = args[0]
 			}
 
-			err = RunPlan(flags)
+			err = runPlan(flags)
 			kubeadmutil.CheckErr(err)
 		},
 	}
@@ -85,8 +85,8 @@ func NewCmdPlan(apf *applyPlanFlags) *cobra.Command {
 	return cmd
 }
 
-// RunPlan takes care of outputting available versions to upgrade to for the user
-func RunPlan(flags *planFlags) error {
+// runPlan takes care of outputting available versions to upgrade to for the user
+func runPlan(flags *planFlags) error {
 	// Start with the basics, verify that the cluster is healthy, build a client and a versionGetter. Never dry-run when planning.
 	klog.V(1).Infof("[upgrade/plan] verifying health of cluster")
 	klog.V(1).Infof("[upgrade/plan] retrieving configuration from cluster")

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -214,8 +214,7 @@ func BytesToInternalConfig(b []byte) (*kubeadmapi.InitConfiguration, error) {
 
 		// Try to get the registration for the ComponentConfig based on the kind
 		regKind := componentconfigs.RegistrationKind(gvk.Kind)
-		registration, found := componentconfigs.Known[regKind]
-		if found {
+		if registration, found := componentconfigs.Known[regKind]; found {
 			// Unmarshal the bytes from the YAML document into a runtime.Object containing the ComponentConfiguration struct
 			obj, err := registration.Unmarshal(fileContent)
 			if err != nil {
@@ -269,8 +268,7 @@ func BytesToInternalConfig(b []byte) (*kubeadmapi.InitConfiguration, error) {
 
 	// Save the loaded ComponentConfig objects in the initcfg object
 	for kind, obj := range decodedComponentConfigObjects {
-		registration, found := componentconfigs.Known[kind]
-		if found {
+		if registration, found := componentconfigs.Known[kind]; found {
 			if ok := registration.SetToInternalConfig(obj, &initcfg.ClusterConfiguration); !ok {
 				return nil, errors.Errorf("couldn't save componentconfig value for kind %q", string(kind))
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is a minor cleanup which helps to make the code of kubeadm a bit less error-prone by reducing the scope of local variables and unexporting functions that are not meant to be used outside of their respective modules.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
