### PR TITLE
kubeadm: remove unused argument from FetchConfigFromFileOrCluster()

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -691,7 +691,7 @@ func fetchInitConfiguration(tlsBootstrapCfg *clientcmdapi.Config) (*kubeadmapi.I
 	}
 
 	// Fetches the init configuration
-	initConfiguration, err := configutil.FetchConfigFromFileOrCluster(tlsClient, os.Stdout, "join", "", true)
+	initConfiguration, err := configutil.FetchConfigFromFileOrCluster(tlsClient, "join", "", true)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch the kubeadm-config ConfigMap")
 	}

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -207,7 +207,7 @@ func getEtcdDataDir(manifestPath string, client clientset.Interface) (string, er
 	var dataDir string
 
 	if client != nil {
-		cfg, err := configutil.FetchConfigFromFileOrCluster(client, os.Stdout, "reset", "", false)
+		cfg, err := configutil.FetchConfigFromFileOrCluster(client, "reset", "", false)
 		if err == nil && cfg.Etcd.Local != nil {
 			return cfg.Etcd.Local.DataDir, nil
 		}

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -71,7 +71,7 @@ func enforceRequirements(flags *applyPlanFlags, dryRun bool, newK8sVersion strin
 
 	// Fetch the configuration from a file or ConfigMap and validate it
 	fmt.Println("[upgrade/config] Making sure the configuration is correct:")
-	cfg, err := configutil.FetchConfigFromFileOrCluster(client, os.Stdout, "upgrade/config", flags.cfgPath, false)
+	cfg, err := configutil.FetchConfigFromFileOrCluster(client, "upgrade/config", flags.cfgPath, false)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			fmt.Printf("[upgrade/config] In order to upgrade, a ConfigMap called %q in the %s namespace must exist.\n", constants.KubeadmConfigConfigMap, metav1.NamespaceSystem)

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -229,7 +229,7 @@ func RunUpgradeControlPlane(flags *controlplaneUpgradeFlags) error {
 	waiter := apiclient.NewKubeWaiter(client, upgrade.UpgradeManifestTimeout, os.Stdout)
 
 	// Fetches the cluster configuration
-	cfg, err := configutil.FetchConfigFromFileOrCluster(client, os.Stdout, "upgrade", "", false)
+	cfg, err := configutil.FetchConfigFromFileOrCluster(client, "upgrade", "", false)
 	if err != nil {
 		return errors.Wrap(err, "unable to fetch the kubeadm-config ConfigMap")
 	}

--- a/cmd/kubeadm/app/util/config/cluster.go
+++ b/cmd/kubeadm/app/util/config/cluster.go
@@ -19,7 +19,6 @@ package config
 import (
 	"crypto/x509"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -40,9 +39,9 @@ import (
 )
 
 // FetchConfigFromFileOrCluster fetches configuration required for upgrading your cluster from a file (which has precedence) or a ConfigMap in the cluster
-func FetchConfigFromFileOrCluster(client clientset.Interface, w io.Writer, logPrefix, cfgPath string, newControlPlane bool) (*kubeadmapi.InitConfiguration, error) {
+func FetchConfigFromFileOrCluster(client clientset.Interface, logPrefix, cfgPath string, newControlPlane bool) (*kubeadmapi.InitConfiguration, error) {
 	// Load the configuration from a file or the cluster
-	initcfg, err := loadConfiguration(client, w, logPrefix, cfgPath, newControlPlane)
+	initcfg, err := loadConfiguration(client, logPrefix, cfgPath, newControlPlane)
 	if err != nil {
 		return nil, err
 	}
@@ -55,15 +54,15 @@ func FetchConfigFromFileOrCluster(client clientset.Interface, w io.Writer, logPr
 }
 
 // loadConfiguration loads the configuration byte slice from either a file or the cluster ConfigMap
-func loadConfiguration(client clientset.Interface, w io.Writer, logPrefix, cfgPath string, newControlPlane bool) (*kubeadmapi.InitConfiguration, error) {
+func loadConfiguration(client clientset.Interface, logPrefix, cfgPath string, newControlPlane bool) (*kubeadmapi.InitConfiguration, error) {
 	// The config file has the highest priority
 	if cfgPath != "" {
-		fmt.Fprintf(w, "[%s] Reading configuration options from a file: %s\n", logPrefix, cfgPath)
+		fmt.Printf("[%s] Reading configuration options from a file: %s\n", logPrefix, cfgPath)
 		return loadInitConfigurationFromFile(cfgPath)
 	}
 
-	fmt.Fprintf(w, "[%s] Reading configuration from the cluster...\n", logPrefix)
-	fmt.Fprintf(w, "[%s] FYI: You can look at this config file with 'kubectl -n %s get cm %s -oyaml'\n", logPrefix, metav1.NamespaceSystem, constants.KubeadmConfigConfigMap)
+	fmt.Printf("[%s] Reading configuration from the cluster...\n", logPrefix)
+	fmt.Printf("[%s] FYI: You can look at this config file with 'kubectl -n %s get cm %s -oyaml'\n", logPrefix, metav1.NamespaceSystem, constants.KubeadmConfigConfigMap)
 	return getInitConfigurationFromCluster(constants.KubernetesDir, client, newControlPlane)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change
/kind cleanup

**What this PR does / why we need it**:
The change simplifies the signature of `FetchConfigFromFileOrCluster()` by removing an unused parameter.

**Special notes for your reviewer**:
This PR is marked of the `api-change` kind because it touches an exported function, but the function is used in one module only.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
