### PR TITLE
Implement port forwarding for windows.

### DIFF
--- a/pkg/kubelet/dockershim/BUILD
+++ b/pkg/kubelet/dockershim/BUILD
@@ -19,6 +19,8 @@ go_library(
         "docker_stats_unsupported.go",
         "docker_stats_windows.go",
         "docker_streaming.go",
+        "docker_streaming_others.go",
+        "docker_streaming_windows.go",
         "exec.go",
         "helpers.go",
         "helpers_linux.go",
@@ -73,6 +75,8 @@ go_library(
         "@io_bazel_rules_go//go/platform:windows": [
             "//pkg/kubelet/apis:go_default_library",
             "//pkg/kubelet/winstats:go_default_library",
+            "//pkg/util/netsh:go_default_library",
+            "//vendor/github.com/Microsoft/hcsshim:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/kubelet/dockershim/docker_streaming.go
+++ b/pkg/kubelet/dockershim/docker_streaming.go
@@ -22,13 +22,9 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"os/exec"
-	"strings"
 	"time"
 
 	dockertypes "github.com/docker/docker/api/types"
-	"k8s.io/klog"
-
 	"k8s.io/client-go/tools/remotecommand"
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -173,61 +169,4 @@ func attachContainer(client libdocker.Interface, containerID string, stdin io.Re
 		RawTerminal:  tty,
 	}
 	return client.AttachToContainer(containerID, opts, sopts)
-}
-
-func portForward(client libdocker.Interface, podSandboxID string, port int32, stream io.ReadWriteCloser) error {
-	container, err := client.InspectContainer(podSandboxID)
-	if err != nil {
-		return err
-	}
-
-	if !container.State.Running {
-		return fmt.Errorf("container not running (%s)", container.ID)
-	}
-
-	containerPid := container.State.Pid
-	socatPath, lookupErr := exec.LookPath("socat")
-	if lookupErr != nil {
-		return fmt.Errorf("unable to do port forwarding: socat not found.")
-	}
-
-	args := []string{"-t", fmt.Sprintf("%d", containerPid), "-n", socatPath, "-", fmt.Sprintf("TCP4:localhost:%d", port)}
-
-	nsenterPath, lookupErr := exec.LookPath("nsenter")
-	if lookupErr != nil {
-		return fmt.Errorf("unable to do port forwarding: nsenter not found.")
-	}
-
-	commandString := fmt.Sprintf("%s %s", nsenterPath, strings.Join(args, " "))
-	klog.V(4).Infof("executing port forwarding command: %s", commandString)
-
-	command := exec.Command(nsenterPath, args...)
-	command.Stdout = stream
-
-	stderr := new(bytes.Buffer)
-	command.Stderr = stderr
-
-	// If we use Stdin, command.Run() won't return until the goroutine that's copying
-	// from stream finishes. Unfortunately, if you have a client like telnet connected
-	// via port forwarding, as long as the user's telnet client is connected to the user's
-	// local listener that port forwarding sets up, the telnet session never exits. This
-	// means that even if socat has finished running, command.Run() won't ever return
-	// (because the client still has the connection and stream open).
-	//
-	// The work around is to use StdinPipe(), as Wait() (called by Run()) closes the pipe
-	// when the command (socat) exits.
-	inPipe, err := command.StdinPipe()
-	if err != nil {
-		return fmt.Errorf("unable to do port forwarding: error creating stdin pipe: %v", err)
-	}
-	go func() {
-		io.Copy(inPipe, stream)
-		inPipe.Close()
-	}()
-
-	if err := command.Run(); err != nil {
-		return fmt.Errorf("%v: %s", err, stderr.String())
-	}
-
-	return nil
 }

--- a/pkg/kubelet/dockershim/docker_streaming_others.go
+++ b/pkg/kubelet/dockershim/docker_streaming_others.go
@@ -1,0 +1,87 @@
+// +build !windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
+)
+
+func portForward(client libdocker.Interface, podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+	container, err := client.InspectContainer(podSandboxID)
+	if err != nil {
+		return err
+	}
+
+	if !container.State.Running {
+		return fmt.Errorf("container not running (%s)", container.ID)
+	}
+
+	containerPid := container.State.Pid
+	socatPath, lookupErr := exec.LookPath("socat")
+	if lookupErr != nil {
+		return fmt.Errorf("unable to do port forwarding: socat not found.")
+	}
+
+	args := []string{"-t", fmt.Sprintf("%d", containerPid), "-n", socatPath, "-", fmt.Sprintf("TCP4:localhost:%d", port)}
+
+	nsenterPath, lookupErr := exec.LookPath("nsenter")
+	if lookupErr != nil {
+		return fmt.Errorf("unable to do port forwarding: nsenter not found.")
+	}
+
+	commandString := fmt.Sprintf("%s %s", nsenterPath, strings.Join(args, " "))
+	klog.V(4).Infof("executing port forwarding command: %s", commandString)
+
+	command := exec.Command(nsenterPath, args...)
+	command.Stdout = stream
+
+	stderr := new(bytes.Buffer)
+	command.Stderr = stderr
+
+	// If we use Stdin, command.Run() won't return until the goroutine that's copying
+	// from stream finishes. Unfortunately, if you have a client like telnet connected
+	// via port forwarding, as long as the user's telnet client is connected to the user's
+	// local listener that port forwarding sets up, the telnet session never exits. This
+	// means that even if socat has finished running, command.Run() won't ever return
+	// (because the client still has the connection and stream open).
+	//
+	// The work around is to use StdinPipe(), as Wait() (called by Run()) closes the pipe
+	// when the command (socat) exits.
+	inPipe, err := command.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("unable to do port forwarding: error creating stdin pipe: %v", err)
+	}
+	go func() {
+		io.Copy(inPipe, stream)
+		inPipe.Close()
+	}()
+
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("%v: %s", err, stderr.String())
+	}
+
+	return nil
+}

--- a/pkg/kubelet/dockershim/docker_streaming_windows.go
+++ b/pkg/kubelet/dockershim/docker_streaming_windows.go
@@ -1,0 +1,103 @@
+// +build windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strings"
+
+	"github.com/Microsoft/hcsshim"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
+	"k8s.io/kubernetes/pkg/util/netsh"
+	utilexec "k8s.io/utils/exec"
+)
+
+func portForward(client libdocker.Interface, podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+	endpoints, err := hcsshim.HNSListEndpointRequest()
+	if err != nil {
+		return err
+	}
+
+	var match *hcsshim.HNSEndpoint
+	for _, endpoint := range endpoints {
+		if strings.HasPrefix(endpoint.Name, podSandboxID) {
+			match = &endpoint
+			break
+		}
+	}
+	if match == nil {
+		return fmt.Errorf("couldn't find a matching endpoint for podSandboxID %s", podSandboxID)
+	}
+	netshClient := netsh.New(utilexec.New())
+	randomPort, err := findOpenPort()
+	if err != nil {
+		return err
+	}
+
+	netshAddArgs := []string{
+		"interface",
+		"portproxy",
+		"add",
+		"v4tov4",
+		fmt.Sprintf("listenport=%d", randomPort),
+		fmt.Sprintf("connectaddress=%s", match.IPAddress.String()),
+		fmt.Sprintf("connectport=%d", port)}
+
+	ok, err := netshClient.EnsurePortProxyRule(netshAddArgs)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("error adding netsh rule: %s", netshAddArgs)
+	}
+	conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", randomPort))
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	go func() {
+		io.Copy(conn, stream)
+	}()
+	io.Copy(stream, conn)
+
+	netshDelArgs := []string{
+		"interface",
+		"portproxy",
+		"delete",
+		"v4tov4",
+		fmt.Sprintf("listenport=%d", randomPort)}
+	return netshClient.DeletePortProxyRule(netshDelArgs)
+}
+
+func findOpenPort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+
+	return l.Addr().(*net.TCPAddr).Port, nil
+}

--- a/pkg/util/netsh/netsh.go
+++ b/pkg/util/netsh/netsh.go
@@ -68,7 +68,7 @@ func New(exec utilexec.Interface) Interface {
 
 // EnsurePortProxyRule checks if the specified redirect exists, if not creates it.
 func (runner *runner) EnsurePortProxyRule(args []string) (bool, error) {
-	klog.V(4).Infof("running netsh interface portproxy add v4tov4 %v", args)
+	klog.V(4).Infof("running netsh %v", args)
 	out, err := runner.exec.Command(cmdNetsh, args...).CombinedOutput()
 
 	if err == nil {
@@ -87,7 +87,7 @@ func (runner *runner) EnsurePortProxyRule(args []string) (bool, error) {
 
 // DeletePortProxyRule deletes the specified portproxy rule.  If the rule did not exist, return error.
 func (runner *runner) DeletePortProxyRule(args []string) error {
-	klog.V(4).Infof("running netsh interface portproxy delete v4tov4 %v", args)
+	klog.V(4).Infof("running netsh %v", args)
 	out, err := runner.exec.Command(cmdNetsh, args...).CombinedOutput()
 
 	if err == nil {


### PR DESCRIPTION

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR makes `kubectl port-forward` work for windows pods.

- Splits docker_streaming portForward function into windows and
not-windows implementations
- On Windows, use netsh to setup portforwarding from a localhost port
into the desired pod port, then have kubelet forward the stream from the
api server to the local port.
- Use Go TCP server to find an open port because netsh doesn't error
when an in-use local port is chosen; it just doesn't work. Netsh does
not appear to have a "pick any open port" option.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #64531

**Special notes for your reviewer**:
We're looking at changing the port-forwarding test to work on windows, and are planning to submit a separate PR for the test.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Implemented port-forwarding for windows pods
```
