### PR TITLE
apimachinery: protobuf: Test protobuf compatibility

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto_test.go
@@ -101,3 +101,40 @@ func TestQuantityProtoUnmarshal(t *testing.T) {
 		}
 	}
 }
+
+func TestProtoCompatibility(t *testing.T) {
+	// Test when d is nil
+	table1 := []struct {
+		input  []byte
+		expect string
+	}{
+		{[]byte{10, 1, 48}, "0"},
+		{[]byte{10, 4, 49, 48, 48, 106}, "100m"},
+		{[]byte{10, 4, 53, 48, 48, 106}, "500m"},
+	}
+	for _, testCase := range table1 {
+		var inputQ Quantity
+		inputQ.Unmarshal(testCase.input)
+		expectQ := Quantity{s: testCase.expect, d: infDecAmount{}, Format: DecimalSI}
+		if inputQ.Cmp(expectQ) != 0 {
+			t.Errorf("Expected: %v, Actual: %v", inputQ, expectQ)
+		}
+	}
+	// Test when i is {0,0}
+	table2 := []struct {
+		input  []byte
+		expect *inf.Dec
+	}{
+		{[]byte{10, 1, 48}, dec(0, 0).Dec},
+		{[]byte{10, 4, 49, 48, 48, 109}, dec(100, -3).Dec},
+		{[]byte{10, 4, 53, 48, 48, 109}, dec(50, -2).Dec},
+	}
+	for _, testCase := range table2 {
+		var inputQ Quantity
+		inputQ.Unmarshal(testCase.input)
+		expectQ := Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{testCase.expect}, Format: DecimalSI}
+		if inputQ.Cmp(expectQ) != 0 {
+			t.Errorf("Expected: %v, Actual: %v", inputQ, expectQ)
+		}
+	}
+}


### PR DESCRIPTION
This patch adds a test which makes sure that protobuf
marshal and unmarshal behave as expected. If protobuf
breaks their api, this test should fail.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #69638 

**Special notes for your reviewer**:

As this is my first pr against k8s, all feedback is greatly appreciated.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
