### PR TITLE
master shutdown hook should use correct constant for reconciling

### DIFF
--- a/pkg/master/controller.go
+++ b/pkg/master/controller.go
@@ -168,7 +168,7 @@ func (c *Controller) Stop() {
 	go func() {
 		defer close(finishedReconciling)
 		klog.Infof("Shutting down kubernetes service endpoint reconciler")
-		if err := c.EndpointReconciler.StopReconciling("kubernetes", c.PublicIP, endpointPorts); err != nil {
+		if err := c.EndpointReconciler.StopReconciling(kubernetesServiceName, c.PublicIP, endpointPorts); err != nil {
 			klog.Error(err)
 		}
 	}()


### PR DESCRIPTION
To prevent accidental drift, use the same constant we use on startup
in the master endpoint reconciler shudown method.

@sttts

/kind cleanup

```release-note
NONE
```