### PR TITLE
Add a comment for evictPod when evict failed

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -558,6 +558,7 @@ func (m *managerImpl) evictPod(pod *v1.Pod, gracePeriodOverride int64, evictMsg 
 	// this is a blocking call and should only return when the pod and its containers are killed.
 	err := m.killPodFunc(pod, status, &gracePeriodOverride)
 	if err != nil {
+		//the pod's status is set to Failed, and the kubelet will retry the deletion when syncing the pod
 		klog.Errorf("eviction manager: pod %s failed to evict %v", format.Pod(pod), err)
 	} else {
 		klog.Infof("eviction manager: pod %s is evicted successfully", format.Pod(pod))


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
When pod failed to be evicted, the evictPod should return false, then synchronize will to evict the next pod of activePods, ensure to evict one pod at a time.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

/release-note-none
/priority backlog