### PR TITLE
Avoid logging normal conflict/notfound error responses in CRD controllers

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish/establishing_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish/establishing_controller.go
@@ -135,6 +135,10 @@ func (ec *EstablishingController) sync(key string) error {
 
 	// Update server with new CRD condition.
 	_, err = ec.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
+	if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
+		// deleted or changed in the meantime, we'll get called again
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -116,6 +116,10 @@ func (c *CRDFinalizer) sync(key string) error {
 		Message: "CustomResource deletion is in progress",
 	})
 	crd, err = c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
+	if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
+		// deleted or changed in the meantime, we'll get called again
+		return nil
+	}
 	if err != nil {
 		return err
 	}
@@ -143,6 +147,10 @@ func (c *CRDFinalizer) sync(key string) error {
 
 	apiextensions.CRDRemoveFinalizer(crd, apiextensions.CustomResourceCleanupFinalizer)
 	crd, err = c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
+	if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
+		// deleted or changed in the meantime, we'll get called again
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -261,6 +261,10 @@ func (c *NamingConditionController) sync(key string) error {
 	apiextensions.SetCRDCondition(crd, establishedCondition)
 
 	updatedObj, err := c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
+	if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
+		// deleted or changed in the meantime, we'll get called again
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/BUILD
@@ -28,6 +28,7 @@ go_library(
     importpath = "k8s.io/kube-aggregator/pkg/controllers/autoregister",
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -237,6 +238,10 @@ func (c *autoRegisterController) checkAPIService(name string) (err error) {
 	// we don't have an entry and we do want one (2B,2C)
 	case apierrors.IsNotFound(err) && desired != nil:
 		_, err := c.apiServiceClient.APIServices().Create(desired)
+		if apierrors.IsAlreadyExists(err) {
+			// created in the meantime, we'll get called again
+			return nil
+		}
 		return err
 
 	// we aren't trying to manage this APIService (3A,3B,3C)
@@ -253,7 +258,13 @@ func (c *autoRegisterController) checkAPIService(name string) (err error) {
 
 	// we have a spurious APIService that we're managing, delete it (5A,6A)
 	case desired == nil:
-		return c.apiServiceClient.APIServices().Delete(curr.Name, nil)
+		opts := &metav1.DeleteOptions{Preconditions: metav1.NewUIDPreconditions(string(curr.UID))}
+		err := c.apiServiceClient.APIServices().Delete(curr.Name, opts)
+		if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
+			// deleted or changed in the meantime, we'll get called again
+			return nil
+		}
+		return err
 
 	// if the specs already match, nothing for us to do
 	case reflect.DeepEqual(curr.Spec, desired.Spec):
@@ -264,6 +275,10 @@ func (c *autoRegisterController) checkAPIService(name string) (err error) {
 	apiService := curr.DeepCopy()
 	apiService.Spec = desired.Spec
 	_, err = c.apiServiceClient.APIServices().Update(apiService)
+	if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
+		// deleted or changed in the meantime, we'll get called again
+		return nil
+	}
 	return err
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
CRD establishing/naming/finalizing/apiservice-registering controllers run in process in the apiserver. In HA environments, they will race each other (which they are designed to tolerate), but complain loudly in the logs about conflict errors.

**Which issue(s) this PR fixes**:
Fixes #72876

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @deads2k 
/sig api-machinery