### PR TITLE
Add support for OpenStack cinder to csi-translation-lib

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/BUILD
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/BUILD
@@ -6,6 +6,7 @@ go_library(
         "aws_ebs.go",
         "gce_pd.go",
         "in_tree_volume.go",
+        "openstack_cinder.go",
     ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/csi-translation-lib/plugins",
     importpath = "k8s.io/csi-translation-lib/plugins",

--- a/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"fmt"
+	"k8s.io/api/core/v1"
+)
+
+const (
+	// CinderDriverName is the name of the CSI driver for Cinder
+	CinderDriverName = "cinder.csi.openstack.org"
+	// CinderInTreePluginName is the name of the intree plugin for Cinder
+	CinderInTreePluginName = "kubernetes.io/cinder"
+)
+
+var _ InTreePlugin = (*osCinderCSITranslator)(nil)
+
+// osCinderCSITranslator handles translation of PV spec from In-tree Cinder to CSI Cinder and vice versa
+type osCinderCSITranslator struct{}
+
+// NewOpenStackCinderCSITranslator returns a new instance of osCinderCSITranslator
+func NewOpenStackCinderCSITranslator() InTreePlugin {
+	return &osCinderCSITranslator{}
+}
+
+// TranslateInTreePVToCSI takes a PV with Cinder set from in-tree
+// and converts the Cinder source to a CSIPersistentVolumeSource
+func (t *osCinderCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	if pv == nil || pv.Spec.Cinder == nil {
+		return nil, fmt.Errorf("pv is nil or Cinder not defined on pv")
+	}
+
+	cinderSource := pv.Spec.Cinder
+
+	csiSource := &v1.CSIPersistentVolumeSource{
+		Driver:           CinderDriverName,
+		VolumeHandle:     cinderSource.VolumeID,
+		ReadOnly:         cinderSource.ReadOnly,
+		FSType:           cinderSource.FSType,
+		VolumeAttributes: map[string]string{},
+	}
+
+	pv.Spec.Cinder = nil
+	pv.Spec.CSI = csiSource
+	return pv, nil
+}
+
+// TranslateCSIPVToInTree takes a PV with CSIPersistentVolumeSource set and
+// translates the Cinder CSI source to a Cinder In-tree source.
+func (t *osCinderCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	if pv == nil || pv.Spec.CSI == nil {
+		return nil, fmt.Errorf("pv is nil or CSI source not defined on pv")
+	}
+
+	csiSource := pv.Spec.CSI
+
+	cinderSource := &v1.CinderPersistentVolumeSource{
+		VolumeID: csiSource.VolumeHandle,
+		FSType:   csiSource.FSType,
+		ReadOnly: csiSource.ReadOnly,
+	}
+
+	pv.Spec.CSI = nil
+	pv.Spec.Cinder = cinderSource
+	return pv, nil
+}
+
+// CanSupport tests whether the plugin supports a given volume
+// specification from the API.  The spec pointer should be considered
+// const.
+func (t *osCinderCSITranslator) CanSupport(pv *v1.PersistentVolume) bool {
+	return pv != nil && pv.Spec.Cinder != nil
+}
+
+// GetInTreePluginName returns the name of the intree plugin driver
+func (t *osCinderCSITranslator) GetInTreePluginName() string {
+	return CinderInTreePluginName
+}

--- a/staging/src/k8s.io/csi-translation-lib/translate.go
+++ b/staging/src/k8s.io/csi-translation-lib/translate.go
@@ -27,6 +27,7 @@ var (
 	inTreePlugins = map[string]plugins.InTreePlugin{
 		plugins.GCEPDDriverName:  &plugins.GCEPD{},
 		plugins.AWSEBSDriverName: &plugins.AWSEBS{},
+		plugins.CinderDriverName: plugins.NewOpenStackCinderCSITranslator(),
 	}
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

in support of csi-migration proposal here: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md

Will help with migration of in-tree Cinder storage plugin to Cinder CSI.

Also see https://github.com/kubernetes/enhancements/issues/625

Change-Id: Ic31e8bf1d0c13d099e2eda515b4ad009cc05ff6b

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
