### PR TITLE
Bump kubectl in addon-manager

### DIFF
--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,8 +15,8 @@
 IMAGE=staging-k8s.gcr.io/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v8.9
-KUBECTL_VERSION?=v1.11.3
+VERSION=v9.0
+KUBECTL_VERSION?=v1.13.2
 
 BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.4.0
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
* Updates kubectl version in add-on manager to ensure we stay within supported skew
* Bumps version of add-on manager

**Which issue(s) this PR fixes**:
xref #43214 

**Special notes for your reviewer**:
Rebuilding addon-manager will also pick up https://github.com/kubernetes/kubernetes/pull/72203/files#diff-32466b23d956bf8ce719bd73ff419872, which makes the addon-manager prune workload API objects via the apps/v1 APIs, not extensions/v1beta1

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cluster-lifecycle
/cc @roberthbailey 