### PR TITLE
Improve FindPodVolumes performance

### DIFF
--- a/pkg/controller/volume/persistentvolume/scheduler_binder.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder.go
@@ -182,6 +182,11 @@ func (b *volumeBinder) FindPodVolumes(pod *v1.Pod, node *v1.Node) (unboundVolume
 	)
 	defer func() {
 		// We recreate bindings for each new schedule loop.
+		if len(matchedClaims) == 0 && len(provisionedClaims) == 0 {
+			// Clear cache if no claims to bind or provision for this node.
+			b.podBindingCache.ClearBindings(pod, node.Name)
+			return
+		}
 		// Although we do not distinguish nil from empty in this function, for
 		// easier testing, we normalize empty to nil.
 		if len(matchedClaims) == 0 {

--- a/pkg/controller/volume/persistentvolume/scheduler_binder.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder.go
@@ -160,11 +160,8 @@ func (b *volumeBinder) FindPodVolumes(pod *v1.Pod, node *v1.Node) (unboundVolume
 		if len(provisionedClaims) == 0 {
 			provisionedClaims = nil
 		}
-		// TODO merge into one atomic function
-		// Mark cache with all the matches for each PVC for this node
-		b.podBindingCache.UpdateBindings(pod, node.Name, matchedClaims)
-		// Mark cache with all the PVCs that need provisioning for this node
-		b.podBindingCache.UpdateProvisionedPVCs(pod, node.Name, provisionedClaims)
+		// Mark cache with all matched and provisioned claims for this node
+		b.podBindingCache.UpdateBindings(pod, node.Name, matchedClaims, provisionedClaims)
 	}()
 
 	podName := getPodName(pod)
@@ -318,8 +315,7 @@ func (b *volumeBinder) AssumePodVolumes(assumedPod *v1.Pod, nodeName string) (al
 	// Update cache with the assumed pvcs and pvs
 	// Even if length is zero, update the cache with an empty slice to indicate that no
 	// operations are needed
-	b.podBindingCache.UpdateBindings(assumedPod, nodeName, newBindings)
-	b.podBindingCache.UpdateProvisionedPVCs(assumedPod, nodeName, newProvisionedPVCs)
+	b.podBindingCache.UpdateBindings(assumedPod, nodeName, newBindings, newProvisionedPVCs)
 
 	return
 }

--- a/pkg/controller/volume/persistentvolume/scheduler_binder_cache.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder_cache.go
@@ -30,6 +30,9 @@ type PodBindingCache interface {
 	// pod and node.
 	UpdateBindings(pod *v1.Pod, node string, bindings []*bindingInfo, provisionings []*v1.PersistentVolumeClaim)
 
+	// ClearBindings will clear the cached bindings for the given pod and node.
+	ClearBindings(pod *v1.Pod, node string)
+
 	// GetBindings will return the cached bindings for the given pod and node.
 	// A nil return value means that the entry was not found. An empty slice
 	// means that no binding operations are needed.
@@ -147,4 +150,16 @@ func (c *podBindingCache) GetProvisionedPVCs(pod *v1.Pod, node string) []*v1.Per
 		return nil
 	}
 	return decision.provisionings
+}
+
+func (c *podBindingCache) ClearBindings(pod *v1.Pod, node string) {
+	c.rwMutex.Lock()
+	defer c.rwMutex.Unlock()
+
+	podName := getPodName(pod)
+	decisions, ok := c.bindingDecisions[podName]
+	if !ok {
+		return
+	}
+	delete(decisions, node)
 }

--- a/pkg/controller/volume/persistentvolume/scheduler_binder_cache.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder_cache.go
@@ -28,18 +28,13 @@ import (
 type PodBindingCache interface {
 	// UpdateBindings will update the cache with the given bindings for the
 	// pod and node.
-	UpdateBindings(pod *v1.Pod, node string, bindings []*bindingInfo)
+	UpdateBindings(pod *v1.Pod, node string, bindings []*bindingInfo, provisionings []*v1.PersistentVolumeClaim)
 
 	// GetBindings will return the cached bindings for the given pod and node.
 	// A nil return value means that the entry was not found. An empty slice
 	// means that no binding operations are needed.
 	GetBindings(pod *v1.Pod, node string) []*bindingInfo
 
-	// UpdateProvisionedPVCs will update the cache with the given provisioning decisions
-	// for the pod and node.
-	UpdateProvisionedPVCs(pod *v1.Pod, node string, provisionings []*v1.PersistentVolumeClaim)
-
-	// GetProvisionedPVCs will return the cached provisioning decisions for the given pod and node.
 	// A nil return value means that the entry was not found. An empty slice
 	// means that no provisioning operations are needed.
 	GetProvisionedPVCs(pod *v1.Pod, node string) []*v1.PersistentVolumeClaim
@@ -98,7 +93,7 @@ func (c *podBindingCache) DeleteBindings(pod *v1.Pod) {
 	}
 }
 
-func (c *podBindingCache) UpdateBindings(pod *v1.Pod, node string, bindings []*bindingInfo) {
+func (c *podBindingCache) UpdateBindings(pod *v1.Pod, node string, bindings []*bindingInfo, pvcs []*v1.PersistentVolumeClaim) {
 	c.rwMutex.Lock()
 	defer c.rwMutex.Unlock()
 
@@ -111,11 +106,13 @@ func (c *podBindingCache) UpdateBindings(pod *v1.Pod, node string, bindings []*b
 	decision, ok := decisions[node]
 	if !ok {
 		decision = nodeDecision{
-			bindings: bindings,
+			bindings:      bindings,
+			provisionings: pvcs,
 		}
 		VolumeBindingRequestSchedulerBinderCache.WithLabelValues("add").Inc()
 	} else {
 		decision.bindings = bindings
+		decision.provisionings = pvcs
 	}
 	decisions[node] = decision
 }
@@ -134,27 +131,6 @@ func (c *podBindingCache) GetBindings(pod *v1.Pod, node string) []*bindingInfo {
 		return nil
 	}
 	return decision.bindings
-}
-
-func (c *podBindingCache) UpdateProvisionedPVCs(pod *v1.Pod, node string, pvcs []*v1.PersistentVolumeClaim) {
-	c.rwMutex.Lock()
-	defer c.rwMutex.Unlock()
-
-	podName := getPodName(pod)
-	decisions, ok := c.bindingDecisions[podName]
-	if !ok {
-		decisions = nodeDecisions{}
-		c.bindingDecisions[podName] = decisions
-	}
-	decision, ok := decisions[node]
-	if !ok {
-		decision = nodeDecision{
-			provisionings: pvcs,
-		}
-	} else {
-		decision.provisionings = pvcs
-	}
-	decisions[node] = decision
 }
 
 func (c *podBindingCache) GetProvisionedPVCs(pod *v1.Pod, node string) []*v1.PersistentVolumeClaim {

--- a/pkg/controller/volume/persistentvolume/scheduler_binder_cache_test.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder_cache_test.go
@@ -48,6 +48,14 @@ func TestUpdateGetBindings(t *testing.T) {
 			getPod:              "pod1",
 			getNode:             "node2",
 		},
+		"binding-nil": {
+			updatePod:           "pod1",
+			updateNode:          "node1",
+			updateBindings:      nil,
+			updateProvisionings: nil,
+			getPod:              "pod1",
+			getNode:             "node1",
+		},
 		"binding-exists": {
 			updatePod:           "pod1",
 			updateNode:          "node1",
@@ -65,8 +73,7 @@ func TestUpdateGetBindings(t *testing.T) {
 
 		// Perform updates
 		updatePod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: scenario.updatePod, Namespace: "ns"}}
-		cache.UpdateBindings(updatePod, scenario.updateNode, scenario.updateBindings)
-		cache.UpdateProvisionedPVCs(updatePod, scenario.updateNode, scenario.updateProvisionings)
+		cache.UpdateBindings(updatePod, scenario.updateNode, scenario.updateBindings, scenario.updateProvisionings)
 
 		// Verify updated bindings
 		bindings := cache.GetBindings(updatePod, scenario.updateNode)
@@ -116,8 +123,7 @@ func TestDeleteBindings(t *testing.T) {
 	cache.DeleteBindings(pod)
 
 	// Perform updates
-	cache.UpdateBindings(pod, "node1", initialBindings)
-	cache.UpdateProvisionedPVCs(pod, "node1", initialProvisionings)
+	cache.UpdateBindings(pod, "node1", initialBindings, initialProvisionings)
 
 	// Get bindings and provisionings
 	bindings = cache.GetBindings(pod, "node1")

--- a/pkg/controller/volume/persistentvolume/scheduler_binder_test.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder_test.go
@@ -328,8 +328,6 @@ func (env *testEnv) assumeVolumes(t *testing.T, name, node string, pod *v1.Pod, 
 		}
 	}
 
-	env.internalBinder.podBindingCache.UpdateBindings(pod, node, bindings)
-
 	pvcCache := env.internalBinder.pvcCache
 	for _, pvc := range provisionings {
 		if err := pvcCache.Assume(pvc); err != nil {
@@ -337,14 +335,12 @@ func (env *testEnv) assumeVolumes(t *testing.T, name, node string, pod *v1.Pod, 
 		}
 	}
 
-	env.internalBinder.podBindingCache.UpdateProvisionedPVCs(pod, node, provisionings)
+	env.internalBinder.podBindingCache.UpdateBindings(pod, node, bindings, provisionings)
 }
 
 func (env *testEnv) initPodCache(pod *v1.Pod, node string, bindings []*bindingInfo, provisionings []*v1.PersistentVolumeClaim) {
 	cache := env.internalBinder.podBindingCache
-	cache.UpdateBindings(pod, node, bindings)
-
-	cache.UpdateProvisionedPVCs(pod, node, provisionings)
+	cache.UpdateBindings(pod, node, bindings, provisionings)
 }
 
 func (env *testEnv) validatePodCache(t *testing.T, name, node string, pod *v1.Pod, expectedBindings []*bindingInfo, expectedProvisionings []*v1.PersistentVolumeClaim) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

It includes three optimizations:

- Merge UpdateProvisionedPVCs with UpdateBindings: https://github.com/kubernetes/kubernetes/pull/72953/commits/7fe97886a82a4e19af17dfd399b5626073d5f2a9
  - this simplies code and saves a lock for each call
- Skip if pod does not have claims: https://github.com/kubernetes/kubernetes/pull/72953/commits/c2d25e08d79c071c3b8405e98c71251a6dc6fce4
  - most pods does not use claims, there is no need to find pod volumes for them (suggested by @msau42 before in an [old PR](https://github.com/kubernetes/kubernetes/pull/71212#discussion_r235111911) to clear stale pod binding cache too)
  - one thing I am not sure is should we skip `VolumeSchedulingStageLatency` metric too?
- Clear cache instead of saving nils if no claims to bind or provision: https://github.com/kubernetes/kubernetes/pull/72953/commits/dbd80460de04fd1097065dee646b667c0468f2fd
  - This saves memory.

Why: https://github.com/kubernetes/kubernetes/pull/72045#issuecomment-454602165

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/sig storage
/sig scheduling