### PR TITLE
make more of the shell pass lints

### DIFF
--- a/build/build-image/rsyncd.sh
+++ b/build/build-image/rsyncd.sh
@@ -45,7 +45,7 @@ mkdir -p "${CONFDIR}"
 if [[ -f "${PIDFILE}" ]]; then
   PID=$(cat "${PIDFILE}")
   echo "Cleaning up old PID file: ${PIDFILE}"
-  kill $PID &> /dev/null || true
+  kill "${PID}" &> /dev/null || true
   rm "${PIDFILE}"
 fi
 

--- a/build/copy-output.sh
+++ b/build/copy-output.sh
@@ -19,7 +19,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/build/common.sh"
 
 kube::build::verify_prereqs

--- a/build/make-build-image.sh
+++ b/build/make-build-image.sh
@@ -24,7 +24,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT="$(dirname "${BASH_SOURCE}")/.."
+KUBE_ROOT="$(dirname "${BASH_SOURCE[0]}")/.."
 source "${KUBE_ROOT}/build/common.sh"
 
 kube::build::verify_prereqs

--- a/build/make-clean.sh
+++ b/build/make-clean.sh
@@ -19,7 +19,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/build/common.sh"
 
 kube::build::verify_prereqs false

--- a/build/package-tarballs.sh
+++ b/build/package-tarballs.sh
@@ -18,7 +18,7 @@ set -o nounset
 set -o pipefail
 
 # Complete the release with the standard env
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/build/common.sh"
 source "${KUBE_ROOT}/build/lib/release.sh"
 

--- a/build/release-images.sh
+++ b/build/release-images.sh
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/build/common.sh"
 source "${KUBE_ROOT}/build/lib/release.sh"
 

--- a/build/release-in-a-container.sh
+++ b/build/release-in-a-container.sh
@@ -18,7 +18,7 @@ set -o nounset
 set -o pipefail
 
 # Complete the release with the standard env
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # Check and error if not "in-a-container"
 if [[ ! -f /.dockerenv ]]; then
@@ -46,4 +46,4 @@ if [[ $KUBE_RELEASE_RUN_TESTS =~ ^[yY]$ ]]; then
   make test
 fi
 
-$KUBE_ROOT/build/package-tarballs.sh
+"${KUBE_ROOT}/build/package-tarballs.sh"

--- a/build/release.sh
+++ b/build/release.sh
@@ -25,7 +25,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/build/common.sh"
 source "${KUBE_ROOT}/build/lib/release.sh"
 

--- a/build/run.sh
+++ b/build/run.sh
@@ -22,7 +22,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "$KUBE_ROOT/build/common.sh"
 
 KUBE_RUN_COPY_OUTPUT="${KUBE_RUN_COPY_OUTPUT:-y}"

--- a/build/shell.sh
+++ b/build/shell.sh
@@ -22,7 +22,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/build/common.sh"
 
 KUBE_RUN_COPY_OUTPUT="${KUBE_RUN_COPY_OUTPUT:-n}" "${KUBE_ROOT}/build/run.sh" bash "$@"

--- a/build/util.sh
+++ b/build/util.sh
@@ -16,17 +16,17 @@
 
 # Common utility functions for build scripts
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 function kube::release::semantic_version() {
   # This takes:
   # Client Version: version.Info{Major:"1", Minor:"1+", GitVersion:"v1.1.0-alpha.0.2328+3c0a05de4a38e3", GitCommit:"3c0a05de4a38e355d147dbfb4d85bad6d2d73bb9", GitTreeState:"clean"}
   # and spits back the GitVersion piece in a way that is somewhat
   # resilient to the other fields changing (we hope)
-  ${KUBE_ROOT}/cluster/kubectl.sh version --client | sed "s/, */\\
-/g" | egrep "^GitVersion:" | cut -f2 -d: | cut -f2 -d\"
+  "${KUBE_ROOT}/cluster/kubectl.sh" version --client | sed "s/, */\\
+/g" | grep -E "^GitVersion:" | cut -f2 -d: | cut -f2 -d\"
 }
 
 function kube::release::semantic_image_tag_version() {
-    printf "$(kube::release::semantic_version)" | tr + _
+    printf "%s" "$(kube::release::semantic_version)" | tr + _
 }

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -4,7 +4,6 @@
 ./build/make-build-image.sh
 ./build/make-clean.sh
 ./build/package-tarballs.sh
-./build/release-images.sh
 ./build/release-in-a-container.sh
 ./build/util.sh
 ./cluster/addons/addon-manager/kube-addons.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -8,7 +8,6 @@
 ./build/release-in-a-container.sh
 ./build/release.sh
 ./build/run.sh
-./build/shell.sh
 ./build/util.sh
 ./cluster/addons/addon-manager/kube-addons.sh
 ./cluster/addons/fluentd-elasticsearch/es-image/run.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -1,5 +1,4 @@
 ./build/common.sh
-./build/copy-output.sh
 ./build/lib/release.sh
 ./cluster/addons/addon-manager/kube-addons.sh
 ./cluster/addons/fluentd-elasticsearch/es-image/run.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -6,7 +6,6 @@
 ./build/package-tarballs.sh
 ./build/release-images.sh
 ./build/release-in-a-container.sh
-./build/release.sh
 ./build/util.sh
 ./cluster/addons/addon-manager/kube-addons.sh
 ./cluster/addons/fluentd-elasticsearch/es-image/run.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -1,7 +1,6 @@
 ./build/common.sh
 ./build/copy-output.sh
 ./build/lib/release.sh
-./build/make-build-image.sh
 ./build/util.sh
 ./cluster/addons/addon-manager/kube-addons.sh
 ./cluster/addons/fluentd-elasticsearch/es-image/run.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -4,7 +4,6 @@
 ./build/make-build-image.sh
 ./build/make-clean.sh
 ./build/package-tarballs.sh
-./build/release-in-a-container.sh
 ./build/util.sh
 ./cluster/addons/addon-manager/kube-addons.sh
 ./cluster/addons/fluentd-elasticsearch/es-image/run.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -2,7 +2,6 @@
 ./build/copy-output.sh
 ./build/lib/release.sh
 ./build/make-build-image.sh
-./build/make-clean.sh
 ./build/util.sh
 ./cluster/addons/addon-manager/kube-addons.sh
 ./cluster/addons/fluentd-elasticsearch/es-image/run.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -3,7 +3,6 @@
 ./build/lib/release.sh
 ./build/make-build-image.sh
 ./build/make-clean.sh
-./build/package-tarballs.sh
 ./build/util.sh
 ./cluster/addons/addon-manager/kube-addons.sh
 ./cluster/addons/fluentd-elasticsearch/es-image/run.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -1,4 +1,3 @@
-./build/build-image/rsyncd.sh
 ./build/common.sh
 ./build/copy-output.sh
 ./build/lib/release.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -1,7 +1,6 @@
 ./build/common.sh
 ./build/copy-output.sh
 ./build/lib/release.sh
-./build/util.sh
 ./cluster/addons/addon-manager/kube-addons.sh
 ./cluster/addons/fluentd-elasticsearch/es-image/run.sh
 ./cluster/addons/fluentd-elasticsearch/fluentd-es-image/run.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -7,7 +7,6 @@
 ./build/release-images.sh
 ./build/release-in-a-container.sh
 ./build/release.sh
-./build/run.sh
 ./build/util.sh
 ./cluster/addons/addon-manager/kube-addons.sh
 ./cluster/addons/fluentd-elasticsearch/es-image/run.sh


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**: makes more of the shell scripts pass hack/verify-shellcheck.sh

While these changes are mostly small and low hanging fruit, we gain removing these files from hack/.shellcheck_failures, which should prevent regressions.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
work towards #72956 

**Special notes for your reviewer**: 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
