### PR TITLE
Fix flaky test TestBindAPIUpdate

### DIFF
--- a/pkg/controller/volume/persistentvolume/scheduler_binder_test.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder_test.go
@@ -471,7 +471,10 @@ func (env *testEnv) validateBind(
 		if err != nil {
 			t.Errorf("Test %q failed: GetPV %q returned error: %v", name, pv.Name, err)
 		}
-		if !reflect.DeepEqual(cachedPV, pv) {
+		// Cache may be overridden by API object with higher version, compare but ignore resource version.
+		newCachedPV := cachedPV.DeepCopy()
+		newCachedPV.ResourceVersion = pv.ResourceVersion
+		if !reflect.DeepEqual(newCachedPV, pv) {
 			t.Errorf("Test %q failed: cached PV check failed [A-expected, B-got]:\n%s", name, diff.ObjectDiff(pv, cachedPV))
 		}
 	}
@@ -496,7 +499,10 @@ func (env *testEnv) validateProvision(
 		if err != nil {
 			t.Errorf("Test %q failed: GetPVC %q returned error: %v", name, getPVCName(pvc), err)
 		}
-		if !reflect.DeepEqual(cachedPVC, pvc) {
+		// Cache may be overridden by API object with higher version, compare but ignore resource version.
+		newCachedPVC := cachedPVC.DeepCopy()
+		newCachedPVC.ResourceVersion = pvc.ResourceVersion
+		if !reflect.DeepEqual(newCachedPVC, pvc) {
 			t.Errorf("Test %q failed: cached PVC check failed [A-expected, B-got]:\n%s", name, diff.ObjectDiff(pvc, cachedPVC))
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Because I setup watch mechanism in #72045, assumed cache will be overridden by API objects. It's not reliable to check assumed cache after bindAPIUpdate now.

~~One way to fix is to disable watch mechanism to check assumed cache like before. But I suggest to keep it and check API objects only.~~

~~I think there is no need to check assumed cache in TestBindAPIUpdate because~~

~~1) if API update succeeds, cache will be overridden by new API object, actually we
check against API server~~
~~2) if API update fails, cache is same with assumed cache, and we already
have tests for AssumePodVolumes~~

We compare but ignore resource version for now.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72954

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
