### PR TITLE
Introduce EndpointsControllerCache.

### DIFF
--- a/pkg/controller/endpoint/BUILD
+++ b/pkg/controller/endpoint/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = [
         "doc.go",
         "endpoints_controller.go",
+        "endpoints_controller_cache.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/controller/endpoint",
     deps = [
@@ -39,7 +40,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["endpoints_controller_test.go"],
+    srcs = [
+        "endpoints_controller_cache_test.go",
+        "endpoints_controller_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/api/testapi:go_default_library",
@@ -48,13 +52,14 @@ go_test(
         "//pkg/controller:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",

--- a/pkg/controller/endpoint/endpoints_controller_cache.go
+++ b/pkg/controller/endpoint/endpoints_controller_cache.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/kubernetes/pkg/controller"
+)
+
+// EndpointsControllerCache is a util that manages a local copy of the state of pods and services
+// for purpose of endpoints object syncing.
+//
+// The purpose of this util is to create a single source of truth that is thread-safe and avoids
+// potential race-conditions in the endpoints-controller. In addition it allows to easily determine
+// which object (pod/service) changes resulted in the endpoints object change, which is crucial in
+// implementing the network programming latency metric.
+//
+// The cache should be initialized via pod and service listers and kept up-to-date via the
+// (Add|Update|Delete)(Pod|Service) methods called in the EndpointsController's event handlers.
+// The Initialize method together with the event handlers method are guarded by the same mutex which
+// guarantees that no information is ever missed and all events are processed in the serial order.
+//
+// The cache doesn't store full objects, it stores only references to minimize the memory
+// consumption.
+type endpointsControllerCache struct {
+	// pods is a map of pods indexed by namespace and name, i.e. namespace -> name -> pod.
+	pods map[string]map[string]*v1.Pod
+	// pods is a map of services indexed by namespace and name, i.e. namespace -> name -> service.
+	services map[string]map[string]*v1.Service
+
+	// Mutex guarding this util.
+	mutex sync.Mutex
+}
+
+// Creates new instance of the endpointsControllerCache.
+func newEndpointsControllerCache() *endpointsControllerCache {
+	return &endpointsControllerCache{
+		pods:     make(map[string]map[string]*v1.Pod),
+		services: make(map[string]map[string]*v1.Service),
+	}
+}
+
+// Initialize initializes the cache with pods and services obtained from the provided listers.
+// Pods and services are listed behind the mutex, which temporarily disables event listener
+// callbacks (e.g. AddPod, UpdateService, etc.) - making them (this method and informer events)
+// mutually exclusive. Given that and the fact that listers always see everything that has been
+// already delivered via informer events, this implementation guarantees that no information will be
+// ever lost.
+// This method should be called exactly once on the startup, before the first call of the
+// GetServiceAndPods method, after the lister have synced.
+// TODO(mm4tt): Support initialization natively in the Informer framework and get rid of this method.
+//              This will require a new signal (and callback in the event handler) informing
+//              that the state has been synced and fully delivered to the event handlers via the
+//              OnAdd callbacks.
+func (e *endpointsControllerCache) Initialize(serviceLister corelisters.ServiceLister, podLister corelisters.PodLister) error {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	services, err := serviceLister.List(labels.Everything())
+	if err != nil {
+		// Error shouldn't happened as we're getting objects from a local cache, so fail if it does.
+		return fmt.Errorf("unable to list services due to %v", err)
+	}
+	// Please note that we're listing pods from a different lister, so it's possible that we will
+	// initialize the cache with a pod state newer or older than the service state. This inaccuracy
+	// doesn't matter in the long run though. If the service / pod state returned by lister is
+	// behind, and doesn't reflect what is stored in etcd, then we're guaranteed to get the
+	// service / pod state updates via the (Add|Update|Delete)(Pod|Service) methods which will
+	// eventually make the state consistent. In other words we're always guaranteed to reach the
+	// state when there are no Informer events to be processed (for the moment) and the state of
+	// this cache fully reflects the state stored in etcd.
+	pods, err := podLister.List(labels.Everything())
+	if err != nil {
+		// Error shouldn't happened as we're getting objects from a local cache, so fail if it does.
+		return fmt.Errorf("unable to list pods due to %v", err)
+	}
+
+	for _, service := range services {
+		e.getServices(service.Namespace)[service.Name] = service
+	}
+	for _, pod := range pods {
+		e.getPods(pod.Namespace)[pod.Name] = pod
+	}
+	return nil
+}
+
+// AddPod adds new pod to the cache and returns a list of namespaced names of service / endpoints
+// objects that should be synced after this operation has been completed.
+func (e *endpointsControllerCache) AddPod(pod *v1.Pod) []string {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	e.getPods(pod.Namespace)[pod.Name] = pod
+	return e.getPodServiceMemberships(pod)
+}
+
+// UpdatePod updates the pod in the cache and returns a list of namespaced names of
+// service / endpoints objects that should be synced after this operation has been completed.
+func (e *endpointsControllerCache) UpdatePod(before, after *v1.Pod) []string {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	e.getPods(after.Namespace)[after.Name] = after
+
+	services := sets.NewString()
+	services.Insert(e.getPodServiceMemberships(before)...)
+	services.Insert(e.getPodServiceMemberships(after)...)
+	return services.List()
+}
+
+// DeletePod deletes the pod from the cache and returns a list of namespaced names of
+// service / endpoints objects that should be synced after this operation has been completed.
+func (e *endpointsControllerCache) DeletePod(pod *v1.Pod) []string {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	delete(e.getPods(pod.Namespace), pod.Name)
+	return e.getPodServiceMemberships(pod)
+}
+
+// AddService adds the service to the cache and returns the namespaced name of the service
+// being added.
+func (e *endpointsControllerCache) AddService(service *v1.Service) (string, error) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	e.getServices(service.Namespace)[service.Name] = service
+	return getNamespacedName(service)
+}
+
+// UpdateService updates the service in the cache and returns the namespaced name of the service
+// being updated.
+func (e *endpointsControllerCache) UpdateService(before, after *v1.Service) (string, error) {
+	return e.AddService(after)
+}
+
+// DeleteService deletes the service from the cache and returns the namespaced name of the service
+// being deleted.
+func (e *endpointsControllerCache) DeleteService(service *v1.Service) (string, error) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	delete(e.getServices(service.Namespace), service.Name)
+	return getNamespacedName(service)
+}
+
+// GetServiceAndPods returns service identified by the provided key (namespaced name) and all the
+// pods belonging to the service from the cache. This method will be called in the
+// EndpointsController.syncService method.
+func (e *endpointsControllerCache) GetServiceAndPods(namespace, name string) (service *v1.Service, pods []*v1.Pod) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	service, ok := e.getServices(namespace)[name]
+	if ok && service.Spec.Selector != nil {
+		selector := labels.Set(service.Spec.Selector).AsSelectorPreValidated()
+		for _, pod := range e.getPods(namespace) {
+			if selector.Matches(labels.Set(pod.Labels)) {
+				pods = append(pods, pod)
+			}
+		}
+	}
+	return service, pods
+}
+
+// getPodServiceMemberships returns slice of strings, where each string represents a namespaced
+// service name that the provided pod belongs to.
+func (e *endpointsControllerCache) getPodServiceMemberships(pod *v1.Pod) (ret []string) {
+	ret = []string{}
+	for _, service := range e.getServices(pod.Namespace) {
+		if service.Spec.Selector == nil {
+			// services with nil selectors match nothing, not everything.
+			continue
+		}
+		selector := labels.Set(service.Spec.Selector).AsSelectorPreValidated()
+		if selector.Matches(labels.Set(pod.Labels)) {
+			key, err := getNamespacedName(service)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("unable to get key for service %#v", service))
+				continue
+			}
+			ret = append(ret, key)
+		}
+	}
+	return ret
+}
+
+// getPods returns pod map (name->pod) for the given namespace. This method takes care of
+// initialization if the pod map doesn't exist yet for the given namespace, in other words it will
+// never return nil.
+func (e *endpointsControllerCache) getPods(namespace string) map[string]*v1.Pod {
+	if _, ok := e.pods[namespace]; !ok {
+		e.pods[namespace] = make(map[string]*v1.Pod)
+	}
+	return e.pods[namespace]
+}
+
+// getServices returns service map (name->service) for the given namespace. This method takes care
+// of the map initialization if the service map doesn't exist yet for the given namespace, in other
+// words it will never return nil.
+func (e *endpointsControllerCache) getServices(namespace string) map[string]*v1.Service {
+	if _, ok := e.services[namespace]; !ok {
+		e.services[namespace] = make(map[string]*v1.Service)
+	}
+	return e.services[namespace]
+}
+
+// ----- Util Functions -----
+
+// getNamespacedName returns namespaced name of the provided service.
+func getNamespacedName(service *v1.Service) (string, error) {
+	return controller.KeyFunc(service)
+}

--- a/pkg/controller/endpoint/endpoints_controller_cache_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_cache_test.go
@@ -1,0 +1,464 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	corelisters "k8s.io/client-go/listers/core/v1"
+)
+
+const (
+	namespace = "NS1"
+)
+
+var (
+	frontend1Pod = createPod(namespace, "frontend1", "app:frontend")
+	frontend2Pod = createPod(namespace, "frontend2", "app:frontend")
+	backend1Pod  = createPod(namespace, "backend1", "app:backend")
+	backend2Pod  = createPod(namespace, "backend2", "app:backend")
+
+	frontendService = createService(namespace, "frontend", "app:frontend")
+	backendService  = createService(namespace, "backend", "app:backend")
+)
+
+func TestGetServiceAndPods(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod, backend2Pod})
+
+	cache.whenGetServiceAndPods(namespace, "frontend").
+		expectService(frontendService).
+		expectPods(frontend1Pod, frontend2Pod)
+}
+
+func TestGetServiceAndPods_ServiceDeleted(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod, backend2Pod})
+
+	cache.DeleteService(frontendService)
+
+	// Sync can happen after service was deleted, this is a valid call and should return nil service
+	// and no pods.
+	cache.whenGetServiceAndPods(namespace, "frontend").
+		expectService(nil).
+		expectPods()
+}
+
+func TestGetServiceAndPods_ServiceAddedNoPods(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod, backend2Pod})
+
+	service := createService(namespace, "my-service", "app:new-app")
+	cache.AddService(service)
+
+	cache.whenGetServiceAndPods(namespace, "my-service").
+		expectService(service).
+		expectPods() // No Pods
+}
+
+func TestGetServiceAndPods_ServiceAddedMatchingPods(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	pod1 := createPod(namespace, "pod1", "app:new-app")
+	pod2 := createPod(namespace, "pod2", "app:new-app")
+
+	cache.initialize(
+		[]*v1.Service{},
+		[]*v1.Pod{pod1, pod2})
+
+	service := createService(namespace, "my-service", "app:new-app")
+	cache.AddService(service)
+
+	cache.whenGetServiceAndPods(namespace, "my-service").
+		expectService(service).
+		expectPods(pod1, pod2) // No Pods
+}
+
+func TestGetServiceAndPods_ServiceWithEmptySelector(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod, backend2Pod})
+
+	service := createService(namespace, "my-service") // No selector.
+	cache.AddService(service)
+
+	cache.whenGetServiceAndPods(namespace, "my-service").
+		expectService(service).
+		expectPods() // No Pods, no selector = nothing.
+}
+
+func TestGetServiceAndPods_ServiceUpdated(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	pod1 := createPod(namespace, "pod1", "app:frontend", "env:dev")
+	pod2 := createPod(namespace, "pod2", "app:frontend", "env:prod")
+
+	service := createService(namespace, "my-service", "app:frontend")
+
+	cache.initialize(
+		[]*v1.Service{frontendService, service},
+		[]*v1.Pod{pod1, pod2})
+
+	cache.whenGetServiceAndPods(namespace, "my-service").
+		expectService(service).
+		expectPods(pod1, pod2)
+
+	// Updated service matches only "prod" pods.
+	updatedService := createService(namespace, "my-service", "app:frontend", "env:prod")
+	cache.UpdateService(service, updatedService)
+
+	cache.whenGetServiceAndPods(namespace, "my-service").
+		expectService(updatedService).
+		expectPods(pod2)
+}
+
+func TestGetServiceAndPods_PodAdded(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod, backend2Pod})
+
+	cache.whenGetServiceAndPods(namespace, "frontend").
+		expectService(frontendService).
+		expectPods(frontend1Pod, frontend2Pod)
+
+	pod := createPod(namespace, "pod1", "app:frontend")
+	cache.AddPod(pod)
+
+	cache.whenGetServiceAndPods(namespace, "frontend").
+		expectService(frontendService).
+		expectPods(frontend1Pod, frontend2Pod, pod)
+}
+
+func TestGetServiceAndPods_PodUpdated(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	pod := createPod(namespace, "pod1", "app:frontend")
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod, backend2Pod, pod})
+
+	cache.whenGetServiceAndPods(namespace, "frontend").
+		expectService(frontendService).
+		expectPods(frontend1Pod, frontend2Pod, pod)
+	cache.whenGetServiceAndPods(namespace, "backend").
+		expectService(backendService).
+		expectPods(backend1Pod, backend2Pod)
+
+	updatedPod := createPod(namespace, "pod1", "app:backend") // Now pod belongs to backend.
+	cache.UpdatePod(pod, updatedPod)
+
+	cache.whenGetServiceAndPods(namespace, "frontend").
+		expectService(frontendService).
+		expectPods(frontend1Pod, frontend2Pod)
+	cache.whenGetServiceAndPods(namespace, "backend").
+		expectService(backendService).
+		expectPods(backend1Pod, backend2Pod, updatedPod)
+}
+
+func TestGetServiceAndPods_PodDeleted(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod, backend2Pod})
+
+	cache.whenGetServiceAndPods(namespace, "frontend").
+		expectService(frontendService).
+		expectPods(frontend1Pod, frontend2Pod)
+
+	cache.DeletePod(frontend1Pod)
+
+	cache.whenGetServiceAndPods(namespace, "frontend").
+		expectService(frontendService).
+		expectPods(frontend2Pod)
+}
+
+func TestGetServiceAndPods_PodInDIfferentNamespace(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	ns2Pod := createPod("NS2", "frontend1", "app:frontend")
+	ns2Service := createService("NS2", "frontend", "app:frontend")
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService, ns2Service},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod, backend2Pod, ns2Pod})
+
+	cache.whenGetServiceAndPods(namespace, "frontend").
+		expectService(frontendService).
+		expectPods(frontend1Pod, frontend2Pod) // No ns2Pod.
+
+	cache.whenGetServiceAndPods("NS2", "frontend").
+		expectService(ns2Service).
+		expectPods(ns2Pod)
+}
+
+func TestAddPod(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod})
+
+	cache.whenAddPod(backend2Pod).expect("NS1/backend")
+}
+
+func TestAddPod_NoMatchingService(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod})
+
+	pod := createPod(namespace, "pod", "app:new-app")
+	cache.whenAddPod(pod).expect()
+}
+
+func TestAddPod_MultiServicePod(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	pod := createPod(namespace, "my-pod", "app:frontend", "env:dev")
+	service := createService(namespace, "dev", "env:dev")
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService, service},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod, pod})
+
+	cache.whenAddPod(pod).expect("NS1/dev", "NS1/frontend")
+}
+
+func TestUpdatePod(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod, backend2Pod})
+
+	updatedPod := createPod(namespace, "frontend2", "app:backend")
+	cache.whenUpdatePod(frontend2Pod, updatedPod).
+		// Pod moved from backend to frontend, both services should be synced.
+		expect("NS1/frontend", "NS1/backend")
+}
+
+func TestDeletePod(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod, backend2Pod})
+
+	cache.whenDeletePod(backend1Pod).expect("NS1/backend")
+}
+
+func TestAddPod_DifferentNamespace(t *testing.T) {
+	cache := newCacheUnderTest(t)
+
+	ns2Service := createService("NS2", "frontend", "app:frontend")
+
+	cache.initialize(
+		[]*v1.Service{frontendService, backendService, ns2Service},
+		[]*v1.Pod{frontend1Pod, frontend2Pod, backend1Pod})
+
+	pod := createPod("NS2", "frontend1", "app:frontend")
+	// NS1/frontend not returned, even though selector matches.
+	cache.whenAddPod(pod).expect("NS2/frontend")
+}
+
+// ------- Test Utils -------
+
+type tester struct {
+	*endpointsControllerCache
+	t *testing.T
+}
+
+func newCacheUnderTest(t *testing.T) *tester {
+	return &tester{newEndpointsControllerCache(), t}
+}
+
+func (t *tester) initialize(services []*v1.Service, pods []*v1.Pod) {
+	t.Initialize(serviceLister(services), podLister(pods))
+}
+
+func (t *tester) whenGetServiceAndPods(namespace, name string) *serviceAndPodsSubject {
+	service, pods := t.GetServiceAndPods(namespace, name)
+	sortPods(pods)
+	return &serviceAndPodsSubject{service, pods, t.t}
+}
+
+func (t *tester) whenAddPod(pod *v1.Pod) *serviceNameSliceSubject {
+	return newServiceNameSliceSubject(t.AddPod(pod), t.t)
+}
+
+func (t *tester) whenUpdatePod(before, after *v1.Pod) *serviceNameSliceSubject {
+	return newServiceNameSliceSubject(t.UpdatePod(before, after), t.t)
+}
+
+func (t *tester) whenDeletePod(pod *v1.Pod) *serviceNameSliceSubject {
+	return newServiceNameSliceSubject(t.DeletePod(pod), t.t)
+}
+
+type serviceAndPodsSubject struct {
+	gotService *v1.Service
+	gotPods    []*v1.Pod
+	t          *testing.T
+}
+
+func (s *serviceAndPodsSubject) expectService(expected *v1.Service) *serviceAndPodsSubject {
+	assertEqual(s.gotService, expected, s.t)
+	return s
+}
+
+func (s *serviceAndPodsSubject) expectPods(expected ...*v1.Pod) *serviceAndPodsSubject {
+	sortPods(expected)
+	assertEqual(s.gotPods, expected, s.t)
+	return s
+}
+
+type serviceNameSliceSubject struct {
+	got []string
+	t   *testing.T
+}
+
+func newServiceNameSliceSubject(got []string, t *testing.T) *serviceNameSliceSubject {
+	sort.Strings(got)
+	return &serviceNameSliceSubject{got, t}
+}
+
+func (s *serviceNameSliceSubject) expect(expected ...string) {
+	if expected == nil {
+		expected = []string{}
+	}
+	sort.Strings(expected)
+	assertEqual(s.got, expected, s.t)
+}
+
+func assertEqual(got interface{}, expected interface{}, t *testing.T) {
+	if !reflect.DeepEqual(got, expected) {
+		_, fn, line, _ := runtime.Caller(2)
+		t.Errorf("Failed assertion in %s:%d expected %s, got %s",
+			fn, line, toString(expected), toString(got))
+	}
+}
+
+func toString(o interface{}) string {
+	if o == nil {
+		return "<nil>"
+	} else if s, ok := o.(string); ok {
+		return s
+	} else if pod, ok := o.(*v1.Pod); ok {
+		return fmt.Sprintf("Pod %s/%s", pod.Namespace, pod.Name)
+	} else if service, ok := o.(*v1.Service); ok {
+		return fmt.Sprintf("Service %s/%s", service.Namespace, service.Name)
+	} else if reflect.TypeOf(o).Kind() == reflect.Slice {
+		slice := reflect.ValueOf(o)
+		stringSlice := make([]string, slice.Len())
+		for i := 0; i < slice.Len(); i++ {
+			stringSlice[i] = toString(slice.Index(i).Interface())
+		}
+		return "[ " + strings.Join(stringSlice, ", ") + " ]"
+	}
+
+	panic(fmt.Sprintf("Unexpected object: %s", o))
+}
+
+func sortPods(pods []*v1.Pod) {
+	sort.Slice(pods, func(i, j int) bool {
+		key := func(i int) string { return pods[i].Namespace + "/" + pods[i].Name }
+		return key(i) < key(j)
+	})
+}
+
+func parseLabels(labelsAsStrings []string) (labels map[string]string) {
+	if len(labelsAsStrings) == 0 {
+		return nil
+	}
+	labels = make(map[string]string)
+	for _, label := range labelsAsStrings {
+		keyAndValue := strings.Split(label, ":")
+		labels[keyAndValue[0]] = keyAndValue[1]
+	}
+	return labels
+}
+
+func createPod(namespace, name string, labelsAsStrings ...string) *v1.Pod {
+	return &v1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    parseLabels(labelsAsStrings),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{Ports: []v1.ContainerPort{}}},
+		},
+		Status: v1.PodStatus{
+			PodIP: "1.2.3.4",
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodReady,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func createService(namespace, name string, selectorAsStrings ...string) *v1.Service {
+	return &v1.Service{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: v1.ServiceSpec{
+			Selector: parseLabels(selectorAsStrings),
+			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt(8080)}},
+		},
+	}
+}
+
+type serviceLister []*v1.Service
+
+func (s serviceLister) List(selector labels.Selector) (ret []*v1.Service, err error) { return s, nil }
+func (serviceLister) Services(namespace string) corelisters.ServiceNamespaceLister {
+	panic("Not Implemented")
+}
+func (serviceLister) GetPodServices(pod *v1.Pod) ([]*v1.Service, error) { panic("Not Implemented") }
+
+type podLister []*v1.Pod
+
+func (p podLister) List(selector labels.Selector) (ret []*v1.Pod, err error) { return p, nil }
+func (podLister) Pods(namespace string) corelisters.PodNamespaceLister       { panic("Not Implemented!") }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
EndpointsControllerCache is a util that manages a local copy of the state of pods and services for
purpose of endpoints object syncing.

The purpose of this util is to create a single source of truth that is thread-safe and avoids
potential race-conditions in the endpoints-controller. In addition it allows to easily determine
which object (pod/service) changes resulted in the endpoints object change.
**This is crucial in implementing the network programming latency metric.**

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
