### PR TITLE
Use actual node hostname during test "EmptyDir Wrapper Volume, ConfigMap volumes, no race"

### DIFF
--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -342,6 +342,8 @@ func makeConfigMapVolumes(configMapNames []string) (volumes []v1.Volume, volumeM
 }
 
 func testNoWrappedVolumeRace(f *framework.Framework, volumes []v1.Volume, volumeMounts []v1.VolumeMount, podCount int32) {
+	const nodeHostnameLabelKey = "kubernetes.io/hostname"
+
 	rcName := wrappedVolumeRaceRCNamePrefix + string(uuid.NewUUID())
 	nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 	Expect(len(nodeList.Items)).To(BeNumerically(">", 0))
@@ -355,9 +357,9 @@ func testNoWrappedVolumeRace(f *framework.Framework, volumes []v1.Volume, volume
 					{
 						MatchExpressions: []v1.NodeSelectorRequirement{
 							{
-								Key:      "kubernetes.io/hostname",
+								Key:      nodeHostnameLabelKey,
 								Operator: v1.NodeSelectorOpIn,
-								Values:   []string{targetNode.Name},
+								Values:   []string{targetNode.Labels[nodeHostnameLabelKey]},
 							},
 						},
 					},


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
The conformance test `EmptyDir Wrapper Volume, ConfigMap volumes, no race` uses a ReplicationController with a `nodeAffinity`:
```yaml
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/hostname
            operator: In
            values:
            - some-node-hostname
```

`node.name` will be taken for the match expression which does not work on AWS.
On AWS node names are the private DNS name like: `ip-172-31-1-104.eu-central-1.compute.internal`.
The hostname on a AWS node though is just a subset of the node name: `ip-172-31-1-104`.

Thus affinity cannot match.

**Special notes for your reviewer**:
This should be cherry picked to v1.13.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
