### PR TITLE
fix bugs for pod worker latency metrics

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1994,7 +1994,7 @@ func (kl *Kubelet) dispatchWork(pod *v1.Pod, syncType kubetypes.SyncPodType, mir
 		MirrorPod:  mirrorPod,
 		UpdateType: syncType,
 		OnCompleteFunc: func(err error) {
-			if err != nil {
+			if err == nil {
 				metrics.PodWorkerLatency.WithLabelValues(syncType.String()).Observe(metrics.SinceInMicroseconds(start))
 			}
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix the way of collecting the metric kubelet_pod_worker_latency_microseconds.

https://github.com/kubernetes/kubernetes/blob/fdfd88588596c5d35c6d62e0b8658f05f3e165c9/pkg/kubelet/metrics/metrics.go#L78

The explanation of the metric kubelet_pod_worker_latency_microseconds is 

> Latency in microseconds to sync a single pod. Broken down by operation type: create, update, or sync

This metric is only collected in one anonymous function which is assigned to the `OnCompleteFunc` field of struct `UpdatePodOptions`

https://github.com/kubernetes/kubernetes/blob/fdfd88588596c5d35c6d62e0b8658f05f3e165c9/pkg/kubelet/kubelet.go#L1996

And then, the `UpdatePodOptions` param will be passed into func `UpdatePod`, then passed into func `managePodLoop`

https://github.com/kubernetes/kubernetes/blob/fdfd88588596c5d35c6d62e0b8658f05f3e165c9/pkg/kubelet/pod_workers.go#L199

https://github.com/kubernetes/kubernetes/blob/fdfd88588596c5d35c6d62e0b8658f05f3e165c9/pkg/kubelet/pod_workers.go#L157

At last, the  `OnCompleteFunc` will be executed in func `managePodLoop ` when the func `syncPodFn ` is executed, no matter the result of `syncPodFn` has error or none.

https://github.com/kubernetes/kubernetes/blob/fdfd88588596c5d35c6d62e0b8658f05f3e165c9/pkg/kubelet/pod_workers.go#L174

So I think the metrics should be collected when the `syncPodFn` within func ``managePodLoop`` is executed successfully with no errors returned. 

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

```release-note

```
