### PR TITLE
removing some cluster-service deprecated label

### DIFF
--- a/cluster/addons/calico-policy-controller/bgpconfigurations-crd.yaml
+++ b/cluster/addons/calico-policy-controller/bgpconfigurations-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/calico-clusterrole.yaml
+++ b/cluster/addons/calico-policy-controller/calico-clusterrole.yaml
@@ -4,7 +4,6 @@ metadata:
   name: calico
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
   - apiGroups: [""]

--- a/cluster/addons/calico-policy-controller/calico-clusterrolebinding.yaml
+++ b/cluster/addons/calico-policy-controller/calico-clusterrolebinding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   name: calico
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cluster/addons/calico-policy-controller/calico-cpva-clusterrole.yaml
+++ b/cluster/addons/calico-policy-controller/calico-cpva-clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-cpva
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
   - apiGroups: [""]

--- a/cluster/addons/calico-policy-controller/calico-cpva-clusterrolebinding.yaml
+++ b/cluster/addons/calico-policy-controller/calico-cpva-clusterrolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-cpva
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 subjects:
   - kind: ServiceAccount

--- a/cluster/addons/calico-policy-controller/calico-cpva-serviceaccount.yaml
+++ b/cluster/addons/calico-policy-controller/calico-cpva-serviceaccount.yaml
@@ -4,5 +4,4 @@ metadata:
   name: calico-cpva
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
@@ -4,7 +4,6 @@ metadata:
   name: calico-node
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: calico-node
 spec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes label kubernetes.io/cluster-service='true' from some addons files as this is now depricated.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
work towards #72757 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
