### PR TITLE
Update addon-manager changelog/image

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 9.0  (Wed January 16 2019 Jordan Liggitt <liggitt@google.com>)
+ - Prune workload resources via apps/v1 APIs
+ - Update kubectl to v1.13.2.
+
 ### Version 8.9  (Fri October 19 2018 Jeff Grafton <jgrafton@google.com>)
  - Update to use debian-base:0.4.0.
  - Update kubectl to v1.11.3.

--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -14,7 +14,7 @@ spec:
   - name: kube-addon-manager
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: k8s.gcr.io/kube-addon-manager:v8.9
+    image: k8s.gcr.io/kube-addon-manager:v9.0
     command:
     - /bin/bash
     - -c

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v8.9
+    image: {{kube_docker_registry}}/kube-addon-manager:v9.0
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Follow up to https://github.com/kubernetes/kubernetes/pull/72940

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/kubernetes/issues/43214

**Does this PR introduce a user-facing change?**:
```release-note
kube-addon-manager was updated to v9.0, and now uses kubectl v1.13.2 and prunes workload resources via the apps/v1 API
```
