### PR TITLE
Automated cherry pick of #65983: apiextensions-apiserver: wire through CountMetricPollPeriod

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -664,6 +664,7 @@ type CRDRESTOptionsGetter struct {
 	DefaultWatchCacheSize   int
 	EnableGarbageCollection bool
 	DeleteCollectionWorkers int
+	CountMetricPollPeriod   time.Duration
 }
 
 func (t CRDRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (generic.RESTOptions, error) {
@@ -673,6 +674,7 @@ func (t CRDRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (gen
 		EnableGarbageCollection: t.EnableGarbageCollection,
 		DeleteCollectionWorkers: t.DeleteCollectionWorkers,
 		ResourcePrefix:          resource.Group + "/" + resource.Resource,
+		CountMetricPollPeriod:   t.CountMetricPollPeriod,
 	}
 	if t.EnableWatchCache {
 		ret.Decorator = genericregistry.StorageWithCacher(t.DefaultWatchCacheSize)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
@@ -125,6 +125,7 @@ func NewCRDRESTOptionsGetter(etcdOptions genericoptions.EtcdOptions) genericregi
 		DefaultWatchCacheSize:   etcdOptions.DefaultWatchCacheSize,
 		EnableGarbageCollection: etcdOptions.EnableGarbageCollection,
 		DeleteCollectionWorkers: etcdOptions.DeleteCollectionWorkers,
+		CountMetricPollPeriod:   etcdOptions.StorageConfig.CountMetricPollPeriod,
 	}
 	ret.StorageConfig.Codec = unstructured.UnstructuredJSONScheme
 


### PR DESCRIPTION
Cherry pick of #65983 on release-1.11.

#65983: apiextensions-apiserver: wire through CountMetricPollPeriod