### PR TITLE
Don't fail swap check if /proc/swaps is missing

### DIFF
--- a/pkg/kubelet/cm/BUILD
+++ b/pkg/kubelet/cm/BUILD
@@ -133,6 +133,7 @@ go_test(
         "node_container_manager_linux_test.go",
         "pod_container_manager_linux_test.go",
     ],
+    data = [":testdata"],
     embed = [":go_default_library"],
     deps = select({
         "@io_bazel_rules_go//go/platform:linux": [

--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -142,3 +142,20 @@ func TestSoftRequirementsValidationSuccess(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, f.cpuHardcapping, "cpu hardcapping is expected to be enabled")
 }
+
+// These files exist
+func TestErrorOnSwapOn(t *testing.T) {
+	err := checkSwapOn("testdata/swaps.bad")
+	assert.Error(t, err)
+}
+
+func TestSuccessOnSwapOff(t *testing.T) {
+	err := checkSwapOn("testdata/swaps.good")
+	assert.NoError(t, err)
+}
+
+// This one doesn't
+func TestSuccessOnProcSwapsMissing(t *testing.T) {
+	err := checkSwapOn("testdata/I.do.not.exist")
+	assert.NoError(t, err)
+}

--- a/pkg/kubelet/cm/testdata/swaps.bad
+++ b/pkg/kubelet/cm/testdata/swaps.bad
@@ -1,0 +1,2 @@
+Filename                          Type        Size     Used    Priority
+/dev/mapper/VolGroup00-LogVol01   partition   524280   0       -1

--- a/pkg/kubelet/cm/testdata/swaps.good
+++ b/pkg/kubelet/cm/testdata/swaps.good
@@ -1,0 +1,1 @@
+Filename				Type		Size	Used	Priority


### PR DESCRIPTION
On systems where swap has been turned off entirely, e.g. some Chromebooks,
there's no /proc/swaps. Whitelist the case where the file is not found.
Move the code into its own function and add good/bad test files.

See https://bugs.chromium.org/p/chromium/issues/detail?id=878034

/kind bug

**What this PR does / why we need it**:

This blocks kubelet from running on systems without a `/proc/swaps`, e.g.
under Crostini on some Chromebooks. Check the ChromeOS bug linked above.

```release-note
NONE
```
