### PR TITLE
Promote RunAsGroup to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -278,7 +278,7 @@ const (
 	CRIContainerLogRotation utilfeature.Feature = "CRIContainerLogRotation"
 
 	// owner: @krmayankk
-	// alpha: v1.10
+	// beta: v1.14
 	//
 	// Enables control over the primary group ID of containers' init processes.
 	RunAsGroup utilfeature.Feature = "RunAsGroup"
@@ -465,7 +465,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	CSIMigration:                                {Default: false, PreRelease: utilfeature.Alpha},
 	CSIMigrationGCE:                             {Default: false, PreRelease: utilfeature.Alpha},
 	CSIMigrationAWS:                             {Default: false, PreRelease: utilfeature.Alpha},
-	RunAsGroup:                                  {Default: false, PreRelease: utilfeature.Alpha},
+	RunAsGroup:                                  {Default: true, PreRelease: utilfeature.Beta},
 	VolumeSubpath:                               {Default: true, PreRelease: utilfeature.GA},
 	BalanceAttachedNodeVolumes:                  {Default: false, PreRelease: utilfeature.Alpha},
 	PodReadinessGates:                           {Default: true, PreRelease: utilfeature.Beta},

--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -60,10 +60,10 @@ func scTestPod(hostIPC bool, hostPID bool) *v1.Pod {
 	return pod
 }
 
-var _ = SIGDescribe("Security Context [Feature:SecurityContext]", func() {
+var _ = SIGDescribe("Security Context", func() {
 	f := framework.NewDefaultFramework("security-context")
 
-	It("should support pod.Spec.SecurityContext.SupplementalGroups", func() {
+	It("should support pod.Spec.SecurityContext.SupplementalGroups [LinuxOnly]", func() {
 		pod := scTestPod(false, false)
 		pod.Spec.Containers[0].Command = []string{"id", "-G"}
 		pod.Spec.SecurityContext.SupplementalGroups = []int64{1234, 5678}
@@ -71,7 +71,7 @@ var _ = SIGDescribe("Security Context [Feature:SecurityContext]", func() {
 		f.TestContainerOutput("pod.Spec.SecurityContext.SupplementalGroups", pod, 0, groups)
 	})
 
-	It("should support pod.Spec.SecurityContext.RunAsUser", func() {
+	It("should support pod.Spec.SecurityContext.RunAsUser [LinuxOnly]", func() {
 		pod := scTestPod(false, false)
 		userID := int64(1001)
 		pod.Spec.SecurityContext.RunAsUser = &userID
@@ -83,7 +83,7 @@ var _ = SIGDescribe("Security Context [Feature:SecurityContext]", func() {
 		})
 	})
 
-	It("should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]", func() {
+	It("should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [LinuxOnly]", func() {
 		pod := scTestPod(false, false)
 		userID := int64(1001)
 		groupID := int64(2002)
@@ -97,7 +97,7 @@ var _ = SIGDescribe("Security Context [Feature:SecurityContext]", func() {
 		})
 	})
 
-	It("should support container.SecurityContext.RunAsUser", func() {
+	It("should support container.SecurityContext.RunAsUser [LinuxOnly]", func() {
 		pod := scTestPod(false, false)
 		userID := int64(1001)
 		overrideUserID := int64(1002)
@@ -112,7 +112,7 @@ var _ = SIGDescribe("Security Context [Feature:SecurityContext]", func() {
 		})
 	})
 
-	It("should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]", func() {
+	It("should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [LinuxOnly]", func() {
 		pod := scTestPod(false, false)
 		userID := int64(1001)
 		groupID := int64(2001)
@@ -131,19 +131,19 @@ var _ = SIGDescribe("Security Context [Feature:SecurityContext]", func() {
 		})
 	})
 
-	It("should support volume SELinux relabeling", func() {
+	It("should support volume SELinux relabeling [Flaky] [LinuxOnly]", func() {
 		testPodSELinuxLabeling(f, false, false)
 	})
 
-	It("should support volume SELinux relabeling when using hostIPC", func() {
+	It("should support volume SELinux relabeling when using hostIPC [Flaky] [LinuxOnly]", func() {
 		testPodSELinuxLabeling(f, true, false)
 	})
 
-	It("should support volume SELinux relabeling when using hostPID", func() {
+	It("should support volume SELinux relabeling when using hostPID [Flaky] [LinuxOnly]", func() {
 		testPodSELinuxLabeling(f, false, true)
 	})
 
-	It("should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]", func() {
+	It("should support seccomp alpha unconfined annotation on the container [Feature:Seccomp] [LinuxOnly]", func() {
 		// TODO: port to SecurityContext as soon as seccomp is out of alpha
 		pod := scTestPod(false, false)
 		pod.Annotations[v1.SeccompContainerAnnotationKeyPrefix+"test-container"] = "unconfined"
@@ -152,7 +152,7 @@ var _ = SIGDescribe("Security Context [Feature:SecurityContext]", func() {
 		f.TestContainerOutput(v1.SeccompPodAnnotationKey, pod, 0, []string{"0"}) // seccomp disabled
 	})
 
-	It("should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]", func() {
+	It("should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp] [LinuxOnly]", func() {
 		// TODO: port to SecurityContext as soon as seccomp is out of alpha
 		pod := scTestPod(false, false)
 		pod.Annotations[v1.SeccompPodAnnotationKey] = "unconfined"
@@ -160,7 +160,7 @@ var _ = SIGDescribe("Security Context [Feature:SecurityContext]", func() {
 		f.TestContainerOutput(v1.SeccompPodAnnotationKey, pod, 0, []string{"0"}) // seccomp disabled
 	})
 
-	It("should support seccomp alpha runtime/default annotation [Feature:Seccomp]", func() {
+	It("should support seccomp alpha runtime/default annotation [Feature:Seccomp] [LinuxOnly]", func() {
 		// TODO: port to SecurityContext as soon as seccomp is out of alpha
 		pod := scTestPod(false, false)
 		pod.Annotations[v1.SeccompContainerAnnotationKeyPrefix+"test-container"] = v1.SeccompProfileRuntimeDefault
@@ -168,7 +168,7 @@ var _ = SIGDescribe("Security Context [Feature:SecurityContext]", func() {
 		f.TestContainerOutput(v1.SeccompPodAnnotationKey, pod, 0, []string{"2"}) // seccomp filtered
 	})
 
-	It("should support seccomp default which is unconfined [Feature:Seccomp]", func() {
+	It("should support seccomp default which is unconfined [Feature:Seccomp] [LinuxOnly]", func() {
 		// TODO: port to SecurityContext as soon as seccomp is out of alpha
 		pod := scTestPod(false, false)
 		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}


### PR DESCRIPTION
What this PR does / why we need it:
promote this feature to beta for 1.14 https://github.com/kubernetes/enhancements/issues/213

- API is unchanged
- Leave all feature gate checks
- Enable it by default
 
```release-note
The `RunAsGroup` feature has been promoted to beta and enabled by default. PodSpec and PodSecurityPolicy objects can be used to control the primary GID of containers on supported container runtimes.
```

/milestone v1.14