### PR TITLE
skip node reboot test if provider is local.

### DIFF
--- a/test/e2e/lifecycle/reboot.go
+++ b/test/e2e/lifecycle/reboot.go
@@ -59,6 +59,9 @@ var _ = SIGDescribe("Reboot [Disruptive] [Feature:Reboot]", func() {
 
 		// Cluster must support node reboot
 		framework.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
+
+		// Should not reboot itself if local provider.
+		framework.SkipIfProviderIs("local")
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Skip node reboot test using the cluster set up by local-up-cluster.sh (local provider).
Because It will reboot the node that ran e2e test.

**Which issue(s) this PR fixes**:
Fixes #72225 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
