### PR TITLE
reduce log spam and optimize Update/Add cloud node

### DIFF
--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	clientretry "k8s.io/client-go/util/retry"
-	"k8s.io/cloud-provider"
+	cloudprovider "k8s.io/cloud-provider"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reduce log spam and optimize Update/Add cloud node.


**Related issue/pr**: 
- [This node <name> is registered without the cloud taint. Will not process.](https://github.com/kubernetes/cloud-provider-openstack/issues/140)
- [warning: "This node xxx is registered without the cloud taint. Will not process"](https://github.com/baidu/cloud-provider-baiducloud/issues/22)
- #65981 , this pr has some Conflicting files and keep hold.

**Release note**:
```release-note
NONE
```