### PR TITLE
Image is a required parameter

### DIFF
--- a/pkg/kubectl/cmd/create/create_job.go
+++ b/pkg/kubectl/cmd/create/create_job.go
@@ -82,7 +82,7 @@ func NewCreateJobOptions(ioStreams genericclioptions.IOStreams) *CreateJobOption
 func NewCmdCreateJob(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	o := NewCreateJobOptions(ioStreams)
 	cmd := &cobra.Command{
-		Use:     "job NAME [--image=image --from=cronjob/name] -- [COMMAND] [args...]",
+		Use:     "job NAME --image=image [--from=cronjob/name] -- [COMMAND] [args...]",
 		Short:   jobLong,
 		Long:    jobLong,
 		Example: jobExample,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes example in `kubectl create job` so that it clearly shows `--image` parameter is required. 

**Special notes for your reviewer**:
/assign @juanvallejo 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
