### PR TITLE
Replace ListWatchUntil with UntilWithSync to avoid watch timeouts

### DIFF
--- a/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
+++ b/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
@@ -17,6 +17,7 @@ limitations under the License.
 package csr
 
 import (
+	"context"
 	"crypto"
 	"crypto/x509"
 	"encoding/pem"
@@ -84,8 +85,9 @@ func RequestCertificate(client certificatesclient.CertificateSigningRequestInter
 func WaitForCertificate(client certificatesclient.CertificateSigningRequestInterface, req *certificates.CertificateSigningRequest, timeout time.Duration) (certData []byte, err error) {
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", req.Name).String()
 
-	event, err := watchtools.ListWatchUntil(
-		timeout,
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	event, err := watchtools.UntilWithSync(ctx,
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.FieldSelector = fieldSelector
@@ -95,7 +97,7 @@ func WaitForCertificate(client certificatesclient.CertificateSigningRequestInter
 				options.FieldSelector = fieldSelector
 				return client.Watch(options)
 			},
-		},
+		}, &certificates.CertificateSigningRequest{}, nil,
 		func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Modified, watch.Added:


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
ListWatchUntil can't handle closed watches and is being replaced by UntilWithSync based on informers.


**Special notes for your reviewer**:
Continued from #72648

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

cc @wojtek-t @liggitt 