### PR TITLE
Switch WaitForCertificate to informers to avoid broken watches

### DIFF
--- a/staging/src/k8s.io/client-go/util/certificate/BUILD
+++ b/staging/src/k8s.io/client-go/util/certificate/BUILD
@@ -20,7 +20,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
+++ b/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
@@ -17,6 +17,7 @@ limitations under the License.
 package csr
 
 import (
+	"context"
 	"crypto"
 	"crypto/x509"
 	"encoding/pem"
@@ -83,19 +84,23 @@ func RequestCertificate(client certificatesclient.CertificateSigningRequestInter
 // WaitForCertificate waits for a certificate to be issued until timeout, or returns an error.
 func WaitForCertificate(client certificatesclient.CertificateSigningRequestInterface, req *certificates.CertificateSigningRequest, timeout time.Duration) (certData []byte, err error) {
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", req.Name).String()
-
-	event, err := watchtools.ListWatchUntil(
-		timeout,
-		&cache.ListWatch{
-			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				options.FieldSelector = fieldSelector
-				return client.List(options)
-			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				options.FieldSelector = fieldSelector
-				return client.Watch(options)
-			},
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fieldSelector
+			return client.List(options)
 		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fieldSelector
+			return client.Watch(options)
+		},
+	}
+	ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), timeout)
+	defer cancel()
+	event, err := watchtools.UntilWithSync(
+		ctx,
+		lw,
+		&certificates.CertificateSigningRequest{},
+		nil,
 		func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Modified, watch.Added:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
ListWatchUntil can't handle closed watches and is being replaced by UntilWithSync based on informers.

**Special notes for your reviewer**:
Split from https://github.com/kubernetes/kubernetes/pull/50102

Replaces https://github.com/kubernetes/kubernetes/pull/73027 since this was already done in https://github.com/kubernetes/kubernetes/pull/50102 and we don't need to write it all over again.

Requires:
 - [x] https://github.com/kubernetes/kubernetes/pull/73080

**Release note:**
```release-note
NONE
```

/cc @wojtek-t @liggitt @tedyu
