### PR TITLE
make api-resource discovery errors non-fatal

### DIFF
--- a/pkg/kubectl/cmd/apiresources/BUILD
+++ b/pkg/kubectl/cmd/apiresources/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//pkg/kubectl/util/templates:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/client-go/discovery:go_default_library",


### PR DESCRIPTION
**Does this PR introduce a user-facing change?**:
```release-note
The "kubectl api-resources" command will no longer fail to display any resources on a single failure 
```

cc @soltysh @seans3 

/sig cli