### PR TITLE
Automated cherry pick of #72053 upstream release 1.13

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go
@@ -64,7 +64,7 @@ func NewDecoder(r io.ReadCloser, d runtime.Decoder) Decoder {
 		reader:   r,
 		decoder:  d,
 		buf:      make([]byte, 1024),
-		maxBytes: 1024 * 1024,
+		maxBytes: 16 * 1024 * 1024,
 	}
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
@@ -51,7 +51,7 @@ func TestDecoder(t *testing.T) {
 	frames := [][]byte{
 		make([]byte, 1025),
 		make([]byte, 1024*5),
-		make([]byte, 1024*1024*5),
+		make([]byte, 1024*1024*17),
 		make([]byte, 1025),
 	}
 	pr, pw := io.Pipe()


### PR DESCRIPTION
Cherry pick of #72053 on release-1.13.
#72053 : Increase limit for object size in streaming serializer