### PR TITLE
Enable NodeLease tests by default

### DIFF
--- a/test/e2e/common/node_lease.go
+++ b/test/e2e/common/node_lease.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("[Feature:NodeLease][NodeAlphaFeature:NodeLease]", func() {
+var _ = framework.KubeDescribe("NodeLease", func() {
 	var nodeName string
 	f := framework.NewDefaultFramework("node-lease-test")
 

--- a/test/e2e/lifecycle/node_lease.go
+++ b/test/e2e/lifecycle/node_lease.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = SIGDescribe("[Feature:NodeLease][NodeAlphaFeature:NodeLease][Disruptive]", func() {
+var _ = SIGDescribe("[Disruptive]NodeLease", func() {
 	f := framework.NewDefaultFramework("node-lease-test")
 	var systemPodsNo int32
 	var c clientset.Interface


### PR DESCRIPTION
With NodeLease being enabled by default in https://github.com/kubernetes/kubernetes/pull/72096,
we should also enable the corresponding tests by default.