### PR TITLE
kubelet: fix some race conditions with logs -f

### DIFF
--- a/pkg/kubelet/kuberuntime/logs/logs.go
+++ b/pkg/kubelet/kuberuntime/logs/logs.go
@@ -56,6 +56,9 @@ const (
 	// the container log. Kubelet should not keep following the log when the
 	// container is not running.
 	stateCheckPeriod = 5 * time.Second
+
+	// logForceCheckPeriod is the period to check for a new read
+	logForceCheckPeriod = 1 * time.Second
 )
 
 var (
@@ -426,6 +429,8 @@ func waitLogs(ctx context.Context, id string, w *fsnotify.Watcher, runtimeServic
 				return false, false, err
 			}
 			errRetry--
+		case <-time.After(logForceCheckPeriod):
+			return true, false, nil
 		case <-time.After(stateCheckPeriod):
 			if running, err := isContainerRunning(id, runtimeService); !running {
 				return false, false, err

--- a/pkg/kubelet/kuberuntime/logs/logs.go
+++ b/pkg/kubelet/kuberuntime/logs/logs.go
@@ -316,6 +316,9 @@ func ReadLogs(ctx context.Context, path, containerID string, opts *LogOptions, r
 					if err := watcher.Add(f.Name()); err != nil {
 						return fmt.Errorf("failed to watch file %q: %v", f.Name(), err)
 					}
+					// If we just created the watcher, try again to read as we might have missed
+					// the event.
+					continue
 				}
 				// Wait until the next log change.
 				if found, err := waitLogs(ctx, containerID, watcher, runtimeService); !found {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

fixes some race conditions with `kubectl logs -f`.  More details are in the message for each commit.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
