### PR TITLE
Add common functionality required for all in-tree to CSI Migration shim code pieces

### DIFF
--- a/pkg/controller/volume/attachdetach/testing/testvolumespec.go
+++ b/pkg/controller/volume/attachdetach/testing/testvolumespec.go
@@ -253,6 +253,10 @@ func (plugin *TestPlugin) CanSupport(spec *volume.Spec) bool {
 	return true
 }
 
+func (plugin *TestPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *TestPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -1258,6 +1258,10 @@ func (plugin *mockVolumePlugin) CanSupport(spec *vol.Spec) bool {
 	return true
 }
 
+func (plugin *mockVolumePlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *mockVolumePlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -390,6 +390,24 @@ const (
 	//
 	// Enables the kubelet's pod resources grpc endpoint
 	KubeletPodResources utilfeature.Feature = "KubeletPodResources"
+
+	// owner: @davidz627
+	// alpha: v1.14
+	//
+	// Enables the in-tree storage to CSI Plugin migration feature.
+	CSIMigration utilfeature.Feature = "CSIMigration"
+
+	// owner: @davidz627
+	// alpha: v1.14
+	//
+	// Enables the GCE PD in-tree driver to GCE CSI Driver migration feature.
+	CSIMigrationGCE utilfeature.Feature = "CSIMigrationGCE"
+
+	// owner: @leakingtapan
+	// alpha: v1.14
+	//
+	// Enables the AWS EBS in-tree driver to AWS EBS CSI Driver migration feature.
+	CSIMigrationAWS utilfeature.Feature = "CSIMigrationAWS"
 )
 
 func init() {
@@ -442,6 +460,9 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	BoundServiceAccountTokenVolume:              {Default: false, PreRelease: utilfeature.Alpha},
 	CRIContainerLogRotation:                     {Default: true, PreRelease: utilfeature.Beta},
 	GCERegionalPersistentDisk:                   {Default: true, PreRelease: utilfeature.GA},
+	CSIMigration:                                {Default: false, PreRelease: utilfeature.Alpha},
+	CSIMigrationGCE:                             {Default: false, PreRelease: utilfeature.Alpha},
+	CSIMigrationAWS:                             {Default: false, PreRelease: utilfeature.Alpha},
 	RunAsGroup:                                  {Default: false, PreRelease: utilfeature.Alpha},
 	VolumeSubpath:                               {Default: true, PreRelease: utilfeature.GA},
 	BalanceAttachedNodeVolumes:                  {Default: false, PreRelease: utilfeature.Alpha},

--- a/pkg/volume/awsebs/aws_ebs.go
+++ b/pkg/volume/awsebs/aws_ebs.go
@@ -86,6 +86,11 @@ func (plugin *awsElasticBlockStorePlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.AWSElasticBlockStore != nil)
 }
 
+func (plugin *awsElasticBlockStorePlugin) IsMigratedToCSI() bool {
+	return utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) &&
+		utilfeature.DefaultFeatureGate.Enabled(features.CSIMigrationAWS)
+}
+
 func (plugin *awsElasticBlockStorePlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -121,6 +121,10 @@ func (plugin *azureDataDiskPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.AzureDisk != nil)
 }
 
+func (plugin *azureDataDiskPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *azureDataDiskPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -80,6 +80,10 @@ func (plugin *azureFilePlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.AzureFile != nil)
 }
 
+func (plugin *azureFilePlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *azureFilePlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/cephfs/cephfs.go
+++ b/pkg/volume/cephfs/cephfs.go
@@ -71,6 +71,10 @@ func (plugin *cephfsPlugin) CanSupport(spec *volume.Spec) bool {
 	return (spec.Volume != nil && spec.Volume.CephFS != nil) || (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.CephFS != nil)
 }
 
+func (plugin *cephfsPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *cephfsPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -108,6 +108,10 @@ func (plugin *cinderPlugin) CanSupport(spec *volume.Spec) bool {
 	return (spec.Volume != nil && spec.Volume.Cinder != nil) || (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.Cinder != nil)
 }
 
+func (plugin *cinderPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *cinderPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -77,6 +77,10 @@ func (plugin *configMapPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.Volume != nil && spec.Volume.ConfigMap != nil
 }
 
+func (plugin *configMapPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *configMapPlugin) RequiresRemount() bool {
 	return true
 }

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -279,6 +279,10 @@ func (p *csiPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.PersistentVolume != nil && spec.PersistentVolume.Spec.CSI != nil
 }
 
+func (p *csiPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (p *csiPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -81,6 +81,10 @@ func (plugin *downwardAPIPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.Volume != nil && spec.Volume.DownwardAPI != nil
 }
 
+func (plugin *downwardAPIPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *downwardAPIPlugin) RequiresRemount() bool {
 	return true
 }

--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -89,6 +89,10 @@ func (plugin *emptyDirPlugin) CanSupport(spec *volume.Spec) bool {
 	return false
 }
 
+func (plugin *emptyDirPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *emptyDirPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -85,6 +85,10 @@ func (plugin *fcPlugin) CanSupport(spec *volume.Spec) bool {
 	return (spec.Volume != nil && spec.Volume.FC != nil) || (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.FC != nil)
 }
 
+func (plugin *fcPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *fcPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -149,6 +149,10 @@ func (plugin *flexVolumePlugin) CanSupport(spec *volume.Spec) bool {
 	return sourceDriver == plugin.driverName
 }
 
+func (plugin *flexVolumePlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 // RequiresRemount is part of the volume.VolumePlugin interface.
 func (plugin *flexVolumePlugin) RequiresRemount() bool {
 	return false

--- a/pkg/volume/flocker/flocker.go
+++ b/pkg/volume/flocker/flocker.go
@@ -108,6 +108,10 @@ func (p *flockerPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.Flocker != nil)
 }
 
+func (p *flockerPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (p *flockerPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/gcepd/gce_pd.go
+++ b/pkg/volume/gcepd/gce_pd.go
@@ -98,6 +98,11 @@ func (plugin *gcePersistentDiskPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.GCEPersistentDisk != nil)
 }
 
+func (plugin *gcePersistentDiskPlugin) IsMigratedToCSI() bool {
+	return utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) &&
+		utilfeature.DefaultFeatureGate.Enabled(features.CSIMigrationGCE)
+}
+
 func (plugin *gcePersistentDiskPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -78,6 +78,10 @@ func (plugin *gitRepoPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.Volume != nil && spec.Volume.GitRepo != nil
 }
 
+func (plugin *gitRepoPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *gitRepoPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -114,6 +114,10 @@ func (plugin *glusterfsPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.Glusterfs != nil)
 }
 
+func (plugin *glusterfsPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *glusterfsPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -83,6 +83,10 @@ func (plugin *hostPathPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.HostPath != nil)
 }
 
+func (plugin *hostPathPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *hostPathPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -76,6 +76,10 @@ func (plugin *iscsiPlugin) CanSupport(spec *volume.Spec) bool {
 	return (spec.Volume != nil && spec.Volume.ISCSI != nil) || (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.ISCSI != nil)
 }
 
+func (plugin *iscsiPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *iscsiPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -82,6 +82,10 @@ func (plugin *localVolumePlugin) CanSupport(spec *volume.Spec) bool {
 	return (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.Local != nil)
 }
 
+func (plugin *localVolumePlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *localVolumePlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -84,6 +84,10 @@ func (plugin *nfsPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.NFS != nil)
 }
 
+func (plugin *nfsPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *nfsPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/noop_expandable_plugin.go
+++ b/pkg/volume/noop_expandable_plugin.go
@@ -48,6 +48,10 @@ func (n *noopExpandableVolumePluginInstance) CanSupport(spec *Spec) bool {
 	return true
 }
 
+func (n *noopExpandableVolumePluginInstance) IsMigratedToCSI() bool {
+	return false
+}
+
 func (n *noopExpandableVolumePluginInstance) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/photon_pd/photon_pd.go
+++ b/pkg/volume/photon_pd/photon_pd.go
@@ -74,6 +74,10 @@ func (plugin *photonPersistentDiskPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.PhotonPersistentDisk != nil)
 }
 
+func (plugin *photonPersistentDiskPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *photonPersistentDiskPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/plugins_test.go
+++ b/pkg/volume/plugins_test.go
@@ -75,6 +75,10 @@ func (plugin *testPlugins) CanSupport(spec *Spec) bool {
 	return true
 }
 
+func (plugin *testPlugins) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *testPlugins) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/portworx/portworx.go
+++ b/pkg/volume/portworx/portworx.go
@@ -95,6 +95,10 @@ func (plugin *portworxVolumePlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.PortworxVolume != nil)
 }
 
+func (plugin *portworxVolumePlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *portworxVolumePlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -96,6 +96,10 @@ func (plugin *projectedPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.Volume != nil && spec.Volume.Projected != nil
 }
 
+func (plugin *projectedPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *projectedPlugin) RequiresRemount() bool {
 	return true
 }

--- a/pkg/volume/quobyte/quobyte.go
+++ b/pkg/volume/quobyte/quobyte.go
@@ -110,6 +110,10 @@ func (plugin *quobytePlugin) CanSupport(spec *volume.Spec) bool {
 	return false
 }
 
+func (plugin *quobytePlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *quobytePlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -107,6 +107,10 @@ func (plugin *rbdPlugin) CanSupport(spec *volume.Spec) bool {
 	return (spec.Volume != nil && spec.Volume.RBD != nil) || (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.RBD != nil)
 }
 
+func (plugin *rbdPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *rbdPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/scaleio/sio_plugin.go
+++ b/pkg/volume/scaleio/sio_plugin.go
@@ -72,6 +72,10 @@ func (p *sioPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.ScaleIO != nil)
 }
 
+func (p *sioPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (p *sioPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -80,6 +80,10 @@ func (plugin *secretPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.Volume != nil && spec.Volume.Secret != nil
 }
 
+func (plugin *secretPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *secretPlugin) RequiresRemount() bool {
 	return true
 }

--- a/pkg/volume/storageos/storageos.go
+++ b/pkg/volume/storageos/storageos.go
@@ -91,6 +91,10 @@ func (plugin *storageosPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.StorageOS != nil)
 }
 
+func (plugin *storageosPlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *storageosPlugin) RequiresRemount() bool {
 	return false
 }

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -313,6 +313,10 @@ func (plugin *FakeVolumePlugin) CanSupport(spec *Spec) bool {
 	return true
 }
 
+func (plugin *FakeVolumePlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *FakeVolumePlugin) RequiresRemount() bool {
 	return false
 }
@@ -526,6 +530,10 @@ func (f *FakeBasicVolumePlugin) CanSupport(spec *Spec) bool {
 	return strings.HasPrefix(spec.Name(), f.GetPluginName())
 }
 
+func (plugin *FakeBasicVolumePlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (f *FakeBasicVolumePlugin) ConstructVolumeSpec(ame, mountPath string) (*Spec, error) {
 	return f.Plugin.ConstructVolumeSpec(ame, mountPath)
 }
@@ -609,6 +617,10 @@ func (plugin *FakeFileVolumePlugin) GetVolumeName(spec *Spec) (string, error) {
 
 func (plugin *FakeFileVolumePlugin) CanSupport(spec *Spec) bool {
 	return true
+}
+
+func (plugin *FakeFileVolumePlugin) IsMigratedToCSI() bool {
+	return false
 }
 
 func (plugin *FakeFileVolumePlugin) RequiresRemount() bool {

--- a/pkg/volume/util/operationexecutor/BUILD
+++ b/pkg/volume/util/operationexecutor/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
+        "//staging/src/k8s.io/csi-translation-lib:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -76,11 +76,11 @@ func NewOperationGenerator(kubeClient clientset.Interface,
 	blkUtil volumepathhandler.BlockVolumePathHandler) OperationGenerator {
 
 	return &operationGenerator{
-		kubeClient:      kubeClient,
-		volumePluginMgr: volumePluginMgr,
-		recorder:        recorder,
+		kubeClient:                       kubeClient,
+		volumePluginMgr:                  volumePluginMgr,
+		recorder:                         recorder,
 		checkNodeCapabilitiesBeforeMount: checkNodeCapabilitiesBeforeMount,
-		blkUtil: blkUtil,
+		blkUtil:                          blkUtil,
 	}
 }
 

--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -81,6 +81,10 @@ func (plugin *vsphereVolumePlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.VsphereVolume != nil)
 }
 
+func (plugin *vsphereVolumePlugin) IsMigratedToCSI() bool {
+	return false
+}
+
 func (plugin *vsphereVolumePlugin) RequiresRemount() bool {
 	return false
 }


### PR DESCRIPTION
Many of the CSI Migration shim pieces depend on some common functionality, mostly revolving around feature flags and this plugin interface method. Would be nice to get these pieces in first so that the work on different pieces of migration can continue in parallel without rebasing issues.

/kind feature
/sig storage
/assign @saad-ali @jsafrane 
/cc @ddebroy @leakingtapan @dims 

```release-note
NONE
```
