### PR TITLE
Fix websocket e2e tests for https endpoints

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4226,7 +4226,7 @@ func OpenWebSocketForURL(url *url.URL, config *restclient.Config, protocols []st
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create tls config: %v", err)
 	}
-	if tlsConfig != nil {
+	if tlsConfig != nil || url.Scheme == "https" {
 		url.Scheme = "wss"
 		if !strings.Contains(url.Host, ":") {
 			url.Host += ":443"

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4226,16 +4226,10 @@ func OpenWebSocketForURL(url *url.URL, config *restclient.Config, protocols []st
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create tls config: %v", err)
 	}
-	if tlsConfig != nil || url.Scheme == "https" {
+	if url.Scheme == "https" {
 		url.Scheme = "wss"
-		if !strings.Contains(url.Host, ":") {
-			url.Host += ":443"
-		}
 	} else {
 		url.Scheme = "ws"
-		if !strings.Contains(url.Host, ":") {
-			url.Host += ":80"
-		}
 	}
 	headers, err := headersForConfig(config, url)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When running e2e conformance tests against a public https protected
APIserver the websocket tests would fail because it fell back to using
`ws://` instead of `wss://` for the websocket connection.

This happened because the code detect if HTTPS is used only looks for
HTTPS related configuration in the kubeconfig, like a custom CA or
certificates.

The fix is to always use HTTPS when the apiserver URL has the scheme `https://`.

**Which issue(s) this PR fixes**:

Fixes #73044

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: No
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
