### PR TITLE
kubelet: promote OS & arch labels to GA

### DIFF
--- a/pkg/kubelet/apis/well_known_labels.go
+++ b/pkg/kubelet/apis/well_known_labels.go
@@ -30,16 +30,19 @@ const (
 
 	LabelInstanceType = "beta.kubernetes.io/instance-type"
 
-	LabelOS   = "beta.kubernetes.io/os"
-	LabelArch = "beta.kubernetes.io/arch"
+	LabelOS   = "kubernetes.io/os"
+	LabelArch = "kubernetes.io/arch"
+	// The OS/Arch labels are promoted to GA in 1.14. kubelet applies both beta
+	// and GA labels to ensure backward compatibility.
+	// TODO: stop applying the beta OS/Arch labels in Kubernetes 1.17.
+	LegacyLabelOS   = "beta.kubernetes.io/os"
+	LegacyLabelArch = "beta.kubernetes.io/arch"
 
 	// GA versions of the legacy beta labels.
 	// TODO: update kubelet and controllers to set both beta and GA labels, then export these constants
 	labelZoneFailureDomainGA = "failure-domain.kubernetes.io/zone"
 	labelZoneRegionGA        = "failure-domain.kubernetes.io/region"
 	labelInstanceTypeGA      = "kubernetes.io/instance-type"
-	labelOSGA                = "kubernetes.io/os"
-	labelArchGA              = "kubernetes.io/arch"
 
 	// LabelNamespaceSuffixKubelet is an allowed label namespace suffix kubelets can self-set ([*.]kubelet.kubernetes.io/*)
 	LabelNamespaceSuffixKubelet = "kubelet.kubernetes.io"
@@ -62,11 +65,12 @@ var kubeletLabels = sets.NewString(
 	LabelOS,
 	LabelArch,
 
+	LegacyLabelOS,
+	LegacyLabelArch,
+
 	labelZoneFailureDomainGA,
 	labelZoneRegionGA,
 	labelInstanceTypeGA,
-	labelOSGA,
-	labelArchGA,
 )
 
 var kubeletLabelNamespaces = sets.NewString(

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -151,6 +151,8 @@ func (kl *Kubelet) updateDefaultLabels(initialNode, existingNode *v1.Node) bool 
 		kubeletapis.LabelInstanceType,
 		kubeletapis.LabelOS,
 		kubeletapis.LabelArch,
+		kubeletapis.LegacyLabelOS,
+		kubeletapis.LegacyLabelArch,
 	}
 
 	needsUpdate := false
@@ -213,9 +215,11 @@ func (kl *Kubelet) initialNode() (*v1.Node, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: string(kl.nodeName),
 			Labels: map[string]string{
-				kubeletapis.LabelHostname: kl.hostname,
-				kubeletapis.LabelOS:       goruntime.GOOS,
-				kubeletapis.LabelArch:     goruntime.GOARCH,
+				kubeletapis.LabelHostname:   kl.hostname,
+				kubeletapis.LabelOS:         goruntime.GOOS,
+				kubeletapis.LabelArch:       goruntime.GOARCH,
+				kubeletapis.LegacyLabelOS:   goruntime.GOOS,
+				kubeletapis.LegacyLabelArch: goruntime.GOARCH,
 			},
 		},
 		Spec: v1.NodeSpec{

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -1046,9 +1046,11 @@ func TestRegisterWithApiServer(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testKubeletHostname,
 				Labels: map[string]string{
-					kubeletapis.LabelHostname: testKubeletHostname,
-					kubeletapis.LabelOS:       goruntime.GOOS,
-					kubeletapis.LabelArch:     goruntime.GOARCH,
+					kubeletapis.LabelHostname:   testKubeletHostname,
+					kubeletapis.LabelOS:         goruntime.GOOS,
+					kubeletapis.LabelArch:       goruntime.GOARCH,
+					kubeletapis.LegacyLabelOS:   goruntime.GOOS,
+					kubeletapis.LegacyLabelArch: goruntime.GOARCH,
 				},
 			},
 		}, nil
@@ -1091,9 +1093,11 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 		node := &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					kubeletapis.LabelHostname: testKubeletHostname,
-					kubeletapis.LabelOS:       goruntime.GOOS,
-					kubeletapis.LabelArch:     goruntime.GOARCH,
+					kubeletapis.LabelHostname:   testKubeletHostname,
+					kubeletapis.LabelOS:         goruntime.GOOS,
+					kubeletapis.LabelArch:       goruntime.GOARCH,
+					kubeletapis.LegacyLabelOS:   goruntime.GOOS,
+					kubeletapis.LegacyLabelArch: goruntime.GOARCH,
 				},
 			},
 		}


### PR DESCRIPTION
kubelet now applies both the beta and the GA labels to ensure backward
compatibility.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72929

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Node OS/arch labels are promoted to GA
```
