### PR TITLE
fix some verify script shellcheck lints 

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -136,7 +136,6 @@
 ./hack/update-staging-godeps.sh
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
-./hack/verify-generated-docs.sh
 ./hack/verify-generated-files-remake.sh
 ./hack/verify-generated-files.sh
 ./hack/verify-generated-kms.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -137,7 +137,6 @@
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
 ./hack/verify-generated-files-remake.sh
-./hack/verify-generated-pod-resources.sh
 ./hack/verify-generated-protobuf.sh
 ./hack/verify-generated-runtime.sh
 ./hack/verify-generated-swagger-docs.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -136,7 +136,6 @@
 ./hack/update-staging-godeps.sh
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
-./hack/verify-description.sh
 ./hack/verify-generated-device-plugin.sh
 ./hack/verify-generated-docs.sh
 ./hack/verify-generated-files-remake.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -136,7 +136,6 @@
 ./hack/update-staging-godeps.sh
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
-./hack/verify-cli-conventions.sh
 ./hack/verify-codegen.sh
 ./hack/verify-description.sh
 ./hack/verify-generated-device-plugin.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -137,7 +137,6 @@
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
 ./hack/verify-generated-files-remake.sh
-./hack/verify-gofmt.sh
 ./hack/verify-golint.sh
 ./hack/verify-govet.sh
 ./hack/verify-import-boss.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -137,7 +137,6 @@
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
 ./hack/verify-generated-files-remake.sh
-./hack/verify-generated-swagger-docs.sh
 ./hack/verify-godep-licenses.sh
 ./hack/verify-godeps.sh
 ./hack/verify-gofmt.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -136,7 +136,6 @@
 ./hack/update-staging-godeps.sh
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
-./hack/verify-generated-device-plugin.sh
 ./hack/verify-generated-docs.sh
 ./hack/verify-generated-files-remake.sh
 ./hack/verify-generated-files.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -136,7 +136,6 @@
 ./hack/update-staging-godeps.sh
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
-./hack/verify-boilerplate.sh
 ./hack/verify-cli-conventions.sh
 ./hack/verify-codegen.sh
 ./hack/verify-description.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -136,7 +136,6 @@
 ./hack/update-staging-godeps.sh
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
-./hack/verify-bazel.sh
 ./hack/verify-boilerplate.sh
 ./hack/verify-cli-conventions.sh
 ./hack/verify-codegen.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -137,7 +137,6 @@
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
 ./hack/verify-generated-files-remake.sh
-./hack/verify-generated-kms.sh
 ./hack/verify-generated-kubelet-plugin-registration.sh
 ./hack/verify-generated-pod-resources.sh
 ./hack/verify-generated-protobuf.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -137,7 +137,6 @@
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
 ./hack/verify-generated-files-remake.sh
-./hack/verify-godeps.sh
 ./hack/verify-gofmt.sh
 ./hack/verify-golint.sh
 ./hack/verify-govet.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -136,7 +136,6 @@
 ./hack/update-staging-godeps.sh
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
-./hack/verify-all.sh
 ./hack/verify-api-groups.sh
 ./hack/verify-bazel.sh
 ./hack/verify-boilerplate.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -137,7 +137,6 @@
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
 ./hack/verify-generated-files-remake.sh
-./hack/verify-godep-licenses.sh
 ./hack/verify-godeps.sh
 ./hack/verify-gofmt.sh
 ./hack/verify-golint.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -136,7 +136,6 @@
 ./hack/update-staging-godeps.sh
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
-./hack/verify-api-groups.sh
 ./hack/verify-bazel.sh
 ./hack/verify-boilerplate.sh
 ./hack/verify-cli-conventions.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -136,7 +136,6 @@
 ./hack/update-staging-godeps.sh
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
-./hack/verify-codegen.sh
 ./hack/verify-description.sh
 ./hack/verify-generated-device-plugin.sh
 ./hack/verify-generated-docs.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -137,7 +137,6 @@
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
 ./hack/verify-generated-files-remake.sh
-./hack/verify-generated-runtime.sh
 ./hack/verify-generated-swagger-docs.sh
 ./hack/verify-godep-licenses.sh
 ./hack/verify-godeps.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -137,7 +137,6 @@
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
 ./hack/verify-generated-files-remake.sh
-./hack/verify-generated-kubelet-plugin-registration.sh
 ./hack/verify-generated-pod-resources.sh
 ./hack/verify-generated-protobuf.sh
 ./hack/verify-generated-runtime.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -137,7 +137,6 @@
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
 ./hack/verify-generated-files-remake.sh
-./hack/verify-generated-files.sh
 ./hack/verify-generated-kms.sh
 ./hack/verify-generated-kubelet-plugin-registration.sh
 ./hack/verify-generated-pod-resources.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -137,7 +137,6 @@
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
 ./hack/verify-generated-files-remake.sh
-./hack/verify-generated-protobuf.sh
 ./hack/verify-generated-runtime.sh
 ./hack/verify-generated-swagger-docs.sh
 ./hack/verify-godep-licenses.sh

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # For help output
 ARGHELP=""

--- a/hack/verify-api-groups.sh
+++ b/hack/verify-api-groups.sh
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 prefix="${KUBE_ROOT%"k8s.io/kubernetes"}"
 
@@ -112,8 +112,8 @@ for expected_install_package in "${expected_install_packages[@]}"; do
 	fi
 
 	for known_version_file in "${known_version_files[@]}"; do
-		if ! grep -q "${expected_install_package}/install" ${known_version_files} ; then
-			echo "missing ${expected_install_package}/install from ${known_version_files}"
+		if ! grep -q "${expected_install_package}/install" "${known_version_file}" ; then
+			echo "missing ${expected_install_package}/install from ${known_version_file}"
 			exit 1
 		fi
 	done

--- a/hack/verify-api-groups.sh
+++ b/hack/verify-api-groups.sh
@@ -88,36 +88,6 @@ for group_dirname in "${group_dirnames[@]}"; do
 	fi
 done
 
-# import_known_versions checks to be sure we'll get installed
-# groups_without_codegen is the list of group we EXPECT to not have the client generated for
-# them.  This happens for types that aren't served from the API server
-packages_without_install=(
-	"k8s.io/kubernetes/pkg/apis/abac"
-	"k8s.io/kubernetes/pkg/apis/admission"
-	"k8s.io/kubernetes/pkg/apis/componentconfig" # TODO: Remove this package completely and from this list
-)
-known_version_files=(
-	"pkg/master/import_known_versions.go"
-	"pkg/client/clientset_generated/internal_clientset/import_known_versions.go"
-)
-for expected_install_package in "${expected_install_packages[@]}"; do
-	found=0
-	for package_without_install in "${packages_without_install[@]}"; do
-		if [ "${package_without_install}" == "${expected_install_package}" ]; then
-			found=1
-		fi
-	done
-	if [[ "${found}" -eq "1" ]] ; then
-		continue
-	fi
-
-	for known_version_file in "${known_version_files[@]}"; do
-		if ! grep -q "${expected_install_package}/install" "${known_version_file}" ; then
-			echo "missing ${expected_install_package}/install from ${known_version_file}"
-			exit 1
-		fi
-	done
-done
 
 # check all groupversions to make sure they're in the init.sh file.  This isn't perfect, but its slightly
 # better than nothing

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -17,7 +17,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+export KUBE_ROOT
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 if [[ ! -f "${KUBE_ROOT}/vendor/BUILD" ]]; then
@@ -31,7 +32,7 @@ fi
 # TODO(spxtr): Remove this line once Bazel is the only way to build.
 rm -f "${KUBE_ROOT}/pkg/generated/openapi/zz_generated.openapi.go"
 
-_tmpdir="$(kube::realpath $(mktemp -d -t verify-bazel.XXXXXX))"
+_tmpdir="$(kube::realpath "$(mktemp -d -t verify-bazel.XXXXXX)")"
 kube::util::trap_add "rm -rf ${_tmpdir}" EXIT
 
 _tmp_gopath="${_tmpdir}/go"

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -18,12 +18,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 boilerDir="${KUBE_ROOT}/hack/boilerplate"
 boiler="${boilerDir}/boilerplate.py"
 
-files_need_boilerplate=($(${boiler} "$@"))
+files_need_boilerplate=()
+while IFS=$'\n' read -r line; do files_need_boilerplate+=("$line"); done < <(${boiler} "$@")
 
 # Run boilerplate check
 if [[ ${#files_need_boilerplate[@]} -gt 0 ]]; then

--- a/hack/verify-cli-conventions.sh
+++ b/hack/verify-cli-conventions.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env

--- a/hack/verify-description.sh
+++ b/hack/verify-description.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
@@ -49,7 +49,7 @@ find_files() {
 }
 
 if [[ $# -eq 0 ]]; then
-  versioned_api_files=$(find_files | egrep "pkg/.[^/]*/((v.[^/]*)|unversioned)/types\.go") || true
+  versioned_api_files=$(find_files | grep -E "pkg/.[^/]*/((v.[^/]*)|unversioned)/types\.go") || true
 else
   versioned_api_files="${*}"
 fi

--- a/hack/verify-generated-device-plugin.sh
+++ b/hack/verify-generated-device-plugin.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 ERROR="Device plugin api is out of date. Please run hack/update-generated-device-plugin.sh"
 DEVICE_PLUGIN_ALPHA="${KUBE_ROOT}/pkg/kubelet/apis/deviceplugin/v1alpha/"
 DEVICE_PLUGIN_V1BETA1="${KUBE_ROOT}/pkg/kubelet/apis/deviceplugin/v1beta1/"
@@ -27,19 +27,19 @@ source "${KUBE_ROOT}/hack/lib/protoc.sh"
 kube::golang::setup_env
 
 function cleanup {
-	rm -rf ${DEVICE_PLUGIN_ALPHA}/_tmp/
-	rm -rf ${DEVICE_PLUGIN_V1BETA1}/_tmp/
+	rm -rf "${DEVICE_PLUGIN_ALPHA}/_tmp/"
+	rm -rf "${DEVICE_PLUGIN_V1BETA1}/_tmp/"
 }
 
 trap cleanup EXIT
 
-mkdir -p ${DEVICE_PLUGIN_ALPHA}/_tmp
-cp ${DEVICE_PLUGIN_ALPHA}/api.pb.go ${DEVICE_PLUGIN_ALPHA}/_tmp/
-mkdir -p ${DEVICE_PLUGIN_V1BETA1}/_tmp
-cp ${DEVICE_PLUGIN_V1BETA1}/api.pb.go ${DEVICE_PLUGIN_V1BETA1}/_tmp/
+mkdir -p "${DEVICE_PLUGIN_ALPHA}/_tmp"
+cp "${DEVICE_PLUGIN_ALPHA}/api.pb.go" "${DEVICE_PLUGIN_ALPHA}/_tmp/"
+mkdir -p "${DEVICE_PLUGIN_V1BETA1}/_tmp"
+cp "${DEVICE_PLUGIN_V1BETA1}/api.pb.go" "${DEVICE_PLUGIN_V1BETA1}/_tmp/"
 
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-device-plugin.sh"
-kube::protoc::diff "${DEVICE_PLUGIN_ALPHA}/api.pb.go" "${DEVICE_PLUGIN_ALPHA}/_tmp/api.pb.go" ${ERROR}
+kube::protoc::diff "${DEVICE_PLUGIN_ALPHA}/api.pb.go" "${DEVICE_PLUGIN_ALPHA}/_tmp/api.pb.go" "${ERROR}"
 echo "Generated device plugin alpha api is up to date."
-kube::protoc::diff "${DEVICE_PLUGIN_V1BETA1}/api.pb.go" "${DEVICE_PLUGIN_V1BETA1}/_tmp/api.pb.go" ${ERROR}
+kube::protoc::diff "${DEVICE_PLUGIN_V1BETA1}/api.pb.go" "${DEVICE_PLUGIN_V1BETA1}/_tmp/api.pb.go" "${ERROR}"
 echo "Generated device plugin beta api is up to date."

--- a/hack/verify-generated-docs.sh
+++ b/hack/verify-generated-docs.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
@@ -43,7 +43,7 @@ fi
 
 # Verify the files in the repo all contain the boilerplate instead of the actual
 # content.
-while read file; do
+while read -r file; do
   # Ignore docs/.generated_docs-- it should not have the boilerplate!
   [[ "${file}" == "docs/.generated_docs" ]] && continue
 

--- a/hack/verify-generated-files.sh
+++ b/hack/verify-generated-files.sh
@@ -18,12 +18,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+export KUBE_ROOT
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::util::ensure_clean_working_dir
 
-_tmpdir="$(kube::realpath $(mktemp -d -t verify-generated-files.XXXXXX))"
+_tmpdir="$(kube::realpath "$(mktemp -d -t verify-generated-files.XXXXXX)")"
 kube::util::trap_add "rm -rf ${_tmpdir}" EXIT
 
 _tmp_gopath="${_tmpdir}/go"

--- a/hack/verify-generated-kms.sh
+++ b/hack/verify-generated-kms.sh
@@ -18,27 +18,27 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 KUBE_KMS_GRPC_ROOT="${KUBE_ROOT}/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1/"
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
 function cleanup {
-	rm -rf ${KUBE_KMS_GRPC_ROOT}/_tmp/
+	rm -rf "${KUBE_KMS_GRPC_ROOT}/_tmp/"
 }
 
 trap cleanup EXIT
 
-mkdir -p ${KUBE_KMS_GRPC_ROOT}/_tmp
-cp ${KUBE_KMS_GRPC_ROOT}/service.pb.go ${KUBE_KMS_GRPC_ROOT}/_tmp/
+mkdir -p "${KUBE_KMS_GRPC_ROOT}/_tmp"
+cp "${KUBE_KMS_GRPC_ROOT}/service.pb.go" "${KUBE_KMS_GRPC_ROOT}/_tmp/"
 
 ret=0
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-kms.sh"
-diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr ${KUBE_KMS_GRPC_ROOT}/_tmp/service.pb.go ${KUBE_KMS_GRPC_ROOT}/service.pb.go || ret=$?
+diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr "${KUBE_KMS_GRPC_ROOT}/_tmp/service.pb.go" "${KUBE_KMS_GRPC_ROOT}/service.pb.go" || ret=$?
 if [[ $ret -eq 0 ]]; then
     echo "Generated KMS gRPC is up to date."
-    cp ${KUBE_KMS_GRPC_ROOT}/_tmp/service.pb.go ${KUBE_KMS_GRPC_ROOT}/
+    cp "${KUBE_KMS_GRPC_ROOT}/_tmp/service.pb.go" "${KUBE_KMS_GRPC_ROOT}/"
 else
     echo "Generated KMS gRPC is out of date. Please run hack/update-generated-kms.sh"
     exit 1

--- a/hack/verify-generated-kubelet-plugin-registration.sh
+++ b/hack/verify-generated-kubelet-plugin-registration.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 ERROR="Kubelet Plugin Registration api is out of date. Please run hack/update-generated-kubelet-plugin-registration.sh"
 KUBELET_PLUGIN_REGISTRATION_V1ALPHA="${KUBE_ROOT}/pkg/kubelet/apis/pluginregistration/v1alpha1/"
 KUBELET_PLUGIN_REGISTRATION_V1BETA="${KUBE_ROOT}/pkg/kubelet/apis/pluginregistration/v1beta1/"
@@ -27,24 +27,24 @@ source "${KUBE_ROOT}/hack/lib/protoc.sh"
 kube::golang::setup_env
 
 function cleanup {
-	rm -rf ${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp/
-	rm -rf ${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp/
+	rm -rf "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp/"
+	rm -rf "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp/"
 }
 
 trap cleanup EXIT
 
-mkdir -p ${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp
-mkdir -p ${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp
+mkdir -p "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp"
+mkdir -p "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp"
 
-cp ${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/api.pb.go ${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp/
-cp ${KUBELET_PLUGIN_REGISTRATION_V1BETA}/api.pb.go ${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp/
+cp "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/api.pb.go" "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp/"
+cp "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/api.pb.go" "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp/"
 
 # Check V1Alpha
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-kubelet-plugin-registration.sh"
-kube::protoc::diff "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/api.pb.go" "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp/api.pb.go" ${ERROR}
+kube::protoc::diff "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/api.pb.go" "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp/api.pb.go" "${ERROR}"
 echo "Generated Kubelet Plugin Registration api is up to date."
 
 # Check V1Beta
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-kubelet-plugin-registration.sh"
-kube::protoc::diff "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/api.pb.go" "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp/api.pb.go" ${ERROR}
+kube::protoc::diff "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/api.pb.go" "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp/api.pb.go" "${ERROR}"
 echo "Generated Kubelet Plugin Registration api is up to date."

--- a/hack/verify-generated-pod-resources.sh
+++ b/hack/verify-generated-pod-resources.sh
@@ -18,27 +18,27 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 KUBE_REMOTE_RUNTIME_ROOT="${KUBE_ROOT}/pkg/kubelet/apis/podresources/v1alpha1"
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
 function cleanup {
-	rm -rf ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/
+	rm -rf "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/"
 }
 
 trap cleanup EXIT
 
-mkdir -p ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp
-cp ${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/
+mkdir -p "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp"
+cp "${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/"
 
 ret=0
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-pod-resources.sh"
-diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go ${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go || ret=$?
+diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go" || ret=$?
 if [[ $ret -eq 0 ]]; then
     echo "Generated pod resources api is up to date."
-    cp ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go ${KUBE_REMOTE_RUNTIME_ROOT}/
+    cp "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/"
 else
     echo "Generated pod resources api is out of date. Please run hack/update-generated-pod-resources.sh"
     exit 1

--- a/hack/verify-generated-protobuf.sh
+++ b/hack/verify-generated-protobuf.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env

--- a/hack/verify-generated-runtime.sh
+++ b/hack/verify-generated-runtime.sh
@@ -18,27 +18,27 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 KUBE_REMOTE_RUNTIME_ROOT="${KUBE_ROOT}/pkg/kubelet/apis/cri/runtime/v1alpha2"
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
 function cleanup {
-	rm -rf ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/
+	rm -rf "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/"
 }
 
 trap cleanup EXIT
 
-mkdir -p ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp
-cp ${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/
+mkdir -p "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp"
+cp "${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/"
 
 ret=0
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-runtime.sh"
-diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go ${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go || ret=$?
+diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go" || ret=$?
 if [[ $ret -eq 0 ]]; then
     echo "Generated container runtime api is up to date."
-    cp ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go ${KUBE_REMOTE_RUNTIME_ROOT}/
+    cp "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/"
 else
     echo "Generated container runtime api is out of date. Please run hack/update-generated-runtime.sh"
     exit 1

--- a/hack/verify-generated-swagger-docs.sh
+++ b/hack/verify-generated-swagger-docs.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env

--- a/hack/verify-godep-licenses.sh
+++ b/hack/verify-godep-licenses.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
@@ -48,7 +48,7 @@ ln -s "${KUBE_ROOT}/vendor" "${_tmpdir}"
 LICENSE_ROOT="${_tmpdir}" "${KUBE_ROOT}/hack/update-godep-licenses.sh"
 
 # Compare Godep Licenses
-if ! _out="$(diff -Naupr ${KUBE_ROOT}/Godeps/LICENSES ${_tmpdir}/Godeps/LICENSES)"; then
+if ! _out="$(diff -Naupr "${KUBE_ROOT}/Godeps/LICENSES" "${_tmpdir}/Godeps/LICENSES")"; then
   echo "Your godep licenses file is out of date. Run hack/update-godep-licenses.sh and commit the results." >&2
   echo "${_out}" >&2
   exit 1

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
@@ -35,7 +35,7 @@ kube::util::ensure_godep_version
 
 if [[ -z ${TMP_GOPATH:-} ]]; then
   # Create a nice clean place to put our new godeps
-  _tmpdir="$(kube::realpath $(mktemp -d -t gopath.XXXXXX))"
+  _tmpdir="$(kube::realpath "$(mktemp -d -t gopath.XXXXXX)")"
 else
   # reuse what we might have saved previously
   _tmpdir="${TMP_GOPATH}"
@@ -58,7 +58,7 @@ trap cleanup EXIT
 _kubetmp="${_tmpdir}/src/k8s.io"
 mkdir -p "${_kubetmp}"
 # should create ${_kubectmp}/kubernetes
-git archive --format=tar --prefix=kubernetes/ $(git write-tree) | (cd "${_kubetmp}" && tar xf -)
+git archive --format=tar --prefix=kubernetes/ "$(git write-tree)" | (cd "${_kubetmp}" && tar xf -)
 _kubetmp="${_kubetmp}/kubernetes"
 
 # Do all our work in the new GOPATH
@@ -84,7 +84,7 @@ ret=0
 
 pushd "${KUBE_ROOT}" > /dev/null 2>&1
   # Test for diffs
-  if ! _out="$(diff -Naupr --ignore-matching-lines='^\s*\"GoVersion\":' Godeps/Godeps.json ${_kubetmp}/Godeps/Godeps.json)"; then
+  if ! _out="$(diff -Naupr --ignore-matching-lines='^\s*\"GoVersion\":' Godeps/Godeps.json "${_kubetmp}/Godeps/Godeps.json")"; then
     echo "Your Godeps.json is different:" >&2
     echo "${_out}" >&2
     echo "Godeps Verify failed." >&2
@@ -101,7 +101,7 @@ pushd "${KUBE_ROOT}" > /dev/null 2>&1
     ret=1
   fi
 
-  if ! _out="$(diff -Naupr -x "BUILD" -x "AUTHORS*" -x "CONTRIBUTORS*" vendor ${_kubetmp}/vendor)"; then
+  if ! _out="$(diff -Naupr -x "BUILD" -x "AUTHORS*" -x "CONTRIBUTORS*" vendor "${_kubetmp}/vendor")"; then
     echo "Your vendored results are different:" >&2
     echo "${_out}" >&2
     echo "Godeps Verify failed." >&2

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 cd "${KUBE_ROOT}"
@@ -53,7 +53,7 @@ find_files() {
 # formatting (e.g., a file does not parse correctly). Without "|| true" this
 # would have led to no useful error message from gofmt, because the script would
 # have failed before getting to the "echo" in the block below.
-diff=$(find_files | xargs ${gofmt} -d -s 2>&1) || true
+diff=$(find_files | xargs "${gofmt}" -d -s 2>&1) || true
 if [[ -n "${diff}" ]]; then
   echo "${diff}" >&2
   echo >&2

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -173,6 +173,8 @@ else
     echo 'Please review the above warnings. You can test via "./hack/verify-shellcheck"'
     echo 'If the above warnings do not make sense, you can exempt this package from shellcheck'
     echo 'checking by adding it to hack/.shellcheck_failures (if your reviewer is okay with it).'
+    echo 'NOTE: please strongly consider NOT adding any more files to hack/.shellcheck_failures,'
+    echo 'since we ignore _all_ failures for files listed there. See issue #72956.'
     echo
   } >&2
   false


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**: makes more of the shell scripts pass hack/verify-shellcheck.sh

(And additionally adds some language to the lint to discourage adding more known failures)

While these changes are mostly small and low hanging fruit, we gain removing these files from hack/.shellcheck_failures, which should prevent regressions.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This is work towards #72956 

**Special notes for your reviewer**: 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig testing