### PR TITLE
Improve custom-columns option of `kubectl get ` command

### DIFF
--- a/pkg/kubectl/cmd/get/customcolumn.go
+++ b/pkg/kubectl/cmd/get/customcolumn.go
@@ -75,7 +75,7 @@ func NewCustomColumnsPrinterFromSpec(spec string, decoder runtime.Decoder, noHea
 	parts := strings.Split(spec, ",")
 	columns := make([]Column, len(parts))
 	for ix := range parts {
-		colSpec := strings.Split(parts[ix], ":")
+		colSpec := strings.SplitN(parts[ix], ":", 2)
 		if len(colSpec) != 2 {
 			return nil, fmt.Errorf("unexpected custom-columns spec: %s, expected <header>:<json-path-expr>", parts[ix])
 		}


### PR DESCRIPTION

 /kind bug

**What this PR does / why we need it**:
    The client-go library supports user get Object info in the form of .spec.containers[0:3].name.
    But kubectl get command doesn't support this.
    This patch fix this, now users could get object info like:
    a. kubectl get pod test-pod -o custom-columns=CONTAINER:.spec.containers[0:3].name
    b. kubectl get pod test-pod -o custom-columns=CONTAINER:.spec.containers[-2:].name





**Special notes for your reviewer**:
I will uncomment the test case after patch https://github.com/kubernetes/kubernetes/pull/72952 merged. Or panic would happen

```release-note
Now users could get object info like:
a. kubectl get pod test-pod -o custom-columns=CONTAINER:.spec.containers[0:3].name
b. kubectl get pod test-pod -o custom-columns=CONTAINER:.spec.containers[-2:].name
```
