### PR TITLE
Set the informer on the user cloud object for out-of-tree cloudproviders

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -213,6 +213,10 @@ func startControllers(c *cloudcontrollerconfig.CompletedConfig, stopCh <-chan st
 	if cloud != nil {
 		// Initialize the cloud provider with a reference to the clientBuilder
 		cloud.Initialize(c.ClientBuilder, stopCh)
+		// Set the informer on the user cloud object
+		if informerUserCloud, ok := cloud.(cloudprovider.InformerUser); ok {
+			informerUserCloud.SetInformers(c.SharedInformers)
+		}
 	}
 
 	for controllerName, initFn := range controllers {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Try to fix this #73069 .
For out-off-tree cloudproviders, [cloud.go](https://github.com/kubernetes/kubernetes/blob/76961c517e538206dd121c60a37736df9c328726/staging/src/k8s.io/cloud-provider/cloud.go#L64) support below interface:
```Golang
type InformerUser interface {
	// SetInformers sets the informer on the cloud object.
	SetInformers(informerFactory informers.SharedInformerFactory)
}
```
But, when cloud controller manager starts, it does not call it.

This PR set the informer on the user cloud object just after CCM initialize cloudprovider.

```release-note
None
```
