### PR TITLE
Make UntilWithSync wait for integrated informers to stop

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -58,8 +58,10 @@ func (t *ticketer) WaitForTicket(ticket uint64, f func()) {
 
 // NewIndexerInformerWatcher will create an IndexerInformer and wrap it into watch.Interface
 // so you can use it anywhere where you'd have used a regular Watcher returned from Watch method.
-func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (cache.Indexer, cache.Controller, watch.Interface) {
+// it also returns a channel you can use to wait for the informers to fully shutdown.
+func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (cache.Indexer, cache.Controller, watch.Interface, <-chan struct{}) {
 	ch := make(chan watch.Event)
+	doneCh := make(chan struct{})
 	w := watch.NewProxyWatcher(ch)
 	t := newTicketer()
 
@@ -107,8 +109,9 @@ func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (
 	}, cache.Indexers{})
 
 	go func() {
+		defer close(doneCh)
 		informer.Run(w.StopChan())
 	}()
 
-	return indexer, informer, w
+	return indexer, informer, w, doneCh
 }

--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher_test.go
@@ -188,7 +188,7 @@ func TestNewInformerWatcher(t *testing.T) {
 					return fake.Core().Secrets("").Watch(options)
 				},
 			}
-			_, _, w := NewIndexerInformerWatcher(lw, &corev1.Secret{})
+			_, _, w, done := NewIndexerInformerWatcher(lw, &corev1.Secret{})
 
 			var result []watch.Event
 		loop:
@@ -227,9 +227,7 @@ func TestNewInformerWatcher(t *testing.T) {
 			// Stop before reading all the data to make sure the informer can deal with closed channel
 			w.Stop()
 
-			// Wait a bit to see if the informer won't panic
-			// TODO: Try to figure out a more reliable mechanism than time.Sleep (https://github.com/kubernetes/kubernetes/pull/50102/files#r184716591)
-			time.Sleep(1 * time.Second)
+			<-done
 		})
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Not waiting was breaking non-multi threaded clients (fakes) and tests akwardly sleep

**Does this PR introduce a user-facing change?**:
The signature changes for UntilWithSync. How do we feel about backports in that case (up to 1.12)?
```release-note
None
```

Requires:
- [x] https://github.com/kubernetes/kubernetes/pull/73137

/cc @liggitt @wojtek-t @smarterclayton 