### PR TITLE
Patch concurrent-job-syncs into v1.11

### DIFF
--- a/cmd/controller-manager/app/options/jobcontroller.go
+++ b/cmd/controller-manager/app/options/jobcontroller.go
@@ -31,6 +31,8 @@ func (o *JobControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	if o == nil {
 		return
 	}
+	
+	fs.Int32Var(&o.ConcurrentJobSyncs, "concurrent-job-syncs", o.ConcurrentJobSyncs, "The number of job objects that are allowed to sync concurrently. Larger number = more responsive jobs, but more CPU (and network) load (default 10)")
 }
 
 // ApplyTo fills up JobController config with options.

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -462,7 +462,7 @@ type JobControllerConfiguration struct {
 	// concurrentJobSyncs is the number of job objects that are
 	// allowed to sync concurrently. Larger number = more responsive jobs,
 	// but more CPU (and network) load.
-	ConcurrentJobSyncs int32
+	ConcurrentJobSyncs int32 `json:"concurrentJobSyncs"`
 }
 
 type NamespaceControllerConfiguration struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
There is no configuration flag for the 'ConcurrentJobSyncs' option, forcing it to be left at the default of 5. I am working on adding the flag in starting at v 1.11 and moving forward.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Adds --concurrent-job-syncs flag to kube-controller-manager
```

"I signed it"