### PR TITLE
Deflake ImageLocalityPriority integration test

### DIFF
--- a/test/integration/scheduler/priorities_test.go
+++ b/test/integration/scheduler/priorities_test.go
@@ -180,12 +180,6 @@ func TestImageLocality(t *testing.T) {
 	context := initTest(t, "image-locality")
 	defer cleanupTest(t, context)
 
-	// Add a few nodes.
-	_, err := createNodes(context.clientSet, "testnode", nil, 10)
-	if err != nil {
-		t.Fatalf("cannot create nodes: %v", err)
-	}
-
 	// We use a fake large image as the test image used by the pod, which has relatively large image size.
 	image := v1.ContainerImage{
 		Names: []string{
@@ -194,10 +188,16 @@ func TestImageLocality(t *testing.T) {
 		SizeBytes: 3000 * 1024 * 1024,
 	}
 
-	// Create a node with the large image
+	// Create a node with the large image.
 	nodeWithLargeImage, err := createNodeWithImages(context.clientSet, "testnode-large-image", nil, []v1.ContainerImage{image})
 	if err != nil {
 		t.Fatalf("cannot create node with a large image: %v", err)
+	}
+
+	// Add a few nodes.
+	_, err = createNodes(context.clientSet, "testnode", nil, 10)
+	if err != nil {
+		t.Fatalf("cannot create nodes: %v", err)
 	}
 
 	// Create a pod with containers each having the specified image.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR attempts to fix an occasional false-positive in the TestImageLocality integration test. 

The speculation is that the false-positive happened due to the testnode-large-image has not been made visible to the scheduler before it schedules the pod-using-large-image. Hence the PR moves the creation of testnode-large-image ahead of other test nodes' creation. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#72903](https://github.com/kubernetes/kubernetes/issues/72903)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
