### PR TITLE
Fix golint failures on handlers/negotiation

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -531,7 +531,6 @@ staging/src/k8s.io/apiserver/pkg/endpoints
 staging/src/k8s.io/apiserver/pkg/endpoints/discovery
 staging/src/k8s.io/apiserver/pkg/endpoints/filters
 staging/src/k8s.io/apiserver/pkg/endpoints/handlers
-staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation
 staging/src/k8s.io/apiserver/pkg/endpoints/metrics
 staging/src/k8s.io/apiserver/pkg/endpoints/openapi/testing
 staging/src/k8s.io/apiserver/pkg/endpoints/request

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/errors.go
@@ -29,6 +29,7 @@ type errNotAcceptable struct {
 	accepted []string
 }
 
+// NewNotAcceptableError returns an error of NotAcceptable which contains specified string
 func NewNotAcceptableError(accepted []string) error {
 	return errNotAcceptable{accepted}
 }
@@ -51,6 +52,7 @@ type errUnsupportedMediaType struct {
 	accepted []string
 }
 
+// NewUnsupportedMediaTypeError returns an error of UnsupportedMediaType which contains specified string
 func NewUnsupportedMediaTypeError(accepted []string) error {
 	return errUnsupportedMediaType{accepted}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
@@ -133,6 +133,8 @@ type EndpointRestrictions interface {
 	AllowsStreamSchema(schema string) bool
 }
 
+// DefaultEndpointRestrictions is the default EndpointRestrictions which allows
+// content-type negotiation to verify server support for specific options
 var DefaultEndpointRestrictions = emptyEndpointRestrictions{}
 
 type emptyEndpointRestrictions struct{}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This fixes golint failures on k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go.
DefaultEndpointRestrictions is only used in the module, so this renames it to defaultEndpointRestrictions.

**Special notes for your reviewer**:

ref: https://github.com/kubernetes/kubernetes/issues/68026

**Does this PR introduce a user-facing change?**:
```
None
```
