### PR TITLE
kubeadm: adapt timeout for new etcd member to join

### DIFF
--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -40,7 +40,7 @@ const (
 	etcdVolumeName           = "etcd-data"
 	certsVolumeName          = "etcd-certs"
 	etcdHealthyCheckInterval = 5 * time.Second
-	etcdHealthyCheckRetries  = 20
+	etcdHealthyCheckRetries  = 8
 )
 
 // CreateLocalEtcdStaticPodManifestFile will write local etcd static pod manifest file.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Change the `etcd` number of retries when waiting for the new member to join the `etcd` cluster as discussed in https://github.com/kubernetes/kubernetes/pull/72984#discussion_r249065708

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/1353

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
