### PR TITLE
Fix PV allocation on non-English vSphere

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/BUILD
+++ b/pkg/cloudprovider/providers/vsphere/BUILD
@@ -31,6 +31,8 @@ go_library(
         "//vendor/github.com/vmware/govmomi/vapi/tags:go_default_library",
         "//vendor/github.com/vmware/govmomi/vim25:go_default_library",
         "//vendor/github.com/vmware/govmomi/vim25/mo:go_default_library",
+        "//vendor/github.com/vmware/govmomi/vim25/soap:go_default_library",
+        "//vendor/github.com/vmware/govmomi/vim25/types:go_default_library",
         "//vendor/gopkg.in/gcfg.v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
@@ -41,6 +43,7 @@ go_test(
     srcs = [
         "credentialmanager_test.go",
         "vsphere_test.go",
+        "vsphere_util_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
@@ -55,6 +58,7 @@ go_test(
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//vendor/github.com/vmware/govmomi:go_default_library",
         "//vendor/github.com/vmware/govmomi/lookup/simulator:go_default_library",
         "//vendor/github.com/vmware/govmomi/property:go_default_library",
         "//vendor/github.com/vmware/govmomi/simulator:go_default_library",

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/simulator"
+)
+
+func TestGetPathFromFileNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	// vCenter model + initial set of objects (cluster, hosts, VMs, network, datastore, etc)
+	model := simulator.VPX()
+
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vc := &vclib.VSphereConnection{Client: c.Client}
+
+	dc, err := vclib.GetDatacenter(ctx, vc, vclib.TestDefaultDatacenter)
+	if err != nil {
+		t.Errorf("failed to get datacenter: %v", err)
+	}
+
+	requestDiskPath := fmt.Sprintf("[%s] %s", vclib.TestDefaultDatastore, DummyDiskName)
+	_, err = dc.GetVirtualDiskPage83Data(ctx, requestDiskPath)
+	if err == nil {
+		t.Error("expected error when calling GetVirtualDiskPage83Data")
+	}
+
+	_, err = getPathFromFileNotFound(err)
+	if err != nil {
+		t.Errorf("expected err to be nil but was %v", err)
+	}
+
+	_, err = getPathFromFileNotFound(nil)
+	if err == nil {
+		t.Errorf("expected err when calling getPathFromFileNotFound with nil err")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Fixes PV allocation on a non-English vSphere installation

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #71997

**Special notes for your reviewer**:

I have manually verified that PV allocation still works on an English vSphere. I can not test it on a non-English vsphere as I don't have that at hand, however since the testcase contains the error message @ipointffogl  mentioned in #71997 I'd argue its safe to assume that this will fix the issue.

The whole thing still feels like a rubberduck fix because the proper solution would be to not use API error messages to gather infos. 

/shrug
/area vsphere

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a bug that caused PV allocation on non-English vSphere installations to fail 
```
