### PR TITLE
remove deprecated openapi paths in favor of /openapi/v2

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -83,7 +83,7 @@ fi
 
 kube::log::status "Updating " ${OPENAPI_ROOT_DIR}
 
-curl -w "\n" -fs "${API_HOST}:${API_PORT}/swagger.json" > "${OPENAPI_ROOT_DIR}/swagger.json"
+curl -w "\n" -fs "${API_HOST}:${API_PORT}/openapi/v2" > "${OPENAPI_ROOT_DIR}/swagger.json"
 
 kube::log::status "SUCCESS"
 

--- a/pkg/master/master_openapi_test.go
+++ b/pkg/master/master_openapi_test.go
@@ -61,7 +61,7 @@ func TestValidOpenAPISpec(t *testing.T) {
 	// make sure swagger.json is not registered before calling PrepareRun.
 	server := httptest.NewServer(master.GenericAPIServer.Handler.Director)
 	defer server.Close()
-	resp, err := http.Get(server.URL + "/swagger.json")
+	resp, err := http.Get(server.URL + "/openapi/v2")
 	if !assert.NoError(err) {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestValidOpenAPISpec(t *testing.T) {
 
 	master.GenericAPIServer.PrepareRun()
 
-	resp, err = http.Get(server.URL + "/swagger.json")
+	resp, err = http.Get(server.URL + "/openapi/v2")
 	if !assert.NoError(err) {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestValidOpenAPISpec(t *testing.T) {
 	}
 
 	// Validate OpenApi spec
-	doc, err := loads.Spec(server.URL + "/swagger.json")
+	doc, err := loads.Spec(server.URL + "/openapi/v2")
 	if assert.NoError(err) {
 		validator := validate.NewSpecValidator(doc.Schema(), strfmt.Default)
 		res, warns := validator.Validate(doc)

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -199,9 +199,6 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("get").URLs(
 					"/healthz", "/version", "/version/",
-					// do not expand this pattern for openapi discovery docs
-					// move to a single openapi endpoint that takes accept/accept-encoding headers
-					"/swagger.json", "/swagger-2.0.0.pb-v1",
 					"/openapi", "/openapi/*",
 					"/api", "/api/*",
 					"/apis", "/apis/*",

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -550,8 +550,6 @@ items:
     - /healthz
     - /openapi
     - /openapi/*
-    - /swagger-2.0.0.pb-v1
-    - /swagger.json
     - /version
     - /version/
     verbs:

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go
@@ -32,14 +32,7 @@ type OpenAPI struct {
 
 // Install adds the SwaggerUI webservice to the given mux.
 func (oa OpenAPI) Install(c *restful.Container, mux *mux.PathRecorderMux) {
-	// NOTE: [DEPRECATION] We will announce deprecation for format-separated endpoints for OpenAPI spec,
-	// and switch to a single /openapi/v2 endpoint in Kubernetes 1.10. The design doc and deprecation process
-	// are tracked at: https://docs.google.com/document/d/19lEqE9lc4yHJ3WJAJxS_G7TcORIJXGHyq3wpwcH28nU.
-	_, err := handler.BuildAndRegisterOpenAPIService("/swagger.json", c.RegisteredWebServices(), oa.Config, mux)
-	if err != nil {
-		klog.Fatalf("Failed to register open api spec for root: %v", err)
-	}
-	_, err = handler.BuildAndRegisterOpenAPIVersionedService("/openapi/v2", c.RegisteredWebServices(), oa.Config, mux)
+	_, err := handler.BuildAndRegisterOpenAPIVersionedService("/openapi/v2", c.RegisteredWebServices(), oa.Config, mux)
 	if err != nil {
 		klog.Fatalf("Failed to register versioned open api spec for root: %v", err)
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/downloader.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/downloader.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
-// Downloader is the OpenAPI downloader type. It will try to download spec from /swagger.json endpoint.
+// Downloader is the OpenAPI downloader type. It will try to download spec from /openapi/v2 or /swagger.json endpoint.
 type Downloader struct {
 }
 
@@ -89,7 +89,7 @@ func etagFor(data []byte) string {
 	return fmt.Sprintf("%s%X\"", locallyGeneratedEtagPrefix, sha512.Sum512(data))
 }
 
-// Download downloads openAPI spec from /swagger.json endpoint of the given handler.
+// Download downloads openAPI spec from /openapi/v2 or /swagger.json endpoint of the given handler.
 // httpStatus is only valid if err == nil
 func (s *Downloader) Download(handler http.Handler, etag string) (returnSpec *spec.Swagger, newEtag string, httpStatus int, err error) {
 	handler = s.handlerWithUser(handler, &user.DefaultInfo{Name: aggregatorUser})

--- a/test/integration/master/kube_apiserver_test.go
+++ b/test/integration/master/kube_apiserver_test.go
@@ -96,11 +96,11 @@ func TestOpenAPIDelegationChainPlumbing(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	result := kubeclient.RESTClient().Get().AbsPath("/swagger.json").Do()
+	result := kubeclient.RESTClient().Get().AbsPath("/openapi/v2").Do()
 	status := 0
 	result.StatusCode(&status)
 	if status != http.StatusOK {
-		t.Fatalf("GET /swagger.json failed: expected status=%d, got=%d", http.StatusOK, status)
+		t.Fatalf("GET /openapi/v2 failed: expected status=%d, got=%d", http.StatusOK, status)
 	}
 
 	raw, err := result.Raw()


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Which issue(s) this PR fixes**:
Fixes #73083

**Does this PR introduce a user-facing change?**:
```release-note
The /swagger.json and /swagger-2.0.0.pb-v1 schema documents, deprecated since v1.10, have been removed in favor of `/openapi/v2`
```

/sig api-machinery
/cc @mbohlool @apelisse 