### PR TITLE
ccm: ignore nodes not present in cloud-provider

### DIFF
--- a/pkg/controller/cloud/BUILD
+++ b/pkg/controller/cloud/BUILD
@@ -9,6 +9,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "annotations.go",
         "node_controller.go",
         "node_lifecycle_controller.go",
         "pvlcontroller.go",

--- a/pkg/controller/cloud/annotations.go
+++ b/pkg/controller/cloud/annotations.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+const (
+	// UnmanagedNodeAnnotationKey is the annotation placed on nodes that CCM is to ignore.
+	UnmanagedNodeAnnotationKey = "node.cloud.kubernetes.io/unmanaged"
+)

--- a/pkg/controller/cloud/node_lifecycle_controller_test.go
+++ b/pkg/controller/cloud/node_lifecycle_controller_test.go
@@ -43,7 +43,7 @@ func Test_NodesDeleted(t *testing.T) {
 		deleteNodes []*v1.Node
 	}{
 		{
-			name: "node is not ready and does not exist",
+			name: "managed node is not ready and does not exist",
 			fnh: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
 					{
@@ -74,7 +74,41 @@ func Test_NodesDeleted(t *testing.T) {
 			},
 		},
 		{
-			name: "node is not ready and provider returns err",
+			name: "unmanaged node is not ready and does not exist",
+			fnh: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								UnmanagedNodeAnnotationKey: "true",
+							},
+							Name:              "node0",
+							CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{
+									Type:               v1.NodeReady,
+									Status:             v1.ConditionFalse,
+									LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+								},
+							},
+						},
+					},
+				},
+				DeletedNodes: []*v1.Node{},
+				Clientset:    fake.NewSimpleClientset(),
+			},
+			fakeCloud: &fakecloud.FakeCloud{
+				ExistsByProviderID: false,
+			},
+			deleteNodes: []*v1.Node{
+				// No nodes should be deleted in this scenario.
+			},
+		},
+		{
+			name: "managed node is not ready and provider returns err",
 			fnh: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
 					{
@@ -107,7 +141,7 @@ func Test_NodesDeleted(t *testing.T) {
 			deleteNodes: []*v1.Node{},
 		},
 		{
-			name: "node is not ready but still exists",
+			name: "managed node is not ready but still exists",
 			fnh: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
 					{
@@ -139,7 +173,7 @@ func Test_NodesDeleted(t *testing.T) {
 			deleteNodes: []*v1.Node{},
 		},
 		{
-			name: "node ready condition is unknown, node doesn't exist",
+			name: "managed node ready condition is unknown, node doesn't exist",
 			fnh: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
 					{
@@ -170,7 +204,7 @@ func Test_NodesDeleted(t *testing.T) {
 			},
 		},
 		{
-			name: "node ready condition is unknown, node exists",
+			name: "managed node ready condition is unknown, node exists",
 			fnh: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
 					{
@@ -203,7 +237,7 @@ func Test_NodesDeleted(t *testing.T) {
 			deleteNodes: []*v1.Node{},
 		},
 		{
-			name: "node is ready, but provider said it is deleted (maybe a bug in provider)",
+			name: "managed node is ready, but provider said it is deleted (maybe a bug in provider)",
 			fnh: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
 					{
@@ -274,7 +308,7 @@ func Test_NodesShutdown(t *testing.T) {
 		updatedNodes []*v1.Node
 	}{
 		{
-			name: "node is not ready and was shutdown",
+			name: "managed node is not ready and was shutdown",
 			fnh: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
 					{
@@ -326,7 +360,42 @@ func Test_NodesShutdown(t *testing.T) {
 			},
 		},
 		{
-			name: "node is not ready, but there is error checking if node is shutdown",
+			name: "unmanaged node is not ready and was shutdown",
+			fnh: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								UnmanagedNodeAnnotationKey: "true",
+							},
+							Name:              "node0",
+							CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.Local),
+						},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{
+									Type:               v1.NodeReady,
+									Status:             v1.ConditionFalse,
+									LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.Local),
+									LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.Local),
+								},
+							},
+						},
+					},
+				},
+				UpdatedNodes: []*v1.Node{},
+				Clientset:    fake.NewSimpleClientset(),
+			},
+			fakeCloud: &fakecloud.FakeCloud{
+				NodeShutdown:            true,
+				ErrShutdownByProviderID: nil,
+			},
+			updatedNodes: []*v1.Node{
+				// No nodes should be updated in this scenario.
+			},
+		},
+		{
+			name: "managed node is not ready, but there is error checking if node is shutdown",
 			fnh: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
 					{
@@ -356,7 +425,7 @@ func Test_NodesShutdown(t *testing.T) {
 			updatedNodes: []*v1.Node{},
 		},
 		{
-			name: "node is not ready and is not shutdown",
+			name: "managed node is not ready and is not shutdown",
 			fnh: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
 					{
@@ -386,7 +455,7 @@ func Test_NodesShutdown(t *testing.T) {
 			updatedNodes: []*v1.Node{},
 		},
 		{
-			name: "node is ready but provider says it's shutdown (maybe a bug by provider)",
+			name: "managed node is ready but provider says it's shutdown (maybe a bug by provider)",
 			fnh: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
 					{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

A follow-up to https://github.com/kubernetes/kubernetes/pull/70344, this PR introduces the `node.cloud.kubernetes.io/unmanaged` annotation. This annotation tells CCM if it should skip tainting/deleting nodes that are not known to the cloud provider.
This is required by projects such as the [Virtual Kubelet](https://github.com/virtual-kubelet/virtual-kubelet), which is currently deleted shortly after being detected as not ready by the CCM.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

The current behaviour of considering (and tainting/deleting) a node when the annotation is not present is kept intact. In order for CCM to skip a node, the annotation must be explicitly set.

This has been discussed with @andrewsykim and I now expect feedback from @kubernetes/sig-cloud-provider-pr-reviews.

**Does this PR introduce a user-facing change?**:

```release-note
Allow for CCM to skip tainting/deleting nodes that are not known to the cloud provider.
```
