### PR TITLE
Run injector as privileged pod

### DIFF
--- a/test/e2e/framework/volume_util.go
+++ b/test/e2e/framework/volume_util.go
@@ -486,6 +486,7 @@ func InjectHtml(client clientset.Interface, config VolumeTestConfig, volume v1.V
 	podClient := client.CoreV1().Pods(config.Namespace)
 	podName := fmt.Sprintf("%s-injector-%s", config.Prefix, rand.String(4))
 	volMountName := fmt.Sprintf("%s-volume-%s", config.Prefix, rand.String(4))
+	privileged := true
 
 	injectPod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -511,11 +512,9 @@ func InjectHtml(client clientset.Interface, config VolumeTestConfig, volume v1.V
 							MountPath: "/mnt",
 						},
 					},
-				},
-			},
-			SecurityContext: &v1.PodSecurityContext{
-				SELinuxOptions: &v1.SELinuxOptions{
-					Level: "s0:c0,c1",
+					SecurityContext: &v1.SecurityContext{
+						Privileged: &privileged,
+					},
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever,


### PR DESCRIPTION
Privileged pod can write bypass any SELinux checks. NFS, CephFS and Gluster test now work without setting special SELinux boolean for them.

Note that SubPath tests already run all modifications of volumes in privileged pods.

/kind failing-test
/sig storage

Only reproducible on machines with SELinux

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

cc @gnufied 