### PR TITLE
Report proper namespace in TTLAfterFinished test

### DIFF
--- a/test/e2e/node/ttlafterfinished.go
+++ b/test/e2e/node/ttlafterfinished.go
@@ -69,7 +69,7 @@ func testFinishedJob(f *framework.Framework) {
 	job.ObjectMeta.Finalizers = []string{dummyFinalizer}
 	defer cleanupJob(f, job)
 
-	framework.Logf("Create a Job %s/%s with TTL", job.Namespace, job.Name)
+	framework.Logf("Create a Job %s/%s with TTL", ns, job.Name)
 	job, err := framework.CreateJob(c, ns, job)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR fixes the namespace reported in e2e test. Before creating a job its namespace field is empty, thus we weren't getting any data in the logs.

/assign @janetkuo 

/sig node
/sig apps
/priority important-longterm


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
