### PR TITLE
Added micahhausler as approver for AWS cloud provider

### DIFF
--- a/pkg/cloudprovider/providers/aws/OWNERS
+++ b/pkg/cloudprovider/providers/aws/OWNERS
@@ -3,6 +3,7 @@ approvers:
 - zmerlynn
 - gnufied
 - jsafrane
+- micahhausler
 reviewers:
 - gnufied
 - jsafrane


### PR DESCRIPTION
Added self as approver for AWS cloud provider

* [Reviews](https://github.com/kubernetes/kubernetes/issues?q=assignee%3Amicahhausler+is%3Aclosed)
* [Contributions](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+author%3Amicahhausler+is%3Aclosed)

**What type of PR is this?**

/kind documentation
/sig aws
/priority awaiting-more-evidence 

**What this PR does / why we need it**:

Adds micahhausler as an AWS cloud provider approver.

**Which issue(s) this PR fixes**:

I herby promise, and do swear, to not intentionally break anything.

**Special notes for your reviewer**:

No, YOU are special 🎉 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
