### PR TITLE
Add break for reconcileExtendedResource

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -137,6 +137,7 @@ func (kl *Kubelet) reconcileExtendedResource(initialNode, node *v1.Node) bool {
 			node.Status.Capacity[k] = *resource.NewQuantity(int64(0), resource.DecimalSI)
 			node.Status.Allocatable[k] = *resource.NewQuantity(int64(0), resource.DecimalSI)
 			requiresUpdate = true
+			break
 		}
 	}
 	return requiresUpdate


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Add break for reconcileExtendedResource. When requiresUpdate is set true, it needn't continue the for loop.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

/release-note-none
/priority backlog