### PR TITLE
 Re-Organize the pkutil library

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -27,8 +27,9 @@ import (
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 )
 
 // CreatePKIAssets will create and write to disk all PKI assets necessary to establish the control plane.
@@ -81,7 +82,7 @@ func CreateServiceAccountKeyAndPublicKeyFiles(cfg *kubeadmapi.InitConfiguration)
 // NewServiceAccountSigningKey generate public/private key pairs for signing service account tokens.
 func NewServiceAccountSigningKey() (*rsa.PrivateKey, error) {
 	// The key does NOT exist, let's generate it now
-	saSigningKey, err := certutil.NewPrivateKey()
+	saSigningKey, err := pkiutil.NewPrivateKey()
 	if err != nil {
 		return nil, errors.Wrap(err, "failure while creating service account token signing key")
 	}

--- a/cmd/kubeadm/app/phases/certs/renewal/certsapi.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/certsapi.go
@@ -31,6 +31,7 @@ import (
 	certstype "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
 	certutil "k8s.io/client-go/util/cert"
 	csrutil "k8s.io/client-go/util/certificate/csr"
+	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 )
 
 const certAPIPrefixName = "kubeadm-cert"
@@ -60,7 +61,7 @@ func (r *CertsAPIRenewal) Renew(cfg *certutil.Config) (*x509.Certificate, *rsa.P
 		IPAddresses: cfg.AltNames.IPs,
 	}
 
-	key, err := certutil.NewPrivateKey()
+	key, err := pkiutil.NewPrivateKey()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "couldn't create new private key")
 	}

--- a/cmd/kubeadm/app/phases/certs/renewal/renewal_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/renewal_test.go
@@ -136,7 +136,7 @@ func getCertReq(t *testing.T, caCert *x509.Certificate, caKey *rsa.PrivateKey) *
 					Type: certsapi.CertificateApproved,
 				},
 			},
-			Certificate: certutil.EncodeCertPEM(cert),
+			Certificate: pkiutil.EncodeCertPEM(cert),
 		},
 	}
 }

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -33,8 +33,9 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 )
 
 // clientCertAuth struct holds info required to build a client certificate to provide authentication info in a kubeconfig object
@@ -189,7 +190,7 @@ func buildKubeConfigFromSpec(spec *kubeConfigSpec, clustername string) (*clientc
 			spec.APIServer,
 			clustername,
 			spec.ClientName,
-			certutil.EncodeCertPEM(spec.CACert),
+			pkiutil.EncodeCertPEM(spec.CACert),
 			spec.TokenAuth.Token,
 		), nil
 	}
@@ -210,9 +211,9 @@ func buildKubeConfigFromSpec(spec *kubeConfigSpec, clustername string) (*clientc
 		spec.APIServer,
 		clustername,
 		spec.ClientName,
-		certutil.EncodeCertPEM(spec.CACert),
+		pkiutil.EncodeCertPEM(spec.CACert),
 		certutil.EncodePrivateKeyPEM(clientKey),
-		certutil.EncodeCertPEM(clientCert),
+		pkiutil.EncodeCertPEM(clientCert),
 	), nil
 }
 

--- a/cmd/kubeadm/app/util/certs/util.go
+++ b/cmd/kubeadm/app/util/certs/util.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 )
 
 // SetupCertificateAuthorithy is a utility function for kubeadm testing that creates a
@@ -229,11 +229,11 @@ func WritePKIFiles(t *testing.T, dir string, files PKIFiles) {
 	for filename, body := range files {
 		switch body := body.(type) {
 		case *x509.Certificate:
-			if err := certutil.WriteCert(path.Join(dir, filename), certutil.EncodeCertPEM(body)); err != nil {
+			if err := certutil.WriteCert(path.Join(dir, filename), pkiutil.EncodeCertPEM(body)); err != nil {
 				t.Errorf("unable to write certificate to file %q: [%v]", dir, err)
 			}
 		case *rsa.PublicKey:
-			publicKeyBytes, err := certutil.EncodePublicKeyPEM(body)
+			publicKeyBytes, err := pkiutil.EncodePublicKeyPEM(body)
 			if err != nil {
 				t.Errorf("unable to write public key to file %q: [%v]", filename, err)
 			}

--- a/staging/src/k8s.io/client-go/util/cert/cert.go
+++ b/staging/src/k8s.io/client-go/util/cert/cert.go
@@ -21,16 +21,13 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/rand"
 	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"math/big"
 	"net"
 	"path"
@@ -39,7 +36,6 @@ import (
 )
 
 const (
-	rsaKeySize   = 2048
 	duration365d = time.Hour * 24 * 365
 )
 
@@ -59,11 +55,6 @@ type AltNames struct {
 	IPs      []net.IP
 }
 
-// NewPrivateKey creates an RSA private key
-func NewPrivateKey() (*rsa.PrivateKey, error) {
-	return rsa.GenerateKey(cryptorand.Reader, rsaKeySize)
-}
-
 // NewSelfSignedCACert creates a CA certificate
 func NewSelfSignedCACert(cfg Config, key crypto.Signer) (*x509.Certificate, error) {
 	now := time.Now()
@@ -81,39 +72,6 @@ func NewSelfSignedCACert(cfg Config, key crypto.Signer) (*x509.Certificate, erro
 	}
 
 	certDERBytes, err := x509.CreateCertificate(cryptorand.Reader, &tmpl, &tmpl, key.Public(), key)
-	if err != nil {
-		return nil, err
-	}
-	return x509.ParseCertificate(certDERBytes)
-}
-
-// NewSignedCert creates a signed certificate using the given CA certificate and key
-func NewSignedCert(cfg Config, key crypto.Signer, caCert *x509.Certificate, caKey crypto.Signer) (*x509.Certificate, error) {
-	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
-	if err != nil {
-		return nil, err
-	}
-	if len(cfg.CommonName) == 0 {
-		return nil, errors.New("must specify a CommonName")
-	}
-	if len(cfg.Usages) == 0 {
-		return nil, errors.New("must specify at least one ExtKeyUsage")
-	}
-
-	certTmpl := x509.Certificate{
-		Subject: pkix.Name{
-			CommonName:   cfg.CommonName,
-			Organization: cfg.Organization,
-		},
-		DNSNames:     cfg.AltNames.DNSNames,
-		IPAddresses:  cfg.AltNames.IPs,
-		SerialNumber: serial,
-		NotBefore:    caCert.NotBefore,
-		NotAfter:     time.Now().Add(duration365d).UTC(),
-		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  cfg.Usages,
-	}
-	certDERBytes, err := x509.CreateCertificate(cryptorand.Reader, &certTmpl, caCert, key.Public(), caKey)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/util/cert/pem.go
+++ b/staging/src/k8s.io/client-go/util/cert/pem.go
@@ -26,50 +26,18 @@ import (
 )
 
 const (
+
 	// ECPrivateKeyBlockType is a possible value for pem.Block.Type.
 	ECPrivateKeyBlockType = "EC PRIVATE KEY"
 	// RSAPrivateKeyBlockType is a possible value for pem.Block.Type.
 	RSAPrivateKeyBlockType = "RSA PRIVATE KEY"
-	// PrivateKeyBlockType is a possible value for pem.Block.Type.
-	PrivateKeyBlockType = "PRIVATE KEY"
-	// PublicKeyBlockType is a possible value for pem.Block.Type.
-	PublicKeyBlockType = "PUBLIC KEY"
-	// CertificateBlockType is a possible value for pem.Block.Type.
-	CertificateBlockType = "CERTIFICATE"
 	// CertificateRequestBlockType is a possible value for pem.Block.Type.
 	CertificateRequestBlockType = "CERTIFICATE REQUEST"
+	// CertificateBlockType is a possible value for pem.Block.Type.
+	CertificateBlockType = "CERTIFICATE"
+	// PrivateKeyBlockType is a possible value for pem.Block.Type.
+	PrivateKeyBlockType = "PRIVATE KEY"
 )
-
-// EncodePublicKeyPEM returns PEM-encoded public data
-func EncodePublicKeyPEM(key *rsa.PublicKey) ([]byte, error) {
-	der, err := x509.MarshalPKIXPublicKey(key)
-	if err != nil {
-		return []byte{}, err
-	}
-	block := pem.Block{
-		Type:  PublicKeyBlockType,
-		Bytes: der,
-	}
-	return pem.EncodeToMemory(&block), nil
-}
-
-// EncodePrivateKeyPEM returns PEM-encoded private key data
-func EncodePrivateKeyPEM(key *rsa.PrivateKey) []byte {
-	block := pem.Block{
-		Type:  RSAPrivateKeyBlockType,
-		Bytes: x509.MarshalPKCS1PrivateKey(key),
-	}
-	return pem.EncodeToMemory(&block)
-}
-
-// EncodeCertPEM returns PEM-endcoded certificate data
-func EncodeCertPEM(cert *x509.Certificate) []byte {
-	block := pem.Block{
-		Type:  CertificateBlockType,
-		Bytes: cert.Raw,
-	}
-	return pem.EncodeToMemory(&block)
-}
 
 // ParsePrivateKeyPEM returns a private key parsed from a PEM block in the supplied data.
 // Recognizes PEM blocks for "EC PRIVATE KEY", "RSA PRIVATE KEY", or "PRIVATE KEY"
@@ -145,6 +113,15 @@ func ParsePublicKeysPEM(keyData []byte) ([]interface{}, error) {
 		return nil, fmt.Errorf("data does not contain any valid RSA or ECDSA public keys")
 	}
 	return keys, nil
+}
+
+// EncodePrivateKeyPEM returns PEM-encoded private key data
+func EncodePrivateKeyPEM(key *rsa.PrivateKey) []byte {
+	block := pem.Block{
+		Type:  RSAPrivateKeyBlockType,
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+	return pem.EncodeToMemory(&block)
 }
 
 // ParseCertsPEM returns the x509.Certificates contained in the given PEM-encoded byte array

--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -27,6 +27,7 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/test/e2e/apimachinery",
     deps = [
+        "//cmd/kubeadm/app/util/pkiutil:go_default_library",
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/apis/rbac/v1beta1:go_default_library",
         "//pkg/printers:go_default_library",

--- a/test/e2e/apimachinery/certs.go
+++ b/test/e2e/apimachinery/certs.go
@@ -21,7 +21,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	"k8s.io/client-go/util/cert"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -39,11 +40,11 @@ func setupServerCert(namespaceName, serviceName string) *certContext {
 		framework.Failf("Failed to create a temp dir for cert generation %v", err)
 	}
 	defer os.RemoveAll(certDir)
-	signingKey, err := cert.NewPrivateKey()
+	signingKey, err := pkiutil.NewPrivateKey()
 	if err != nil {
 		framework.Failf("Failed to create CA private key %v", err)
 	}
-	signingCert, err := cert.NewSelfSignedCACert(cert.Config{CommonName: "e2e-server-cert-ca"}, signingKey)
+	signingCert, err := certutil.NewSelfSignedCACert(certutil.Config{CommonName: "e2e-server-cert-ca"}, signingKey)
 	if err != nil {
 		framework.Failf("Failed to create CA cert for apiserver %v", err)
 	}
@@ -51,15 +52,15 @@ func setupServerCert(namespaceName, serviceName string) *certContext {
 	if err != nil {
 		framework.Failf("Failed to create a temp file for ca cert generation %v", err)
 	}
-	if err := ioutil.WriteFile(caCertFile.Name(), cert.EncodeCertPEM(signingCert), 0644); err != nil {
+	if err := ioutil.WriteFile(caCertFile.Name(), pkiutil.EncodeCertPEM(signingCert), 0644); err != nil {
 		framework.Failf("Failed to write CA cert %v", err)
 	}
-	key, err := cert.NewPrivateKey()
+	key, err := pkiutil.NewPrivateKey()
 	if err != nil {
 		framework.Failf("Failed to create private key for %v", err)
 	}
-	signedCert, err := cert.NewSignedCert(
-		cert.Config{
+	signedCert, err := pkiutil.NewSignedCert(
+		&certutil.Config{
 			CommonName: serviceName + "." + namespaceName + ".svc",
 			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		},
@@ -76,15 +77,15 @@ func setupServerCert(namespaceName, serviceName string) *certContext {
 	if err != nil {
 		framework.Failf("Failed to create a temp file for key generation %v", err)
 	}
-	if err = ioutil.WriteFile(certFile.Name(), cert.EncodeCertPEM(signedCert), 0600); err != nil {
+	if err = ioutil.WriteFile(certFile.Name(), pkiutil.EncodeCertPEM(signedCert), 0600); err != nil {
 		framework.Failf("Failed to write cert file %v", err)
 	}
-	if err = ioutil.WriteFile(keyFile.Name(), cert.EncodePrivateKeyPEM(key), 0644); err != nil {
+	if err = ioutil.WriteFile(keyFile.Name(), certutil.EncodePrivateKeyPEM(key), 0644); err != nil {
 		framework.Failf("Failed to write key file %v", err)
 	}
 	return &certContext{
-		cert:        cert.EncodeCertPEM(signedCert),
-		key:         cert.EncodePrivateKeyPEM(key),
-		signingCert: cert.EncodeCertPEM(signingCert),
+		cert:        pkiutil.EncodeCertPEM(signedCert),
+		key:         certutil.EncodePrivateKeyPEM(key),
+		signingCert: pkiutil.EncodeCertPEM(signingCert),
 	}
 }

--- a/test/e2e/auth/BUILD
+++ b/test/e2e/auth/BUILD
@@ -19,6 +19,7 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/test/e2e/auth",
     deps = [
+        "//cmd/kubeadm/app/util/pkiutil:go_default_library",
         "//pkg/master/ports:go_default_library",
         "//pkg/security/apparmor:go_default_library",
         "//pkg/security/podsecuritypolicy/seccomp:go_default_library",

--- a/test/e2e/auth/certificates.go
+++ b/test/e2e/auth/certificates.go
@@ -22,14 +22,14 @@ import (
 	"encoding/pem"
 	"time"
 
+	. "github.com/onsi/ginkgo"
 	"k8s.io/api/certificates/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	v1beta1client "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
 	"k8s.io/client-go/util/cert"
+	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	"k8s.io/kubernetes/test/e2e/framework"
-
-	. "github.com/onsi/ginkgo"
 )
 
 var _ = SIGDescribe("Certificates API", func() {
@@ -38,7 +38,7 @@ var _ = SIGDescribe("Certificates API", func() {
 	It("should support building a client with a CSR", func() {
 		const commonName = "tester-csr"
 
-		pk, err := cert.NewPrivateKey()
+		pk, err := pkiutil.NewPrivateKey()
 		framework.ExpectNoError(err)
 
 		pkder := x509.MarshalPKCS1PrivateKey(pk)

--- a/test/integration/examples/BUILD
+++ b/test/integration/examples/BUILD
@@ -17,6 +17,7 @@ go_test(
     deps = [
         "//cmd/kube-apiserver/app:go_default_library",
         "//cmd/kube-apiserver/app/options:go_default_library",
+        "//cmd/kubeadm/app/util/pkiutil:go_default_library",
         "//pkg/master:go_default_library",
         "//pkg/master/reconcilers:go_default_library",
         "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",

--- a/test/integration/framework/BUILD
+++ b/test/integration/framework/BUILD
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//cmd/kube-apiserver/app:go_default_library",
         "//cmd/kube-apiserver/app/options:go_default_library",
+        "//cmd/kubeadm/app/util/pkiutil:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/api/testapi:go_default_library",
         "//pkg/apis/batch:go_default_library",

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -32,9 +32,11 @@ import (
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
 	client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/util/cert"
+	certutil "k8s.io/client-go/util/cert"
+
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	"k8s.io/kubernetes/pkg/master"
 )
 
@@ -52,28 +54,28 @@ func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 	}()
 
 	_, defaultServiceClusterIPRange, _ := net.ParseCIDR("10.0.0.0/24")
-	proxySigningKey, err := cert.NewPrivateKey()
+	proxySigningKey, err := pkiutil.NewPrivateKey()
 	if err != nil {
 		t.Fatal(err)
 	}
-	proxySigningCert, err := cert.NewSelfSignedCACert(cert.Config{CommonName: "front-proxy-ca"}, proxySigningKey)
+	proxySigningCert, err := certutil.NewSelfSignedCACert(certutil.Config{CommonName: "front-proxy-ca"}, proxySigningKey)
 	if err != nil {
 		t.Fatal(err)
 	}
 	proxyCACertFile, _ := ioutil.TempFile(certDir, "proxy-ca.crt")
-	if err := ioutil.WriteFile(proxyCACertFile.Name(), cert.EncodeCertPEM(proxySigningCert), 0644); err != nil {
+	if err := ioutil.WriteFile(proxyCACertFile.Name(), pkiutil.EncodeCertPEM(proxySigningCert), 0644); err != nil {
 		t.Fatal(err)
 	}
-	clientSigningKey, err := cert.NewPrivateKey()
+	clientSigningKey, err := pkiutil.NewPrivateKey()
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientSigningCert, err := cert.NewSelfSignedCACert(cert.Config{CommonName: "client-ca"}, clientSigningKey)
+	clientSigningCert, err := certutil.NewSelfSignedCACert(certutil.Config{CommonName: "client-ca"}, clientSigningKey)
 	if err != nil {
 		t.Fatal(err)
 	}
 	clientCACertFile, _ := ioutil.TempFile(certDir, "client-ca.crt")
-	if err := ioutil.WriteFile(clientCACertFile.Name(), cert.EncodeCertPEM(clientSigningCert), 0644); err != nil {
+	if err := ioutil.WriteFile(clientCACertFile.Name(), pkiutil.EncodeCertPEM(clientSigningCert), 0644); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil has some overlap with the other libraries. It is also kubeadm-specific but has several dependencies in client-go that nobody else uses.

#71004

None
