### PR TITLE
[WIP] Introduce callback in informers for finished initial sync.

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -180,13 +180,22 @@ type ResourceEventHandler interface {
 	OnDelete(obj interface{})
 }
 
+// FIXME: Change name and add comment.
+type ResourceEventHandler2 interface {
+	OnAdd(obj interface{})
+	OnUpdate(oldObj, newObj interface{})
+	OnDelete(obj interface{})
+	OnInitialSync()
+}
+
 // ResourceEventHandlerFuncs is an adaptor to let you easily specify as many or
 // as few of the notification functions as you want while still implementing
 // ResourceEventHandler.
 type ResourceEventHandlerFuncs struct {
-	AddFunc    func(obj interface{})
-	UpdateFunc func(oldObj, newObj interface{})
-	DeleteFunc func(obj interface{})
+	AddFunc         func(obj interface{})
+	UpdateFunc      func(oldObj, newObj interface{})
+	DeleteFunc      func(obj interface{})
+	InitialSyncFunc func()
 }
 
 // OnAdd calls AddFunc if it's not nil.
@@ -207,6 +216,13 @@ func (r ResourceEventHandlerFuncs) OnUpdate(oldObj, newObj interface{}) {
 func (r ResourceEventHandlerFuncs) OnDelete(obj interface{}) {
 	if r.DeleteFunc != nil {
 		r.DeleteFunc(obj)
+	}
+}
+
+// On InitialSync calls InitialSyncFunc if it's not nil.
+func (r ResourceEventHandlerFuncs) OnInitialSync() {
+	if r.InitialSyncFunc != nil {
+		r.InitialSyncFunc()
 	}
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo_test.go
@@ -339,6 +339,7 @@ func TestDeltaFIFO_HasSyncedCorrectOnDeletion(t *testing.T) {
 		// it should get a tombstone key with the right Obj.
 		{{Deleted, DeletedFinalStateUnknown{Key: "bar", Obj: mkFifoObj("bar", 6)}}},
 		{{Deleted, DeletedFinalStateUnknown{Key: "baz", Obj: mkFifoObj("baz", 7)}}},
+		{{InitialSync, nil}},
 	}
 
 	for _, expected := range expectedList {
@@ -455,6 +456,13 @@ func TestDeltaFIFO_HasSynced(t *testing.T) {
 			actions: []func(f *DeltaFIFO){
 				func(f *DeltaFIFO) { f.Replace([]interface{}{}, "0") },
 			},
+			expectedSynced: false,
+		},
+		{
+			actions: []func(f *DeltaFIFO){
+				func(f *DeltaFIFO) { f.Replace([]interface{}{}, "0") },
+				func(f *DeltaFIFO) { Pop(f) },
+			},
 			expectedSynced: true,
 		},
 		{
@@ -473,6 +481,7 @@ func TestDeltaFIFO_HasSynced(t *testing.T) {
 		{
 			actions: []func(f *DeltaFIFO){
 				func(f *DeltaFIFO) { f.Replace([]interface{}{mkFifoObj("a", 1), mkFifoObj("b", 2)}, "0") },
+				func(f *DeltaFIFO) { Pop(f) },
 				func(f *DeltaFIFO) { Pop(f) },
 				func(f *DeltaFIFO) { Pop(f) },
 			},


### PR DESCRIPTION
Still lacking tests, but I would like to first get some bu-in on the approach.

There are couple controllers that rely on the fact that actually workers shouldn't start before the state is fully propagated. In the past (when there wasn't shared informers), event handlers were synchronous so detecting if lister is synced was actually enough.
With shared informer, the fact that lister is synced doesn't mean that any callbacks were actually delivered.
The example where it is potentially broken here is kube-proxy:
https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/config/config.go#L105

This PR would provide an ability to get a signal when your workers can actually start.