### PR TITLE
Adds [LinuxOnly] tag to conformance tests that cannot be run on Windows

### DIFF
--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -45,8 +45,9 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		Release : v1.9
 		Testname: ConfigMap Volume, without mapping, volume mode set
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. File mode is changed to a custom value of '0x400'. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST be set to the custom value of ‘0x400’
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func() {
 		defaultMode := int32(0400)
 		doConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode)
 	})
@@ -60,8 +61,9 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		Release : v1.9
 		Testname: ConfigMap Volume, without mapping, non-root user
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Pod is run as a non-root user with uid=1000. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The file on the volume MUST have file mode set to default value of 0x644.
+		This test is marked LinuxOnly since Windows does not support running as UID / GID.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume as non-root [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume as non-root [LinuxOnly] [NodeConformance]", func() {
 		doConfigMapE2EWithoutMappings(f, 1000, 0, nil)
 	})
 
@@ -82,8 +84,9 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		Release : v1.9
 		Testname: ConfigMap Volume, with mapping, volume mode set
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Files are mapped to a path in the volume. File mode is changed to a custom value of '0x400'. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST be set to the custom value of ‘0x400’
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [LinuxOnly] [NodeConformance]", func() {
 		mode := int32(0400)
 		doConfigMapE2EWithMappings(f, 0, 0, &mode)
 	})
@@ -92,8 +95,9 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		Release : v1.9
 		Testname: ConfigMap Volume, with mapping, non-root user
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Files are mapped to a path in the volume. Pod is run as a non-root user with uid=1000. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The file on the volume MUST have file mode set to default value of 0x644.
+		This test is marked LinuxOnly since Windows does not support running as UID / GID.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [LinuxOnly] [NodeConformance]", func() {
 		doConfigMapE2EWithMappings(f, 1000, 0, nil)
 	})
 

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -58,8 +58,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		Release : v1.9
 		Testname: DownwardAPI volume, volume mode 0400
 		Description: A Pod is configured with DownwardAPIVolumeSource with the volumesource mode set to -r-------- and DownwardAPIVolumeFiles contains a item for the Pod name. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should set DefaultMode on files [NodeConformance]", func() {
+	framework.ConformanceIt("should set DefaultMode on files [LinuxOnly] [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
@@ -73,8 +74,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		Release : v1.9
 		Testname: DownwardAPI volume, file mode 0400
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwartAPIVolumeFiles contains a item for the Pod name with the file mode set to -r--------. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should set mode on item file [NodeConformance]", func() {
+	framework.ConformanceIt("should set mode on item file [LinuxOnly] [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)

--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -70,8 +70,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium memory, volume mode default
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("volume on tmpfs should have the correct mode [NodeConformance]", func() {
+	framework.ConformanceIt("volume on tmpfs should have the correct mode [LinuxOnly] [NodeConformance]", func() {
 		doTestVolumeMode(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
@@ -79,8 +80,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium memory, volume mode 0644
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0644. The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents MUST be readable.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("should support (root,0644,tmpfs) [NodeConformance]", func() {
+	framework.ConformanceIt("should support (root,0644,tmpfs) [LinuxOnly] [NodeConformance]", func() {
 		doTest0644(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
@@ -88,8 +90,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium memory, volume mode 0666
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0666. The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents MUST be readable.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("should support (root,0666,tmpfs) [NodeConformance]", func() {
+	framework.ConformanceIt("should support (root,0666,tmpfs) [LinuxOnly] [NodeConformance]", func() {
 		doTest0666(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
@@ -97,8 +100,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium memory, volume mode 0777
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0777.  The volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs and the contents MUST be readable.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("should support (root,0777,tmpfs) [NodeConformance]", func() {
+	framework.ConformanceIt("should support (root,0777,tmpfs) [LinuxOnly] [NodeConformance]", func() {
 		doTest0777(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
@@ -106,8 +110,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium memory, volume mode 0644, non-root user
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0644. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents MUST be readable.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("should support (non-root,0644,tmpfs) [NodeConformance]", func() {
+	framework.ConformanceIt("should support (non-root,0644,tmpfs) [LinuxOnly] [NodeConformance]", func() {
 		doTest0644(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
@@ -115,8 +120,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium memory, volume mode 0666,, non-root user
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0666. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents MUST be readable.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("should support (non-root,0666,tmpfs) [NodeConformance]", func() {
+	framework.ConformanceIt("should support (non-root,0666,tmpfs) [LinuxOnly] [NodeConformance]", func() {
 		doTest0666(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
@@ -124,8 +130,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium memory, volume mode 0777, non-root user
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0777. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rwxrwxrwx and mount type set to tmpfs and the contents MUST be readable.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("should support (non-root,0777,tmpfs) [NodeConformance]", func() {
+	framework.ConformanceIt("should support (non-root,0777,tmpfs) [LinuxOnly] [NodeConformance]", func() {
 		doTest0777(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
@@ -133,8 +140,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium default, volume mode default
 		Description: A Pod created with an 'emptyDir' Volume, the volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("volume on default medium should have the correct mode [NodeConformance]", func() {
+	framework.ConformanceIt("volume on default medium should have the correct mode [LinuxOnly] [NodeConformance]", func() {
 		doTestVolumeMode(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
@@ -142,8 +150,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium default, volume mode 0644
 		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0644. The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents MUST be readable.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should support (root,0644,default) [NodeConformance]", func() {
+	framework.ConformanceIt("should support (root,0644,default) [LinuxOnly] [NodeConformance]", func() {
 		doTest0644(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
@@ -151,8 +160,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium default, volume mode 0666
 		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0666. The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents MUST be readable.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should support (root,0666,default) [NodeConformance]", func() {
+	framework.ConformanceIt("should support (root,0666,default) [LinuxOnly] [NodeConformance]", func() {
 		doTest0666(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
@@ -160,8 +170,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium default, volume mode 0777
 		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0777.  The volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs and the contents MUST be readable.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should support (root,0777,default) [NodeConformance]", func() {
+	framework.ConformanceIt("should support (root,0777,default) [LinuxOnly] [NodeConformance]", func() {
 		doTest0777(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
@@ -169,8 +180,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium default, volume mode 0644
 		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0644. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents MUST be readable.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should support (non-root,0644,default) [NodeConformance]", func() {
+	framework.ConformanceIt("should support (non-root,0644,default) [LinuxOnly] [NodeConformance]", func() {
 		doTest0644(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 
@@ -178,8 +190,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium default, volume mode 0666
 		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0666. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents MUST be readable.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should support (non-root,0666,default) [NodeConformance]", func() {
+	framework.ConformanceIt("should support (non-root,0666,default) [LinuxOnly] [NodeConformance]", func() {
 		doTest0666(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 
@@ -187,8 +200,9 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		Release : v1.9
 		Testname: EmptyDir, medium default, volume mode 0777
 		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0777. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rwxrwxrwx and mount type set to tmpfs and the contents MUST be readable.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should support (non-root,0777,default) [NodeConformance]", func() {
+	framework.ConformanceIt("should support (non-root,0777,default) [LinuxOnly] [NodeConformance]", func() {
 		doTest0777(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 })

--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -44,8 +44,9 @@ var _ = Describe("[sig-storage] HostPath", func() {
 	   Release : v1.9
 	   Testname: Host path, volume mode default
 	   Description: Create a Pod with host volume mounted. The volume mounted MUST be a directory with permissions mode -rwxrwxrwx and that is has the sticky bit (mode flag t) set.
+	   This test is marked LinuxOnly since Windows does not support setting the sticky bit (mode flag t).
 	*/
-	framework.ConformanceIt("should give a volume the correct mode [NodeConformance]", func() {
+	framework.ConformanceIt("should give a volume the correct mode [LinuxOnly] [NodeConformance]", func() {
 		source := &v1.HostPathVolumeSource{
 			Path: "/tmp",
 		}

--- a/test/e2e/common/kubelet.go
+++ b/test/e2e/common/kubelet.go
@@ -190,8 +190,9 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 			Release : v1.13
 			Testname: Kubelet, pod with read only root file system
 			Description: Create a Pod with security context set with ReadOnlyRootFileSystem set to true. The Pod then tries to write to the /file on the root, write operation to the root filesystem MUST fail as expected.
+			This test is marked LinuxOnly since Windows does not support creating containers with read-only access.
 		*/
-		framework.ConformanceIt("should not write to root filesystem [NodeConformance]", func() {
+		framework.ConformanceIt("should not write to root filesystem [LinuxOnly] [NodeConformance]", func() {
 			isReadOnly := true
 			podClient.CreateSync(&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/common/kubelet_etc_hosts.go
+++ b/test/e2e/common/kubelet_etc_hosts.go
@@ -57,8 +57,9 @@ var _ = framework.KubeDescribe("KubeletManagedEtcHosts", func() {
 			1. The Pod with hostNetwork=false MUST have /etc/hosts of containers managed by the Kubelet.
 			2. The Pod with hostNetwork=false but the container mounts /etc/hosts file from the host. The /etc/hosts file MUST not be managed by the Kubelet.
 			3. The Pod with hostNetwork=true , /etc/hosts file MUST not be managed by the Kubelet.
+		This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 	*/
-	framework.ConformanceIt("should test kubelet managed /etc/hosts file [NodeConformance]", func() {
+	framework.ConformanceIt("should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance]", func() {
 		By("Setting up the test")
 		config.setup()
 

--- a/test/e2e/common/networking.go
+++ b/test/e2e/common/networking.go
@@ -35,8 +35,9 @@ var _ = Describe("[sig-network] Networking", func() {
 			Testname: Networking, intra pod http
 			Description: Create a hostexec pod that is capable of curl to netcat commands. Create a test Pod that will act as a webserver front end exposing ports 8080 for tcp and 8081 for udp. The netserver service proxies are created on specified number of nodes.
 			The kubectl exec on the webserver container MUST reach a http port on the each of service proxy endpoints in the cluster and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
+			This test is marked LinuxOnly since HostNetwork is not supported on other platforms like Windows.
 		*/
-		framework.ConformanceIt("should function for intra-pod communication: http [NodeConformance]", func() {
+		framework.ConformanceIt("should function for intra-pod communication: http [LinuxOnly] [NodeConformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
 			for _, endpointPod := range config.EndpointPods {
 				config.DialFromTestContainer("http", endpointPod.Status.PodIP, framework.EndpointHttpPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
@@ -48,8 +49,9 @@ var _ = Describe("[sig-network] Networking", func() {
 			Testname: Networking, intra pod udp
 			Description: Create a hostexec pod that is capable of curl to netcat commands. Create a test Pod that will act as a webserver front end exposing ports 8080 for tcp and 8081 for udp. The netserver service proxies are created on specified number of nodes.
 			The kubectl exec on the webserver container MUST reach a udp port on the each of service proxy endpoints in the cluster and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
+			This test is marked LinuxOnly since HostNetwork is not supported on other platforms like Windows.
 		*/
-		framework.ConformanceIt("should function for intra-pod communication: udp [NodeConformance]", func() {
+		framework.ConformanceIt("should function for intra-pod communication: udp [LinuxOnly] [NodeConformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
 			for _, endpointPod := range config.EndpointPods {
 				config.DialFromTestContainer("udp", endpointPod.Status.PodIP, framework.EndpointUdpPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
@@ -61,8 +63,9 @@ var _ = Describe("[sig-network] Networking", func() {
 			Testname: Networking, intra pod http, from node
 			Description: Create a hostexec pod that is capable of curl to netcat commands. Create a test Pod that will act as a webserver front end exposing ports 8080 for tcp and 8081 for udp. The netserver service proxies are created on specified number of nodes.
 			The kubectl exec on the webserver container MUST reach a http port on the each of service proxy endpoints in the cluster using a http post(protocol=tcp)  and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
+			This test is marked LinuxOnly since HostNetwork is not supported on other platforms like Windows.
 		*/
-		framework.ConformanceIt("should function for node-pod communication: http [NodeConformance]", func() {
+		framework.ConformanceIt("should function for node-pod communication: http [LinuxOnly] [NodeConformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
 			for _, endpointPod := range config.EndpointPods {
 				config.DialFromNode("http", endpointPod.Status.PodIP, framework.EndpointHttpPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
@@ -74,8 +77,9 @@ var _ = Describe("[sig-network] Networking", func() {
 			Testname: Networking, intra pod http, from node
 			Description: Create a hostexec pod that is capable of curl to netcat commands. Create a test Pod that will act as a webserver front end exposing ports 8080 for tcp and 8081 for udp. The netserver service proxies are created on specified number of nodes.
 			The kubectl exec on the webserver container MUST reach a http port on the each of service proxy endpoints in the cluster using a http post(protocol=udp)  and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
+			This test is marked LinuxOnly since HostNetwork is not supported on other platforms like Windows.
 		*/
-		framework.ConformanceIt("should function for node-pod communication: udp [NodeConformance]", func() {
+		framework.ConformanceIt("should function for node-pod communication: udp [LinuxOnly] [NodeConformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
 			for _, endpointPod := range config.EndpointPods {
 				config.DialFromNode("udp", endpointPod.Status.PodIP, framework.EndpointUdpPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))

--- a/test/e2e/common/privileged.go
+++ b/test/e2e/common/privileged.go
@@ -45,7 +45,8 @@ var _ = framework.KubeDescribe("PrivilegedPod [NodeConformance]", func() {
 		notPrivilegedContainer: "not-privileged-container",
 	}
 
-	It("should enable privileged commands", func() {
+	It("should enable privileged commands [LinuxOnly]", func() {
+		// Windows does not support privileged containers.
 		By("Creating a pod with a privileged container")
 		config.createPods()
 

--- a/test/e2e/common/projected_configmap.go
+++ b/test/e2e/common/projected_configmap.go
@@ -46,8 +46,9 @@ var _ = Describe("[sig-storage] Projected configMap", func() {
 	   Release : v1.9
 	   Testname: Projected Volume, ConfigMap, volume mode 0400
 	   Description: A Pod is created with projected volume source ‘ConfigMap’ to store a configMap with permission mode set to 0400. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -r——-——-—-.
+	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func() {
 		defaultMode := int32(0400)
 		doProjectedConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode)
 	})
@@ -61,8 +62,9 @@ var _ = Describe("[sig-storage] Projected configMap", func() {
 	   Release : v1.9
 	   Testname: Projected Volume, ConfigMap, non-root user
 	   Description: A Pod is created with projected volume source ‘ConfigMap’ to store a configMap as non-root user with uid 1000. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -rw—r——r—-.
+	   This test is marked LinuxOnly since Windows does not support running as UID / GID.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume as non-root [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume as non-root [LinuxOnly] [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 1000, 0, nil)
 	})
 
@@ -83,8 +85,9 @@ var _ = Describe("[sig-storage] Projected configMap", func() {
 	   Release : v1.9
 	   Testname: Projected Volume, ConfigMap, mapped, volume mode 0400
 	   Description: A Pod is created with projected volume source ‘ConfigMap’ to store a configMap with permission mode set to 0400. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -r-—r——r—-.
+	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [LinuxOnly] [NodeConformance]", func() {
 		mode := int32(0400)
 		doProjectedConfigMapE2EWithMappings(f, 0, 0, &mode)
 	})
@@ -93,8 +96,9 @@ var _ = Describe("[sig-storage] Projected configMap", func() {
 	   Release : v1.9
 	   Testname: Projected Volume, ConfigMap, mapped, non-root user
 	   Description: A Pod is created with projected volume source ‘ConfigMap’ to store a configMap as non-root user with uid 1000. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -r-—r——r—-.
+	   This test is marked LinuxOnly since Windows does not support running as UID / GID.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [LinuxOnly] [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithMappings(f, 1000, 0, nil)
 	})
 

--- a/test/e2e/common/projected_downwardapi.go
+++ b/test/e2e/common/projected_downwardapi.go
@@ -58,8 +58,9 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 	   Release : v1.9
 	   Testname: Projected Volume, DownwardAPI, volume mode 0400
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. The default mode for the volume mount is set to 0400. Pod MUST be able to read the pod name from the mounted DownwardAPIVolumeFiles and the volume mode must be -r—-—————.
+	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should set DefaultMode on files [NodeConformance]", func() {
+	framework.ConformanceIt("should set DefaultMode on files [LinuxOnly] [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
@@ -73,8 +74,9 @@ var _ = Describe("[sig-storage] Projected downwardAPI", func() {
 	   Release : v1.9
 	   Testname: Projected Volume, DownwardAPI, volume mode 0400
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. The default mode for the volume mount is set to 0400. Pod MUST be able to read the pod name from the mounted DownwardAPIVolumeFiles and the volume mode must be -r—-—————.
+	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should set mode on item file [NodeConformance]", func() {
+	framework.ConformanceIt("should set mode on item file [LinuxOnly] [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)

--- a/test/e2e/common/projected_secret.go
+++ b/test/e2e/common/projected_secret.go
@@ -46,8 +46,9 @@ var _ = Describe("[sig-storage] Projected secret", func() {
 	   Release : v1.9
 	   Testname: Projected Volume, Secrets, volume mode 0400
 	   Description: A Pod is created with a projected volume source ‘secret’ to store a secret with a specified key with permission mode set to 0x400 on the Pod. Pod MUST be able to read the content of the key successfully and the mode MUST be -r—-—————.
+	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func() {
 		defaultMode := int32(0400)
 		doProjectedSecretE2EWithoutMapping(f, &defaultMode, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
@@ -56,8 +57,9 @@ var _ = Describe("[sig-storage] Projected secret", func() {
 	   Release : v1.9
 	   Testname: Project Volume, Secrets, non-root, custom fsGroup
 	   Description: A Pod is created with a projected volume source ‘secret’ to store a secret with a specified key. The volume has permission mode set to 0440, fsgroup set to 1001 and user set to non-root uid of 1000. Pod MUST be able to read the content of the key successfully and the mode MUST be -r—-r————-.
+	   This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [LinuxOnly] [NodeConformance]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		fsGroup := int64(1001)
 		uid := int64(1000)
@@ -77,8 +79,9 @@ var _ = Describe("[sig-storage] Projected secret", func() {
 	   Release : v1.9
 	   Testname: Projected Volume, Secrets, mapped, volume mode 0400
 	   Description: A Pod is created with a projected volume source ‘secret’ to store a secret with a specified key with permission mode set to 0400. The secret is also mapped to a specific name. Pod MUST be able to read the content of the key successfully and the mode MUST be -r—-—————— on the mapped volume.
+	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set [LinuxOnly] [NodeConformance]", func() {
 		mode := int32(0400)
 		doProjectedSecretE2EWithMapping(f, &mode)
 	})

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -202,7 +202,8 @@ while true; do sleep 1; done
 				},
 			} {
 				testCase := testCase
-				It(fmt.Sprintf("should report termination message %s", testCase.name), func() {
+				It(fmt.Sprintf("should report termination message %s [LinuxOnly]", testCase.name), func() {
+					// Cannot mount files in Windows Containers.
 					testCase.container.Name = "termination-message-container"
 					c := ConformanceContainer{
 						PodClient:     f.PodClient(),
@@ -271,13 +272,14 @@ while true; do sleep 1; done
 					waiting:     true,
 				},
 				{
-					description: "should be able to pull image from gcr.io",
+					description: "should be able to pull image from gcr.io [LinuxOnly]",
 					image:       "gcr.io/google-containers/debian-base:0.4.0",
 					phase:       v1.PodRunning,
 					waiting:     false,
 				},
 				{
-					description: "should be able to pull image from docker hub",
+					// TODO(claudiub): Remove the [LinuxOnly] tag when a Windows-friendly image is used instead of alpine.
+					description: "should be able to pull image from docker hub [LinuxOnly]",
 					image:       "alpine:3.7",
 					phase:       v1.PodRunning,
 					waiting:     false,
@@ -289,7 +291,7 @@ while true; do sleep 1; done
 					waiting:     true,
 				},
 				{
-					description: "should be able to pull from private registry with secret",
+					description: "should be able to pull from private registry with secret [LinuxOnly]",
 					image:       "gcr.io/authenticated-image-pulling/alpine:3.7",
 					secret:      true,
 					phase:       v1.PodRunning,

--- a/test/e2e/common/secrets_volume.go
+++ b/test/e2e/common/secrets_volume.go
@@ -46,8 +46,9 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		Release : v1.9
 		Testname: Secrets Volume, volume mode 0400
 		Description: Create a secret. Create a Pod with secret volume source configured into the container with file mode set to 0x400. Pod MUST be able to read the secret from the mounted volume from the container runtime and the file mode of the secret MUST be -r——--—-—- by default.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func() {
 		defaultMode := int32(0400)
 		doSecretE2EWithoutMapping(f, &defaultMode, "secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
@@ -56,8 +57,9 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		Release : v1.9
 		Testname: Secrets Volume, volume mode 0440, fsGroup 1001 and uid 1000
 		Description: Create a secret. Create a Pod with secret volume source configured into the container with file mode set to 0x440 as a non-root user with uid 1000 and fsGroup id 1001. Pod MUST be able to read the secret from the mounted volume from the container runtime and the file mode of the secret MUST be -r——r-—-—- by default.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [LinuxOnly] [NodeConformance]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		fsGroup := int64(1001)
 		uid := int64(1000)
@@ -77,8 +79,9 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		Release : v1.9
 		Testname: Secrets Volume, mapping, volume mode 0400
 		Description: Create a secret. Create a Pod with secret volume source configured into the container with a custom path and file mode set to 0x400. Pod MUST be able to read the secret from the mounted volume from the specified custom path. The file mode of the secret MUST be -r-—r-—r—-.
+		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set [NodeConformance]", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set [LinuxOnly] [NodeConformance]", func() {
 		mode := int32(0400)
 		doSecretE2EWithMapping(f, &mode)
 	})

--- a/test/e2e/common/security_context.go
+++ b/test/e2e/common/security_context.go
@@ -73,8 +73,9 @@ var _ = framework.KubeDescribe("Security Context", func() {
 		  Testname: Security Context: runAsUser (id:65534)
 		  Description: Container created with runAsUser option, passing an id (id:65534) uses that
 		  given id when running the container.
+		  This test is marked LinuxOnly since Windows does not support running as UID / GID.
 		*/
-		It("should run the container with uid 65534 [NodeConformance]", func() {
+		It("should run the container with uid 65534 [LinuxOnly] [NodeConformance]", func() {
 			createAndWaitUserPod(65534)
 		})
 
@@ -83,8 +84,9 @@ var _ = framework.KubeDescribe("Security Context", func() {
 		  Testname: Security Context: runAsUser (id:0)
 		  Description: Container created with runAsUser option, passing an id (id:0) uses that
 		  given id when running the container.
+		  This test is marked LinuxOnly since Windows does not support running as UID / GID.
 		*/
-		It("should run the container with uid 0 [NodeConformance]", func() {
+		It("should run the container with uid 0 [LinuxOnly] [NodeConformance]", func() {
 			createAndWaitUserPod(0)
 		})
 	})
@@ -131,8 +133,9 @@ var _ = framework.KubeDescribe("Security Context", func() {
 		  Release : v1.12
 		  Testname: Security Context: readOnlyRootFilesystem=true.
 		  Description: when a container has configured readOnlyRootFilesystem to true, write operations are not allowed.
+		  This test is marked LinuxOnly since Windows does not support creating containers with read-only access.
 		*/
-		It("should run the container with readonly rootfs when readOnlyRootFilesystem=true [NodeConformance]", func() {
+		It("should run the container with readonly rootfs when readOnlyRootFilesystem=true [LinuxOnly] [NodeConformance]", func() {
 			createAndWaitUserPod(true)
 		})
 
@@ -178,7 +181,8 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			return podName
 		}
 
-		It("should run the container as unprivileged when false [NodeConformance]", func() {
+		It("should run the container as unprivileged when false [LinuxOnly] [NodeConformance]", func() {
+			// This test is marked LinuxOnly since it runs a Linux-specific command, and Windows does not support Windows escalation.
 			podName := createAndWaitUserPod(false)
 			logs, err := framework.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, podName)
 			if err != nil {
@@ -227,8 +231,9 @@ var _ = framework.KubeDescribe("Security Context", func() {
 		  Description: Configuring the allowPrivilegeEscalation unset, allows the privilege escalation operation.
 		  A container is configured with allowPrivilegeEscalation not specified (nil) and a given uid which is not 0.
 		  When the container is run, the container is run using uid=0.
+		  This test is marked LinuxOnly since Windows does not support running as UID / GID, or privilege escalation.
 		*/
-		It("should allow privilege escalation when not explicitly set and uid != 0 [NodeConformance]", func() {
+		It("should allow privilege escalation when not explicitly set and uid != 0 [LinuxOnly] [NodeConformance]", func() {
 			podName := "alpine-nnp-nil-" + string(uuid.NewUUID())
 			if err := createAndMatchOutput(podName, "Effective uid: 0", nil, 1000); err != nil {
 				framework.Failf("Match output for pod %q failed: %v", podName, err)
@@ -240,8 +245,9 @@ var _ = framework.KubeDescribe("Security Context", func() {
 		  Description: Configuring the allowPrivilegeEscalation to false, does not allow the privilege escalation operation.
 		  A container is configured with allowPrivilegeEscalation=false and a given uid (1000) which is not 0.
 		  When the container is run, the container is run using uid=1000.
+		  This test is marked LinuxOnly since Windows does not support running as UID / GID, or privilege escalation.
 		*/
-		It("should not allow privilege escalation when false [NodeConformance]", func() {
+		It("should not allow privilege escalation when false [LinuxOnly] [NodeConformance]", func() {
 			podName := "alpine-nnp-false-" + string(uuid.NewUUID())
 			apeFalse := false
 			if err := createAndMatchOutput(podName, "Effective uid: 1000", &apeFalse, 1000); err != nil {
@@ -254,8 +260,9 @@ var _ = framework.KubeDescribe("Security Context", func() {
 		  Description: Configuring the allowPrivilegeEscalation to true, allows the privilege escalation operation.
 		  A container is configured with allowPrivilegeEscalation=true and a given uid (1000) which is not 0.
 		  When the container is run, the container is run using uid=0 (making use of the privilege escalation).
+		  This test is marked LinuxOnly since Windows does not support running as UID / GID.
 		*/
-		It("should allow privilege escalation when true [NodeConformance]", func() {
+		It("should allow privilege escalation when true [LinuxOnly] [NodeConformance]", func() {
 			podName := "alpine-nnp-true-" + string(uuid.NewUUID())
 			apeTrue := true
 			if err := createAndMatchOutput(podName, "Effective uid: 0", &apeTrue, 1000); err != nil {

--- a/test/e2e/storage/subpath.go
+++ b/test/e2e/storage/subpath.go
@@ -55,8 +55,9 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Release : v1.12
 		  Testname: SubPath: Reading content from a secret volume.
 		  Description: Containers in a pod can read content from a secret mounted volume which was configured with a subpath.
+		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 		*/
-		framework.ConformanceIt("should support subpaths with secret pod", func() {
+		framework.ConformanceIt("should support subpaths with secret pod [LinuxOnly]", func() {
 			pod := testsuites.SubpathTestPod(f, "secret-key", "secret", &v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "my-secret"}}, privilegedSecurityContext)
 			testsuites.TestBasicSubpath(f, "secret-value", pod)
 		})
@@ -65,8 +66,9 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Release : v1.12
 		  Testname: SubPath: Reading content from a configmap volume.
 		  Description: Containers in a pod can read content from a configmap mounted volume which was configured with a subpath.
+		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 		*/
-		framework.ConformanceIt("should support subpaths with configmap pod", func() {
+		framework.ConformanceIt("should support subpaths with configmap pod [LinuxOnly]", func() {
 			pod := testsuites.SubpathTestPod(f, "configmap-key", "configmap", &v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "my-configmap"}}}, privilegedSecurityContext)
 			testsuites.TestBasicSubpath(f, "configmap-value", pod)
 		})
@@ -75,8 +77,9 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Release : v1.12
 		  Testname: SubPath: Reading content from a configmap volume.
 		  Description: Containers in a pod can read content from a configmap mounted volume which was configured with a subpath and also using a mountpath that is a specific file.
+		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 		*/
-		framework.ConformanceIt("should support subpaths with configmap pod with mountPath of existing file", func() {
+		framework.ConformanceIt("should support subpaths with configmap pod with mountPath of existing file [LinuxOnly]", func() {
 			pod := testsuites.SubpathTestPod(f, "configmap-key", "configmap", &v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "my-configmap"}}}, privilegedSecurityContext)
 			file := "/etc/resolv.conf"
 			pod.Spec.Containers[0].VolumeMounts[0].MountPath = file
@@ -87,8 +90,9 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Release : v1.12
 		  Testname: SubPath: Reading content from a downwardAPI volume.
 		  Description: Containers in a pod can read content from a downwardAPI mounted volume which was configured with a subpath.
+		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 		*/
-		framework.ConformanceIt("should support subpaths with downward pod", func() {
+		framework.ConformanceIt("should support subpaths with downward pod [LinuxOnly]", func() {
 			pod := testsuites.SubpathTestPod(f, "downward/podname", "downwardAPI", &v1.VolumeSource{
 				DownwardAPI: &v1.DownwardAPIVolumeSource{
 					Items: []v1.DownwardAPIVolumeFile{{Path: "downward/podname", FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.name"}}},
@@ -101,8 +105,9 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Release : v1.12
 		  Testname: SubPath: Reading content from a projected volume.
 		  Description: Containers in a pod can read content from a projected mounted volume which was configured with a subpath.
+		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 		*/
-		framework.ConformanceIt("should support subpaths with projected pod", func() {
+		framework.ConformanceIt("should support subpaths with projected pod [LinuxOnly]", func() {
 			pod := testsuites.SubpathTestPod(f, "projected/configmap-key", "projected", &v1.VolumeSource{
 				Projected: &v1.ProjectedVolumeSource{
 					Sources: []v1.VolumeProjection{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test
/kind feature

/sig testing
/sig windows

**What this PR does / why we need it**:

Some of the tests cannot pass using Windows nodes due to various reasons:

- seLinuxOptions are not supported on Windows.
- Running as an UID / GID is not supported on Windows.
- file permissions work differently on Windows, and they cannot be set in
  the same manner as on Linux.
- individual files cannot be mounted in Windows Containers.
- Cannot create container using Linux image (e.g.: alpine) on Windows.

Because of this, it has been decided [1][2] to use the "[LinuxOnly]" tag for the
tests which cannot run on Windows because of the mentioned reasons. This way,
when running tests using Windows nodes, those tests can simply be skipped by
adding the "[LinuxOnly]" tag to the ginkgo.skip argument.

[1] https://groups.google.com/forum/#!topic/kubernetes-sig-testing/ii5584-Tkqk
[2] https://docs.google.com/document/d/1z8MQpr_jTwhmjLMUaqQyBk1EYG_Y_3D4y4YdMJ7V1Kk/edit#heading=h.ukbaidczvy3r

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #69871

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
