### PR TITLE
Add /var/run/docker/*.log to logrotate

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -360,7 +360,7 @@ function setup-logrotate() {
   #   day).
   # * keep only 5 old (rotated) logs, and will discard older logs.
   cat > /etc/logrotate.d/allvarlogs <<EOF
-/var/log/*.log {
+/var/log/*.log /var/run/docker/*.log {
     rotate ${LOGROTATE_FILES_MAX_COUNT:-5}
     copytruncate
     missingok


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This configuration will avoid [docker daemon logs](https://docs.docker.com/config/daemon/) to fill in the disk

**Which issue(s) this PR fixes**:
https://github.com/kubernetes/kubernetes/issues/73208

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
