### PR TITLE
GCE: update addon DaemonSets to select node OS

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -104,6 +104,7 @@ spec:
       # END_PROMETHEUS_TO_SD
       nodeSelector:
         beta.kubernetes.io/fluentd-ds-ready: "true"
+        beta.kubernetes.io/os: linux
       terminationGracePeriodSeconds: 60
       tolerations:
       - operator: "Exists"

--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -89,4 +89,5 @@ spec:
       # END_PROMETHEUS_TO_SD
       nodeSelector:
         beta.kubernetes.io/metadata-proxy-ready: "true"
+        beta.kubernetes.io/os: linux
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
These DaemonSets supports only Linux today, so this change updates the
specs to reflect this limitation. The labels have recently been promoted
to GA. Using the beta labels for now until node-master version skew
problem no longer exists.

/kind cleanup

**What this PR does / why we need it**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```