### PR TITLE
staging/publishing: skip unsupported 1.10 branch

### DIFF
--- a/staging/publishing/OWNERS
+++ b/staging/publishing/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- sttts
+- nikhita
+- dims
+reviewers:
+- sttts
+- dims
+- nikhita
+labels:
+- sig/release
+- area/release-eng

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1,6 +1,3 @@
-skip-source-branches:
-- release-1.5
-- release-1.6
 recursive-delete-patterns:
 - BUILD
 - "*/BUILD"
@@ -14,15 +11,6 @@ rules:
       branch: master
       dir: staging/src/k8s.io/code-generator
     name: master
-  # - source:
-  #     branch: release-1.8
-  #     dir: staging/src/k8s.io/code-generator
-  #   name: release-1.8
-  # - source:
-  #    branch: release-1.9
-  #    dir: staging/src/k8s.io/code-generator
-  #  name: release-1.9
-  #  go: 1.9.7
   - source:
       branch: release-1.10
       dir: staging/src/k8s.io/code-generator
@@ -50,23 +38,6 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apimachinery
     name: master
-  # - source:
-  #     branch: release-1.6
-  #     dir: staging/src/k8s.io/apimachinery
-  #   name: release-1.6
-  # - source:
-  #     branch: release-1.7
-  #     dir: staging/src/k8s.io/apimachinery
-  #   name: release-1.7
-  # - source:
-  #     branch: release-1.8
-  #     dir: staging/src/k8s.io/apimachinery
-  #   name: release-1.8
-  # - source:
-  #    branch: release-1.9
-  #    dir: staging/src/k8s.io/apimachinery
-  #  name: release-1.9
-  #  go: 1.9.7
   - source:
       branch: release-1.10
       dir: staging/src/k8s.io/apimachinery
@@ -97,21 +68,6 @@ rules:
     dependencies:
     - repository: apimachinery
       branch: master
-  # - source:
-  #     branch: release-1.8
-  #     dir: staging/src/k8s.io/api
-  #   name: release-1.8
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.8
-  # - source:
-  #    branch: release-1.9
-  #    dir: staging/src/k8s.io/api
-  #  name: release-1.9
-  #  go: 1.9.7
-  #  dependencies:
-  #  - repository: apimachinery
-  #    branch: release-1.9
   - source:
       branch: release-1.10
       dir: staging/src/k8s.io/api
@@ -156,43 +112,6 @@ rules:
       branch: master
     - repository: api
       branch: master
-  # - source:
-  #     branch: release-1.5
-  #     dir: staging/src/k8s.io/client-go
-  #   name: release-2.0
-  # - source:
-  #     branch: release-1.6
-  #     dir: staging/src/k8s.io/client-go
-  #   name: release-3.0
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.6
-  # - source:
-  #     branch: release-1.7
-  #     dir: staging/src/k8s.io/client-go
-  #   name: release-4.0
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.7
-  # - source:
-  #     branch: release-1.8
-  #     dir: staging/src/k8s.io/client-go
-  #   name: release-5.0
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.8
-  #   - repository: api
-  #     branch: release-1.8
-  # - source:
-  #   branch: release-1.9
-  #    dir: staging/src/k8s.io/client-go
-  #  name: release-6.0
-  #  go: 1.9.7
-  #  dependencies:
-  #  - repository: apimachinery
-  #    branch: release-1.9
-  #  - repository: api
-  #    branch: release-1.9
   - source:
       branch: release-1.10
       dir: staging/src/k8s.io/client-go
@@ -267,47 +186,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  # - source:
-  #     branch: release-1.6
-  #     dir: staging/src/k8s.io/apiserver
-  #   name: release-1.6
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.6
-  #   - repository: client-go
-  #     branch: release-3.0
-  # - source:
-  #     branch: release-1.7
-  #     dir: staging/src/k8s.io/apiserver
-  #   name: release-1.7
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.7
-  #   - repository: client-go
-  #     branch: release-4.0
-  # - source:
-  #     branch: release-1.8
-  #     dir: staging/src/k8s.io/apiserver
-  #   name: release-1.8
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.8
-  #   - repository: api
-  #     branch: release-1.8
-  #   - repository: client-go
-  #     branch: release-5.0
-  # - source:
-  #    branch: release-1.9
-  #    dir: staging/src/k8s.io/apiserver
-  #  name: release-1.9
-  #  go: 1.9.7
-  #  dependencies:
-  #  - repository: apimachinery
-  #    branch: release-1.9
-  #  - repository: api
-  #    branch: release-1.9
-  #  - repository: client-go
-  #    branch: release-6.0
   - source:
       branch: release-1.10
       dir: staging/src/k8s.io/apiserver
@@ -373,55 +251,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  # - source:
-  #     branch: release-1.6
-  #     dir: staging/src/k8s.io/kube-aggregator
-  #   name: release-1.6
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.6
-  #   - repository: client-go
-  #     branch: release-3.0
-  #   - repository: apiserver
-  #     branch: release-1.6
-  # - source:
-  #     branch: release-1.7
-  #     dir: staging/src/k8s.io/kube-aggregator
-  #   name: release-1.7
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.7
-  #   - repository: client-go
-  #     branch: release-4.0
-  #   - repository: apiserver
-  #     branch: release-1.7
-  # - source:
-  #     branch: release-1.8
-  #     dir: staging/src/k8s.io/kube-aggregator
-  #   name: release-1.8
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.8
-  #   - repository: api
-  #     branch: release-1.8
-  #   - repository: client-go
-  #     branch: release-5.0
-  #   - repository: apiserver
-  #     branch: release-1.8
-  # - source:
-  #    branch: release-1.9
-  #    dir: staging/src/k8s.io/kube-aggregator
-  #  name: release-1.9
-  #  go: 1.9.7
-  #  dependencies:
-  #  - repository: apimachinery
-  #    branch: release-1.9
-  #  - repository: api
-  #    branch: release-1.9
-  #  - repository: client-go
-  #    branch: release-6.0
-  #  - repository: apiserver
-  #    branch: release-1.9
   - source:
       branch: release-1.10
       dir: staging/src/k8s.io/kube-aggregator
@@ -499,63 +328,6 @@ rules:
       branch: master
     required-packages:
     - k8s.io/code-generator
-  # - source:
-  #     branch: release-1.6
-  #     dir: staging/src/k8s.io/sample-apiserver
-  #   name: release-1.6
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.6
-  #   - repository: client-go
-  #     branch: release-3.0
-  #   - repository: apiserver
-  #     branch: release-1.6
-  # - source:
-  #     branch: release-1.7
-  #     dir: staging/src/k8s.io/sample-apiserver
-  #   name: release-1.7
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.7
-  #   - repository: client-go
-  #     branch: release-4.0
-  #   - repository: apiserver
-  #     branch: release-1.7
-  # - source:
-  #     branch: release-1.8
-  #     dir: staging/src/k8s.io/sample-apiserver
-  #   name: release-1.8
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.8
-  #   - repository: api
-  #     branch: release-1.8
-  #   - repository: client-go
-  #     branch: release-5.0
-  #   - repository: apiserver
-  #     branch: release-1.8
-  #   - repository: code-generator
-  #     branch: release-1.8
-  #   required-packages:
-  #   - k8s.io/code-generator
-  # - source:
-  #    branch: release-1.9
-  #    dir: staging/src/k8s.io/sample-apiserver
-  #  name: release-1.9
-  #  go: 1.9.7
-  #  dependencies:
-  #  - repository: apimachinery
-  #    branch: release-1.9
-  #  - repository: api
-  #    branch: release-1.9
-  #  - repository: client-go
-  #    branch: release-6.0
-  #  - repository: apiserver
-  #    branch: release-1.9
-  #  - repository: code-generator
-  #    branch: release-1.9
-  #  required-packages:
-  #  - k8s.io/code-generator
   - source:
       branch: release-1.10
       dir: staging/src/k8s.io/sample-apiserver
@@ -655,22 +427,6 @@ rules:
       branch: master
     required-packages:
     - k8s.io/code-generator
-  # - source:
-  #   branch: release-1.9
-  #    dir: staging/src/k8s.io/sample-controller
-  #  name: release-1.9
-  #  go: 1.9.7
-  #  dependencies:
-  #  - repository: apimachinery
-  #    branch: release-1.9
-  #  - repository: api
-  #    branch: release-1.9
-  #  - repository: client-go
-  #    branch: release-6.0
-  #  - repository: code-generator
-  #    branch: release-1.9
-  #  required-packages:
-  #  - k8s.io/code-generator
   - source:
       branch: release-1.10
       dir: staging/src/k8s.io/sample-controller
@@ -765,52 +521,6 @@ rules:
       branch: master
     required-packages:
     - k8s.io/code-generator
-  # - source:
-  #     branch: release-1.7
-  #     dir: staging/src/k8s.io/apiextensions-apiserver
-  #   name: release-1.7
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.7
-  #   - repository: client-go
-  #     branch: release-4.0
-  #   - repository: apiserver
-  #     branch: release-1.7
-  # - source:
-  #     branch: release-1.8
-  #     dir: staging/src/k8s.io/apiextensions-apiserver
-  #   name: release-1.8
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.8
-  #   - repository: api
-  #     branch: release-1.8
-  #   - repository: client-go
-  #     branch: release-5.0
-  #   - repository: apiserver
-  #     branch: release-1.8
-  #   - repository: code-generator
-  #     branch: release-1.8
-  #   required-packages:
-  #   - k8s.io/code-generator
-  # - source:
-  #    branch: release-1.9
-  #    dir: staging/src/k8s.io/apiextensions-apiserver
-  #  name: release-1.9
-  #  go: 1.9.7
-  #  dependencies:
-  #  - repository: apimachinery
-  #    branch: release-1.9
-  #  - repository: api
-  #    branch: release-1.9
-  #  - repository: client-go
-  #    branch: release-6.0
-  #  - repository: apiserver
-  #    branch: release-1.9
-  #  - repository: code-generator
-  #    branch: release-1.9
-  #  required-packages:
-  #  - k8s.io/code-generator
   - source:
       branch: release-1.10
       dir: staging/src/k8s.io/apiextensions-apiserver
@@ -897,38 +607,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  # - source:
-  #     branch: release-1.7
-  #     dir: staging/src/k8s.io/metrics
-  #   name: release-1.7
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.7
-  #   - repository: client-go
-  #     branch: release-4.0
-  # - source:
-  #     branch: release-1.8
-  #     dir: staging/src/k8s.io/metrics
-  #   name: release-1.8
-  #   dependencies:
-  #   - repository: apimachinery
-  #     branch: release-1.8
-  #   - repository: api
-  #     branch: release-1.8
-  #   - repository: client-go
-  #     branch: release-5.0
-  # - source:
-  #    branch: release-1.9
-  #    dir: staging/src/k8s.io/metrics
-  #  name: release-1.9
-  #  go: 1.9.7
-  #  dependencies:
-  #  - repository: apimachinery
-  #    branch: release-1.9
-  #  - repository: api
-  #    branch: release-1.9
-  #  - repository: client-go
-  #    branch: release-6.0
   - source:
       branch: release-1.10
       dir: staging/src/k8s.io/metrics

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1,0 +1,1311 @@
+skip-source-branches:
+- release-1.5
+- release-1.6
+recursive-delete-patterns:
+- BUILD
+- "*/BUILD"
+- BUILD.bazel
+- "*/BUILD.bazel"
+- Gopkg.toml
+rules:
+- destination: code-generator
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/code-generator
+    name: master
+  # - source:
+  #     branch: release-1.8
+  #     dir: staging/src/k8s.io/code-generator
+  #   name: release-1.8
+  # - source:
+  #    branch: release-1.9
+  #    dir: staging/src/k8s.io/code-generator
+  #  name: release-1.9
+  #  go: 1.9.7
+  - source:
+      branch: release-1.10
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.10
+    go: 1.9.7
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.11
+    go: 1.10.2
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.12
+    go: 1.10.4
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.13
+    go: 1.11.2
+- destination: apimachinery
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/apimachinery
+    name: master
+  # - source:
+  #     branch: release-1.6
+  #     dir: staging/src/k8s.io/apimachinery
+  #   name: release-1.6
+  # - source:
+  #     branch: release-1.7
+  #     dir: staging/src/k8s.io/apimachinery
+  #   name: release-1.7
+  # - source:
+  #     branch: release-1.8
+  #     dir: staging/src/k8s.io/apimachinery
+  #   name: release-1.8
+  # - source:
+  #    branch: release-1.9
+  #    dir: staging/src/k8s.io/apimachinery
+  #  name: release-1.9
+  #  go: 1.9.7
+  - source:
+      branch: release-1.10
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.10
+    go: 1.9.7
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.11
+    go: 1.10.2
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.12
+    go: 1.10.4
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.13
+    go: 1.11.2
+- destination: api
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/api
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+  # - source:
+  #     branch: release-1.8
+  #     dir: staging/src/k8s.io/api
+  #   name: release-1.8
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.8
+  # - source:
+  #    branch: release-1.9
+  #    dir: staging/src/k8s.io/api
+  #  name: release-1.9
+  #  go: 1.9.7
+  #  dependencies:
+  #  - repository: apimachinery
+  #    branch: release-1.9
+  - source:
+      branch: release-1.10
+      dir: staging/src/k8s.io/api
+    name: release-1.10
+    go: 1.9.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.10
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/api
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/api
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/api
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+- destination: client-go
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/client-go
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+  # - source:
+  #     branch: release-1.5
+  #     dir: staging/src/k8s.io/client-go
+  #   name: release-2.0
+  # - source:
+  #     branch: release-1.6
+  #     dir: staging/src/k8s.io/client-go
+  #   name: release-3.0
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.6
+  # - source:
+  #     branch: release-1.7
+  #     dir: staging/src/k8s.io/client-go
+  #   name: release-4.0
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.7
+  # - source:
+  #     branch: release-1.8
+  #     dir: staging/src/k8s.io/client-go
+  #   name: release-5.0
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.8
+  #   - repository: api
+  #     branch: release-1.8
+  # - source:
+  #   branch: release-1.9
+  #    dir: staging/src/k8s.io/client-go
+  #  name: release-6.0
+  #  go: 1.9.7
+  #  dependencies:
+  #  - repository: apimachinery
+  #    branch: release-1.9
+  #  - repository: api
+  #    branch: release-1.9
+  - source:
+      branch: release-1.10
+      dir: staging/src/k8s.io/client-go
+    name: release-7.0
+    go: 1.9.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.10
+    - repository: api
+      branch: release-1.10
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/client-go
+    name: release-8.0
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/client-go
+    name: release-9.0
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/client-go
+    name: release-10.0
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+  smoke-test: |
+    godep restore
+    go build ./...
+    go test $(go list ./... | grep -v /vendor/)
+- destination: component-base
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/component-base
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+    - repository: client-go
+      branch: master
+- destination: apiserver
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/apiserver
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: component-base
+      branch: master
+  # - source:
+  #     branch: release-1.6
+  #     dir: staging/src/k8s.io/apiserver
+  #   name: release-1.6
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.6
+  #   - repository: client-go
+  #     branch: release-3.0
+  # - source:
+  #     branch: release-1.7
+  #     dir: staging/src/k8s.io/apiserver
+  #   name: release-1.7
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.7
+  #   - repository: client-go
+  #     branch: release-4.0
+  # - source:
+  #     branch: release-1.8
+  #     dir: staging/src/k8s.io/apiserver
+  #   name: release-1.8
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.8
+  #   - repository: api
+  #     branch: release-1.8
+  #   - repository: client-go
+  #     branch: release-5.0
+  # - source:
+  #    branch: release-1.9
+  #    dir: staging/src/k8s.io/apiserver
+  #  name: release-1.9
+  #  go: 1.9.7
+  #  dependencies:
+  #  - repository: apimachinery
+  #    branch: release-1.9
+  #  - repository: api
+  #    branch: release-1.9
+  #  - repository: client-go
+  #    branch: release-6.0
+  - source:
+      branch: release-1.10
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.10
+    go: 1.9.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.10
+    - repository: api
+      branch: release-1.10
+    - repository: client-go
+      branch: release-7.0
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+    - repository: client-go
+      branch: release-8.0
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+- destination: kube-aggregator
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/kube-aggregator
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: apiserver
+      branch: master
+    - repository: component-base
+      branch: master
+  # - source:
+  #     branch: release-1.6
+  #     dir: staging/src/k8s.io/kube-aggregator
+  #   name: release-1.6
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.6
+  #   - repository: client-go
+  #     branch: release-3.0
+  #   - repository: apiserver
+  #     branch: release-1.6
+  # - source:
+  #     branch: release-1.7
+  #     dir: staging/src/k8s.io/kube-aggregator
+  #   name: release-1.7
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.7
+  #   - repository: client-go
+  #     branch: release-4.0
+  #   - repository: apiserver
+  #     branch: release-1.7
+  # - source:
+  #     branch: release-1.8
+  #     dir: staging/src/k8s.io/kube-aggregator
+  #   name: release-1.8
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.8
+  #   - repository: api
+  #     branch: release-1.8
+  #   - repository: client-go
+  #     branch: release-5.0
+  #   - repository: apiserver
+  #     branch: release-1.8
+  # - source:
+  #    branch: release-1.9
+  #    dir: staging/src/k8s.io/kube-aggregator
+  #  name: release-1.9
+  #  go: 1.9.7
+  #  dependencies:
+  #  - repository: apimachinery
+  #    branch: release-1.9
+  #  - repository: api
+  #    branch: release-1.9
+  #  - repository: client-go
+  #    branch: release-6.0
+  #  - repository: apiserver
+  #    branch: release-1.9
+  - source:
+      branch: release-1.10
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.10
+    go: 1.9.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.10
+    - repository: api
+      branch: release-1.10
+    - repository: client-go
+      branch: release-7.0
+    - repository: apiserver
+      branch: release-1.10
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+    - repository: client-go
+      branch: release-8.0
+    - repository: apiserver
+      branch: release-1.11
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+    - repository: apiserver
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+    - repository: apiserver
+      branch: release-1.13
+- destination: sample-apiserver
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/sample-apiserver
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: apiserver
+      branch: master
+    - repository: code-generator
+      branch: master
+    - repository: component-base
+      branch: master
+    required-packages:
+    - k8s.io/code-generator
+  # - source:
+  #     branch: release-1.6
+  #     dir: staging/src/k8s.io/sample-apiserver
+  #   name: release-1.6
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.6
+  #   - repository: client-go
+  #     branch: release-3.0
+  #   - repository: apiserver
+  #     branch: release-1.6
+  # - source:
+  #     branch: release-1.7
+  #     dir: staging/src/k8s.io/sample-apiserver
+  #   name: release-1.7
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.7
+  #   - repository: client-go
+  #     branch: release-4.0
+  #   - repository: apiserver
+  #     branch: release-1.7
+  # - source:
+  #     branch: release-1.8
+  #     dir: staging/src/k8s.io/sample-apiserver
+  #   name: release-1.8
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.8
+  #   - repository: api
+  #     branch: release-1.8
+  #   - repository: client-go
+  #     branch: release-5.0
+  #   - repository: apiserver
+  #     branch: release-1.8
+  #   - repository: code-generator
+  #     branch: release-1.8
+  #   required-packages:
+  #   - k8s.io/code-generator
+  # - source:
+  #    branch: release-1.9
+  #    dir: staging/src/k8s.io/sample-apiserver
+  #  name: release-1.9
+  #  go: 1.9.7
+  #  dependencies:
+  #  - repository: apimachinery
+  #    branch: release-1.9
+  #  - repository: api
+  #    branch: release-1.9
+  #  - repository: client-go
+  #    branch: release-6.0
+  #  - repository: apiserver
+  #    branch: release-1.9
+  #  - repository: code-generator
+  #    branch: release-1.9
+  #  required-packages:
+  #  - k8s.io/code-generator
+  - source:
+      branch: release-1.10
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.10
+    go: 1.9.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.10
+    - repository: api
+      branch: release-1.10
+    - repository: client-go
+      branch: release-7.0
+    - repository: apiserver
+      branch: release-1.10
+    - repository: code-generator
+      branch: release-1.10
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+    - repository: client-go
+      branch: release-8.0
+    - repository: apiserver
+      branch: release-1.11
+    - repository: code-generator
+      branch: release-1.11
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+    - repository: apiserver
+      branch: release-1.12
+    - repository: code-generator
+      branch: release-1.12
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+    - repository: apiserver
+      branch: release-1.13
+    - repository: code-generator
+      branch: release-1.13
+    required-packages:
+    - k8s.io/code-generator
+  smoke-test: |
+    # vendor/ should have all dependencies as a non-library
+    go build .
+    # re-create vendor/ and try again
+    godep restore
+    rm -rf vendor/ Godeps/
+    godep save ./...
+    go build .
+- destination: sample-controller
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/sample-controller
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: code-generator
+      branch: master
+    - repository: component-base
+      branch: master
+    required-packages:
+    - k8s.io/code-generator
+  # - source:
+  #   branch: release-1.9
+  #    dir: staging/src/k8s.io/sample-controller
+  #  name: release-1.9
+  #  go: 1.9.7
+  #  dependencies:
+  #  - repository: apimachinery
+  #    branch: release-1.9
+  #  - repository: api
+  #    branch: release-1.9
+  #  - repository: client-go
+  #    branch: release-6.0
+  #  - repository: code-generator
+  #    branch: release-1.9
+  #  required-packages:
+  #  - k8s.io/code-generator
+  - source:
+      branch: release-1.10
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.10
+    go: 1.9.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.10
+    - repository: api
+      branch: release-1.10
+    - repository: client-go
+      branch: release-7.0
+    - repository: code-generator
+      branch: release-1.10
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+    - repository: client-go
+      branch: release-8.0
+    - repository: code-generator
+      branch: release-1.11
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+    - repository: code-generator
+      branch: release-1.12
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+    - repository: code-generator
+      branch: release-1.13
+    required-packages:
+    - k8s.io/code-generator
+  smoke-test: |
+    # vendor/ should have all dependencies as a non-library
+    go build .
+
+    # re-create vendor/ and try again
+    godep restore
+    rm -rf vendor/ Godeps/
+    godep save ./...
+    go build .
+- destination: apiextensions-apiserver
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: apiserver
+      branch: master
+    - repository: code-generator
+      branch: master
+    - repository: component-base
+      branch: master
+    required-packages:
+    - k8s.io/code-generator
+  # - source:
+  #     branch: release-1.7
+  #     dir: staging/src/k8s.io/apiextensions-apiserver
+  #   name: release-1.7
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.7
+  #   - repository: client-go
+  #     branch: release-4.0
+  #   - repository: apiserver
+  #     branch: release-1.7
+  # - source:
+  #     branch: release-1.8
+  #     dir: staging/src/k8s.io/apiextensions-apiserver
+  #   name: release-1.8
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.8
+  #   - repository: api
+  #     branch: release-1.8
+  #   - repository: client-go
+  #     branch: release-5.0
+  #   - repository: apiserver
+  #     branch: release-1.8
+  #   - repository: code-generator
+  #     branch: release-1.8
+  #   required-packages:
+  #   - k8s.io/code-generator
+  # - source:
+  #    branch: release-1.9
+  #    dir: staging/src/k8s.io/apiextensions-apiserver
+  #  name: release-1.9
+  #  go: 1.9.7
+  #  dependencies:
+  #  - repository: apimachinery
+  #    branch: release-1.9
+  #  - repository: api
+  #    branch: release-1.9
+  #  - repository: client-go
+  #    branch: release-6.0
+  #  - repository: apiserver
+  #    branch: release-1.9
+  #  - repository: code-generator
+  #    branch: release-1.9
+  #  required-packages:
+  #  - k8s.io/code-generator
+  - source:
+      branch: release-1.10
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.10
+    go: 1.9.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.10
+    - repository: api
+      branch: release-1.10
+    - repository: client-go
+      branch: release-7.0
+    - repository: apiserver
+      branch: release-1.10
+    - repository: code-generator
+      branch: release-1.10
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+    - repository: client-go
+      branch: release-8.0
+    - repository: apiserver
+      branch: release-1.11
+    - repository: code-generator
+      branch: release-1.11
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+    - repository: apiserver
+      branch: release-1.12
+    - repository: code-generator
+      branch: release-1.12
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+    - repository: apiserver
+      branch: release-1.13
+    - repository: code-generator
+      branch: release-1.13
+    required-packages:
+    - k8s.io/code-generator
+- destination: metrics
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/metrics
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+  # - source:
+  #     branch: release-1.7
+  #     dir: staging/src/k8s.io/metrics
+  #   name: release-1.7
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.7
+  #   - repository: client-go
+  #     branch: release-4.0
+  # - source:
+  #     branch: release-1.8
+  #     dir: staging/src/k8s.io/metrics
+  #   name: release-1.8
+  #   dependencies:
+  #   - repository: apimachinery
+  #     branch: release-1.8
+  #   - repository: api
+  #     branch: release-1.8
+  #   - repository: client-go
+  #     branch: release-5.0
+  # - source:
+  #    branch: release-1.9
+  #    dir: staging/src/k8s.io/metrics
+  #  name: release-1.9
+  #  go: 1.9.7
+  #  dependencies:
+  #  - repository: apimachinery
+  #    branch: release-1.9
+  #  - repository: api
+  #    branch: release-1.9
+  #  - repository: client-go
+  #    branch: release-6.0
+  - source:
+      branch: release-1.10
+      dir: staging/src/k8s.io/metrics
+    name: release-1.10
+    go: 1.9.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.10
+    - repository: api
+      branch: release-1.10
+    - repository: client-go
+      branch: release-7.0
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/metrics
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+    - repository: client-go
+      branch: release-8.0
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/metrics
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/metrics
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+- destination: csi-api
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/csi-api
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: apiextensions-apiserver
+      branch: master
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/csi-api
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+    - repository: apiextensions-apiserver
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/csi-api
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+    - repository: apiextensions-apiserver
+      branch: release-1.13
+- destination: cli-runtime
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/cli-runtime
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+    - repository: client-go
+      branch: master
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: api
+      branch: release-1.12
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: api
+      branch: release-1.13
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+- destination: sample-cli-plugin
+  library: false
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+    - repository: cli-runtime
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: component-base
+      branch: master
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: api
+      branch: release-1.12
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: cli-runtime
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: api
+      branch: release-1.13
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: cli-runtime
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+- destination: kube-proxy
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/kube-proxy
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: component-base
+      branch: master
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+- destination: kubelet
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/kubelet
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: component-base
+      branch: master
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+- destination: kube-scheduler
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/kube-scheduler
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: apiserver
+      branch: master
+    - repository: component-base
+      branch: master
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: apiserver
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: apiserver
+      branch: release-1.13
+- destination: kube-controller-manager
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: apiserver
+      branch: master
+    - repository: component-base
+      branch: master
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.12
+    go: 1.10.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: apiserver
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: apiserver
+      branch: release-1.13
+- destination: cluster-bootstrap
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+- destination: cloud-provider
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/cloud-provider
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+    - repository: client-go
+      branch: master
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/cloud-provider
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: api
+      branch: release-1.13
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+- destination: node-api
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/node-api
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+    - repository: client-go
+      branch: master
+- destination: csi-translation-lib
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/csi-translation-lib
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1,3 +1,5 @@
+skip-source-branches:
+- release-1.10
 recursive-delete-patterns:
 - BUILD
 - "*/BUILD"


### PR DESCRIPTION
According to https://github.com/kubernetes/client-go/blob/master/README.md, 1.10 is out of support.