### PR TITLE
Enable multi-arch build for add-on manager

### DIFF
--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -20,6 +20,8 @@ KUBECTL_VERSION?=v1.13.2
 
 BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.4.0
 
+SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
+
 .PHONY: build push
 
 all: build
@@ -29,6 +31,12 @@ build:
 	curl -sSL --retry 5 https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/$(ARCH)/kubectl > $(TEMP_DIR)/kubectl
 	chmod +x $(TEMP_DIR)/kubectl
 	cd $(TEMP_DIR) && sed -i.back "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+
+ifneq ($(ARCH),amd64)
+	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
+	$(SUDO) ../../../third_party/multiarch/qemu-user-static/register/register.sh --reset
+endif
+
 	docker build --pull -t $(IMAGE)-$(ARCH):$(VERSION) $(TEMP_DIR)
 
 push: build


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes multi-arch build for add-on manager

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @ixdy 