### PR TITLE
Add back --cert-dir option for kubeadm init phase certs sa

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/certs.go
@@ -111,10 +111,11 @@ func newCertSubPhases() []workflow.Phase {
 
 	// SA creates the private/public key pair, which doesn't use x509 at all
 	saPhase := workflow.Phase{
-		Name:  "sa",
-		Short: "Generates a private key for signing service account tokens along with its public key",
-		Long:  saKeyLongDesc,
-		Run:   runCertsSa,
+		Name:         "sa",
+		Short:        "Generates a private key for signing service account tokens along with its public key",
+		Long:         saKeyLongDesc,
+		Run:          runCertsSa,
+		InheritFlags: []string{options.CertificatesDir},
 	}
 
 	subPhases = append(subPhases, saPhase)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fixes a regression that was introduced that got rid of the `--cert-dir` option for service account key pair generation. More info available in https://github.com/kubernetes/kubeadm/issues/1354.  

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/1354

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: add back `--cert-dir` option for `kubeadm init phase certs sa`
```
