### PR TITLE
Bugfix/nodeunschedule taint cleanup

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -965,7 +965,7 @@ func (nc *Controller) tryUpdateNodeHealth(node *v1.Node) (time.Duration, v1.Node
 				status:                   &node.Status,
 				probeTimestamp:           nc.nodeHealthMap[node.Name].probeTimestamp,
 				readyTransitionTimestamp: nc.now(),
-				lease: 					  observedLease,
+				lease: 	                  observedLease,
 			}
 			return gracePeriod, observedReadyCondition, currentReadyCondition, nil
 		}

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -965,7 +965,7 @@ func (nc *Controller) tryUpdateNodeHealth(node *v1.Node) (time.Duration, v1.Node
 				status:                   &node.Status,
 				probeTimestamp:           nc.nodeHealthMap[node.Name].probeTimestamp,
 				readyTransitionTimestamp: nc.now(),
-				lease: observedLease,
+				lease: 					  observedLease,
 			}
 			return gracePeriod, observedReadyCondition, currentReadyCondition, nil
 		}

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -515,6 +515,8 @@ func (nc *Controller) doNoScheduleTaintingPass(nodeName string) error {
 			}
 		}
 	}
+
+	//add related taint when taintNodeByCondition is enabled
 	if nc.taintNodeByCondition && node.Spec.Unschedulable {
 		// If unschedulable, append related taint.
 		taints = append(taints, v1.Taint{
@@ -956,7 +958,7 @@ func (nc *Controller) tryUpdateNodeHealth(node *v1.Node) (time.Duration, v1.Node
 				status:                   &node.Status,
 				probeTimestamp:           nc.nodeHealthMap[node.Name].probeTimestamp,
 				readyTransitionTimestamp: nc.now(),
-				lease: observedLease,
+				lease:                    observedLease,
 			}
 			return gracePeriod, observedReadyCondition, currentReadyCondition, nil
 		}

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -508,23 +508,14 @@ func (nc *Controller) doNoScheduleTaintingPass(nodeName string) error {
 	for _, condition := range node.Status.Conditions {
 		if taintMap, found := nodeConditionToTaintKeyStatusMap[condition.Type]; found {
 			if taintKey, found := taintMap[condition.Status]; found {
-				if taintKey == schedulerapi.TaintNodeUnschedulable {
-					if node.Spec.Unschedulable {
-						taints = append(taints, v1.Taint{
-							Key:    taintKey,
-							Effect: v1.TaintEffectNoSchedule,
-						})
-					}
-				} else {
-					taints = append(taints, v1.Taint{
-						Key:    taintKey,
-						Effect: v1.TaintEffectNoSchedule,
-					})
-				}
+				taints = append(taints, v1.Taint{
+					Key:    taintKey,
+					Effect: v1.TaintEffectNoSchedule,
+				})
 			}
 		}
 	}
-	if node.Spec.Unschedulable {
+	if nc.taintNodeByCondition && node.Spec.Unschedulable {
 		// If unschedulable, append related taint.
 		taints = append(taints, v1.Taint{
 			Key:    schedulerapi.TaintNodeUnschedulable,
@@ -965,7 +956,7 @@ func (nc *Controller) tryUpdateNodeHealth(node *v1.Node) (time.Duration, v1.Node
 				status:                   &node.Status,
 				probeTimestamp:           nc.nodeHealthMap[node.Name].probeTimestamp,
 				readyTransitionTimestamp: nc.now(),
-				lease: 	                  observedLease,
+				lease: observedLease,
 			}
 			return gracePeriod, observedReadyCondition, currentReadyCondition, nil
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

this PR fix this case: 
Node is schedulable but somehow it  has taint node.kubernetes.io/unschedulable,so it cannot be scheduled if no pod tolerate it.
Clean up unused  taint(node.kubernetes.io/unschedulable) is required whenever TaintNodesByCondition feature is enabled

By this way,I can recreate the case: 

1. cordon node A 
2. enable TaintNodesByCondition
3. controller mark nodeA with node.kubernetes.io/unschedulable taint 
4. disable TaintNodesByCondition
5. uncordon node A

Then node.kubernetes.io/unschedulable taint stay and is not cleaned up 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
