### PR TITLE
Mark rules field as optional

### DIFF
--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -43,6 +43,7 @@ message ClusterRole {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules holds all the PolicyRules for this ClusterRole
+  // +optional
   repeated PolicyRule rules = 2;
 
   // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -121,6 +122,7 @@ message Role {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules holds all the PolicyRules for this Role
+  // +optional
   repeated PolicyRule rules = 2;
 }
 

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -108,6 +108,7 @@ type Role struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Rules holds all the PolicyRules for this Role
+	// +optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -170,6 +171,7 @@ type ClusterRole struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Rules holds all the PolicyRules for this ClusterRole
+	// +optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -43,6 +43,7 @@ message ClusterRole {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules holds all the PolicyRules for this ClusterRole
+  // +optional
   repeated PolicyRule rules = 2;
 
   // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -122,6 +123,7 @@ message Role {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules holds all the PolicyRules for this Role
+  // +optional
   repeated PolicyRule rules = 2;
 }
 

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -110,6 +110,7 @@ type Role struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Rules holds all the PolicyRules for this Role
+	// +optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -172,6 +173,7 @@ type ClusterRole struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Rules holds all the PolicyRules for this ClusterRole
+	// +optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -43,6 +43,7 @@ message ClusterRole {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules holds all the PolicyRules for this ClusterRole
+  // +optional
   repeated PolicyRule rules = 2;
 
   // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -122,6 +123,7 @@ message Role {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules holds all the PolicyRules for this Role
+  // +optional
   repeated PolicyRule rules = 2;
 }
 

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -109,6 +109,7 @@ type Role struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Rules holds all the PolicyRules for this Role
+	// +optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -171,6 +172,7 @@ type ClusterRole struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Rules holds all the PolicyRules for this ClusterRole
+	// +optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 	// If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The rules lists in RBAC Role/ClusterRole objects are not required. Marking them as optional allows manifests without them present to be submitted without kubectl complaining. Note that this doesn't change serialization in any way.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/73050

**Does this PR introduce a user-facing change?**:
```release-note
The `rules` field in RBAC Role and ClusterRole objects is now correctly reported as optional in the openapi schema.
```

/sig auth