### PR TITLE
kubectl run --quiet suppresses deletion messages

### DIFF
--- a/pkg/kubectl/cmd/delete/delete.go
+++ b/pkg/kubectl/cmd/delete/delete.go
@@ -102,6 +102,7 @@ type DeleteOptions struct {
 	DeleteNow           bool
 	ForceDeletion       bool
 	WaitForDeletion     bool
+	Quiet               bool
 
 	GracePeriod int
 	Timeout     time.Duration
@@ -313,7 +314,9 @@ func (o *DeleteOptions) deleteResource(info *resource.Info, deleteOptions *metav
 		return nil, cmdutil.AddSourceToErr("deleting", info.Source, err)
 	}
 
-	o.PrintObj(info)
+	if !o.Quiet {
+		o.PrintObj(info)
+	}
 	return deleteResponse, nil
 }
 

--- a/pkg/kubectl/cmd/run/run.go
+++ b/pkg/kubectl/cmd/run/run.go
@@ -241,6 +241,7 @@ func (o *RunOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 	deleteOpts.IgnoreNotFound = true
 	deleteOpts.WaitForDeletion = false
 	deleteOpts.GracePeriod = -1
+	deleteOpts.Quiet = o.Quiet
 
 	o.DeleteOptions = deleteOpts
 


### PR DESCRIPTION
The `--quiet` option should prevent `kubectl run` from polluting the output of an attached container - make it apply to the resource deletion messages emitted by the `--rm` option.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`kubectl run --quiet --rm` defies expectations by mixing messages about resource deletion into the output from an attached container.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The `--quiet` option to `kubectl run` now suppresses resource deletion messages emitted when the `--rm` option is specified.
```
