### PR TITLE
Detect zone of MIG in e2e VPA tests

### DIFF
--- a/test/e2e/framework/providers/gce/gce.go
+++ b/test/e2e/framework/providers/gce/gce.go
@@ -184,16 +184,12 @@ func (p *Provider) EnsureLoadBalancerResourcesDeleted(ip, portRange string) erro
 }
 
 func getGCEZoneForGroup(group string) (string, error) {
-	zone := framework.TestContext.CloudConfig.Zone
-	if framework.TestContext.CloudConfig.MultiZone {
-		output, err := exec.Command("gcloud", "compute", "instance-groups", "managed", "list",
-			"--project="+framework.TestContext.CloudConfig.ProjectID, "--format=value(zone)", "--filter=name="+group).CombinedOutput()
-		if err != nil {
-			return "", fmt.Errorf("Failed to get zone for node group %s: %s", group, output)
-		}
-		zone = strings.TrimSpace(string(output))
+	output, err := exec.Command("gcloud", "compute", "instance-groups", "managed", "list",
+		"--project="+framework.TestContext.CloudConfig.ProjectID, "--format=value(zone)", "--filter=name="+group).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get zone for node group %s: %s", group, output)
 	}
-	return zone, nil
+	return strings.TrimSpace(string(output)), nil
 }
 
 // DeleteNode deletes a node which is specified as the argument


### PR DESCRIPTION
I was running e2e VPA tests and some were failing because the tests
assume thata they're running on:
- zonal single-zone cluster, or
- regional multi-zone cluster.

And I was running them on regional, single-zoned cluster.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Have VPA e2e tests pass on single-zone regional clusters.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
