### PR TITLE
Optimize event list from etcd

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
@@ -39,6 +39,9 @@ const (
 
 	// audiencesKey is the context key for request audiences.
 	audiencesKey
+	
+	// objectNameKey is the context key for the involved object name.
+	objectNameKey
 )
 
 // NewContext instantiates a base context object for request flows.
@@ -93,4 +96,21 @@ func WithAuditEvent(parent context.Context, ev *audit.Event) context.Context {
 func AuditEventFrom(ctx context.Context) *audit.Event {
 	ev, _ := ctx.Value(auditKey).(*audit.Event)
 	return ev
+}
+
+// WithInvolvedObjectName returns a copy of parent in which the involved object name value is set
+func WithInvolvedObjectName(parent context.Context, involvedObjectName string) context.Context {
+	return WithValue(parent, objectNameKey, involvedObjectName)
+}
+
+// InvolvedObjectNameFrom returns the value of the involved object name key on the ctx
+func InvolvedObjectNameFrom(ctx context.Context) (string, bool) {
+	involvedObjectName, ok := ctx.Value(objectNameKey).(string)
+	return involvedObjectName, ok
+}
+
+// InvolvedObjectNameValue returns the value of the involved object name key on the ctx, or the empty string if none
+func InvolvedObjectNameValue(ctx context.Context) string {
+	involvedObjectName, _ := InvolvedObjectNameFrom(ctx)
+	return involvedObjectName
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/context_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/context_test.go
@@ -91,3 +91,62 @@ func TestUserContext(t *testing.T) {
 	}
 
 }
+
+//TestUIDContext validates that a UID can be get/set on a context object
+func TestUIDContext(t *testing.T) {
+	ctx := genericapirequest.NewContext()
+	_, ok := genericapirequest.UIDFrom(ctx)
+	if ok {
+		t.Fatalf("Should not be ok because there is no UID on the context")
+	}
+	ctx = genericapirequest.WithUID(
+		ctx,
+		types.UID("testUID"),
+	)
+	_, ok = genericapirequest.UIDFrom(ctx)
+	if !ok {
+		t.Fatalf("Error getting UID")
+	}
+}
+
+//TestUserAgentContext validates that a useragent can be get/set on a context object
+func TestUserAgentContext(t *testing.T) {
+	ctx := genericapirequest.NewContext()
+	_, ok := genericapirequest.UserAgentFrom(ctx)
+	if ok {
+		t.Fatalf("Should not be ok because there is no UserAgent on the context")
+	}
+
+	ctx = genericapirequest.WithUserAgent(
+		ctx,
+		"TestUserAgent",
+	)
+	result, ok := genericapirequest.UserAgentFrom(ctx)
+	if !ok {
+		t.Fatalf("Error getting UserAgent")
+	}
+	expectedResult := "TestUserAgent"
+	if result != expectedResult {
+		t.Fatalf("Get user agent error, Expected: %s, Actual: %s", expectedResult, result)
+	}
+}
+
+// TestInvolvedObjectNameContext validates that a Involved Object Name  can be get/set on a context object
+func TestInvolvedObjectNameContext(t *testing.T) {
+	ctx := genericapirequest.NewDefaultContext()
+	_, ok := genericapirequest.InvolvedObjectNameFrom(ctx)
+	if ok {
+		t.Fatalf("Should not be ok because there is no Involved Object Name on the context")
+	}
+
+	expectedResult := "testID"
+	ctx = genericapirequest.WithInvolvedObjectName(ctx, expectedResult)
+	result, ok := genericapirequest.InvolvedObjectNameFrom(ctx)
+	if !ok {
+		t.Fatalf("Error getting Involved Object Name")
+	}
+
+	if result != expectedResult {
+		t.Fatalf("Get Involved Object Name error, Expected: %s, Actual: %s", expectedResult, result)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
@@ -74,6 +74,10 @@ func (s *DryRunnableStorage) List(ctx context.Context, key string, resourceVersi
 	return s.Storage.List(ctx, key, resourceVersion, p, listObj)
 }
 
+func (s *DryRunnableStorage) ListAll(ctx context.Context, keyPrefix string, resourceVersion string, p storage.SelectionPredicate, listObj runtime.Object) error {
+	return s.Storage.ListAll(ctx, keyPrefix, resourceVersion, p, listObj)
+}
+
 func (s *DryRunnableStorage) GuaranteedUpdate(
 	ctx context.Context, key string, ptrToType runtime.Object, ignoreNotFound bool,
 	preconditions *storage.Preconditions, tryUpdate storage.UpdateFunc, dryRun bool, suggestion ...runtime.Object) error {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -471,7 +471,17 @@ func (c *Cacher) GetToList(ctx context.Context, key string, resourceVersion stri
 }
 
 // List implements storage.Interface.
+func (c *Cacher) ListAll(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate, listObj runtime.Object) error {
+	return c.doList(ctx, key, resourceVersion, pred, listObj, true)
+}
+
+// Implements storage.Interface.
 func (c *Cacher) List(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate, listObj runtime.Object) error {
+	return c.doList(ctx, key, resourceVersion, pred, listObj, false)
+}
+
+// Back-end for Cacher.List() & Cacher.ListAll()
+func (c *Cacher) doList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate, listObj runtime.Object, all bool) error {
 	pagingEnabled := utilfeature.DefaultFeatureGate.Enabled(features.APIListChunking)
 	hasContinuation := pagingEnabled && len(pred.Continue) > 0
 	hasLimit := pagingEnabled && pred.Limit > 0 && resourceVersion != "0"
@@ -479,10 +489,11 @@ func (c *Cacher) List(ctx context.Context, key string, resourceVersion string, p
 		// If resourceVersion is not specified, serve it from underlying
 		// storage (for backward compatibility). If a continuation is
 		// requested, serve it from the underlying storage as well.
-		// Limits are only sent to storage when resourceVersion is non-zero
-		// since the watch cache isn't able to perform continuations, and
-		// limits are ignored when resource version is zero.
-		return c.storage.List(ctx, key, resourceVersion, pred, listObj)
+		if all {
+			return c.storage.ListAll(ctx, key, resourceVersion, pred, listObj)
+		} else {
+			return c.storage.List(ctx, key, resourceVersion, pred, listObj)
+		}
 	}
 
 	// If resourceVersion is specified, serve it from cache.
@@ -496,7 +507,11 @@ func (c *Cacher) List(ctx context.Context, key string, resourceVersion string, p
 	if listRV == 0 && !c.ready.check() {
 		// If Cacher is not yet initialized and we don't require any specific
 		// minimal resource version, simply forward the request to storage.
-		return c.storage.List(ctx, key, resourceVersion, pred, listObj)
+		if all {
+			return c.storage.ListAll(ctx, key, resourceVersion, pred, listObj)
+		} else {
+			return c.storage.List(ctx, key, resourceVersion, pred, listObj)
+		}
 	}
 
 	trace := utiltrace.New(fmt.Sprintf("cacher %v: List", c.objectType.String()))

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -833,6 +833,7 @@ func TestList(t *testing.T) {
 		expectedOut    []*example.Pod
 		expectContinue bool
 		expectError    bool
+		listAll        bool
 	}{
 		{
 			name:        "rejects invalid resource version",
@@ -858,6 +859,17 @@ func TestList(t *testing.T) {
 			prefix:      "/one-level/",
 			pred:        storage.Everything,
 			expectedOut: []*example.Pod{preset[0].storedObj},
+		},
+		{
+			prefix:      "/one-",
+			pred:        storage.Everything,
+			expectedOut: nil,
+		},
+		{
+			prefix:      "/one-",
+			pred:        storage.Everything,
+			expectedOut: []*example.Pod{preset[0].storedObj},
+			listAll:     true,
 		},
 		{
 			name:        "test List on non-existing key",
@@ -1043,7 +1055,9 @@ func TestList(t *testing.T) {
 
 		out := &example.PodList{}
 		var err error
-		if tt.disablePaging {
+		if tt.listAll {
+			err = store.ListAll(ctx, tt.prefix, tt.rv, tt.pred, out)
+		} else if tt.disablePaging {
 			err = disablePagingStore.List(ctx, tt.prefix, tt.rv, tt.pred, out)
 		} else {
 			err = store.List(ctx, tt.prefix, tt.rv, tt.pred, out)

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -183,6 +183,12 @@ type Interface interface {
 	// be have at least 'resourceVersion'.
 	List(ctx context.Context, key string, resourceVersion string, p SelectionPredicate, listObj runtime.Object) error
 
+	// ListAll unmarshalls jsons found by key prefix and opaque them
+	// into *List api object (an object that satisfies runtime.IsList definition).
+	// The returned contents may be delayed, but it is guaranteed that they will
+	// be have at least 'resourceVersion'.
+	ListAll(ctx context.Context, keyPrefix string, resourceVersion string, p SelectionPredicate, listObj runtime.Object) error
+
 	// GuaranteedUpdate keeps calling 'tryUpdate()' to update key 'key' (of type 'ptrToType')
 	// retrying the update until success if there is index conflict.
 	// Note that object passed to tryUpdate may change across invocations of tryUpdate() if

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
@@ -351,6 +351,14 @@ type injectListError struct {
 	storage.Interface
 }
 
+func (self *injectListError) ListAll(ctx context.Context, keyPrefix string, resourceVersion string, p storage.SelectionPredicate, listObj runtime.Object) error {
+	if self.errors > 0 {
+		self.errors--
+		return fmt.Errorf("injected error")
+	}
+	return self.Interface.ListAll(ctx, keyPrefix, resourceVersion, p, listObj)
+}
+
 func (self *injectListError) List(ctx context.Context, key string, resourceVersion string, p storage.SelectionPredicate, listObj runtime.Object) error {
 	if self.errors > 0 {
 		self.errors--


### PR DESCRIPTION
If involvedObject.name specified during event List operation,
add involvedObject.name to etcd key to fetch only events, related to involved object.

**What type of PR is this?**

/kind bug
/sig apimachinery


**What this PR does / why we need it**:
In clusters with lot of events in the namespace, event listing to one pod (e/g/ during describe pod) tooks a long time due to apiserver fetches _all_ events in specified namespace, unmarshall it and then filter it by selector. Due to etcd key schema of event  (`/registry/events/NAMESPACE/POD_NAME.EVENT_ID`), it seems reasonable fetch events related only to involved object by prefix: `/registry/events/NAMESPACE/POD_NAME`, that significantly decreaces amount of keys fetched from etcd.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
List objects from etcd was optimized
```
