### PR TITLE
Add the http2 GOAWAY error to IsProbableEOF for ignoring in watch

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -68,14 +68,17 @@ func IsProbableEOF(err error) bool {
 	if uerr, ok := err.(*url.Error); ok {
 		err = uerr.Err
 	}
+	msg := err.Error()
 	switch {
 	case err == io.EOF:
 		return true
-	case err.Error() == "http: can't write HTTP request on broken connection":
+	case msg == "http: can't write HTTP request on broken connection":
 		return true
-	case strings.Contains(err.Error(), "connection reset by peer"):
+	case strings.Contains(msg, "http2: server sent GOAWAY and closed the connection"):
 		return true
-	case strings.Contains(strings.ToLower(err.Error()), "use of closed network connection"):
+	case strings.Contains(msg, "connection reset by peer"):
+		return true
+	case strings.Contains(strings.ToLower(msg), "use of closed network connection"):
 		return true
 	}
 	return false


### PR DESCRIPTION
http2 is allowed to tell us to go away, and for watch it is safe to exit and restart in almost all cases where a connection is forcibly closed by the upstream. This error message happens a lot behind ELB and other http2 aware proxies.

Treat the error as "basically done" as suggested by: https://github.com/golang/go/issues/18639#issuecomment-285515534

Otherwise, we log at V(0) which shows up in command line tools, scripting, etc and is totally not actionable.

For instance, in a CLI tool using watch.Until against an apiserver behind AWS ELB:

```
level=info msg="Waiting up to 30m0s for the bootstrap-complete event..."
E0124 06:00:48.845920      29 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=3, ErrCode=NO_ERROR, debug=""
```

/kind bug

```release-note
When a watch is closed by an HTTP2 load balancer and we are told to go away, skip printing the message to stderr by default.
```