### PR TITLE
Automated cherry pick of #73239: Add back --cert-dir option for init phase certs sa

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/certs.go
@@ -111,10 +111,11 @@ func newCertSubPhases() []workflow.Phase {
 
 	// SA creates the private/public key pair, which doesn't use x509 at all
 	saPhase := workflow.Phase{
-		Name:  "sa",
-		Short: "Generates a private key for signing service account tokens along with its public key",
-		Long:  saKeyLongDesc,
-		Run:   runCertsSa,
+		Name:         "sa",
+		Short:        "Generates a private key for signing service account tokens along with its public key",
+		Long:         saKeyLongDesc,
+		Run:          runCertsSa,
+		InheritFlags: []string{options.CertificatesDir},
 	}
 
 	subPhases = append(subPhases, saPhase)


### PR DESCRIPTION
Cherry pick of #73239 on release-1.13.

#73239: Add back --cert-dir option for init phase certs sa