### PR TITLE
windows/service: implement graceful shutdown when run as windows service

### DIFF
--- a/pkg/windows/service/BUILD
+++ b/pkg/windows/service/BUILD
@@ -11,6 +11,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/windows/service",
     deps = select({
         "@io_bazel_rules_go//go/platform:windows": [
+            "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
             "//vendor/golang.org/x/sys/windows:go_default_library",
             "//vendor/golang.org/x/sys/windows/svc:go_default_library",
             "//vendor/k8s.io/klog:go_default_library",

--- a/pkg/windows/service/service.go
+++ b/pkg/windows/service/service.go
@@ -19,6 +19,9 @@ limitations under the License.
 package service
 
 import (
+	"os"
+	"time"
+
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/klog"
 
@@ -85,12 +88,24 @@ Loop:
 				// If we do not do this, our main threads won't be notified of the upcoming shutdown.
 				// Since Windows services do not use any console, we cannot simply generate a CTRL_BREAK_EVENT
 				// but need a dedicated notification mechanism.
-				server.RequestShutdown()
+				graceful := server.RequestShutdown()
 
 				// Free up the control handler and let us terminate as gracefully as possible.
 				// If that takes too long, the service controller will kill the remaining threads.
 				// As per https://docs.microsoft.com/en-us/windows/desktop/services/service-control-handler-function
 				s <- svc.Status{State: svc.StopPending}
+
+				// If we cannot exit gracefully, we really only can exit our process, so atleast the
+				// service manager will think that we gracefully exited. At the time of writing this comment this is
+				// needed for applications that do not use signals (e.g. kube-proxy)
+				if !graceful {
+					go func() {
+						// Ensure the SCM was notified (The operation above (send to s) was received and communicated to the
+						// service control manager - so it doesn't look like the service crashes)
+						time.Sleep(1 * time.Second)
+						os.Exit(0)
+					}()
+				}
 				break Loop
 			}
 		}

--- a/pkg/windows/service/service.go
+++ b/pkg/windows/service/service.go
@@ -19,8 +19,7 @@ limitations under the License.
 package service
 
 import (
-	"os"
-
+	"k8s.io/apiserver/pkg/server"
 	"k8s.io/klog"
 
 	"golang.org/x/sys/windows"
@@ -80,9 +79,19 @@ Loop:
 			case svc.Interrogate:
 				s <- c.CurrentStatus
 			case svc.Stop, svc.Shutdown:
-				s <- svc.Status{State: svc.Stopped}
-				// TODO: Stop the kubelet gracefully instead of killing the process
-				os.Exit(0)
+				klog.Infof("Service stopping")
+				// We need to translate this request into a signal that can be handled by the the signal handler
+				// handling shutdowns normally (currently apiserver/pkg/server/signal.go).
+				// If we do not do this, our main threads won't be notified of the upcoming shutdown.
+				// Since Windows services do not use any console, we cannot simply generate a CTRL_BREAK_EVENT
+				// but need a dedicated notification mechanism.
+				server.RequestShutdown()
+
+				// Free up the control handler and let us terminate as gracefully as possible.
+				// If that takes too long, the service controller will kill the remaining threads.
+				// As per https://docs.microsoft.com/en-us/windows/desktop/services/service-control-handler-function
+				s <- svc.Status{State: svc.StopPending}
+				break Loop
 			}
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/signal.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/signal.go
@@ -22,13 +22,15 @@ import (
 )
 
 var onlyOneSignalHandler = make(chan struct{})
-var shutdownHandler = make(chan os.Signal, 2)
+var shutdownHandler chan os.Signal
 
 // SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
 // which is closed on one of these signals. If a second signal is caught, the program
 // is terminated with exit code 1.
 func SetupSignalHandler() <-chan struct{} {
 	close(onlyOneSignalHandler) // panics when called twice
+
+	shutdownHandler = make(chan os.Signal, 2)
 
 	stop := make(chan struct{})
 	signal.Notify(shutdownHandler, shutdownSignals...)
@@ -43,9 +45,15 @@ func SetupSignalHandler() <-chan struct{} {
 }
 
 // RequestShutdown emulates a received event that is considered as shutdown signal (SIGTERM/SIGINT)
-func RequestShutdown() {
-	select {
-	case shutdownHandler <- shutdownSignals[0]:
-	default:
+// This returns whether a handler was notified
+func RequestShutdown() bool {
+	if shutdownHandler != nil {
+		select {
+		case shutdownHandler <- shutdownSignals[0]:
+			return true
+		default:
+		}
 	}
+
+	return false
 }


### PR DESCRIPTION
The issue here originally is that os.Exit() is called which exits
the process too early (before svc.Execute updates the status to stopped).
This is picked up as service error and leads to restarting,
if restart-on-fail is configured for the windows service.
svc.Execute already guarantees that the application is exited after,
so that os.Exit call would be unnecessary.

This rework also adds graceful shutdown, which also resolves the
underlying root cause. The graceful shutdown is not guaranteed
to succeed, since the service controller can decide to kill
the service any time after exceeding a shutdown timeout.

/sig windows
/kind bug

```release-note
windows: Ensure graceful termination when being run as windows service
```

Fixes #72900