### PR TITLE
Update PV/PVC assume cache before moving pods to active queue

### DIFF
--- a/pkg/controller/volume/persistentvolume/scheduler_assume_cache_test.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_assume_cache_test.go
@@ -107,7 +107,7 @@ func TestAssumePV(t *testing.T) {
 	}
 
 	for name, scenario := range scenarios {
-		cache := NewPVAssumeCache(nil)
+		cache := NewPVAssumeCache()
 		internal_cache, ok := cache.(*pvAssumeCache)
 		if !ok {
 			t.Fatalf("Failed to get internal cache")
@@ -141,7 +141,7 @@ func TestAssumePV(t *testing.T) {
 }
 
 func TestRestorePV(t *testing.T) {
-	cache := NewPVAssumeCache(nil)
+	cache := NewPVAssumeCache()
 	internal_cache, ok := cache.(*pvAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
@@ -181,7 +181,7 @@ func TestRestorePV(t *testing.T) {
 }
 
 func TestBasicPVCache(t *testing.T) {
-	cache := NewPVAssumeCache(nil)
+	cache := NewPVAssumeCache()
 	internal_cache, ok := cache.(*pvAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
@@ -225,7 +225,7 @@ func TestBasicPVCache(t *testing.T) {
 }
 
 func TestPVCacheWithStorageClasses(t *testing.T) {
-	cache := NewPVAssumeCache(nil)
+	cache := NewPVAssumeCache()
 	internal_cache, ok := cache.(*pvAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
@@ -271,7 +271,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 }
 
 func TestAssumeUpdatePVCache(t *testing.T) {
-	cache := NewPVAssumeCache(nil)
+	cache := NewPVAssumeCache()
 	internal_cache, ok := cache.(*pvAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
@@ -364,7 +364,7 @@ func TestAssumePVC(t *testing.T) {
 	}
 
 	for name, scenario := range scenarios {
-		cache := NewPVCAssumeCache(nil)
+		cache := NewPVCAssumeCache()
 		internal_cache, ok := cache.(*pvcAssumeCache)
 		if !ok {
 			t.Fatalf("Failed to get internal cache")
@@ -398,7 +398,7 @@ func TestAssumePVC(t *testing.T) {
 }
 
 func TestRestorePVC(t *testing.T) {
-	cache := NewPVCAssumeCache(nil)
+	cache := NewPVCAssumeCache()
 	internal_cache, ok := cache.(*pvcAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
@@ -438,7 +438,7 @@ func TestRestorePVC(t *testing.T) {
 }
 
 func TestAssumeUpdatePVCCache(t *testing.T) {
-	cache := NewPVCAssumeCache(nil)
+	cache := NewPVCAssumeCache()
 	internal_cache, ok := cache.(*pvcAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")

--- a/pkg/controller/volume/persistentvolume/scheduler_binder.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder.go
@@ -115,8 +115,8 @@ type volumeBinder struct {
 func NewVolumeBinder(
 	kubeClient clientset.Interface,
 	nodeInformer coreinformers.NodeInformer,
-	pvcInformer coreinformers.PersistentVolumeClaimInformer,
-	pvInformer coreinformers.PersistentVolumeInformer,
+	pvcCache PVCAssumeCache,
+	pvCache PVAssumeCache,
 	storageClassInformer storageinformers.StorageClassInformer,
 	bindTimeout time.Duration) SchedulerVolumeBinder {
 
@@ -129,8 +129,8 @@ func NewVolumeBinder(
 	b := &volumeBinder{
 		ctrl:            ctrl,
 		nodeInformer:    nodeInformer,
-		pvcCache:        NewPVCAssumeCache(pvcInformer.Informer()),
-		pvCache:         NewPVAssumeCache(pvInformer.Informer()),
+		pvcCache:        pvcCache,
+		pvCache:         pvCache,
 		podBindingCache: NewPodBindingCache(),
 		bindTimeout:     bindTimeout,
 	}

--- a/pkg/scheduler/volumebinder/volume_binder.go
+++ b/pkg/scheduler/volumebinder/volume_binder.go
@@ -28,20 +28,24 @@ import (
 
 // VolumeBinder sets up the volume binding library
 type VolumeBinder struct {
-	Binder persistentvolume.SchedulerVolumeBinder
+	Binder         persistentvolume.SchedulerVolumeBinder
+	PVCAssumeCache persistentvolume.PVCAssumeCache
+	PVAssumeCache  persistentvolume.PVAssumeCache
 }
 
 // NewVolumeBinder sets up the volume binding library and binding queue
 func NewVolumeBinder(
 	client clientset.Interface,
 	nodeInformer coreinformers.NodeInformer,
-	pvcInformer coreinformers.PersistentVolumeClaimInformer,
-	pvInformer coreinformers.PersistentVolumeInformer,
 	storageClassInformer storageinformers.StorageClassInformer,
 	bindTimeout time.Duration) *VolumeBinder {
 
+	pvcCache := persistentvolume.NewPVCAssumeCache()
+	pvCache := persistentvolume.NewPVAssumeCache()
 	return &VolumeBinder{
-		Binder: persistentvolume.NewVolumeBinder(client, nodeInformer, pvcInformer, pvInformer, storageClassInformer, bindTimeout),
+		Binder:         persistentvolume.NewVolumeBinder(client, nodeInformer, pvcCache, pvCache, storageClassInformer, bindTimeout),
+		PVCAssumeCache: pvcCache,
+		PVAssumeCache:  pvCache,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Volume scheduler cache registers a handler that gets invoked in the scheduler factory's event handler, instead of registering as a separate informer handler.

There is no guarantee in which order different event handlers will be
called. If we use different event handlers, it's possible that PV/PVC
assume cache is updated after pods are moved to active queue and
scheduler may use stale cache in scheduling.

Example race case:

1. pod go through volume scheduling, fail because of PVCs not bound, pod will be marked unscheduable
2. PVC/PV are bound
3. scheduler factory informer handler is run, pod will be moved to active queue
4. scheduler main thread runs this pod immediately and will use stale PV/PVC cache
  - this pod will be marked unscheduable again
  - if no new events to move it to active queue, this pod will be stuck forever
5. volume binder informer handler is run, PVC/PV cache is updated

3) and 5) are run in different event handlers and there is guarantee in which order they are run, if 3) happens before 5) pods scheduled between them will use stale cache.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
fixes #73216

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update volume scheduling cache in scheduler factory event handler instead of in a separate event handler to avoid scheduling race.
```
