### PR TITLE
Added resource name to timeout error output on WAIT cmd

### DIFF
--- a/pkg/kubectl/cmd/wait/BUILD
+++ b/pkg/kubectl/cmd/wait/BUILD
@@ -51,7 +51,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions/printers:go_default_library",

--- a/pkg/kubectl/cmd/wait/wait.go
+++ b/pkg/kubectl/cmd/wait/wait.go
@@ -292,9 +292,10 @@ func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error
 		}
 
 		timeout := endTime.Sub(time.Now())
+		errWaitTimeoutWithName := extendErrWaitTimeout(wait.ErrWaitTimeout, info)
 		if timeout < 0 {
 			// we're out of time
-			return gottenObj, false, wait.ErrWaitTimeout
+			return gottenObj, false, errWaitTimeoutWithName
 		}
 
 		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), o.Timeout)
@@ -307,9 +308,9 @@ func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error
 			continue
 		case err == wait.ErrWaitTimeout:
 			if watchEvent != nil {
-				return watchEvent.Object, false, wait.ErrWaitTimeout
+				return watchEvent.Object, false, errWaitTimeoutWithName
 			}
-			return gottenObj, false, wait.ErrWaitTimeout
+			return gottenObj, false, errWaitTimeoutWithName
 		default:
 			return gottenObj, false, err
 		}
@@ -386,9 +387,10 @@ func (w ConditionalWait) IsConditionMet(info *resource.Info, o *WaitOptions) (ru
 		}
 
 		timeout := endTime.Sub(time.Now())
+		errWaitTimeoutWithName := extendErrWaitTimeout(wait.ErrWaitTimeout, info)
 		if timeout < 0 {
 			// we're out of time
-			return gottenObj, false, wait.ErrWaitTimeout
+			return gottenObj, false, errWaitTimeoutWithName
 		}
 
 		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), o.Timeout)
@@ -401,9 +403,9 @@ func (w ConditionalWait) IsConditionMet(info *resource.Info, o *WaitOptions) (ru
 			continue
 		case err == wait.ErrWaitTimeout:
 			if watchEvent != nil {
-				return watchEvent.Object, false, wait.ErrWaitTimeout
+				return watchEvent.Object, false, errWaitTimeoutWithName
 			}
-			return gottenObj, false, wait.ErrWaitTimeout
+			return gottenObj, false, errWaitTimeoutWithName
 		default:
 			return gottenObj, false, err
 		}
@@ -448,4 +450,8 @@ func (w ConditionalWait) isConditionMet(event watch.Event) (bool, error) {
 	}
 	obj := event.Object.(*unstructured.Unstructured)
 	return w.checkCondition(obj)
+}
+
+func extendErrWaitTimeout(err error, info *resource.Info) error {
+	return fmt.Errorf("%s on %s/%s", err.Error(), info.Mapping.Resource.Resource, info.Name)
 }

--- a/pkg/kubectl/cmd/wait/wait_test.go
+++ b/pkg/kubectl/cmd/wait/wait_test.go
@@ -18,11 +18,9 @@ package wait
 
 import (
 	"io/ioutil"
-	"testing"
-
-	"time"
-
 	"strings"
+	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 
@@ -32,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
@@ -203,7 +200,7 @@ func TestWaitForDeletion(t *testing.T) {
 			},
 			timeout: 1 * time.Second,
 
-			expectedErr: wait.ErrWaitTimeout.Error(),
+			expectedErr: "timed out waiting for the condition on theresource/name-foo",
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
 				if len(actions) != 2 {
 					t.Fatal(spew.Sdump(actions))
@@ -254,7 +251,7 @@ func TestWaitForDeletion(t *testing.T) {
 			},
 			timeout: 3 * time.Second,
 
-			expectedErr: wait.ErrWaitTimeout.Error(),
+			expectedErr: "timed out waiting for the condition on theresource/name-foo",
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
 				if len(actions) != 4 {
 					t.Fatal(spew.Sdump(actions))
@@ -502,7 +499,7 @@ func TestWaitForCondition(t *testing.T) {
 			},
 			timeout: 1 * time.Second,
 
-			expectedErr: wait.ErrWaitTimeout.Error(),
+			expectedErr: "timed out waiting for the condition on theresource/name-foo",
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
 				if len(actions) != 2 {
 					t.Fatal(spew.Sdump(actions))
@@ -553,7 +550,7 @@ func TestWaitForCondition(t *testing.T) {
 			},
 			timeout: 3 * time.Second,
 
-			expectedErr: wait.ErrWaitTimeout.Error(),
+			expectedErr: "timed out waiting for the condition on theresource/name-foo",
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
 				if len(actions) != 4 {
 					t.Fatal(spew.Sdump(actions))


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adedd resource name for `wait` command output on timeout error, to make error message more explicit.
Before:
`timed out waiting for condition`
With this PR:
`timed out waiting for condition on resource_name`

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/73205

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```
The timeout error message on wait command will contain resource name on which condition wasn't met.

```
