### PR TITLE
Add check-file-in-alphabetical-order for cleanup

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -781,6 +781,23 @@ function kube::util::ensure-gnu-sed {
   fi
 }
 
+# kube::util::check-file-in-alphabetical-order <file>
+# Check that the file is in alphabetical order
+#
+function kube::util::check-file-in-alphabetical-order {
+  local failure_file="$1"
+  if ! diff -u "${failure_file}" <(LC_ALL=C sort "${failure_file}"); then
+    {
+      echo
+      echo "${failure_file} is not in alphabetical order. Please sort it:"
+      echo
+      echo "  LC_ALL=C sort -o ${failure_file} ${failure_file}"
+      echo
+    } >&2
+    false
+  fi
+}
+
 # Some useful colors.
 if [[ -z "${color_start-}" ]]; then
   declare -r color_start="\033["

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -20,6 +20,7 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
+source "${KUBE_ROOT}/hack/lib/util.sh"
 
 kube::golang::verify_go_version
 
@@ -49,16 +50,7 @@ array_contains () {
 
 # Check that the file is in alphabetical order
 failure_file="${KUBE_ROOT}/hack/.golint_failures"
-if ! diff -u "${failure_file}" <(LC_ALL=C sort "${failure_file}"); then
-  {
-    echo
-    echo "hack/.golint_failures is not in alphabetical order. Please sort it:"
-    echo
-    echo "  LC_ALL=C sort -o hack/.golint_failures hack/.golint_failures"
-    echo
-  } >&2
-  false
-fi
+kube::util::check-file-in-alphabetical-order "${failure_file}"
 
 export IFS=$'\n'
 # NOTE: when "go list -e ./..." is run within GOPATH, it turns the k8s.io/kubernetes

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -20,6 +20,7 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
+source "${KUBE_ROOT}/hack/lib/util.sh"
 
 # required version for this script, if not installed on the host we will
 # use the official docker image instead. keep this in sync with SHELLCHECK_IMAGE
@@ -79,16 +80,7 @@ done < <(find . -name "*.sh" \
 
 # make sure known failures are sorted
 failure_file="${KUBE_ROOT}/hack/.shellcheck_failures"
-if ! diff -u "${failure_file}" <(LC_ALL=C sort "${failure_file}"); then
-  {
-    echo
-    echo "hack/.shellcheck_failures is not in alphabetical order. Please sort it:"
-    echo
-    echo "  LC_ALL=C sort -o hack/.shellcheck_failures hack/.shellcheck_failures"
-    echo
-  } >&2
-  false
-fi
+kube::util::check-file-in-alphabetical-order "${failure_file}"
 
 # load known failure files
 failing_files=()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Both verify-golint.sh and verify-shellcheck.sh have the same logic
which checks failure_file in alphabetical order.
In addition, we'd like to add another script which requires the
same logic. So this add a common function for cleanup.

**Does this PR introduce a user-facing change?**:
``````
