### PR TITLE
Always include `=` in v1.Taint string representation

### DIFF
--- a/pkg/apis/core/taint.go
+++ b/pkg/apis/core/taint.go
@@ -27,10 +27,8 @@ func (t *Taint) MatchTaint(taintToMatch Taint) bool {
 	return t.Key == taintToMatch.Key && t.Effect == taintToMatch.Effect
 }
 
-// taint.ToString() converts taint struct to string in format key=value:effect or key:effect.
+// taint.ToString() converts taint struct to string in format key=value:effect.
+// The value is optional and may be an empty string.
 func (t *Taint) ToString() string {
-	if len(t.Value) == 0 {
-		return fmt.Sprintf("%v:%v", t.Key, t.Effect)
-	}
 	return fmt.Sprintf("%v=%v:%v", t.Key, t.Value, t.Effect)
 }

--- a/pkg/apis/core/taint_test.go
+++ b/pkg/apis/core/taint_test.go
@@ -36,7 +36,7 @@ func TestTaintToString(t *testing.T) {
 				Key:    "foo",
 				Effect: TaintEffectNoSchedule,
 			},
-			expectedString: "foo:NoSchedule",
+			expectedString: "foo=:NoSchedule",
 		},
 	}
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Ensure that the string representation of a v1.Taint includes the `=` character.

**Which issue(s) this PR fixes**:
Fixes #73249 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```