### PR TITLE
cpuPeriod was not reset

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers_linux.go
+++ b/pkg/kubelet/kuberuntime/helpers_linux.go
@@ -18,11 +18,6 @@ limitations under the License.
 
 package kuberuntime
 
-import (
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	kubefeatures "k8s.io/kubernetes/pkg/features"
-)
-
 const (
 	// Taken from lmctfy https://github.com/google/lmctfy/blob/master/lmctfy/controllers/cpu_controller.cc
 	minShares     = 2
@@ -58,9 +53,6 @@ func milliCPUToQuota(milliCPU int64, period int64) (quota int64) {
 	// see https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt for details
 	if milliCPU == 0 {
 		return
-	}
-	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.CPUCFSQuotaPeriod) {
-		period = quotaPeriod
 	}
 
 	// we then convert your milliCPU to a value normalized over a period

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"k8s.io/api/core/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	kubefeatures "k8s.io/kubernetes/pkg/features"
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 )
@@ -67,7 +69,10 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerConfig(container *v1.C
 	if m.cpuCFSQuota {
 		// if cpuLimit.Amount is nil, then the appropriate default value is returned
 		// to allow full usage of cpu resource.
-		cpuPeriod := int64(m.cpuCFSQuotaPeriod.Duration / time.Microsecond)
+		cpuPeriod := int64(quotaPeriod)
+		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.CPUCFSQuotaPeriod) {
+			cpuPeriod = int64(m.cpuCFSQuotaPeriod.Duration / time.Microsecond)
+		}
 		cpuQuota := milliCPUToQuota(cpuLimit.MilliValue(), cpuPeriod)
 		lc.Resources.CpuQuota = cpuQuota
 		lc.Resources.CpuPeriod = cpuPeriod


### PR DESCRIPTION
```release-note
fix #73264 cpuPeriod was not reset, but used as set via flag, although it was disabled via alpha gate
```

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>
