### PR TITLE
Use read lock for scheduler_binder_cache GetDecisions

### DIFF
--- a/pkg/controller/volume/persistentvolume/scheduler_binder_cache.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder_cache.go
@@ -74,8 +74,8 @@ func NewPodBindingCache() PodBindingCache {
 }
 
 func (c *podBindingCache) GetDecisions(pod *v1.Pod) nodeDecisions {
-	c.rwMutex.Lock()
-	defer c.rwMutex.Unlock()
+	c.rwMutex.RLock()
+	defer c.rwMutex.RUnlock()
 	podName := getPodName(pod)
 	decisions, ok := c.bindingDecisions[podName]
 	if !ok {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The GetDecisions func should use read lock.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

sig/apps