### PR TITLE
publishing: bump go version to 1.10.8 for release-1.12

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -25,7 +25,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/code-generator
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
   - source:
       branch: release-1.13
       dir: staging/src/k8s.io/code-generator
@@ -52,7 +52,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/apimachinery
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
   - source:
       branch: release-1.13
       dir: staging/src/k8s.io/apimachinery
@@ -88,7 +88,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/api
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: apimachinery
       branch: release-1.12
@@ -214,7 +214,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/apiserver
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: apimachinery
       branch: release-1.12
@@ -283,7 +283,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: apimachinery
       branch: release-1.12
@@ -368,7 +368,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: apimachinery
       branch: release-1.12
@@ -463,7 +463,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/sample-controller
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: apimachinery
       branch: release-1.12
@@ -561,7 +561,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: apimachinery
       branch: release-1.12
@@ -635,7 +635,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/metrics
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: apimachinery
       branch: release-1.12
@@ -675,7 +675,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/csi-api
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: apimachinery
       branch: release-1.12
@@ -717,7 +717,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: api
       branch: release-1.12
@@ -759,7 +759,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: api
       branch: release-1.12
@@ -799,7 +799,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: apimachinery
       branch: release-1.12
@@ -829,7 +829,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/kubelet
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: apimachinery
       branch: release-1.12
@@ -863,7 +863,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: apimachinery
       branch: release-1.12
@@ -897,7 +897,7 @@ rules:
       branch: release-1.12
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.12
-    go: 1.10.4
+    go: 1.10.8
     dependencies:
     - repository: apimachinery
       branch: release-1.12


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/73329

/kind cleanup

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
