### PR TITLE
test/e2e/framework: fix external/internal typo err in GetNodeInternalIP

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4916,7 +4916,7 @@ func GetNodeInternalIP(node *v1.Node) (string, error) {
 		}
 	}
 	if host == "" {
-		return "", fmt.Errorf("Couldn't get the external IP of host %s with addresses %v", node.Name, node.Status.Addresses)
+		return "", fmt.Errorf("Couldn't get the internal IP of host %s with addresses %v", node.Name, node.Status.Addresses)
 	}
 	return host, nil
 }


### PR DESCRIPTION
/kind cleanup

```release-note
NONE
```
