### PR TITLE
Shorten health check timeout for AWS NLB with externalTrafficPolicy: Local

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
@@ -550,6 +550,11 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
 		// Account for externalTrafficPolicy = "Local"
 		if mapping.HealthCheckPort != mapping.TrafficPort {
 			input.HealthCheckPort = aws.String(strconv.Itoa(int(mapping.HealthCheckPort)))
+			// Local traffic should have more aggressive health checking by default.
+			// Min allowed by NLB is 10 seconds, and 2 threshold count
+			input.HealthCheckIntervalSeconds = aws.Int64(10)
+			input.HealthyThresholdCount = aws.Int64(2)
+			input.UnhealthyThresholdCount = aws.Int64(2)
 		}
 
 		result, err := c.elbv2.CreateTargetGroup(input)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Shorten AWS NLB health check time when externalTrafficPolicy is Local to minimum

**Which issue(s) this PR fixes**:
Fixes #73362

```release-note
Minimize AWS NLB health check timeout when externalTrafficPolicy set to Local
```
