### PR TITLE
Set ProviderID when running kubemark node

### DIFF
--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubemark
 
 import (
+	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,6 +122,7 @@ func GetHollowKubeletConfig(
 	f.MaxPerPodContainerCount = 2
 	f.RegisterNode = true
 	f.RegisterSchedulable = true
+	f.ProviderID = fmt.Sprintf("kubemark://%v", nodeName)
 
 	// Config struct
 	c, err := options.NewKubeletConfiguration()


### PR DESCRIPTION
Kubemark is very useful tool for exercising various solutions requiring to run
many nodes on a small set of physical nodes. E.g. for development and testing
of cluster autoscaler where some use cases might require tens or hundreds
of nodes to be scalled up and down. Using kubemark saves computation
resources.

As part of integration of cluster-api project into cluster-autoscaler project,
the autoscaler uses the ProviderID field to index nodes through informer.
Setting the ProviderID field even by Kubemark allows to autoscale cluster
made of hollow nodes.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As part of integration of cluster-api project into cluster-autoscaler project,
the autoscaler uses the ProviderID field to index nodes through informer.
Setting the ProviderID field even by Kubemark allows to autoscale cluster
made of hollow nodes.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
