### PR TITLE
Allow to specify external runtime health checkers

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -239,26 +239,27 @@ type Dependencies struct {
 	Options []Option
 
 	// Injected Dependencies
-	Auth                    server.AuthInterface
-	CAdvisorInterface       cadvisor.Interface
-	Cloud                   cloudprovider.Interface
-	ContainerManager        cm.ContainerManager
-	DockerClientConfig      *dockershim.ClientConfig
-	EventClient             v1core.EventsGetter
-	HeartbeatClient         clientset.Interface
-	OnHeartbeatFailure      func()
-	KubeClient              clientset.Interface
-	CSIClient               csiclientset.Interface
-	DynamicKubeClient       dynamic.Interface
-	Mounter                 mount.Interface
-	OOMAdjuster             *oom.OOMAdjuster
-	OSInterface             kubecontainer.OSInterface
-	PodConfig               *config.PodConfig
-	Recorder                record.EventRecorder
-	VolumePlugins           []volume.VolumePlugin
-	DynamicPluginProber     volume.DynamicPluginProber
-	TLSOptions              *server.TLSOptions
-	KubeletConfigController *kubeletconfig.Controller
+	Auth                         server.AuthInterface
+	CAdvisorInterface            cadvisor.Interface
+	Cloud                        cloudprovider.Interface
+	ContainerManager             cm.ContainerManager
+	DockerClientConfig           *dockershim.ClientConfig
+	EventClient                  v1core.EventsGetter
+	HeartbeatClient              clientset.Interface
+	OnHeartbeatFailure           func()
+	KubeClient                   clientset.Interface
+	CSIClient                    csiclientset.Interface
+	DynamicKubeClient            dynamic.Interface
+	Mounter                      mount.Interface
+	OOMAdjuster                  *oom.OOMAdjuster
+	OSInterface                  kubecontainer.OSInterface
+	PodConfig                    *config.PodConfig
+	Recorder                     record.EventRecorder
+	VolumePlugins                []volume.VolumePlugin
+	DynamicPluginProber          volume.DynamicPluginProber
+	TLSOptions                   *server.TLSOptions
+	KubeletConfigController      *kubeletconfig.Controller
+	ExternalRuntimeHealthChecker []RuntimeHealthChecker
 }
 
 // makePodSourceConfig creates a config.PodConfig from the given
@@ -719,6 +720,10 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.pleg = pleg.NewGenericPLEG(klet.containerRuntime, plegChannelCapacity, plegRelistPeriod, klet.podCache, clock.RealClock{})
 	klet.runtimeState = newRuntimeState(maxWaitForContainerRuntime)
 	klet.runtimeState.addHealthCheck("PLEG", klet.pleg.Healthy)
+	for _, checker := range kubeDeps.ExternalRuntimeHealthChecker {
+		klet.runtimeState.addHealthCheck(checker.Name(), checker.Healthy)
+	}
+
 	if _, err := klet.updatePodCIDR(kubeCfg.PodCIDR); err != nil {
 		klog.Errorf("Pod CIDR update failed %v", err)
 	}

--- a/pkg/kubelet/runtime.go
+++ b/pkg/kubelet/runtime.go
@@ -110,3 +110,12 @@ func newRuntimeState(
 		networkError:             ErrNetworkUnknown,
 	}
 }
+
+// RuntimeHealthChecker for any implementations capable of providing
+// kubelet runtime check.
+type RuntimeHealthChecker interface {
+	// Name for health checker name
+	Name() string
+	// Healthy checks if specific part of runtime is healthy
+	Healthy() (bool, error)
+}


### PR DESCRIPTION
The main purpose of Kubemark is to allow register more virtual nodes than there is physical ones. Yet, presenting all the virtuals nodes as real ones by running kubelet with fake container runtime.

Though, the real nodes can manifest in many ways (e.g. nodes going into Unready status, nodes reporting disk pressure) that Kubemark can not currently simulate. Providing a way to configure hollow node to e.g. go Unready would help to improve ability to cover more testing scenarios.

In case of cluster-api nodes are backed up by machine objects. One of the goals of the cluster-api project is to improve self-healing ability of a cluster. Allowing a node to conditionally go unready allows to test a case of self-healing machine which is not easy to reproduce in a cluster with only real nodes.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

> /kind feature

**What this PR does / why we need it**:

This PR gives kubelet the ability to inject external runtime health checker.
In case of Kubemark ability to inject runtime disruptor that allows
Kubelet runtime to conditionally report error causing a node to report
unreadiness.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
