### PR TITLE
WIP: Allow kubemark to conditionally disrupt kubelet runtime

### DIFF
--- a/cmd/kubemark/BUILD
+++ b/cmd/kubemark/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//pkg/version/prometheus:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -239,26 +239,27 @@ type Dependencies struct {
 	Options []Option
 
 	// Injected Dependencies
-	Auth                    server.AuthInterface
-	CAdvisorInterface       cadvisor.Interface
-	Cloud                   cloudprovider.Interface
-	ContainerManager        cm.ContainerManager
-	DockerClientConfig      *dockershim.ClientConfig
-	EventClient             v1core.EventsGetter
-	HeartbeatClient         clientset.Interface
-	OnHeartbeatFailure      func()
-	KubeClient              clientset.Interface
-	CSIClient               csiclientset.Interface
-	DynamicKubeClient       dynamic.Interface
-	Mounter                 mount.Interface
-	OOMAdjuster             *oom.OOMAdjuster
-	OSInterface             kubecontainer.OSInterface
-	PodConfig               *config.PodConfig
-	Recorder                record.EventRecorder
-	VolumePlugins           []volume.VolumePlugin
-	DynamicPluginProber     volume.DynamicPluginProber
-	TLSOptions              *server.TLSOptions
-	KubeletConfigController *kubeletconfig.Controller
+	Auth                         server.AuthInterface
+	CAdvisorInterface            cadvisor.Interface
+	Cloud                        cloudprovider.Interface
+	ContainerManager             cm.ContainerManager
+	DockerClientConfig           *dockershim.ClientConfig
+	EventClient                  v1core.EventsGetter
+	HeartbeatClient              clientset.Interface
+	OnHeartbeatFailure           func()
+	KubeClient                   clientset.Interface
+	CSIClient                    csiclientset.Interface
+	DynamicKubeClient            dynamic.Interface
+	Mounter                      mount.Interface
+	OOMAdjuster                  *oom.OOMAdjuster
+	OSInterface                  kubecontainer.OSInterface
+	PodConfig                    *config.PodConfig
+	Recorder                     record.EventRecorder
+	VolumePlugins                []volume.VolumePlugin
+	DynamicPluginProber          volume.DynamicPluginProber
+	TLSOptions                   *server.TLSOptions
+	KubeletConfigController      *kubeletconfig.Controller
+	ExternalRuntimeHealthChecker []RuntimeHealthChecker
 }
 
 // makePodSourceConfig creates a config.PodConfig from the given
@@ -719,6 +720,10 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.pleg = pleg.NewGenericPLEG(klet.containerRuntime, plegChannelCapacity, plegRelistPeriod, klet.podCache, clock.RealClock{})
 	klet.runtimeState = newRuntimeState(maxWaitForContainerRuntime)
 	klet.runtimeState.addHealthCheck("PLEG", klet.pleg.Healthy)
+	for _, checker := range kubeDeps.ExternalRuntimeHealthChecker {
+		klet.runtimeState.addHealthCheck(checker.Name(), checker.Healthy)
+	}
+
 	if _, err := klet.updatePodCIDR(kubeCfg.PodCIDR); err != nil {
 		klog.Errorf("Pod CIDR update failed %v", err)
 	}

--- a/pkg/kubelet/runtime.go
+++ b/pkg/kubelet/runtime.go
@@ -110,3 +110,12 @@ func newRuntimeState(
 		networkError:             ErrNetworkUnknown,
 	}
 }
+
+// RuntimeHealthChecker for any implementations capable of providing
+// kubelet runtime check.
+type RuntimeHealthChecker interface {
+	// Name for health checker name
+	Name() string
+	// Healthy checks if specific part of runtime is healthy
+	Healthy() (bool, error)
+}

--- a/pkg/kubemark/BUILD
+++ b/pkg/kubemark/BUILD
@@ -9,6 +9,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "controller.go",
+        "disruptor.go",
         "hollow_kubelet.go",
         "hollow_proxy.go",
     ],
@@ -17,6 +18,7 @@ go_library(
         "//cmd/kube-proxy/app:go_default_library",
         "//cmd/kubelet/app:go_default_library",
         "//cmd/kubelet/app/options:go_default_library",
+        "//pkg/apis/core:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/kubelet:go_default_library",
         "//pkg/kubelet/apis/config:go_default_library",

--- a/pkg/kubemark/disruptor.go
+++ b/pkg/kubemark/disruptor.go
@@ -1,0 +1,92 @@
+package kubemark
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/kubernetes/pkg/kubelet"
+)
+
+// RuntimeDisrupter allows to report unhealthy state based on the following criteria:
+// - periodically switching from Healthy to not Healthy and back (e.g. to simulate a case
+//   where Node object switches its Ready condition into false for a period of time to
+//   exercise infrastructure activity)
+// - switch node Ready condition to false permanently (e.g. to exercise if node controller
+//   properly removes and possible drains node before deletion)
+type RuntimeDisrupter struct {
+	// TurnUnhealthyAfter starts reporting unhealthy after specified period of time
+	TurnUnhealthyAfter        bool
+	TurnUnhealthyPeriodically bool
+	UnhealthyDuration         metav1.Duration
+	HealthyDuration           metav1.Duration
+
+	healthy    bool
+	healthyErr error
+	healthyMux sync.Mutex
+	stop       bool
+}
+
+// Name for health checker name
+func (rd *RuntimeDisrupter) Name() string {
+	return "RuntimeDisrupter"
+}
+
+// Start starts the runtime disruptor
+func (rd *RuntimeDisrupter) Start() {
+	rd.healthyMux.Lock()
+	rd.healthy = true
+	rd.stop = false
+	rd.healthyMux.Unlock()
+
+	if rd.TurnUnhealthyAfter {
+		// Wait for TurnUnhealthyAfter time, then switch to unhealthy
+		go func() {
+			time.Sleep(rd.HealthyDuration.Duration)
+			rd.healthyMux.Lock()
+			defer rd.healthyMux.Unlock()
+			rd.healthy = false
+			rd.healthyErr = fmt.Errorf("reporting unhealty indefinitely on request (%v after start up)", rd.HealthyDuration.Duration)
+		}()
+	}
+	if rd.TurnUnhealthyPeriodically {
+		go func() {
+			for {
+				time.Sleep(rd.HealthyDuration.Duration)
+				rd.healthyMux.Lock()
+				rd.healthy = false
+				rd.healthyErr = fmt.Errorf("reporting unhealty periodically on request (every %v)", rd.UnhealthyDuration.Duration)
+				if rd.stop {
+					return
+				}
+				rd.healthyMux.Unlock()
+
+				time.Sleep(rd.UnhealthyDuration.Duration)
+				rd.healthyMux.Lock()
+				rd.healthy = true
+				if rd.stop {
+					return
+				}
+				rd.healthyMux.Unlock()
+			}
+		}()
+	}
+}
+
+// Stop stops the runtime disruptor
+func (rd *RuntimeDisrupter) Stop() {
+	rd.healthyMux.Lock()
+	defer rd.healthyMux.Unlock()
+	rd.stop = true
+}
+
+// Healthy checks if specific part of runtime is healthy
+func (rd *RuntimeDisrupter) Healthy() (bool, error) {
+	rd.healthyMux.Lock()
+	defer rd.healthyMux.Unlock()
+	return rd.healthy, rd.healthyErr
+}
+
+var _ kubelet.RuntimeHealthChecker = &RuntimeDisrupter{}

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubemark
 
 import (
+	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,6 +122,7 @@ func GetHollowKubeletConfig(
 	f.MaxPerPodContainerCount = 2
 	f.RegisterNode = true
 	f.RegisterSchedulable = true
+	f.ProviderID = fmt.Sprintf("kubemark://%v", nodeName)
 
 	// Config struct
 	c, err := options.NewKubeletConfiguration()


### PR DESCRIPTION
The main purpose of Kubemark is to allow register more virtual nodes than there is physical ones. Yet, presenting all the virtuals nodes as real ones by running kubelet with fake container runtime.
    
Though, the real nodes can manifest in many ways (e.g. nodes going into Unready status, nodes reporting disk pressure) that Kubemark can not currently simulate. Providing a way to configure hollow node to e.g. go Unready would help to improve ability to cover more testing scenarios.
    
In case of cluster-api nodes are backed up by machine objects. One of the goals of the cluster-api project is to improve self-healing ability of a cluster, Allowing a node to conditionally go unready allows
to test a case of self-healing machine which is not easy to reproduce in a cluster with only real nodes.

Depends on:
- https://github.com/kubernetes/kubernetes/pull/73393
- https://github.com/kubernetes/kubernetes/pull/73398

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind feature

**What this PR does / why we need it**:

This PR gives kubemark the ability to:
- configure kubelet to force node status to report unreadiness (either indefinitely or periodically)
- set node taint to NoSchedule
- change node status update frequency
    
Examples:
- Start reporting Node status Unready after 40s from the kubelet startup:
  ```$ ./kubemark ... --turn-unhealthy-after=true --healthy-duration=40s```
- Switch node status to Unready after 40s in Ready status to Unready for 5s and back to Ready periodically
  ```$ ./kubemark ... --turn-unhealthy-periodically=true --unhealthy-duration=5s --healthy-duration=40s```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
