### PR TITLE
Fixes authz compatibility w/ nil authorizer in apiserver

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -575,9 +575,18 @@ func (s *SecureServingInfo) HostPort() (string, int, error) {
 }
 
 // AuthorizeClientBearerToken wraps the authenticator and authorizer in loopback authentication logic
-// if the loopback client config is specified AND it has a bearer token.
+// if the loopback client config is specified AND it has a bearer token. Note that if either authn or
+// authz is nil, this function won't add a token authenticator or authorizer.
 func AuthorizeClientBearerToken(loopback *restclient.Config, authn *AuthenticationInfo, authz *AuthorizationInfo) {
-	if loopback == nil || authn == nil || authz == nil || authn.Authenticator == nil && authz.Authorizer == nil || len(loopback.BearerToken) == 0 {
+	if loopback == nil || len(loopback.BearerToken) == 0 {
+		return
+	}
+	if authn == nil || authz == nil {
+		// prevent nil pointer panic
+	}
+	if authn.Authenticator == nil || authz.Authorizer == nil {
+		// authenticator or authorizer might be nil if we want to bypass authz/authn
+		// and we also do nothing in this case.
 		return
 	}
 


### PR DESCRIPTION
/sig api-machinery
/assign @sttts

before #65832, we allow nil-valued authorizer and it will bypass all authz validation in its filter handler. but now a nil authorizer might be straightly plumbed into union authorizer as an element which will lead to a panic as is shown in the following traces:

```
goroutine 329 [running]:
xxx/vendor/k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1.1(0xc00004af60)
        /Users/zuoxiu.jm/go/src/xxx/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:103 +0xe1
panic(0x2425f60, 0x4b9df00)
        /usr/local/Cellar/go/1.11.1/src/runtime/panic.go:513 +0x1b9
xxx/vendor/k8s.io/apiserver/pkg/authorization/union.unionAuthzHandler.Authorize(0xc000414e80, 0x2, 0x2, 0x3a291c0, 0xc0004dca00, 0x0, 0x1, 0xc0011e0120, 0x203000, 0xc000e1cd10)
        /Users/zuoxiu.jm/go/src/xxx/vendor/k8s.io/apiserver/pkg/authorization/union/union.go:51 +0xb7
xxx/vendor/k8s.io/apiserver/pkg/authorization/union.unionAuthzHandler.Authorize(0xc000415340, 0x2, 0x2, 0x3a291c0, 0xc0004dca00, 0xc000cbf7a0, 0xc00088ce70, 0xc0011f4a01, 0x1, 0xc0004dca00)
        /Users/zuoxiu.jm/go/src/xxx/vendor/k8s.io/apiserver/pkg/authorization/union/union.go:51 +0xdb
xxx/vendor/k8s.io/apiserver/pkg/endpoints/filters.WithAuthorization.func1(0x9290e48, 0xc000126680, 0xc000883500)
        /Users/zuoxiu.jm/go/src/xxx/vendor/k8s.io/apiserver/pkg/endpoints/filters/authorization.go:59 +0x12d
net/http.HandlerFunc.ServeHTTP(0xc0004c3000, 0x9290e48, 0xc000126680, 0xc000883500)
        /usr/local/Cellar/go/1.11.1/src/net/http/server.go:1964 +0x44
xxx/vendor/k8s.io/apiserver/pkg/server/filters.WithMaxInFlightLimit.func1(0x9290e48, 0xc000126680, 0xc000883500)
        /Users/zuoxiu.jm/go/src/xxxx/vendor/k8s.io/apiserver/pkg/server/filters/maxinflight.go:160 +0x434
net/http.HandlerFunc.ServeHTTP(0xc0002dd140, 0x9290e48, 0xc000126680, 0xc000883500)

```
the curx is that we didn't correctly pass some logic when we have a non-nil authenticator and a nil authorizer at the same time (which is the case in one of our AA servers) since we are deciding to bypass by checking `authn.Authenticator == nil && authz.Authorizer == nil`. 

[https://github.com/kubernetes/kubernetes/blob/8b98e802eddb9f478ff7d991a2f72f60c165388a/staging/src/k8s.io/apiserver/pkg/server/config.go#L597](https://github.com/kubernetes/kubernetes/blob/8b98e802eddb9f478ff7d991a2f72f60c165388a/staging/src/k8s.io/apiserver/pkg/server/config.go#L597)



**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
