### PR TITLE
kubeadm: Cleanup of phases

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -148,6 +148,7 @@ func NewCmdInit(out io.Writer, initOptions *initOptions) *cobra.Command {
 			err = showJoinCommand(data, out)
 			kubeadmutil.CheckErr(err)
 		},
+		Args: cobra.NoArgs,
 	}
 
 	// adds flags to the init command
@@ -286,27 +287,27 @@ func newInitData(cmd *cobra.Command, args []string, options *initOptions, out io
 	// validated values to the public kubeadm config API when applicable
 	var err error
 	if options.externalcfg.FeatureGates, err = features.NewFeatureGate(&features.InitFeatureGates, options.featureGatesString); err != nil {
-		return &initData{}, err
+		return nil, err
 	}
 
 	ignorePreflightErrorsSet, err := validation.ValidateIgnorePreflightErrors(options.ignorePreflightErrors)
 	if err != nil {
-		return &initData{}, err
+		return nil, err
 	}
 
 	if err = validation.ValidateMixedArguments(cmd.Flags()); err != nil {
-		return &initData{}, err
+		return nil, err
 	}
 
 	if err = options.bto.ApplyTo(options.externalcfg); err != nil {
-		return &initData{}, err
+		return nil, err
 	}
 
 	// Either use the config file if specified, or convert public kubeadm API to the internal InitConfiguration
 	// and validates InitConfiguration
 	cfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(options.cfgPath, options.externalcfg)
 	if err != nil {
-		return &initData{}, err
+		return nil, err
 	}
 
 	// override node name and CRI socket from the command line options
@@ -318,17 +319,17 @@ func newInitData(cmd *cobra.Command, args []string, options *initOptions, out io
 	}
 
 	if err := configutil.VerifyAPIServerBindAddress(cfg.LocalAPIEndpoint.AdvertiseAddress); err != nil {
-		return &initData{}, err
+		return nil, err
 	}
 	if err := features.ValidateVersion(features.InitFeatureGates, cfg.FeatureGates, cfg.KubernetesVersion); err != nil {
-		return &initData{}, err
+		return nil, err
 	}
 
 	// if dry running creates a temporary folder for saving kubeadm generated files
 	dryRunDir := ""
 	if options.dryRun {
 		if dryRunDir, err = ioutil.TempDir("", "kubeadm-init-dryrun"); err != nil {
-			return &initData{}, errors.Wrap(err, "couldn't create a temporary directory")
+			return nil, errors.Wrap(err, "couldn't create a temporary directory")
 		}
 	}
 
@@ -340,7 +341,7 @@ func newInitData(cmd *cobra.Command, args []string, options *initOptions, out io
 			kubeconfigDir = dryRunDir
 		}
 		if err := kubeconfigphase.ValidateKubeconfigsForExternalCA(kubeconfigDir, cfg); err != nil {
-			return &initData{}, err
+			return nil, err
 		}
 	}
 

--- a/cmd/kubeadm/app/cmd/phases/workflow/runner.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/runner.go
@@ -309,7 +309,7 @@ func (e *Runner) BindToCommand(cmd *cobra.Command) {
 	phaseCommand := &cobra.Command{
 		Use:   "phase",
 		Short: fmt.Sprintf("use this command to invoke single phase of the %s workflow", cmd.Name()),
-		// TODO: this logic is currently lacking verification if a suphase name is valid!
+		Args:  cobra.NoArgs,
 	}
 
 	cmd.AddCommand(phaseCommand)
@@ -352,7 +352,7 @@ func (e *Runner) BindToCommand(cmd *cobra.Command) {
 					os.Exit(1)
 				}
 			},
-			Args: cobra.NoArgs, // this forces cobra to fail if a wrong phase name is passed
+			Args: cobra.NoArgs,
 		}
 
 		// makes the new command inherits local flags from the parent command


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
* Return `nil` instead of a pointer to an empty struct when possible,
  before the pointer was introduced the empty struct was required.

* Always accept no args in specific phases, ideally all arguments should
  be provided as named flags when calling to phases leafs.

* Explicitly accept only one argument maximum for `kubeadm join` as in
  `kubeadm join <master>`. This is a GA contract and we need to keep this,
  but named flags should be encouraged from now on, also for top level commands
  like `join` and `init`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/1365

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
