### PR TITLE
test/e2e/framework: validate external node IPs

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4894,8 +4894,10 @@ func GetNodeExternalIP(node *v1.Node) (string, error) {
 	host := ""
 	for _, a := range node.Status.Addresses {
 		if a.Type == v1.NodeExternalIP {
-			host = net.JoinHostPort(a.Address, sshPort)
-			break
+			if a.Address != "" {
+				host = net.JoinHostPort(a.Address, sshPort)
+				break
+			}
 		}
 	}
 	if host == "" {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
It is possible for a node not to have an external IP address. This extra
check is copied directly from GetNodeInternalIP and prevents errors like
the following:

    INFO: Getting external IP address for ip-10-0-133-82.ec2.internal
    error dialing core@:22: 'dial tcp :22: connect: connection refused'

In this case, there was no public IP for this host, but
GetNodeExternalIP returned ":22" instead of an error.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
