### PR TITLE
Fix typo, and note BoundObjectRef isn't always checked

### DIFF
--- a/pkg/apis/authentication/types.go
+++ b/pkg/apis/authentication/types.go
@@ -135,7 +135,9 @@ type TokenRequestSpec struct {
 	ExpirationSeconds int64
 
 	// BoundObjectRef is a reference to an object that the token will be bound to.
-	// The token will only be valid for as long as the bound objet exists.
+	// The token will only be valid for as long as the bound object exists.
+	// NOTE: The API server will validate the BoundObjectRef, but other audiences
+	// may not. Keep ExpirationSeconds small if you want prompt revocation.
 	BoundObjectRef *BoundObjectReference
 }
 

--- a/pkg/apis/authentication/types.go
+++ b/pkg/apis/authentication/types.go
@@ -136,8 +136,9 @@ type TokenRequestSpec struct {
 
 	// BoundObjectRef is a reference to an object that the token will be bound to.
 	// The token will only be valid for as long as the bound object exists.
-	// NOTE: The API server will validate the BoundObjectRef, but other audiences
-	// may not. Keep ExpirationSeconds small if you want prompt revocation.
+	// NOTE: The API server's TokenReview endpoint will validate the
+	// BoundObjectRef, but other audiences may not. Keep ExpirationSeconds
+	// small if you want prompt revocation.
 	BoundObjectRef *BoundObjectReference
 }
 

--- a/staging/src/k8s.io/api/authentication/v1/generated.proto
+++ b/staging/src/k8s.io/api/authentication/v1/generated.proto
@@ -84,7 +84,10 @@ message TokenRequestSpec {
   optional int64 expirationSeconds = 4;
 
   // BoundObjectRef is a reference to an object that the token will be bound to.
-  // The token will only be valid for as long as the bound objet exists.
+  // The token will only be valid for as long as the bound object exists.
+  // NOTE: The API server's TokenReview endpoint will validate the
+  // BoundObjectRef, but other audiences may not. Keep ExpirationSeconds
+  // small if you want prompt revocation.
   // +optional
   optional BoundObjectReference boundObjectRef = 3;
 }

--- a/staging/src/k8s.io/api/authentication/v1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1/types.go
@@ -155,7 +155,10 @@ type TokenRequestSpec struct {
 	ExpirationSeconds *int64 `json:"expirationSeconds" protobuf:"varint,4,opt,name=expirationSeconds"`
 
 	// BoundObjectRef is a reference to an object that the token will be bound to.
-	// The token will only be valid for as long as the bound objet exists.
+	// The token will only be valid for as long as the bound object exists.
+	// NOTE: The API server's TokenReview endpoint will validate the
+	// BoundObjectRef, but other audiences may not. Keep ExpirationSeconds
+	// small if you want prompt revocation.
 	// +optional
 	BoundObjectRef *BoundObjectReference `json:"boundObjectRef" protobuf:"bytes,3,opt,name=boundObjectRef"`
 }

--- a/staging/src/k8s.io/api/authentication/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/authentication/v1/types_swagger_doc_generated.go
@@ -51,7 +51,7 @@ var map_TokenRequestSpec = map[string]string{
 	"":                  "TokenRequestSpec contains client provided parameters of a token request.",
 	"audiences":         "Audiences are the intendend audiences of the token. A recipient of a token must identitfy themself with an identifier in the list of audiences of the token, and otherwise should reject the token. A token issued for multiple audiences may be used to authenticate against any of the audiences listed but implies a high degree of trust between the target audiences.",
 	"expirationSeconds": "ExpirationSeconds is the requested duration of validity of the request. The token issuer may return a token with a different validity duration so a client needs to check the 'expiration' field in a response.",
-	"boundObjectRef":    "BoundObjectRef is a reference to an object that the token will be bound to. The token will only be valid for as long as the bound objet exists.",
+	"boundObjectRef":    "BoundObjectRef is a reference to an object that the token will be bound to. The token will only be valid for as long as the bound object exists. NOTE: The API server's TokenReview endpoint will validate the BoundObjectRef, but other audiences may not. Keep ExpirationSeconds small if you want prompt revocation.",
 }
 
 func (TokenRequestSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

- "Object" was missing a "c".
- Only the API server can be asserted to have access to the bound object; an arbitrary relying party doesn't necessarily have access to the object in the API server that is named in the claim. Note this in the `BoundObjectRef` field's documentation.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Thanks!

**Does this PR introduce a user-facing change?**:

```release-note
NONE

```

Per discussion:

/cc @mikedanese 

Thanks!