### PR TITLE
Remove remaining code for deprecated openapi paths

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -392,7 +392,7 @@ func (d *DiscoveryClient) OpenAPISchema() (*openapi_v2.Document, error) {
 	if err != nil {
 		if errors.IsForbidden(err) || errors.IsNotFound(err) || errors.IsNotAcceptable(err) {
 			// single endpoint not found/registered in old server, try to fetch old endpoint
-			// TODO(roycaihw): remove this in 1.11
+			// TODO: remove this when kubectl/client-go don't work with 1.9 server
 			data, err = d.restClient.Get().AbsPath("/swagger-2.0.0.pb-v1").Do().Raw()
 			if err != nil {
 				return nil, err

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator_test.go
@@ -92,32 +92,6 @@ func (h handlerTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write(h.data)
 }
 
-type handlerDeprecatedTest struct {
-	etag string
-	data []byte
-}
-
-var _ http.Handler = handlerDeprecatedTest{}
-
-func (h handlerDeprecatedTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// old server returns 403 on new endpoint
-	if r.URL.Path == "/openapi/v2" {
-		w.WriteHeader(http.StatusForbidden)
-		return
-	}
-	if len(h.etag) > 0 {
-		w.Header().Add("Etag", h.etag)
-	}
-	ifNoneMatches := r.Header["If-None-Match"]
-	for _, match := range ifNoneMatches {
-		if match == h.etag {
-			w.WriteHeader(http.StatusNotModified)
-			return
-		}
-	}
-	w.Write(h.data)
-}
-
 func assertDownloadedSpec(actualSpec *spec.Swagger, actualEtag string, err error,
 	expectedSpecID string, expectedEtag string) error {
 	if err != nil {
@@ -157,9 +131,4 @@ func TestDownloadOpenAPISpec(t *testing.T) {
 	actualSpec, actualEtag, _, err = s.Download(
 		handlerTest{data: []byte("{\"id\": \"test\"}"), etag: "etag_test1"}, "etag_test2")
 	assert.NoError(t, assertDownloadedSpec(actualSpec, actualEtag, err, "test", "etag_test1"))
-
-	// Test old server fallback path
-	actualSpec, actualEtag, _, err = s.Download(handlerDeprecatedTest{data: []byte("{\"id\": \"test\"}")}, "")
-	assert.NoError(t, assertDownloadedSpec(actualSpec, actualEtag, err, "test", "\"6E8F849B434D4B98A569B9D7718876E9-356ECAB19D7FBE1336BABB1E70F8F3025050DE218BE78256BE81620681CFC9A268508E542B8B55974E17B2184BBFC8FFFAA577E51BE195D32B3CA2547818ABE4\""))
-
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Followup of #73148. Remove remaining fallback logic in discovery client and aggregator downloader.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kube-apiserver now only aggregates openapi schemas from `/openapi/v2` endpoints of aggregated API servers. The fallback to aggregate from `/swagger.json` has been removed. Ensure aggregated API servers provide schema information via `/openapi/v2` (available since v1.10).
```

/cc @liggitt @mbohlool 