### PR TITLE
Update cluster-proportional-autoscaler to 1.4.0 to use apps/v1

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -33,7 +33,7 @@ rules:
   - apiGroups: [""]
     resources: ["replicationcontrollers/scale"]
     verbs: ["get", "update"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["extensions","apps"]
     resources: ["deployments/scale", "replicasets/scale"]
     verbs: ["get", "update"]
 # Remove the configmaps rule once below issue is fixed:
@@ -85,7 +85,7 @@ spec:
         fsGroup: 65534
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.3.0
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.4.0
         resources:
             requests:
                 cpu: "20m"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Updates cluster-proportional-autoscaler to use an image that scales via apps/v1 APIs.

Extracted from https://github.com/kubernetes/kubernetes/pull/70672 for separate review/merge

xref #43214

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
