### PR TITLE
staging: update README to reflect recent file moves

### DIFF
--- a/staging/README.md
+++ b/staging/README.md
@@ -65,7 +65,7 @@ for creating the staging repository.
 
 3. Add a symlink to the staging repo in `vendor/k8s.io`.
 
-4. Update [`hack/import-restrictions.yaml`](https://github.com/kubernetes/kubernetes/blob/master/hack/import-restrictions.yaml)
+4. Update [`import-restrictions.yaml`](/staging/publishing/import-restrictions.yaml)
 to add the list of other staging repos that this new repo can import.
 
 5. Add all mandatory template files to the staging repo as mentioned in
@@ -92,7 +92,7 @@ for an example.
 3. Once the repository has been created in the Kubernetes org,
 update the publishing-bot to publish the staging repository by updating:
 
-    - [`kubernetes-rules-configmap.yaml`](https://github.com/kubernetes/publishing-bot/blob/master/configs/kubernetes-rules-configmap.yaml):
+    - [`rules.yaml`](/staging/publishing/rules.yaml):
     Make sure that the list of dependencies reflects the staging repos in the `Godeps.json` file.
 
     - [`fetch-all-latest-and-push.sh`](https://github.com/kubernetes/publishing-bot/blob/master/hack/fetch-all-latest-and-push.sh):


### PR DESCRIPTION
The rules and `import-restrictions.yaml` files were moved to the publishing directory. This PR updates the README to reflect those moves.

/kind cleanup
/cc @dims @sttts 


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
