### PR TITLE
Tune suggested master disk sizes for big clusters.

### DIFF
--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -43,11 +43,11 @@ function get-master-size {
 #   NUM_NODES
 function get-master-root-disk-size() {
   local suggested_master_root_disk_size="20GB"
-  if [[ "${NUM_NODES}" -gt "1000" ]]; then
-    suggested_master_root_disk_size="50GB"
-  fi
-  if [[ "${NUM_NODES}" -gt "2000" ]]; then
+  if [[ "${NUM_NODES}" -gt "500" ]]; then
     suggested_master_root_disk_size="100GB"
+  fi
+  if [[ "${NUM_NODES}" -gt "3000" ]]; then
+    suggested_master_root_disk_size="500GB"
   fi
   echo "${suggested_master_root_disk_size}"
 }
@@ -56,10 +56,10 @@ function get-master-root-disk-size() {
 #   NUM_NODES
 function get-master-disk-size() {
   local suggested_master_disk_size="20GB"
-  if [[ "${NUM_NODES}" -gt "1000" ]]; then
+  if [[ "${NUM_NODES}" -gt "500" ]]; then
     suggested_master_disk_size="100GB"
   fi
-  if [[ "${NUM_NODES}" -gt "2000" ]]; then
+  if [[ "${NUM_NODES}" -gt "3000" ]]; then
     suggested_master_disk_size="200GB"
   fi
   echo "${suggested_master_disk_size}"


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
The get-master-root-disk-size() and get-master-disk-size() functions didn't anticipate clusters bigger than 2K nodes.

In #72976 we found out that 100GB may be not enough for large clusters (5K nodes) when it comes to the master root disk size.

Updating both get-master-root-disk-size() and get-master-disk-size() to make them consistent and match cluster sizes with get-master-size() function.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
