### PR TITLE
kubeadm: Introduce ValidateSupportedVersion

### DIFF
--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -17,187 +17,66 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/lithammer/dedent"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeadmapiv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
-var files = map[string][]byte{
-	"Master_v1alpha1": []byte(`
-apiVersion: kubeadm.k8s.io/v1alpha1
-kind: InitConfiguration
-`),
-	"Node_v1alpha1": []byte(`
-apiVersion: kubeadm.k8s.io/v1alpha1
-kind: NodeConfiguration
-`),
-	"Master_v1alpha2": []byte(`
-apiVersion: kubeadm.k8s.io/v1alpha2
-kind: MasterConfiguration
-`),
-	"Node_v1alpha2": []byte(`
-apiVersion: kubeadm.k8s.io/v1alpha2
-kind: NodeConfiguration
-`),
-	"Init_v1alpha3": []byte(`
-apiVersion: kubeadm.k8s.io/v1alpha3
-kind: InitConfiguration
-`),
-	"Join_v1alpha3": []byte(`
-apiVersion: kubeadm.k8s.io/v1alpha3
-kind: JoinConfiguration
-`),
-	"Init_v1beta1": []byte(`
-apiVersion: kubeadm.k8s.io/v1beta1
-kind: InitConfiguration
-`),
-	"Join_v1beta1": []byte(`
-apiVersion: kubeadm.k8s.io/v1beta1
-kind: JoinConfiguration
-`),
-	"NoKind": []byte(`
-apiVersion: baz.k8s.io/v1
-foo: foo
-bar: bar
-`),
-	"NoAPIVersion": []byte(`
-kind: Bar
-foo: foo
-bar: bar
-`),
-	"Foo": []byte(`
-apiVersion: foo.k8s.io/v1
-kind: Foo
-`),
-}
+func TestValidateSupportedVersion(t *testing.T) {
+	const KubeadmGroupName = "kubeadm.k8s.io"
 
-func TestDetectUnsupportedVersion(t *testing.T) {
-	var tests = []struct {
-		name         string
-		fileContents []byte
-		expectedErr  bool
+	tests := []struct {
+		gv          schema.GroupVersion
+		expectedErr bool
 	}{
 		{
-			name:         "Master_v1alpha1",
-			fileContents: files["Master_v1alpha1"],
-			expectedErr:  true,
+			gv: schema.GroupVersion{
+				Group:   KubeadmGroupName,
+				Version: "v1alpha1",
+			},
+			expectedErr: true,
 		},
 		{
-			name:         "Node_v1alpha1",
-			fileContents: files["Node_v1alpha1"],
-			expectedErr:  true,
+			gv: schema.GroupVersion{
+				Group:   KubeadmGroupName,
+				Version: "v1alpha2",
+			},
+			expectedErr: true,
 		},
 		{
-			name:         "Master_v1alpha2",
-			fileContents: files["Master_v1alpha2"],
-			expectedErr:  true,
+			gv: schema.GroupVersion{
+				Group:   KubeadmGroupName,
+				Version: "v1alpha3",
+			},
 		},
 		{
-			name:         "Node_v1alpha2",
-			fileContents: files["Node_v1alpha2"],
-			expectedErr:  true,
+			gv: schema.GroupVersion{
+				Group:   KubeadmGroupName,
+				Version: "v1beta1",
+			},
 		},
 		{
-			name:         "Init_v1alpha3",
-			fileContents: files["Init_v1alpha3"],
-		},
-		{
-			name:         "Join_v1alpha3",
-			fileContents: files["Join_v1alpha3"],
-		},
-		{
-			name:         "Init_v1beta1",
-			fileContents: files["Init_v1beta1"],
-		},
-		{
-			name:         "Join_v1beta1",
-			fileContents: files["Join_v1beta1"],
-		},
-		{
-			name:         "DuplicateInit v1alpha3",
-			fileContents: bytes.Join([][]byte{files["Init_v1alpha3"], files["Init_v1alpha3"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  true,
-		},
-		{
-			name:         "DuplicateInit v1beta1",
-			fileContents: bytes.Join([][]byte{files["Init_v1beta1"], files["Init_v1beta1"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  true,
-		},
-		{
-			name:         "DuplicateInit v1beta1 and v1alpha3",
-			fileContents: bytes.Join([][]byte{files["Init_v1beta1"], files["Init_v1alpha3"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  true,
-		},
-		{
-			name:         "DuplicateJoin v1alpha3",
-			fileContents: bytes.Join([][]byte{files["Join_v1alpha3"], files["Join_v1alpha3"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  true,
-		},
-		{
-			name:         "DuplicateJoin v1beta1",
-			fileContents: bytes.Join([][]byte{files["Join_v1beta1"], files["Join_v1beta1"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  true,
-		},
-		{
-			name:         "DuplicateJoin v1beta1 and v1alpha3",
-			fileContents: bytes.Join([][]byte{files["Join_v1beta1"], files["Join_v1alpha3"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  true,
-		},
-		{
-			name:         "NoKind",
-			fileContents: files["NoKind"],
-			expectedErr:  true,
-		},
-		{
-			name:         "NoAPIVersion",
-			fileContents: files["NoAPIVersion"],
-			expectedErr:  true,
-		},
-		{
-			name:         "Ignore other Kind",
-			fileContents: bytes.Join([][]byte{files["Foo"], files["Master_v1alpha3"]}, []byte(constants.YAMLDocumentSeparator)),
-		},
-		{
-			name:         "Ignore other Kind",
-			fileContents: bytes.Join([][]byte{files["Foo"], files["Master_v1beta1"]}, []byte(constants.YAMLDocumentSeparator)),
-		},
-		// CanMixInitJoin cases used to be MustNotMixInitJoin, however due to UX issues DetectUnsupportedVersion had to tolerate that.
-		// So the following tests actually verify, that Init and Join can be mixed together with no error.
-		{
-			name:         "CanMixInitJoin v1alpha3",
-			fileContents: bytes.Join([][]byte{files["Init_v1alpha3"], files["Join_v1alpha3"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  false,
-		},
-		{
-			name:         "CanMixInitJoin v1alpha3 - v1beta1",
-			fileContents: bytes.Join([][]byte{files["Init_v1alpha3"], files["Join_v1beta1"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  false,
-		},
-		{
-			name:         "CanMixInitJoin v1beta1 - v1alpha3",
-			fileContents: bytes.Join([][]byte{files["Init_v1beta1"], files["Join_v1alpha3"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  false,
-		},
-		{
-			name:         "CanMixInitJoin v1beta1",
-			fileContents: bytes.Join([][]byte{files["Init_v1beta1"], files["Join_v1beta1"]}, []byte(constants.YAMLDocumentSeparator)),
-			expectedErr:  false,
+			gv: schema.GroupVersion{
+				Group:   "foo.k8s.io",
+				Version: "v1",
+			},
 		},
 	}
 
 	for _, rt := range tests {
-		t.Run(rt.name, func(t2 *testing.T) {
-
-			err := DetectUnsupportedVersion(rt.fileContents)
-			if (err != nil) != rt.expectedErr {
-				t2.Errorf("expected error: %t, actual: %t", rt.expectedErr, err != nil)
+		t.Run(rt.gv.String(), func(t *testing.T) {
+			err := ValidateSupportedVersion(rt.gv)
+			if rt.expectedErr && err == nil {
+				t.Error("unexpected success")
+			} else if !rt.expectedErr && err != nil {
+				t.Errorf("unexpected failure: %v", err)
 			}
 		})
 	}

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -208,16 +208,17 @@ func BytesToInternalConfig(b []byte) (*kubeadmapi.InitConfiguration, error) {
 	var clustercfg *kubeadmapi.ClusterConfiguration
 	decodedComponentConfigObjects := map[componentconfigs.RegistrationKind]runtime.Object{}
 
-	if err := DetectUnsupportedVersion(b); err != nil {
-		return nil, err
-	}
-
 	gvkmap, err := kubeadmutil.SplitYAMLDocuments(b)
 	if err != nil {
 		return nil, err
 	}
 
 	for gvk, fileContent := range gvkmap {
+		// first, check if this GVK is supported one
+		if err := ValidateSupportedVersion(gvk.GroupVersion()); err != nil {
+			return nil, err
+		}
+
 		// verify the validity of the YAML
 		strict.VerifyUnmarshalStrict(fileContent, gvk)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Introduce `ValidateSupportedVersion` in place of `DetectUnsupportedVersion`
    
`DetectUnsupportedVersion` is somewhat uncomfortable, complex and inefficient function to use. It takes an entire YAML document as bytes, splits it up to byte slices of the different YAML sub-documents and group-version-kinds and  searches through those to detect an unsupported kubeadm config. If such config is detected, the function returns an error, if it is not (i.e. the normal function operation) everything done so far is discarded.
    
This could have been acceptable, if not the fact, that in all cases that this function is called, the YAML document bytes are split up and an iteration on GVK map is performed yet again. Hence, we don't need `DetectUnsupportedVersion` in its current form as it's inefficient, complex and takes only YAML document bytes.
    
This change replaces `DetectUnsupportedVersion` with `ValidateSupportedVersion`, which takes a `GroupVersion` argument and checks if it is on the list of unsupported config versions. In that case an error is returned.
`ValidateSupportedVersion` relies on the caller to read and split the YAML document and then iterate on its GVK map checking if the particular `GroupVersion` is supported or not.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refs kubernetes/kubeadm#1296
Refs kubernetes/kubeadm#1084

**Special notes for your reviewer**:

This is a step towards simplifying the config APIs and making them more efficient.

Also, this is a step in introducing the concept of "deprecated config", which is supported config, that can be used at API level and as a source to migrate to the current config (via `kubeadm config migrate`), but not create a new cluster from it. This will be done in a future followup PR.

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/assign @fabriziopandini
/assign @timothysc 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
