### PR TITLE
Pass HostAliases test for separate host lines

### DIFF
--- a/test/e2e/common/kubelet.go
+++ b/test/e2e/common/kubelet.go
@@ -175,7 +175,9 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 				buf.ReadFrom(rc)
 				hostsFileContent := buf.String()
 
-				if !strings.Contains(hostsFileContent, "123.45.67.89\tfoo\tbar") {
+				if !strings.Contains(hostsFileContent, "123.45.67.89\tfoo\tbar") &&
+					!(strings.Contains(hostsFileContent, "123.45.67.89\tfoo") &&
+						strings.Contains(hostsFileContent, "123.45.67.89\tbar")) {
 					return fmt.Errorf("expected hosts file to contain entries from HostAliases. Got:\n%+v", hostsFileContent)
 				}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If the hostfile contains the same hosts but on separate lines the test
would fail.

This test makes the test not fail if both hostnames exist in the
hostfile on separate lines.


```release-note
NONE
```