### PR TITLE
Always select the in-memory group/version as a target when decoding from storage

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = [
+        "codec_test.go",
         "conversion_test.go",
         "converter_test.go",
         "embedded_test.go",

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/codec_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/codec_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func gv(group, version string) schema.GroupVersion {
+	return schema.GroupVersion{Group: group, Version: version}
+}
+func gvk(group, version, kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: group, Version: version, Kind: kind}
+}
+func gk(group, kind string) schema.GroupKind {
+	return schema.GroupKind{Group: group, Kind: kind}
+}
+
+func TestCoercingMultiGroupVersioner(t *testing.T) {
+	testcases := []struct {
+		name           string
+		target         schema.GroupVersion
+		preferredKinds []schema.GroupKind
+		kinds          []schema.GroupVersionKind
+		expectKind     schema.GroupVersionKind
+	}{
+		{
+			name:           "matched preferred group/kind",
+			target:         gv("mygroup", "__internal"),
+			preferredKinds: []schema.GroupKind{gk("mygroup", "Foo"), gk("anothergroup", "Bar")},
+			kinds:          []schema.GroupVersionKind{gvk("yetanother", "v1", "Baz"), gvk("anothergroup", "v1", "Bar")},
+			expectKind:     gvk("mygroup", "__internal", "Bar"),
+		},
+		{
+			name:           "matched preferred group",
+			target:         gv("mygroup", "__internal"),
+			preferredKinds: []schema.GroupKind{gk("mygroup", ""), gk("anothergroup", "")},
+			kinds:          []schema.GroupVersionKind{gvk("yetanother", "v1", "Baz"), gvk("anothergroup", "v1", "Bar")},
+			expectKind:     gvk("mygroup", "__internal", "Bar"),
+		},
+		{
+			name:           "no preferred group/kind match, uses first kind in list",
+			target:         gv("mygroup", "__internal"),
+			preferredKinds: []schema.GroupKind{gk("mygroup", ""), gk("anothergroup", "")},
+			kinds:          []schema.GroupVersionKind{gvk("yetanother", "v1", "Baz"), gvk("yetanother", "v1", "Bar")},
+			expectKind:     gvk("mygroup", "__internal", "Baz"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewCoercingMultiGroupVersioner(tc.target, tc.preferredKinds...)
+			kind, ok := v.KindForGroupVersionKinds(tc.kinds)
+			if !ok {
+				t.Error("got no kind")
+			}
+			if kind != tc.expectKind {
+				t.Errorf("expected %#v, got %#v", tc.expectKind, kind)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_codec.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_codec.go
@@ -85,7 +85,7 @@ func NewStorageCodec(opts StorageCodecConfig) (runtime.Codec, error) {
 	)
 	decoder := opts.StorageSerializer.DecoderToVersion(
 		recognizer.NewDecoder(decoders...),
-		runtime.NewMultiGroupVersioner(
+		runtime.NewCoercingMultiGroupVersioner(
 			opts.MemoryVersion,
 			schema.GroupKind{Group: opts.MemoryVersion.Group},
 			schema.GroupKind{Group: opts.StorageVersion.Group},

--- a/test/integration/etcd/BUILD
+++ b/test/integration/etcd/BUILD
@@ -6,6 +6,7 @@ go_test(
     name = "go_default_test",
     size = "large",
     srcs = [
+        "etcd_cross_group_test.go",
         "etcd_storage_path_test.go",
         "main_test.go",
     ],
@@ -24,6 +25,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//test/integration/framework:go_default_library",
         "//vendor/github.com/coreos/etcd/clientv3:go_default_library",

--- a/test/integration/etcd/etcd_cross_group_test.go
+++ b/test/integration/etcd/etcd_cross_group_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+)
+
+// TestCrossGroupStorage tests to make sure that all objects stored in an expected location in etcd can be converted/read.
+func TestCrossGroupStorage(t *testing.T) {
+	master := StartRealMasterOrDie(t, func(opts *options.ServerRunOptions) {
+		// force enable all resources so we can check storage.
+		// TODO: drop these once we stop allowing them to be served.
+		opts.APIEnablement.RuntimeConfig["extensions/v1beta1/deployments"] = "true"
+		opts.APIEnablement.RuntimeConfig["extensions/v1beta1/daemonsets"] = "true"
+		opts.APIEnablement.RuntimeConfig["extensions/v1beta1/replicasets"] = "true"
+		opts.APIEnablement.RuntimeConfig["extensions/v1beta1/podsecuritypolicies"] = "true"
+		opts.APIEnablement.RuntimeConfig["extensions/v1beta1/networkpolicies"] = "true"
+	})
+	defer master.Cleanup()
+
+	etcdStorageData := GetEtcdStorageData()
+
+	crossGroupResources := map[schema.GroupVersionKind][]Resource{}
+
+	master.Client.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}})
+
+	// Group by persisted GVK
+	for _, resourceToPersist := range master.Resources {
+		gvk := resourceToPersist.Mapping.GroupVersionKind
+		data, exists := etcdStorageData[resourceToPersist.Mapping.Resource]
+		if !exists {
+			continue
+		}
+		storageGVK := gvk
+		if data.ExpectedGVK != nil {
+			storageGVK = *data.ExpectedGVK
+		}
+		crossGroupResources[storageGVK] = append(crossGroupResources[storageGVK], resourceToPersist)
+	}
+
+	// Clear any without cross-group sources
+	for gvk, resources := range crossGroupResources {
+		groups := sets.NewString()
+		for _, resource := range resources {
+			groups.Insert(resource.Mapping.GroupVersionKind.Group)
+		}
+		if len(groups) < 2 {
+			delete(crossGroupResources, gvk)
+		}
+	}
+
+	if len(crossGroupResources) == 0 {
+		// Sanity check
+		t.Fatal("no cross-group resources found")
+	}
+
+	// Test all potential cross-group sources can be watched and fetched from all other sources
+	for gvk, resources := range crossGroupResources {
+		t.Run(gvk.String(), func(t *testing.T) {
+			// use the first one to create the initial object
+			resource := resources[0]
+
+			// compute namespace
+			ns := ""
+			if resource.Mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+				ns = testNamespace
+			}
+
+			data := etcdStorageData[resource.Mapping.Resource]
+			// create object
+			resourceClient, obj, err := JSONToUnstructured(data.Stub, ns, resource.Mapping, master.Dynamic)
+			if err != nil {
+				t.Fatal(err)
+			}
+			actual, err := resourceClient.Create(obj, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			name := actual.GetName()
+
+			// Set up clients, versioned data, and watches for all versions
+			var (
+				clients       = map[schema.GroupVersionResource]dynamic.ResourceInterface{}
+				versionedData = map[schema.GroupVersionResource]*unstructured.Unstructured{}
+				watches       = map[schema.GroupVersionResource]watch.Interface{}
+			)
+			for _, resource := range resources {
+				clients[resource.Mapping.Resource] = master.Dynamic.Resource(resource.Mapping.Resource).Namespace(ns)
+				versionedData[resource.Mapping.Resource], err = clients[resource.Mapping.Resource].Get(name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("error finding resource via %s: %v", resource.Mapping.Resource.GroupVersion().String(), err)
+				}
+				watches[resource.Mapping.Resource], err = clients[resource.Mapping.Resource].Watch(metav1.ListOptions{ResourceVersion: actual.GetResourceVersion()})
+				if err != nil {
+					t.Fatalf("error opening watch via %s: %v", resource.Mapping.Resource.GroupVersion().String(), err)
+				}
+			}
+
+			for _, resource := range resources {
+				// clear out the things cleared in etcd
+				versioned := versionedData[resource.Mapping.Resource]
+				versioned.SetResourceVersion("")
+				versioned.SetSelfLink("")
+				versionedJSON, err := versioned.MarshalJSON()
+				if err != nil {
+					t.Error(err)
+					continue
+				}
+
+				// Update in etcd
+				if _, err := master.KV.Put(context.Background(), data.ExpectedEtcdPath, string(versionedJSON)); err != nil {
+					t.Error(err)
+					continue
+				}
+				t.Logf("wrote %s to etcd", resource.Mapping.Resource.GroupVersion().String())
+
+				// Ensure everyone gets a watch event with the right version
+				for watchResource, watcher := range watches {
+					select {
+					case event, ok := <-watcher.ResultChan():
+						if !ok {
+							t.Fatalf("watch of %s closed in response to persisting %s", watchResource.GroupVersion().String(), resource.Mapping.Resource.GroupVersion().String())
+						}
+						if event.Type != watch.Modified {
+							eventJSON, _ := json.Marshal(event)
+							t.Errorf("unexpected watch event sent to watch of %s in response to persisting %s: %s", watchResource.GroupVersion().String(), resource.Mapping.Resource.GroupVersion().String(), string(eventJSON))
+							continue
+						}
+						if event.Object.GetObjectKind().GroupVersionKind().GroupVersion() != watchResource.GroupVersion() {
+							t.Errorf("unexpected group version object sent to watch of %s in response to persisting %s: %#v", watchResource.GroupVersion().String(), resource.Mapping.Resource.GroupVersion().String(), event.Object)
+							continue
+						}
+						t.Logf("     received event for %s", watchResource.GroupVersion().String())
+					case <-time.After(30 * time.Second):
+						t.Errorf("timed out waiting for watch event for %s in response to persisting %s", watchResource.GroupVersion().String(), resource.Mapping.Resource.GroupVersion().String())
+						continue
+					}
+				}
+
+				// Ensure everyone can do a direct get and gets the right version
+				for clientResource, client := range clients {
+					obj, err := client.Get(name, metav1.GetOptions{})
+					if err != nil {
+						t.Errorf("error looking up %s after persisting %s", clientResource.GroupVersion().String(), resource.Mapping.Resource.GroupVersion().String())
+						continue
+					}
+					if obj.GetObjectKind().GroupVersionKind().GroupVersion() != clientResource.GroupVersion() {
+						t.Errorf("unexpected group version retrieved from %s after persisting %s: %#v", clientResource.GroupVersion().String(), resource.Mapping.Resource.GroupVersion().String(), obj)
+						continue
+					}
+					t.Logf("     fetched object for %s", clientResource.GroupVersion().String())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Avoids artificially limiting the source API groups we support when decoding watch events from storage. The current group version selection did not handle decoding watch events from storage resulting in writes from skewed API servers across group boundaries for cohabitating resources.

**Which issue(s) this PR fixes**:
Fixes #73478

**Special notes for your reviewer**:
We'll want to take this back to all release branches. The problem exists as far back as 1.6.

**Does this PR introduce a user-facing change?**:
```release-note
fixes an error processing watch events when running skewed apiservers
```


Test output:
```
    --- PASS: TestCrossGroupStorage/apps/v1,_Kind=DaemonSet (0.06s)
        etcd_cross_group_test.go:141: wrote extensions/v1beta1 to etcd
        etcd_cross_group_test.go:163:      received event for apps/v1
        etcd_cross_group_test.go:163:      received event for apps/v1beta2
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for apps/v1
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta2
        etcd_cross_group_test.go:141: wrote apps/v1 to etcd
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:163:      received event for apps/v1
        etcd_cross_group_test.go:163:      received event for apps/v1beta2
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for apps/v1
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta2
        etcd_cross_group_test.go:141: wrote apps/v1beta2 to etcd
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:163:      received event for apps/v1
        etcd_cross_group_test.go:163:      received event for apps/v1beta2
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for apps/v1
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta2
    --- PASS: TestCrossGroupStorage/networking.k8s.io/v1,_Kind=NetworkPolicy (0.03s)
        etcd_cross_group_test.go:141: wrote extensions/v1beta1 to etcd
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:163:      received event for networking.k8s.io/v1
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for networking.k8s.io/v1
        etcd_cross_group_test.go:141: wrote networking.k8s.io/v1 to etcd
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:163:      received event for networking.k8s.io/v1
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for networking.k8s.io/v1
    --- PASS: TestCrossGroupStorage//v1,_Kind=Event (0.04s)
        etcd_cross_group_test.go:141: wrote v1 to etcd
        etcd_cross_group_test.go:163:      received event for v1
        etcd_cross_group_test.go:163:      received event for events.k8s.io/v1beta1
        etcd_cross_group_test.go:181:      fetched object for v1
        etcd_cross_group_test.go:181:      fetched object for events.k8s.io/v1beta1
        etcd_cross_group_test.go:141: wrote events.k8s.io/v1beta1 to etcd
        etcd_cross_group_test.go:163:      received event for v1
        etcd_cross_group_test.go:163:      received event for events.k8s.io/v1beta1
        etcd_cross_group_test.go:181:      fetched object for v1
        etcd_cross_group_test.go:181:      fetched object for events.k8s.io/v1beta1
    --- PASS: TestCrossGroupStorage/apps/v1,_Kind=Deployment (0.06s)
        etcd_cross_group_test.go:141: wrote extensions/v1beta1 to etcd
        etcd_cross_group_test.go:163:      received event for apps/v1
        etcd_cross_group_test.go:163:      received event for apps/v1beta2
        etcd_cross_group_test.go:163:      received event for apps/v1beta1
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta2
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta1
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for apps/v1
        etcd_cross_group_test.go:141: wrote apps/v1 to etcd
        etcd_cross_group_test.go:163:      received event for apps/v1
        etcd_cross_group_test.go:163:      received event for apps/v1beta2
        etcd_cross_group_test.go:163:      received event for apps/v1beta1
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for apps/v1
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta2
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta1
        etcd_cross_group_test.go:141: wrote apps/v1beta2 to etcd
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:163:      received event for apps/v1
        etcd_cross_group_test.go:163:      received event for apps/v1beta2
        etcd_cross_group_test.go:163:      received event for apps/v1beta1
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for apps/v1
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta2
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta1
        etcd_cross_group_test.go:141: wrote apps/v1beta1 to etcd
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:163:      received event for apps/v1
        etcd_cross_group_test.go:163:      received event for apps/v1beta2
        etcd_cross_group_test.go:163:      received event for apps/v1beta1
        etcd_cross_group_test.go:181:      fetched object for apps/v1
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta2
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta1
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
    --- PASS: TestCrossGroupStorage/apps/v1,_Kind=ReplicaSet (0.05s)
        etcd_cross_group_test.go:141: wrote extensions/v1beta1 to etcd
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:163:      received event for apps/v1
        etcd_cross_group_test.go:163:      received event for apps/v1beta2
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for apps/v1
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta2
        etcd_cross_group_test.go:141: wrote apps/v1 to etcd
        etcd_cross_group_test.go:163:      received event for apps/v1
        etcd_cross_group_test.go:163:      received event for apps/v1beta2
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for apps/v1
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta2
        etcd_cross_group_test.go:141: wrote apps/v1beta2 to etcd
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:163:      received event for apps/v1
        etcd_cross_group_test.go:163:      received event for apps/v1beta2
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for apps/v1
        etcd_cross_group_test.go:181:      fetched object for apps/v1beta2
    --- PASS: TestCrossGroupStorage/policy/v1beta1,_Kind=PodSecurityPolicy (0.03s)
        etcd_cross_group_test.go:141: wrote extensions/v1beta1 to etcd
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:163:      received event for policy/v1beta1
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for policy/v1beta1
        etcd_cross_group_test.go:141: wrote policy/v1beta1 to etcd
        etcd_cross_group_test.go:163:      received event for extensions/v1beta1
        etcd_cross_group_test.go:163:      received event for policy/v1beta1
        etcd_cross_group_test.go:181:      fetched object for extensions/v1beta1
        etcd_cross_group_test.go:181:      fetched object for policy/v1beta1
```