### PR TITLE
Sort apiservices properly during openapi aggregation

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator.go
@@ -139,6 +139,12 @@ func (a byPriority) Len() int      { return len(a.specs) }
 func (a byPriority) Swap(i, j int) { a.specs[i], a.specs[j] = a.specs[j], a.specs[i] }
 func (a byPriority) Less(i, j int) bool {
 	// All local specs will come first
+	if a.specs[i].apiService.Spec.Service == nil && a.specs[j].apiService.Spec.Service != nil {
+		return true
+	}
+	if a.specs[i].apiService.Spec.Service != nil && a.specs[j].apiService.Spec.Service == nil {
+		return false
+	}
 	// WARNING: This will result in not following priorities for local APIServices.
 	if a.specs[i].apiService.Spec.Service == nil {
 		// Sort local specs with their name. This is the order in the delegation chain (aggregator first).

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator_test.go
@@ -38,6 +38,15 @@ func newAPIServiceForTest(name, group string, minGroupPriority, versionPriority 
 	return r
 }
 
+func newLocalAPIServiceForTest(name, group string, minGroupPriority, versionPriority int32) apiregistration.APIService {
+	r := apiregistration.APIService{}
+	r.Spec.Group = group
+	r.Spec.GroupPriorityMinimum = minGroupPriority
+	r.Spec.VersionPriority = versionPriority
+	r.Name = name
+	return r
+}
+
 func assertSortedServices(t *testing.T, actual []openAPISpecInfo, expectedNames []string) {
 	actualNames := []string{}
 	for _, a := range actual {
@@ -66,9 +75,21 @@ func TestAPIServiceSort(t *testing.T) {
 			apiService: newAPIServiceForTest("ThirdService", "Group3", 15, 3),
 			spec:       &spec.Swagger{},
 		},
+		{
+			apiService: newLocalAPIServiceForTest("FirstLocalSpec", "Group1", 15, 5),
+			spec:       &spec.Swagger{},
+		},
+		{
+			apiService: newLocalAPIServiceForTest("SecondLocalSpec", "Group2", 14, 6),
+			spec:       &spec.Swagger{},
+		},
+		{
+			apiService: newLocalAPIServiceForTest("ThirdLocalSpec", "Group3", 16, 3),
+			spec:       &spec.Swagger{},
+		},
 	}
 	sortByPriority(list)
-	assertSortedServices(t, list, []string{"FirstService", "FirstServiceInternal", "SecondService", "ThirdService"})
+	assertSortedServices(t, list, []string{"FirstLocalSpec", "SecondLocalSpec", "ThirdLocalSpec", "FirstService", "FirstServiceInternal", "SecondService", "ThirdService"})
 }
 
 type handlerTest struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The first openapi spec out of the sorted list defines the basic swagger information that we serve. We documented "All local specs will come first" but the implementation doesn't guarantee that. As a result, aggregated apiservice may override swagger `securityDefinitions` and swagger `info` in kube-apiserver. This PR fixes that.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug that aggregated openapi spec may override swagger securityDefinitions and swagger info in kube-apiserver
```

/cc @liggitt @mbohlool 
/sig api-machinery 