### PR TITLE
Fix TLS config in load test clients

### DIFF
--- a/test/e2e/scalability/load.go
+++ b/test/e2e/scalability/load.go
@@ -377,9 +377,13 @@ func createClients(numberOfClients int) ([]clientset.Interface, []internalclient
 				KeepAlive: 30 * time.Second,
 			}).DialContext,
 		})
+		config.WrapTransport = transportConfig.WrapTransport
+		config.Dial = transportConfig.Dial
 		// Overwrite TLS-related fields from config to avoid collision with
 		// Transport field.
 		config.TLSClientConfig = restclient.TLSClientConfig{}
+		config.AuthProvider = nil
+		config.ExecProvider = nil
 
 		c, err := clientset.NewForConfig(config)
 		if err != nil {


### PR DESCRIPTION
When using custom transport (like we're doing in our load tests), we cannot specify TLS certificate options in the rest client (see https://github.com/kubernetes/client-go/issues/452). As a result we need to clear out TLS fields in the rest config and specify wrappers for custom transport.

/cc @liggitt 
fyi - @micahhausler  

```release-note
NONE
```

/sig scalability
/kind bug
/priority important-soon