### PR TITLE
Add e2e test for getting componentstatuses by kubectl

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -724,6 +724,19 @@ metadata:
 		})
 	})
 
+	framework.KubeDescribe("Kubectl get componentstatuses", func() {
+		It("should get componentstatuses", func() {
+			By("getting list of componentstatuses")
+			output := framework.RunKubectlOrDie("get", "componentstatuses", "-o", "jsonpath={.items[*].metadata.name}")
+			components := strings.Split(output, " ")
+			By("getting details of componentstatuses")
+			for _, component := range components {
+				By("getting status of " + component)
+				framework.RunKubectlOrDie("get", "componentstatuses", component)
+			}
+		})
+	})
+
 	framework.KubeDescribe("Kubectl apply", func() {
 		It("should apply a new configuration to an existing RC", func() {
 			controllerJson := commonutils.SubstituteImageName(string(readTestFileOrDie(redisControllerFilename)))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This patch adds e2e test for getting componentstatuses by kubectl to cover the following API.
- GET /api/v1/componentstatuses
- GET /api/v1/componentstatuses/{name}

**Which issue(s) this PR fixes**:
Fixes #73499

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
