### PR TITLE
kubeadm: fix incorrect criSocket override

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -158,11 +158,6 @@ func runApply(flags *applyFlags) error {
 		return err
 	}
 
-	if len(flags.criSocket) != 0 {
-		fmt.Println("[upgrade/apply] Respecting the --cri-socket flag that is set with higher priority than the config file.")
-		upgradeVars.cfg.NodeRegistration.CRISocket = flags.criSocket
-	}
-
 	// Validate requested and validate actual version
 	klog.V(1).Infof("[upgrade/apply] validating requested and actual version")
 	if err := configutil.NormalizeKubernetesVersion(&upgradeVars.cfg.ClusterConfiguration); err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

"kubeadm upgrade" overrides criSocket configuration option with
the value of --cri-socket command line option even if
this option is not used.

Removing overriding logic. Fixing the logic doesn't make sense
as --cri-socket option is deprecated for kubeadm upgrade.

**Which issue(s) this PR fixes**:

Fixes kubernetes/kubeadm#1322

**Special notes for your reviewer**:
This can be related to  kubernetes/kubeadm#1356

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: fix incorrect criSocket override
```