### PR TITLE
Enhance debuggability of e2e tests using exec command

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3407,7 +3407,7 @@ func NewHostExecPodSpec(ns, name string) *v1.Pod {
 // RunHostCmd runs the given cmd in the context of the given pod using `kubectl exec`
 // inside of a shell.
 func RunHostCmd(ns, name, cmd string) (string, error) {
-	return RunKubectl("exec", fmt.Sprintf("--namespace=%v", ns), name, "--", "/bin/sh", "-c", cmd)
+	return RunKubectl("exec", fmt.Sprintf("--namespace=%v", ns), name, "--", "/bin/sh", "-x", "-c", cmd)
 }
 
 // RunHostCmdOrDie calls RunHostCmd and dies on error.


### PR DESCRIPTION
**What this PR does / why we need it**:
I was debugging a Statefulset test hanging for 15m using `kubectl exec ` to run `touch /data/statefulset-continue; sync` and was unable to prove what exactly it was waiting on - if the kubectl exec API calls were hung up somewhere, if the commands inside even run, or some of them was causing it to wait. I suspected the `sync`, but it would be nice to have the e2e logs confirm that. Adding `-x` flag to bash does just that.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @kubernetes/sig-apps-pr-reviews 