### PR TITLE
Use debian-base for kubemark image

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -71,15 +71,6 @@ load(
 container_repositories()
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
-
-container_pull(
-    name = "official_busybox",
-    digest = "sha256:5e8e0509e829bb8f990249135a36e81a3ecbe94294e7a185cc14616e5fad96bd",
-    registry = "index.docker.io",
-    repository = "library/busybox",
-    tag = "latest",  # ignored, but kept here for documentation
-)
-
 load("//build:workspace.bzl", "release_dependencies")
 
 release_dependencies()

--- a/cluster/images/kubemark/BUILD
+++ b/cluster/images/kubemark/BUILD
@@ -4,7 +4,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image", "cont
 
 container_image(
     name = "image",
-    base = "@official_busybox//image",
+    base = "@debian-base-amd64//image",
     entrypoint = ["/kubemark"],
     files = ["//cmd/kubemark"],
     stamp = True,

--- a/cluster/images/kubemark/BUILD
+++ b/cluster/images/kubemark/BUILD
@@ -4,7 +4,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image", "cont
 
 container_image(
     name = "image",
-    base = "@debian-base-amd64//image",
+    base = "@debian-hyperkube-base-amd64//image",
     entrypoint = ["/kubemark"],
     files = ["//cmd/kubemark"],
     stamp = True,

--- a/cluster/images/kubemark/Dockerfile
+++ b/cluster/images/kubemark/Dockerfile
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/debian-base-amd64:0.4.1
-
-RUN clean-install bash
+FROM k8s.gcr.io/debian-hyperkube-base-amd64:0.12.1
 
 COPY kubemark /kubemark

--- a/cluster/images/kubemark/Dockerfile
+++ b/cluster/images/kubemark/Dockerfile
@@ -14,4 +14,6 @@
 
 FROM k8s.gcr.io/debian-base-amd64:0.4.1
 
+RUN clean-install bash
+
 COPY kubemark /kubemark

--- a/cluster/images/kubemark/Dockerfile
+++ b/cluster/images/kubemark/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM k8s.gcr.io/debian-base-amd64:0.4.1
 
 COPY kubemark /kubemark

--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -51,9 +51,13 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         command:
-        - /bin/sh
-        - -c
-        - /kubemark --morph=kubelet --name=$(NODE_NAME) {{hollow_kubelet_params}} --kubeconfig=/kubeconfig/kubelet.kubeconfig $(CONTENT_TYPE) --alsologtostderr 1>>/var/log/kubelet-$(NODE_NAME).log 2>&1
+        - /kubemark
+        - --morph=kubelet
+        - --name=$(NODE_NAME)
+        - {{hollow_kubelet_params}}
+        - --kubeconfig=/kubeconfig/kubelet.kubeconfig
+        - $(CONTENT_TYPE)
+        - --log-file=/var/log/kubelet-$(NODE_NAME).log
         volumeMounts:
         - name: kubeconfig-volume
           mountPath: /kubeconfig
@@ -79,9 +83,13 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         command:
-        - /bin/sh
-        - -c
-        - /kubemark --morph=proxy --name=$(NODE_NAME) {{hollow_proxy_params}} --kubeconfig=/kubeconfig/kubeproxy.kubeconfig $(CONTENT_TYPE) --alsologtostderr 1>>/var/log/kubeproxy-$(NODE_NAME).log 2>&1
+        - /kubemark
+        - --morph=proxy
+        - --name=$(NODE_NAME)
+        - {{hollow_proxy_params}}
+        - --kubeconfig=/kubeconfig/kubeproxy.kubeconfig
+        - $(CONTENT_TYPE)
+        - --log-file=/var/log/kubeproxy-$(NODE_NAME).log
         volumeMounts:
         - name: kubeconfig-volume
           mountPath: /kubeconfig


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**: this defines a consistent base image to use with the kubemark image; previously the docker build workflow used `debian:jessie` (`debian-base` is now based on stretch) and bazel used `busybox`.

This is basically a followup on https://github.com/kubernetes/kubernetes/pull/70245#discussion_r228286114.

**Special notes for your reviewer**: this partially depends on `debian-base-amd64:0.4.1`, which is being added in https://github.com/kubernetes/kubernetes/pull/73493. I figured it was better to use the new version instead of racing with an older version.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The kubemark image is now based on `debian-base`.
```

/assign @BenTheElder @wojtek-t @tallclair 