### PR TITLE
make missing-directory errors non fatal

### DIFF
--- a/pkg/kubectl/cmd/plugin/BUILD
+++ b/pkg/kubectl/cmd/plugin/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//pkg/kubectl/util/templates:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/kubectl/cmd/plugin/plugin.go
+++ b/pkg/kubectl/cmd/plugin/plugin.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
@@ -117,6 +118,11 @@ func (o *PluginListOptions) Run() error {
 	for _, dir := range uniquePathsList(o.PluginPaths) {
 		files, err := ioutil.ReadDir(dir)
 		if err != nil {
+			if _, ok := err.(*os.PathError); ok && strings.Contains(err.Error(), "no such file") {
+				klog.V(3).Infof("unable to find directory %q in your PATH. Skipping...", dir)
+				continue
+			}
+
 			pluginErrors = append(pluginErrors, fmt.Errorf("error: unable to read directory %q in your PATH: %v", dir, err))
 			continue
 		}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubectl/issues/574

/kind cleanup
/sig cli

```release-note
Missing directories listed in a user's PATH are no longer considered errors and are instead logged by the "kubectl plugin list" command when listing available plugins.
```

cc @soltysh @ahmetb  
