### PR TITLE
Add monitoring for RuntimeClass

### DIFF
--- a/pkg/kubelet/kuberuntime/instrumented_services.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services.go
@@ -178,10 +178,15 @@ func (in instrumentedRuntimeService) Attach(req *runtimeapi.AttachRequest) (*run
 
 func (in instrumentedRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error) {
 	const operation = "run_podsandbox"
-	defer recordOperation(operation, time.Now())
+	startTime := time.Now()
+	defer recordOperation(operation, startTime)
+	defer metrics.RunPodSandboxLatencies.WithLabelValues(runtimeHandler).Observe(metrics.SinceInMicroseconds(startTime))
 
 	out, err := in.service.RunPodSandbox(config, runtimeHandler)
 	recordError(operation, err)
+	if err != nil {
+		metrics.RunPodSandboxErrors.WithLabelValues(runtimeHandler).Inc()
+	}
 	return out, err
 }
 

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -62,6 +62,10 @@ const (
 	ConfigUIDLabelKey             = "node_config_uid"
 	ConfigResourceVersionLabelKey = "node_config_resource_version"
 	KubeletConfigKeyLabelKey      = "node_config_kubelet_key"
+
+	// Metrics keys for RuntimeClass
+	RunPodSandboxLatenciesKey = "run_podsandbox_latencies"
+	RunPodSandboxErrorsKey    = "run_podsandbox_errors"
 )
 
 var (
@@ -198,6 +202,22 @@ var (
 			Name:      ConfigErrorKey,
 			Help:      "This metric is true (1) if the node is experiencing a configuration-related error, false (0) otherwise.",
 		},
+	)
+	RunPodSandboxLatencies = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Subsystem: KubeletSubsystem,
+			Name:      RunPodSandboxLatenciesKey,
+			Help:      "Latencies in microseconds of the run_podsandbox operations. Broken down by RuntimeClass.",
+		},
+		[]string{"runtime_handler"},
+	)
+	RunPodSandboxErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: KubeletSubsystem,
+			Name:      RunPodSandboxErrorsKey,
+			Help:      "Cumulative number of the run_podsandbox operation errors by RuntimeClass.",
+		},
+		[]string{"runtime_handler"},
 	)
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add monitoring for RuntimeClass usage, and cover:
1) how robust every runtime is?
2) how expensive every runtime is in terms of time overhead?

The monitoring of RuntimeClass is documented in https://github.com/kubernetes/enhancements/pull/756.

**Which issue(s) this PR fixes**:
This PR is for #73058

```release-note
NONE
```