### PR TITLE
Setting json patch parameters for the apiserver

### DIFF
--- a/pkg/kubectl/cmd/patch/patch.go
+++ b/pkg/kubectl/cmd/patch/patch.go
@@ -42,6 +42,18 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
 )
 
+func init() {
+	// Negative index is not supported in the JSON patch spec (ietf
+	// rfc6902), so we disable it.
+	jsonpatch.SupportNegativeIndices = false
+	// The apiserver limits the size of persisted object to be 1MB. Setting
+	// the upper limit of the length of any array in a single object to 1
+	// million is more than enough. On the other hand, a slice consists of
+	// 1 million empty jsonpatch.lazyNode costs 8MB memory, which is
+	// insignificant.
+	jsonpatch.ArraySizeLimit = 1024 * 1024
+}
+
 var patchTypes = map[string]types.PatchType{"json": types.JSONPatchType, "merge": types.MergePatchType, "strategic": types.StrategicMergePatchType}
 
 // PatchOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -40,6 +40,18 @@ import (
 	"k8s.io/apiserver/pkg/util/webhook"
 )
 
+func init() {
+	// Negative index is not supported in the JSON patch spec (ietf
+	// rfc6902), so we disable it.
+	jsonpatch.SupportNegativeIndices = false
+	// The apiserver limits the size of persisted object to be 1MB. Setting
+	// the upper limit of the length of any array in a single object to 1
+	// million is more than enough. On the other hand, a slice consists of
+	// 1 million empty jsonpatch.lazyNode costs 8MB memory, which is
+	// insignificant.
+	jsonpatch.ArraySizeLimit = 1024 * 1024
+}
+
 type mutatingDispatcher struct {
 	cm     *webhook.ClientManager
 	plugin *Plugin

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -47,6 +47,18 @@ import (
 	utiltrace "k8s.io/utils/trace"
 )
 
+func init() {
+	// Negative index is not supported in the JSON patch spec (ietf
+	// rfc6902), so we disable it.
+	jsonpatch.SupportNegativeIndices = false
+	// The apiserver limits the size of persisted object to be 1MB. Setting
+	// the upper limit of the length of any array in a single object to 1
+	// million is more than enough. On the other hand, a slice consists of
+	// 1 million empty jsonpatch.lazyNode costs 8MB memory, which is
+	// insignificant.
+	jsonpatch.ArraySizeLimit = 1024 * 1024
+}
+
 // PatchResource returns a function that will handle a resource patch.
 func PatchResource(r rest.Patcher, scope RequestScope, admit admission.Interface, patchTypes []string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Setting json patch parameters to 
* avoid excessive memory allocation.
* avoid behavior not specified in the RFC.

There are other places import the json-patch lib, but they don't apply the patch, so they don't need to set the parameters.

I didn't set the [ArraySizeAdditionLimit](https://github.com/evanphx/json-patch/blob/master/patch.go#L19), because the ArraySizeLimit provides enough protection.

I will send followup PRs or issues to fix the client-side error message. Currently they are not helpful.

/assign @liggitt @cjcullen 
/kind bug-fix
/sig api-machinery
Fix #68578

```release-note
kubectl and the kube-apiserver stops supporting negative indices in json patch.
```

The release note doesn't mention the size limit because patches that violate the limit have always been invalid.