### PR TITLE
KUBE_JUNIT_REPORT_DIR fixes

### DIFF
--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -41,6 +41,7 @@ export KUBE_RACE=" "
 # Disable coverage report
 export KUBE_COVER="n"
 export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}
+export FULL_LOG="true"
 
 mkdir -p "${ARTIFACTS}"
 cd /go/src/k8s.io/kubernetes

--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -34,6 +34,7 @@ retry() {
 export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 
 go install k8s.io/kubernetes/vendor/github.com/cespare/prettybench
+go install k8s.io/kubernetes/vendor/github.com/jstemmer/go-junit-report
 
 # Disable the Go race detector.
 export KUBE_RACE=" "

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -188,6 +188,10 @@ if [[ -n "${KUBE_JUNIT_REPORT_DIR}" ]] ; then
   go_test_grep_pattern="^[^[:space:]]\+[[:space:]]\+[^[:space:]]\+/[^[[:space:]]\+"
 fi
 
+if [[ -n "${FULL_LOG:-}" ]] ; then
+  go_test_grep_pattern=".*"
+fi
+
 # Filter out arguments that start with "-" and move them to goflags.
 testcases=()
 for arg; do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes k8s.io/kubernetes/hack/jenkins/benchmark-dockerized.sh script.
- If KUBE_JUNIT_REPORT_DIR is provided, benchmark-dockerized.sh script should ensure that there is  go-junit-report installed.
- KUBE_JUNIT_REPORT_DIR is nor provided, k8s.io/kubernetes/hack/make-rules/test.sh should write log to sdtout.

**Which issue(s) this PR fixes**:
ref #72363 

**Special notes for your reviewer**:
reverting some changes from #72218 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
