### PR TITLE
TestCreatePodSandbox_RuntimeClass should not expect RunPodSandbox when runtime class not found

### DIFF
--- a/pkg/kubelet/kuberuntime/BUILD
+++ b/pkg/kubelet/kuberuntime/BUILD
@@ -110,6 +110,7 @@ go_test(
         "//pkg/kubelet/runtimeclass:go_default_library",
         "//pkg/kubelet/runtimeclass/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

In case the "phantom" runtime class is being tested, this test can fail expecting the `RunPodSandbox` is called. According to https://github.com/kubernetes/kubernetes/blob/e27f7ef151d2207d1952b5d096cdb4d0ae184f56/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go#L55 when the `LookupRuntimeHandler` return not found (the "phantom" case, the call will fail with error and not progress further).

What is weird is that this test is flaky, meaning that something this won't error out even when the "phantom" is not found (?).

```release-note
NONE
```