### PR TITLE
Fix #73479 AWS NLB target groups missing tags

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -143,10 +143,7 @@ func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBa
 		loadBalancer = createResponse.LoadBalancers[0]
 
 		// Create Target Groups
-		addTagsInput := &elbv2.AddTagsInput{
-			ResourceArns: []*string{},
-			Tags:         []*elbv2.Tag{},
-		}
+		resourceArns := make([]*string, 0, len(mappings))
 
 		for i := range mappings {
 			// It is easier to keep track of updates by having possibly
@@ -155,20 +152,28 @@ func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBa
 			if err != nil {
 				return nil, fmt.Errorf("Error creating listener: %q", err)
 			}
-			addTagsInput.ResourceArns = append(addTagsInput.ResourceArns, targetGroupArn)
+			resourceArns = append(resourceArns, targetGroupArn)
 
 		}
 
 		// Add tags to targets
+		targetGroupTags := make([]*elbv2.Tag, 0, len(tags))
+
 		for k, v := range tags {
-			addTagsInput.Tags = append(addTagsInput.Tags, &elbv2.Tag{
+			targetGroupTags = append(targetGroupTags, &elbv2.Tag{
 				Key: aws.String(k), Value: aws.String(v),
 			})
 		}
-		if len(addTagsInput.ResourceArns) > 0 && len(addTagsInput.Tags) > 0 {
-			_, err = c.elbv2.AddTags(addTagsInput)
-			if err != nil {
-				return nil, fmt.Errorf("Error adding tags after creating Load Balancer: %q", err)
+		if len(resourceArns) > 0 && len(targetGroupTags) > 0 {
+			// elbv2.AddTags doesn't allow to tag multiple resources at once
+			for _, arn := range resourceArns {
+				_, err = c.elbv2.AddTags(&elbv2.AddTagsInput{
+					ResourceArns: []*string{arn},
+					Tags:         targetGroupTags,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("Error adding tags after creating Load Balancer: %q", err)
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig aws

**What this PR does / why we need it**:

`elbv2.AddTags` doesn't seem to support assigning the same set of tags to multiple resources at once leading to the following error:
>  Error adding tags after modifying load balancer targets:
>  "ValidationError: Only one resource can be tagged at a time"

This can happen when using AWS NLB with multiple listeners pointing to different node ports.

When k8s creates a NLB it creates a target group per listener along with installing security group ingress rules allowing the traffic to reach the k8s nodes.

Unfortunately if those target groups are not tagged, k8s thinks the security group ingress rules are orphaned and removes them, making it impossible for external trafic to reach the cluster
nodes.

This small change assigns tags one target group at a time instead of batching them as before.

**Which issue(s) this PR fixes**:

Fixes #73479 

**Special notes for your reviewer**:

It seems that this part of the code is not covered by unit tests. I thus haven't tried to add tests of this change. If it is required to do so, please let me know and I'll amend the PR.

**Does this PR introduce a user-facing change?**:

I'm not quite sure this can qualify as a 'user-facing change' as it restores the intended behavior, but anyway here are some release notes

```release-note
Prevent AWS Network Load Balancer security groups ingress rules to be deleted by ensuring target groups are tagged.
```

