### PR TITLE
Preserve authentication webhook error message, deduplicate aggregated errors when printing

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/errors/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/errors/BUILD
@@ -20,6 +20,7 @@ go_library(
     ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/errors",
     importpath = "k8s.io/apimachinery/pkg/util/errors",
+    deps = ["//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library"],
 )
 
 filegroup(

--- a/staging/src/k8s.io/apimachinery/pkg/util/errors/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/errors/errors_test.go
@@ -147,6 +147,38 @@ func TestPluralAggregate(t *testing.T) {
 	}
 }
 
+func TestDedupeAggregate(t *testing.T) {
+	var slice []error = []error{fmt.Errorf("abc"), fmt.Errorf("abc")}
+	var agg Aggregate
+
+	agg = NewAggregate(slice)
+	if agg == nil {
+		t.Errorf("expected non-nil")
+	}
+	if s := agg.Error(); s != "abc" {
+		t.Errorf("expected 'abc', got %q", s)
+	}
+	if s := agg.Errors(); len(s) != 2 {
+		t.Errorf("expected two-elements slice, got %#v", s)
+	}
+}
+
+func TestDedupePluralAggregate(t *testing.T) {
+	var slice []error = []error{fmt.Errorf("abc"), fmt.Errorf("abc"), fmt.Errorf("123")}
+	var agg Aggregate
+
+	agg = NewAggregate(slice)
+	if agg == nil {
+		t.Errorf("expected non-nil")
+	}
+	if s := agg.Error(); s != "[abc, 123]" {
+		t.Errorf("expected '[abc, 123]', got %q", s)
+	}
+	if s := agg.Errors(); len(s) != 3 {
+		t.Errorf("expected three-elements slice, got %#v", s)
+	}
+}
+
 func TestFilterOut(t *testing.T) {
 	testCases := []struct {
 		err      error

--- a/staging/src/k8s.io/apimachinery/pkg/util/errors/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/errors/errors_test.go
@@ -179,6 +179,38 @@ func TestDedupePluralAggregate(t *testing.T) {
 	}
 }
 
+func TestFlattenAndDedupeAggregate(t *testing.T) {
+	var slice []error = []error{fmt.Errorf("abc"), fmt.Errorf("abc"), NewAggregate([]error{fmt.Errorf("abc")})}
+	var agg Aggregate
+
+	agg = NewAggregate(slice)
+	if agg == nil {
+		t.Errorf("expected non-nil")
+	}
+	if s := agg.Error(); s != "abc" {
+		t.Errorf("expected 'abc', got %q", s)
+	}
+	if s := agg.Errors(); len(s) != 3 {
+		t.Errorf("expected three-elements slice, got %#v", s)
+	}
+}
+
+func TestFlattenAggregate(t *testing.T) {
+	var slice []error = []error{fmt.Errorf("abc"), fmt.Errorf("abc"), NewAggregate([]error{fmt.Errorf("abc"), fmt.Errorf("def"), NewAggregate([]error{fmt.Errorf("def"), fmt.Errorf("ghi")})})}
+	var agg Aggregate
+
+	agg = NewAggregate(slice)
+	if agg == nil {
+		t.Errorf("expected non-nil")
+	}
+	if s := agg.Error(); s != "[abc, def, ghi]" {
+		t.Errorf("expected '[abc, def, ghi]', got %q", s)
+	}
+	if s := agg.Errors(); len(s) != 3 {
+		t.Errorf("expected three-elements slice, got %#v", s)
+	}
+}
+
 func TestFilterOut(t *testing.T) {
 	testCases := []struct {
 		err      error

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
@@ -19,6 +19,7 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	authentication "k8s.io/api/authentication/v1beta1"
@@ -120,7 +121,11 @@ func (w *WebhookTokenAuthenticator) AuthenticateToken(ctx context.Context, token
 
 	r.Status = result.Status
 	if !r.Status.Authenticated {
-		return nil, false, nil
+		var err error
+		if len(r.Status.Error) != 0 {
+			err = errors.New(r.Status.Error)
+		}
+		return nil, false, err
 	}
 
 	var extra map[string][]string


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
* Plumbs an error message returned from an authentication webhook
* Improves string output of aggregated errors containing duplicated or nested messages

**Which issue(s) this PR fixes**:
Fixes #73592

**Does this PR introduce a user-facing change?**:
```release-note
error messages returned in authentication webhook status responses are now correctly included in the apiserver log
```

/sig auth