### PR TITLE
Add ps1 to windows executable extensions

### DIFF
--- a/pkg/kubectl/cmd/plugin/plugin.go
+++ b/pkg/kubectl/cmd/plugin/plugin.go
@@ -229,7 +229,7 @@ func isExecutable(fullPath string) (bool, error) {
 		fileExt := strings.ToLower(filepath.Ext(fullPath))
 
 		switch fileExt {
-		case ".bat", ".cmd", ".com", ".exe":
+		case ".bat", ".cmd", ".com", ".exe", ".ps1":
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

.ps1 is for Windows PowerShell Cmdlet which is among windows executable extensions

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
