### PR TITLE
move GCERegionalPersistentDisk feature to k8s.io/cloud-provider/features

### DIFF
--- a/pkg/cloudprovider/providers/gce/BUILD
+++ b/pkg/cloudprovider/providers/gce/BUILD
@@ -47,7 +47,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/gce",
     deps = [
         "//pkg/api/v1/service:go_default_library",
-        "//pkg/features:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/master/ports:go_default_library",
         "//pkg/util/net/sets:go_default_library",
@@ -74,6 +73,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/features:go_default_library",
         "//vendor/cloud.google.com/go/compute/metadata:go_default_library",
         "//vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud:go_default_library",
         "//vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter:go_default_library",

--- a/pkg/features/BUILD
+++ b/pkg/features/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/features:go_default_library",
     ],
 )
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -20,6 +20,7 @@ import (
 	apiextensionsfeatures "k8s.io/apiextensions-apiserver/pkg/features"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	cloudfeatures "k8s.io/cloud-provider/features"
 )
 
 const (
@@ -282,12 +283,6 @@ const (
 	// Enable container log rotation for cri container runtime
 	CRIContainerLogRotation utilfeature.Feature = "CRIContainerLogRotation"
 
-	// owner: @verult
-	// GA: v1.13
-	//
-	// Enables the regional PD feature on GCE.
-	GCERegionalPersistentDisk utilfeature.Feature = "GCERegionalPersistentDisk"
-
 	// owner: @krmayankk
 	// alpha: v1.10
 	//
@@ -460,7 +455,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	TokenRequestProjection:                      {Default: true, PreRelease: utilfeature.Beta},
 	BoundServiceAccountTokenVolume:              {Default: false, PreRelease: utilfeature.Alpha},
 	CRIContainerLogRotation:                     {Default: true, PreRelease: utilfeature.Beta},
-	GCERegionalPersistentDisk:                   {Default: true, PreRelease: utilfeature.GA},
+	cloudfeatures.GCERegionalPersistentDisk:     {Default: true, PreRelease: utilfeature.GA},
 	CSIMigration:                                {Default: false, PreRelease: utilfeature.Alpha},
 	CSIMigrationGCE:                             {Default: false, PreRelease: utilfeature.Alpha},
 	CSIMigrationAWS:                             {Default: false, PreRelease: utilfeature.Alpha},

--- a/pkg/volume/gcepd/BUILD
+++ b/pkg/volume/gcepd/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/features:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
         "//vendor/k8s.io/utils/path:go_default_library",

--- a/pkg/volume/gcepd/gce_util.go
+++ b/pkg/volume/gcepd/gce_util.go
@@ -28,9 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	cloudprovider "k8s.io/cloud-provider"
+	cloudfeatures "k8s.io/cloud-provider/features"
 	"k8s.io/klog"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
-	"k8s.io/kubernetes/pkg/features"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
@@ -127,10 +127,10 @@ func (util *GCEDiskUtil) CreateVolume(c *gcePersistentDiskProvisioner, node *v1.
 				return "", 0, nil, "", err
 			}
 		case "replication-type":
-			if !utilfeature.DefaultFeatureGate.Enabled(features.GCERegionalPersistentDisk) {
+			if !utilfeature.DefaultFeatureGate.Enabled(cloudfeatures.GCERegionalPersistentDisk) {
 				return "", 0, nil, "",
 					fmt.Errorf("the %q option for volume plugin %v is only supported with the %q Kubernetes feature gate enabled",
-						k, c.plugin.GetPluginName(), features.GCERegionalPersistentDisk)
+						k, c.plugin.GetPluginName(), cloudfeatures.GCERegionalPersistentDisk)
 			}
 			replicationType = strings.ToLower(v)
 		case volume.VolumeParameterFSType:

--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -188,6 +188,7 @@
   allowedImports:
   - k8s.io/api
   - k8s.io/apimachinery
+  - k8s.io/apiserver
   - k8s.io/client-go
   - k8s.io/klog
 

--- a/staging/src/k8s.io/cloud-provider/BUILD
+++ b/staging/src/k8s.io/cloud-provider/BUILD
@@ -35,6 +35,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//staging/src/k8s.io/cloud-provider/features:all-srcs",
         "//staging/src/k8s.io/cloud-provider/node:all-srcs",
     ],
     tags = ["automanaged"],

--- a/staging/src/k8s.io/cloud-provider/Godeps/Godeps.json
+++ b/staging/src/k8s.io/cloud-provider/Godeps/Godeps.json
@@ -91,6 +91,10 @@
 			"Rev": "5f041e8faa004a95c88a202771f4cc3e991971e6"
 		},
 		{
+			"ImportPath": "github.com/spf13/pflag",
+			"Rev": "583c0c0531f06d5278b7d917446061adc344b5cd"
+		},
+		{
 			"ImportPath": "golang.org/x/crypto/ssh/terminal",
 			"Rev": "de0752318171da717af4ce24d0a2e8626afaeb11"
 		},
@@ -456,6 +460,10 @@
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/apiserver/pkg/util/feature",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{

--- a/staging/src/k8s.io/cloud-provider/features/BUILD
+++ b/staging/src/k8s.io/cloud-provider/features/BUILD
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["gce.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/cloud-provider/features",
+    importpath = "k8s.io/cloud-provider/features",
+    visibility = ["//visibility:public"],
+    deps = ["//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/cloud-provider/features/gce.go
+++ b/staging/src/k8s.io/cloud-provider/features/gce.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+)
+
+// TODO: this file should ideally live in k8s.io/cloud-provider-gcp, but it is
+// temporarily placed here to remove dependencies to k8s.io/kubernetes in the
+// in-tree GCE cloud provider. Move this to k8s.io/cloud-provider-gcp as soon
+// as it's ready to be used
+const (
+	// owner: @verult
+	// GA: v1.13
+	//
+	// Enables the regional PD feature on GCE.
+	GCERegionalPersistentDisk utilfeature.Feature = "GCERegionalPersistentDisk"
+)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Temporarily moves `GCERegionalPersistentDisk` feature to `k8s.io/cloud-provider/features/gce.go` in order to remove internal dependnecy to `pkg/feature`. This is required as part of https://github.com/kubernetes/kubernetes/issues/69585. 

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/kubernetes/issues/69585

**Special notes for your reviewer**:
This ideally should be moved to `k8s.io/cloud-provider-gcp` but I don't think that repo is setup to do that yet. Left a TODO for this. I understand this is not ideal, but this would unblock the cloud provider extraction work and I think it's worth the trade-off, happy to consider alternatives though. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cloud-provider
/assign @cheftako 
