### PR TITLE
Deleting pods assigned to not existing nodes only if

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -964,8 +964,11 @@ func (dsc *DaemonSetsController) manage(ds *apps.DaemonSet, hash string) error {
 		failedPodsObserved += failedPodsObservedOnNode
 	}
 
-	// Remove pods assigned to not existing nodes.
-	podsToDelete = append(podsToDelete, getPodsWithoutNode(nodeList, nodeToDaemonPods)...)
+	// Remove pods assigned to not existing nodes when daemonset pods are scheduled by default scheduler.
+	// If node doesn't exist then pods are never scheduled and can't be deleted by PodGCController.
+	if utilfeature.DefaultFeatureGate.Enabled(features.ScheduleDaemonSetPods) {
+		podsToDelete = append(podsToDelete, getPodsWithoutNode(nodeList, nodeToDaemonPods)...)
+	}
 
 	// Label new pods using the hash label value of the current history when creating them
 	if err = dsc.syncNodes(ds, podsToDelete, nodesNeedingDaemonPods, hash); err != nil {
@@ -1529,8 +1532,7 @@ func failedPodsBackoffKey(ds *apps.DaemonSet, nodeName string) string {
 }
 
 // getPodsWithoutNode returns list of pods assigned to not existing nodes.
-func getPodsWithoutNode(
-	runningNodesList []*v1.Node, nodeToDaemonPods map[string][]*v1.Pod) []string {
+func getPodsWithoutNode(runningNodesList []*v1.Node, nodeToDaemonPods map[string][]*v1.Pod) []string {
 	var results []string
 	isNodeRunning := make(map[string]bool)
 	for _, node := range runningNodesList {

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -2461,7 +2461,11 @@ func TestDeletePodForNotExistingNode(t *testing.T) {
 			addNodes(manager.nodeStore, 0, 1, nil)
 			addPods(manager.podStore, "node-0", simpleDaemonSetLabel, ds, 1)
 			addPods(manager.podStore, "node-1", simpleDaemonSetLabel, ds, 1)
-			syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 1, 0)
+			if f {
+				syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 1, 0)
+			} else {
+				syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 0, 0)
+			}
 		}
 	}
 }


### PR DESCRIPTION
ScheduleDaemonSetPods is enabled.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
PR adds checking ScheduleDaemonSetPods feature gate check for deleting pods assigned to not existing nodes.
**Which issue(s) this PR fixes**:

Fixes ##71349

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```