### PR TITLE
return original error, unless error is *meta.NoKindMatchError

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
@@ -708,12 +708,12 @@ func (b *Builder) mappingFor(resourceOrKindArg string) (*meta.RESTMapping, error
 		// if we error out here, it is because we could not match a resource or a kind
 		// for the given argument. To maintain consistency with previous behavior,
 		// announce that a resource type could not be found.
-		// if the error is a URL error, then we had trouble doing discovery, so we should return the original
-		// error since it may help a user diagnose what is actually wrong
-		if _, ok := err.(*url.Error); ok {
-			return nil, err
+		// if the error is _not_ a *meta.NoKindMatchError, then we had trouble doing discovery,
+		// so we should return the original error since it may help a user diagnose what is actually wrong
+		if meta.IsNoMatchError(err) {
+			return nil, fmt.Errorf("the server doesn't have a resource type %q", groupResource.Resource)
 		}
-		return nil, fmt.Errorf("the server doesn't have a resource type %q", groupResource.Resource)
+		return nil, err
 	}
 
 	return mapping, nil


### PR DESCRIPTION
/kind cleanup
/sig cli

Makes it easier to debug errors associated with discovery. If we're unable to obtain a rest mapping for a resource due to miscellaneous discovery errors, that error is now printed out. For errors pertaining to non-existent resources, the original error `error: the server doesn't have a resource type "..."` is still returned.

```release-note
NONE
```

cc @deads2k @smarterclayton @soltysh 