### PR TITLE
remove GCE cloud provider dependency to pkg/master/ports

### DIFF
--- a/pkg/cloudprovider/providers/gce/BUILD
+++ b/pkg/cloudprovider/providers/gce/BUILD
@@ -49,7 +49,6 @@ go_library(
         "//pkg/api/v1/service:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
-        "//pkg/master/ports:go_default_library",
         "//pkg/util/net/sets:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",

--- a/pkg/cloudprovider/providers/gce/gce_healthchecks.go
+++ b/pkg/cloudprovider/providers/gce/gce_healthchecks.go
@@ -28,12 +28,15 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/api/core/v1"
 	utilversion "k8s.io/apimachinery/pkg/util/version"
-	"k8s.io/kubernetes/pkg/master/ports"
 )
 
 const (
-	nodesHealthCheckPath   = "/healthz"
-	lbNodesHealthCheckPort = ports.ProxyHealthzPort
+	nodesHealthCheckPath = "/healthz"
+	// NOTE: Please keep the following port in sync with ProxyHealthzPort in pkg/master/ports/ports.go
+	// ports.ProxyHealthzPort was not used here to avoid dependencies to k8s.io/kubernetes in the
+	// GCE cloud provider which is required as part of the out-of-tree cloud provider efforts.
+	// TODO: use a shared constant once ports in pkg/master/ports are in a common external repo.
+	lbNodesHealthCheckPort = 10256
 )
 
 var (


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Duplicates the proxy port value to remove dependencies to k8s.io/kubernetes in the GCE provider. 

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/kubernetes/issues/69585

**Special notes for your reviewer**:
Not ideal to duplicate the port value there but it will unblock us from being able to move the GCE provider out-of-tree. I think it's worth the trade-off. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @cheftako @bowei 