### PR TITLE
remove dep to pkg/version in vSphere provider

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vclib/BUILD
+++ b/pkg/cloudprovider/providers/vsphere/vclib/BUILD
@@ -24,7 +24,7 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib",
     deps = [
-        "//pkg/version:go_default_library",
+        "//staging/src/k8s.io/client-go/pkg/version:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/vmware/govmomi/find:go_default_library",
         "//vendor/github.com/vmware/govmomi/object:go_default_library",

--- a/pkg/cloudprovider/providers/vsphere/vclib/connection.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/connection.go
@@ -29,8 +29,8 @@ import (
 	"github.com/vmware/govmomi/sts"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
+	"k8s.io/client-go/pkg/version"
 	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/version"
 )
 
 // VSphereConnection contains information for connecting to vCenter


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Accidentally left out the vSphere provider as part of https://github.com/kubernetes/kubernetes/pull/73550

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/kubernetes/issues/69585 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
