### PR TITLE
Cleanup: Audit log and error capitalization #15863

### DIFF
--- a/cluster/images/etcd-version-monitor/etcd-version-monitor.go
+++ b/cluster/images/etcd-version-monitor/etcd-version-monitor.go
@@ -19,10 +19,12 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	goflag "flag"
 	"fmt"
 	"net/http"
 	"time"
+	
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
@@ -202,21 +204,21 @@ func getVersion(lastSeenBinaryVersion *string) error {
 	// Create the get request for the etcd version endpoint.
 	req, err := http.NewRequest("GET", etcdVersionScrapeURI, nil)
 	if err != nil {
-		return fmt.Errorf("Failed to create GET request for etcd version: %v", err)
+		return fmt.Errorf("failed to create GET request for etcd version: %v", err)
 	}
 
 	// Send the get request and receive a response.
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("Failed to receive GET response for etcd version: %v", err)
+		return fmt.Errorf("failed to receive GET response for etcd version: %v", err)
 	}
 	defer resp.Body.Close()
 
 	// Obtain EtcdVersion from the JSON response.
 	var version EtcdVersion
 	if err := json.NewDecoder(resp.Body).Decode(&version); err != nil {
-		return fmt.Errorf("Failed to decode etcd version JSON: %v", err)
+		return fmt.Errorf("failed to decode etcd version JSON: %v", err)
 	}
 
 	// Return without updating the version if it stayed the same since last time.
@@ -228,7 +230,7 @@ func getVersion(lastSeenBinaryVersion *string) error {
 	if *lastSeenBinaryVersion != "" {
 		deleted := etcdVersion.Delete(prometheus.Labels{"binary_version": *lastSeenBinaryVersion})
 		if !deleted {
-			return fmt.Errorf("Failed to delete previous version's metric")
+			return errors.New("failed to delete previous version's metric")
 		}
 	}
 
@@ -259,14 +261,14 @@ func getVersionPeriodically(stopCh <-chan struct{}) {
 func scrapeMetrics() (map[string]*dto.MetricFamily, error) {
 	req, err := http.NewRequest("GET", etcdMetricsScrapeURI, nil)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create GET request for etcd metrics: %v", err)
+		return nil, fmt.Errorf("failed to create GET request for etcd metrics: %v", err)
 	}
 
 	// Send the get request and receive a response.
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to receive GET response for etcd metrics: %v", err)
+		return nil, fmt.Errorf("failed to receive GET response for etcd metrics: %v", err)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup


**What this PR does / why we need it**:
Consistent format for error strings
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->Partial Fix for #15863


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->NO
```release-note

```This commit solve the problem of inconsistent format of error string in etc-version-monitor file.