### PR TITLE
mount rbd device back if detach it failed

### DIFF
--- a/pkg/volume/rbd/BUILD
+++ b/pkg/volume/rbd/BUILD
@@ -41,7 +41,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["rbd_test.go"],
+    srcs = [
+        "attacher_test.go",
+        "rbd_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/util/mount:go_default_library",

--- a/pkg/volume/rbd/attacher_test.go
+++ b/pkg/volume/rbd/attacher_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	utiltesting "k8s.io/client-go/util/testing"
+	"k8s.io/kubernetes/pkg/util/mount"
+)
+
+type fakeMounter struct {
+	*mount.FakeMounter
+	unmountFunc func() error
+	remounted   bool
+}
+
+func (fm *fakeMounter) Unmount(target string) error {
+	return fm.unmountFunc()
+}
+func (fm *fakeMounter) Mount(source string, target string, fstype string, options []string) error {
+	fm.remounted = true
+	return nil
+}
+
+type fakeDetachDiskManger struct {
+	fakeDiskManager
+	detachFunc func() error
+}
+
+func (fddm *fakeDetachDiskManger) DetachDisk(r *rbdPlugin, deviceMountPath string, device string) error {
+	return fddm.detachFunc()
+}
+func TestDetachRBDDisk(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("rbd_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	mountPath := tmpDir + "/plugins/kubernetes.io/rbd/mounts/k8s_storage_kc1-image-kubernetes-dynamic-pvc-d95297dd-0b1a-11e9-a20e-0e392efe0609"
+	os.MkdirAll(mountPath, 0700)
+	mountPath, _ = filepath.EvalSymlinks(mountPath)
+
+	mounter := &mount.FakeMounter{
+		MountPoints: []mount.MountPoint{
+			{
+				Device: "/dev/rbd0",
+				Path:   mountPath,
+				Type:   "ext4",
+				Opts:   []string{"rw", "relatime", "stripe=4096", "data=ordered"},
+			},
+		},
+	}
+
+	tests := []struct {
+		comment    string
+		mounter    *fakeMounter
+		manager    *fakeDetachDiskManger
+		expectFunc func(mounter *fakeMounter, manager *fakeDetachDiskManger, err error) error
+	}{
+		{
+			comment: "unmount mountpoint failed",
+			mounter: &fakeMounter{
+				FakeMounter: mounter,
+				unmountFunc: func() func() error {
+					errs := []string{"unmount failed"}
+					index := 0
+					return func() error {
+						defer func() { index++ }()
+						return errors.New(errs[index])
+					}
+				}(),
+			},
+			manager: &fakeDetachDiskManger{
+				detachFunc: func() func() error {
+					return nil
+				}(),
+			},
+			expectFunc: func(_ *fakeMounter, _ *fakeDetachDiskManger, err error) error {
+				expect := "unmount failed"
+				if err.Error() != expect {
+					return fmt.Errorf("expect error: %v, got: %v", expect, err)
+				}
+				return nil
+			},
+		},
+		{
+			comment: "detach device failed after extra 5 retries, elapsed 15 seconds, and device got remounted",
+			mounter: &fakeMounter{
+				FakeMounter: mounter,
+				unmountFunc: func() func() error {
+					return func() error {
+						return nil
+					}
+				}(),
+			},
+			manager: &fakeDetachDiskManger{
+				detachFunc: func() func() error {
+					errs := []string{
+						"rbd: failed to unmap device /dev/rbd0",
+						"rbd: failed to unmap device /dev/rbd0",
+						"rbd: failed to unmap device /dev/rbd0",
+						"rbd: failed to unmap device /dev/rbd0",
+						"rbd: failed to unmap device /dev/rbd0",
+					}
+					index := 0
+					return func() error {
+						defer func() { index++ }()
+						return errors.New(errs[index])
+					}
+				}(),
+			},
+			expectFunc: func(mounter *fakeMounter, _ *fakeDetachDiskManger, err error) error {
+				expect := "rbd: failed to unmap device /dev/rbd0"
+				if err.Error() != expect {
+					return fmt.Errorf("expect error: %v, got: %v", expect, err)
+				}
+				if !mounter.remounted {
+					return fmt.Errorf("the device is not remounted")
+				}
+				return nil
+			},
+		},
+		{
+			comment: "detach device successfully after extra 2 retries, elapsed 3 seconds",
+			mounter: &fakeMounter{
+				FakeMounter: mounter,
+				unmountFunc: func() func() error {
+					return func() error {
+						return nil
+					}
+				}(),
+			},
+			manager: &fakeDetachDiskManger{
+				detachFunc: func() func() error {
+					errs := []string{
+						"rbd: failed to unmap device /dev/rbd0",
+						"rbd: failed to unmap device /dev/rbd0",
+						"",
+					}
+					index := 0
+					return func() error {
+						defer func() { index++ }()
+						if len(errs[index]) == 0 {
+							return nil
+						}
+						return errors.New(errs[index])
+					}
+				}(),
+			},
+			expectFunc: func(mounter *fakeMounter, _ *fakeDetachDiskManger, err error) error {
+				if err != nil {
+					return fmt.Errorf("expect no error, but got: %v", err)
+				}
+				return nil
+			},
+		},
+	}
+	for _, test := range tests {
+		detacher := &rbdDetacher{
+			manager: test.manager,
+			mounter: &mount.SafeFormatAndMount{Interface: test.mounter},
+		}
+		err := detacher.UnmountDevice(mountPath)
+		if ee := test.expectFunc(test.mounter, test.manager, err); ee != nil {
+			t.Fatal(ee)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`rbdDetacher.UnmountDevice` operation is not an atomic transaction. there are two steps to do rbd UnmountDevice operation, 1.) unmount the MountPoint; 2.) detach the rbd disk.  The second step is easily got failed, when the first step has already finished. when try to do `rbdDetacher.UnmountDevice` again, the function can't get `devicePath` from the none exist mountpoint,  so the rbd device will get no chance to be unmounted. 

we suffer a lot of cases like above. we still don't know  the reason why the detach operation failed, even it hasn't been used in the container.

```
Dec 26 20:14:48 node1 kubelet[114943]: E1226 20:14:48.554594  114943 nestedpendingoperations.go:267] Operation for "\"kubernetes.io/rbd/k8s_storage:kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a\"" failed. No retries permitted until 2018-12-26 20:14:49.05453596 +0800 CST m=+5.254243490 (durationBeforeRetry 500ms). Error: "UnmountDevice failed for volume \"pvc-77daf081-baeb-11e8-a78a-505dac4a782a\" (UniqueName: \"kubernetes.io/rbd/k8s_storage:kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a\") on node \"node1\" : rbd: failed to unmap device /dev/rbd2, error exit status 16, rbd output: [114 98 100 58 32 115 121 115 102 115 32 119 114 105 116 101 32 102 97 105 108 101 100 10 114 98 100 58 32 117 110 109 97 112 32 102 97 105 108 101 100 58 32 40 49 54 41 32 68 101 118 105 99 101 32 111 114 32 114 101 115 111 117 114 99 101 32 98 117 115 121 10]"
Dec 26 20:14:49 node1 kubelet[114943]: I1226 20:14:49.119631  114943 reconciler.go:278] operationExecutor.UnmountDevice started for volume "pvc-77daf081-baeb-11e8-a78a-505dac4a782a" (UniqueName: "kubernetes.io/rbd/k8s_storage:kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a") on node "node1"
Dec 26 20:14:49 node1 kubelet[114943]: W1226 20:14:49.120922  114943 mount_linux.go:179] could not determine device for path: "/data/kubelet/plugins/kubernetes.io/rbd/mounts/k8s_storage-image-kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a"
Dec 26 20:14:49 node1 kubelet[114943]: E1226 20:14:49.122054  114943 nestedpendingoperations.go:267] Operation for "\"kubernetes.io/rbd/k8s_storage:kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a\"" failed. No retries permitted until 2018-12-26 20:14:50.122036175 +0800 CST m=+6.321743682 (durationBeforeRetry 1s). Error: "UnmountDevice failed for volume \"pvc-77daf081-baeb-11e8-a78a-505dac4a782a\" (UniqueName: \"kubernetes.io/rbd/k8s_storage:kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a\") on node \"node1\" : DetachDisk failed , device is empty"
Dec 26 20:14:50 node1 kubelet[114943]: I1226 20:14:50.123622  114943 reconciler.go:278] operationExecutor.UnmountDevice started for volume "pvc-77daf081-baeb-11e8-a78a-505dac4a782a" (UniqueName: "kubernetes.io/rbd/k8s_storage:kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a") on node "node1"
Dec 26 20:14:50 node1 kubelet[114943]: W1226 20:14:50.124503  114943 mount_linux.go:179] could not determine device for path: "/data/kubelet/plugins/kubernetes.io/rbd/mounts/k8s_storage-image-kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a"
Dec 26 20:14:50 node1 kubelet[114943]: E1226 20:14:50.125198  114943 nestedpendingoperations.go:267] Operation for "\"kubernetes.io/rbd/k8s_storage:kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a\"" failed. No retries permitted until 2018-12-26 20:14:52.125180173 +0800 CST m=+8.324887680 (durationBeforeRetry 2s). Error: "UnmountDevice failed for volume \"pvc-77daf081-baeb-11e8-a78a-505dac4a782a\" (UniqueName: \"kubernetes.io/rbd/k8s_storage:kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a\") on node \"node1\" : DetachDisk failed , device is empty"
Dec 26 20:14:52 node1 kubelet[114943]: I1226 20:14:52.128452  114943 reconciler.go:278] operationExecutor.UnmountDevice started for volume "pvc-77daf081-baeb-11e8-a78a-505dac4a782a" (UniqueName: "kubernetes.io/rbd/k8s_storage:kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a") on node "node1"
Dec 26 20:14:52 node1 kubelet[114943]: W1226 20:14:52.129248  114943 mount_linux.go:179] could not determine device for path: "/data/kubelet/plugins/kubernetes.io/rbd/mounts/k8s_storage-image-kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a"
Dec 26 20:14:52 node1 kubelet[114943]: E1226 20:14:52.129881  114943 nestedpendingoperations.go:267] Operation for "\"kubernetes.io/rbd/k8s_storage:kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a\"" failed. No retries permitted until 2018-12-26 20:14:56.129857143 +0800 CST m=+12.329564653 (durationBeforeRetry 4s). Error: "UnmountDevice failed for volume \"pvc-77daf081-baeb-11e8-a78a-505dac4a782a\" (UniqueName: \"kubernetes.io/rbd/k8s_storage:kubernetes-dynamic-pvc-77f4dba8-baeb-11e8-b258-96499d9dda9a\") on node \"node1\" : DetachDisk failed , device is empty"
```

so we try more detaches if the previous one failed and mount the device back if all tries failed. this solved our rbd detach problems.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
