### PR TITLE
Add "empty username" check in the test

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/basicauth_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/basicauth_test.go
@@ -63,6 +63,12 @@ func TestBasicAuth(t *testing.T) {
 			ExpectedPassword: "",
 			ExpectedErr:      true,
 		},
+		"empty username": {
+			ExpectedCalled:   true,
+			ExpectedUsername: "",
+			ExpectedPassword: "mypassword",
+			ExpectedErr:      true,
+		},
 		"valid basic header": {
 			ExpectedCalled:   true,
 			ExpectedUsername: "myuser",


### PR DESCRIPTION
Check empty username in the  basicauth_test.go. 