### PR TITLE
Fix typo in create-heapster-node

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2774,7 +2774,7 @@ function create-heapster-node() {
       --tags "${NODE_TAG}" \
       ${network} \
       $(get-scope-flags) \
-      --metadata-from-file "$(get-linux-node-instance-metadata-from-file)"
+      --metadata-from-file "$(get-node-instance-metadata-from-file)"
 }
 
 # Assumes:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Without this PR, all tests using special heapster node are failing with:
```
I0201 08:06:13.544] Creating a special node for heapster with machine-type n1-standard-32
W0201 08:06:14.107] /workspace/kubernetes/cluster/../cluster/../cluster/gce/util.sh: line 2764: get-linux-node-instance-metadata-from-file: command not found
W0201 08:06:14.404] ERROR: (gcloud.compute.instances.create) argument --metadata-from-file: not enough args
```
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #73632

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @wojtek-t @mm4tt 