### PR TITLE
kubeadm: fix nil pointer dereference

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -62,10 +62,8 @@ func NewCmdReset(in io.Reader, out io.Writer) *cobra.Command {
 			kubeadmutil.CheckErr(err)
 
 			kubeConfigFile = cmdutil.FindExistingKubeConfig(kubeConfigFile)
-			if _, err := os.Stat(kubeConfigFile); !os.IsNotExist(err) {
-				client, err = getClientset(kubeConfigFile, false)
-				kubeadmutil.CheckErr(err)
-			}
+			client, err = getClientset(kubeConfigFile, false)
+			kubeadmutil.CheckErr(err)
 
 			if criSocketPath == "" {
 				criSocketPath, err = resetDetectCRISocket(client)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If configuration file doesn't exist 'client' variable is not assigned and causes kubeadm crash:

$ sudo ./_output/bin/kubeadm reset
[reset] Reading configuration from the cluster...
[reset] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -oyaml'
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xf8 pc=0x108c9e7]

goroutine 1 [running]:
cmd/kubeadm/app/util/config.getInitConfigurationFromCluster(0x171109b, 0xf, 0x0, 0x0, 0xc0005b5a00, 0x3, 0x3, 0x69)
	cmd/kubeadm/app/util/config/cluster.go:93 +0x37
cmd/kubeadm/app/util/config.loadConfiguration(0x0, 0x0, 0x18d63a0, 0xc00000c018, 0x170620b, 0x5, 0x0, 0x0, 0x15d6000, 0x18d7601, ...)
	cmd/kubeadm/app/util/config/cluster.go:67 +0x374
k8s.io/kubernetes/cmd/kubeadm/app/util/config.FetchConfigFromFileOrCluster(0x0, 0x0, 0x18d63a0, 0xc00000c018, 0x170620b, 0x5, 0x0, 0x0, 0x497700, 0x18d63e0, ...)
	cmd/kubeadm/app/util/config/cluster.go:45 +0x9c
k8s.io/kubernetes/cmd/kubeadm/app/cmd.resetDetectCRISocket(0x0, 0x0, 0x1, 0x0, 0x18d63e0, 0xc0003f0630)
	cmd/kubeadm/app/cmd/reset.go:304 +0x73
k8s.io/kubernetes/cmd/kubeadm/app/cmd.NewCmdReset.func1(0xc0002a6780, 0x26dd548, 0x0, 0x0)
	cmd/kubeadm/app/cmd/reset.go:71 +0x267
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).execute(0xc0002a6780, 0x26dd548, 0x0, 0x0, 0xc0002a6780, 0x26dd548)
	vendor/github.com/spf13/cobra/command.go:760 +0x2cc
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc00019a000, 0xc000389180, 0xc00019a500, 0xc00057c1a0)
	vendor/github.com/spf13/cobra/command.go:846 +0x2fd
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).Execute(0xc00019a000, 0xc00000c010, 0x18d63a0)
	vendor/github.com/spf13/cobra/command.go:794 +0x2b
k8s.io/kubernetes/cmd/kubeadm/app.Run(0xc000086180, 0x18b)
	cmd/kubeadm/app/kubeadm.go:48 +0x202
main.main()
	cmd/kubeadm/kubeadm.go:29 +0x33

Removing check for configuration file existence should fix the issue.

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm reset: fixed crash caused by absence of a configuration file
```
