### PR TITLE
Removes deprecated label kubernetes.io/cluster-service in yaml files of kubernetes add-ons. Bug fix #72757

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -4,7 +4,6 @@ metadata:
   name: heapster
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: v1
@@ -13,7 +12,6 @@ metadata:
   name: heapster-config
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
 data:
   NannyConfiguration: |-
@@ -26,7 +24,6 @@ metadata:
   name: eventer-config
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
 data:
   NannyConfiguration: |-
@@ -40,7 +37,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: heapster
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     version: v1.6.0-beta.1
 spec:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -4,7 +4,6 @@ metadata:
   name: heapster
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: v1
@@ -13,7 +12,6 @@ metadata:
   name: heapster-config
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
 data:
   NannyConfiguration: |-
@@ -26,7 +24,6 @@ metadata:
   name: eventer-config
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
 data:
   NannyConfiguration: |-
@@ -40,7 +37,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: heapster
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     version: v1.6.0-beta.1
 spec:

--- a/cluster/addons/cluster-monitoring/heapster-rbac.yaml
+++ b/cluster/addons/cluster-monitoring/heapster-rbac.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   name: heapster-binding
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22,7 +21,6 @@ metadata:
   name: system:pod-nanny
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
@@ -45,7 +43,6 @@ metadata:
   name: heapster-binding
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -4,7 +4,6 @@ metadata:
   name: heapster
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: v1
@@ -13,7 +12,6 @@ metadata:
   name: heapster-config
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
 data:
   NannyConfiguration: |-
@@ -26,7 +24,6 @@ metadata:
   name: eventer-config
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
 data:
   NannyConfiguration: |-
@@ -40,7 +37,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: heapster
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     version: v1.6.0-beta.1
 spec:

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     k8s-app: influxGrafana
     version: v4
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -4,7 +4,6 @@ metadata:
   name: heapster
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: v1
@@ -13,7 +12,6 @@ metadata:
   name: heapster-config
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
 data:
   NannyConfiguration: |-
@@ -27,7 +25,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: heapster
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     version: v1.6.0-beta.1
 spec:

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -4,7 +4,6 @@ metadata:
   name: heapster
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: v1
@@ -13,7 +12,6 @@ metadata:
   name: heapster-config
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
 data:
   NannyConfiguration: |-
@@ -27,7 +25,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: heapster
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     version: v1.6.0-beta.1
 spec:

--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -14,7 +14,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes deprecated labels in kuberenetes add-ons

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Remove deprecated label kubernetes.io/cluster-service in yaml files of kubernetes add-ons. Ref #72757

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
