### PR TITLE
move AddToNodeAddresses to k8s.io/cloud-provider/node/helpers

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -280,23 +280,6 @@ func IsStandardFinalizerName(str string) bool {
 	return standardFinalizers.Has(str)
 }
 
-// AddToNodeAddresses appends the NodeAddresses to the passed-by-pointer slice,
-// only if they do not already exist
-func AddToNodeAddresses(addresses *[]core.NodeAddress, addAddresses ...core.NodeAddress) {
-	for _, add := range addAddresses {
-		exists := false
-		for _, existing := range *addresses {
-			if existing.Address == add.Address && existing.Type == add.Type {
-				exists = true
-				break
-			}
-		}
-		if !exists {
-			*addresses = append(*addresses, add)
-		}
-	}
-}
-
 // TODO: make method on LoadBalancerStatus?
 func LoadBalancerStatusEqual(l, r *core.LoadBalancerStatus) bool {
 	return ingressSliceEqual(l.Ingress, r.Ingress)

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -85,63 +85,6 @@ func TestIsStandardContainerResource(t *testing.T) {
 	}
 }
 
-func TestAddToNodeAddresses(t *testing.T) {
-	testCases := []struct {
-		existing []core.NodeAddress
-		toAdd    []core.NodeAddress
-		expected []core.NodeAddress
-	}{
-		{
-			existing: []core.NodeAddress{},
-			toAdd:    []core.NodeAddress{},
-			expected: []core.NodeAddress{},
-		},
-		{
-			existing: []core.NodeAddress{},
-			toAdd: []core.NodeAddress{
-				{Type: core.NodeExternalIP, Address: "1.1.1.1"},
-				{Type: core.NodeHostName, Address: "localhost"},
-			},
-			expected: []core.NodeAddress{
-				{Type: core.NodeExternalIP, Address: "1.1.1.1"},
-				{Type: core.NodeHostName, Address: "localhost"},
-			},
-		},
-		{
-			existing: []core.NodeAddress{},
-			toAdd: []core.NodeAddress{
-				{Type: core.NodeExternalIP, Address: "1.1.1.1"},
-				{Type: core.NodeExternalIP, Address: "1.1.1.1"},
-			},
-			expected: []core.NodeAddress{
-				{Type: core.NodeExternalIP, Address: "1.1.1.1"},
-			},
-		},
-		{
-			existing: []core.NodeAddress{
-				{Type: core.NodeExternalIP, Address: "1.1.1.1"},
-				{Type: core.NodeInternalIP, Address: "10.1.1.1"},
-			},
-			toAdd: []core.NodeAddress{
-				{Type: core.NodeExternalIP, Address: "1.1.1.1"},
-				{Type: core.NodeHostName, Address: "localhost"},
-			},
-			expected: []core.NodeAddress{
-				{Type: core.NodeExternalIP, Address: "1.1.1.1"},
-				{Type: core.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: core.NodeHostName, Address: "localhost"},
-			},
-		},
-	}
-
-	for i, tc := range testCases {
-		AddToNodeAddresses(&tc.existing, tc.toAdd...)
-		if !Semantic.DeepEqual(tc.expected, tc.existing) {
-			t.Errorf("case[%d], expected: %v, got: %v", i, tc.expected, tc.existing)
-		}
-	}
-}
-
 func TestGetAccessModesFromString(t *testing.T) {
 	modes := GetAccessModesFromString("ROX")
 	if !containsAccessMode(modes, core.ReadOnlyMany) {

--- a/pkg/apis/core/v1/helper/helpers.go
+++ b/pkg/apis/core/v1/helper/helpers.go
@@ -108,23 +108,6 @@ func IsServiceIPSet(service *v1.Service) bool {
 	return service.Spec.ClusterIP != v1.ClusterIPNone && service.Spec.ClusterIP != ""
 }
 
-// AddToNodeAddresses appends the NodeAddresses to the passed-by-pointer slice,
-// only if they do not already exist
-func AddToNodeAddresses(addresses *[]v1.NodeAddress, addAddresses ...v1.NodeAddress) {
-	for _, add := range addAddresses {
-		exists := false
-		for _, existing := range *addresses {
-			if existing.Address == add.Address && existing.Type == add.Type {
-				exists = true
-				break
-			}
-		}
-		if !exists {
-			*addresses = append(*addresses, add)
-		}
-	}
-}
-
 // TODO: make method on LoadBalancerStatus?
 func LoadBalancerStatusEqual(l, r *v1.LoadBalancerStatus) bool {
 	return ingressSliceEqual(l.Ingress, r.Ingress)

--- a/pkg/apis/core/v1/helper/helpers_test.go
+++ b/pkg/apis/core/v1/helper/helpers_test.go
@@ -147,63 +147,6 @@ func TestIsOvercommitAllowed(t *testing.T) {
 	}
 }
 
-func TestAddToNodeAddresses(t *testing.T) {
-	testCases := []struct {
-		existing []v1.NodeAddress
-		toAdd    []v1.NodeAddress
-		expected []v1.NodeAddress
-	}{
-		{
-			existing: []v1.NodeAddress{},
-			toAdd:    []v1.NodeAddress{},
-			expected: []v1.NodeAddress{},
-		},
-		{
-			existing: []v1.NodeAddress{},
-			toAdd: []v1.NodeAddress{
-				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
-				{Type: v1.NodeHostName, Address: "localhost"},
-			},
-			expected: []v1.NodeAddress{
-				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
-				{Type: v1.NodeHostName, Address: "localhost"},
-			},
-		},
-		{
-			existing: []v1.NodeAddress{},
-			toAdd: []v1.NodeAddress{
-				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
-			},
-			expected: []v1.NodeAddress{
-				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
-			},
-		},
-		{
-			existing: []v1.NodeAddress{
-				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-			},
-			toAdd: []v1.NodeAddress{
-				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
-				{Type: v1.NodeHostName, Address: "localhost"},
-			},
-			expected: []v1.NodeAddress{
-				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeHostName, Address: "localhost"},
-			},
-		},
-	}
-
-	for i, tc := range testCases {
-		AddToNodeAddresses(&tc.existing, tc.toAdd...)
-		if !apiequality.Semantic.DeepEqual(tc.expected, tc.existing) {
-			t.Errorf("case[%d], expected: %v, got: %v", i, tc.expected, tc.existing)
-		}
-	}
-}
-
 func TestGetAccessModesFromString(t *testing.T) {
 	modes := GetAccessModesFromString("ROX")
 	if !containsAccessMode(modes, v1.ReadOnlyMany) {

--- a/pkg/cloudprovider/providers/openstack/BUILD
+++ b/pkg/cloudprovider/providers/openstack/BUILD
@@ -21,7 +21,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack",
     deps = [
         "//pkg/api/v1/service:go_default_library",
-        "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/volume:go_default_library",
@@ -34,6 +33,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/node/helpers:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions:go_default_library",

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -46,8 +46,8 @@ import (
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	certutil "k8s.io/client-go/util/cert"
 	cloudprovider "k8s.io/cloud-provider"
+	nodehelpers "k8s.io/cloud-provider/node/helpers"
 	"k8s.io/klog"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 )
 
 const (
@@ -476,7 +476,7 @@ func nodeAddresses(srv *servers.Server) ([]v1.NodeAddress, error) {
 				addressType = v1.NodeInternalIP
 			}
 
-			v1helper.AddToNodeAddresses(&addrs,
+			nodehelpers.AddToNodeAddresses(&addrs,
 				v1.NodeAddress{
 					Type:    addressType,
 					Address: props.Addr,
@@ -487,7 +487,7 @@ func nodeAddresses(srv *servers.Server) ([]v1.NodeAddress, error) {
 
 	// AccessIPs are usually duplicates of "public" addresses.
 	if srv.AccessIPv4 != "" {
-		v1helper.AddToNodeAddresses(&addrs,
+		nodehelpers.AddToNodeAddresses(&addrs,
 			v1.NodeAddress{
 				Type:    v1.NodeExternalIP,
 				Address: srv.AccessIPv4,
@@ -496,7 +496,7 @@ func nodeAddresses(srv *servers.Server) ([]v1.NodeAddress, error) {
 	}
 
 	if srv.AccessIPv6 != "" {
-		v1helper.AddToNodeAddresses(&addrs,
+		nodehelpers.AddToNodeAddresses(&addrs,
 			v1.NodeAddress{
 				Type:    v1.NodeExternalIP,
 				Address: srv.AccessIPv6,
@@ -505,7 +505,7 @@ func nodeAddresses(srv *servers.Server) ([]v1.NodeAddress, error) {
 	}
 
 	if srv.Metadata[TypeHostName] != "" {
-		v1helper.AddToNodeAddresses(&addrs,
+		nodehelpers.AddToNodeAddresses(&addrs,
 			v1.NodeAddress{
 				Type:    v1.NodeHostName,
 				Address: srv.Metadata[TypeHostName],

--- a/pkg/cloudprovider/providers/photon/BUILD
+++ b/pkg/cloudprovider/providers/photon/BUILD
@@ -11,10 +11,10 @@ go_library(
     srcs = ["photon.go"],
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/photon",
     deps = [
-        "//pkg/apis/core/v1/helper:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/node/helpers:go_default_library",
         "//vendor/github.com/vmware/photon-controller-go-sdk/photon:go_default_library",
         "//vendor/gopkg.in/gcfg.v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/pkg/cloudprovider/providers/photon/photon.go
+++ b/pkg/cloudprovider/providers/photon/photon.go
@@ -39,8 +39,8 @@ import (
 	"k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	nodehelpers "k8s.io/cloud-provider/node/helpers"
 	"k8s.io/klog"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 )
 
 const (
@@ -326,14 +326,14 @@ func (pc *PCCloud) NodeAddresses(ctx context.Context, nodeName k8stypes.NodeName
 							// Filter external IP by MAC address OUIs from vCenter and from ESX
 							if strings.HasPrefix(i.HardwareAddr.String(), MAC_OUI_VC) ||
 								strings.HasPrefix(i.HardwareAddr.String(), MAC_OUI_ESX) {
-								v1helper.AddToNodeAddresses(&nodeAddrs,
+								nodehelpers.AddToNodeAddresses(&nodeAddrs,
 									v1.NodeAddress{
 										Type:    v1.NodeExternalIP,
 										Address: ipnet.IP.String(),
 									},
 								)
 							} else {
-								v1helper.AddToNodeAddresses(&nodeAddrs,
+								nodehelpers.AddToNodeAddresses(&nodeAddrs,
 									v1.NodeAddress{
 										Type:    v1.NodeInternalIP,
 										Address: ipnet.IP.String(),
@@ -396,14 +396,14 @@ func (pc *PCCloud) NodeAddresses(ctx context.Context, nodeName k8stypes.NodeName
 						if ipAddr != "-" {
 							if strings.HasPrefix(macAddr, MAC_OUI_VC) ||
 								strings.HasPrefix(macAddr, MAC_OUI_ESX) {
-								v1helper.AddToNodeAddresses(&nodeAddrs,
+								nodehelpers.AddToNodeAddresses(&nodeAddrs,
 									v1.NodeAddress{
 										Type:    v1.NodeExternalIP,
 										Address: ipAddr,
 									},
 								)
 							} else {
-								v1helper.AddToNodeAddresses(&nodeAddrs,
+								nodehelpers.AddToNodeAddresses(&nodeAddrs,
 									v1.NodeAddress{
 										Type:    v1.NodeInternalIP,
 										Address: ipAddr,

--- a/pkg/cloudprovider/providers/vsphere/BUILD
+++ b/pkg/cloudprovider/providers/vsphere/BUILD
@@ -16,7 +16,6 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere",
     deps = [
-        "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/cloudprovider/providers/vsphere/vclib:go_default_library",
         "//pkg/cloudprovider/providers/vsphere/vclib/diskmanagers:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
@@ -27,6 +26,7 @@ go_library(
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/node/helpers:go_default_library",
         "//vendor/github.com/vmware/govmomi/vapi/rest:go_default_library",
         "//vendor/github.com/vmware/govmomi/vapi/tags:go_default_library",
         "//vendor/github.com/vmware/govmomi/vim25:go_default_library",

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -41,8 +41,8 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	cloudprovider "k8s.io/cloud-provider"
+	nodehelpers "k8s.io/cloud-provider/node/helpers"
 	"k8s.io/klog"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers"
 )
@@ -551,7 +551,7 @@ func getLocalIP() ([]v1.NodeAddress, error) {
 						var addressType v1.NodeAddressType
 						if strings.HasPrefix(i.HardwareAddr.String(), MacOuiVC) ||
 							strings.HasPrefix(i.HardwareAddr.String(), MacOuiEsx) {
-							v1helper.AddToNodeAddresses(&addrs,
+							nodehelpers.AddToNodeAddresses(&addrs,
 								v1.NodeAddress{
 									Type:    v1.NodeExternalIP,
 									Address: ipnet.IP.String(),
@@ -614,7 +614,7 @@ func (vs *VSphere) NodeAddresses(ctx context.Context, nodeName k8stypes.NodeName
 			return nil, err
 		}
 		// add the hostname address
-		v1helper.AddToNodeAddresses(&addrs, v1.NodeAddress{Type: v1.NodeHostName, Address: vs.hostName})
+		nodehelpers.AddToNodeAddresses(&addrs, v1.NodeAddress{Type: v1.NodeHostName, Address: vs.hostName})
 		return addrs, nil
 	}
 
@@ -652,7 +652,7 @@ func (vs *VSphere) NodeAddresses(ctx context.Context, nodeName k8stypes.NodeName
 		if vs.cfg.Network.PublicNetwork == v.Network {
 			for _, ip := range v.IpAddress {
 				if net.ParseIP(ip).To4() != nil {
-					v1helper.AddToNodeAddresses(&addrs,
+					nodehelpers.AddToNodeAddresses(&addrs,
 						v1.NodeAddress{
 							Type:    v1.NodeExternalIP,
 							Address: ip,

--- a/staging/src/k8s.io/cloud-provider/node/helpers/BUILD
+++ b/staging/src/k8s.io/cloud-provider/node/helpers/BUILD
@@ -1,8 +1,11 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["taints.go"],
+    srcs = [
+        "address.go",
+        "taints.go",
+    ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/cloud-provider/node/helpers",
     importpath = "k8s.io/cloud-provider/node/helpers",
     visibility = ["//visibility:public"],
@@ -30,4 +33,14 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["address_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+    ],
 )

--- a/staging/src/k8s.io/cloud-provider/node/helpers/address.go
+++ b/staging/src/k8s.io/cloud-provider/node/helpers/address.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+// AddToNodeAddresses appends the NodeAddresses to the passed-by-pointer slice,
+// only if they do not already exist
+func AddToNodeAddresses(addresses *[]v1.NodeAddress, addAddresses ...v1.NodeAddress) {
+	for _, add := range addAddresses {
+		exists := false
+		for _, existing := range *addresses {
+			if existing.Address == add.Address && existing.Type == add.Type {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			*addresses = append(*addresses, add)
+		}
+	}
+}

--- a/staging/src/k8s.io/cloud-provider/node/helpers/address_test.go
+++ b/staging/src/k8s.io/cloud-provider/node/helpers/address_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+func TestAddToNodeAddresses(t *testing.T) {
+	testCases := []struct {
+		existing []v1.NodeAddress
+		toAdd    []v1.NodeAddress
+		expected []v1.NodeAddress
+	}{
+		{
+			existing: []v1.NodeAddress{},
+			toAdd:    []v1.NodeAddress{},
+			expected: []v1.NodeAddress{},
+		},
+		{
+			existing: []v1.NodeAddress{},
+			toAdd: []v1.NodeAddress{
+				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
+				{Type: v1.NodeHostName, Address: "localhost"},
+			},
+			expected: []v1.NodeAddress{
+				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
+				{Type: v1.NodeHostName, Address: "localhost"},
+			},
+		},
+		{
+			existing: []v1.NodeAddress{},
+			toAdd: []v1.NodeAddress{
+				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
+			},
+			expected: []v1.NodeAddress{
+				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
+			},
+		},
+		{
+			existing: []v1.NodeAddress{
+				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+			},
+			toAdd: []v1.NodeAddress{
+				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
+				{Type: v1.NodeHostName, Address: "localhost"},
+			},
+			expected: []v1.NodeAddress{
+				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeHostName, Address: "localhost"},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		AddToNodeAddresses(&tc.existing, tc.toAdd...)
+		if !apiequality.Semantic.DeepEqual(tc.expected, tc.existing) {
+			t.Errorf("case[%d], expected: %v, got: %v", i, tc.expected, tc.existing)
+		}
+	}
+}

--- a/staging/src/k8s.io/cloud-provider/node/helpers/address_test.go
+++ b/staging/src/k8s.io/cloud-provider/node/helpers/address_test.go
@@ -25,16 +25,19 @@ import (
 
 func TestAddToNodeAddresses(t *testing.T) {
 	testCases := []struct {
+		name     string
 		existing []v1.NodeAddress
 		toAdd    []v1.NodeAddress
 		expected []v1.NodeAddress
 	}{
 		{
+			name:     "add no addresses to empty node addresses",
 			existing: []v1.NodeAddress{},
 			toAdd:    []v1.NodeAddress{},
 			expected: []v1.NodeAddress{},
 		},
 		{
+			name:     "add new node addresses to empty existing addresses",
 			existing: []v1.NodeAddress{},
 			toAdd: []v1.NodeAddress{
 				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
@@ -46,6 +49,7 @@ func TestAddToNodeAddresses(t *testing.T) {
 			},
 		},
 		{
+			name:     "add a duplicate node address",
 			existing: []v1.NodeAddress{},
 			toAdd: []v1.NodeAddress{
 				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
@@ -56,6 +60,7 @@ func TestAddToNodeAddresses(t *testing.T) {
 			},
 		},
 		{
+			name: "add 1 new and 1 duplicate address",
 			existing: []v1.NodeAddress{
 				{Type: v1.NodeExternalIP, Address: "1.1.1.1"},
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
@@ -72,10 +77,12 @@ func TestAddToNodeAddresses(t *testing.T) {
 		},
 	}
 
-	for i, tc := range testCases {
-		AddToNodeAddresses(&tc.existing, tc.toAdd...)
-		if !apiequality.Semantic.DeepEqual(tc.expected, tc.existing) {
-			t.Errorf("case[%d], expected: %v, got: %v", i, tc.expected, tc.existing)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			AddToNodeAddresses(&tc.existing, tc.toAdd...)
+			if !apiequality.Semantic.DeepEqual(tc.expected, tc.existing) {
+				t.Errorf("expected: %v, got: %v", tc.expected, tc.existing)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Co-authored-by: Weibin Lin <linweibin1@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes cloud provider dependencies to `k8s.io/kubernetes/pkg/apis/core/helpers`.

**Which issue(s) this PR fixes**:
Part of cloud provider extraction effort and removing deps to k8s.io/kubernetes https://github.com/kubernetes/kubernetes/issues/69585 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
