### PR TITLE
catch some unhandled errors

### DIFF
--- a/cmd/kube-apiserver/app/apiextensions.go
+++ b/cmd/kube-apiserver/app/apiextensions.go
@@ -48,12 +48,15 @@ func createAPIExtensionsConfig(
 
 	// override genericConfig.AdmissionControl with apiextensions' scheme,
 	// because apiextentions apiserver should use its own scheme to convert resources.
-	commandOptions.Admission.ApplyTo(
+	err := commandOptions.Admission.ApplyTo(
 		&genericConfig,
 		externalInformers,
 		genericConfig.LoopbackClientConfig,
 		apiextensionsapiserver.Scheme,
 		pluginInitializers...)
+	if err != nil {
+		return nil, err
+	}
 
 	// copy the etcd options so we don't mutate originals.
 	etcdOptions := *commandOptions.Etcd


### PR DESCRIPTION
golang doesn't have exceptions to make sure that you always handle errors. That didn't work out so well for us.

```release-note
NONE
```

@kubernetes/sig-api-machinery-bugs 