### PR TITLE
Support dynamic provisioning for CSI migration scenarios

### DIFF
--- a/pkg/controller/volume/persistentvolume/BUILD
+++ b/pkg/controller/volume/persistentvolume/BUILD
@@ -61,6 +61,7 @@ go_library(
         "//staging/src/k8s.io/cloud-provider:go_default_library",
         "//staging/src/k8s.io/cloud-provider/volume/errors:go_default_library",
         "//staging/src/k8s.io/csi-api/pkg/client/clientset/versioned:go_default_library",
+        "//staging/src/k8s.io/csi-translation-lib:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/controller/volume/persistentvolume/provision_test.go
+++ b/pkg/controller/volume/persistentvolume/provision_test.go
@@ -421,6 +421,17 @@ func TestProvisionSync(t *testing.T) {
 			[]string{"Warning ProvisioningFailed Mount options"},
 			noerrors, wrapTestWithProvisionCalls([]provisionCall{}, testSyncClaim),
 		},
+		{
+			// No provisioning due to CSI migration + normal event with external provisioner
+			"11-21 - external provisioner for CSI migration",
+			novolumes,
+			novolumes,
+			newClaimArray("claim11-21", "uid11-21", "1Gi", "", v1.ClaimPending, &classGold),
+			claimWithAnnotation(annStorageProvisioner, "vendor.com/MockCSIPlugin",
+				newClaimArray("claim11-21", "uid11-21", "1Gi", "", v1.ClaimPending, &classGold)),
+			[]string{"Normal ExternalProvisioning"},
+			noerrors, wrapTestWithCSIMigrationProvisionCalls(testSyncClaim),
+		},
 	}
 	runSyncTests(t, tests, storageClasses, []*v1.Pod{})
 }

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"k8s.io/api/core/v1"
-	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -428,8 +427,8 @@ func (ctrl *PersistentVolumeController) resync() {
 
 // setClaimProvisioner saves
 // claim.Annotations[annStorageProvisioner] = class.Provisioner
-func (ctrl *PersistentVolumeController) setClaimProvisioner(claim *v1.PersistentVolumeClaim, class *storage.StorageClass) (*v1.PersistentVolumeClaim, error) {
-	if val, ok := claim.Annotations[annStorageProvisioner]; ok && val == class.Provisioner {
+func (ctrl *PersistentVolumeController) setClaimProvisioner(claim *v1.PersistentVolumeClaim, provisionerName string) (*v1.PersistentVolumeClaim, error) {
+	if val, ok := claim.Annotations[annStorageProvisioner]; ok && val == provisionerName {
 		// annotation is already set, nothing to do
 		return claim, nil
 	}
@@ -437,7 +436,7 @@ func (ctrl *PersistentVolumeController) setClaimProvisioner(claim *v1.Persistent
 	// The volume from method args can be pointing to watcher cache. We must not
 	// modify these, therefore create a copy.
 	claimClone := claim.DeepCopy()
-	metav1.SetMetaDataAnnotation(&claimClone.ObjectMeta, annStorageProvisioner, class.Provisioner)
+	metav1.SetMetaDataAnnotation(&claimClone.ObjectMeta, annStorageProvisioner, provisionerName)
 	newClaim, err := ctrl.kubeClient.CoreV1().PersistentVolumeClaims(claim.Namespace).Update(claimClone)
 	if err != nil {
 		return newClaim, err


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR introduces a set of changes needed in in-tree PV Controller to call out to the external provisioning controller for in-tree plugins if they are migratable to CSI. The basic steps are:
1. Check if in-tree plugin is migratable to CSI. If so:
2. Set `annStorageProvisioner` in the PVC to CSI plugin name that superseded the specified in-tree plugin.
3. Do not proceed with in-tree provisioning and return so that external provisioner can act on the claim.

In addition to the above, the PR also introduces a new API `TranslateInTreeStorageClassParametersToCSI` in the CSI translation staging repo. This will be used by the external provisioner to translate from in-tree storage class parameters to CSI plugin parameters.

**Which issue(s) this PR fixes**:
Fixes # 

**Special notes for your reviewer**:
Part of enhancements for https://github.com/kubernetes/enhancements/issues/625

For the changes in this PR to take an effect, we need a separate set of changes in https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner.git which does the following:
1. Enhances `getStorageClassFields` to check (through `GetCSINameFromIntreeName`) if the storageclass provisioner has a corresponding CSI plugin that supersedes it. If so:
2. Makes `getStorageClassFields` aware that it's handling dynamic volume provisioning for an in-tree plugin that has been migrated to CSI because [a] For regular in-tree provisioning path, external provisioning will never get invoked [b] For regular CSI provisioning path, `GetCSINameFromIntreeName` would not return anything for a CSI plugin name.
3. Enhances `getStorageClassFields` to [a] translate in-tree storage class parameters to the corresponding CSI plugin parameters using `TranslateInTreeStorageClassParametersToCSI` [b] return the CSI plugin name (instead of the storage class in-tree provisioner) as the provisioner name (so that it aligns with `ctrl.provisionerName`) and [c] return a boolean to `provisionClaimOperation` indicating dynamic provisioning in a CSI migration context
4. Enhances `provisionClaimOperation` to invoke `TranslateCSIPVToInTree` for dynamic provisioning in a CSI migration context.

The above PR depends on `TranslateInTreeStorageClassParametersToCSI` from this PR to be staged first.

**Does this PR introduce a user-facing change?**:
```release-note
Introduce dynamic volume provisioning shim for CSI migration
```

/sig-storage
/assign @jsafrane @saad-ali
/cc @msau42 @leakingtapan @davidz627