### PR TITLE
Allow maxunavailable for a successful 

### DIFF
--- a/pkg/kubectl/rollout_status.go
+++ b/pkg/kubectl/rollout_status.go
@@ -108,6 +108,8 @@ func (s *DaemonSetStatusViewer) Status(obj runtime.Unstructured, revision int64)
 	if daemon.Generation <= daemon.Status.ObservedGeneration {
 		//we can stop with some unavailable as long as it's less than maxUnavailble. This should help when there are node issues
 		//and not all daemonse pods can be succesfully updated/ready
+		//may already be handled here https://github.com/kubernetes/kubernetes/blob/8e05f0904b36aeaa828c2f716d72b665921d97bb/pkg/controller/daemon/update.go
+
 		numberRequiredForSuccess := daemon.Status.DesiredNumberScheduled - daemon.spec.updateStrategy.maxUnavailable
 		
 		if daemon.Status.UpdatedNumberScheduled < numberRequiredForSuccess {

--- a/pkg/kubectl/rollout_status.go
+++ b/pkg/kubectl/rollout_status.go
@@ -107,9 +107,8 @@ func (s *DaemonSetStatusViewer) Status(obj runtime.Unstructured, revision int64)
 	}
 	if daemon.Generation <= daemon.Status.ObservedGeneration {
 		//we can stop with some unavailable as long as it's less than maxUnavailble. This should help when there are node issues
-		//and not all daemonse pods can be succesfully updated/ready
-		//may already be handled here https://github.com/kubernetes/kubernetes/blob/8e05f0904b36aeaa828c2f716d72b665921d97bb/pkg/controller/daemon/update.go
-
+		//and not all daemons pods can be succesfully updated/ready. 
+		//pkg/controller/daemon/update.go could also set using shouldschedule from  nodeShouldRunDaemonPod instead of want to run
 		numberRequiredForSuccess := daemon.Status.DesiredNumberScheduled - daemon.spec.updateStrategy.maxUnavailable
 		
 		if daemon.Status.UpdatedNumberScheduled < numberRequiredForSuccess {

--- a/pkg/kubectl/rollout_status.go
+++ b/pkg/kubectl/rollout_status.go
@@ -102,7 +102,7 @@ func (s *DaemonSetStatusViewer) Status(obj runtime.Unstructured, revision int64)
 		return "", false, fmt.Errorf("failed to convert %T to %T: %v", obj, daemon, err)
 	}
 	
-	if daemon.Spec.UpdateStrategy.cType != appsv1.RollingUpdateDaemonSetStrategyType {
+	if daemon.Spec.UpdateStrategy.Type != appsv1.RollingUpdateDaemonSetStrategyType {
 		return "", true, fmt.Errorf("rollout status is only available for %s strategy type", appsv1.RollingUpdateStatefulSetStrategyType)
 	}
 	if daemon.Generation <= daemon.Status.ObservedGeneration {


### PR DESCRIPTION


**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
Allows rollout status to ignore maxunavailable failures to account 
**Which issue(s) this PR fixes**:
Haven't opened issue but can. 

**Special notes for your reviewer**:
I may be misreading nodeShouldRunDaemonPod . Maybe it is already smart enough to account for most not ready nodes and DesiredNumberScheduled  should just use shouldschedule rather than wanttorun from nodeShouldRunDaemonPod 

**Does this PR introduce a user-facing change?**:
```release-note
if max unavailable is set daemonset deployments that wouldn't have succeeded before would now. 
```
