### PR TITLE
Remove dead code about failure-domains option in kube-scheduler

### DIFF
--- a/cmd/kube-scheduler/app/options/deprecated.go
+++ b/cmd/kube-scheduler/app/options/deprecated.go
@@ -65,8 +65,6 @@ func (o *DeprecatedOptions) AddFlags(fs *pflag.FlagSet, cfg *kubeschedulerconfig
 		"RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule corresponding "+
 			"to every RequiredDuringScheduling affinity rule. --hard-pod-affinity-symmetric-weight represents the weight of implicit PreferredDuringScheduling affinity rule. Must be in the range 0-100.")
 	fs.MarkDeprecated("hard-pod-affinity-symmetric-weight", "This option was moved to the policy configuration file")
-	fs.StringVar(&cfg.FailureDomains, "failure-domains", cfg.FailureDomains, "Indicate the \"all topologies\" set for an empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.")
-	fs.MarkDeprecated("failure-domains", "Doesn't have any effect. Will be removed in future version.")
 }
 
 // Validate validates the deprecated scheduler options.

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -206,7 +206,6 @@ users:
 				HardPodAffinitySymmetricWeight: 1,
 				HealthzBindAddress:             "0.0.0.0:10251",
 				MetricsBindAddress:             "0.0.0.0:10251",
-				FailureDomains:                 "kubernetes.io/hostname,failure-domain.beta.kubernetes.io/zone,failure-domain.beta.kubernetes.io/region",
 				LeaderElection: kubeschedulerconfig.KubeSchedulerLeaderElectionConfiguration{
 					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
 						LeaderElect:   true,
@@ -286,7 +285,6 @@ users:
 				HardPodAffinitySymmetricWeight: 1,
 				HealthzBindAddress:             "", // defaults empty when not running from config file
 				MetricsBindAddress:             "", // defaults empty when not running from config file
-				FailureDomains:                 "kubernetes.io/hostname,failure-domain.beta.kubernetes.io/zone,failure-domain.beta.kubernetes.io/region",
 				LeaderElection: kubeschedulerconfig.KubeSchedulerLeaderElectionConfiguration{
 					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
 						LeaderElect:   true,

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -82,10 +82,6 @@ type KubeSchedulerConfiguration struct {
 	// nodes will be scored.
 	PercentageOfNodesToScore int32
 
-	// DEPRECATED.
-	// Indicate the "all topologies" set for empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.
-	FailureDomains string
-
 	// Duration to wait for a binding operation to complete before timing out
 	// Value must be non-negative integer. The value zero indicates no waiting.
 	// If this value is nil, the default value will be used.

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -85,10 +85,6 @@ func SetDefaults_KubeSchedulerConfiguration(obj *kubescedulerconfigv1alpha1.Kube
 		obj.LeaderElection.LockObjectName = kubescedulerconfigv1alpha1.SchedulerDefaultLockObjectName
 	}
 
-	if len(obj.FailureDomains) == 0 {
-		obj.FailureDomains = defaultFailureDomains
-	}
-
 	if len(obj.ClientConnection.ContentType) == 0 {
 		obj.ClientConnection.ContentType = "application/vnd.kubernetes.protobuf"
 	}

--- a/pkg/scheduler/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1alpha1/zz_generated.conversion.go
@@ -119,7 +119,6 @@ func autoConvert_v1alpha1_KubeSchedulerConfiguration_To_config_KubeSchedulerConf
 	}
 	out.DisablePreemption = in.DisablePreemption
 	out.PercentageOfNodesToScore = in.PercentageOfNodesToScore
-	out.FailureDomains = in.FailureDomains
 	out.BindTimeoutSeconds = (*int64)(unsafe.Pointer(in.BindTimeoutSeconds))
 	return nil
 }
@@ -148,7 +147,6 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1alpha1_KubeSchedulerConf
 	}
 	out.DisablePreemption = in.DisablePreemption
 	out.PercentageOfNodesToScore = in.PercentageOfNodesToScore
-	out.FailureDomains = in.FailureDomains
 	out.BindTimeoutSeconds = (*int64)(unsafe.Pointer(in.BindTimeoutSeconds))
 	return nil
 }

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
@@ -78,10 +78,6 @@ type KubeSchedulerConfiguration struct {
 	// nodes will be scored.
 	PercentageOfNodesToScore int32 `json:"percentageOfNodesToScore"`
 
-	// DEPRECATED.
-	// Indicate the "all topologies" set for empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.
-	FailureDomains string `json:"failureDomains"`
-
 	// Duration to wait for a binding operation to complete before timing out
 	// Value must be non-negative integer. The value zero indicates no waiting.
 	// If this value is nil, the default value will be used.


### PR DESCRIPTION

 /kind cleanup


**What this PR does / why we need it**:
Remove dead code about failure-domains option in kube-scheduler

#41195
```release-note
NONE
```
