### PR TITLE
publishing: add apiserver as a dependency to cloud-provider

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -947,6 +947,8 @@ rules:
       branch: master
     - repository: apimachinery
       branch: master
+    - repository: apiserver
+      branch: master
     - repository: client-go
       branch: master
   - source:


### PR DESCRIPTION
apiserver was added as a dependency to cloud-provider in https://github.com/kubernetes/kubernetes/pull/73604 but the rules were not updated so this broke the publishing-bot. This PR updates the rules to add apiserver as a depdency to cloud-provider.

/cc @sttts @dims @andrewsykim 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
