### PR TITLE
client-go: Dynamically assigned local port number not retrievable when port-forwarding

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -197,8 +197,9 @@ func (pf *PortForwarder) forward() error {
 	var err error
 
 	listenSuccess := false
-	for _, port := range pf.ports {
-		err = pf.listenOnPort(&port)
+	for i := range pf.ports {
+		port := &pf.ports[i]
+		err = pf.listenOnPort(port)
 		switch {
 		case err == nil:
 			listenSuccess = true

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
@@ -18,11 +18,13 @@ package portforward
 
 import (
 	"net"
+	"net/http"
 	"os"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/httpstream"
 )
@@ -37,6 +39,37 @@ type fakeDialer struct {
 func (d *fakeDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
 	d.dialed = true
 	return d.conn, d.negotiatedProtocol, d.err
+}
+
+type fakeConnection struct {
+	closed    bool
+	closeChan chan bool
+}
+
+func newFakeConnection() httpstream.Connection {
+	return &fakeConnection{
+		closeChan: make(chan bool),
+	}
+}
+
+func (c *fakeConnection) CreateStream(headers http.Header) (httpstream.Stream, error) {
+	return nil, nil
+}
+
+func (c *fakeConnection) Close() error {
+	if !c.closed {
+		c.closed = true
+		close(c.closeChan)
+	}
+	return nil
+}
+
+func (c *fakeConnection) CloseChan() <-chan bool {
+	return c.closeChan
+}
+
+func (c *fakeConnection) SetIdleTimeout(timeout time.Duration) {
+	// no-op
 }
 
 func TestParsePortsAndNew(t *testing.T) {
@@ -252,5 +285,48 @@ func TestGetListener(t *testing.T) {
 		}
 		listener.Close()
 
+	}
+}
+
+func TestGetPortsReturnsDynamicallyAssignedLocalPort(t *testing.T) {
+	dialer := &fakeDialer{
+		conn: newFakeConnection(),
+	}
+
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+	errChan := make(chan error)
+
+	defer func() {
+		close(stopChan)
+
+		forwardErr := <-errChan
+		if forwardErr != nil {
+			t.Fatalf("ForwardPorts returned error: %s", forwardErr)
+		}
+	}()
+
+	pf, err := New(dialer, []string{":5000"}, stopChan, readyChan, os.Stdout, os.Stderr)
+
+	if err != nil {
+		t.Fatalf("error while calling New: %s", err)
+	}
+
+	go func() {
+		errChan <- pf.ForwardPorts()
+		close(errChan)
+	}()
+
+	<-pf.Ready
+
+	ports, err := pf.GetPorts()
+
+	if len(ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(ports))
+	}
+
+	port := ports[0]
+	if port.Local == 0 {
+		t.Fatalf("local port is 0, expected != 0")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When setting up a port forwarding with the client-go library (using the `k8s.io/client-go/tools/portforward.PortForwarder`) with a non-defined local port (i.e. passing `:80` as `ports` parameter to `portforward.New(...)`), a local port will be assigned dynamically. The [documentation](https://godoc.org/k8s.io/client-go/tools/portforward#PortForwarder.GetPorts) states that the assigned port number can be retrieved by using the `GetPorts()` method:

>GetPorts will return the ports that were forwarded; this can be used to retrieve the locally-bound port in cases where the input was port 0.

Currently, the local port will be *always* 0 if it was not specified initially. This is because the assigned local port is only set on a *copy* of the actual `ForwardedPort` type that is obtained in a `range` loop. This PR changes this behaviour to set the local port at the correct instance by passing a pointer instead of a copy to the relevant functions.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
n/a

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
client-go: PortForwarder.GetPorts() now contain correct local port if no local port was initially specified when setting up the port forwarder
```
