### PR TITLE
e2e: Use cluster-driver-registrar for CSIDriverRegistry tests

### DIFF
--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -64,7 +64,6 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/cloud-provider/volume/helpers:go_default_library",
-        "//staging/src/k8s.io/csi-api/pkg/apis/csi/v1alpha1:go_default_library",
         "//staging/src/k8s.io/csi-api/pkg/client/clientset/versioned:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/metrics:go_default_library",

--- a/test/e2e/storage/utils/deployment.go
+++ b/test/e2e/storage/utils/deployment.go
@@ -97,6 +97,10 @@ func PatchCSIDeployment(f *framework.Framework, o PatchCSIOptions, object interf
 				// Driver name is expected to be the same
 				// as the snapshotter here.
 				container.Args = append(container.Args, "--snapshotter="+o.NewDriverName)
+			case o.ClusterRegistrarContainerName:
+				if o.PodInfoVersion != nil {
+					container.Args = append(container.Args, "--pod-info-mount-version="+*o.PodInfoVersion)
+				}
 			}
 		}
 	}
@@ -153,6 +157,12 @@ type PatchCSIOptions struct {
 	// If non-empty, --snapshotter with new name will be appended
 	// to the argument list.
 	SnapshotterContainerName string
+	// The name of the container which has the cluster-driver-registrar
+	// binary.
+	ClusterRegistrarContainerName string
 	// If non-empty, all pods are forced to run on this node.
 	NodeName string
+	// If not nil, the argument to pass to the cluster-driver-registrar's
+	// pod-info-mount-version argument.
+	PodInfoVersion *string
 }

--- a/test/e2e/testing-manifests/storage-csi/cluster-driver-registrar/README.md
+++ b/test/e2e/testing-manifests/storage-csi/cluster-driver-registrar/README.md
@@ -1,0 +1,1 @@
+The original file is (or will be) https://github.com/kubernetes-csi/cluster-driver-registrar/blob/master/deploy/kubernetes/rbac.yaml

--- a/test/e2e/testing-manifests/storage-csi/cluster-driver-registrar/rbac.yaml
+++ b/test/e2e/testing-manifests/storage-csi/cluster-driver-registrar/rbac.yaml
@@ -1,0 +1,38 @@
+# This YAML file contains all RBAC objects that are necessary to run
+# cluster-driver-registrar.
+#
+# In production, each CSI driver deployment has to be customized:
+# - to avoid conflicts, use non-default namespace and different names
+#   for non-namespaced entities like the ClusterRole
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-cluster-driver-registrar
+  # replace with non-default namespace name
+  namespace: default
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-driver-registrar-runner
+rules:
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-cluster-driver-registrar-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-cluster-driver-registrar
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-driver-registrar-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-cluster-driver-registrar.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-cluster-driver-registrar.yaml
@@ -1,0 +1,33 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-mockplugin-cluster-driver-registrar
+spec:
+  selector:
+    matchLabels:
+      app: csi-mockplugin-cluster-driver-registrar
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: csi-mockplugin-cluster-driver-registrar
+    spec:
+      serviceAccountName: csi-mock
+      containers:
+        - name: csi-cluster-driver-registrar
+          image: quay.io/k8scsi/csi-cluster-driver-registrar:canary
+          args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          imagePullPolicy: Always
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-mock
+            type: DirectoryOrCreate
+          name: socket-dir

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
@@ -1,0 +1,34 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-mockplugin-attacher
+spec:
+  selector:
+    matchLabels:
+      app: csi-mockplugin-attacher
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: csi-mockplugin-attacher
+    spec:
+      serviceAccountName: csi-mock
+      containers:
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v1.0.1
+          args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          imagePullPolicy: Always
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-mock
+            type: DirectoryOrCreate
+          name: socket-dir
+

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
@@ -16,18 +16,6 @@ spec:
       containers:
 
 
-        - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.0.1
-          args:
-            - --v=5
-            - --csi-address=$(ADDRESS)
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
-          imagePullPolicy: Always
-          volumeMounts:
-          - mountPath: /csi
-            name: socket-dir
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v1.0.1
           args:

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-rbac.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-rbac.yaml
@@ -32,6 +32,20 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-controller-cluster-driver-registrar-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-mock
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-driver-registrar-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
 # priviledged Pod Security Policy, previously defined via PrivilegedTestPSPClusterRoleBinding()
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
/kind bug
/sig storage

Fixes #70750

CSIDriverRegistry e2e tests run successfully against local-up-cluster.

```release-note
NONE
```

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>