### PR TITLE
Remove very old debugging log lines that are no longer needed

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -217,11 +217,9 @@ func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
 	if d.decoder == nil {
 		buffer, origData, isJSON := GuessJSONStream(d.r, d.bufferSize)
 		if isJSON {
-			klog.V(4).Infof("decoding stream as JSON")
 			d.decoder = json.NewDecoder(buffer)
 			d.rawData = origData
 		} else {
-			klog.V(4).Infof("decoding stream as YAML")
 			d.decoder = NewYAMLToJSONDecoder(buffer)
 		}
 	}


### PR DESCRIPTION
When we originally added YAML guessing we had a reasonable concern
that we might get it wrong and need debugging. In the last 4 years
we have not yet had such a case, and v(4) often shows up in operator
style logs when it adds nothing.

Remove the lines.


/kind bug

```release-note
NONE
```