### PR TITLE
verify-generated-files-remake.sh: fix issues reported by shellcheck (part 2)

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -125,7 +125,6 @@
 ./hack/verify-description.sh
 ./hack/verify-generated-device-plugin.sh
 ./hack/verify-generated-docs.sh
-./hack/verify-generated-files-remake.sh
 ./hack/verify-generated-files.sh
 ./hack/verify-generated-kms.sh
 ./hack/verify-generated-kubelet-plugin-registration.sh

--- a/hack/verify-generated-files-remake.sh
+++ b/hack/verify-generated-files-remake.sh
@@ -23,7 +23,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::util::ensure_clean_working_dir
 
-_tmpdir="$(kube::realpath $(mktemp -d -t verify-generated-files.XXXXXX))"
+_tmpdir="$(kube::realpath "$(mktemp -d -t verify-generated-files.XXXXXX)")"
 kube::util::trap_add "rm -rf ${_tmpdir}" EXIT
 
 _tmp_gopath="${_tmpdir}/go"

--- a/hack/verify-generated-files-remake.sh
+++ b/hack/verify-generated-files-remake.sh
@@ -73,10 +73,11 @@ function assert_clean() {
     make generated_files >/dev/null
     touch "${STAMP}"
     make generated_files >/dev/null
-    X=($(newer deepcopy "${STAMP}"))
-    if [[ "${#X[*]}" != 0 ]]; then
+    X="$(newer deepcopy "${STAMP}")"
+    if [[ -n "${X}" ]]; then
         echo "Generated files changed on back-to-back 'make' runs:"
-        echo "  ${X[*]:-(none)}"
+        echo "  ${X}" | tr '\n' ' '
+        echo ""
         return 1
     fi
     true
@@ -91,25 +92,28 @@ STAMP=/tmp/stamp.$RANDOM
 assert_clean
 
 DIR=staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1
-touch "$DIR/types.go"
+touch "${DIR}/types.go"
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(newer deepcopy "${STAMP}"))
-if [[ "${#X[*]}" != 1 || ! ( "${X[0]}" =~ "${DIR}/zz_generated.deepcopy.go" ) ]]; then
+X="$(newer deepcopy "${STAMP}")"
+if [[ -z "${X}" || ${X} != "./${DIR}/zz_generated.deepcopy.go" ]]; then
     echo "Wrong generated deepcopy files changed after touching src file:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X:-(none)}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
-X=($(newer defaults "${STAMP}"))
-if [[ "${#X[*]}" != 1 || ! ( "${X[0]}" =~ "${DIR}/zz_generated.defaults.go" ) ]]; then
+X="$(newer defaults "${STAMP}")"
+if [[ -z "${X}" || ${X} != "./${DIR}/zz_generated.defaults.go" ]]; then
     echo "Wrong generated defaults files changed after touching src file:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X:-(none)}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
-X=($(newer conversion "${STAMP}"))
-if [[ "${#X[*]}" != 1 || ! ( "${X[0]}" =~ "${DIR}/zz_generated.conversion.go" ) ]]; then
+X="$(newer conversion "${STAMP}")"
+if [[ -z "${X}" || ${X} != "./${DIR}/zz_generated.conversion.go" ]]; then
     echo "Wrong generated conversion files changed after touching src file:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X:-(none)}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -122,10 +126,11 @@ assert_clean
 touch staging/src/k8s.io/code-generator/cmd/deepcopy-gen/main.go
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older deepcopy "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older deepcopy "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated deepcopy files did not change after touching code-generator file:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -134,10 +139,11 @@ assert_clean
 touch staging/src/k8s.io/code-generator/cmd/deepcopy-gen/
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older deepcopy "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older deepcopy "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated deepcopy files did not change after touching code-generator dir:"
-    echo "  ${X[*]}:-(none)"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -146,10 +152,11 @@ assert_clean
 touch vendor/k8s.io/gengo/examples/deepcopy-gen/generators/deepcopy.go
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older deepcopy "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older deepcopy "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated deepcopy files did not change after touching code-generator dep file:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -158,10 +165,11 @@ assert_clean
 touch vendor/k8s.io/gengo/examples/deepcopy-gen/generators/
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older deepcopy "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older deepcopy "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated deepcopy files did not change after touching code-generator dep dir:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -174,10 +182,11 @@ assert_clean
 touch staging/src/k8s.io/code-generator/cmd/defaulter-gen/main.go
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older defaults "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older defaults "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated defaults files did not change after touching code-generator file:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -186,10 +195,11 @@ assert_clean
 touch staging/src/k8s.io/code-generator/cmd/defaulter-gen/
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older defaults "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older defaults "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated defaults files did not change after touching code-generator dir:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -198,10 +208,11 @@ assert_clean
 touch vendor/k8s.io/gengo/examples/defaulter-gen/generators/defaulter.go
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older defaults "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older defaults "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated defaults files did not change after touching code-generator dep file:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -210,10 +221,11 @@ assert_clean
 touch vendor/k8s.io/gengo/examples/defaulter-gen/generators/
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older defaults "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older defaults "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated defaults files did not change after touching code-generator dep dir:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -226,10 +238,11 @@ assert_clean
 touch staging/src/k8s.io/code-generator/cmd/conversion-gen/main.go
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older conversion "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older conversion "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated conversion files did not change after touching code-generator file:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -238,10 +251,11 @@ assert_clean
 touch staging/src/k8s.io/code-generator/cmd/conversion-gen/
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older conversion "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older conversion "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated conversion files did not change after touching code-generator dir:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -250,10 +264,11 @@ assert_clean
 touch vendor/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older conversion "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older conversion "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated conversion files did not change after touching code-generator dep file:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -262,10 +277,11 @@ assert_clean
 touch vendor/k8s.io/code-generator/cmd/conversion-gen/generators/
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older conversion "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older conversion "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated conversion files did not change after touching code-generator dep dir:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -278,10 +294,11 @@ assert_clean
 touch "staging/src/k8s.io/api/core/v1/types.go"
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(newer openapi "${STAMP}"))
-if [[ "${#X[*]}" != 1 || ! ( "${X[0]}" =~ "pkg/generated/openapi/zz_generated.openapi.go" ) ]]; then
+X="$(newer openapi "${STAMP}")"
+if [[ -z "${X}" || ${X} != "./pkg/generated/openapi/zz_generated.openapi.go" ]]; then
     echo "Wrong generated openapi files changed after touching src file:"
-    echo "${X[*]:-(none)}"
+    echo "  ${X:-(none)}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -294,10 +311,11 @@ assert_clean
 touch vendor/k8s.io/kube-openapi/cmd/openapi-gen/openapi-gen.go
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older openapi "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older openapi "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated openapi files did not change after touching code-generator file:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -306,10 +324,11 @@ assert_clean
 touch vendor/k8s.io/kube-openapi/cmd/openapi-gen/
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older openapi "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older openapi "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated openapi files did not change after touching code-generator dir:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -318,10 +337,11 @@ assert_clean
 touch vendor/k8s.io/kube-openapi/pkg/generators/openapi.go
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older openapi "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older openapi "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated openapi files did not change after touching code-generator dep file:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi
 
@@ -330,9 +350,10 @@ assert_clean
 touch vendor/k8s.io/kube-openapi/pkg/generators
 touch "${STAMP}"
 make generated_files >/dev/null
-X=($(older openapi "${STAMP}"))
-if [[ "${#X[*]}" != 0 ]]; then
+X="$(older openapi "${STAMP}")"
+if [[ -n "${X}" ]]; then
     echo "Generated openapi files did not change after touching code-generator dep dir:"
-    echo "  ${X[*]:-(none)}"
+    echo "  ${X}" | tr '\n' ' '
+    echo ""
     exit 1
 fi

--- a/hack/verify-generated-files-remake.sh
+++ b/hack/verify-generated-files-remake.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::util::ensure_clean_working_dir


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Shellcheck cleanups for `hack/verify-generated-files-remake.sh`. Change the script logic a bit to fixes issues related to array creation by removing unnecessary arrays. Remove regexps too. Continues work started in https://github.com/kubernetes/kubernetes/pull/73464. The second patch contains a script for validating the assumptions made in script logic changes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
