### PR TITLE
Update doc.go import for staging/src/k8s.io/api/storage/v1/doc.go

### DIFF
--- a/staging/src/k8s.io/api/storage/v1/doc.go
+++ b/staging/src/k8s.io/api/storage/v1/doc.go
@@ -18,4 +18,4 @@ limitations under the License.
 // +groupName=storage.k8s.io
 // +k8s:openapi-gen=true
 
-package v1
+package v1 // import "k8s.io/api/storage/v1"


### PR DESCRIPTION
What this PR does / why we need it:
update doc.go in:
staging/src/k8s.io/api/storage/v1/doc.go

This is necessary so that if someone wants to import only this package, the import path is not referred to as github.com, but as the k8s.io vanity url.
Ref: https://golang.org/doc/go1.4#canonicalimports

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Only a partial fix for #68231

Special notes for your reviewer:

Release note:

NONE