### PR TITLE
Rename AttachableLogsForObjectFunc -> AttachablePodForObjectFunc to better reflect its purpose

### DIFF
--- a/pkg/kubectl/cmd/attach/attach.go
+++ b/pkg/kubectl/cmd/attach/attach.go
@@ -76,7 +76,7 @@ type AttachOptions struct {
 	AttachFunc       func(*AttachOptions, *corev1.Container, bool, remotecommand.TerminalSizeQueue) func() error
 	Resources        []string
 	Builder          func() *resource.Builder
-	AttachablePodFn  polymorphichelpers.AttachableLogsForObjectFunc
+	AttachablePodFn  polymorphichelpers.AttachablePodForObjectFunc
 	restClientGetter genericclioptions.RESTClientGetter
 
 	Attach        RemoteAttach

--- a/pkg/kubectl/cmd/attach/attach_test.go
+++ b/pkg/kubectl/cmd/attach/attach_test.go
@@ -51,7 +51,7 @@ func (f *fakeRemoteAttach) Attach(method string, url *url.URL, config *restclien
 	return f.err
 }
 
-func fakeAttachablePodFn(pod *corev1.Pod) polymorphichelpers.AttachableLogsForObjectFunc {
+func fakeAttachablePodFn(pod *corev1.Pod) polymorphichelpers.AttachablePodForObjectFunc {
 	return func(getter genericclioptions.RESTClientGetter, obj runtime.Object, timeout time.Duration) (*corev1.Pod, error) {
 		return pod, nil
 	}

--- a/pkg/kubectl/polymorphichelpers/interface.go
+++ b/pkg/kubectl/polymorphichelpers/interface.go
@@ -34,11 +34,11 @@ type LogsForObjectFunc func(restClientGetter genericclioptions.RESTClientGetter,
 // LogsForObjectFn gives a way to easily override the function for unit testing if needed.
 var LogsForObjectFn LogsForObjectFunc = logsForObject
 
-// AttachableLogsForObjectFunc is a function type that can tell you how to get the pod for which to attach a given object
-type AttachableLogsForObjectFunc func(restClientGetter genericclioptions.RESTClientGetter, object runtime.Object, timeout time.Duration) (*v1.Pod, error)
+// AttachablePodForObjectFunc is a function type that can tell you how to get the pod for which to attach a given object
+type AttachablePodForObjectFunc func(restClientGetter genericclioptions.RESTClientGetter, object runtime.Object, timeout time.Duration) (*v1.Pod, error)
 
 // AttachablePodForObjectFn gives a way to easily override the function for unit testing if needed.
-var AttachablePodForObjectFn AttachableLogsForObjectFunc = attachablePodForObject
+var AttachablePodForObjectFn AttachablePodForObjectFunc = attachablePodForObject
 
 // HistoryViewerFunc is a function type that can tell you how to view change history
 type HistoryViewerFunc func(restClientGetter genericclioptions.RESTClientGetter, mapping *meta.RESTMapping) (kubectl.HistoryViewer, error)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:
/assign @juanvallejo 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
