### PR TITLE
Better error messages for type error in strategic patch

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -229,7 +229,7 @@ func fromUnstructured(sv, dv reflect.Value) error {
 	case reflect.Interface:
 		return interfaceFromUnstructured(sv, dv)
 	default:
-		return fmt.Errorf("unrecognized type: %v", dt.Kind())
+		return fmt.Errorf("Can't convert value %#v of type %v -> %v", sv, st.Kind(), dt.Kind())
 	}
 }
 
@@ -618,7 +618,7 @@ func toUnstructured(sv, dv reflect.Value) error {
 	case reflect.Interface:
 		return interfaceToUnstructured(sv, dv)
 	default:
-		return fmt.Errorf("unrecognized type: %v", st.Kind())
+		return fmt.Errorf("Can't convert value %#v of type %v -> %v", sv, st.Kind(), dt.Kind())
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -334,7 +334,7 @@ func strategicPatchObject(
 ) error {
 	originalObjMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(originalObject)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error encoding object to be patched: %v", err)
 	}
 
 	patchMap := make(map[string]interface{})
@@ -415,7 +415,7 @@ func applyPatchToObject(
 
 	// Rather than serialize the patched map to JSON, then decode it to an object, we go directly from a map to an object
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(patchedObjMap, objToUpdate); err != nil {
-		return err
+		return fmt.Errorf("Error decoding patch: %v", err)
 	}
 	// Decoding from JSON to a versioned object would apply defaults, so we do the same here
 	defaulter.Default(objToUpdate)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
(arguable.  I got the impression k8s considers insufficiently friendly errors as bugs?  feel free to relabel as feature.)

**What this PR does / why we need it**:
Improves server-side error message from unexpected types in strategic patch (also shown by `kubectl apply` and _sometimes_ by `kubectl edit` #26050).  Before:
```bash
$ cluster/kubectl.sh patch --type=strategic -p '{"spec": {"replicas": "1"}}'  deployment/sise
Error from server: unrecognized type: int32
```
After:
```bash
$ cluster/kubectl.sh patch --type=strategic -p '{"spec": {"replicas": "1"}}'  deployment/sise
Error from server: Error decoding patch: Can't convert value "1" of type string -> int32
```
In a large patch (especially via kubectl apply), this will help locating the problem.
See #73692 for details.

I don't know how to trigger the opposite `ToUnstructured` code path error that I worded "Error encoding object to be patched:".  Does that ever happen that an object fails conversion to unstructured map?  Anyway, as the messages were the same but source of problem is opposite, I wanted to disambiguate...

**Which issue(s) this PR fixes**:
Improves #73692 but not fully fixes — ideally would show exact path of problematic data.

**Special notes for your reviewer**:
Didn't add tests.  I'd appreciate guidance where / what kind of tests to add, if you want any.

**Does this PR introduce a user-facing change?**:
```release-note
Improved server's error message on unexpected types in strategic patch.
```
