### PR TITLE
Don't update the Pod object after each scheduling attempt

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -98,13 +98,17 @@ var highPriorityPod, highPriNominatedPod, medPriorityPod, unschedulablePod = v1.
 func addOrUpdateUnschedulablePod(p *PriorityQueue, pod *v1.Pod) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	p.unschedulableQ.addOrUpdate(pod)
+	p.unschedulableQ.addOrUpdate(newPodInfoNoTimestamp(pod))
 }
 
 func getUnschedulablePod(p *PriorityQueue, pod *v1.Pod) *v1.Pod {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	return p.unschedulableQ.get(pod)
+	pInfo := p.unschedulableQ.get(pod)
+	if pInfo != nil {
+		return pInfo.pod
+	}
+	return nil
 }
 
 func TestPriorityQueue_Add(t *testing.T) {
@@ -275,7 +279,7 @@ func TestPriorityQueue_AddUnschedulableIfNotPresent_Async(t *testing.T) {
 	wg.Wait()
 	// all other pods should be in active queue again
 	for i := 1; i < totalNum; i++ {
-		if _, exists, _ := q.activeQ.Get(&expectedPods[i]); !exists {
+		if _, exists, _ := q.activeQ.Get(newPodInfoNoTimestamp(&expectedPods[i])); !exists {
 			t.Errorf("Expected %v to be added to activeQ.", expectedPods[i].Name)
 		}
 	}
@@ -301,7 +305,7 @@ func TestPriorityQueue_Pop(t *testing.T) {
 func TestPriorityQueue_Update(t *testing.T) {
 	q := NewPriorityQueue(nil)
 	q.Update(nil, &highPriorityPod)
-	if _, exists, _ := q.activeQ.Get(&highPriorityPod); !exists {
+	if _, exists, _ := q.activeQ.Get(newPodInfoNoTimestamp(&highPriorityPod)); !exists {
 		t.Errorf("Expected %v to be added to activeQ.", highPriorityPod.Name)
 	}
 	if len(q.nominatedPods.nominatedPods) != 0 {
@@ -318,15 +322,15 @@ func TestPriorityQueue_Update(t *testing.T) {
 	// Updating an unschedulable pod which is not in any of the two queues, should
 	// add the pod to activeQ.
 	q.Update(&unschedulablePod, &unschedulablePod)
-	if _, exists, _ := q.activeQ.Get(&unschedulablePod); !exists {
+	if _, exists, _ := q.activeQ.Get(newPodInfoNoTimestamp(&unschedulablePod)); !exists {
 		t.Errorf("Expected %v to be added to activeQ.", unschedulablePod.Name)
 	}
 	// Updating a pod that is already in activeQ, should not change it.
 	q.Update(&unschedulablePod, &unschedulablePod)
-	if len(q.unschedulableQ.pods) != 0 {
+	if len(q.unschedulableQ.podInfoMap) != 0 {
 		t.Error("Expected unschedulableQ to be empty.")
 	}
-	if _, exists, _ := q.activeQ.Get(&unschedulablePod); !exists {
+	if _, exists, _ := q.activeQ.Get(newPodInfoNoTimestamp(&unschedulablePod)); !exists {
 		t.Errorf("Expected: %v to be added to activeQ.", unschedulablePod.Name)
 	}
 	if p, err := q.Pop(); err != nil || p != &highPriNominatedPod {
@@ -341,10 +345,10 @@ func TestPriorityQueue_Delete(t *testing.T) {
 	if err := q.Delete(&highPriNominatedPod); err != nil {
 		t.Errorf("delete failed: %v", err)
 	}
-	if _, exists, _ := q.activeQ.Get(&unschedulablePod); !exists {
+	if _, exists, _ := q.activeQ.Get(newPodInfoNoTimestamp(&unschedulablePod)); !exists {
 		t.Errorf("Expected %v to be in activeQ.", unschedulablePod.Name)
 	}
-	if _, exists, _ := q.activeQ.Get(&highPriNominatedPod); exists {
+	if _, exists, _ := q.activeQ.Get(newPodInfoNoTimestamp(&highPriNominatedPod)); exists {
 		t.Errorf("Didn't expect %v to be in activeQ.", highPriorityPod.Name)
 	}
 	if len(q.nominatedPods.nominatedPods) != 1 {
@@ -416,7 +420,7 @@ func TestPriorityQueue_AssignedPodAdded(t *testing.T) {
 	if getUnschedulablePod(q, affinityPod) != nil {
 		t.Error("affinityPod is still in the unschedulableQ.")
 	}
-	if _, exists, _ := q.activeQ.Get(affinityPod); !exists {
+	if _, exists, _ := q.activeQ.Get(newPodInfoNoTimestamp(affinityPod)); !exists {
 		t.Error("affinityPod is not moved to activeQ.")
 	}
 	// Check that the other pod is still in the unschedulableQ.
@@ -588,98 +592,98 @@ func TestUnschedulablePodsMap(t *testing.T) {
 	tests := []struct {
 		name                   string
 		podsToAdd              []*v1.Pod
-		expectedMapAfterAdd    map[string]*v1.Pod
+		expectedMapAfterAdd    map[string]*podInfo
 		podsToUpdate           []*v1.Pod
-		expectedMapAfterUpdate map[string]*v1.Pod
+		expectedMapAfterUpdate map[string]*podInfo
 		podsToDelete           []*v1.Pod
-		expectedMapAfterDelete map[string]*v1.Pod
+		expectedMapAfterDelete map[string]*podInfo
 	}{
 		{
 			name:      "create, update, delete subset of pods",
 			podsToAdd: []*v1.Pod{pods[0], pods[1], pods[2], pods[3]},
-			expectedMapAfterAdd: map[string]*v1.Pod{
-				util.GetPodFullName(pods[0]): pods[0],
-				util.GetPodFullName(pods[1]): pods[1],
-				util.GetPodFullName(pods[2]): pods[2],
-				util.GetPodFullName(pods[3]): pods[3],
+			expectedMapAfterAdd: map[string]*podInfo{
+				util.GetPodFullName(pods[0]): {pod: pods[0]},
+				util.GetPodFullName(pods[1]): {pod: pods[1]},
+				util.GetPodFullName(pods[2]): {pod: pods[2]},
+				util.GetPodFullName(pods[3]): {pod: pods[3]},
 			},
 			podsToUpdate: []*v1.Pod{updatedPods[0]},
-			expectedMapAfterUpdate: map[string]*v1.Pod{
-				util.GetPodFullName(pods[0]): updatedPods[0],
-				util.GetPodFullName(pods[1]): pods[1],
-				util.GetPodFullName(pods[2]): pods[2],
-				util.GetPodFullName(pods[3]): pods[3],
+			expectedMapAfterUpdate: map[string]*podInfo{
+				util.GetPodFullName(pods[0]): {pod: updatedPods[0]},
+				util.GetPodFullName(pods[1]): {pod: pods[1]},
+				util.GetPodFullName(pods[2]): {pod: pods[2]},
+				util.GetPodFullName(pods[3]): {pod: pods[3]},
 			},
 			podsToDelete: []*v1.Pod{pods[0], pods[1]},
-			expectedMapAfterDelete: map[string]*v1.Pod{
-				util.GetPodFullName(pods[2]): pods[2],
-				util.GetPodFullName(pods[3]): pods[3],
+			expectedMapAfterDelete: map[string]*podInfo{
+				util.GetPodFullName(pods[2]): {pod: pods[2]},
+				util.GetPodFullName(pods[3]): {pod: pods[3]},
 			},
 		},
 		{
 			name:      "create, update, delete all",
 			podsToAdd: []*v1.Pod{pods[0], pods[3]},
-			expectedMapAfterAdd: map[string]*v1.Pod{
-				util.GetPodFullName(pods[0]): pods[0],
-				util.GetPodFullName(pods[3]): pods[3],
+			expectedMapAfterAdd: map[string]*podInfo{
+				util.GetPodFullName(pods[0]): {pod: pods[0]},
+				util.GetPodFullName(pods[3]): {pod: pods[3]},
 			},
 			podsToUpdate: []*v1.Pod{updatedPods[3]},
-			expectedMapAfterUpdate: map[string]*v1.Pod{
-				util.GetPodFullName(pods[0]): pods[0],
-				util.GetPodFullName(pods[3]): updatedPods[3],
+			expectedMapAfterUpdate: map[string]*podInfo{
+				util.GetPodFullName(pods[0]): {pod: pods[0]},
+				util.GetPodFullName(pods[3]): {pod: updatedPods[3]},
 			},
 			podsToDelete:           []*v1.Pod{pods[0], pods[3]},
-			expectedMapAfterDelete: map[string]*v1.Pod{},
+			expectedMapAfterDelete: map[string]*podInfo{},
 		},
 		{
 			name:      "delete non-existing and existing pods",
 			podsToAdd: []*v1.Pod{pods[1], pods[2]},
-			expectedMapAfterAdd: map[string]*v1.Pod{
-				util.GetPodFullName(pods[1]): pods[1],
-				util.GetPodFullName(pods[2]): pods[2],
+			expectedMapAfterAdd: map[string]*podInfo{
+				util.GetPodFullName(pods[1]): {pod: pods[1]},
+				util.GetPodFullName(pods[2]): {pod: pods[2]},
 			},
 			podsToUpdate: []*v1.Pod{updatedPods[1]},
-			expectedMapAfterUpdate: map[string]*v1.Pod{
-				util.GetPodFullName(pods[1]): updatedPods[1],
-				util.GetPodFullName(pods[2]): pods[2],
+			expectedMapAfterUpdate: map[string]*podInfo{
+				util.GetPodFullName(pods[1]): {pod: updatedPods[1]},
+				util.GetPodFullName(pods[2]): {pod: pods[2]},
 			},
 			podsToDelete: []*v1.Pod{pods[2], pods[3]},
-			expectedMapAfterDelete: map[string]*v1.Pod{
-				util.GetPodFullName(pods[1]): updatedPods[1],
+			expectedMapAfterDelete: map[string]*podInfo{
+				util.GetPodFullName(pods[1]): {pod: updatedPods[1]},
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			upm := newUnschedulablePodsMap()
+			upm := newUnschedulablePodsMap(nil)
 			for _, p := range test.podsToAdd {
-				upm.addOrUpdate(p)
+				upm.addOrUpdate(newPodInfoNoTimestamp(p))
 			}
-			if !reflect.DeepEqual(upm.pods, test.expectedMapAfterAdd) {
+			if !reflect.DeepEqual(upm.podInfoMap, test.expectedMapAfterAdd) {
 				t.Errorf("Unexpected map after adding pods. Expected: %v, got: %v",
-					test.expectedMapAfterAdd, upm.pods)
+					test.expectedMapAfterAdd, upm.podInfoMap)
 			}
 
 			if len(test.podsToUpdate) > 0 {
 				for _, p := range test.podsToUpdate {
-					upm.addOrUpdate(p)
+					upm.addOrUpdate(newPodInfoNoTimestamp(p))
 				}
-				if !reflect.DeepEqual(upm.pods, test.expectedMapAfterUpdate) {
+				if !reflect.DeepEqual(upm.podInfoMap, test.expectedMapAfterUpdate) {
 					t.Errorf("Unexpected map after updating pods. Expected: %v, got: %v",
-						test.expectedMapAfterUpdate, upm.pods)
+						test.expectedMapAfterUpdate, upm.podInfoMap)
 				}
 			}
 			for _, p := range test.podsToDelete {
 				upm.delete(p)
 			}
-			if !reflect.DeepEqual(upm.pods, test.expectedMapAfterDelete) {
+			if !reflect.DeepEqual(upm.podInfoMap, test.expectedMapAfterDelete) {
 				t.Errorf("Unexpected map after deleting pods. Expected: %v, got: %v",
-					test.expectedMapAfterDelete, upm.pods)
+					test.expectedMapAfterDelete, upm.podInfoMap)
 			}
 			upm.clear()
-			if len(upm.pods) != 0 {
-				t.Errorf("Expected the map to be empty, but has %v elements.", len(upm.pods))
+			if len(upm.podInfoMap) != 0 {
+				t.Errorf("Expected the map to be empty, but has %v elements.", len(upm.podInfoMap))
 			}
 		})
 	}
@@ -799,14 +803,15 @@ func TestPodFailedSchedulingMultipleTimesDoesNotBlockNewerPod(t *testing.T) {
 			NominatedNodeName: "node1",
 		},
 	}
+
 	// Update pod condition to unschedulable.
 	podutil.UpdatePodCondition(&unschedulablePod.Status, &v1.PodCondition{
-		Type:          v1.PodScheduled,
-		Status:        v1.ConditionFalse,
-		Reason:        v1.PodReasonUnschedulable,
-		Message:       "fake scheduling failure",
-		LastProbeTime: metav1.Now(),
+		Type:    v1.PodScheduled,
+		Status:  v1.ConditionFalse,
+		Reason:  v1.PodReasonUnschedulable,
+		Message: "fake scheduling failure",
 	})
+
 	// Put in the unschedulable queue
 	q.AddUnschedulableIfNotPresent(&unschedulablePod, q.SchedulingCycle())
 	// Clear its backoff to simulate backoff its expiration
@@ -844,12 +849,12 @@ func TestPodFailedSchedulingMultipleTimesDoesNotBlockNewerPod(t *testing.T) {
 
 	// And then unschedulablePod was determined as unschedulable AGAIN.
 	podutil.UpdatePodCondition(&unschedulablePod.Status, &v1.PodCondition{
-		Type:          v1.PodScheduled,
-		Status:        v1.ConditionFalse,
-		Reason:        v1.PodReasonUnschedulable,
-		Message:       "fake scheduling failure",
-		LastProbeTime: metav1.Now(),
+		Type:    v1.PodScheduled,
+		Status:  v1.ConditionFalse,
+		Reason:  v1.PodReasonUnschedulable,
+		Message: "fake scheduling failure",
 	})
+
 	// And then, put unschedulable pod to the unschedulable queue
 	q.AddUnschedulableIfNotPresent(&unschedulablePod, q.SchedulingCycle())
 	// Clear its backoff to simulate its backoff expiration
@@ -962,31 +967,171 @@ func TestHighProirotyFlushUnschedulableQLeftover(t *testing.T) {
 		},
 	}
 
-	addOrUpdateUnschedulablePod(q, &highPod)
-	addOrUpdateUnschedulablePod(q, &midPod)
-
 	// Update pod condition to highPod.
 	podutil.UpdatePodCondition(&highPod.Status, &v1.PodCondition{
-		Type:          v1.PodScheduled,
-		Status:        v1.ConditionFalse,
-		Reason:        v1.PodReasonUnschedulable,
-		Message:       "fake scheduling failure",
-		LastProbeTime: metav1.Time{Time: time.Now().Add(-1 * unschedulableQTimeInterval)},
+		Type:    v1.PodScheduled,
+		Status:  v1.ConditionFalse,
+		Reason:  v1.PodReasonUnschedulable,
+		Message: "fake scheduling failure",
 	})
 
 	// Update pod condition to midPod.
 	podutil.UpdatePodCondition(&midPod.Status, &v1.PodCondition{
-		Type:          v1.PodScheduled,
-		Status:        v1.ConditionFalse,
-		Reason:        v1.PodReasonUnschedulable,
-		Message:       "fake scheduling failure",
-		LastProbeTime: metav1.Time{Time: time.Now().Add(-1 * unschedulableQTimeInterval)},
+		Type:    v1.PodScheduled,
+		Status:  v1.ConditionFalse,
+		Reason:  v1.PodReasonUnschedulable,
+		Message: "fake scheduling failure",
 	})
+
+	q.unschedulableQ.addOrUpdate(newPodInfoNoTimestamp(&highPod))
+	q.unschedulableQ.addOrUpdate(newPodInfoNoTimestamp(&midPod))
+	q.unschedulableQ.podInfoMap[util.GetPodFullName(&highPod)].timestamp = time.Now().Add(-1 * unschedulableQTimeInterval)
+	q.unschedulableQ.podInfoMap[util.GetPodFullName(&midPod)].timestamp = time.Now().Add(-1 * unschedulableQTimeInterval)
 
 	if p, err := q.Pop(); err != nil || p != &highPod {
 		t.Errorf("Expected: %v after Pop, but got: %v", highPriorityPod.Name, p.Name)
 	}
 	if p, err := q.Pop(); err != nil || p != &midPod {
 		t.Errorf("Expected: %v after Pop, but got: %v", medPriorityPod.Name, p.Name)
+	}
+}
+
+// TestPodTimestamp tests the operations related to podInfo.
+func TestPodTimestamp(t *testing.T) {
+	pod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-1",
+			Namespace: "ns1",
+			UID:       types.UID("tp-1"),
+		},
+		Status: v1.PodStatus{
+			NominatedNodeName: "node1",
+		},
+	}
+
+	pod2 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-2",
+			Namespace: "ns2",
+			UID:       types.UID("tp-2"),
+		},
+		Status: v1.PodStatus{
+			NominatedNodeName: "node2",
+		},
+	}
+
+	pInfo1 := &podInfo{
+		pod:       pod1,
+		timestamp: util.RealClock{}.Now(),
+	}
+	pInfo2 := &podInfo{
+		pod:       pod2,
+		timestamp: util.RealClock{}.Now().Add(1 * time.Second),
+	}
+
+	var queue *PriorityQueue
+	type operation = func()
+	addPodActiveQ := func(pInfo *podInfo) operation {
+		return func() {
+			queue.lock.Lock()
+			defer queue.lock.Unlock()
+			queue.activeQ.Add(pInfo)
+		}
+	}
+	updatePodActiveQ := func(pInfo *podInfo) operation {
+		return func() {
+			queue.lock.Lock()
+			defer queue.lock.Unlock()
+			queue.activeQ.Update(pInfo)
+		}
+	}
+	addPodUnschedulableQ := func(pInfo *podInfo) operation {
+		return func() {
+			queue.lock.Lock()
+			defer queue.lock.Unlock()
+			// Update pod condition to unschedulable.
+			podutil.UpdatePodCondition(&pInfo.pod.Status, &v1.PodCondition{
+				Type:    v1.PodScheduled,
+				Status:  v1.ConditionFalse,
+				Reason:  v1.PodReasonUnschedulable,
+				Message: "fake scheduling failure",
+			})
+			queue.unschedulableQ.addOrUpdate(pInfo)
+		}
+	}
+	addPodBackoffQ := func(pInfo *podInfo) operation {
+		return func() {
+			queue.lock.Lock()
+			defer queue.lock.Unlock()
+			queue.podBackoffQ.Add(pInfo)
+		}
+	}
+	moveAllToActiveQ := func() operation {
+		return func() {
+			queue.MoveAllToActiveQueue()
+		}
+	}
+	flushBackoffQ := func() operation {
+		return func() {
+			queue.flushBackoffQCompleted()
+		}
+	}
+	tests := []struct {
+		name       string
+		operations []operation
+		expected   []*podInfo
+	}{
+		{
+			name: "add two pod to activeQ and sort them by the timestamp",
+			operations: []operation{
+				addPodActiveQ(pInfo2), addPodActiveQ(pInfo1),
+			},
+			expected: []*podInfo{pInfo1, pInfo2},
+		},
+		{
+			name: "update two pod to activeQ and sort them by the timestamp",
+			operations: []operation{
+				updatePodActiveQ(pInfo2), updatePodActiveQ(pInfo1),
+			},
+			expected: []*podInfo{pInfo1, pInfo2},
+		},
+		{
+			name: "add two pod to unschedulableQ then move them to activeQ and sort them by the timestamp",
+			operations: []operation{
+				addPodUnschedulableQ(pInfo2), addPodUnschedulableQ(pInfo1), moveAllToActiveQ(),
+			},
+			expected: []*podInfo{pInfo1, pInfo2},
+		},
+		{
+			name: "add one pod to BackoffQ and move it to activeQ",
+			operations: []operation{
+				addPodActiveQ(pInfo2), addPodBackoffQ(pInfo1), flushBackoffQ(), moveAllToActiveQ(),
+			},
+			expected: []*podInfo{pInfo1, pInfo2},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			queue = NewPriorityQueue(nil)
+			var podInfoList []*podInfo
+
+			for _, op := range test.operations {
+				op()
+			}
+
+			for i := 0; i < len(test.expected); i++ {
+				if pInfo, err := queue.activeQ.Pop(); err != nil {
+					t.Errorf("Error while popping the head of the queue: %v", err)
+				} else {
+					podInfoList = append(podInfoList, pInfo.(*podInfo))
+				}
+			}
+
+			if !reflect.DeepEqual(test.expected, podInfoList) {
+				t.Errorf("Unexpected podInfo list. Expected: %v, got: %v",
+					test.expected, podInfoList)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -265,11 +265,10 @@ func (sched *Scheduler) recordSchedulingFailure(pod *v1.Pod, err error, reason s
 	sched.config.Error(pod, err)
 	sched.config.Recorder.Event(pod, v1.EventTypeWarning, "FailedScheduling", message)
 	sched.config.PodConditionUpdater.Update(pod, &v1.PodCondition{
-		Type:          v1.PodScheduled,
-		Status:        v1.ConditionFalse,
-		LastProbeTime: metav1.Now(),
-		Reason:        reason,
-		Message:       err.Error(),
+		Type:    v1.PodScheduled,
+		Status:  v1.ConditionFalse,
+		Reason:  reason,
+		Message: err.Error(),
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig scheduling
/priority important-soon

**What this PR does / why we need it**:
We recently added a PR to put a timestamp on a Pod object every time it is attempted by the scheduler. However, this change could increase the number of pod updates and could raise the load of the API server in some scenarios. This is particularly problematic in clusters with a lot of unschedulable pods that remain unschedulable for a long time and getting attempted many times.

In fact, we don't need to keep this timestamp in the API object. This is needed only for the scheduler to keep track of the time that a pod is attempted. In other words, this timestamp can be kept in the scheduler's internal state only. We should add a timestamp to every pod in the scheduling queue. The timestamp will be the time that the pod is added to the queue. The scheduler should use this timestamp for sorting pods with the same priority. By doing this we will not update the API object after every scheduling attempt.

When I went to solve this issue, I find [flush UnschedulableQ Leftover to activeQ in 30s](https://github.com/kubernetes/kubernetes/pull/72558#discussion_r245399399) depends on the timestamp the pod is attempted by the scheduler. So In addition to recording the time when pod joined activeq, I also recorded the time when pod joined unschedulerq. 

**Which issue(s) this PR fixes**:
Fixes #73485

**Special notes for your reviewer**:

```release-note
Don't update the Pod object after each scheduling attempt by adding a timestamp to the scheduling queue.
```
