### PR TITLE
kubelet: upgrade sourceFile to use fsnotify

### DIFF
--- a/pkg/kubelet/config/BUILD
+++ b/pkg/kubelet/config/BUILD
@@ -48,7 +48,7 @@ go_library(
     ] + select({
         "@io_bazel_rules_go//go/platform:linux": [
             "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
-            "//vendor/github.com/sigma/go-inotify:go_default_library",
+            "//vendor/github.com/fsnotify/fsnotify:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/kubelet/config/file_linux.go
+++ b/pkg/kubelet/config/file_linux.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sigma/go-inotify"
+	"github.com/fsnotify/fsnotify"
 	"k8s.io/klog"
 
 	"k8s.io/api/core/v1"
@@ -77,30 +77,30 @@ func (s *sourceFile) doWatch() error {
 		return &retryableError{"path does not exist, ignoring"}
 	}
 
-	w, err := inotify.NewWatcher()
+	w, err := fsnotify.NewWatcher()
 	if err != nil {
 		return fmt.Errorf("unable to create inotify: %v", err)
 	}
 	defer w.Close()
 
-	err = w.AddWatch(s.path, inotify.IN_DELETE_SELF|inotify.IN_CREATE|inotify.IN_MOVED_TO|inotify.IN_MODIFY|inotify.IN_MOVED_FROM|inotify.IN_DELETE|inotify.IN_ATTRIB)
+	err = w.Add(s.path)
 	if err != nil {
 		return fmt.Errorf("unable to create inotify for path %q: %v", s.path, err)
 	}
 
 	for {
 		select {
-		case event := <-w.Event:
-			if err = s.produceWatchEvent(event); err != nil {
+		case event := <-w.Events:
+			if err = s.produceWatchEvent(&event); err != nil {
 				return fmt.Errorf("error while processing inotify event (%+v): %v", event, err)
 			}
-		case err = <-w.Error:
+		case err = <-w.Errors:
 			return fmt.Errorf("error while watching %q: %v", s.path, err)
 		}
 	}
 }
 
-func (s *sourceFile) produceWatchEvent(e *inotify.Event) error {
+func (s *sourceFile) produceWatchEvent(e *fsnotify.Event) error {
 	// Ignore file start with dots
 	if strings.HasPrefix(filepath.Base(e.Name), ".") {
 		klog.V(4).Infof("Ignored pod manifest: %s, because it starts with dots", e.Name)
@@ -108,23 +108,16 @@ func (s *sourceFile) produceWatchEvent(e *inotify.Event) error {
 	}
 	var eventType podEventType
 	switch {
-	case (e.Mask & inotify.IN_ISDIR) > 0:
-		klog.Errorf("Not recursing into manifest path %q", s.path)
-		return nil
-	case (e.Mask & inotify.IN_CREATE) > 0:
+	case (e.Op & fsnotify.Create) > 0:
 		eventType = podAdd
-	case (e.Mask & inotify.IN_MOVED_TO) > 0:
-		eventType = podAdd
-	case (e.Mask & inotify.IN_MODIFY) > 0:
+	case (e.Op & fsnotify.Write) > 0:
 		eventType = podModify
-	case (e.Mask & inotify.IN_ATTRIB) > 0:
+	case (e.Op & fsnotify.Chmod) > 0:
 		eventType = podModify
-	case (e.Mask & inotify.IN_DELETE) > 0:
+	case (e.Op & fsnotify.Remove) > 0:
 		eventType = podDelete
-	case (e.Mask & inotify.IN_MOVED_FROM) > 0:
+	case (e.Op & fsnotify.Rename) > 0:
 		eventType = podDelete
-	case (e.Mask & inotify.IN_DELETE_SELF) > 0:
-		return fmt.Errorf("the watched path is deleted")
 	default:
 		// Ignore rest events
 		return nil

--- a/pkg/kubelet/config/file_linux_test.go
+++ b/pkg/kubelet/config/file_linux_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -428,7 +427,7 @@ func writeFile(filename string, data []byte) error {
 func changeFileName(dir, from, to string, t *testing.T) {
 	fromPath := filepath.Join(dir, from)
 	toPath := filepath.Join(dir, to)
-	if err := exec.Command("mv", fromPath, toPath).Run(); err != nil {
+	if err := os.Rename(fromPath, toPath); err != nil {
 		t.Errorf("Fail to change file name: %s", err)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Mitigate some flakes for deleted watch directories and use the
maintained fsnotify package.

**Which issue(s) this PR fixes**:
Fixes https://github.com/openshift/origin/issues/21876

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/cc @sjenning 
/sig @kubernetes/sig-node-pr-reviews 