### PR TITLE
csr signer has no need to sign certificates for a duration longer than the signer itself

### DIFF
--- a/pkg/controller/certificates/signer/cfssl_signer.go
+++ b/pkg/controller/certificates/signer/cfssl_signer.go
@@ -59,6 +59,9 @@ type cfsslSigner struct {
 	sigAlgo             x509.SignatureAlgorithm
 	client              clientset.Interface
 	certificateDuration time.Duration
+
+	// nowFn returns the current time.  We have here for unit testing
+	nowFn func() time.Time
 }
 
 func newCFSSLSigner(caFile, caKeyFile string, client clientset.Interface, certificateDuration time.Duration) (*cfsslSigner, error) {
@@ -92,6 +95,7 @@ func newCFSSLSigner(caFile, caKeyFile string, client clientset.Interface, certif
 		sigAlgo:             signer.DefaultSigAlgo(priv),
 		client:              client,
 		certificateDuration: certificateDuration,
+		nowFn:               time.Now,
 	}, nil
 }
 
@@ -115,11 +119,21 @@ func (s *cfsslSigner) sign(csr *capi.CertificateSigningRequest) (*capi.Certifica
 	for _, usage := range csr.Spec.Usages {
 		usages = append(usages, string(usage))
 	}
+
+	certExpiryDuration := s.certificateDuration
+	durationUntilExpiry := s.ca.NotAfter.Sub(s.nowFn())
+	if durationUntilExpiry <= 0 {
+		return nil, fmt.Errorf("the signer has expired: %v", s.ca.NotAfter)
+	}
+	if durationUntilExpiry < certExpiryDuration {
+		certExpiryDuration = durationUntilExpiry
+	}
+
 	policy := &config.Signing{
 		Default: &config.SigningProfile{
 			Usage:        usages,
-			Expiry:       s.certificateDuration,
-			ExpiryString: s.certificateDuration.String(),
+			Expiry:       certExpiryDuration,
+			ExpiryString: certExpiryDuration.String(),
 		},
 	}
 	cfs, err := local.NewSigner(s.priv, s.ca, s.sigAlgo, policy)


### PR DESCRIPTION
The CSR signing controller will currently sign certificates with a duration longer than the remaining life of the signer.  Since such a certificate should not validate after the signer expires anyway so, we can choose the minimum of the requested duration and remaining life of the signer.  This doesn't protect expiration of an entire chain, but it does help for the one part of the chain we know of for sure.

```release-note
NONE
```

@kubernetes/sig-auth-bugs 
@sjenning @derekwaynecarr I think this is the culprit