### PR TITLE
Automated cherry pick of #73401: Delete pods assigned to not existing nodes. #73606: Deleting pods assigned to not existing nodes only if

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -966,6 +966,9 @@ func (dsc *DaemonSetsController) manage(ds *apps.DaemonSet, hash string) error {
 		failedPodsObserved += failedPodsObservedOnNode
 	}
 
+	// Remove pods assigned to not existing nodes.
+	podsToDelete = append(podsToDelete, getPodsWithoutNode(nodeList, nodeToDaemonPods)...)
+
 	// Label new pods using the hash label value of the current history when creating them
 	if err = dsc.syncNodes(ds, podsToDelete, nodesNeedingDaemonPods, hash); err != nil {
 		return err
@@ -1534,4 +1537,22 @@ func isControlledByDaemonSet(p *v1.Pod, uuid types.UID) bool {
 
 func failedPodsBackoffKey(ds *apps.DaemonSet, nodeName string) string {
 	return fmt.Sprintf("%s/%d/%s", ds.UID, ds.Status.ObservedGeneration, nodeName)
+}
+
+// getPodsWithoutNode returns list of pods assigned to not existing nodes.
+func getPodsWithoutNode(
+	runningNodesList []*v1.Node, nodeToDaemonPods map[string][]*v1.Pod) []string {
+	var results []string
+	isNodeRunning := make(map[string]bool)
+	for _, node := range runningNodesList {
+		isNodeRunning[node.Name] = true
+	}
+	for n, pods := range nodeToDaemonPods {
+		if !isNodeRunning[n] {
+			for _, pod := range pods {
+				results = append(results, pod.Name)
+			}
+		}
+	}
+	return results
 }

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -2493,7 +2493,11 @@ func TestDeletePodForNotExistingNode(t *testing.T) {
 			addNodes(manager.nodeStore, 0, 1, nil)
 			addPods(manager.podStore, "node-0", simpleDaemonSetLabel, ds, 1)
 			addPods(manager.podStore, "node-1", simpleDaemonSetLabel, ds, 1)
-			syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 1, 0)
+			if f {
+				syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 1, 0)
+			} else {
+				syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 0, 0)
+			}
 		}
 	}
 }

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -2479,6 +2479,25 @@ func TestDeleteNoDaemonPod(t *testing.T) {
 	}
 }
 
+func TestDeletePodForNotExistingNode(t *testing.T) {
+	for _, f := range []bool{true, false} {
+		defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ScheduleDaemonSetPods, f)()
+		for _, strategy := range updateStrategies() {
+			ds := newDaemonSet("foo")
+			ds.Spec.UpdateStrategy = *strategy
+			manager, podControl, _, err := newTestController(ds)
+			if err != nil {
+				t.Fatalf("error creating DaemonSets controller: %v", err)
+			}
+			manager.dsStore.Add(ds)
+			addNodes(manager.nodeStore, 0, 1, nil)
+			addPods(manager.podStore, "node-0", simpleDaemonSetLabel, ds, 1)
+			addPods(manager.podStore, "node-1", simpleDaemonSetLabel, ds, 1)
+			syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 1, 0)
+		}
+	}
+}
+
 func TestGetNodesToDaemonPods(t *testing.T) {
 	for _, f := range []bool{true, false} {
 		defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ScheduleDaemonSetPods, f)()


### PR DESCRIPTION
Cherry pick of #73401 #73606 on release-1.13.

#73401: Delete pods assigned to not existing nodes.
#73606: Deleting pods assigned to not existing nodes only if

```release-note
Adds deleting pods created by DaemonSet assigned to not existing nodes.
```
