### PR TITLE
Automated cherry pick of #73401: Delete pods assigned to not existing nodes. #73606: Deleting pods assigned to not existing nodes only if

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -967,6 +967,9 @@ func (dsc *DaemonSetsController) manage(ds *apps.DaemonSet, hash string) error {
 		failedPodsObserved += failedPodsObservedOnNode
 	}
 
+	// Remove pods assigned to not existing nodes.
+	podsToDelete = append(podsToDelete, getPodsWithoutNode(nodeList, nodeToDaemonPods)...)
+
 	// Label new pods using the hash label value of the current history when creating them
 	if err = dsc.syncNodes(ds, podsToDelete, nodesNeedingDaemonPods, hash); err != nil {
 		return err
@@ -1547,4 +1550,22 @@ func isControlledByDaemonSet(p *v1.Pod, uuid types.UID) bool {
 
 func failedPodsBackoffKey(ds *apps.DaemonSet, nodeName string) string {
 	return fmt.Sprintf("%s/%d/%s", ds.UID, ds.Status.ObservedGeneration, nodeName)
+}
+
+// getPodsWithoutNode returns list of pods assigned to not existing nodes.
+func getPodsWithoutNode(
+	runningNodesList []*v1.Node, nodeToDaemonPods map[string][]*v1.Pod) []string {
+	var results []string
+	isNodeRunning := make(map[string]bool)
+	for _, node := range runningNodesList {
+		isNodeRunning[node.Name] = true
+	}
+	for n, pods := range nodeToDaemonPods {
+		if !isNodeRunning[n] {
+			for _, pod := range pods {
+				results = append(results, pod.Name)
+			}
+		}
+	}
+	return results
 }

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -967,8 +967,11 @@ func (dsc *DaemonSetsController) manage(ds *apps.DaemonSet, hash string) error {
 		failedPodsObserved += failedPodsObservedOnNode
 	}
 
-	// Remove pods assigned to not existing nodes.
-	podsToDelete = append(podsToDelete, getPodsWithoutNode(nodeList, nodeToDaemonPods)...)
+	// Remove pods assigned to not existing nodes when daemonset pods are scheduled by default scheduler.
+	// If node doesn't exist then pods are never scheduled and can't be deleted by PodGCController.
+	if utilfeature.DefaultFeatureGate.Enabled(features.ScheduleDaemonSetPods) {
+		podsToDelete = append(podsToDelete, getPodsWithoutNode(nodeList, nodeToDaemonPods)...)
+	}
 
 	// Label new pods using the hash label value of the current history when creating them
 	if err = dsc.syncNodes(ds, podsToDelete, nodesNeedingDaemonPods, hash); err != nil {
@@ -1553,8 +1556,7 @@ func failedPodsBackoffKey(ds *apps.DaemonSet, nodeName string) string {
 }
 
 // getPodsWithoutNode returns list of pods assigned to not existing nodes.
-func getPodsWithoutNode(
-	runningNodesList []*v1.Node, nodeToDaemonPods map[string][]*v1.Pod) []string {
+func getPodsWithoutNode(runningNodesList []*v1.Node, nodeToDaemonPods map[string][]*v1.Pod) []string {
 	var results []string
 	isNodeRunning := make(map[string]bool)
 	for _, node := range runningNodesList {

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -2678,7 +2678,11 @@ func TestDeletePodForNotExistingNode(t *testing.T) {
 			addNodes(manager.nodeStore, 0, 1, nil)
 			addPods(manager.podStore, "node-0", simpleDaemonSetLabel, ds, 1)
 			addPods(manager.podStore, "node-1", simpleDaemonSetLabel, ds, 1)
-			syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 1, 0)
+			if f {
+				syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 1, 0)
+			} else {
+				syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 0, 0)
+			}
 		}
 	}
 }

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -2664,6 +2664,25 @@ func TestDeleteNoDaemonPod(t *testing.T) {
 	}
 }
 
+func TestDeletePodForNotExistingNode(t *testing.T) {
+	for _, f := range []bool{true, false} {
+		defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ScheduleDaemonSetPods, f)()
+		for _, strategy := range updateStrategies() {
+			ds := newDaemonSet("foo")
+			ds.Spec.UpdateStrategy = *strategy
+			manager, podControl, _, err := newTestController(ds)
+			if err != nil {
+				t.Fatalf("error creating DaemonSets controller: %v", err)
+			}
+			manager.dsStore.Add(ds)
+			addNodes(manager.nodeStore, 0, 1, nil)
+			addPods(manager.podStore, "node-0", simpleDaemonSetLabel, ds, 1)
+			addPods(manager.podStore, "node-1", simpleDaemonSetLabel, ds, 1)
+			syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 1, 0)
+		}
+	}
+}
+
 func TestGetNodesToDaemonPods(t *testing.T) {
 	for _, f := range []bool{true, false} {
 		setFeatureGate(t, features.ScheduleDaemonSetPods, f)

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -2666,7 +2666,7 @@ func TestDeleteNoDaemonPod(t *testing.T) {
 
 func TestDeletePodForNotExistingNode(t *testing.T) {
 	for _, f := range []bool{true, false} {
-		defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ScheduleDaemonSetPods, f)()
+		setFeatureGate(t, features.ScheduleDaemonSetPods, f)
 		for _, strategy := range updateStrategies() {
 			ds := newDaemonSet("foo")
 			ds.Spec.UpdateStrategy = *strategy


### PR DESCRIPTION
Cherry pick of #73401 #73606 on release-1.12.

#73401: Delete pods assigned to not existing nodes.
#73606: Deleting pods assigned to not existing nodes only if

```release-note
Adds deleting pods created by DaemonSet assigned to not existing nodes.
```
