### PR TITLE
In SelectorSpreadPriority, consider all pods when scoring for zone

### DIFF
--- a/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
+++ b/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
@@ -343,6 +343,7 @@ func TestSelectorSpreadPriority(t *testing.T) {
 				controllerLister:  schedulertesting.FakeControllerLister(test.rcs),
 				replicaSetLister:  schedulertesting.FakeReplicaSetLister(test.rss),
 				statefulSetLister: schedulertesting.FakeStatefulSetLister(test.sss),
+				podLister:         schedulertesting.FakePodLister(test.pods),
 			}
 
 			metaDataProducer := NewPriorityMetadataFactory(
@@ -579,6 +580,7 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 				controllerLister:  schedulertesting.FakeControllerLister(test.rcs),
 				replicaSetLister:  schedulertesting.FakeReplicaSetLister(test.rss),
 				statefulSetLister: schedulertesting.FakeStatefulSetLister(test.sss),
+				podLister:         schedulertesting.FakePodLister(test.pods),
 			}
 
 			metaDataProducer := NewPriorityMetadataFactory(

--- a/pkg/scheduler/algorithm/types.go
+++ b/pkg/scheduler/algorithm/types.go
@@ -48,6 +48,7 @@ type PodLister interface {
 	// This is similar to "List()", but the returned slice does not
 	// contain pods that don't pass `podFilter`.
 	FilteredList(podFilter PodFilter, selector labels.Selector) ([]*v1.Pod, error)
+	Search(selectors []labels.Selector) (ret []*v1.Pod, err error)
 }
 
 // ServiceLister interface represents anything that can produce a list of services; the list is consumed by a scheduler.

--- a/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
@@ -38,7 +38,7 @@ func init() {
 		priorities.ServiceSpreadingPriority,
 		factory.PriorityConfigFactory{
 			MapReduceFunction: func(args factory.PluginFactoryArgs) (priorities.PriorityMapFunction, priorities.PriorityReduceFunction) {
-				return priorities.NewSelectorSpreadPriority(args.ServiceLister, algorithm.EmptyControllerLister{}, algorithm.EmptyReplicaSetLister{}, algorithm.EmptyStatefulSetLister{})
+				return priorities.NewSelectorSpreadPriority(args.ServiceLister, algorithm.EmptyControllerLister{}, algorithm.EmptyReplicaSetLister{}, algorithm.EmptyStatefulSetLister{}, args.PodLister)
 			},
 			Weight: 1,
 		},
@@ -59,7 +59,7 @@ func init() {
 		priorities.SelectorSpreadPriority,
 		factory.PriorityConfigFactory{
 			MapReduceFunction: func(args factory.PluginFactoryArgs) (priorities.PriorityMapFunction, priorities.PriorityReduceFunction) {
-				return priorities.NewSelectorSpreadPriority(args.ServiceLister, args.ControllerLister, args.ReplicaSetLister, args.StatefulSetLister)
+				return priorities.NewSelectorSpreadPriority(args.ServiceLister, args.ControllerLister, args.ReplicaSetLister, args.StatefulSetLister, args.PodLister)
 			},
 			Weight: 1,
 		},

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -984,7 +984,8 @@ func TestZeroRequest(t *testing.T) {
 				schedulertesting.FakeServiceLister([]*v1.Service{}),
 				schedulertesting.FakeControllerLister([]*v1.ReplicationController{}),
 				schedulertesting.FakeReplicaSetLister([]*apps.ReplicaSet{}),
-				schedulertesting.FakeStatefulSetLister([]*apps.StatefulSet{}))
+				schedulertesting.FakeStatefulSetLister([]*apps.StatefulSet{}),
+				schedulertesting.FakePodLister([]*v1.Pod{}))
 			pc := priorities.PriorityConfig{Map: selectorSpreadPriorityMap, Reduce: selectorSpreadPriorityReduce, Weight: 1}
 			priorityConfigs = append(priorityConfigs, pc)
 

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -246,6 +246,22 @@ func (cache *schedulerCache) List(selector labels.Selector) ([]*v1.Pod, error) {
 	return cache.FilteredList(alwaysTrue, selector)
 }
 
+func (cache *schedulerCache) Search(selectors []labels.Selector) ([]*v1.Pod, error) {
+	if len(selectors) == 0 {
+		return []*v1.Pod{}, nil
+	}
+	matchAllSelctors := func(p *v1.Pod) bool {
+		for _, selector := range selectors {
+			if !selector.Matches(labels.Set(p.Labels)) {
+				return false
+			}
+		}
+		return true
+	}
+
+	return cache.FilteredList(matchAllSelctors, selectors[0])
+}
+
 func (cache *schedulerCache) FilteredList(podFilter algorithm.PodFilter, selector labels.Selector) ([]*v1.Pod, error) {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()

--- a/pkg/scheduler/internal/cache/fake/fake_cache.go
+++ b/pkg/scheduler/internal/cache/fake/fake_cache.go
@@ -93,6 +93,9 @@ func (c *Cache) UpdateNodeInfoSnapshot(nodeSnapshot *schedulernodeinfo.Snapshot)
 // List is a fake method for testing.
 func (c *Cache) List(s labels.Selector) ([]*v1.Pod, error) { return nil, nil }
 
+// Search is a fake method for testing.
+func (c *Cache) Search(s []labels.Selector) ([]*v1.Pod, error) { return nil, nil }
+
 // FilteredList is a fake method for testing.
 func (c *Cache) FilteredList(filter algorithm.PodFilter, selector labels.Selector) ([]*v1.Pod, error) {
 	return nil, nil

--- a/pkg/scheduler/testing/fake_lister.go
+++ b/pkg/scheduler/testing/fake_lister.go
@@ -53,6 +53,23 @@ func (f FakePodLister) List(s labels.Selector) (selected []*v1.Pod, err error) {
 	return selected, nil
 }
 
+// Search returns pods matching all selectors
+func (f FakePodLister) Search(selectors []labels.Selector) (selected []*v1.Pod, err error) {
+	for _, pod := range f {
+		matched := true
+		for _, s := range selectors {
+			if !s.Matches(labels.Set(pod.Labels)) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			selected = append(selected, pod)
+		}
+	}
+	return selected, nil
+}
+
 // FilteredList returns pods matching a pod filter and a label selector.
 func (f FakePodLister) FilteredList(podFilter algorithm.PodFilter, s labels.Selector) (selected []*v1.Pod, err error) {
 	for _, pod := range f {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Predicates filter nodes. Existing pods on those nodes will be not be counted when calculating max pods per zone, resulting in imbalanced cluster. 

If one zone is more loaded than other zones, this makes it worse by getting more and more pods scheduled in the same zone.

Fix: Consider all pods matching all the selectors when spreading across zones.

**Which issue(s) this PR fixes**:
Fixes #72916

**Special notes for your reviewer**:

Follow up to 
PR: https://github.com/kubernetes/kubernetes/pull/72801
Issue: https://github.com/kubernetes/kubernetes/issues/71327


**Does this PR introduce a user-facing change?**:
```release-note
In SelectorSpreadPriority, count all pods when spreading for zone.
```

/sig scheduling