### PR TITLE
Bump debian-* base image versions to latest

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -89,8 +89,8 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
   local arch=$1
-  local debian_base_version=0.4.0
-  local debian_iptables_version=v11.0
+  local debian_base_version=0.4.1
+  local debian_iptables_version=v11.0.1
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets
   local targets=(

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -70,26 +70,26 @@ http_file(
 
 docker_pull(
     name = "debian-base-amd64",
-    digest = "sha256:86176bc8ccdc4d8ea7fbf6ba4b57fcefc2cb61ff7413114630940474ff9bf751",
+    digest = "sha256:8ccb65cd2dd7e0c24193d0742a20e4a673dbd11af5a33f16fcd471a31486866c",
     registry = "k8s.gcr.io",
     repository = "debian-base-amd64",
-    tag = "0.4.0",  # ignored, but kept here for documentation
+    tag = "0.4.1",  # ignored, but kept here for documentation
 )
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:d4ff8136b9037694a3165a7fff6a91e7fc828741b8ea1eda226d4d9ea5d23abb",
+    digest = "sha256:9c41b4c326304b94eb96fdd2e181aa6e9995cc4642fcdfb570cedd73a419ba39",
     registry = "k8s.gcr.io",
     repository = "debian-iptables-amd64",
-    tag = "v11.0",  # ignored, but kept here for documentation
+    tag = "v11.0.1",  # ignored, but kept here for documentation
 )
 
 docker_pull(
     name = "debian-hyperkube-base-amd64",
-    digest = "sha256:4a77bc882f7d629c088a11ff144a2e86660268fddf63b61f52b6a93d16ab83f0",
+    digest = "sha256:5d4ea2fb5fbe9a9a9da74f67cf2faefc881968bc39f2ac5d62d9167e575812a1",
     registry = "k8s.gcr.io",
     repository = "debian-hyperkube-base-amd64",
-    tag = "0.12.0",  # ignored, but kept here for documentation
+    tag = "0.12.1",  # ignored, but kept here for documentation
 )
 
 docker_pull(

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -18,7 +18,7 @@ TEMP_DIR:=$(shell mktemp -d)
 VERSION=v9.0
 KUBECTL_VERSION?=v1.13.2
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.4.0
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.4.1
 
 SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
 

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -25,7 +25,7 @@ KUBECTL_BIN?=$(shell pwd)/../../../$(OUT_DIR)/dockerized/bin/linux/$(ARCH)/kubec
 E2E_TEST_BIN?=$(shell pwd)/../../../$(OUT_DIR)/dockerized/bin/linux/$(ARCH)/e2e.test
 CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
-BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.12.0
+BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.12.1
 TEMP_DIR:=$(shell mktemp -d -t conformanceXXXXXX)
 
 all: build

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -22,7 +22,7 @@ ARCH?=amd64
 OUT_DIR?=_output
 HYPERKUBE_BIN?=$(shell pwd)/../../../$(OUT_DIR)/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.12.0
+BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.12.1
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -273,7 +273,7 @@ while true; do sleep 1; done
 				},
 				{
 					description: "should be able to pull image from gcr.io [LinuxOnly]",
-					image:       "gcr.io/google-containers/debian-base:0.4.0",
+					image:       "gcr.io/google-containers/debian-base:0.4.1",
 					phase:       v1.PodRunning,
 					waiting:     false,
 				},

--- a/test/images/pets/peer-finder/BASEIMAGE
+++ b/test/images/pets/peer-finder/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.4.0
-arm=k8s.gcr.io/debian-base-arm:0.4.0
-arm64=k8s.gcr.io/debian-base-arm64:0.4.0
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4.0
+amd64=k8s.gcr.io/debian-base-amd64:0.4.1
+arm=k8s.gcr.io/debian-base-arm:0.4.1
+arm64=k8s.gcr.io/debian-base-arm64:0.4.1
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4.1

--- a/test/images/pets/redis-installer/BASEIMAGE
+++ b/test/images/pets/redis-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.4.0
-arm=k8s.gcr.io/debian-base-arm:0.4.0
-arm64=k8s.gcr.io/debian-base-arm64:0.4.0
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4.0
+amd64=k8s.gcr.io/debian-base-amd64:0.4.1
+arm=k8s.gcr.io/debian-base-arm:0.4.1
+arm64=k8s.gcr.io/debian-base-arm64:0.4.1
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4.1

--- a/test/images/pets/zookeeper-installer/BASEIMAGE
+++ b/test/images/pets/zookeeper-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.4.0
-arm=k8s.gcr.io/debian-base-arm:0.4.0
-arm64=k8s.gcr.io/debian-base-arm64:0.4.0
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4.0
+amd64=k8s.gcr.io/debian-base-amd64:0.4.1
+arm=k8s.gcr.io/debian-base-arm:0.4.1
+arm64=k8s.gcr.io/debian-base-arm64:0.4.1
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4.1

--- a/test/images/resource-consumer/BASEIMAGE
+++ b/test/images/resource-consumer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.4.0
-arm=k8s.gcr.io/debian-base-arm:0.4.0
-arm64=k8s.gcr.io/debian-base-arm64:0.4.0
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4.0
+amd64=k8s.gcr.io/debian-base-amd64:0.4.1
+arm=k8s.gcr.io/debian-base-arm:0.4.1
+arm64=k8s.gcr.io/debian-base-arm64:0.4.1
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4.1


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Follow up to https://github.com/kubernetes/kubernetes/pull/73493 to use the new images.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @ixdy 
/priority critical-urgent
/sig release