### PR TITLE
Clarify documentation for resource.Value()

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -680,7 +680,7 @@ func NewScaledQuantity(value int64, scale Scale) *Quantity {
 	}
 }
 
-// Value returns the value of q; any fractional part will be lost.
+// Value returns the unscaled value of q rounded up to the nearest integer away from 0.
 func (q *Quantity) Value() int64 {
 	return q.ScaledValue(0)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

The documentation for `resource.Value()` is very misleading. By saying the fractional part is lost, it implies that integer truncation will be performed (or the same idea - I realize we're dealing with fixed point here). For example, I would expect the result of `quantity.MustParse("500m").Value()` to be `0`, but instead it is `1` because rounding is performed.

This rounding is always performed away from zero, so e.g. `-200m` results in a return value of `-1`.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
I do feel it may be worth adding a more friendly API similar to `MilliValue()` but that also takes into consideration overflow (it would have to return an `error` too, e.g. `WouldOverflow`). A user could just use this and trust that it's safe / does the expected thing.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```