### PR TITLE
add --all-namespaces to kubectl delete

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -177,6 +177,7 @@
 ./test/cmd/core.sh
 ./test/cmd/crd.sh
 ./test/cmd/create.sh
+./test/cmd/delete.sh
 ./test/cmd/diff.sh
 ./test/cmd/discovery.sh
 ./test/cmd/generic-resources.sh

--- a/pkg/kubectl/cmd/delete/delete.go
+++ b/pkg/kubectl/cmd/delete/delete.go
@@ -93,14 +93,15 @@ var (
 type DeleteOptions struct {
 	resource.FilenameOptions
 
-	LabelSelector   string
-	FieldSelector   string
-	DeleteAll       bool
-	IgnoreNotFound  bool
-	Cascade         bool
-	DeleteNow       bool
-	ForceDeletion   bool
-	WaitForDeletion bool
+	LabelSelector       string
+	FieldSelector       string
+	DeleteAll           bool
+	DeleteAllNamespaces bool
+	IgnoreNotFound      bool
+	Cascade             bool
+	DeleteNow           bool
+	ForceDeletion       bool
+	WaitForDeletion     bool
 
 	GracePeriod int
 	Timeout     time.Duration
@@ -170,6 +171,7 @@ func (o *DeleteOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Co
 		LabelSelectorParam(o.LabelSelector).
 		FieldSelectorParam(o.FieldSelector).
 		SelectAllParam(o.DeleteAll).
+		AllNamespaces(o.DeleteAllNamespaces).
 		ResourceTypeOrNameArgs(false, args...).RequireObject(false).
 		Flatten().
 		Do()

--- a/pkg/kubectl/cmd/delete/delete_flags.go
+++ b/pkg/kubectl/cmd/delete/delete_flags.go
@@ -33,6 +33,7 @@ type DeleteFlags struct {
 	FieldSelector *string
 
 	All            *bool
+	AllNamespaces  *bool
 	Cascade        *bool
 	Force          *bool
 	GracePeriod    *int
@@ -67,6 +68,9 @@ func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams generic
 
 	if f.All != nil {
 		options.DeleteAll = *f.All
+	}
+	if f.AllNamespaces != nil {
+		options.DeleteAllNamespaces = *f.AllNamespaces
 	}
 	if f.Cascade != nil {
 		options.Cascade = *f.Cascade
@@ -104,6 +108,9 @@ func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 	if f.All != nil {
 		cmd.Flags().BoolVar(f.All, "all", *f.All, "Delete all resources, including uninitialized ones, in the namespace of the specified resource types.")
 	}
+	if f.AllNamespaces != nil {
+		cmd.Flags().BoolVarP(f.AllNamespaces, "all-namespaces", "A", *f.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	}
 	if f.Force != nil {
 		cmd.Flags().BoolVar(f.Force, "force", *f.Force, "Only used when grace-period=0. If true, immediately remove resources from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
 	}
@@ -137,6 +144,7 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 
 	// setup command defaults
 	all := false
+	allNamespaces := false
 	force := false
 	ignoreNotFound := false
 	now := false
@@ -158,6 +166,7 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 		GracePeriod: &gracePeriod,
 
 		All:            &all,
+		AllNamespaces:  &allNamespaces,
 		Force:          &force,
 		IgnoreNotFound: &ignoreNotFound,
 		Now:            &now,

--- a/test/cmd/delete.sh
+++ b/test/cmd/delete.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Runs tests related to kubectl delete --all-namespaces.
+run_kubectl_delete_allnamespaces_tests() {
+  set -o nounset
+  set -o errexit
+
+  ns_one="namespace-$(date +%s)-${RANDOM}"
+  ns_two="namespace-$(date +%s)-${RANDOM}"
+  kubectl create namespace "${ns_one}"
+  kubectl create namespace "${ns_two}"
+
+  kubectl create configmap "one" --namespace="${ns_one}"
+  kubectl create configmap "two" --namespace="${ns_two}"
+  kubectl label configmap "one" --namespace="${ns_one}" deletetest=true
+  kubectl label configmap "two" --namespace="${ns_two}" deletetest=true
+  kubectl delete configmap -l deletetest=true --all-namespaces
+
+  # no configmaps should be in either of those namespaces
+  kubectl config set-context "${CONTEXT}" --namespace="${ns_one}"
+  kube::test::get_object_assert configmap "{{range.items}}{{$id_field}}:{{end}}" ''
+  kubectl config set-context "${CONTEXT}" --namespace="${ns_two}"
+  kube::test::get_object_assert configmap "{{range.items}}{{$id_field}}:{{end}}" ''
+
+  set +o nounset
+  set +o errexit
+}

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -35,6 +35,7 @@ source "${KUBE_ROOT}/test/cmd/certificate.sh"
 source "${KUBE_ROOT}/test/cmd/core.sh"
 source "${KUBE_ROOT}/test/cmd/crd.sh"
 source "${KUBE_ROOT}/test/cmd/create.sh"
+source "${KUBE_ROOT}/test/cmd/delete.sh"
 source "${KUBE_ROOT}/test/cmd/diff.sh"
 source "${KUBE_ROOT}/test/cmd/discovery.sh"
 source "${KUBE_ROOT}/test/cmd/generic-resources.sh"
@@ -490,6 +491,13 @@ runTests() {
   ######################
   if kube::test::if_supports_resource "${secrets}" ; then
     record_command run_create_secret_tests
+  fi
+
+  ######################
+  # Delete             #
+  ######################
+  if kube::test::if_supports_resource "${configmaps}" ; then
+    record_command run_kubectl_delete_allnamespaces_tests
   fi
 
   ##################


### PR DESCRIPTION
`kubectl delete` should support `--all-namespaces`.  Since we now have CRDs, wanting to delete all of a particular type is a more reasonable use-case to support.  There are also edges where I want this today.

@kubernetes/sig-cli-maintainers 

```release-note
`kubectl delete --all-namespaces` is a recognized flag.
```

@enj since you hit it.