### PR TITLE
remove cloud provider dependencies to pkg/api/v1/service

### DIFF
--- a/pkg/cloudprovider/providers/.import-restrictions
+++ b/pkg/cloudprovider/providers/.import-restrictions
@@ -15,8 +15,6 @@
 			"SelectorRegexp": "k8s[.]io/kubernetes",
 			"AllowedPrefixes": [
 				"k8s.io/kubernetes/pkg/api/legacyscheme",
-				"k8s.io/kubernetes/pkg/api/service",
-				"k8s.io/kubernetes/pkg/api/v1/service",
 				"k8s.io/kubernetes/pkg/apis/core",
 				"k8s.io/kubernetes/pkg/cloudprovider",
 				"k8s.io/kubernetes/pkg/credentialprovider",

--- a/pkg/cloudprovider/providers/aws/BUILD
+++ b/pkg/cloudprovider/providers/aws/BUILD
@@ -27,7 +27,6 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/aws",
     deps = [
-        "//pkg/api/v1/service:go_default_library",
         "//pkg/credentialprovider/aws:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/volume:go_default_library",
@@ -45,6 +44,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
         "//staging/src/k8s.io/cloud-provider/node/helpers:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/service/helpers:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/awserr:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/credentials:go_default_library",

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -59,7 +59,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	cloudprovider "k8s.io/cloud-provider"
 	nodehelpers "k8s.io/cloud-provider/node/helpers"
-	"k8s.io/kubernetes/pkg/api/v1/service"
+	servicehelpers "k8s.io/cloud-provider/service/helpers"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
@@ -3434,7 +3434,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 		return nil, err
 	}
 
-	sourceRanges, err := service.GetLoadBalancerSourceRanges(apiService)
+	sourceRanges, err := servicehelpers.GetLoadBalancerSourceRanges(apiService)
 	if err != nil {
 		return nil, err
 	}
@@ -3450,7 +3450,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 
 	if isNLB(annotations) {
 
-		if path, healthCheckNodePort := service.GetServiceHealthCheckPathPort(apiService); path != "" {
+		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 			for i := range v2Mappings {
 				v2Mappings[i].HealthCheckPort = int64(healthCheckNodePort)
 				v2Mappings[i].HealthCheckPath = path
@@ -3708,7 +3708,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 		}
 	}
 
-	if path, healthCheckNodePort := service.GetServiceHealthCheckPathPort(apiService); path != "" {
+	if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 		klog.V(4).Infof("service %v (%v) needs health checks on :%d%s)", apiService.Name, loadBalancerName, healthCheckNodePort, path)
 		err = c.ensureLoadBalancerHealthCheck(loadBalancer, "HTTP", healthCheckNodePort, path, annotations)
 		if err != nil {

--- a/pkg/cloudprovider/providers/azure/BUILD
+++ b/pkg/cloudprovider/providers/azure/BUILD
@@ -36,7 +36,6 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/azure",
     deps = [
-        "//pkg/api/v1/service:go_default_library",
         "//pkg/cloudprovider/providers/azure/auth:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/volume:go_default_library",
@@ -58,6 +57,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/service/helpers:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-07-01/storage:go_default_library",
@@ -93,7 +93,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/v1/service:go_default_library",
         "//pkg/cloudprovider/providers/azure/auth:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
@@ -101,6 +100,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/service/helpers:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-07-01/storage:go_default_library",

--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
+	servicehelpers "k8s.io/cloud-provider/service/helpers"
 	"k8s.io/klog"
-	serviceapi "k8s.io/kubernetes/pkg/api/v1/service"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -888,8 +888,8 @@ func (az *Cloud) reconcileLoadBalancerRule(
 			return expectedProbes, expectedRules, err
 		}
 
-		if serviceapi.NeedsHealthCheck(service) {
-			podPresencePath, podPresencePort := serviceapi.GetServiceHealthCheckPathPort(service)
+		if servicehelpers.NeedsHealthCheck(service) {
+			podPresencePath, podPresencePort := servicehelpers.GetServiceHealthCheckPathPort(service)
 
 			expectedProbes = append(expectedProbes, network.Probe{
 				Name: &lbRuleName,
@@ -983,7 +983,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 		destinationIPAddress = "*"
 	}
 
-	sourceRanges, err := serviceapi.GetLoadBalancerSourceRanges(service)
+	sourceRanges, err := servicehelpers.GetLoadBalancerSourceRanges(service)
 	if err != nil {
 		return nil, err
 	}
@@ -992,7 +992,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 		return nil, err
 	}
 	var sourceAddressPrefixes []string
-	if (sourceRanges == nil || serviceapi.IsAllowAll(sourceRanges)) && len(serviceTags) == 0 {
+	if (sourceRanges == nil || servicehelpers.IsAllowAll(sourceRanges)) && len(serviceTags) == 0 {
 		if !requiresInternalLoadBalancer(service) {
 			sourceAddressPrefixes = []string{"Internet"}
 		}

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	serviceapi "k8s.io/kubernetes/pkg/api/v1/service"
+	servicehelpers "k8s.io/cloud-provider/service/helpers"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/azure/auth"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 
@@ -1231,8 +1231,8 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 
 			expectedProbeCount++
 			foundProbe := false
-			if serviceapi.NeedsHealthCheck(&svc) {
-				path, port := serviceapi.GetServiceHealthCheckPathPort(&svc)
+			if servicehelpers.NeedsHealthCheck(&svc) {
+				path, port := servicehelpers.GetServiceHealthCheckPathPort(&svc)
 				for _, actualProbe := range *loadBalancer.Probes {
 					if strings.EqualFold(*actualProbe.Name, wantedRuleName) &&
 						*actualProbe.Port == port &&

--- a/pkg/cloudprovider/providers/gce/BUILD
+++ b/pkg/cloudprovider/providers/gce/BUILD
@@ -46,7 +46,6 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/gce",
     deps = [
-        "//pkg/api/v1/service:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
@@ -72,6 +71,7 @@ go_library(
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
         "//staging/src/k8s.io/cloud-provider/features:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/service/helpers:go_default_library",
         "//vendor/cloud.google.com/go/compute/metadata:go_default_library",
         "//vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud:go_default_library",
         "//vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter:go_default_library",
@@ -109,7 +109,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/v1/service:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
@@ -117,6 +116,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/service/helpers:go_default_library",
         "//vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud:go_default_library",
         "//vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta:go_default_library",
         "//vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock:go_default_library",

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	apiservice "k8s.io/kubernetes/pkg/api/v1/service"
+	servicehelpers "k8s.io/cloud-provider/service/helpers"
 	utilnet "k8s.io/utils/net"
 
 	computealpha "google.golang.org/api/compute/v0.alpha"
@@ -162,7 +162,7 @@ func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string,
 	// is because the forwarding rule is used as the indicator that the load
 	// balancer is fully created - it's what getLoadBalancer checks for.
 	// Check if user specified the allow source range
-	sourceRanges, err := apiservice.GetLoadBalancerSourceRanges(apiService)
+	sourceRanges, err := servicehelpers.GetLoadBalancerSourceRanges(apiService)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string,
 	if err != nil && !isHTTPErrorCode(err, http.StatusNotFound) {
 		return nil, fmt.Errorf("error checking HTTP health check for load balancer (%s): %v", lbRefStr, err)
 	}
-	if path, healthCheckNodePort := apiservice.GetServiceHealthCheckPathPort(apiService); path != "" {
+	if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 		klog.V(4).Infof("ensureExternalLoadBalancer(%s): Service needs local traffic health checks on: %d%s.", lbRefStr, healthCheckNodePort, path)
 		if hcLocalTrafficExisting == nil {
 			// This logic exists to detect a transition for non-OnlyLocal to OnlyLocal service
@@ -292,7 +292,7 @@ func (g *Cloud) ensureExternalLoadBalancerDeleted(clusterName, clusterID string,
 	lbRefStr := fmt.Sprintf("%v(%v)", loadBalancerName, serviceName)
 
 	var hcNames []string
-	if path, _ := apiservice.GetServiceHealthCheckPathPort(service); path != "" {
+	if path, _ := servicehelpers.GetServiceHealthCheckPathPort(service); path != "" {
 		hcToDelete, err := g.GetHTTPHealthCheck(loadBalancerName)
 		if err != nil && !isHTTPErrorCode(err, http.StatusNotFound) {
 			klog.Infof("ensureExternalLoadBalancerDeleted(%s): Failed to retrieve health check:%v.", lbRefStr, err)

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	servicehelpers "k8s.io/cloud-provider/service/helpers"
 	"k8s.io/klog"
-	v1_service "k8s.io/kubernetes/pkg/api/v1/service"
 )
 
 const (
@@ -69,12 +69,12 @@ func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v
 
 	// Ensure health check exists before creating the backend service. The health check is shared
 	// if externalTrafficPolicy=Cluster.
-	sharedHealthCheck := !v1_service.RequestsOnlyLocalTraffic(svc)
+	sharedHealthCheck := !servicehelpers.RequestsOnlyLocalTraffic(svc)
 	hcName := makeHealthCheckName(loadBalancerName, clusterID, sharedHealthCheck)
 	hcPath, hcPort := GetNodesHealthCheckPath(), GetNodesHealthCheckPort()
 	if !sharedHealthCheck {
 		// Service requires a special health check, retrieve the OnlyLocal port & path
-		hcPath, hcPort = v1_service.GetServiceHealthCheckPathPort(svc)
+		hcPath, hcPort = servicehelpers.GetServiceHealthCheckPathPort(svc)
 	}
 	hc, err := g.ensureInternalHealthCheck(hcName, nm, sharedHealthCheck, hcPath, hcPort)
 	if err != nil {
@@ -224,7 +224,7 @@ func (g *Cloud) ensureInternalLoadBalancerDeleted(clusterName, clusterID string,
 	_, protocol := getPortsAndProtocol(svc.Spec.Ports)
 	scheme := cloud.SchemeInternal
 	sharedBackend := shareBackendService(svc)
-	sharedHealthCheck := !v1_service.RequestsOnlyLocalTraffic(svc)
+	sharedHealthCheck := !servicehelpers.RequestsOnlyLocalTraffic(svc)
 
 	g.sharedResourceLock.Lock()
 	defer g.sharedResourceLock.Unlock()
@@ -367,7 +367,7 @@ func (g *Cloud) ensureInternalFirewalls(loadBalancerName, ipAddress, clusterID s
 	// First firewall is for ingress traffic
 	fwDesc := makeFirewallDescription(nm.String(), ipAddress)
 	ports, protocol := getPortsAndProtocol(svc.Spec.Ports)
-	sourceRanges, err := v1_service.GetLoadBalancerSourceRanges(svc)
+	sourceRanges, err := servicehelpers.GetLoadBalancerSourceRanges(svc)
 	if err != nil {
 		return err
 	}
@@ -581,7 +581,7 @@ func (g *Cloud) ensureInternalBackendServiceGroups(name string, igLinks []string
 }
 
 func shareBackendService(svc *v1.Service) bool {
-	return GetLoadBalancerAnnotationBackendShare(svc) && !v1_service.RequestsOnlyLocalTraffic(svc)
+	return GetLoadBalancerAnnotationBackendShare(svc) && !servicehelpers.RequestsOnlyLocalTraffic(svc)
 }
 
 func backendsFromGroupLinks(igLinks []string) (backends []*compute.Backend) {

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	v1_service "k8s.io/kubernetes/pkg/api/v1/service"
+	servicehelper "k8s.io/cloud-provider/service/helpers"
 )
 
 func createInternalLoadBalancer(gce *Cloud, svc *v1.Service, existingFwdRule *compute.ForwardingRule, nodeNames []string, clusterName, clusterID, zoneName string) (*v1.LoadBalancerStatus, error) {
@@ -169,7 +169,7 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 	nm := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
 	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
 
-	sharedHealthCheck := !v1_service.RequestsOnlyLocalTraffic(svc)
+	sharedHealthCheck := !servicehelper.RequestsOnlyLocalTraffic(svc)
 	hcName := makeHealthCheckName(lbName, vals.ClusterID, sharedHealthCheck)
 	hcPath, hcPort := GetNodesHealthCheckPath(), GetNodesHealthCheckPort()
 	existingHC := newInternalLBHealthCheck(hcName, nm, sharedHealthCheck, hcPath, hcPort)
@@ -224,7 +224,7 @@ func TestEnsureInternalLoadBalancerClearPreviousResources(t *testing.T) {
 	}
 	gce.CreateFirewall(existingFirewall)
 
-	sharedHealthCheck := !v1_service.RequestsOnlyLocalTraffic(svc)
+	sharedHealthCheck := !servicehelper.RequestsOnlyLocalTraffic(svc)
 	hcName := makeHealthCheckName(lbName, vals.ClusterID, sharedHealthCheck)
 	hcPath, hcPort := GetNodesHealthCheckPath(), GetNodesHealthCheckPort()
 	nm := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
@@ -278,7 +278,7 @@ func TestEnsureInternalLoadBalancerHealthCheckConfigurable(t *testing.T) {
 	svc := fakeLoadbalancerService(string(LBTypeInternal))
 	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
 
-	sharedHealthCheck := !v1_service.RequestsOnlyLocalTraffic(svc)
+	sharedHealthCheck := !servicehelper.RequestsOnlyLocalTraffic(svc)
 	hcName := makeHealthCheckName(lbName, vals.ClusterID, sharedHealthCheck)
 	hcPath, hcPort := GetNodesHealthCheckPath(), GetNodesHealthCheckPort()
 	nm := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_utils_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_utils_test.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
-	v1_service "k8s.io/kubernetes/pkg/api/v1/service"
+	servicehelpers "k8s.io/cloud-provider/service/helpers"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 )
 
@@ -211,7 +211,7 @@ func assertInternalLbResources(t *testing.T, gce *Cloud, apiService *v1.Service,
 	}
 
 	// Check that HealthCheck is created
-	sharedHealthCheck := !v1_service.RequestsOnlyLocalTraffic(apiService)
+	sharedHealthCheck := !servicehelpers.RequestsOnlyLocalTraffic(apiService)
 	hcName := makeHealthCheckName(lbName, vals.ClusterID, sharedHealthCheck)
 	healthcheck, err := gce.GetHealthCheck(hcName)
 	require.NoError(t, err)
@@ -243,7 +243,7 @@ func assertInternalLbResources(t *testing.T, gce *Cloud, apiService *v1.Service,
 
 func assertInternalLbResourcesDeleted(t *testing.T, gce *Cloud, apiService *v1.Service, vals TestClusterValues, firewallsDeleted bool) {
 	lbName := gce.GetLoadBalancerName(context.TODO(), "", apiService)
-	sharedHealthCheck := !v1_service.RequestsOnlyLocalTraffic(apiService)
+	sharedHealthCheck := !servicehelpers.RequestsOnlyLocalTraffic(apiService)
 	hcName := makeHealthCheckName(lbName, vals.ClusterID, sharedHealthCheck)
 
 	// ensureExternalLoadBalancer and ensureInternalLoadBalancer both create

--- a/pkg/cloudprovider/providers/openstack/BUILD
+++ b/pkg/cloudprovider/providers/openstack/BUILD
@@ -20,7 +20,6 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack",
     deps = [
-        "//pkg/api/v1/service:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/volume:go_default_library",
@@ -34,6 +33,7 @@ go_library(
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
         "//staging/src/k8s.io/cloud-provider/node/helpers:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/service/helpers:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions:go_default_library",

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -44,7 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
-	"k8s.io/kubernetes/pkg/api/v1/service"
+	servicehelpers "k8s.io/cloud-provider/service/helpers"
 )
 
 // Note: when creating a new Loadbalancer (VM), it can take some time before it is ready for use,
@@ -722,12 +722,12 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 		}
 	}
 
-	sourceRanges, err := service.GetLoadBalancerSourceRanges(apiService)
+	sourceRanges, err := servicehelpers.GetLoadBalancerSourceRanges(apiService)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get source ranges for loadbalancer service %s/%s: %v", apiService.Namespace, apiService.Name, err)
 	}
 
-	if !service.IsAllowAll(sourceRanges) && !lbaas.opts.ManageSecurityGroups {
+	if !servicehelpers.IsAllowAll(sourceRanges) && !lbaas.opts.ManageSecurityGroups {
 		return nil, fmt.Errorf("source range restrictions are not supported for openstack load balancers without managing security groups")
 	}
 
@@ -1030,7 +1030,7 @@ func (lbaas *LbaasV2) ensureSecurityGroup(clusterName string, apiService *v1.Ser
 	}
 
 	// get service source ranges
-	sourceRanges, err := service.GetLoadBalancerSourceRanges(apiService)
+	sourceRanges, err := servicehelpers.GetLoadBalancerSourceRanges(apiService)
 	if err != nil {
 		return fmt.Errorf("failed to get source ranges for loadbalancer service %s/%s: %v", apiService.Namespace, apiService.Name, err)
 	}

--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -191,6 +191,7 @@
   - k8s.io/apiserver
   - k8s.io/client-go
   - k8s.io/klog
+  - k8s.io/utils
 
 - baseImportPath: "./vendor/k8s.io/node-api/"
   allowedImports:

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -951,6 +951,8 @@ rules:
       branch: master
     - repository: client-go
       branch: master
+    - repository: utils
+      branch: master
   - source:
       branch: release-1.13
       dir: staging/src/k8s.io/cloud-provider

--- a/staging/src/k8s.io/cloud-provider/BUILD
+++ b/staging/src/k8s.io/cloud-provider/BUILD
@@ -37,6 +37,7 @@ filegroup(
         ":package-srcs",
         "//staging/src/k8s.io/cloud-provider/features:all-srcs",
         "//staging/src/k8s.io/cloud-provider/node:all-srcs",
+        "//staging/src/k8s.io/cloud-provider/service/helpers:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/staging/src/k8s.io/cloud-provider/Godeps/Godeps.json
+++ b/staging/src/k8s.io/cloud-provider/Godeps/Godeps.json
@@ -987,6 +987,10 @@
 			"Rev": "ed37f7428a91fc2a81070808937195dcd46d320e"
 		},
 		{
+			"ImportPath": "k8s.io/utils/net",
+			"Rev": "ed37f7428a91fc2a81070808937195dcd46d320e"
+		},
+		{
 			"ImportPath": "k8s.io/utils/trace",
 			"Rev": "ed37f7428a91fc2a81070808937195dcd46d320e"
 		},

--- a/staging/src/k8s.io/cloud-provider/service/helpers/BUILD
+++ b/staging/src/k8s.io/cloud-provider/service/helpers/BUILD
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["helper.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/cloud-provider/service/helpers",
+    importpath = "k8s.io/cloud-provider/service/helpers",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["helper_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
+    ],
+)

--- a/staging/src/k8s.io/cloud-provider/service/helpers/helper.go
+++ b/staging/src/k8s.io/cloud-provider/service/helpers/helper.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	utilnet "k8s.io/utils/net"
+)
+
+/*
+This file is duplicated from "k8s.io/kubernetes/pkg/api/v1/service/util.go"
+in order for in-tree cloud providers to not depend on internal packages.
+*/
+
+const (
+	defaultLoadBalancerSourceRanges = "0.0.0.0/0"
+)
+
+// IsAllowAll checks whether the utilnet.IPNet allows traffic from 0.0.0.0/0
+func IsAllowAll(ipnets utilnet.IPNetSet) bool {
+	for _, s := range ipnets.StringSlice() {
+		if s == "0.0.0.0/0" {
+			return true
+		}
+	}
+	return false
+}
+
+// GetLoadBalancerSourceRanges first try to parse and verify LoadBalancerSourceRanges field from a service.
+// If the field is not specified, turn to parse and verify the AnnotationLoadBalancerSourceRangesKey annotation from a service,
+// extracting the source ranges to allow, and if not present returns a default (allow-all) value.
+func GetLoadBalancerSourceRanges(service *v1.Service) (utilnet.IPNetSet, error) {
+	var ipnets utilnet.IPNetSet
+	var err error
+	// if SourceRange field is specified, ignore sourceRange annotation
+	if len(service.Spec.LoadBalancerSourceRanges) > 0 {
+		specs := service.Spec.LoadBalancerSourceRanges
+		ipnets, err = utilnet.ParseIPNets(specs...)
+
+		if err != nil {
+			return nil, fmt.Errorf("service.Spec.LoadBalancerSourceRanges: %v is not valid. Expecting a list of IP ranges. For example, 10.0.0.0/24. Error msg: %v", specs, err)
+		}
+	} else {
+		val := service.Annotations[v1.AnnotationLoadBalancerSourceRangesKey]
+		val = strings.TrimSpace(val)
+		if val == "" {
+			val = defaultLoadBalancerSourceRanges
+		}
+		specs := strings.Split(val, ",")
+		ipnets, err = utilnet.ParseIPNets(specs...)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %s is not valid. Expecting a comma-separated list of source IP ranges. For example, 10.0.0.0/24,192.168.2.0/24", v1.AnnotationLoadBalancerSourceRangesKey, val)
+		}
+	}
+	return ipnets, nil
+}
+
+// GetServiceHealthCheckPathPort returns the path and nodePort programmed into the Cloud LB Health Check
+func GetServiceHealthCheckPathPort(service *v1.Service) (string, int32) {
+	if !NeedsHealthCheck(service) {
+		return "", 0
+	}
+	port := service.Spec.HealthCheckNodePort
+	if port == 0 {
+		return "", 0
+	}
+	return "/healthz", port
+}
+
+// RequestsOnlyLocalTraffic checks if service requests OnlyLocal traffic.
+func RequestsOnlyLocalTraffic(service *v1.Service) bool {
+	if service.Spec.Type != v1.ServiceTypeLoadBalancer &&
+		service.Spec.Type != v1.ServiceTypeNodePort {
+		return false
+	}
+	return service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal
+}
+
+// NeedsHealthCheck checks if service needs health check.
+func NeedsHealthCheck(service *v1.Service) bool {
+	if service.Spec.Type != v1.ServiceTypeLoadBalancer {
+		return false
+	}
+	return RequestsOnlyLocalTraffic(service)
+}

--- a/staging/src/k8s.io/cloud-provider/service/helpers/helper_test.go
+++ b/staging/src/k8s.io/cloud-provider/service/helpers/helper_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	utilnet "k8s.io/utils/net"
+)
+
+/*
+This file is duplicated from "k8s.io/kubernetes/pkg/api/v1/service/util_test.go"
+in order for in-tree cloud providers to not depend on internal packages.
+*/
+
+func TestGetLoadBalancerSourceRanges(t *testing.T) {
+	checkError := func(v string) {
+		annotations := make(map[string]string)
+		annotations[v1.AnnotationLoadBalancerSourceRangesKey] = v
+		svc := v1.Service{}
+		svc.Annotations = annotations
+		_, err := GetLoadBalancerSourceRanges(&svc)
+		if err == nil {
+			t.Errorf("Expected error parsing: %q", v)
+		}
+		svc = v1.Service{}
+		svc.Spec.LoadBalancerSourceRanges = strings.Split(v, ",")
+		_, err = GetLoadBalancerSourceRanges(&svc)
+		if err == nil {
+			t.Errorf("Expected error parsing: %q", v)
+		}
+	}
+	checkError("10.0.0.1/33")
+	checkError("foo.bar")
+	checkError("10.0.0.1/32,*")
+	checkError("10.0.0.1/32,")
+	checkError("10.0.0.1/32, ")
+	checkError("10.0.0.1")
+
+	checkOK := func(v string) utilnet.IPNetSet {
+		annotations := make(map[string]string)
+		annotations[v1.AnnotationLoadBalancerSourceRangesKey] = v
+		svc := v1.Service{}
+		svc.Annotations = annotations
+		cidrs, err := GetLoadBalancerSourceRanges(&svc)
+		if err != nil {
+			t.Errorf("Unexpected error parsing: %q", v)
+		}
+		svc = v1.Service{}
+		svc.Spec.LoadBalancerSourceRanges = strings.Split(v, ",")
+		cidrs, err = GetLoadBalancerSourceRanges(&svc)
+		if err != nil {
+			t.Errorf("Unexpected error parsing: %q", v)
+		}
+		return cidrs
+	}
+	cidrs := checkOK("192.168.0.1/32")
+	if len(cidrs) != 1 {
+		t.Errorf("Expected exactly one CIDR: %v", cidrs.StringSlice())
+	}
+	cidrs = checkOK("192.168.0.1/32,192.168.0.1/32")
+	if len(cidrs) != 1 {
+		t.Errorf("Expected exactly one CIDR (after de-dup): %v", cidrs.StringSlice())
+	}
+	cidrs = checkOK("192.168.0.1/32,192.168.0.2/32")
+	if len(cidrs) != 2 {
+		t.Errorf("Expected two CIDRs: %v", cidrs.StringSlice())
+	}
+	cidrs = checkOK("  192.168.0.1/32 , 192.168.0.2/32   ")
+	if len(cidrs) != 2 {
+		t.Errorf("Expected two CIDRs: %v", cidrs.StringSlice())
+	}
+	// check LoadBalancerSourceRanges not specified
+	svc := v1.Service{}
+	cidrs, err := GetLoadBalancerSourceRanges(&svc)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(cidrs) != 1 {
+		t.Errorf("Expected exactly one CIDR: %v", cidrs.StringSlice())
+	}
+	if !IsAllowAll(cidrs) {
+		t.Errorf("Expected default to be allow-all: %v", cidrs.StringSlice())
+	}
+	// check SourceRanges annotation is empty
+	annotations := make(map[string]string)
+	annotations[v1.AnnotationLoadBalancerSourceRangesKey] = ""
+	svc = v1.Service{}
+	svc.Annotations = annotations
+	cidrs, err = GetLoadBalancerSourceRanges(&svc)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(cidrs) != 1 {
+		t.Errorf("Expected exactly one CIDR: %v", cidrs.StringSlice())
+	}
+	if !IsAllowAll(cidrs) {
+		t.Errorf("Expected default to be allow-all: %v", cidrs.StringSlice())
+	}
+}
+
+func TestAllowAll(t *testing.T) {
+	checkAllowAll := func(allowAll bool, cidrs ...string) {
+		ipnets, err := utilnet.ParseIPNets(cidrs...)
+		if err != nil {
+			t.Errorf("Unexpected error parsing cidrs: %v", cidrs)
+		}
+		if allowAll != IsAllowAll(ipnets) {
+			t.Errorf("IsAllowAll did not return expected value for %v", cidrs)
+		}
+	}
+	checkAllowAll(false, "10.0.0.1/32")
+	checkAllowAll(false, "10.0.0.1/32", "10.0.0.2/32")
+	checkAllowAll(false, "10.0.0.1/32", "10.0.0.1/32")
+
+	checkAllowAll(true, "0.0.0.0/0")
+	checkAllowAll(true, "192.168.0.0/0")
+	checkAllowAll(true, "192.168.0.1/32", "0.0.0.0/0")
+}
+
+func TestRequestsOnlyLocalTraffic(t *testing.T) {
+	checkRequestsOnlyLocalTraffic := func(requestsOnlyLocalTraffic bool, service *v1.Service) {
+		res := RequestsOnlyLocalTraffic(service)
+		if res != requestsOnlyLocalTraffic {
+			t.Errorf("Expected requests OnlyLocal traffic = %v, got %v",
+				requestsOnlyLocalTraffic, res)
+		}
+	}
+
+	checkRequestsOnlyLocalTraffic(false, &v1.Service{})
+	checkRequestsOnlyLocalTraffic(false, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeClusterIP,
+		},
+	})
+	checkRequestsOnlyLocalTraffic(false, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeNodePort,
+		},
+	})
+	checkRequestsOnlyLocalTraffic(false, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeNodePort,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+		},
+	})
+	checkRequestsOnlyLocalTraffic(true, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeNodePort,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+		},
+	})
+	checkRequestsOnlyLocalTraffic(false, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+		},
+	})
+	checkRequestsOnlyLocalTraffic(true, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+		},
+	})
+}
+
+func TestNeedsHealthCheck(t *testing.T) {
+	checkNeedsHealthCheck := func(needsHealthCheck bool, service *v1.Service) {
+		res := NeedsHealthCheck(service)
+		if res != needsHealthCheck {
+			t.Errorf("Expected needs health check = %v, got %v",
+				needsHealthCheck, res)
+		}
+	}
+
+	checkNeedsHealthCheck(false, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeClusterIP,
+		},
+	})
+	checkNeedsHealthCheck(false, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeNodePort,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+		},
+	})
+	checkNeedsHealthCheck(false, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeNodePort,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+		},
+	})
+	checkNeedsHealthCheck(false, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+		},
+	})
+	checkNeedsHealthCheck(true, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+		},
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes dependencies to `pkg/api/v1/service` from the in-tree cloud providers. 

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/kubernetes/issues/69585 

**Special notes for your reviewer**:
Tried to avoid as much duplication as possible, but the way some of the functions are used in internal registry/validation made it difficult/messy to do. Ended up just duplicating files for now and using `k8s.io/cloud-provider/service/helpers` in the cloud providers. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
