### PR TITLE
Fix MAC filtering in vSphere cloud provider

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -53,8 +53,6 @@ const (
 	VolDir                        = "kubevols"
 	RoundTripperDefaultCount      = 3
 	DummyVMPrefixName             = "vsphere-k8s"
-	MacOuiVC                      = "00:50:56"
-	MacOuiEsx                     = "00:0c:29"
 	CleanUpDummyVMRoutineInterval = 5
 )
 
@@ -533,6 +531,15 @@ func (vs *VSphere) Instances() (cloudprovider.Instances, bool) {
 }
 
 func getLocalIP() ([]v1.NodeAddress, error) {
+	// hashtable with VMware-allocated OUIs for MAC filtering
+	// List of official OUIs: http://standards-oui.ieee.org/oui.txt
+	vmwareOUI := map[string]bool{
+		"00:05:69": true,
+		"00:0c:29": true,
+		"00:1c:14": true,
+		"00:50:56": true,
+	}
+
 	addrs := []v1.NodeAddress{}
 	ifaces, err := net.Interfaces()
 	if err != nil {
@@ -548,9 +555,12 @@ func getLocalIP() ([]v1.NodeAddress, error) {
 				if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
 					if ipnet.IP.To4() != nil {
 						// Filter external IP by MAC address OUIs from vCenter and from ESX
-						var addressType v1.NodeAddressType
-						if strings.HasPrefix(i.HardwareAddr.String(), MacOuiVC) ||
-							strings.HasPrefix(i.HardwareAddr.String(), MacOuiEsx) {
+						vmMACAddr := strings.ToLower(i.HardwareAddr.String())
+						// Making sure that the MAC address is long enough
+						if len(vmMACAddr) < 17 {
+							return addrs, fmt.Errorf("MAC address %q is invalid", vmMACAddr)
+						}
+						if vmwareOUI[vmMACAddr[:8]] {
 							nodehelpers.AddToNodeAddresses(&addrs,
 								v1.NodeAddress{
 									Type:    v1.NodeExternalIP,
@@ -561,8 +571,10 @@ func getLocalIP() ([]v1.NodeAddress, error) {
 									Address: ipnet.IP.String(),
 								},
 							)
+							klog.V(4).Infof("Detected local IP address as %q", ipnet.IP.String())
+						} else {
+							klog.Warningf("Failed to patch IP as MAC address %q does not belong to a VMware platform", vmMACAddr)
 						}
-						klog.V(4).Infof("Find local IP address %v and set type to %v", ipnet.IP.String(), addressType)
 					}
 				}
 			}


### PR DESCRIPTION
vSphere cloud provider patches node ips only if they're from a mac address that is associated to the VMware OUI, the previous list was missing two allocated OUIs, this led to cloud provider not patching node ips correctly.

**What type of PR is this?**

/kind bug

/sig cloud-provider
/sig vmware

/assign @andrewsykim @SandeepPissay @dougm 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MAC Address filter has been fixed in vSphere Cloud Provider, it no longer ignores `00:1c:14` and `00:05:69` prefixes
```