### PR TITLE
Presize map with proper capacity in cache

### DIFF
--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -108,12 +108,12 @@ func (cache *schedulerCache) Snapshot() *Snapshot {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
 
-	nodes := make(map[string]*schedulernodeinfo.NodeInfo)
+	nodes := make(map[string]*schedulernodeinfo.NodeInfo, len(cache.nodes))
 	for k, v := range cache.nodes {
 		nodes[k] = v.Clone()
 	}
 
-	assumedPods := make(map[string]bool)
+	assumedPods := make(map[string]bool, len(cache.assumedPods))
 	for k, v := range cache.assumedPods {
 		assumedPods[k] = v
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The Snapshot function of pkg/scheduler/internal/cache/cache.go can presize the cloned maps with sizes of respective maps.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
sig/scheduling