### PR TITLE
Add subphase all to control-plane-prepare phase

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/controlplane.go
@@ -108,6 +108,12 @@ func NewControlPlanePreparePhase() workflow.Phase {
 		Short: "Prepares the machine for serving a control plane.",
 		Long:  cmdutil.MacroCommandLongDescription,
 		Phases: []workflow.Phase{
+			{
+				Name:           "all",
+				Short:          "Prepares the machine for serving a control plane.",
+				InheritFlags:   getControlPlanePreparePhaseFlags(),
+				RunAllSiblings: true,
+			},
 			newControlPlanePrepareCertsSubphase(),
 			newControlPlanePrepareKubeconfigSubphase(),
 			newControlPlanePrepareManifestsSubphases(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Add subphase all  to control-plane-prepare phase

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refs [kubernetes/kubeadm#1204](https://github.com/kubernetes/kubeadm/issues/1204)

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/kind cleanup
/priority important-soon
@kubernetes/sig-cluster-lifecycle-pr-reviews 
