### PR TITLE
Add CSI Translation API for Storage Class parameters

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
@@ -40,6 +40,11 @@ func NewAWSElasticBlockStoreCSITranslator() InTreePlugin {
 	return &awsElasticBlockStoreCSITranslator{}
 }
 
+// TranslateInTreeStorageClassParametersToCSI translates InTree EBS storage class parameters to CSI storage class
+func (t *awsElasticBlockStoreCSITranslator) TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error) {
+	return scParameters, nil
+}
+
 // TranslateInTreePVToCSI takes a PV with AWSElasticBlockStore set from in-tree
 // and converts the AWSElasticBlockStore source to a CSIPersistentVolumeSource
 func (t *awsElasticBlockStoreCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {

--- a/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd.go
@@ -58,6 +58,11 @@ func NewGCEPersistentDiskCSITranslator() InTreePlugin {
 	return &gcePersistentDiskCSITranslator{}
 }
 
+// TranslateInTreeStorageClassParametersToCSI translates InTree GCE storage class parameters to CSI storage class
+func (g *gcePersistentDiskCSITranslator) TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error) {
+	return scParameters, nil
+}
+
 // TranslateInTreePVToCSI takes a PV with GCEPersistentDisk set from in-tree
 // and converts the GCEPersistentDisk source to a CSIPersistentVolumeSource
 func (g *gcePersistentDiskCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {

--- a/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
@@ -20,6 +20,11 @@ import "k8s.io/api/core/v1"
 
 // InTreePlugin handles translations between CSI and in-tree sources in a PV
 type InTreePlugin interface {
+
+	// TranslateInTreeStorageClassParametersToCSI takes in-tree storage class
+	// parameters and translates them to a set of parameters consumable by CSI plugin
+	TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error)
+
 	// TranslateInTreePVToCSI takes a persistent volume and will translate
 	// the in-tree source to a CSI Source. The input persistent volume can be modified
 	TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error)

--- a/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
@@ -38,6 +38,11 @@ func NewOpenStackCinderCSITranslator() InTreePlugin {
 	return &osCinderCSITranslator{}
 }
 
+// TranslateInTreeStorageClassParametersToCSI translates InTree Cinder storage class parameters to CSI storage class
+func (t *osCinderCSITranslator) TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error) {
+	return scParameters, nil
+}
+
 // TranslateInTreePVToCSI takes a PV with Cinder set from in-tree
 // and converts the Cinder source to a CSIPersistentVolumeSource
 func (t *osCinderCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {

--- a/staging/src/k8s.io/csi-translation-lib/translate.go
+++ b/staging/src/k8s.io/csi-translation-lib/translate.go
@@ -31,6 +31,17 @@ var (
 	}
 )
 
+// TranslateInTreeStorageClassParametersToCSI takes in-tree storage class
+// parameters and translates them to a set of parameters consumable by CSI plugin
+func TranslateInTreeStorageClassParametersToCSI(inTreePluginName string, scParameters map[string]string) (map[string]string, error) {
+	for _, curPlugin := range inTreePlugins {
+		if inTreePluginName == curPlugin.GetInTreePluginName() {
+			return curPlugin.TranslateInTreeStorageClassParametersToCSI(scParameters)
+		}
+	}
+	return nil, fmt.Errorf("could not find in-tree storage class parameter translation logic for %#v", inTreePluginName)
+}
+
 // TranslateInTreePVToCSI takes a persistent volume and will translate
 // the in-tree source to a CSI Source if the translation logic
 // has been implemented. The input persistent volume will not


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR introduces a new API `TranslateInTreeStorageClassParametersToCSI` in the CSI translation staging repo. This will be used by the external provisioner to translate from in-tree storage class parameters to CSI plugin parameters.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # 

**Special notes for your reviewer**:
Part of enhancements for [kubernetes/enhancements#625](https://github.com/kubernetes/enhancements/issues/625)

This is just the CSI translation library portion of https://github.com/kubernetes/kubernetes/pull/73653 as suggested in https://github.com/kubernetes/kubernetes/pull/73653#issuecomment-460453421

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig-storage
/assign @jsafrane @saad-ali
/cc @msau42 @leakingtapan @davidz627