### PR TITLE
Remove inactive maintainers

### DIFF
--- a/cluster/juju/OWNERS
+++ b/cluster/juju/OWNERS
@@ -1,14 +1,7 @@
 approvers:
-- castrojo
-- chuckbutler
-- marcoceppi
-- mbruzek
 - Cynerva
 - ktsakalozos
 reviewers:
-- chuckbutler
-- marcoceppi
-- mbruzek
 - thockin
 - mikedanese
 - eparis


### PR DESCRIPTION
The bot keeps assigning me reviews here and I'm no longer involved in this, so I figure I would update them across the board.

Signed-off-by: Jorge O. Castro <jorgec@vmware.com>

/cc @tvansteenburgh @ktsakalozos 