### PR TITLE
publishing: remove utils from rules

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -951,8 +951,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-    - repository: utils
-      branch: master
   - source:
       branch: release-1.13
       dir: staging/src/k8s.io/cloud-provider


### PR DESCRIPTION
utils is not a staging repo and shouldn't be included in rules (added in https://github.com/kubernetes/kubernetes/pull/73719). This fixes the publishing bot.

/assign @sttts @dims @andrewsykim 
/kind bug
/priority critical-urgent

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
