### PR TITLE
kubelet: set low oom_score_adj for containers in critical pods

### DIFF
--- a/pkg/kubelet/qos/BUILD
+++ b/pkg/kubelet/qos/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = ["policy_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apis/scheduling:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],
@@ -25,6 +26,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubelet/qos",
     deps = [
         "//pkg/apis/core/v1/helper/qos:go_default_library",
+        "//pkg/kubelet/types:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
     ],
 )

--- a/pkg/kubelet/qos/policy.go
+++ b/pkg/kubelet/qos/policy.go
@@ -17,8 +17,9 @@ limitations under the License.
 package qos
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
+	"k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 const (
@@ -41,6 +42,11 @@ const (
 // and 1000. Containers with higher OOM scores are killed if the system runs out of memory.
 // See https://lwn.net/Articles/391222/ for more information.
 func GetContainerOOMScoreAdjust(pod *v1.Pod, container *v1.Container, memoryCapacity int64) int {
+	if types.IsCriticalPod(pod) {
+		// Critical pods should be the last to get killed.
+		return guaranteedOOMScoreAdj
+	}
+
 	switch v1qos.GetPodQOS(pod) {
 	case v1.PodQOSGuaranteed:
 		// Guaranteed containers should be the last to get killed.

--- a/pkg/kubelet/qos/policy_test.go
+++ b/pkg/kubelet/qos/policy_test.go
@@ -20,8 +20,9 @@ import (
 	"strconv"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/apis/scheduling"
 )
 
 const (
@@ -135,6 +136,19 @@ var (
 			},
 		},
 	}
+
+	systemCritical = scheduling.SystemCriticalPriority
+
+	critical = v1.Pod{
+		Spec: v1.PodSpec{
+			Priority: &systemCritical,
+			Containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{},
+				},
+			},
+		},
+	}
 )
 
 type oomTest struct {
@@ -187,6 +201,12 @@ func TestGetContainerOOMScoreAdjust(t *testing.T) {
 			memoryCapacity:  standardMemoryAmount,
 			lowOOMScoreAdj:  2,
 			highOOMScoreAdj: 2,
+		},
+		{
+			pod:             &critical,
+			memoryCapacity:  4000000000,
+			lowOOMScoreAdj:  -998,
+			highOOMScoreAdj: -998,
 		},
 	}
 	for _, test := range oomTests {


### PR DESCRIPTION
@dashpole this is really all I was talking about in sig-node.

Currently, the only way to get the lowest `oom_score_adj` is to set `requests`/`limits` on the containers in a Pod such that it is in the `Guaranteed` pod QoS tier.  This requires placing a memory limit on the Pod.  This can make the Pod _more_ susceptible to OOM kills in that, if it exceeds its memory limit, it is killed regardless of its `oom_score_adj` because it is the only candidate process in the cgroup under memory pressure. 

`oom_score_adj` is really an expression of priority.  Currently users must express that priority through layers of indirection; namely container request/limits expressing pod QoS expressing oom_score_adj.

We have two reserved critical pod priority classes which users can explicitly convey: `system-node-critical` and `system-cluster-critical`.

We should treat this expression as the primary indicator of priority and, therefore, oom_adjust_score.

```release-note
Set a low oom_score_adj for containers in pods with system-critical priorities
```