### PR TITLE
Support make test WHAT=path/to/pkg/...

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -223,6 +223,10 @@ verifyAndSuggestPackagePath() {
   local original_package_path="$3"
   local suggestion_package_path="$4"
 
+  if [[ "${specified_package_path}" =~ '/...'$ ]]; then
+    specified_package_path=${specified_package_path::-4}
+  fi
+
   if ! [ -d "${specified_package_path}" ]; then
     # Because k8s sets a localized $GOPATH for testing, seeing the actual
     # directory can be confusing. Instead, just show $GOPATH if it exists in the


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In 99cdc069e2604decae6883dd46015c2118d55a8a, we added a check for
whether the directory the user was attempting to test existed or not.
However, adding this check prevented us from running `make test
WHAT=./path/to/pkg/...`, because we believed that `./path/to/pkg/...`
wasn't a valid path to a directory.

Fix this by stripping `/...` before checking whether the directory
exists.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
