### PR TITLE
Ensure conditional validation has knowledge of old and new object

### DIFF
--- a/pkg/apis/core/validation/BUILD
+++ b/pkg/apis/core/validation/BUILD
@@ -7,6 +7,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "conditional_validation.go",
         "doc.go",
         "events.go",
         "validation.go",
@@ -46,6 +47,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "conditional_validation_test.go",
         "events_test.go",
         "validation_test.go",
     ],
@@ -59,6 +61,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",

--- a/pkg/apis/core/validation/conditional_validation.go
+++ b/pkg/apis/core/validation/conditional_validation.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+// ValidateConditionalService validates conditionally valid fields.
+func ValidateConditionalService(service, oldService *api.Service) field.ErrorList {
+	var errs field.ErrorList
+	// If the SCTPSupport feature is disabled, and the old object isn't using the SCTP feature, prevent the new object from using it
+	if !utilfeature.DefaultFeatureGate.Enabled(features.SCTPSupport) && len(serviceSCTPFields(oldService)) == 0 {
+		for _, f := range serviceSCTPFields(service) {
+			errs = append(errs, field.NotSupported(f, api.ProtocolSCTP, []string{string(api.ProtocolTCP), string(api.ProtocolUDP)}))
+		}
+	}
+	return errs
+}
+
+func serviceSCTPFields(service *api.Service) []*field.Path {
+	if service == nil {
+		return nil
+	}
+	fields := []*field.Path{}
+	for pIndex, p := range service.Spec.Ports {
+		if p.Protocol == api.ProtocolSCTP {
+			fields = append(fields, field.NewPath("spec.ports").Index(pIndex).Child("protocol"))
+		}
+	}
+	return fields
+}
+
+// ValidateConditionalEndpoints validates conditionally valid fields.
+func ValidateConditionalEndpoints(endpoints, oldEndpoints *api.Endpoints) field.ErrorList {
+	var errs field.ErrorList
+	// If the SCTPSupport feature is disabled, and the old object isn't using the SCTP feature, prevent the new object from using it
+	if !utilfeature.DefaultFeatureGate.Enabled(features.SCTPSupport) && len(endpointsSCTPFields(oldEndpoints)) == 0 {
+		for _, f := range endpointsSCTPFields(endpoints) {
+			errs = append(errs, field.NotSupported(f, api.ProtocolSCTP, []string{string(api.ProtocolTCP), string(api.ProtocolUDP)}))
+		}
+	}
+	return errs
+}
+
+func endpointsSCTPFields(endpoints *api.Endpoints) []*field.Path {
+	if endpoints == nil {
+		return nil
+	}
+	fields := []*field.Path{}
+	for sIndex, s := range endpoints.Subsets {
+		for pIndex, p := range s.Ports {
+			if p.Protocol == api.ProtocolSCTP {
+				fields = append(fields, field.NewPath("subsets").Index(sIndex).Child("ports").Index(pIndex).Child("protocol"))
+			}
+		}
+	}
+	return fields
+}
+
+// ValidateConditionalPodTemplate validates conditionally valid fields.
+// This should be called from Validate/ValidateUpdate for all resources containing a PodTemplateSpec
+func ValidateConditionalPodTemplate(podTemplate, oldPodTemplate *api.PodTemplateSpec, fldPath *field.Path) field.ErrorList {
+	var (
+		podSpec    *api.PodSpec
+		oldPodSpec *api.PodSpec
+	)
+	if podTemplate != nil {
+		podSpec = &podTemplate.Spec
+	}
+	if oldPodTemplate != nil {
+		oldPodSpec = &oldPodTemplate.Spec
+	}
+	return validateConditionalPodSpec(podSpec, oldPodSpec, fldPath.Child("spec"))
+}
+
+// ValidateConditionalPod validates conditionally valid fields.
+// This should be called from Validate/ValidateUpdate for all resources containing a Pod
+func ValidateConditionalPod(pod, oldPod *api.Pod, fldPath *field.Path) field.ErrorList {
+	var (
+		podSpec    *api.PodSpec
+		oldPodSpec *api.PodSpec
+	)
+	if pod != nil {
+		podSpec = &pod.Spec
+	}
+	if oldPod != nil {
+		oldPodSpec = &oldPod.Spec
+	}
+	return validateConditionalPodSpec(podSpec, oldPodSpec, fldPath.Child("spec"))
+}
+
+func validateConditionalPodSpec(podSpec, oldPodSpec *api.PodSpec, fldPath *field.Path) field.ErrorList {
+	// Always make sure we have a non-nil current pod spec
+	if podSpec == nil {
+		podSpec = &api.PodSpec{}
+	}
+
+	errs := field.ErrorList{}
+
+	// If the SCTPSupport feature is disabled, and the old object isn't using the SCTP feature, prevent the new object from using it
+	if !utilfeature.DefaultFeatureGate.Enabled(features.SCTPSupport) && len(podSCTPFields(oldPodSpec, nil)) == 0 {
+		for _, f := range podSCTPFields(podSpec, fldPath) {
+			errs = append(errs, field.NotSupported(f, api.ProtocolSCTP, []string{string(api.ProtocolTCP), string(api.ProtocolUDP)}))
+		}
+	}
+
+	return errs
+}
+
+func podSCTPFields(podSpec *api.PodSpec, fldPath *field.Path) []*field.Path {
+	if podSpec == nil {
+		return nil
+	}
+	fields := []*field.Path{}
+	for cIndex, c := range podSpec.InitContainers {
+		for pIndex, p := range c.Ports {
+			if p.Protocol == api.ProtocolSCTP {
+				fields = append(fields, fldPath.Child("initContainers").Index(cIndex).Child("ports").Index(pIndex).Child("protocol"))
+			}
+		}
+	}
+	for cIndex, c := range podSpec.Containers {
+		for pIndex, p := range c.Ports {
+			if p.Protocol == api.ProtocolSCTP {
+				fields = append(fields, fldPath.Child("containers").Index(cIndex).Child("ports").Index(pIndex).Child("protocol"))
+			}
+		}
+	}
+	return fields
+}

--- a/pkg/apis/core/validation/conditional_validation_test.go
+++ b/pkg/apis/core/validation/conditional_validation_test.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	utilfeaturetesting "k8s.io/apiserver/pkg/util/feature/testing"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+func TestValidatePodSCTP(t *testing.T) {
+	objectWithValue := func() *api.Pod {
+		return &api.Pod{
+			Spec: api.PodSpec{
+				Containers:     []api.Container{{Name: "container1", Image: "testimage", Ports: []api.ContainerPort{{ContainerPort: 80, Protocol: api.ProtocolSCTP}}}},
+				InitContainers: []api.Container{{Name: "container2", Image: "testimage", Ports: []api.ContainerPort{{ContainerPort: 90, Protocol: api.ProtocolSCTP}}}},
+			},
+		}
+	}
+	objectWithoutValue := func() *api.Pod {
+		return &api.Pod{
+			Spec: api.PodSpec{
+				Containers:     []api.Container{{Name: "container1", Image: "testimage", Ports: []api.ContainerPort{{ContainerPort: 80, Protocol: api.ProtocolTCP}}}},
+				InitContainers: []api.Container{{Name: "container2", Image: "testimage", Ports: []api.ContainerPort{{ContainerPort: 90, Protocol: api.ProtocolTCP}}}},
+			},
+		}
+	}
+
+	objectInfo := []struct {
+		description string
+		hasValue    bool
+		object      func() *api.Pod
+	}{
+		{
+			description: "has value",
+			hasValue:    true,
+			object:      objectWithValue,
+		},
+		{
+			description: "does not have value",
+			hasValue:    false,
+			object:      objectWithoutValue,
+		},
+		{
+			description: "is nil",
+			hasValue:    false,
+			object:      func() *api.Pod { return nil },
+		},
+	}
+
+	for _, enabled := range []bool{true, false} {
+		for _, oldPodInfo := range objectInfo {
+			for _, newPodInfo := range objectInfo {
+				oldPodHasValue, oldPod := oldPodInfo.hasValue, oldPodInfo.object()
+				newPodHasValue, newPod := newPodInfo.hasValue, newPodInfo.object()
+				if newPod == nil {
+					continue
+				}
+
+				t.Run(fmt.Sprintf("feature enabled=%v, old object %v, new object %v", enabled, oldPodInfo.description, newPodInfo.description), func(t *testing.T) {
+					defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SCTPSupport, enabled)()
+					errs := ValidateConditionalPod(newPod, oldPod, nil)
+					// objects should never be changed
+					if !reflect.DeepEqual(oldPod, oldPodInfo.object()) {
+						t.Errorf("old object changed: %v", diff.ObjectReflectDiff(oldPod, oldPodInfo.object()))
+					}
+					if !reflect.DeepEqual(newPod, newPodInfo.object()) {
+						t.Errorf("new object changed: %v", diff.ObjectReflectDiff(newPod, newPodInfo.object()))
+					}
+
+					switch {
+					case enabled || oldPodHasValue || !newPodHasValue:
+						if len(errs) > 0 {
+							t.Errorf("unexpected errors: %v", errs)
+						}
+					default:
+						if len(errs) != 2 {
+							t.Errorf("expected 2 errors, got %v", errs)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestValidateServiceSCTP(t *testing.T) {
+	objectWithValue := func() *api.Service {
+		return &api.Service{
+			Spec: api.ServiceSpec{
+				Ports: []api.ServicePort{{Protocol: api.ProtocolSCTP}},
+			},
+		}
+	}
+	objectWithoutValue := func() *api.Service {
+		return &api.Service{
+			Spec: api.ServiceSpec{
+				Ports: []api.ServicePort{{Protocol: api.ProtocolTCP}},
+			},
+		}
+	}
+
+	objectInfo := []struct {
+		description string
+		hasValue    bool
+		object      func() *api.Service
+	}{
+		{
+			description: "has value",
+			hasValue:    true,
+			object:      objectWithValue,
+		},
+		{
+			description: "does not have value",
+			hasValue:    false,
+			object:      objectWithoutValue,
+		},
+		{
+			description: "is nil",
+			hasValue:    false,
+			object:      func() *api.Service { return nil },
+		},
+	}
+
+	for _, enabled := range []bool{true, false} {
+		for _, oldServiceInfo := range objectInfo {
+			for _, newServiceInfo := range objectInfo {
+				oldServiceHasValue, oldService := oldServiceInfo.hasValue, oldServiceInfo.object()
+				newServiceHasValue, newService := newServiceInfo.hasValue, newServiceInfo.object()
+				if newService == nil {
+					continue
+				}
+
+				t.Run(fmt.Sprintf("feature enabled=%v, old object %v, new object %v", enabled, oldServiceInfo.description, newServiceInfo.description), func(t *testing.T) {
+					defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SCTPSupport, enabled)()
+					errs := ValidateConditionalService(newService, oldService)
+					// objects should never be changed
+					if !reflect.DeepEqual(oldService, oldServiceInfo.object()) {
+						t.Errorf("old object changed: %v", diff.ObjectReflectDiff(oldService, oldServiceInfo.object()))
+					}
+					if !reflect.DeepEqual(newService, newServiceInfo.object()) {
+						t.Errorf("new object changed: %v", diff.ObjectReflectDiff(newService, newServiceInfo.object()))
+					}
+
+					switch {
+					case enabled || oldServiceHasValue || !newServiceHasValue:
+						if len(errs) > 0 {
+							t.Errorf("unexpected errors: %v", errs)
+						}
+					default:
+						if len(errs) != 1 {
+							t.Errorf("expected 1 error, got %v", errs)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestValidateEndpointsSCTP(t *testing.T) {
+	objectWithValue := func() *api.Endpoints {
+		return &api.Endpoints{
+			Subsets: []api.EndpointSubset{
+				{Ports: []api.EndpointPort{{Protocol: api.ProtocolSCTP}}},
+			},
+		}
+	}
+	objectWithoutValue := func() *api.Endpoints {
+		return &api.Endpoints{
+			Subsets: []api.EndpointSubset{
+				{Ports: []api.EndpointPort{{Protocol: api.ProtocolTCP}}},
+			},
+		}
+	}
+
+	objectInfo := []struct {
+		description string
+		hasValue    bool
+		object      func() *api.Endpoints
+	}{
+		{
+			description: "has value",
+			hasValue:    true,
+			object:      objectWithValue,
+		},
+		{
+			description: "does not have value",
+			hasValue:    false,
+			object:      objectWithoutValue,
+		},
+		{
+			description: "is nil",
+			hasValue:    false,
+			object:      func() *api.Endpoints { return nil },
+		},
+	}
+
+	for _, enabled := range []bool{true, false} {
+		for _, oldEndpointsInfo := range objectInfo {
+			for _, newEndpointsInfo := range objectInfo {
+				oldEndpointsHasValue, oldEndpoints := oldEndpointsInfo.hasValue, oldEndpointsInfo.object()
+				newEndpointsHasValue, newEndpoints := newEndpointsInfo.hasValue, newEndpointsInfo.object()
+				if newEndpoints == nil {
+					continue
+				}
+
+				t.Run(fmt.Sprintf("feature enabled=%v, old object %v, new object %v", enabled, oldEndpointsInfo.description, newEndpointsInfo.description), func(t *testing.T) {
+					defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SCTPSupport, enabled)()
+					errs := ValidateConditionalEndpoints(newEndpoints, oldEndpoints)
+					// objects should never be changed
+					if !reflect.DeepEqual(oldEndpoints, oldEndpointsInfo.object()) {
+						t.Errorf("old object changed: %v", diff.ObjectReflectDiff(oldEndpoints, oldEndpointsInfo.object()))
+					}
+					if !reflect.DeepEqual(newEndpoints, newEndpointsInfo.object()) {
+						t.Errorf("new object changed: %v", diff.ObjectReflectDiff(newEndpoints, newEndpointsInfo.object()))
+					}
+
+					switch {
+					case enabled || oldEndpointsHasValue || !newEndpointsHasValue:
+						if len(errs) > 0 {
+							t.Errorf("unexpected errors: %v", errs)
+						}
+					default:
+						if len(errs) != 1 {
+							t.Errorf("expected 1 error, got %v", errs)
+						}
+					}
+				})
+			}
+		}
+	}
+}

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -1969,8 +1969,6 @@ func validateContainerPorts(ports []core.ContainerPort, fldPath *field.Path) fie
 		}
 		if len(port.Protocol) == 0 {
 			allErrs = append(allErrs, field.Required(idxPath.Child("protocol"), ""))
-		} else if !utilfeature.DefaultFeatureGate.Enabled(features.SCTPSupport) && port.Protocol == core.ProtocolSCTP {
-			allErrs = append(allErrs, field.NotSupported(idxPath.Child("protocol"), port.Protocol, []string{string(core.ProtocolTCP), string(core.ProtocolUDP)}))
 		} else if !supportedPortProtocols.Has(string(port.Protocol)) {
 			allErrs = append(allErrs, field.NotSupported(idxPath.Child("protocol"), port.Protocol, supportedPortProtocols.List()))
 		}
@@ -3724,9 +3722,7 @@ func ValidateService(service *core.Service) field.ErrorList {
 		includeProtocols := sets.NewString()
 		for i := range service.Spec.Ports {
 			portPath := portsPath.Index(i)
-			if !utilfeature.DefaultFeatureGate.Enabled(features.SCTPSupport) && service.Spec.Ports[i].Protocol == core.ProtocolSCTP {
-				allErrs = append(allErrs, field.NotSupported(portPath.Child("protocol"), service.Spec.Ports[i].Protocol, []string{string(core.ProtocolTCP), string(core.ProtocolUDP)}))
-			} else if !supportedPortProtocols.Has(string(service.Spec.Ports[i].Protocol)) {
+			if !supportedPortProtocols.Has(string(service.Spec.Ports[i].Protocol)) {
 				allErrs = append(allErrs, field.Invalid(portPath.Child("protocol"), service.Spec.Ports[i].Protocol, "cannot create an external load balancer with non-TCP/UDP/SCTP ports"))
 			} else {
 				includeProtocols.Insert(string(service.Spec.Ports[i].Protocol))
@@ -3825,8 +3821,6 @@ func validateServicePort(sp *core.ServicePort, requireName, isHeadlessService bo
 
 	if len(sp.Protocol) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("protocol"), ""))
-	} else if !utilfeature.DefaultFeatureGate.Enabled(features.SCTPSupport) && sp.Protocol == core.ProtocolSCTP {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("protocol"), sp.Protocol, []string{string(core.ProtocolTCP), string(core.ProtocolUDP)}))
 	} else if !supportedPortProtocols.Has(string(sp.Protocol)) {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("protocol"), sp.Protocol, supportedPortProtocols.List()))
 	}
@@ -5133,8 +5127,6 @@ func validateEndpointPort(port *core.EndpointPort, requireName bool, fldPath *fi
 	}
 	if len(port.Protocol) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("protocol"), ""))
-	} else if !utilfeature.DefaultFeatureGate.Enabled(features.SCTPSupport) && port.Protocol == core.ProtocolSCTP {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("protocol"), port.Protocol, []string{string(core.ProtocolTCP), string(core.ProtocolUDP)}))
 	} else if !supportedPortProtocols.Has(string(port.Protocol)) {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("protocol"), port.Protocol, supportedPortProtocols.List()))
 	}

--- a/pkg/apis/networking/validation/BUILD
+++ b/pkg/apis/networking/validation/BUILD
@@ -8,13 +8,17 @@ load(
 
 go_test(
     name = "go_default_test",
-    srcs = ["validation_test.go"],
+    srcs = [
+        "conditional_validation_test.go",
+        "validation_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/networking:go_default_library",
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature/testing:go_default_library",
@@ -23,7 +27,10 @@ go_test(
 
 go_library(
     name = "go_default_library",
-    srcs = ["validation.go"],
+    srcs = [
+        "conditional_validation.go",
+        "validation.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/apis/networking/validation",
     deps = [
         "//pkg/apis/core:go_default_library",

--- a/pkg/apis/networking/validation/conditional_validation.go
+++ b/pkg/apis/networking/validation/conditional_validation.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/networking"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+// ValidateConditionalNetworkPolicy validates conditionally valid fields.
+func ValidateConditionalNetworkPolicy(np, oldNP *networking.NetworkPolicy) field.ErrorList {
+	var errs field.ErrorList
+	// If the SCTPSupport feature is disabled, and the old object isn't using the SCTP feature, prevent the new object from using it
+	if !utilfeature.DefaultFeatureGate.Enabled(features.SCTPSupport) && len(sctpFields(oldNP)) == 0 {
+		for _, f := range sctpFields(np) {
+			errs = append(errs, field.NotSupported(f, api.ProtocolSCTP, []string{string(api.ProtocolTCP), string(api.ProtocolUDP)}))
+		}
+	}
+	return errs
+}
+
+func sctpFields(np *networking.NetworkPolicy) []*field.Path {
+	if np == nil {
+		return nil
+	}
+	fields := []*field.Path{}
+	for iIndex, e := range np.Spec.Ingress {
+		for pIndex, p := range e.Ports {
+			if p.Protocol != nil && *p.Protocol == api.ProtocolSCTP {
+				fields = append(fields, field.NewPath("spec.ingress").Index(iIndex).Child("ports").Index(pIndex).Child("protocol"))
+			}
+		}
+	}
+	for eIndex, e := range np.Spec.Egress {
+		for pIndex, p := range e.Ports {
+			if p.Protocol != nil && *p.Protocol == api.ProtocolSCTP {
+				fields = append(fields, field.NewPath("spec.egress").Index(eIndex).Child("ports").Index(pIndex).Child("protocol"))
+			}
+		}
+	}
+	return fields
+}

--- a/pkg/apis/networking/validation/conditional_validation_test.go
+++ b/pkg/apis/networking/validation/conditional_validation_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	utilfeaturetesting "k8s.io/apiserver/pkg/util/feature/testing"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/networking"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+func TestValidateNetworkPolicySCTP(t *testing.T) {
+	sctpProtocol := api.ProtocolSCTP
+	tcpProtocol := api.ProtocolTCP
+	objectWithValue := func() *networking.NetworkPolicy {
+		return &networking.NetworkPolicy{
+			Spec: networking.NetworkPolicySpec{
+				Ingress: []networking.NetworkPolicyIngressRule{{Ports: []networking.NetworkPolicyPort{{Protocol: &sctpProtocol}}}},
+				Egress:  []networking.NetworkPolicyEgressRule{{Ports: []networking.NetworkPolicyPort{{Protocol: &sctpProtocol}}}},
+			},
+		}
+	}
+	objectWithoutValue := func() *networking.NetworkPolicy {
+		return &networking.NetworkPolicy{
+			Spec: networking.NetworkPolicySpec{
+				Ingress: []networking.NetworkPolicyIngressRule{{Ports: []networking.NetworkPolicyPort{{Protocol: &tcpProtocol}}}},
+				Egress:  []networking.NetworkPolicyEgressRule{{Ports: []networking.NetworkPolicyPort{{Protocol: &tcpProtocol}}}},
+			},
+		}
+	}
+
+	objectInfo := []struct {
+		description string
+		hasValue    bool
+		object      func() *networking.NetworkPolicy
+	}{
+		{
+			description: "has value",
+			hasValue:    true,
+			object:      objectWithValue,
+		},
+		{
+			description: "does not have value",
+			hasValue:    false,
+			object:      objectWithoutValue,
+		},
+		{
+			description: "is nil",
+			hasValue:    false,
+			object:      func() *networking.NetworkPolicy { return nil },
+		},
+	}
+
+	for _, enabled := range []bool{true, false} {
+		for _, oldNetworkPolicyInfo := range objectInfo {
+			for _, newNetworkPolicyInfo := range objectInfo {
+				oldNetworkPolicyHasValue, oldNetworkPolicy := oldNetworkPolicyInfo.hasValue, oldNetworkPolicyInfo.object()
+				newNetworkPolicyHasValue, newNetworkPolicy := newNetworkPolicyInfo.hasValue, newNetworkPolicyInfo.object()
+				if newNetworkPolicy == nil {
+					continue
+				}
+
+				t.Run(fmt.Sprintf("feature enabled=%v, old object %v, new object %v", enabled, oldNetworkPolicyInfo.description, newNetworkPolicyInfo.description), func(t *testing.T) {
+					defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SCTPSupport, enabled)()
+					errs := ValidateConditionalNetworkPolicy(newNetworkPolicy, oldNetworkPolicy)
+					// objects should never be changed
+					if !reflect.DeepEqual(oldNetworkPolicy, oldNetworkPolicyInfo.object()) {
+						t.Errorf("old object changed: %v", diff.ObjectReflectDiff(oldNetworkPolicy, oldNetworkPolicyInfo.object()))
+					}
+					if !reflect.DeepEqual(newNetworkPolicy, newNetworkPolicyInfo.object()) {
+						t.Errorf("new object changed: %v", diff.ObjectReflectDiff(newNetworkPolicy, newNetworkPolicyInfo.object()))
+					}
+
+					switch {
+					case enabled || oldNetworkPolicyHasValue || !newNetworkPolicyHasValue:
+						if len(errs) > 0 {
+							t.Errorf("unexpected errors: %v", errs)
+						}
+					default:
+						if len(errs) != 2 {
+							t.Errorf("expected 2 errors, got %v", errs)
+						}
+					}
+				})
+			}
+		}
+	}
+}

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -23,11 +23,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/apis/networking"
-	"k8s.io/kubernetes/pkg/features"
 )
 
 // ValidateNetworkPolicyName can be used to check whether the given networkpolicy
@@ -39,12 +37,8 @@ func ValidateNetworkPolicyName(name string, prefix bool) []string {
 // ValidateNetworkPolicyPort validates a NetworkPolicyPort
 func ValidateNetworkPolicyPort(port *networking.NetworkPolicyPort, portPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if utilfeature.DefaultFeatureGate.Enabled(features.SCTPSupport) {
-		if port.Protocol != nil && *port.Protocol != api.ProtocolTCP && *port.Protocol != api.ProtocolUDP && *port.Protocol != api.ProtocolSCTP {
-			allErrs = append(allErrs, field.NotSupported(portPath.Child("protocol"), *port.Protocol, []string{string(api.ProtocolTCP), string(api.ProtocolUDP), string(api.ProtocolSCTP)}))
-		}
-	} else if port.Protocol != nil && *port.Protocol != api.ProtocolTCP && *port.Protocol != api.ProtocolUDP {
-		allErrs = append(allErrs, field.NotSupported(portPath.Child("protocol"), *port.Protocol, []string{string(api.ProtocolTCP), string(api.ProtocolUDP)}))
+	if port.Protocol != nil && *port.Protocol != api.ProtocolTCP && *port.Protocol != api.ProtocolUDP && *port.Protocol != api.ProtocolSCTP {
+		allErrs = append(allErrs, field.NotSupported(portPath.Child("protocol"), *port.Protocol, []string{string(api.ProtocolTCP), string(api.ProtocolUDP), string(api.ProtocolSCTP)}))
 	}
 	if port.Port != nil {
 		if port.Port.Type == intstr.Int {

--- a/pkg/registry/apps/daemonset/BUILD
+++ b/pkg/registry/apps/daemonset/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/api/pod:go_default_library",
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/apps/validation:go_default_library",
+        "//pkg/apis/core/validation:go_default_library",
         "//staging/src/k8s.io/api/apps/v1beta2:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/registry/apps/daemonset/strategy.go
+++ b/pkg/registry/apps/daemonset/strategy.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/apps/validation"
+	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 )
 
 // daemonSetStrategy implements verification logic for daemon sets.
@@ -115,7 +116,9 @@ func (daemonSetStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.
 // Validate validates a new daemon set.
 func (daemonSetStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	daemonSet := obj.(*apps.DaemonSet)
-	return validation.ValidateDaemonSet(daemonSet)
+	allErrs := validation.ValidateDaemonSet(daemonSet)
+	allErrs = append(allErrs, corevalidation.ValidateConditionalPodTemplate(&daemonSet.Spec.Template, nil, field.NewPath("spec.template"))...)
+	return allErrs
 }
 
 // Canonicalize normalizes the object after validation.
@@ -134,6 +137,7 @@ func (daemonSetStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Ob
 	oldDaemonSet := old.(*apps.DaemonSet)
 	allErrs := validation.ValidateDaemonSet(obj.(*apps.DaemonSet))
 	allErrs = append(allErrs, validation.ValidateDaemonSetUpdate(newDaemonSet, oldDaemonSet)...)
+	allErrs = append(allErrs, corevalidation.ValidateConditionalPodTemplate(&newDaemonSet.Spec.Template, &oldDaemonSet.Spec.Template, field.NewPath("spec.template"))...)
 
 	// Update is not allowed to set Spec.Selector for apps/v1 and apps/v1beta2 (allowed for extensions/v1beta1).
 	// If RequestInfo is nil, it is better to revert to old behavior (i.e. allow update to set Spec.Selector)

--- a/pkg/registry/apps/deployment/BUILD
+++ b/pkg/registry/apps/deployment/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/api/pod:go_default_library",
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/apps/validation:go_default_library",
+        "//pkg/apis/core/validation:go_default_library",
         "//staging/src/k8s.io/api/apps/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/apps/v1beta2:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",

--- a/pkg/registry/apps/deployment/strategy.go
+++ b/pkg/registry/apps/deployment/strategy.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/apps/validation"
+	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 )
 
 // deploymentStrategy implements behavior for Deployments.
@@ -79,7 +80,9 @@ func (deploymentStrategy) PrepareForCreate(ctx context.Context, obj runtime.Obje
 // Validate validates a new deployment.
 func (deploymentStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	deployment := obj.(*apps.Deployment)
-	return validation.ValidateDeployment(deployment)
+	allErrs := validation.ValidateDeployment(deployment)
+	allErrs = append(allErrs, corevalidation.ValidateConditionalPodTemplate(&deployment.Spec.Template, nil, field.NewPath("spec.template"))...)
+	return allErrs
 }
 
 // Canonicalize normalizes the object after validation.
@@ -113,6 +116,7 @@ func (deploymentStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.O
 	newDeployment := obj.(*apps.Deployment)
 	oldDeployment := old.(*apps.Deployment)
 	allErrs := validation.ValidateDeploymentUpdate(newDeployment, oldDeployment)
+	allErrs = append(allErrs, corevalidation.ValidateConditionalPodTemplate(&newDeployment.Spec.Template, &oldDeployment.Spec.Template, field.NewPath("spec.template"))...)
 
 	// Update is not allowed to set Spec.Selector for all groups/versions except extensions/v1beta1.
 	// If RequestInfo is nil, it is better to revert to old behavior (i.e. allow update to set Spec.Selector)

--- a/pkg/registry/apps/replicaset/BUILD
+++ b/pkg/registry/apps/replicaset/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/api/pod:go_default_library",
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/apps/validation:go_default_library",
+        "//pkg/apis/core/validation:go_default_library",
         "//staging/src/k8s.io/api/apps/v1beta2:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/registry/apps/statefulset/BUILD
+++ b/pkg/registry/apps/statefulset/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/api/pod:go_default_library",
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/apps/validation:go_default_library",
+        "//pkg/apis/core/validation:go_default_library",
         "//staging/src/k8s.io/api/apps/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/apps/v1beta2:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/registry/batch/cronjob/BUILD
+++ b/pkg/registry/batch/cronjob/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/api/pod:go_default_library",
         "//pkg/apis/batch:go_default_library",
         "//pkg/apis/batch/validation:go_default_library",
+        "//pkg/apis/core/validation:go_default_library",
         "//staging/src/k8s.io/api/batch/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/batch/v2alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/batch/cronjob/strategy.go
+++ b/pkg/registry/batch/cronjob/strategy.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/batch/validation"
+	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 )
 
 // cronJobStrategy implements verification logic for Replication Controllers.
@@ -83,7 +84,9 @@ func (cronJobStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Ob
 // Validate validates a new scheduled job.
 func (cronJobStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	cronJob := obj.(*batch.CronJob)
-	return validation.ValidateCronJob(cronJob)
+	allErrs := validation.ValidateCronJob(cronJob)
+	allErrs = append(allErrs, corevalidation.ValidateConditionalPodTemplate(&cronJob.Spec.JobTemplate.Spec.Template, nil, field.NewPath("spec.jobTemplate.spec.template"))...)
+	return allErrs
 }
 
 // Canonicalize normalizes the object after validation.
@@ -101,7 +104,14 @@ func (cronJobStrategy) AllowCreateOnUpdate() bool {
 
 // ValidateUpdate is the default update validation for an end user.
 func (cronJobStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateCronJobUpdate(obj.(*batch.CronJob), old.(*batch.CronJob))
+	newCronJob := obj.(*batch.CronJob)
+	oldCronJob := old.(*batch.CronJob)
+	allErrs := validation.ValidateCronJobUpdate(newCronJob, oldCronJob)
+	allErrs = append(allErrs, corevalidation.ValidateConditionalPodTemplate(
+		&newCronJob.Spec.JobTemplate.Spec.Template,
+		&oldCronJob.Spec.JobTemplate.Spec.Template,
+		field.NewPath("spec.jobTemplate.spec.template"))...)
+	return allErrs
 }
 
 type cronJobStatusStrategy struct {

--- a/pkg/registry/batch/job/BUILD
+++ b/pkg/registry/batch/job/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/api/pod:go_default_library",
         "//pkg/apis/batch:go_default_library",
         "//pkg/apis/batch/validation:go_default_library",
+        "//pkg/apis/core/validation:go_default_library",
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/batch/validation"
+	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
 )
 
@@ -103,7 +104,9 @@ func (jobStrategy) Validate(ctx context.Context, obj runtime.Object) field.Error
 	if job.Spec.ManualSelector == nil || *job.Spec.ManualSelector == false {
 		generateSelector(job)
 	}
-	return validation.ValidateJob(job)
+	allErrs := validation.ValidateJob(job)
+	allErrs = append(allErrs, corevalidation.ValidateConditionalPodTemplate(&job.Spec.Template, nil, field.NewPath("spec.template"))...)
+	return allErrs
 }
 
 // generateSelector adds a selector to a job and labels to its template
@@ -171,8 +174,11 @@ func (jobStrategy) AllowCreateOnUpdate() bool {
 
 // ValidateUpdate is the default update validation for an end user.
 func (jobStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	validationErrorList := validation.ValidateJob(obj.(*batch.Job))
-	updateErrorList := validation.ValidateJobUpdate(obj.(*batch.Job), old.(*batch.Job))
+	job := obj.(*batch.Job)
+	oldJob := old.(*batch.Job)
+	validationErrorList := validation.ValidateJob(job)
+	updateErrorList := validation.ValidateJobUpdate(job, oldJob)
+	updateErrorList = append(updateErrorList, corevalidation.ValidateConditionalPodTemplate(&job.Spec.Template, &oldJob.Spec.Template, field.NewPath("spec.template"))...)
 	return append(validationErrorList, updateErrorList...)
 }
 

--- a/pkg/registry/core/endpoint/strategy.go
+++ b/pkg/registry/core/endpoint/strategy.go
@@ -53,7 +53,9 @@ func (endpointsStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.
 
 // Validate validates a new endpoints.
 func (endpointsStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateEndpoints(obj.(*api.Endpoints))
+	allErrs := validation.ValidateEndpoints(obj.(*api.Endpoints))
+	allErrs = append(allErrs, validation.ValidateConditionalEndpoints(obj.(*api.Endpoints), nil)...)
+	return allErrs
 }
 
 // Canonicalize normalizes the object after validation.
@@ -70,7 +72,9 @@ func (endpointsStrategy) AllowCreateOnUpdate() bool {
 // ValidateUpdate is the default update validation for an end user.
 func (endpointsStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	errorList := validation.ValidateEndpoints(obj.(*api.Endpoints))
-	return append(errorList, validation.ValidateEndpointsUpdate(obj.(*api.Endpoints), old.(*api.Endpoints))...)
+	errorList = append(errorList, validation.ValidateEndpointsUpdate(obj.(*api.Endpoints), old.(*api.Endpoints))...)
+	errorList = append(errorList, validation.ValidateConditionalEndpoints(obj.(*api.Endpoints), old.(*api.Endpoints))...)
+	return errorList
 }
 
 func (endpointsStrategy) AllowUnconditionalUpdate() bool {

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -84,7 +84,9 @@ func (podStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object
 // Validate validates a new pod.
 func (podStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	pod := obj.(*api.Pod)
-	return validation.ValidatePod(pod)
+	allErrs := validation.ValidatePod(pod)
+	allErrs = append(allErrs, validation.ValidateConditionalPod(pod, nil, field.NewPath(""))...)
+	return allErrs
 }
 
 // Canonicalize normalizes the object after validation.
@@ -99,7 +101,9 @@ func (podStrategy) AllowCreateOnUpdate() bool {
 // ValidateUpdate is the default update validation for an end user.
 func (podStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	errorList := validation.ValidatePod(obj.(*api.Pod))
-	return append(errorList, validation.ValidatePodUpdate(obj.(*api.Pod), old.(*api.Pod))...)
+	errorList = append(errorList, validation.ValidatePodUpdate(obj.(*api.Pod), old.(*api.Pod))...)
+	errorList = append(errorList, validation.ValidateConditionalPod(obj.(*api.Pod), old.(*api.Pod), field.NewPath(""))...)
+	return errorList
 }
 
 // AllowUnconditionalUpdate allows pods to be overwritten

--- a/pkg/registry/core/replicationcontroller/strategy.go
+++ b/pkg/registry/core/replicationcontroller/strategy.go
@@ -108,7 +108,9 @@ func (rcStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object)
 // Validate validates a new replication controller.
 func (rcStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	controller := obj.(*api.ReplicationController)
-	return validation.ValidateReplicationController(controller)
+	allErrs := validation.ValidateReplicationController(controller)
+	allErrs = append(allErrs, validation.ValidateConditionalPodTemplate(controller.Spec.Template, nil, field.NewPath("spec.template"))...)
+	return allErrs
 }
 
 // Canonicalize normalizes the object after validation.
@@ -128,6 +130,7 @@ func (rcStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) f
 
 	validationErrorList := validation.ValidateReplicationController(newRc)
 	updateErrorList := validation.ValidateReplicationControllerUpdate(newRc, oldRc)
+	updateErrorList = append(updateErrorList, validation.ValidateConditionalPodTemplate(newRc.Spec.Template, oldRc.Spec.Template, field.NewPath("spec.template"))...)
 	errs := append(validationErrorList, updateErrorList...)
 
 	for key, value := range helper.NonConvertibleFields(oldRc.Annotations) {

--- a/pkg/registry/core/service/strategy.go
+++ b/pkg/registry/core/service/strategy.go
@@ -59,7 +59,9 @@ func (svcStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object
 // Validate validates a new service.
 func (svcStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	service := obj.(*api.Service)
-	return validation.ValidateService(service)
+	allErrs := validation.ValidateService(service)
+	allErrs = append(allErrs, validation.ValidateConditionalService(service, nil)...)
+	return allErrs
 }
 
 // Canonicalize normalizes the object after validation.
@@ -71,7 +73,9 @@ func (svcStrategy) AllowCreateOnUpdate() bool {
 }
 
 func (svcStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateServiceUpdate(obj.(*api.Service), old.(*api.Service))
+	allErrs := validation.ValidateServiceUpdate(obj.(*api.Service), old.(*api.Service))
+	allErrs = append(allErrs, validation.ValidateConditionalService(obj.(*api.Service), old.(*api.Service))...)
+	return allErrs
 }
 
 func (svcStrategy) AllowUnconditionalUpdate() bool {

--- a/pkg/registry/networking/networkpolicy/strategy.go
+++ b/pkg/registry/networking/networkpolicy/strategy.go
@@ -64,7 +64,9 @@ func (networkPolicyStrategy) PrepareForUpdate(ctx context.Context, obj, old runt
 // Validate validates a new NetworkPolicy.
 func (networkPolicyStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	networkPolicy := obj.(*networking.NetworkPolicy)
-	return validation.ValidateNetworkPolicy(networkPolicy)
+	allErrs := validation.ValidateNetworkPolicy(networkPolicy)
+	allErrs = append(allErrs, validation.ValidateConditionalNetworkPolicy(networkPolicy, nil)...)
+	return allErrs
 }
 
 // Canonicalize normalizes the object after validation.
@@ -79,6 +81,7 @@ func (networkPolicyStrategy) AllowCreateOnUpdate() bool {
 func (networkPolicyStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	validationErrorList := validation.ValidateNetworkPolicy(obj.(*networking.NetworkPolicy))
 	updateErrorList := validation.ValidateNetworkPolicyUpdate(obj.(*networking.NetworkPolicy), old.(*networking.NetworkPolicy))
+	updateErrorList = append(updateErrorList, validation.ValidateConditionalNetworkPolicy(obj.(*networking.NetworkPolicy), old.(*networking.NetworkPolicy))...)
 	return append(validationErrorList, updateErrorList...)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Moves conditional validation to methods with knowledge of the old and new object, to ensure we never fail an object based on a validation check of data which is already in the existing persisted object.

This ensures that once the SCTP feature is enabled, rollback of one version is safe (API validation-wise).

**Which issue(s) this PR fixes**:
Finishes https://github.com/kubernetes/kubernetes/issues/72651

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery
/cc @sbezverk 