### PR TITLE
deprecate API ExportOptions

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -194,11 +194,14 @@ message Duration {
 }
 
 // ExportOptions is the query options to the standard REST get call.
+// Deprecated. Planned for removal in 1.18.
 message ExportOptions {
   // Should this value be exported.  Export strips fields that a user can not specify.
+  // Deprecated. Planned for removal in 1.18.
   optional bool export = 1;
 
   // Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'.
+  // Deprecated. Planned for removal in 1.18.
   optional bool exact = 2;
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -399,11 +399,14 @@ type ListOptions struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ExportOptions is the query options to the standard REST get call.
+// Deprecated. Planned for removal in 1.18.
 type ExportOptions struct {
 	TypeMeta `json:",inline"`
 	// Should this value be exported.  Export strips fields that a user can not specify.
+	// Deprecated. Planned for removal in 1.18.
 	Export bool `json:"export" protobuf:"varint,1,opt,name=export"`
 	// Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'.
+	// Deprecated. Planned for removal in 1.18.
 	Exact bool `json:"exact" protobuf:"varint,2,opt,name=exact"`
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_swagger_doc_generated.go
@@ -109,9 +109,9 @@ func (DeleteOptions) SwaggerDoc() map[string]string {
 }
 
 var map_ExportOptions = map[string]string{
-	"":       "ExportOptions is the query options to the standard REST get call.",
-	"export": "Should this value be exported.  Export strips fields that a user can not specify.",
-	"exact":  "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'.",
+	"":       "ExportOptions is the query options to the standard REST get call. Deprecated. Planned for removal in 1.18.",
+	"export": "Should this value be exported.  Export strips fields that a user can not specify. Deprecated. Planned for removal in 1.18.",
+	"exact":  "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'. Deprecated. Planned for removal in 1.18.",
 }
 
 func (ExportOptions) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Export has fundamental issues with handling multiple use cases. As we discussed with @liggitt and @bgrant0607 in https://github.com/kubernetes/kubernetes/issues/24855 and https://github.com/kubernetes/kubernetes/issues/49497, this can't be solved server-side.  Avoiding export and instead just getting the resource as it exists today. The transformations could then be done client-side and at some later date. Doing it this way allows a single retrieval to be used for different purposes and allows an "export" to be done before deciding how you may later use it.


```release-note
export query parameter is deprecated and will be removed in a future release
```

@kubernetes/sig-api-machinery-bugs 
/assign @liggitt 
@liggitt you probably know.  Any idea how to ripple this into the openapi doc?

