### PR TITLE
Propagate dump_systemd_journal to logexporter job.

### DIFF
--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -349,6 +349,7 @@ function dump_nodes_with_logexporter() {
   sed -i'' -e "s@{{.CloudProvider}}@${cloud_provider}@g" "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"
   sed -i'' -e "s@{{.GCSPath}}@${gcs_artifacts_dir}@g" "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"
   sed -i'' -e "s@{{.EnableHollowNodeLogs}}@${enable_hollow_node_logs}@g" "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"
+  sed -i'' -e "s@{{.DumpSystemdJournal}}@${dump_systemd_journal}@g" "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"
 
   # Create the logexporter namespace, service-account secret and the logexporter daemonset within that namespace.
   KUBECTL="${KUBE_ROOT}/cluster/kubectl.sh"

--- a/cluster/log-dump/logexporter-daemonset.yaml
+++ b/cluster/log-dump/logexporter-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: gcr.io/k8s-testimages/logexporter:v0.1.3
+        image: gcr.io/k8s-testimages/logexporter:v0.1.4
         env:
         - name: NODE_NAME
           valueFrom:
@@ -49,6 +49,7 @@ spec:
         - --gcs-path={{.GCSPath}}
         - --gcloud-auth-file-path=/etc/service-account/service-account.json
         - --enable-hollow-node-logs={{.EnableHollowNodeLogs}}
+        - --dump-systemd-journal={{.DumpSystemdJournal}}
         - --sleep-duration=24h
         - --alsologtostderr
         volumeMounts:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

Propagates the dump_systemd_journal flag to the log exporter tool.
Log exporter changes have been made in https://github.com/kubernetes/test-infra/pull/11121 and the new version has been pushed in https://github.com/kubernetes/test-infra/pull/11149


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
