### PR TITLE
Deprecate --export flag from get command

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -175,6 +175,7 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericclioptions.IOStr
 	addOpenAPIPrintColumnFlags(cmd, o)
 	addServerPrintColumnFlags(cmd, o)
 	cmd.Flags().BoolVar(&o.Export, "export", o.Export, "If true, use 'export' for the resources.  Exported resources are stripped of cluster-specific information.")
+	cmd.Flags().MarkDeprecated("export", "This flag is deprecated and will be removed in future.")
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to get from a server.")
 	return cmd
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change
/sig cli
/sig architecture
/priority important-longterm

**What this PR does / why we need it**:
`kubectl get --export` was broken almost from its inception, multiple bugs (eg. https://github.com/kubernetes/kubernetes/issues/28551) were reported wrt its functionality but not much was addressed. 
Additionally, server-side export (https://github.com/kubernetes/kubernetes/issues/24855) was brought for discussion and most of the time sig-apimachinery decided not to do it. 
Given all of the above I think it's the time to start the process of deprecating this functionality. 

**Special notes for your reviewer**:
/assign @deads2k @liggitt 
/cc @kubernetes/api-approvers 

**Does this PR introduce a user-facing change?**:
```release-note
Deprecate --export flag from kubectl get command.
```
