### PR TITLE
ControllerRef creation through factory function

### DIFF
--- a/pkg/controller/history/controller_history.go
+++ b/pkg/controller/history/controller_history.go
@@ -72,7 +72,7 @@ func NewControllerRevision(parent metav1.Object,
 	}
 	cr := &apps.ControllerRevision{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: labelMap,
+			Labels:          labelMap,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(parent, parentKind)},
 		},
 		Data:     data,

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -484,16 +484,7 @@ func (rsc *ReplicaSetController) manageReplicas(filteredPods []*v1.Pod, rs *apps
 		// after one of its pods fails.  Conveniently, this also prevents the
 		// event spam that those failures would generate.
 		successfulCreations, err := slowStartBatch(diff, controller.SlowStartInitialBatchSize, func() error {
-			boolPtr := func(b bool) *bool { return &b }
-			controllerRef := &metav1.OwnerReference{
-				APIVersion:         rsc.GroupVersion().String(),
-				Kind:               rsc.Kind,
-				Name:               rs.Name,
-				UID:                rs.UID,
-				BlockOwnerDeletion: boolPtr(true),
-				Controller:         boolPtr(true),
-			}
-			err := rsc.podControl.CreatePodsWithControllerRef(rs.Namespace, &rs.Spec.Template, rs, controllerRef)
+			err := rsc.podControl.CreatePodsWithControllerRef(rs.Namespace, &rs.Spec.Template, rs, metav1.NewControllerRef(rs, rsc.GroupVersionKind))
 			if err != nil && errors.IsTimeout(err) {
 				// Pod is created but its initialization has timed out.
 				// If the initialization is successful eventually, the


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The following controllers were duplicating the factory function for `ControllerRef`s:
- `ReplicaSetController`
- `fakeHistory`
- `defaultStatefulSetControl`

**Special notes for your reviewer**:
The following controllers already used the factory function:
- `CronJobController`: [here](https://github.com/kubernetes/kubernetes/blob/6796645672b4de8d2b6fae780c660926a23e326a/pkg/controller/cronjob/utils.go#L163)
- `DaemonSetsController`: [here](https://github.com/kubernetes/kubernetes/blob/6796645672b4de8d2b6fae780c660926a23e326a/pkg/controller/daemon/daemon_controller.go#L1045), [here](https://github.com/kubernetes/kubernetes/blob/6796645672b4de8d2b6fae780c660926a23e326a/pkg/controller/daemon/daemon_controller.go#L1051) and [here](https://github.com/kubernetes/kubernetes/blob/6796645672b4de8d2b6fae780c660926a23e326a/pkg/controller/daemon/update.go#L327)
- `DeploymentController`: [here](https://github.com/kubernetes/kubernetes/blob/6796645672b4de8d2b6fae780c660926a23e326a/pkg/controller/deployment/sync.go#L194)
- `JobController`: [here](https://github.com/kubernetes/kubernetes/blob/6796645672b4de8d2b6fae780c660926a23e326a/pkg/controller/job/job_controller.go#L771)
- `defaultStatefulSetControl`: [here](https://github.com/kubernetes/kubernetes/blob/6796645672b4de8d2b6fae780c660926a23e326a/pkg/controller/statefulset/stateful_set_utils.go#L251)
- `SampleController`: [here](https://github.com/kubernetes/kubernetes/blob/6796645672b4de8d2b6fae780c660926a23e326a/staging/src/k8s.io/sample-controller/controller.go#L401-L405)
- Controllers build with `kubebuilder`: [here](https://github.com/kubernetes-sigs/controller-runtime/blob/6443f37724542b887b17f51fa6024ac976f15faf/pkg/controller/controllerutil/controllerutil.go#L68)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```