### PR TITLE
Return error when schema is not available

### DIFF
--- a/pkg/kubectl/explain/explain.go
+++ b/pkg/kubectl/explain/explain.go
@@ -17,6 +17,7 @@ limitations under the License.
 package explain
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
@@ -62,6 +63,9 @@ func PrintModelDescription(fieldsPath []string, w io.Writer, schema proto.Schema
 	schema, err := LookupSchemaForField(schema, fieldsPath)
 	if err != nil {
 		return err
+	}
+	if schema == nil {
+		return fmt.Errorf("couldn't find %q for %q", strings.Join(fieldsPath, "."), gvk)
 	}
 	b := fieldsPrinterBuilder{Recursive: recursive}
 	f := &Formatter{Writer: w, Wrap: 80}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/priority important-longterm
/sig cli

**What this PR does / why we need it**:
If schema is nil or in general not available on server, just return error instead of panic-ing. 

**Which issue(s) this PR fixes**:
This was noticed in https://github.com/kubernetes/kubernetes/pull/71192

**Special notes for your reviewer**:
/assign @liggitt @sttts @roycaihw

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
