### PR TITLE
add e2e test when expansion is disabled

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -368,7 +368,7 @@ if [[ -n "${GCE_GLBC_IMAGE:-}" ]]; then
 fi
 
 if [[ -z "${KUBE_ADMISSION_CONTROL:-}" ]]; then
-  ADMISSION_CONTROL="NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,PodPreset,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,Priority,StorageObjectInUseProtection"
+  ADMISSION_CONTROL="NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,PodPreset,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,Priority,StorageObjectInUseProtection,PersistentVolumeClaimResize"
   if [[ "${ENABLE_POD_SECURITY_POLICY:-}" == "true" ]]; then
     ADMISSION_CONTROL="${ADMISSION_CONTROL},PodSecurityPolicy"
   fi

--- a/test/e2e/storage/flexvolume_mounted_volume_resize.go
+++ b/test/e2e/storage/flexvolume_mounted_volume_resize.go
@@ -18,6 +18,8 @@ package storage
 
 import (
 	"fmt"
+	"path"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
@@ -27,8 +29,8 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
-	"path"
 )
 
 var _ = utils.SIGDescribe("Mounted flexvolume expand[Slow]", func() {
@@ -72,7 +74,14 @@ var _ = utils.SIGDescribe("Mounted flexvolume expand[Slow]", func() {
 			isNodeLabeled = true
 		}
 
-		resizableSc, err = createStorageClass(ns, c)
+		test := testsuites.StorageClassTest{
+			Name:                 "flexvolume-resize",
+			ClaimSize:            "2Gi",
+			AllowVolumeExpansion: true,
+			Provisioner:          "flex-expand",
+		}
+
+		resizableSc, err = createStorageClass(test, ns, "resizing", c)
 		if err != nil {
 			fmt.Printf("storage class creation error: %v\n", err)
 		}

--- a/test/e2e/storage/flexvolume_online_resize.go
+++ b/test/e2e/storage/flexvolume_online_resize.go
@@ -18,6 +18,8 @@ package storage
 
 import (
 	"fmt"
+	"path"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
@@ -26,20 +28,9 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
-	"path"
 )
-
-func createStorageClass(ns string, c clientset.Interface) (*storage.StorageClass, error) {
-	bindingMode := storage.VolumeBindingImmediate
-	stKlass := getStorageClass("flex-expand", map[string]string{}, &bindingMode, ns, "resizing")
-	allowExpansion := true
-	stKlass.AllowVolumeExpansion = &allowExpansion
-
-	var err error
-	stKlass, err = c.StorageV1().StorageClasses().Create(stKlass)
-	return stKlass, err
-}
 
 var _ = utils.SIGDescribe("Mounted flexvolume volume expand [Slow] [Feature:ExpandInUsePersistentVolumes]", func() {
 	var (
@@ -82,7 +73,14 @@ var _ = utils.SIGDescribe("Mounted flexvolume volume expand [Slow] [Feature:Expa
 			isNodeLabeled = true
 		}
 
-		resizableSc, err = createStorageClass(ns, c)
+		test := testsuites.StorageClassTest{
+			Name:                 "flexvolume-resize",
+			ClaimSize:            "2Gi",
+			AllowVolumeExpansion: true,
+			Provisioner:          "flex-expand",
+		}
+
+		resizableSc, err = createStorageClass(test, ns, "resizing", c)
 		if err != nil {
 			fmt.Printf("storage class creation error: %v\n", err)
 		}

--- a/test/e2e/storage/mounted_volume_resize.go
+++ b/test/e2e/storage/mounted_volume_resize.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
-var _ = utils.SIGDescribe("Mounted volume expand[Slow]", func() {
+var _ = utils.SIGDescribe("Mounted volume expand", func() {
 	var (
 		c                 clientset.Interface
 		ns                string

--- a/test/e2e/storage/mounted_volume_resize.go
+++ b/test/e2e/storage/mounted_volume_resize.go
@@ -74,10 +74,11 @@ var _ = utils.SIGDescribe("Mounted volume expand[Slow]", func() {
 		}
 
 		test := testsuites.StorageClassTest{
-			Name:      "default",
-			ClaimSize: "2Gi",
+			Name:                 "default",
+			ClaimSize:            "2Gi",
+			AllowVolumeExpansion: true,
 		}
-		resizableSc, err = createResizableStorageClass(test, ns, "resizing", c)
+		resizableSc, err = createStorageClass(test, ns, "resizing", c)
 		Expect(err).NotTo(HaveOccurred(), "Error creating resizable storage class")
 		Expect(*resizableSc.AllowVolumeExpansion).To(BeTrue())
 

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -41,16 +41,17 @@ import (
 // StorageClassTest represents parameters to be used by provisioning tests.
 // Not all parameters are used by all tests.
 type StorageClassTest struct {
-	Name             string
-	CloudProviders   []string
-	Provisioner      string
-	StorageClassName string
-	Parameters       map[string]string
-	DelayBinding     bool
-	ClaimSize        string
-	ExpectedSize     string
-	PvCheck          func(claim *v1.PersistentVolumeClaim, volume *v1.PersistentVolume)
-	VolumeMode       *v1.PersistentVolumeMode
+	Name                 string
+	CloudProviders       []string
+	Provisioner          string
+	StorageClassName     string
+	Parameters           map[string]string
+	DelayBinding         bool
+	ClaimSize            string
+	ExpectedSize         string
+	PvCheck              func(claim *v1.PersistentVolumeClaim, volume *v1.PersistentVolume)
+	VolumeMode           *v1.PersistentVolumeMode
+	AllowVolumeExpansion bool
 }
 
 type provisioningTestSuite struct {

--- a/test/e2e/storage/volume_expand.go
+++ b/test/e2e/storage/volume_expand.go
@@ -40,7 +40,7 @@ const (
 	totalResizeWaitPeriod = 20 * time.Minute
 )
 
-var _ = utils.SIGDescribe("Volume expand [Slow]", func() {
+var _ = utils.SIGDescribe("Volume expand", func() {
 	var (
 		c           clientset.Interface
 		ns          string
@@ -78,9 +78,8 @@ var _ = utils.SIGDescribe("Volume expand [Slow]", func() {
 
 	It("should not allow expansion of pvcs without AllowVolumeExpansion property", func() {
 		test := testsuites.StorageClassTest{
-			Name:                 "no-expansion",
-			ClaimSize:            "2Gi",
-			AllowVolumeExpansion: false,
+			Name:      "no-expansion",
+			ClaimSize: "2Gi",
 		}
 		regularSC, err := createStorageClass(test, ns, "noexpand", c)
 		Expect(err).NotTo(HaveOccurred(), "Error creating non-expandable storage class")
@@ -88,9 +87,7 @@ var _ = utils.SIGDescribe("Volume expand [Slow]", func() {
 		defer func() {
 			framework.ExpectNoError(c.StorageV1().StorageClasses().Delete(regularSC.Name, nil))
 		}()
-
-		Expect(regularSC.AllowVolumeExpansion).NotTo(BeNil())
-		Expect(*resizableSc.AllowVolumeExpansion).To(BeFalse())
+		Expect(regularSC.AllowVolumeExpansion).To(BeNil())
 
 		noExpandPVC := newClaim(test, ns, "noexpand")
 		noExpandPVC.Spec.StorageClassName = &regularSC.Name
@@ -108,7 +105,7 @@ var _ = utils.SIGDescribe("Volume expand [Slow]", func() {
 
 		By("Expanding non-expandable pvc")
 		newSize := resource.MustParse("6Gi")
-		pvc, err = expandPVCSize(noExpandPVC, newSize, c)
+		noExpandPVC, err = expandPVCSize(noExpandPVC, newSize, c)
 		Expect(err).To(HaveOccurred(), "While updating non-expandable PVC")
 	})
 

--- a/test/e2e/storage/volume_expand.go
+++ b/test/e2e/storage/volume_expand.go
@@ -56,10 +56,11 @@ var _ = utils.SIGDescribe("Volume expand [Slow]", func() {
 		ns = f.Namespace.Name
 		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
 		test := testsuites.StorageClassTest{
-			Name:      "default",
-			ClaimSize: "2Gi",
+			Name:                 "default",
+			ClaimSize:            "2Gi",
+			AllowVolumeExpansion: true,
 		}
-		resizableSc, err = createResizableStorageClass(test, ns, "resizing", c)
+		resizableSc, err = createStorageClass(test, ns, "resizing", c)
 		Expect(err).NotTo(HaveOccurred(), "Error creating resizable storage class")
 		Expect(resizableSc.AllowVolumeExpansion).NotTo(BeNil())
 		Expect(*resizableSc.AllowVolumeExpansion).To(BeTrue())
@@ -73,6 +74,42 @@ var _ = utils.SIGDescribe("Volume expand [Slow]", func() {
 	AfterEach(func() {
 		framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, pvc.Namespace))
 		framework.ExpectNoError(c.StorageV1().StorageClasses().Delete(resizableSc.Name, nil))
+	})
+
+	It("should not allow expansion of pvcs without AllowVolumeExpansion property", func() {
+		test := testsuites.StorageClassTest{
+			Name:                 "no-expansion",
+			ClaimSize:            "2Gi",
+			AllowVolumeExpansion: false,
+		}
+		regularSC, err := createStorageClass(test, ns, "noexpand", c)
+		Expect(err).NotTo(HaveOccurred(), "Error creating non-expandable storage class")
+
+		defer func() {
+			framework.ExpectNoError(c.StorageV1().StorageClasses().Delete(regularSC.Name, nil))
+		}()
+
+		Expect(regularSC.AllowVolumeExpansion).NotTo(BeNil())
+		Expect(*resizableSc.AllowVolumeExpansion).To(BeFalse())
+
+		noExpandPVC := newClaim(test, ns, "noexpand")
+		noExpandPVC.Spec.StorageClassName = &regularSC.Name
+		noExpandPVC, err = c.CoreV1().PersistentVolumeClaims(noExpandPVC.Namespace).Create(noExpandPVC)
+		Expect(err).NotTo(HaveOccurred(), "Error creating pvc")
+
+		defer func() {
+			framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, noExpandPVC.Name, noExpandPVC.Namespace))
+		}()
+
+		pvcClaims := []*v1.PersistentVolumeClaim{noExpandPVC}
+		pvs, err := framework.WaitForPVClaimBoundPhase(c, pvcClaims, framework.ClaimProvisionTimeout)
+		Expect(err).NotTo(HaveOccurred(), "Failed waiting for PVC to be bound %v", err)
+		Expect(len(pvs)).To(Equal(1))
+
+		By("Expanding non-expandable pvc")
+		newSize := resource.MustParse("6Gi")
+		pvc, err = expandPVCSize(noExpandPVC, newSize, c)
+		Expect(err).To(HaveOccurred(), "While updating non-expandable PVC")
 	})
 
 	It("Verify if editing PVC allows resize", func() {
@@ -134,10 +171,8 @@ var _ = utils.SIGDescribe("Volume expand [Slow]", func() {
 	})
 })
 
-func createResizableStorageClass(t testsuites.StorageClassTest, ns string, suffix string, c clientset.Interface) (*storage.StorageClass, error) {
+func createStorageClass(t testsuites.StorageClassTest, ns string, suffix string, c clientset.Interface) (*storage.StorageClass, error) {
 	stKlass := newStorageClass(t, ns, suffix)
-	allowExpansion := true
-	stKlass.AllowVolumeExpansion = &allowExpansion
 
 	var err error
 	stKlass, err = c.StorageV1().StorageClasses().Create(stKlass)

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -1063,7 +1063,11 @@ func newStorageClass(t testsuites.StorageClassTest, ns string, suffix string) *s
 	if t.DelayBinding {
 		bindingMode = storage.VolumeBindingWaitForFirstConsumer
 	}
-	return getStorageClass(pluginName, t.Parameters, &bindingMode, ns, suffix)
+	sc := getStorageClass(pluginName, t.Parameters, &bindingMode, ns, suffix)
+	if t.AllowVolumeExpansion {
+		sc.AllowVolumeExpansion = &t.AllowVolumeExpansion
+	}
+	return sc
 }
 
 func getStorageClass(


### PR DESCRIPTION
Add a e2e for disallowed volume expansion. Also refactor some of the code around creation of SC.

Also remove `[Slow]` from resizing tests because they aren't slow anymore.  On AWS after https://github.com/kubernetes/kubernetes/pull/66728 was merged, they became fast and they were quite fast already on GCE.


/sig storage

cc @jsafrane @wongma7 