### PR TITLE
Fit RuntimeClass metrics to prometheus conventions

### DIFF
--- a/pkg/kubelet/kuberuntime/instrumented_services.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services.go
@@ -183,7 +183,7 @@ func (in instrumentedRuntimeService) RunPodSandbox(config *runtimeapi.PodSandbox
 	const operation = "run_podsandbox"
 	startTime := time.Now()
 	defer recordOperation(operation, startTime)
-	defer metrics.RunPodSandboxLatencies.WithLabelValues(runtimeHandler).Observe(metrics.SinceInMicroseconds(startTime))
+	defer metrics.RunPodSandboxDuration.WithLabelValues(runtimeHandler).Observe(metrics.SinceInSeconds(startTime))
 
 	out, err := in.service.RunPodSandbox(config, runtimeHandler)
 	recordError(operation, err)

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -80,8 +80,8 @@ const (
 	KubeletConfigKeyLabelKey      = "node_config_kubelet_key"
 
 	// Metrics keys for RuntimeClass
-	RunPodSandboxLatenciesKey = "run_podsandbox_latencies"
-	RunPodSandboxErrorsKey    = "run_podsandbox_errors"
+	RunPodSandboxDurationKey = "run_podsandbox_duration_seconds"
+	RunPodSandboxErrorsKey   = "run_podsandbox_errors_total"
 )
 
 var (
@@ -338,11 +338,13 @@ var (
 			Help:      "This metric is true (1) if the node is experiencing a configuration-related error, false (0) otherwise.",
 		},
 	)
-	RunPodSandboxLatencies = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	RunPodSandboxDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Subsystem: KubeletSubsystem,
-			Name:      RunPodSandboxLatenciesKey,
-			Help:      "Latencies in microseconds of the run_podsandbox operations. Broken down by RuntimeClass.",
+			Name:      RunPodSandboxDurationKey,
+			Help:      "Duration in seconds of the run_podsandbox operations. Broken down by RuntimeClass.",
+			// Use DefBuckets for now, will customize the buckets if necessary.
+			Buckets: prometheus.DefBuckets,
 		},
 		[]string{"runtime_handler"},
 	)
@@ -407,7 +409,7 @@ func SinceInMicroseconds(start time.Time) float64 {
 	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
 }
 
-// Gets the time since the specified start in seconds.
+// SinceInSeconds gets the time since the specified start in seconds.
 func SinceInSeconds(start time.Time) float64 {
 	return time.Since(start).Seconds()
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/pull/73549 added two RuntimeClass metrics, but does not follow prometheus conventions properly.
This PR aims to fix it:
1) Add suffix (`seconds` or `total`) to metric name 
2) Switch Summary metric to Histogram metric (Summary metrics are not
supported completely by prometheus-to-sd and can't be aggregated.)

**Which issue(s) this PR fixes**:
This PR is for #73058

```release-note
NONE
```
