### PR TITLE
e2e upgrade test: rename functions to match f0f78299348afcf770d4e8d89dcea82f80811b28

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -213,7 +213,7 @@ function setup-base-image() {
     
     source "${KUBE_ROOT}/cluster/gce/${NODE_OS_DISTRIBUTION}/node-helper.sh"
     # Reset the node image based on current os distro
-    set-node-image
+    set-linux-node-image
   fi
 }
 
@@ -263,12 +263,12 @@ function prepare-node-upgrade() {
 
   # TODO(zmerlynn): How do we ensure kube-env is written in a ${version}-
   #                 compatible way?
-  write-node-env
+  write-linux-node-env
 
   # TODO(zmerlynn): Get configure-vm script from ${version}. (Must plumb this
-  #                 through all create-node-instance-template implementations).
+  #                 through all create-linux-node-instance-template implementations).
   local template_name=$(get-template-name-from-version ${SANITIZED_VERSION})
-  create-node-instance-template "${template_name}"
+  create-linux-node-instance-template "${template_name}"
   # The following is echo'd so that callers can get the template name.
   echo "Instance template name: ${template_name}"
   echo "== Finished preparing node upgrade (to ${KUBE_VERSION}). ==" >&2


### PR DESCRIPTION
These functions were renamed in
f0f78299348afcf770d4e8d89dcea82f80811b28, but cluster/gce/upgrade.sh
was missed.

Issue #73705
Issue #73696

/kind bug

```release-note
NONE
```