### PR TITLE
Clarify hostname emptiness in CRI.

### DIFF
--- a/pkg/kubelet/apis/cri/runtime/v1alpha2/api.pb.go
+++ b/pkg/kubelet/apis/cri/runtime/v1alpha2/api.pb.go
@@ -736,7 +736,8 @@ type PodSandboxConfig struct {
 	// operation. The runtime may also use this information to improve UX, such
 	// as by constructing a readable name.
 	Metadata *PodSandboxMetadata `protobuf:"bytes,1,opt,name=metadata" json:"metadata,omitempty"`
-	// Hostname of the sandbox.
+	// Hostname of the sandbox. Hostname could only be empty when the pod
+	// network namespace is NODE.
 	Hostname string `protobuf:"bytes,2,opt,name=hostname,proto3" json:"hostname,omitempty"`
 	// Path to the directory on the host in which container log files are
 	// stored.

--- a/pkg/kubelet/apis/cri/runtime/v1alpha2/api.proto
+++ b/pkg/kubelet/apis/cri/runtime/v1alpha2/api.proto
@@ -313,7 +313,8 @@ message PodSandboxConfig {
     // operation. The runtime may also use this information to improve UX, such
     // as by constructing a readable name.
     PodSandboxMetadata metadata = 1;
-    // Hostname of the sandbox.
+    // Hostname of the sandbox. Hostname could only be empty when the pod
+    // network namespace is NODE.
     string hostname = 2;
     // Path to the directory on the host in which container log files are
     // stored.


### PR DESCRIPTION
Hostname can only be empty in CRI when using host network.

```release-note
none
```
