### PR TITLE
kubeadm: add a preflight check for Docker and cgroup driver

### DIFF
--- a/cmd/kubeadm/app/preflight/BUILD
+++ b/cmd/kubeadm/app/preflight/BUILD
@@ -10,6 +10,8 @@ go_library(
     name = "go_default_library",
     srcs = [
         "checks.go",
+        "checks_darwin.go",
+        "checks_linux.go",
         "checks_unix.go",
         "checks_windows.go",
         "utils.go",
@@ -33,7 +35,12 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//cmd/kubeadm/app/util:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_test(

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -226,6 +226,14 @@ func (IsPrivilegedUserCheck) Name() string {
 	return "IsPrivilegedUser"
 }
 
+// IsDockerSystemdCheck verifies if Docker is setup to use systemd as the cgroup driver.
+type IsDockerSystemdCheck struct{}
+
+// Name returns name for IsDockerSystemdCheck
+func (IsDockerSystemdCheck) Name() string {
+	return "IsDockerSystemdCheck"
+}
+
 // DirAvailableCheck checks if the given directory either does not exist, or is empty.
 type DirAvailableCheck struct {
 	Path  string
@@ -998,6 +1006,10 @@ func addCommonChecks(execer utilsexec.Interface, cfg kubeadmapi.CommonConfigurat
 		if containerRuntime.IsDocker() {
 			isDocker = true
 			checks = append(checks, ServiceCheck{Service: "docker", CheckIfActive: true})
+			// Linux only
+			// TODO: support other CRIs for this check eventually
+			// https://github.com/kubernetes/kubeadm/issues/874
+			checks = append(checks, IsDockerSystemdCheck{})
 		}
 	}
 

--- a/cmd/kubeadm/app/preflight/checks_darwin.go
+++ b/cmd/kubeadm/app/preflight/checks_darwin.go
@@ -1,0 +1,27 @@
+// +build darwin
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+// This is a MacOS stub
+
+// Check validates if Docker is setup to use systemd as the cgroup driver.
+// No-op for Darwin (MacOS).
+func (idsc IsDockerSystemdCheck) Check() (warnings, errorList []error) {
+	return nil, nil
+}

--- a/cmd/kubeadm/app/preflight/checks_linux.go
+++ b/cmd/kubeadm/app/preflight/checks_linux.go
@@ -1,0 +1,44 @@
+// +build linux
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util"
+	"k8s.io/utils/exec"
+)
+
+// Check validates if Docker is setup to use systemd as the cgroup driver.
+func (idsc IsDockerSystemdCheck) Check() (warnings, errorList []error) {
+	warnings = []error{}
+	driver, err := util.GetCgroupDriverDocker(exec.New())
+	if err != nil {
+		errorList = append(errorList, err)
+		return nil, errorList
+	}
+	if driver != util.CgroupDriverSystemd {
+		err = errors.Errorf("detected %q as the Docker cgroup driver. "+
+			"The recommended driver is %q. "+
+			"Please follow the guide at https://kubernetes.io/docs/setup/cri/",
+			driver,
+			util.CgroupDriverSystemd)
+		warnings = append(warnings, err)
+	}
+	return warnings, nil
+}

--- a/cmd/kubeadm/app/preflight/checks_windows.go
+++ b/cmd/kubeadm/app/preflight/checks_windows.go
@@ -43,3 +43,9 @@ func (ipuc IsPrivilegedUserCheck) Check() (warnings, errorList []error) {
 
 	return nil, errorList
 }
+
+// Check validates if Docker is setup to use systemd as the cgroup driver.
+// No-op for Windows.
+func (idsc IsDockerSystemdCheck) Check() (warnings, errorList []error) {
+	return nil, nil
+}

--- a/cmd/kubeadm/app/util/cgroupdriver.go
+++ b/cmd/kubeadm/app/util/cgroupdriver.go
@@ -24,6 +24,13 @@ import (
 	utilsexec "k8s.io/utils/exec"
 )
 
+const (
+	// CgroupDriverSystemd holds the systemd driver type
+	CgroupDriverSystemd = "systemd"
+	// CgroupDriverCgroupfs holds the cgroupfs driver type
+	CgroupDriverCgroupfs = "cgroupfs"
+)
+
 // TODO: add support for detecting the cgroup driver for CRI other than
 // Docker. Currently only Docker driver detection is supported:
 // Discussion:
@@ -39,7 +46,7 @@ func GetCgroupDriverDocker(execer utilsexec.Interface) (string, error) {
 }
 
 func validateCgroupDriver(driver string) error {
-	if driver != "cgroupfs" && driver != "systemd" {
+	if driver != CgroupDriverCgroupfs && driver != CgroupDriverSystemd {
 		return errors.Errorf("unknown cgroup driver %q", driver)
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
systemd is the recommended driver as per the setup of running
the kubelet using systemd as the init system. Add a preflight
check that throws a warning if this isn't the case.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref kubernetes/kubeadm#1394

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: add a preflight check that throws a warning if the cgroup driver for Docker on Linux is not "systemd" as per the k8s.io CRI installation guide.
```

/assign @timothysc 
/cc @rosti 
cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/kind bug
/priority critical-urgent

can be of `kind feature` too.
