### PR TITLE
Fix linting in cmd/kubemark package

### DIFF
--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -49,7 +49,7 @@ import (
 	fakeexec "k8s.io/utils/exec/testing"
 )
 
-type HollowNodeConfig struct {
+type hollowNodeConfig struct {
 	KubeconfigPath       string
 	KubeletPort          int
 	KubeletReadOnlyPort  int
@@ -71,7 +71,7 @@ const (
 // and make the config driven.
 var knownMorphs = sets.NewString("kubelet", "proxy")
 
-func (c *HollowNodeConfig) addFlags(fs *pflag.FlagSet) {
+func (c *hollowNodeConfig) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.KubeconfigPath, "kubeconfig", "/kubeconfig/kubeconfig", "Path to kubeconfig file.")
 	fs.IntVar(&c.KubeletPort, "kubelet-port", 10250, "Port on which HollowKubelet should be listening.")
 	fs.IntVar(&c.KubeletReadOnlyPort, "kubelet-read-only-port", 10255, "Read-only port on which Kubelet is listening.")
@@ -84,7 +84,7 @@ func (c *HollowNodeConfig) addFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&c.ProxierMinSyncPeriod, "proxier-min-sync-period", 0, "Minimum period that proxy rules are refreshed in hollow-proxy.")
 }
 
-func (c *HollowNodeConfig) createClientConfigFromFile() (*restclient.Config, error) {
+func (c *hollowNodeConfig) createClientConfigFromFile() (*restclient.Config, error) {
 	clientConfig, err := clientcmd.LoadFromFile(c.KubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("error while loading kubeconfig from file %v: %v", c.KubeconfigPath, err)
@@ -121,7 +121,7 @@ func main() {
 
 // newControllerManagerCommand creates a *cobra.Command object with default parameters
 func newHollowNodeCommand() *cobra.Command {
-	s := &HollowNodeConfig{}
+	s := &hollowNodeConfig{}
 
 	cmd := &cobra.Command{
 		Use:  "kubemark",
@@ -136,7 +136,7 @@ func newHollowNodeCommand() *cobra.Command {
 	return cmd
 }
 
-func run(config *HollowNodeConfig) {
+func run(config *hollowNodeConfig) {
 	if !knownMorphs.Has(config.Morph) {
 		klog.Fatalf("Unknown morph: %v. Allowed values: %v", config.Morph, knownMorphs.List())
 	}

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -9,7 +9,6 @@ cmd/kubeadm/app/util/config
 cmd/kubeadm/app/util/system
 cmd/kubelet/app
 cmd/kubelet/app/options
-cmd/kubemark
 pkg/apis/abac/latest
 pkg/apis/admission
 pkg/apis/admission/v1beta1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes linting issue in cmd/kubemark package by making the HollowNodeConfig private as it was unused outside the package. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
 `Fixes (https://github.com/kubernetes/kubernetes/issues/68026)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes (https://github.com/kubernetes/kubernetes/issues/68026)

**Special notes for your reviewer**:
I have intentionally made the PR short as this is my first PR. :)

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
