### PR TITLE
Limit the list of scheduling maintainers to active members of the sig

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -125,13 +125,11 @@ aliases:
   sig-storage-reviewers:
     - saad-ali
     - childsb
+
   sig-scheduling-maintainers:
     - bsalamat
-    - davidopp
     - k82cn
-    - timothysc
     - wojtek-t
-    - aveshagarwal
     - ravisantoshgudimetla
   sig-scheduling:
     - bsalamat
@@ -141,6 +139,7 @@ aliases:
     - misterikkit
     - Huang-Wei
     - wgliang
+
   sig-cli-maintainers:
     - adohe
     - brendandburns


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig scheduling
