### PR TITLE
Use kube::util::array_contains() in hack

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -36,18 +36,6 @@ go install k8s.io/kubernetes/vendor/golang.org/x/lint/golint
 
 cd "${KUBE_ROOT}"
 
-array_contains () {
-    local seeking=$1; shift # shift will iterate through the array
-    local in=1 # in holds the exit status for the function
-    for element; do
-        if [[ "$element" == "$seeking" ]]; then
-            in=0 # set in to 0 since we found it
-            break
-        fi
-    done
-    return $in
-}
-
 # Check that the file is in alphabetical order
 failure_file="${KUBE_ROOT}/hack/.golint_failures"
 kube::util::check-file-in-alphabetical-order "${failure_file}"
@@ -76,7 +64,7 @@ for p in "${all_packages[@]}"; do
   # Ref: https://github.com/kubernetes/kubernetes/pull/67675
   # Ref: https://github.com/golang/lint/issues/68
   failedLint=$(ls "$p"/*.go | egrep -v "(zz_generated.*.go|generated.pb.go|generated.proto|types_swagger_doc_generated.go)" | xargs -L1 golint 2>/dev/null)
-  array_contains "$p" "${failing_packages[@]}" && in_failing=$? || in_failing=$?
+  kube::util::array_contains "$p" "${failing_packages[@]}" && in_failing=$? || in_failing=$?
   if [[ -n "${failedLint}" ]] && [[ "${in_failing}" -ne "0" ]]; then
     errors+=( "${failedLint}" )
   fi
@@ -88,7 +76,7 @@ done
 # Check that all failing_packages actually still exist
 gone=()
 for p in "${failing_packages[@]}"; do
-  array_contains "$p" "${all_packages[@]}" || gone+=( "$p" )
+  kube::util::array_contains "$p" "${all_packages[@]}" || gone+=( "$p" )
 done
 
 # Check to be sure all the packages that should pass lint are.

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -88,20 +88,6 @@ while IFS=$'\n' read -r script;
   do failing_files+=("$script");
 done < <(cat "${failure_file}")
 
-# TODO(bentheelder): we should probably move this and the copy in verify-golint.sh
-# to one of the bash libs
-array_contains () {
-  local seeking=$1; shift # shift will iterate through the array
-  local in=1 # in holds the exit status for the function
-  for element; do
-    if [[ "$element" == "$seeking" ]]; then
-      in=0 # set in to 0 since we found it
-      break
-    fi
-  done
-  return $in
-}
-
 # detect if the host machine has the required shellcheck version installed
 # if so, we will use that instead.
 HAVE_SHELLCHECK=false
@@ -143,7 +129,7 @@ for f in "${all_shell_scripts[@]}"; do
                  shellcheck --exclude="${SHELLCHECK_DISABLED}" "${f}")
   fi  
   set -o errexit
-  array_contains "${f}" "${failing_files[@]}" && in_failing=$? || in_failing=$?
+  kube::util::array_contains "${f}" "${failing_files[@]}" && in_failing=$? || in_failing=$?
   if [[ -n "${failedLint}" ]] && [[ "${in_failing}" -ne "0" ]]; then
     errors+=( "${failedLint}" )
   fi
@@ -185,7 +171,7 @@ fi
 # Check that all failing_packages actually still exist
 gone=()
 for f in "${failing_files[@]}"; do
-  array_contains "$f" "${all_shell_scripts[@]}" || gone+=( "$f" )
+  kube::util::array_contains "$f" "${all_shell_scripts[@]}" || gone+=( "$f" )
 done
 
 if [[ ${#gone[@]} -gt 0 ]]; then


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The common kube::util::array_contains() is already there, so this
makes both scripts use it.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
NONE
```
