### PR TITLE
Remove \0 in zone key

### DIFF
--- a/pkg/controller/testutil/test_utils.go
+++ b/pkg/controller/testutil/test_utils.go
@@ -490,7 +490,7 @@ func GetZones(nodeHandler *FakeNodeHandler) []string {
 
 // CreateZoneID returns a single zoneID for a given region and zone.
 func CreateZoneID(region, zone string) string {
-	return region + ":\x00:" + zone
+	return region + "::" + zone
 }
 
 // GetKey is a helper function used by controllers unit tests to get the

--- a/pkg/scheduler/internal/cache/node_tree_test.go
+++ b/pkg/scheduler/internal/cache/node_tree_test.go
@@ -146,22 +146,22 @@ func TestNodeTree_AddNode(t *testing.T) {
 			name:       "mix of nodes with and without proper labels",
 			nodesToAdd: allNodes[:4],
 			expectedTree: map[string]*nodeArray{
-				"":                     {[]string{"node-0"}, 0},
-				"region-1:\x00:":       {[]string{"node-1"}, 0},
-				":\x00:zone-2":         {[]string{"node-2"}, 0},
-				"region-1:\x00:zone-2": {[]string{"node-3"}, 0},
+				"":                 {[]string{"node-0"}, 0},
+				"region-1::":       {[]string{"node-1"}, 0},
+				"::zone-2":         {[]string{"node-2"}, 0},
+				"region-1::zone-2": {[]string{"node-3"}, 0},
 			},
 		},
 		{
 			name:       "mix of nodes with and without proper labels and some zones with multiple nodes",
 			nodesToAdd: allNodes[:7],
 			expectedTree: map[string]*nodeArray{
-				"":                     {[]string{"node-0"}, 0},
-				"region-1:\x00:":       {[]string{"node-1"}, 0},
-				":\x00:zone-2":         {[]string{"node-2"}, 0},
-				"region-1:\x00:zone-2": {[]string{"node-3", "node-4"}, 0},
-				"region-1:\x00:zone-3": {[]string{"node-5"}, 0},
-				"region-2:\x00:zone-2": {[]string{"node-6"}, 0},
+				"":                 {[]string{"node-0"}, 0},
+				"region-1::":       {[]string{"node-1"}, 0},
+				"::zone-2":         {[]string{"node-2"}, 0},
+				"region-1::zone-2": {[]string{"node-3", "node-4"}, 0},
+				"region-1::zone-3": {[]string{"node-5"}, 0},
+				"region-2::zone-2": {[]string{"node-6"}, 0},
 			},
 		},
 	}
@@ -190,11 +190,11 @@ func TestNodeTree_RemoveNode(t *testing.T) {
 			existingNodes: allNodes[:7],
 			nodesToRemove: allNodes[:1],
 			expectedTree: map[string]*nodeArray{
-				"region-1:\x00:":       {[]string{"node-1"}, 0},
-				":\x00:zone-2":         {[]string{"node-2"}, 0},
-				"region-1:\x00:zone-2": {[]string{"node-3", "node-4"}, 0},
-				"region-1:\x00:zone-3": {[]string{"node-5"}, 0},
-				"region-2:\x00:zone-2": {[]string{"node-6"}, 0},
+				"region-1::":       {[]string{"node-1"}, 0},
+				"::zone-2":         {[]string{"node-2"}, 0},
+				"region-1::zone-2": {[]string{"node-3", "node-4"}, 0},
+				"region-1::zone-3": {[]string{"node-5"}, 0},
+				"region-2::zone-2": {[]string{"node-6"}, 0},
 			},
 		},
 		{
@@ -202,10 +202,10 @@ func TestNodeTree_RemoveNode(t *testing.T) {
 			existingNodes: allNodes[:7],
 			nodesToRemove: allNodes[1:4],
 			expectedTree: map[string]*nodeArray{
-				"":                     {[]string{"node-0"}, 0},
-				"region-1:\x00:zone-2": {[]string{"node-4"}, 0},
-				"region-1:\x00:zone-3": {[]string{"node-5"}, 0},
-				"region-2:\x00:zone-2": {[]string{"node-6"}, 0},
+				"":                 {[]string{"node-0"}, 0},
+				"region-1::zone-2": {[]string{"node-4"}, 0},
+				"region-1::zone-3": {[]string{"node-5"}, 0},
+				"region-2::zone-2": {[]string{"node-6"}, 0},
 			},
 		},
 		{
@@ -257,11 +257,11 @@ func TestNodeTree_UpdateNode(t *testing.T) {
 				},
 			},
 			expectedTree: map[string]*nodeArray{
-				"region-1:\x00:":       {[]string{"node-1"}, 0},
-				":\x00:zone-2":         {[]string{"node-2"}, 0},
-				"region-1:\x00:zone-2": {[]string{"node-3", "node-4", "node-0"}, 0},
-				"region-1:\x00:zone-3": {[]string{"node-5"}, 0},
-				"region-2:\x00:zone-2": {[]string{"node-6"}, 0},
+				"region-1::":       {[]string{"node-1"}, 0},
+				"::zone-2":         {[]string{"node-2"}, 0},
+				"region-1::zone-2": {[]string{"node-3", "node-4", "node-0"}, 0},
+				"region-1::zone-3": {[]string{"node-5"}, 0},
+				"region-2::zone-2": {[]string{"node-6"}, 0},
 			},
 		},
 		{
@@ -277,7 +277,7 @@ func TestNodeTree_UpdateNode(t *testing.T) {
 				},
 			},
 			expectedTree: map[string]*nodeArray{
-				"region-1:\x00:zone-2": {[]string{"node-0"}, 0},
+				"region-1::zone-2": {[]string{"node-0"}, 0},
 			},
 		},
 		{
@@ -293,8 +293,8 @@ func TestNodeTree_UpdateNode(t *testing.T) {
 				},
 			},
 			expectedTree: map[string]*nodeArray{
-				"":                     {[]string{"node-0"}, 0},
-				"region-1:\x00:zone-2": {[]string{"node-new"}, 0},
+				"":                 {[]string{"node-0"}, 0},
+				"region-1::zone-2": {[]string{"node-new"}, 0},
 			},
 		},
 	}

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -152,10 +152,7 @@ func GetZoneKey(node *v1.Node) string {
 		return ""
 	}
 
-	// We include the null character just in case region or failureDomain has a colon
-	// (We do assume there's no null characters in a region or failureDomain)
-	// As a nice side-benefit, the null character is not printed by fmt.Print or glog
-	return region + ":\x00:" + failureDomain
+	return region + "::" + failureDomain
 }
 
 // SetNodeCondition updates specific node condition with patch operation.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Controller's prometheus endpoint has \0.

```
node_collector_evictions_number{zone="us-east-1:^@:us-east-1a"} 1
node_collector_evictions_number{zone="us-east-1:^@:us-east-1b"} 3
node_collector_evictions_number{zone="us-east-1:^@:us-east-1e"} 4
# HELP node_collector_unhealthy_nodes_in_zone Gauge measuring number of not Ready Nodes per zones.
# TYPE node_collector_unhealthy_nodes_in_zone gauge
node_collector_unhealthy_nodes_in_zone{zone="us-east-1:^@:us-east-1a"} 0
node_collector_unhealthy_nodes_in_zone{zone="us-east-1:^@:us-east-1b"} 0
node_collector_unhealthy_nodes_in_zone{zone="us-east-1:^@:us-east-1e"} 0
# HELP node_collector_zone_health Gauge measuring percentage of healthy nodes per zone.
# TYPE node_collector_zone_health gauge
node_collector_zone_health{zone="us-east-1:^@:us-east-1a"} 100
node_collector_zone_health{zone="us-east-1:^@:us-east-1b"} 100
node_collector_zone_health{zone="us-east-1:^@:us-east-1e"} 100
# HELP node_collector_zone_size Gauge measuring number of registered Nodes per zones.
# TYPE node_collector_zone_size gauge
node_collector_zone_size{zone="us-east-1:^@:us-east-1a"} 383
node_collector_zone_size{zone="us-east-1:^@:us-east-1b"} 383
node_collector_zone_size{zone="us-east-1:^@:us-east-1e"} 381
```

https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
That is not conformant to prometheus's allowed characters.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #73867

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove \0 in CreateZoneID as it gets emitted as metric (not valid Prometheus label) 
```
/sig cluster-lifecycle