### PR TITLE
Skip validation for clusterCIDR in node ipam controller.

### DIFF
--- a/pkg/controller/nodeipam/node_ipam_controller.go
+++ b/pkg/controller/nodeipam/node_ipam_controller.go
@@ -106,13 +106,12 @@ func NewNodeIpamController(
 		metrics.RegisterMetricAndTrackRateLimiterUsage("node_ipam_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
 	}
 
-	if clusterCIDR == nil {
-		klog.Fatal("Controller: Must specify --cluster-cidr if --allocate-node-cidrs is set")
-	}
-	mask := clusterCIDR.Mask
 	if allocatorType != ipam.CloudAllocatorType {
 		// Cloud CIDR allocator does not rely on clusterCIDR or nodeCIDRMaskSize for allocation.
-		if maskSize, _ := mask.Size(); maskSize > nodeCIDRMaskSize {
+		if clusterCIDR == nil {
+			klog.Fatal("Controller: Must specify --cluster-cidr if --allocate-node-cidrs is set")
+		}
+		if maskSize, _ := clusterCIDR.Mask.Size(); maskSize > nodeCIDRMaskSize {
 			klog.Fatal("Controller: Invalid --cluster-cidr, mask size of cluster CIDR must be less than --node-cidr-mask-size")
 		}
 	}

--- a/pkg/controller/nodeipam/node_ipam_controller_test.go
+++ b/pkg/controller/nodeipam/node_ipam_controller_test.go
@@ -70,7 +70,8 @@ func TestNewNodeIpamControllerWithCIDRMasks(t *testing.T) {
 		{"valid_cloud_allocator", "10.0.0.0/21", "10.1.0.0/21", 24, ipam.CloudAllocatorType, false},
 		{"valid_ipam_from_cluster", "10.0.0.0/21", "10.1.0.0/21", 24, ipam.IPAMFromClusterAllocatorType, false},
 		{"valid_ipam_from_cloud", "10.0.0.0/21", "10.1.0.0/21", 24, ipam.IPAMFromCloudAllocatorType, false},
-		{"invalid_cluster_CIDR", "invalid", "10.1.0.0/21", 24, ipam.CloudAllocatorType, true},
+		{"valid_skip_cluster_CIDR_validation_for_cloud_allocator", "invalid", "10.1.0.0/21", 24, ipam.CloudAllocatorType, false},
+		{"invalid_cluster_CIDR", "invalid", "10.1.0.0/21", 24, ipam.IPAMFromClusterAllocatorType, true},
 		{"valid_CIDR_smaller_than_mask_cloud_allocator", "10.0.0.0/26", "10.1.0.0/21", 24, ipam.CloudAllocatorType, false},
 		{"invalid_CIDR_smaller_than_mask_other_allocators", "10.0.0.0/26", "10.1.0.0/21", 24, ipam.IPAMFromCloudAllocatorType, true},
 	} {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When CIDRAllocationType == ipam.CloudAllocatorType, clusterCIDR will not be used but decided at the cloud provider side. Thus we should not validate against clusterCIDR, and allow clusters with an nil clusterCIDR.

clusterCIDR is passed down from kube_env CLUSTER_IP_RANGE to the flag --cluster-cidr.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
None
```

/assign @freehan 
