### PR TITLE
Make CRD column printers consistent with typed printers

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/table/table.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/table/table.go
@@ -67,5 +67,5 @@ func ConvertToHumanReadableDateType(timestamp metav1.Time) string {
 	if timestamp.IsZero() {
 		return "<unknown>"
 	}
-	return duration.ShortHumanDuration(time.Now().Sub(timestamp.Time))
+	return duration.HumanDuration(time.Now().Sub(timestamp.Time))
 }


### PR DESCRIPTION
Almost all other server side printers use duration.HumanDuration
which has higher precision output. Switch CRD printers to use this
as well.


/kind bug

```release-note
NONE
```