### PR TITLE
Improve in-cluster-client-conf client-go docs

### DIFF
--- a/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/README.md
+++ b/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/README.md
@@ -25,7 +25,9 @@ build the image on Minikube:
     docker build -t in-cluster .
 
 If you are not using Minikube, you should build this image and push it to a registry
-that your Kubernetes cluster can pull from. If you have RBAC enabled, use the following
+that your Kubernetes cluster can pull from.
+
+If you have RBAC enabled on your cluster, use the following
 snippet to create role binding which will grant the default service account view
 permissions.
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Make a small formatting change to make it clear that you must take the
RBAC actions regardless of whether you're using Minikube or not.

**Which issue(s) this PR fixes**:
Fixes #73796 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
