### PR TITLE
generated_files: remove line about /docs/.generated_docs (fix PR size plugin)

### DIFF
--- a/.generated_files
+++ b/.generated_files
@@ -25,5 +25,3 @@ file-name	types_swagger_doc_generated.go
 path-prefix	Godeps/
 path-prefix	vendor/
 path-prefix	pkg/generated/
-
-paths-from-repo	docs/.generated_docs


### PR DESCRIPTION
**What this PR does / why we need it**:

after https://github.com/kubernetes/kubernetes/pull/70052 was merged @cjwagner found that a certain line in `/.generated_files` has to be removed too:
https://github.com/kubernetes/kubernetes/pull/70052#issuecomment-462196779

remove the line in question.

> Until this is merged the `size` plugin will fail to apply and update `size/*` labels on all PRs in the k/k repo.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @cjwagner @spiffxp 
/kind cleanup
/kind failing-test
/priority important-longterm
/sig testing
