### PR TITLE
Upgrade tests don't tolerate nodes with taints correctly

### DIFF
--- a/test/e2e/upgrades/apparmor.go
+++ b/test/e2e/upgrades/apparmor.go
@@ -66,7 +66,7 @@ func (t *AppArmorUpgradeTest) Setup(f *framework.Framework) {
 // pod can still consume the secret.
 func (t *AppArmorUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade UpgradeType) {
 	<-done
-	if upgrade == MasterUpgrade {
+	if upgrade == MasterUpgrade || upgrade == ClusterUpgrade {
 		t.verifyPodStillUp(f)
 	}
 	t.verifyNodesAppArmorEnabled(f)

--- a/test/e2e/upgrades/apps/daemonsets.go
+++ b/test/e2e/upgrades/apps/daemonsets.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -59,6 +59,9 @@ func (t *DaemonSetUpgradeTest) Setup(f *framework.Framework) {
 					Labels: labelSet,
 				},
 				Spec: v1.PodSpec{
+					Tolerations: []v1.Toleration{
+						{Operator: v1.TolerationOpExists},
+					},
 					Containers: []v1.Container{
 						{
 							Name:  daemonSetName,

--- a/test/e2e/upgrades/ingress.go
+++ b/test/e2e/upgrades/ingress.go
@@ -115,7 +115,7 @@ func (t *IngressUpgradeTest) Setup(f *framework.Framework) {
 // with a connectvity check to the loadbalancer ip.
 func (t *IngressUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade UpgradeType) {
 	switch upgrade {
-	case MasterUpgrade:
+	case MasterUpgrade, ClusterUpgrade:
 		// Restarting the ingress controller shouldn't disrupt a steady state
 		// Ingress. Restarting the ingress controller and deleting ingresses
 		// while it's down will leak cloud resources, because the ingress

--- a/test/e2e/upgrades/nvidia-gpu.go
+++ b/test/e2e/upgrades/nvidia-gpu.go
@@ -20,7 +20,7 @@ import (
 	"regexp"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/scheduling"
@@ -50,7 +50,7 @@ func (t *NvidiaGPUUpgradeTest) Test(f *framework.Framework, done <-chan struct{}
 	<-done
 	By("Verifying gpu job success")
 	t.verifyJobPodSuccess(f)
-	if upgrade == MasterUpgrade {
+	if upgrade == MasterUpgrade || upgrade == ClusterUpgrade {
 		// MasterUpgrade should be totally hitless.
 		job, err := framework.GetJob(f.ClientSet, f.Namespace.Name, "cuda-add")
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/upgrades/services.go
+++ b/test/e2e/upgrades/services.go
@@ -17,7 +17,7 @@ limitations under the License.
 package upgrades
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -77,7 +77,7 @@ func (t *ServiceUpgradeTest) Setup(f *framework.Framework) {
 // Test runs a connectivity check to the service.
 func (t *ServiceUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade UpgradeType) {
 	switch upgrade {
-	case MasterUpgrade:
+	case MasterUpgrade, ClusterUpgrade:
 		t.test(f, done, true)
 	case NodeUpgrade:
 		// Node upgrades should test during disruption only on GCE/GKE for now.

--- a/test/e2e/upgrades/sysctl.go
+++ b/test/e2e/upgrades/sysctl.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -52,7 +52,7 @@ func (t *SysctlUpgradeTest) Setup(f *framework.Framework) {
 func (t *SysctlUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade UpgradeType) {
 	<-done
 	switch upgrade {
-	case MasterUpgrade:
+	case MasterUpgrade, ClusterUpgrade:
 		By("Checking the safe sysctl pod keeps running on master upgrade")
 		pod, err := f.ClientSet.CoreV1().Pods(t.validPod.Namespace).Get(t.validPod.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The daemonset test should tolerate taints, and ClusterUpgrade type
should be treated equivalent to MasterUpgrade type.

/kind bug

```release-note
NONE
```