### PR TITLE
Improve windows home directory selection

### DIFF
--- a/staging/src/k8s.io/client-go/util/homedir/homedir.go
+++ b/staging/src/k8s.io/client-go/util/homedir/homedir.go
@@ -18,30 +18,75 @@ package homedir
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 )
 
-// HomeDir returns the home directory for the current user
+// HomeDir returns the home directory for the current user.
+// On Windows:
+// 1. the first of %HOME%, %HOMEDRIVE%%HOMEPATH%, %USERPROFILE% containing a `.kube\config` file is returned.
+// 2. if none of those locations contain a `.kube\config` file, the first of %HOME%, %USERPROFILE%, %HOMEDRIVE%%HOMEPATH% that exists and is writeable is returned.
+// 3. if none of those locations are writeable, the first of %HOME%, %USERPROFILE%, %HOMEDRIVE%%HOMEPATH% that exists is returned.
+// 4. if none of those locations exists, the first of %HOME%, %USERPROFILE%, %HOMEDRIVE%%HOMEPATH% that is set is returned.
 func HomeDir() string {
 	if runtime.GOOS == "windows" {
-
-		// First prefer the HOME environmental variable
-		if home := os.Getenv("HOME"); len(home) > 0 {
-			if _, err := os.Stat(home); err == nil {
-				return home
-			}
-		}
+		home := os.Getenv("HOME")
+		homeDriveHomePath := ""
 		if homeDrive, homePath := os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"); len(homeDrive) > 0 && len(homePath) > 0 {
-			homeDir := homeDrive + homePath
-			if _, err := os.Stat(homeDir); err == nil {
-				return homeDir
+			homeDriveHomePath = homeDrive + homePath
+		}
+		userProfile := os.Getenv("USERPROFILE")
+
+		// Return first of %HOME%, %HOMEDRIVE%/%HOMEPATH%, %USERPROFILE% that contains a `.kube\config` file.
+		// %HOMEDRIVE%/%HOMEPATH% is preferred over %USERPROFILE% for backwards-compatibility.
+		for _, p := range []string{home, homeDriveHomePath, userProfile} {
+			if len(p) == 0 {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(p, ".kube", "config")); err != nil {
+				continue
+			}
+			return p
+		}
+
+		firstSetPath := ""
+		firstExistingPath := ""
+
+		// Prefer %USERPROFILE% over %HOMEDRIVE%/%HOMEPATH% for compatibility with other auth-writing tools
+		for _, p := range []string{home, userProfile, homeDriveHomePath} {
+			if len(p) == 0 {
+				continue
+			}
+			if len(firstSetPath) == 0 {
+				// remember the first path that is set
+				firstSetPath = p
+			}
+			info, err := os.Stat(p)
+			if err != nil {
+				continue
+			}
+			if len(firstExistingPath) == 0 {
+				// remember the first path that exists
+				firstExistingPath = p
+			}
+			if info.IsDir() && info.Mode().Perm()&(1<<(uint(7))) != 0 {
+				// return first path that is writeable
+				return p
 			}
 		}
-		if userProfile := os.Getenv("USERPROFILE"); len(userProfile) > 0 {
-			if _, err := os.Stat(userProfile); err == nil {
-				return userProfile
-			}
+
+		// If none are writeable, return first location that exists
+		if len(firstExistingPath) > 0 {
+			return firstExistingPath
 		}
+
+		// If none exist, return first location that is set
+		if len(firstSetPath) > 0 {
+			return firstSetPath
+		}
+
+		// We've got nothing
+		return ""
 	}
 	return os.Getenv("HOME")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Alternative to https://github.com/kubernetes/kubernetes/pull/67403

Improves the selected home directory on windows, while maintaining compatibility with existing configurations that already point at a location containing a kubeconfig file, or a user-writeable directory.

**Which issue(s) this PR fixes**:
Fixes #61946

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
On Windows systems, %USERPROFILE% is now preferred over %HOMEDRIVE%\%HOMEPATH% as the home folder if %HOMEDRIVE%\%HOMEPATH% does not contain a .kube\config file, and %USERPROFILE% exists and is writeable.
```

/sig windows
