### PR TITLE
Warn / Thread through steps for  permissions fixing (pod security policy / fsGroup)

### DIFF
--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -320,7 +320,7 @@ func (c *csiMountMgr) applyFSGroup(fsType string, fsGroup *int64) error {
 			klog.V(4).Info(log("mounter.SetupAt WARNING: skipping fsGroup, fsType not provided"))
 			return nil
 		}
-		if supportsVolumeOwnership(c.readOnly, c.spec) {
+		if supportsVolumeOwnership(c.spec) {
 			klog.Infof("Setting ownership for %v (driver = %v)", c.volumeID, c.driverName)
 			err := volume.SetVolumeOwnership(c, fsGroup)
 			if err != nil {

--- a/pkg/volume/csi/csi_util.go
+++ b/pkg/volume/csi/csi_util.go
@@ -142,16 +142,17 @@ func hasReadWriteOnce(modes []api.PersistentVolumeAccessMode) bool {
 }
 
 // supportsVolumeOwnership encapsulates the logic for wether a volume ownership mode is set.
-func supportsVolumeOwnership(readOnly bool, volSpec *volume.Spec) bool {
-	if volSpec.PersistentVolume.Spec.AccessModes == nil {
+func supportsVolumeOwnership(volSpec *volume.Spec) bool {
+	accessModes := volSpec.PersistentVolume.Spec.AccessModes
+	if accessModes == nil {
 		klog.V(4).Info(log("mounter.SetupAt WARNING: skipping fsGroup, access modes not provided"))
 		return false
 	}
-	if !hasReadWriteOnce(volSpec.PersistentVolume.Spec.AccessModes) {
+	if !hasReadWriteOnce(accessModes) {
 		klog.V(4).Info(log("mounter.SetupAt WARNING: skipping fsGroup, only support ReadWriteOnce access mode"))
 		return false
 	}
-	if readOnly {
+	if volSpec.ReadOnly {
 		klog.V(4).Info(log("mounter.SetupAt WARNING: skipping fsGroup, volume is readOnly"))
 		return false
 	}

--- a/pkg/volume/csi/csi_util.go
+++ b/pkg/volume/csi/csi_util.go
@@ -140,3 +140,20 @@ func hasReadWriteOnce(modes []api.PersistentVolumeAccessMode) bool {
 	}
 	return false
 }
+
+// supportsVolumeOwnership encapsulates the logic for wether a volume ownership mode is set.
+func supportsVolumeOwnership(readOnly bool, volSpec *volume.Spec) bool {
+	if volSpec.PersistentVolume.Spec.AccessModes == nil {
+		klog.V(4).Info(log("mounter.SetupAt WARNING: skipping fsGroup, access modes not provided"))
+		return false
+	}
+	if !hasReadWriteOnce(volSpec.PersistentVolume.Spec.AccessModes) {
+		klog.V(4).Info(log("mounter.SetupAt WARNING: skipping fsGroup, only support ReadWriteOnce access mode"))
+		return false
+	}
+	if readOnly {
+		klog.V(4).Info(log("mounter.SetupAt WARNING: skipping fsGroup, volume is readOnly"))
+		return false
+	}
+	return true
+}

--- a/pkg/volume/volume_linux.go
+++ b/pkg/volume/volume_linux.go
@@ -51,15 +51,14 @@ func calculateMask(mounter Mounter, mode os.FileMode, dir bool) os.FileMode {
 // fsGroup, and sets SetGid so that newly created files are owned by
 // fsGroup. If fsGroup is nil nothing is done.
 func SetVolumeOwnership(mounter Mounter, fsGroup *int64) error {
-	path := mounter.GetPath()
-	klog.Infof("Setting volume ownership for %v to %v", path, fsGroup)
+	klog.Infof("Setting volume ownership for %v to %v", mounter.GetPath(), fsGroup)
 
 	if fsGroup == nil {
 		klog.Infof("No fsGroup specified! No permissions fixing will occur.")
 		return nil
 	}
 
-	klog.Infof("Fixing all permissions under %v file chmod/chown for group %v.", path, fsGroup)
+	klog.Infof("Fixing all permissions under %v file chmod/chown for group %v.", mounter.GetPath(), fsGroup)
 	return filepath.Walk(mounter.GetPath(), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/pkg/volume/volume_unsupported.go
+++ b/pkg/volume/volume_unsupported.go
@@ -18,6 +18,11 @@ limitations under the License.
 
 package volume
 
+import "k8s.io/klog"
+
+// SetVolumeOwnership for unsupported volumes does nothing.  For convention, if an in-tree
+// volume isnt actually setting ownership, it should call this function at the end of its "SetUpAt" implementation.
 func SetVolumeOwnership(mounter Mounter, fsGroup *int64) error {
+	klog.Infof("Warning: Skipped setting fsGroup (%v) volume at path %v.", fsGroup, mounter.GetPath())
 	return nil
 }


### PR DESCRIPTION
Creating a companion issue now.  As of now you cant see what the kubelet is actually doing when its mounting w/ perms.  So its a minor bug i guess.

```release-note

Made kubelet mount / fsgroup and PsP setup logging more explicit.

```
