### PR TITLE
Remove duplicate namespace constants from core/v1

### DIFF
--- a/pkg/controller/history/controller_history_test.go
+++ b/pkg/controller/history/controller_history_test.go
@@ -1639,7 +1639,7 @@ func newStatefulSet(replicas int, name string, uid types.UID, labels map[string]
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: v1.NamespaceDefault,
+			Namespace: metav1.NamespaceDefault,
 			UID:       uid,
 		},
 		Spec: apps.StatefulSetSpec{

--- a/pkg/controller/nodelifecycle/scheduler/taint_manager.go
+++ b/pkg/controller/nodelifecycle/scheduler/taint_manager.go
@@ -127,12 +127,12 @@ func getNoExecuteTaints(taints []v1.Taint) []v1.Taint {
 
 func getPodsAssignedToNode(c clientset.Interface, nodeName string) ([]v1.Pod, error) {
 	selector := fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName})
-	pods, err := c.CoreV1().Pods(v1.NamespaceAll).List(metav1.ListOptions{
+	pods, err := c.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{
 		FieldSelector: selector.String(),
 		LabelSelector: labels.Everything().String(),
 	})
 	for i := 0; i < retries && err != nil; i++ {
-		pods, err = c.CoreV1().Pods(v1.NamespaceAll).List(metav1.ListOptions{
+		pods, err = c.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{
 			FieldSelector: selector.String(),
 			LabelSelector: labels.Everything().String(),
 		})

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -344,7 +344,7 @@ func newStatefulSetWithVolumes(replicas int, name string, petMounts []v1.VolumeM
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: v1.NamespaceDefault,
+			Namespace: metav1.NamespaceDefault,
 			UID:       types.UID("test"),
 		},
 		Spec: apps.StatefulSetSpec{

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -156,7 +156,7 @@ func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2
 
 	stopCh := make(chan struct{})
 
-	pods, err := fakeKubeClient.Core().Pods(v1.NamespaceAll).List(metav1.ListOptions{})
+	pods, err := fakeKubeClient.Core().Pods(metav1.NamespaceAll).List(metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("Run failed with error. Expected: <no error> Actual: %v", err)
 	}

--- a/pkg/kubelet/dockershim/network/hostport/BUILD
+++ b/pkg/kubelet/dockershim/network/hostport/BUILD
@@ -40,6 +40,7 @@ go_test(
     deps = [
         "//pkg/util/iptables:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],

--- a/pkg/kubelet/dockershim/network/hostport/hostport_syncer_test.go
+++ b/pkg/kubelet/dockershim/network/hostport/hostport_syncer_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 )
 
@@ -51,7 +52,7 @@ func TestOpenPodHostports(t *testing.T) {
 		{
 			&PodPortMapping{
 				Name:        "test-pod",
-				Namespace:   v1.NamespaceDefault,
+				Namespace:   metav1.NamespaceDefault,
 				IP:          net.ParseIP("10.1.1.2"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{
@@ -104,7 +105,7 @@ func TestOpenPodHostports(t *testing.T) {
 		{
 			&PodPortMapping{
 				Name:        "another-test-pod",
-				Namespace:   v1.NamespaceDefault,
+				Namespace:   metav1.NamespaceDefault,
 				IP:          net.ParseIP("10.1.1.5"),
 				HostNetwork: false,
 				PortMappings: []*PortMapping{

--- a/pkg/kubelet/kubeletconfig/configsync.go
+++ b/pkg/kubelet/kubeletconfig/configsync.go
@@ -198,7 +198,7 @@ func restartForNewConfig(eventClient v1core.EventsGetter, nodeName string, sourc
 	// because the event recorder won't flush its queue before we exit (we'd lose the event)
 	event := makeEvent(nodeName, apiv1.EventTypeNormal, KubeletConfigChangedEventReason, message)
 	klog.V(3).Infof("Event(%#v): type: '%v' reason: '%v' %v", event.InvolvedObject, event.Type, event.Reason, event.Message)
-	if _, err := eventClient.Events(apiv1.NamespaceDefault).Create(event); err != nil {
+	if _, err := eventClient.Events(metav1.NamespaceDefault).Create(event); err != nil {
 		utillog.Errorf("failed to send event, error: %v", err)
 	}
 	utillog.Infof(message)

--- a/pkg/kubelet/util/sliceutils/sliceutils_test.go
+++ b/pkg/kubelet/util/sliceutils/sliceutils_test.go
@@ -54,7 +54,7 @@ func buildPodsByCreationTime() PodsByCreationTime {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo1",
-				Namespace: v1.NamespaceDefault,
+				Namespace: metav1.NamespaceDefault,
 				CreationTimestamp: metav1.Time{
 					Time: time.Now(),
 				},
@@ -63,7 +63,7 @@ func buildPodsByCreationTime() PodsByCreationTime {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo2",
-				Namespace: v1.NamespaceDefault,
+				Namespace: metav1.NamespaceDefault,
 				CreationTimestamp: metav1.Time{
 					Time: time.Now().Add(time.Hour * 1),
 				},
@@ -72,7 +72,7 @@ func buildPodsByCreationTime() PodsByCreationTime {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo3",
-				Namespace: v1.NamespaceDefault,
+				Namespace: metav1.NamespaceDefault,
 				CreationTimestamp: metav1.Time{
 					Time: time.Now().Add(time.Hour * 2),
 				},

--- a/pkg/master/reconcilers/lease.go
+++ b/pkg/master/reconcilers/lease.go
@@ -160,7 +160,7 @@ func (r *leaseEndpointReconciler) ReconcileEndpoints(serviceName string, ip net.
 }
 
 func (r *leaseEndpointReconciler) doReconcile(serviceName string, endpointPorts []corev1.EndpointPort, reconcilePorts bool) error {
-	e, err := r.endpointClient.Endpoints(corev1.NamespaceDefault).Get(serviceName, metav1.GetOptions{})
+	e, err := r.endpointClient.Endpoints(metav1.NamespaceDefault).Get(serviceName, metav1.GetOptions{})
 	shouldCreate := false
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -171,7 +171,7 @@ func (r *leaseEndpointReconciler) doReconcile(serviceName string, endpointPorts 
 		e = &corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      serviceName,
-				Namespace: corev1.NamespaceDefault,
+				Namespace: metav1.NamespaceDefault,
 			},
 		}
 	}
@@ -221,11 +221,11 @@ func (r *leaseEndpointReconciler) doReconcile(serviceName string, endpointPorts 
 
 	klog.Warningf("Resetting endpoints for master service %q to %v", serviceName, masterIPs)
 	if shouldCreate {
-		if _, err = r.endpointClient.Endpoints(corev1.NamespaceDefault).Create(e); errors.IsAlreadyExists(err) {
+		if _, err = r.endpointClient.Endpoints(metav1.NamespaceDefault).Create(e); errors.IsAlreadyExists(err) {
 			err = nil
 		}
 	} else {
-		_, err = r.endpointClient.Endpoints(corev1.NamespaceDefault).Update(e)
+		_, err = r.endpointClient.Endpoints(metav1.NamespaceDefault).Update(e)
 	}
 	return err
 }

--- a/pkg/master/reconcilers/lease_test.go
+++ b/pkg/master/reconcilers/lease_test.go
@@ -76,7 +76,7 @@ func (f *fakeLeases) GetUpdatedKeys() []string {
 }
 
 func TestLeaseEndpointReconciler(t *testing.T) {
-	ns := corev1.NamespaceDefault
+	ns := metav1.NamespaceDefault
 	om := func(name string) metav1.ObjectMeta {
 		return metav1.ObjectMeta{Namespace: ns, Name: name}
 	}
@@ -431,7 +431,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
 		}
-		actualEndpoints, err := clientset.CoreV1().Endpoints(corev1.NamespaceDefault).Get(test.serviceName, metav1.GetOptions{})
+		actualEndpoints, err := clientset.CoreV1().Endpoints(metav1.NamespaceDefault).Get(test.serviceName, metav1.GetOptions{})
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
 		}
@@ -531,7 +531,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			if err != nil {
 				t.Errorf("case %q: unexpected error: %v", test.testName, err)
 			}
-			actualEndpoints, err := clientset.CoreV1().Endpoints(corev1.NamespaceDefault).Get(test.serviceName, metav1.GetOptions{})
+			actualEndpoints, err := clientset.CoreV1().Endpoints(metav1.NamespaceDefault).Get(test.serviceName, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("case %q: unexpected error: %v", test.testName, err)
 			}
@@ -548,7 +548,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 }
 
 func TestLeaseStopReconciling(t *testing.T) {
-	ns := corev1.NamespaceDefault
+	ns := metav1.NamespaceDefault
 	om := func(name string) metav1.ObjectMeta {
 		return metav1.ObjectMeta{Namespace: ns, Name: name}
 	}
@@ -631,7 +631,7 @@ func TestLeaseStopReconciling(t *testing.T) {
 			if err != nil {
 				t.Errorf("case %q: unexpected error: %v", test.testName, err)
 			}
-			actualEndpoints, err := clientset.CoreV1().Endpoints(corev1.NamespaceDefault).Get(test.serviceName, metav1.GetOptions{})
+			actualEndpoints, err := clientset.CoreV1().Endpoints(metav1.NamespaceDefault).Get(test.serviceName, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("case %q: unexpected error: %v", test.testName, err)
 			}

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -24,10 +24,6 @@ import (
 )
 
 const (
-	// NamespaceDefault means the object is in the default namespace which is applied when not specified by clients
-	NamespaceDefault string = "default"
-	// NamespaceAll is the default argument to specify on a context when you want to list or filter resources across all namespaces
-	NamespaceAll string = ""
 	// NamespaceNodeLease is the namespace where we place node lease objects (used for node heartbeats)
 	NamespaceNodeLease string = "kube-node-lease"
 )

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/BUILD
@@ -19,8 +19,8 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/webhook",
     importpath = "k8s.io/apiserver/pkg/util/webhook",
     deps = [
-        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/authentication.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -47,7 +47,7 @@ func NewDefaultAuthenticationInfoResolverWrapper(
 				return delegate.ClientConfigFor(server)
 			},
 			ClientConfigForServiceFunc: func(serviceName, serviceNamespace string) (*rest.Config, error) {
-				if serviceName == "kubernetes" && serviceNamespace == corev1.NamespaceDefault {
+				if serviceName == "kubernetes" && serviceNamespace == metav1.NamespaceDefault {
 					return kubeapiserverClientConfig, nil
 				}
 				ret, err := delegate.ClientConfigForService(serviceName, serviceNamespace)

--- a/staging/src/k8s.io/client-go/examples/create-update-delete-deployment/main.go
+++ b/staging/src/k8s.io/client-go/examples/create-update-delete-deployment/main.go
@@ -60,7 +60,7 @@ func main() {
 		panic(err)
 	}
 
-	deploymentsClient := clientset.AppsV1().Deployments(apiv1.NamespaceDefault)
+	deploymentsClient := clientset.AppsV1().Deployments(metav1.NamespaceDefault)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -142,7 +142,7 @@ func main() {
 
 	// List Deployments
 	prompt()
-	fmt.Printf("Listing deployments in namespace %q:\n", apiv1.NamespaceDefault)
+	fmt.Printf("Listing deployments in namespace %q:\n", metav1.NamespaceDefault)
 	list, err := deploymentsClient.List(metav1.ListOptions{})
 	if err != nil {
 		panic(err)

--- a/staging/src/k8s.io/client-go/examples/workqueue/main.go
+++ b/staging/src/k8s.io/client-go/examples/workqueue/main.go
@@ -162,7 +162,7 @@ func main() {
 	}
 
 	// create the pod watcher
-	podListWatcher := cache.NewListWatchFromClient(clientset.CoreV1().RESTClient(), "pods", v1.NamespaceDefault, fields.Everything())
+	podListWatcher := cache.NewListWatchFromClient(clientset.CoreV1().RESTClient(), "pods", meta_v1.NamespaceDefault, fields.Everything())
 
 	// create the workqueue
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
@@ -203,7 +203,7 @@ func main() {
 	indexer.Add(&v1.Pod{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "mypod",
-			Namespace: v1.NamespaceDefault,
+			Namespace: meta_v1.NamespaceDefault,
 		},
 	})
 

--- a/test/e2e/apps/network_partition.go
+++ b/test/e2e/apps/network_partition.go
@@ -611,7 +611,7 @@ var _ = SIGDescribe("Network Partition [Disruptive] [Slow]", func() {
 				sleepTime := maxTolerationTime + 20*time.Second
 				By(fmt.Sprintf("Sleeping for %v and checking if all Pods were evicted", sleepTime))
 				time.Sleep(sleepTime)
-				pods, err = c.CoreV1().Pods(v1.NamespaceAll).List(podOpts)
+				pods, err = c.CoreV1().Pods(metav1.NamespaceAll).List(podOpts)
 				framework.ExpectNoError(err)
 				seenRunning := []string{}
 				for _, pod := range pods.Items {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Two namespace-related constants are duplicated in `core/v1` and `meta/v1` (`NamespaceDefault` and `NamespaceAll`). The versions from `core` were referenced about a dozen or so times before this change, while the versions from `meta` are referenced hundreds of times. This change removes the redundant constants in `core` and changes all references to `meta`.

**Special notes for your reviewer**:
Please note that this is my first contribution to K8s and I apologize for any steps I've missed.

There are a lot of broken unit tests at head; I _believe_ there are no remaining failures caused by this change but it's hard to be certain. The following integ tests pass: apimachinery, apiserver, client; the others are still running (when they complete successfully I'll update this description).

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
