### PR TITLE
Move all constants to a single `const (`

### DIFF
--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -16,104 +16,106 @@ limitations under the License.
 
 package options
 
-// APIServerAdvertiseAddress flag sets the IP address the API Server will advertise it's listening on. Specify '0.0.0.0' to use the address of the default network interface.
-const APIServerAdvertiseAddress = "apiserver-advertise-address"
+const (
+	// APIServerAdvertiseAddress flag sets the IP address the API Server will advertise it's listening on. Specify '0.0.0.0' to use the address of the default network interface.
+	APIServerAdvertiseAddress = "apiserver-advertise-address"
 
-// APIServerBindPort flag sets the port for the API Server to bind to.
-const APIServerBindPort = "apiserver-bind-port"
+	// APIServerBindPort flag sets the port for the API Server to bind to.
+	APIServerBindPort = "apiserver-bind-port"
 
-// APIServerCertSANs flag sets extra Subject Alternative Names (SANs) to use for the API Server serving certificate. Can be both IP addresses and DNS names.
-const APIServerCertSANs = "apiserver-cert-extra-sans"
+	// APIServerCertSANs flag sets extra Subject Alternative Names (SANs) to use for the API Server serving certificate. Can be both IP addresses and DNS names.
+	APIServerCertSANs = "apiserver-cert-extra-sans"
 
-// APIServerExtraArgs flag sets a extra flags to pass to the API Server or override default ones in form of <flagname>=<value>.
-const APIServerExtraArgs = "apiserver-extra-args"
+	// APIServerExtraArgs flag sets a extra flags to pass to the API Server or override default ones in form of <flagname>=<value>.
+	APIServerExtraArgs = "apiserver-extra-args"
 
-// CertificatesDir flag sets the path where to save and read the certificates.
-const CertificatesDir = "cert-dir"
+	// CertificatesDir flag sets the path where to save and read the certificates.
+	CertificatesDir = "cert-dir"
 
-// CfgPath flag sets the path to kubeadm config file.
-const CfgPath = "config"
+	// CfgPath flag sets the path to kubeadm config file.
+	CfgPath = "config"
 
-// ControllerManagerExtraArgs flag sets extra flags to pass to the Controller Manager or override default ones in form of <flagname>=<value>.
-const ControllerManagerExtraArgs = "controller-manager-extra-args"
+	// ControllerManagerExtraArgs flag sets extra flags to pass to the Controller Manager or override default ones in form of <flagname>=<value>.
+	ControllerManagerExtraArgs = "controller-manager-extra-args"
 
-// DryRun flag instruct kubeadm to don't apply any changes; just output what would be done.
-const DryRun = "dry-run"
+	// DryRun flag instruct kubeadm to don't apply any changes; just output what would be done.
+	DryRun = "dry-run"
 
-// FeatureGatesString flag sets key=value pairs that describe feature gates for various features.
-const FeatureGatesString = "feature-gates"
+	// FeatureGatesString flag sets key=value pairs that describe feature gates for various features.
+	FeatureGatesString = "feature-gates"
 
-// IgnorePreflightErrors sets the path a list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.
-const IgnorePreflightErrors = "ignore-preflight-errors"
+	// IgnorePreflightErrors sets the path a list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.
+	IgnorePreflightErrors = "ignore-preflight-errors"
 
-// ImageRepository sets the container registry to pull control plane images from.
-const ImageRepository = "image-repository"
+	// ImageRepository sets the container registry to pull control plane images from.
+	ImageRepository = "image-repository"
 
-// KubeconfigDir flag sets the path where to save the kubeconfig file.
-const KubeconfigDir = "kubeconfig-dir"
+	// KubeconfigDir flag sets the path where to save the kubeconfig file.
+	KubeconfigDir = "kubeconfig-dir"
 
-// KubeconfigPath flag sets the kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations are searched for an existing KubeConfig file.
-const KubeconfigPath = "kubeconfig"
+	// KubeconfigPath flag sets the kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations are searched for an existing KubeConfig file.
+	KubeconfigPath = "kubeconfig"
 
-// KubernetesVersion flag sets the Kubernetes version for the control plane.
-const KubernetesVersion = "kubernetes-version"
+	// KubernetesVersion flag sets the Kubernetes version for the control plane.
+	KubernetesVersion = "kubernetes-version"
 
-// NetworkingDNSDomain flag sets the domain for services, e.g. "myorg.internal".
-const NetworkingDNSDomain = "service-dns-domain"
+	// NetworkingDNSDomain flag sets the domain for services, e.g. "myorg.internal".
+	NetworkingDNSDomain = "service-dns-domain"
 
-// NetworkingServiceSubnet flag sets the range of IP address for service VIPs.
-const NetworkingServiceSubnet = "service-cidr"
+	// NetworkingServiceSubnet flag sets the range of IP address for service VIPs.
+	NetworkingServiceSubnet = "service-cidr"
 
-// NetworkingPodSubnet flag sets the range of IP addresses for the pod network. If set, the control plane will automatically allocate CIDRs for every node.
-const NetworkingPodSubnet = "pod-network-cidr"
+	// NetworkingPodSubnet flag sets the range of IP addresses for the pod network. If set, the control plane will automatically allocate CIDRs for every node.
+	NetworkingPodSubnet = "pod-network-cidr"
 
-// NodeCRISocket flag sets the CRI socket to connect to.
-const NodeCRISocket = "cri-socket"
+	// NodeCRISocket flag sets the CRI socket to connect to.
+	NodeCRISocket = "cri-socket"
 
-// NodeName flag sets the node name.
-const NodeName = "node-name"
+	// NodeName flag sets the node name.
+	NodeName = "node-name"
 
-// SchedulerExtraArgs flag sets extra flags to pass to the Scheduler or override default ones in form of <flagname>=<value>".
-const SchedulerExtraArgs = "scheduler-extra-args"
+	// SchedulerExtraArgs flag sets extra flags to pass to the Scheduler or override default ones in form of <flagname>=<value>".
+	SchedulerExtraArgs = "scheduler-extra-args"
 
-// SkipTokenPrint flag instruct kubeadm to skip printing of the default bootstrap token generated by 'kubeadm init'.
-const SkipTokenPrint = "skip-token-print"
+	// SkipTokenPrint flag instruct kubeadm to skip printing of the default bootstrap token generated by 'kubeadm init'.
+	SkipTokenPrint = "skip-token-print"
 
-// CSROnly flag instructs kubeadm to create CSRs instead of automatically creating or renewing certs
-const CSROnly = "csr-only"
+	// CSROnly flag instructs kubeadm to create CSRs instead of automatically creating or renewing certs
+	CSROnly = "csr-only"
 
-// CSRDir flag sets the location for CSRs and flags to be output
-const CSRDir = "csr-dir"
+	// CSRDir flag sets the location for CSRs and flags to be output
+	CSRDir = "csr-dir"
 
-// TokenStr flags sets both the discovery-token and the tls-bootstrap-token when those values are not provided
-const TokenStr = "token"
+	// TokenStr flags sets both the discovery-token and the tls-bootstrap-token when those values are not provided
+	TokenStr = "token"
 
-// TokenTTL flag sets the time to live for token
-const TokenTTL = "token-ttl"
+	// TokenTTL flag sets the time to live for token
+	TokenTTL = "token-ttl"
 
-// TokenUsages flag sets the usages of the token
-const TokenUsages = "usages"
+	// TokenUsages flag sets the usages of the token
+	TokenUsages = "usages"
 
-// TokenGroups flag sets the authentication groups of the token
-const TokenGroups = "groups"
+	// TokenGroups flag sets the authentication groups of the token
+	TokenGroups = "groups"
 
-// TokenDescription flag sets the description of the token
-const TokenDescription = "description"
+	// TokenDescription flag sets the description of the token
+	TokenDescription = "description"
 
-// TLSBootstrapToken flag sets the token used to temporarily authenticate with the Kubernetes Master to submit a certificate signing request (CSR) for a locally created key pair
-const TLSBootstrapToken = "tls-bootstrap-token"
+	// TLSBootstrapToken flag sets the token used to temporarily authenticate with the Kubernetes Master to submit a certificate signing request (CSR) for a locally created key pair
+	TLSBootstrapToken = "tls-bootstrap-token"
 
-// TokenDiscovery flag sets the token used to validate cluster information fetched from the API server (for token-based discovery)
-const TokenDiscovery = "discovery-token"
+	// TokenDiscovery flag sets the token used to validate cluster information fetched from the API server (for token-based discovery)
+	TokenDiscovery = "discovery-token"
 
-// TokenDiscoveryCAHash flag instruct kubeadm to validate that the root CA public key matches this hash (for token-based discovery)
-const TokenDiscoveryCAHash = "discovery-token-ca-cert-hash"
+	// TokenDiscoveryCAHash flag instruct kubeadm to validate that the root CA public key matches this hash (for token-based discovery)
+	TokenDiscoveryCAHash = "discovery-token-ca-cert-hash"
 
-// TokenDiscoverySkipCAHash flag instruct kubeadm to skip CA hash verification (for token-based discovery)
-const TokenDiscoverySkipCAHash = "discovery-token-unsafe-skip-ca-verification"
+	// TokenDiscoverySkipCAHash flag instruct kubeadm to skip CA hash verification (for token-based discovery)
+	TokenDiscoverySkipCAHash = "discovery-token-unsafe-skip-ca-verification"
 
-// FileDiscovery flag sets the file or URL from which to load cluster information (for file-based discovery)
-const FileDiscovery = "discovery-file"
+	// FileDiscovery flag sets the file or URL from which to load cluster information (for file-based discovery)
+	FileDiscovery = "discovery-file"
 
-// ControlPlane flag instruct kubeadm to create a new control plane instance on this node
-const ControlPlane = "experimental-control-plane"
+	// ControlPlane flag instruct kubeadm to create a new control plane instance on this node
+	ControlPlane = "experimental-control-plane"
+)


### PR DESCRIPTION
[#1400]

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR cleans up the constants.go file in which multiple constants were defined in different const's. 

**Which issue(s) this PR fixes**:
Fixes kubernetes/kubeadm#1400

**Special notes for your reviewer**:
Moved all constant into one single `const`

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
