### PR TITLE
kubectl: error logging as string instead of []byte

### DIFF
--- a/pkg/kubectl/generate/versioned/configmap.go
+++ b/pkg/kubectl/generate/versioned/configmap.go
@@ -289,10 +289,10 @@ func validateNewConfigMap(configMap *v1.ConfigMap, keyName string) error {
 	}
 
 	if _, exists := configMap.Data[keyName]; exists {
-		return fmt.Errorf("cannot add key %s, another key by that name already exists in data: %v", keyName, configMap.Data)
+		return fmt.Errorf("cannot add key %q, another key by that name already exists in Data for ConfigMap %q", keyName, configMap.Name)
 	}
 	if _, exists := configMap.BinaryData[keyName]; exists {
-		return fmt.Errorf("cannot add key %s, another key by that name already exists in binaryData: %v", keyName, configMap.BinaryData)
+		return fmt.Errorf("cannot add key %q, another key by that name already exists in BinaryData for ConfigMap %q", keyName, configMap.Name)
 	}
 	return nil
 }

--- a/pkg/kubectl/generate/versioned/secret.go
+++ b/pkg/kubectl/generate/versioned/secret.go
@@ -265,7 +265,7 @@ func addKeyFromLiteralToSecret(secret *v1.Secret, keyName string, data []byte) e
 	}
 
 	if _, entryExists := secret.Data[keyName]; entryExists {
-		return fmt.Errorf("cannot add key %s, another key by that name already exists: %v", keyName, secret.Data)
+		return fmt.Errorf("cannot add key %s, another key by that name already exists", keyName)
 	}
 	secret.Data[keyName] = data
 	return nil


### PR DESCRIPTION
Changes the error output when duplicate keys found while creating `secret` or `configMap` (BinaryData)

Show the data of the duplicated secret as `string` instead of `[]byte`
Removes error output of binary data in `configMaps`

closes #73969

