### PR TITLE
Fix golint failures of test/e2e/framework/timer

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -689,7 +689,6 @@ test/e2e/framework/providers/aws
 test/e2e/framework/providers/azure
 test/e2e/framework/providers/gce
 test/e2e/framework/providers/kubemark
-test/e2e/framework/timer
 test/e2e/instrumentation
 test/e2e/instrumentation/logging
 test/e2e/instrumentation/monitoring

--- a/test/e2e/framework/timer/timer.go
+++ b/test/e2e/framework/timer/timer.go
@@ -29,7 +29,7 @@ import (
 
 var now = time.Now
 
-// Represents a phase of a test. Phases can overlap.
+// Phase represents a phase of a test. Phases can overlap.
 type Phase struct {
 	sequenceNumber int
 	name           string
@@ -63,9 +63,8 @@ func (phase *Phase) duration() time.Duration {
 func (phase *Phase) humanReadable() string {
 	if phase.ended() {
 		return fmt.Sprintf("Phase %s: %v\n", phase.label(), phase.duration())
-	} else {
-		return fmt.Sprintf("Phase %s: %v so far\n", phase.label(), phase.duration())
 	}
+	return fmt.Sprintf("Phase %s: %v so far\n", phase.label(), phase.duration())
 }
 
 // A TestPhaseTimer groups phases and provides a way to export their measurements as JSON or human-readable text.
@@ -93,10 +92,12 @@ func (timer *TestPhaseTimer) StartPhase(sequenceNumber int, phaseName string) *P
 	return newPhase
 }
 
+// SummaryKind returns the summary of test summary.
 func (timer *TestPhaseTimer) SummaryKind() string {
 	return "TestPhaseTimer"
 }
 
+// PrintHumanReadable returns durations of all phases.
 func (timer *TestPhaseTimer) PrintHumanReadable() string {
 	buf := bytes.Buffer{}
 	timer.lock.Lock()
@@ -107,6 +108,7 @@ func (timer *TestPhaseTimer) PrintHumanReadable() string {
 	return buf.String()
 }
 
+// PrintJSON returns durations of all phases with JSON format.
 func (timer *TestPhaseTimer) PrintJSON() string {
 	data := perftype.PerfData{
 		Version: "v1",


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind cleanup

**What this PR does / why we need it**:

Fixes golint failures under test/e2e/framework/timer

ref: https://github.com/kubernetes/kubernetes/issues/68026

**Does this PR introduce a user-facing change?**:

```release-note-none

```
