### PR TITLE
Fix typo in RDP firewall rule name.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2135,8 +2135,8 @@ function create-network() {
 
   # Open up TCP 3389 to allow RDP connections.
   if [[ ${NUM_WINDOWS_NODES} -gt 0 ]]; then
-    if ! gcloud compute firewall-rules describe --project "${NETWORK_PROJECT}" "${NETWORK}-default-rdp" &>/dev/null; then
-      gcloud compute firewall-rules create "${NETWORK}-default-rdp" \
+    if ! gcloud compute firewall-rules describe --project "${NETWORK_PROJECT}" "${NETWORK}-allow-rdp" &>/dev/null; then
+      gcloud compute firewall-rules create "${NETWORK}-allow-rdp" \
         --project "${NETWORK_PROJECT}" \
         --network "${NETWORK}" \
         --source-ranges "0.0.0.0/0" \


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

In my GCP projects right now I have "default-default-rdp" from this script. It should be "default-allow-rdp", to match the other "default-allow-*" firewall rules in GCP projects.