### PR TITLE
Update repo-infra, bazel-skylib, and rules_docker dependencies

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle", "container_image")
-load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
+load("@io_k8s_repo_infra//defs:build.bzl", "release_filegroup")
 load(":code_generation_test.bzl", "code_generation_test_suite")
 
 code_generation_test_suite(
@@ -71,7 +71,6 @@ DOCKERIZED_BINARIES = {
     images = {
         "k8s.gcr.io/%s:{STABLE_DOCKER_TAG}" % binary: binary + "-internal",
     },
-    stamp = True,
 ) for binary in DOCKERIZED_BINARIES.keys()]
 
 [genrule(

--- a/build/code_generation.bzl
+++ b/build/code_generation.bzl
@@ -14,7 +14,7 @@
 
 load("//build:kazel_generated.bzl", "go_prefix", "tags_values_pkgs")
 load("//build:openapi.bzl", "openapi_vendor_prefix")
-load("@io_kubernetes_build//defs:go.bzl", "go_genrule")
+load("@io_k8s_repo_infra//defs:go.bzl", "go_genrule")
 
 def bazel_go_library(pkg):
     """Returns the Bazel label for the Go library for the provided package.

--- a/build/code_generation_test.bzl
+++ b/build/code_generation_test.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(":code_generation.bzl", "bazel_go_library", "go_pkg")
-load("@bazel_skylib//:lib.bzl", "asserts", "unittest")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
 def _bazel_go_library_test_impl(ctx):
     env = unittest.begin(ctx)

--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_kubernetes_build//defs:deb.bzl", "k8s_deb", "deb_data")
-load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
-load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
+load("@io_k8s_repo_infra//defs:deb.bzl", "k8s_deb", "deb_data")
+load("@io_k8s_repo_infra//defs:build.bzl", "release_filegroup")
+load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
 load("//build:workspace.bzl", "CNI_VERSION", "CRI_TOOLS_VERSION")
 
 # We do not include kube-scheduler, kube-controller-manager,

--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
-load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
+load("@io_k8s_repo_infra//defs:build.bzl", "release_filegroup")
+load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "package-srcs",

--- a/build/root/BUILD.root
+++ b/build/root/BUILD.root
@@ -13,7 +13,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@io_kubernetes_build//defs:build.bzl", "gcs_upload")
+load("@io_k8s_repo_infra//defs:build.bzl", "gcs_upload")
 
 filegroup(
     name = "_binary-artifacts-and-hashes",

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -3,23 +3,21 @@ load("//build:workspace_mirror.bzl", "mirror")
 load("//build:workspace.bzl", "CNI_VERSION", "CRI_TOOLS_VERSION")
 
 http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "ade51a315fa17347e5c31201fdc55aa5ffb913377aa315dceb56ee9725e620ee",
-    urls = mirror("https://github.com/bazelbuild/rules_go/releases/download/0.16.6/rules_go-0.16.6.tar.gz"),
-)
-
-http_archive(
-    name = "io_kubernetes_build",
-    sha256 = "21160531ea8a9a4001610223ad815622bf60671d308988c7057168a495a7e2e8",
-    strip_prefix = "repo-infra-b4bc4f1552c7fc1d4654753ca9b0e5e13883429f",
-    urls = mirror("https://github.com/kubernetes/repo-infra/archive/b4bc4f1552c7fc1d4654753ca9b0e5e13883429f.tar.gz"),
-)
-
-http_archive(
     name = "bazel_skylib",
-    sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
-    strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
-    urls = mirror("https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"),
+    sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
+    strip_prefix = "bazel-skylib-0.6.0",
+    urls = mirror("https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz"),
+)
+
+load("@bazel_skylib//lib:versions.bzl", "versions")
+
+versions.check(minimum_bazel_version = "0.18.0")
+
+http_archive(
+    name = "io_k8s_repo_infra",
+    sha256 = "4ce2d8576e786c8fb8bc4f7ed79f5fda543568d78c09306d16cc8d1b7d5621f0",
+    strip_prefix = "repo-infra-8a5707674e76b825bfd9a8624bae045bc6e5f24d",
+    urls = mirror("https://github.com/kubernetes/repo-infra/archive/8a5707674e76b825bfd9a8624bae045bc6e5f24d.tar.gz"),
 )
 
 ETCD_VERSION = "3.3.10"
@@ -33,18 +31,12 @@ http_archive(
 )
 
 http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "29d109605e0d6f9c892584f07275b8c9260803bf0c6fcb7de2623b2bedc910bd",
-    strip_prefix = "rules_docker-0.5.1",
-    urls = mirror("https://github.com/bazelbuild/rules_docker/archive/v0.5.1.tar.gz"),
+    name = "io_bazel_rules_go",
+    sha256 = "492c3ac68ed9dcf527a07e6a1b2dcbf199c6bf8b35517951467ac32e421c06c1",
+    urls = mirror("https://github.com/bazelbuild/rules_go/releases/download/0.17.0/rules_go-0.17.0.tar.gz"),
 )
 
-load("@bazel_skylib//:lib.bzl", "versions")
-
-versions.check(minimum_bazel_version = "0.17.2")
-
-load("@io_bazel_rules_go//go:def.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_pull", "docker_repositories")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
@@ -52,7 +44,21 @@ go_register_toolchains(
     go_version = "1.11.5",
 )
 
-docker_repositories()
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
+    strip_prefix = "rules_docker-0.7.0",
+    urls = mirror("https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"),
+)
+
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
+
+container_repositories()
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 http_file(
     name = "kubernetes_cni",
@@ -68,7 +74,7 @@ http_file(
     urls = mirror("https://github.com/kubernetes-incubator/cri-tools/releases/download/v%s/crictl-v%s-linux-amd64.tar.gz" % (CRI_TOOLS_VERSION, CRI_TOOLS_VERSION)),
 )
 
-docker_pull(
+container_pull(
     name = "debian-base-amd64",
     digest = "sha256:8ccb65cd2dd7e0c24193d0742a20e4a673dbd11af5a33f16fcd471a31486866c",
     registry = "k8s.gcr.io",
@@ -76,7 +82,7 @@ docker_pull(
     tag = "0.4.1",  # ignored, but kept here for documentation
 )
 
-docker_pull(
+container_pull(
     name = "debian-iptables-amd64",
     digest = "sha256:9c41b4c326304b94eb96fdd2e181aa6e9995cc4642fcdfb570cedd73a419ba39",
     registry = "k8s.gcr.io",
@@ -84,7 +90,7 @@ docker_pull(
     tag = "v11.0.1",  # ignored, but kept here for documentation
 )
 
-docker_pull(
+container_pull(
     name = "debian-hyperkube-base-amd64",
     digest = "sha256:5d4ea2fb5fbe9a9a9da74f67cf2faefc881968bc39f2ac5d62d9167e575812a1",
     registry = "k8s.gcr.io",
@@ -92,7 +98,7 @@ docker_pull(
     tag = "0.12.1",  # ignored, but kept here for documentation
 )
 
-docker_pull(
+container_pull(
     name = "official_busybox",
     digest = "sha256:cb63aa0641a885f54de20f61d152187419e8f6b159ed11a251a09d115fdff9bd",
     registry = "index.docker.io",

--- a/build/visible_to/README.md
+++ b/build/visible_to/README.md
@@ -157,7 +157,7 @@ q=//cmd/kubectl:kubectl
 bazel query "buildfiles(deps($q))" | \
     grep -v @bazel_tools | \
     grep -v @io_bazel_rules | \
-    grep -v @io_kubernetes_build | \
+    grep -v @io_k8s_repo_infra | \
     grep -v @local_config | \
     grep -v @local_jdk | \
     grep -v //visible_to: | \

--- a/cluster/BUILD
+++ b/cluster/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
+load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "package-srcs",

--- a/cluster/addons/BUILD
+++ b/cluster/addons/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
+load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "addon-srcs",

--- a/cluster/gce/BUILD
+++ b/cluster/gce/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
-load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
+load("@io_k8s_repo_infra//defs:build.bzl", "release_filegroup")
+load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "package-srcs",

--- a/cluster/gce/addons/BUILD
+++ b/cluster/gce/addons/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
+load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "addon-srcs",

--- a/cluster/gce/gci/BUILD
+++ b/cluster/gce/gci/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
-load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
-load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
+load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
+load("@io_k8s_repo_infra//defs:build.bzl", "release_filegroup")
 
 go_test(
     name = "go_default_test",

--- a/cluster/gce/manifests/BUILD
+++ b/cluster/gce/manifests/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
-load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
+load("@io_k8s_repo_infra//defs:build.bzl", "release_filegroup")
+load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "gce-master-manifests",

--- a/cluster/images/conformance/BUILD
+++ b/cluster/images/conformance/BUILD
@@ -47,7 +47,6 @@ container_image(
 container_bundle(
     name = "conformance",
     images = {"k8s.gcr.io/conformance-amd64:{STABLE_DOCKER_TAG}": "conformance-internal"},
-    stamp = True,
 )
 
 filegroup(

--- a/cluster/images/hyperkube/BUILD
+++ b/cluster/images/hyperkube/BUILD
@@ -12,7 +12,6 @@ container_image(
 container_bundle(
     name = "hyperkube",
     images = {"k8s.gcr.io/hyperkube-amd64:{STABLE_DOCKER_TAG}": "hyperkube-internal"},
-    stamp = True,
 )
 
 filegroup(

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_kubernetes_build//defs:go.bzl", "go_genrule")
+load("@io_k8s_repo_infra//defs:go.bzl", "go_genrule")
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**: this is basically the first commit of #73930, pulled out into a separate PR to separate the update changes from the cross-compilation changes.

Why we're updating:
- **repo-infra**: there's a whole slew of changes incoming (https://github.com/kubernetes/repo-infra/pull/103), but we also recently renamed the bazel workspace from `@io_kubernetes_build` to the more accurate `@io_k8s_repo_infra`. The update in this PR isn't pulling in any functional changes, just the rename.
- **bazel-skylib**: used by several dependencies, as well as us (in #73930). It'd be good to get to a recent tagged version here.
- **rules_docker**: to pick up https://github.com/bazelbuild/rules_docker/pull/544, which allows specifying the platform to download in `container_pull`. There are other internal changes, hence a lot of cleanup in various build files
- **rules_go**: there are expected incompatible changes in bazel's API starting in 0.23.0, and versions of rules_go older than 0.17.0 are not likely to work with bazel 0.23.0+.

rules_go 0.17.0 now requires bazel 0.18.0, so ratchet to that. (We could probably ratchet to something even later; I think Prow is running 0.21.0.)

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @fejta @BenTheElder 