### PR TITLE
Fix golint failures under test/e2e/framework/metrics

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -682,7 +682,6 @@ test/e2e/cloud
 test/e2e/common
 test/e2e/framework
 test/e2e/framework/ingress
-test/e2e/framework/metrics
 test/e2e/framework/providers/aws
 test/e2e/framework/providers/azure
 test/e2e/framework/providers/gce

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -119,7 +119,7 @@ type Framework struct {
 	TestSummaries []TestDataSummary
 
 	// Place to keep ClusterAutoscaler metrics from before test in order to compute delta.
-	clusterAutoscalerMetricsBeforeTest metrics.MetricsCollection
+	clusterAutoscalerMetricsBeforeTest metrics.Collection
 }
 
 type TestDataSummary interface {

--- a/test/e2e/framework/metrics/api_server_metrics.go
+++ b/test/e2e/framework/metrics/api_server_metrics.go
@@ -16,26 +16,28 @@ limitations under the License.
 
 package metrics
 
-type ApiServerMetrics Metrics
+// APIServerMetrics is metrics for API server
+type APIServerMetrics Metrics
 
-func (m *ApiServerMetrics) Equal(o ApiServerMetrics) bool {
+// Equal returns true if all metrics are the same as the arguments.
+func (m *APIServerMetrics) Equal(o APIServerMetrics) bool {
 	return (*Metrics)(m).Equal(Metrics(o))
 }
 
-func NewApiServerMetrics() ApiServerMetrics {
+func newAPIServerMetrics() APIServerMetrics {
 	result := NewMetrics()
-	return ApiServerMetrics(result)
+	return APIServerMetrics(result)
 }
 
-func parseApiServerMetrics(data string) (ApiServerMetrics, error) {
-	result := NewApiServerMetrics()
+func parseAPIServerMetrics(data string) (APIServerMetrics, error) {
+	result := newAPIServerMetrics()
 	if err := parseMetrics(data, (*Metrics)(&result)); err != nil {
-		return ApiServerMetrics{}, err
+		return APIServerMetrics{}, err
 	}
 	return result, nil
 }
 
-func (g *MetricsGrabber) getMetricsFromApiServer() (string, error) {
+func (g *Grabber) getMetricsFromAPIServer() (string, error) {
 	rawOutput, err := g.client.CoreV1().RESTClient().Get().RequestURI("/metrics").Do().Raw()
 	if err != nil {
 		return "", err

--- a/test/e2e/framework/metrics/cluster_autoscaler_metrics.go
+++ b/test/e2e/framework/metrics/cluster_autoscaler_metrics.go
@@ -16,19 +16,21 @@ limitations under the License.
 
 package metrics
 
+// ClusterAutoscalerMetrics is metrics for cluster autoscaller
 type ClusterAutoscalerMetrics Metrics
 
+// Equal returns true if all metrics are the same as the arguments.
 func (m *ClusterAutoscalerMetrics) Equal(o ClusterAutoscalerMetrics) bool {
 	return (*Metrics)(m).Equal(Metrics(o))
 }
 
-func NewClusterAutoscalerMetrics() ClusterAutoscalerMetrics {
+func newClusterAutoscalerMetrics() ClusterAutoscalerMetrics {
 	result := NewMetrics()
 	return ClusterAutoscalerMetrics(result)
 }
 
 func parseClusterAutoscalerMetrics(data string) (ClusterAutoscalerMetrics, error) {
-	result := NewClusterAutoscalerMetrics()
+	result := newClusterAutoscalerMetrics()
 	if err := parseMetrics(data, (*Metrics)(&result)); err != nil {
 		return ClusterAutoscalerMetrics{}, err
 	}

--- a/test/e2e/framework/metrics/controller_manager_metrics.go
+++ b/test/e2e/framework/metrics/controller_manager_metrics.go
@@ -16,19 +16,21 @@ limitations under the License.
 
 package metrics
 
+// ControllerManagerMetrics is metrics for controller manager
 type ControllerManagerMetrics Metrics
 
+// Equal returns true if all metrics are the same as the arguments.
 func (m *ControllerManagerMetrics) Equal(o ControllerManagerMetrics) bool {
 	return (*Metrics)(m).Equal(Metrics(o))
 }
 
-func NewControllerManagerMetrics() ControllerManagerMetrics {
+func newControllerManagerMetrics() ControllerManagerMetrics {
 	result := NewMetrics()
 	return ControllerManagerMetrics(result)
 }
 
 func parseControllerManagerMetrics(data string) (ControllerManagerMetrics, error) {
-	result := NewControllerManagerMetrics()
+	result := newControllerManagerMetrics()
 	if err := parseMetrics(data, (*Metrics)(&result)); err != nil {
 		return ControllerManagerMetrics{}, err
 	}

--- a/test/e2e/framework/metrics/generic_metrics.go
+++ b/test/e2e/framework/metrics/generic_metrics.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metrics
 
 import (
-	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -27,8 +26,10 @@ import (
 	"k8s.io/klog"
 )
 
+// Metrics is generic metrics for other specific metrics
 type Metrics map[string]model.Samples
 
+// Equal returns true if all metrics are the same as the arguments.
 func (m *Metrics) Equal(o Metrics) bool {
 	leftKeySet := []string{}
 	rightKeySet := []string{}
@@ -49,6 +50,7 @@ func (m *Metrics) Equal(o Metrics) bool {
 	return true
 }
 
+// NewMetrics returns new metrics which are initialized.
 func NewMetrics() Metrics {
 	result := make(Metrics)
 	return result

--- a/test/e2e/framework/metrics/generic_metrics.go
+++ b/test/e2e/framework/metrics/generic_metrics.go
@@ -49,26 +49,6 @@ func (m *Metrics) Equal(o Metrics) bool {
 	return true
 }
 
-func PrintSample(sample *model.Sample) string {
-	buf := make([]string, 0)
-	// Id is a VERY special label. For 'normal' container it's useless, but it's necessary
-	// for 'system' containers (e.g. /docker-daemon, /kubelet, etc.). We know if that's the
-	// case by checking if there's a label "kubernetes_container_name" present. It's hacky
-	// but it works...
-	_, normalContainer := sample.Metric["kubernetes_container_name"]
-	for k, v := range sample.Metric {
-		if strings.HasPrefix(string(k), "__") {
-			continue
-		}
-
-		if string(k) == "id" && normalContainer {
-			continue
-		}
-		buf = append(buf, fmt.Sprintf("%v=%v", string(k), v))
-	}
-	return fmt.Sprintf("[%v] = %v", strings.Join(buf, ","), sample.Value)
-}
-
 func NewMetrics() Metrics {
 	result := make(Metrics)
 	return result

--- a/test/e2e/framework/metrics/kubelet_metrics.go
+++ b/test/e2e/framework/metrics/kubelet_metrics.go
@@ -23,12 +23,19 @@ import (
 	"time"
 )
 
+const (
+	proxyTimeout = 2 * time.Minute
+)
+
+// KubeletMetrics is metrics for kubelet
 type KubeletMetrics Metrics
 
+// Equal returns true if all metrics are the same as the arguments.
 func (m *KubeletMetrics) Equal(o KubeletMetrics) bool {
 	return (*Metrics)(m).Equal(Metrics(o))
 }
 
+// NewKubeletMetrics returns new metrics which are initialized.
 func NewKubeletMetrics() KubeletMetrics {
 	result := NewMetrics()
 	return KubeletMetrics(result)
@@ -58,7 +65,7 @@ func parseKubeletMetrics(data string) (KubeletMetrics, error) {
 	return result, nil
 }
 
-func (g *MetricsGrabber) getMetricsFromNode(nodeName string, kubeletPort int) (string, error) {
+func (g *Grabber) getMetricsFromNode(nodeName string, kubeletPort int) (string, error) {
 	// There's a problem with timing out during proxy. Wrapping this in a goroutine to prevent deadlock.
 	// Hanging goroutine will be leaked.
 	finished := make(chan struct{})
@@ -74,7 +81,7 @@ func (g *MetricsGrabber) getMetricsFromNode(nodeName string, kubeletPort int) (s
 		finished <- struct{}{}
 	}()
 	select {
-	case <-time.After(ProxyTimeout):
+	case <-time.After(proxyTimeout):
 		return "", fmt.Errorf("Timed out when waiting for proxy to gather metrics from %v", nodeName)
 	case <-finished:
 		if err != nil {

--- a/test/e2e/framework/metrics/scheduler_metrics.go
+++ b/test/e2e/framework/metrics/scheduler_metrics.go
@@ -16,19 +16,21 @@ limitations under the License.
 
 package metrics
 
+// SchedulerMetrics is metrics for scheduler
 type SchedulerMetrics Metrics
 
+// Equal returns true if all metrics are the same as the arguments.
 func (m *SchedulerMetrics) Equal(o SchedulerMetrics) bool {
 	return (*Metrics)(m).Equal(Metrics(o))
 }
 
-func NewSchedulerMetrics() SchedulerMetrics {
+func newSchedulerMetrics() SchedulerMetrics {
 	result := NewMetrics()
 	return SchedulerMetrics(result)
 }
 
 func parseSchedulerMetrics(data string) (SchedulerMetrics, error) {
-	result := NewSchedulerMetrics()
+	result := newSchedulerMetrics()
 	if err := parseMetrics(data, (*Metrics)(&result)); err != nil {
 		return SchedulerMetrics{}, err
 	}

--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -65,12 +65,12 @@ const (
 	caFunctionMetricLabel = "function"
 )
 
-type MetricsForE2E metrics.MetricsCollection
+type MetricsForE2E metrics.Collection
 
 func (m *MetricsForE2E) filterMetrics() {
-	interestingApiServerMetrics := make(metrics.ApiServerMetrics)
-	for _, metric := range InterestingApiServerMetrics {
-		interestingApiServerMetrics[metric] = (*m).ApiServerMetrics[metric]
+	interestingAPIServerMetrics := make(metrics.APIServerMetrics)
+	for _, metric := range InterestingAPIServerMetrics {
+		interestingAPIServerMetrics[metric] = (*m).APIServerMetrics[metric]
 	}
 	interestingControllerManagerMetrics := make(metrics.ControllerManagerMetrics)
 	for _, metric := range InterestingControllerManagerMetrics {
@@ -87,7 +87,7 @@ func (m *MetricsForE2E) filterMetrics() {
 			interestingKubeletMetrics[kubelet][metric] = grabbed[metric]
 		}
 	}
-	(*m).ApiServerMetrics = interestingApiServerMetrics
+	(*m).APIServerMetrics = interestingAPIServerMetrics
 	(*m).ControllerManagerMetrics = interestingControllerManagerMetrics
 	(*m).KubeletMetrics = interestingKubeletMetrics
 }
@@ -112,12 +112,11 @@ func printSample(sample *model.Sample) string {
 	return fmt.Sprintf("[%v] = %v", strings.Join(buf, ","), sample.Value)
 }
 
-
 func (m *MetricsForE2E) PrintHumanReadable() string {
 	buf := bytes.Buffer{}
-	for _, interestingMetric := range InterestingApiServerMetrics {
+	for _, interestingMetric := range InterestingAPIServerMetrics {
 		buf.WriteString(fmt.Sprintf("For %v:\n", interestingMetric))
-		for _, sample := range (*m).ApiServerMetrics[interestingMetric] {
+		for _, sample := range (*m).APIServerMetrics[interestingMetric] {
 			buf.WriteString(fmt.Sprintf("\t%v\n", printSample(sample)))
 		}
 	}
@@ -156,7 +155,7 @@ func (m *MetricsForE2E) SummaryKind() string {
 
 var SchedulingLatencyMetricName = model.LabelValue(schedulermetric.SchedulerSubsystem + "_" + schedulermetric.SchedulingLatencyName)
 
-var InterestingApiServerMetrics = []string{
+var InterestingAPIServerMetrics = []string{
 	"apiserver_request_total",
 	// TODO(krzysied): apiserver_request_latencies_summary is a deprecated metric.
 	// It should be replaced with new metric.
@@ -815,7 +814,7 @@ func PrintLatencies(latencies []PodLatencyData, header string) {
 	Logf("perc50: %v, perc90: %v, perc99: %v", metrics.Perc50, metrics.Perc90, metrics.Perc99)
 }
 
-func (m *MetricsForE2E) computeClusterAutoscalerMetricsDelta(before metrics.MetricsCollection) {
+func (m *MetricsForE2E) computeClusterAutoscalerMetricsDelta(before metrics.Collection) {
 	if beforeSamples, found := before.ClusterAutoscalerMetrics[caFunctionMetric]; found {
 		if afterSamples, found := m.ClusterAutoscalerMetrics[caFunctionMetric]; found {
 			beforeSamplesMap := make(map[string]*model.Sample)

--- a/test/e2e/instrumentation/monitoring/metrics_grabber.go
+++ b/test/e2e/instrumentation/monitoring/metrics_grabber.go
@@ -32,7 +32,7 @@ import (
 var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 	f := framework.NewDefaultFramework("metrics-grabber")
 	var c, ec clientset.Interface
-	var grabber *metrics.MetricsGrabber
+	var grabber *metrics.Grabber
 	gin.BeforeEach(func() {
 		var err error
 		c = f.ClientSet
@@ -44,7 +44,7 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 
 	gin.It("should grab all metrics from API server.", func() {
 		gin.By("Connecting to /metrics endpoint")
-		response, err := grabber.GrabFromApiServer()
+		response, err := grabber.GrabFromAPIServer()
 		framework.ExpectNoError(err)
 		gom.Expect(response).NotTo(gom.BeEmpty())
 	})

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -42,7 +42,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		c              clientset.Interface
 		ns             string
 		pvc            *v1.PersistentVolumeClaim
-		metricsGrabber *metrics.MetricsGrabber
+		metricsGrabber *metrics.Grabber
 	)
 	f := framework.NewDefaultFramework("pv")
 
@@ -422,7 +422,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 	})
 })
 
-func waitForDetachAndGrabMetrics(oldMetrics map[string]int64, metricsGrabber *metrics.MetricsGrabber) map[string]int64 {
+func waitForDetachAndGrabMetrics(oldMetrics map[string]int64, metricsGrabber *metrics.Grabber) map[string]int64 {
 	backoff := wait.Backoff{
 		Duration: 10 * time.Second,
 		Factor:   1.2,
@@ -527,7 +527,7 @@ func findVolumeStatMetric(metricKeyName string, namespace string, pvcName string
 }
 
 // Wait for the count of a pv controller's metric specified by metricName and dimension bigger than zero.
-func waitForPVControllerSync(metricsGrabber *metrics.MetricsGrabber, metricName, dimension string) {
+func waitForPVControllerSync(metricsGrabber *metrics.Grabber, metricName, dimension string) {
 	backoff := wait.Backoff{
 		Duration: 10 * time.Second,
 		Factor:   1.2,
@@ -608,7 +608,7 @@ func getStatesMetrics(metricKey string, givenMetrics metrics.Metrics) map[string
 	return states
 }
 
-func waitForADControllerStatesMetrics(metricsGrabber *metrics.MetricsGrabber, metricName string, dimensions []string, stateNames []string) {
+func waitForADControllerStatesMetrics(metricsGrabber *metrics.Grabber, metricName string, dimensions []string, stateNames []string) {
 	backoff := wait.Backoff{
 		Duration: 10 * time.Second,
 		Factor:   1.2,


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This just fixes golint failures under test/e2e/framework/metrics

ref: https://github.com/kubernetes/kubernetes/issues/68026

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note-none

```
