### PR TITLE
support pico as the minimum suffix

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount.go
@@ -34,6 +34,7 @@ func (s Scale) infScale() inf.Scale {
 }
 
 const (
+	Pico  Scale = -12
 	Nano  Scale = -9
 	Micro Scale = -6
 	Milli Scale = -3

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
@@ -155,6 +155,8 @@ func positiveScaleInt64(base int64, scale Scale) (int64, bool) {
 		return int64MultiplyScale(base, 1000000)
 	case 9:
 		return int64MultiplyScale(base, 1000000000)
+	case 12:
+		return int64MultiplyScale(base, 1000000000000)
 	default:
 		value := base
 		var ok bool

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -132,7 +132,7 @@ func MustParse(str string) Quantity {
 const (
 	// splitREString is used to separate a number from its suffix; as such,
 	// this is overly permissive, but that's OK-- it will be checked later.
-	splitREString = "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+	splitREString = "^([+-]?[0-9.]+)([eEinumkKMGTpP]*[-+]?[0-9]*)$"
 )
 
 var (
@@ -230,7 +230,7 @@ Num:
 			suffix = str[suffixStart:end]
 			return
 		}
-		if !strings.ContainsAny(str[i:i+1], "eEinumkKMGTP") {
+		if !strings.ContainsAny(str[i:i+1], "eEinumkKMGTpP") {
 			pos = i
 			break
 		}
@@ -302,7 +302,7 @@ func ParseQuantity(str string) (Quantity, error) {
 		// if we have a denominator, shift the entire value to the left by the number of places in the
 		// denominator
 		scale -= int32(len(denom))
-		if scale >= int32(Nano) {
+		if scale >= int32(Pico) {
 			shifted := num + denom
 
 			var value int64
@@ -356,7 +356,7 @@ func ParseQuantity(str string) (Quantity, error) {
 	// of an amount.  Arguably, this should be inf.RoundHalfUp (normal rounding), but that would have
 	// the side effect of rounding values < .5n to zero.
 	if v, ok := amount.Unscaled(); v != int64(0) || !ok {
-		amount.Round(amount, Nano.infScale(), inf.RoundUp)
+		amount.Round(amount, Pico.infScale(), inf.RoundUp)
 	}
 
 	// The max is just a simple cap.

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -226,6 +226,7 @@ func TestQuantityParse(t *testing.T) {
 		expect Quantity
 	}{
 		{"0", decQuantity(0, 0, DecimalSI)},
+		{"0p", decQuantity(0, 0, DecimalSI)},
 		{"0n", decQuantity(0, 0, DecimalSI)},
 		{"0u", decQuantity(0, 0, DecimalSI)},
 		{"0m", decQuantity(0, 0, DecimalSI)},
@@ -254,6 +255,7 @@ func TestQuantityParse(t *testing.T) {
 		{"100Ti", decQuantity(100*1024*1024*1024*1024, 0, BinarySI)},
 
 		// Decimal suffixes
+		{"6p", decQuantity(6, -12, DecimalSI)},
 		{"5n", decQuantity(5, -9, DecimalSI)},
 		{"4u", decQuantity(4, -6, DecimalSI)},
 		{"3m", decQuantity(3, -3, DecimalSI)},
@@ -317,15 +319,15 @@ func TestQuantityParse(t *testing.T) {
 		{"1.01E", decQuantity(101, 16, DecimalSI)},
 
 		// Things that saturate/round
-		{"3.001n", decQuantity(4, -9, DecimalSI)},
-		{"1.1E-9", decQuantity(2, -9, DecimalExponent)},
-		{"0.0000000001", decQuantity(1, -9, DecimalSI)},
-		{"0.0000000005", decQuantity(1, -9, DecimalSI)},
-		{"0.00000000050", decQuantity(1, -9, DecimalSI)},
-		{"0.5e-9", decQuantity(1, -9, DecimalExponent)},
-		{"0.9n", decQuantity(1, -9, DecimalSI)},
-		{"0.00000012345", decQuantity(124, -9, DecimalSI)},
-		{"0.00000012354", decQuantity(124, -9, DecimalSI)},
+		{"3.001p", decQuantity(4, -12, DecimalSI)},
+		{"1.1E-12", decQuantity(2, -12, DecimalExponent)},
+		{"0.0000000000001", decQuantity(1, -12, DecimalSI)},
+		{"0.0000000000005", decQuantity(1, -12, DecimalSI)},
+		{"0.00000000000050", decQuantity(1, -12, DecimalSI)},
+		{"0.5e-12", decQuantity(1, -12, DecimalExponent)},
+		{"0.9p", decQuantity(1, -12, DecimalSI)},
+		{"0.00000000012345", decQuantity(124, -12, DecimalSI)},
+		{"0.00000000012354", decQuantity(124, -12, DecimalSI)},
 		{"9Ei", Quantity{d: maxAllowed, Format: BinarySI}},
 		{"9223372036854775807Ki", Quantity{d: maxAllowed, Format: BinarySI}},
 		{"12E", decQuantity(12, 18, DecimalSI)},
@@ -337,7 +339,7 @@ func TestQuantityParse(t *testing.T) {
 		{"0.025Ti", decQuantity(274877906944, -1, BinarySI)},
 
 		// Things written by trolls
-		{"0.000000000001Ki", decQuantity(2, -9, DecimalSI)}, // rounds up, changes format
+		{"0.000000000000001Ki", decQuantity(2, -12, DecimalSI)}, // rounds up, changes format
 		{".001", decQuantity(1, -3, DecimalSI)},
 		{".0001k", decQuantity(100, -3, DecimalSI)},
 		{"1.", decQuantity(1, 0, DecimalSI)},
@@ -683,6 +685,9 @@ func TestQuantityString(t *testing.T) {
 		{decQuantity(1, -6, DecimalSI), "1u", ""},
 		{decQuantity(80, -6, DecimalSI), "80u", ""},
 		{decQuantity(1080, -6, DecimalSI), "1080u", ""},
+		{decQuantity(1, -12, DecimalSI), "1p", ""},
+		{decQuantity(80, -12, DecimalSI), "80p", ""},
+		{decQuantity(1080, -12, DecimalSI), "1080p", ""},
 	}
 	for _, item := range table {
 		got := item.in.String()
@@ -741,7 +746,8 @@ func TestQuantityParseEmit(t *testing.T) {
 		{".001Ki", "1024m"},
 		{".000001Ki", "1024u"},
 		{".000000001Ki", "1024n"},
-		{".000000000001Ki", "2n"},
+		{".000000000001Ki", "1024p"},
+		{".000000000000001Ki", "2p"},
 	}
 
 	for _, item := range table {
@@ -974,6 +980,8 @@ func TestNewScaledSet(t *testing.T) {
 		scale  Scale
 		expect string
 	}{
+		{1, Pico, "1p"},
+		{1000, Pico, "1n"},
 		{1, Nano, "1n"},
 		{1000, Nano, "1u"},
 		{1, Micro, "1u"},
@@ -1013,18 +1021,27 @@ func TestScaledValue(t *testing.T) {
 		toScale   Scale
 		expected  int64
 	}{
+		{Pico, Pico, 1},
+		{Pico, Nano, 1},
+		{Pico, Micro, 1},
+		{Pico, Milli, 1},
+		{Pico, 0, 1},
+		{Nano, Pico, 1000},
 		{Nano, Nano, 1},
 		{Nano, Micro, 1},
 		{Nano, Milli, 1},
 		{Nano, 0, 1},
+		{Micro, Pico, 1000 * 1000},
 		{Micro, Nano, 1000},
 		{Micro, Micro, 1},
 		{Micro, Milli, 1},
 		{Micro, 0, 1},
+		{Milli, Pico, 1000 * 1000 * 1000},
 		{Milli, Nano, 1000 * 1000},
 		{Milli, Micro, 1000},
 		{Milli, Milli, 1},
 		{Milli, 0, 1},
+		{0, Pico, 1000 * 1000 * 1000 * 1000},
 		{0, Nano, 1000 * 1000 * 1000},
 		{0, Micro, 1000 * 1000},
 		{0, Milli, 1000},

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
@@ -89,6 +89,8 @@ func (l fastLookup) interpret(s suffix) (base, exponent int32, format Format, ok
 	switch s {
 	case "":
 		return 10, 0, DecimalSI, true
+	case "p":
+		return 10, -12, DecimalSI, true
 	case "n":
 		return 10, -9, DecimalSI, true
 	case "u":
@@ -120,6 +122,7 @@ func newSuffixer() suffixer {
 	// a suffix for 2^0.
 	sh.decSuffixes.addSuffix("", bePair{2, 0})
 
+	sh.decSuffixes.addSuffix("p", bePair{10, -12})
 	sh.decSuffixes.addSuffix("n", bePair{10, -9})
 	sh.decSuffixes.addSuffix("u", bePair{10, -6})
 	sh.decSuffixes.addSuffix("m", bePair{10, -3})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/sig api-machinery

**What this PR does / why we need it**:

Support Pico as the minimum suffix.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #73994

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support Pico as the minimum suffix.
```
