### PR TITLE
Improve documentation for rollout subcommands

### DIFF
--- a/pkg/kubectl/cmd/rollout/rollout.go
+++ b/pkg/kubectl/cmd/rollout/rollout.go
@@ -44,6 +44,13 @@ var (
 		   * daemonsets
 		   * statefulsets
 		`)
+
+	// Currently, `pause` and `resume` are only supported for deployments.
+	pauseResumeValidResources = dedent.Dedent(`
+		Valid resource types include:
+
+		   * deployments
+		`)
 )
 
 // NewCmdRollout returns a Command instance for 'rollout' sub command

--- a/pkg/kubectl/cmd/rollout/rollout_history.go
+++ b/pkg/kubectl/cmd/rollout/rollout_history.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	historyLong = templates.LongDesc(`
-		View previous rollout revisions and configurations.`)
+		View previous rollout revisions and configurations.` + rolloutValidResources)
 
 	historyExample = templates.Examples(`
 		# View the rollout history of a deployment

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -56,7 +56,7 @@ var (
 
 		Paused resources will not be reconciled by a controller.
 		Use "kubectl rollout resume" to resume a paused resource.
-		Currently only deployments support being paused.`)
+		Currently only deployments support being paused.` + pauseResumeValidResources)
 
 	pauseExample = templates.Examples(`
 		# Mark the nginx deployment as paused. Any current state of

--- a/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -57,7 +57,7 @@ var (
 
 		Paused resources will not be reconciled by a controller. By resuming a
 		resource, we allow it to be reconciled again.
-		Currently only deployments support being resumed.`)
+		Currently only deployments support being resumed.` + pauseResumeValidResources)
 
 	resumeExample = templates.Examples(`
 		# Resume an already paused deployment

--- a/pkg/kubectl/cmd/rollout/rollout_status.go
+++ b/pkg/kubectl/cmd/rollout/rollout_status.go
@@ -53,7 +53,7 @@ var (
 		you can use --watch=false. Note that if a new rollout starts in-between, then
 		'rollout status' will continue watching the latest revision. If you want to
 		pin to a specific revision and abort if it is rolled over by another revision,
-		use --revision=N where N is the revision you need to watch for.`)
+		use --revision=N where N is the revision you need to watch for.` + rolloutValidResources)
 
 	statusExample = templates.Examples(`
 		# Watch the rollout status of a deployment

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -51,7 +51,7 @@ type UndoOptions struct {
 
 var (
 	undoLong = templates.LongDesc(`
-		Rollback to a previous rollout.`)
+		Rollback to a previous rollout.` + rolloutValidResources)
 
 	undoExample = templates.Examples(`
 		# Rollback to the previous deployment


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Currently, only the top level rollout command lists the allowed resource
types, which caused confusion among users. Update the command
documentation for the subcommands so that they also contain the allowed
resource types.

**Which issue(s) this PR fixes**:
Fixes #67849

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
