### PR TITLE
Sort by resourceVersion when watching from rv=0

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -462,6 +462,8 @@ func (w *watchCache) GetAllEventsSinceThreadUnsafe(resourceVersion uint64) ([]*w
 				ResourceVersion: resourceVersion,
 			}
 		}
+		// Sort by ResourceVersion so we send synthetic ADDED events in order of last update
+		sort.Slice(result, func(i, j int) bool { return result[i].ResourceVersion < result[j].ResourceVersion })
 		return result, nil
 	}
 	if resourceVersion < oldest-1 {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -449,13 +449,17 @@ func (w *watchCache) GetAllEventsSinceThreadUnsafe(resourceVersion uint64) ([]*w
 			if err != nil {
 				return nil, err
 			}
+			resourceVersion, err := w.versioner.ObjectResourceVersion(elem.Object)
+			if err != nil {
+				return nil, err
+			}
 			result[i] = &watchCacheEvent{
 				Type:            watch.Added,
 				Object:          elem.Object,
 				ObjLabels:       objLabels,
 				ObjFields:       objFields,
 				Key:             elem.Key,
-				ResourceVersion: w.resourceVersion,
+				ResourceVersion: resourceVersion,
 			}
 		}
 		return result, nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -178,6 +179,10 @@ func (wc *watchChan) sync() error {
 	if err != nil {
 		return err
 	}
+
+	// Sort by modRevision so we send synthetic ADDED events in order of last update
+	sort.Slice(getResp.Kvs, func(i, j int) bool { return getResp.Kvs[i].ModRevision < getResp.Kvs[j].ModRevision })
+
 	wc.initialRev = getResp.Header.Revision
 	for _, kv := range getResp.Kvs {
 		wc.sendEvent(parseKV(kv))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When watching from rv=0, ensure synthetic ADDED events are in the correct order with the correct resourceVersion, so a broken/re-established watch doesn't skip events.

Fixes #74022

**Does this PR introduce a user-facing change?**:
```release-note
kube-apiserver: initial watch events from a watch started with resourceVersion=0 now appear in the correct order
```

/sig api-machinery
/cc @wojtek-t @tnozicka 