### PR TITLE
kubeadm: Replace MigrateOldConfigFromFile

### DIFF
--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -246,7 +246,10 @@ func NewCmdConfigMigrate(out io.Writer) *cobra.Command {
 				kubeadmutil.CheckErr(errors.New("The --old-config flag is mandatory"))
 			}
 
-			outputBytes, err := configutil.MigrateOldConfigFromFile(oldCfgPath)
+			oldCfgBytes, err := ioutil.ReadFile(oldCfgPath)
+			kubeadmutil.CheckErr(err)
+
+			outputBytes, err := configutil.MigrateOldConfig(oldCfgBytes)
 			kubeadmutil.CheckErr(err)
 
 			if newCfgPath == "" {

--- a/cmd/kubeadm/app/phases/upgrade/BUILD
+++ b/cmd/kubeadm/app/phases/upgrade/BUILD
@@ -76,7 +76,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
-        "//cmd/kubeadm/app/apis/kubeadm/validation:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/phases/certs:go_default_library",
         "//cmd/kubeadm/app/phases/controlplane:go_default_library",

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pkg/errors"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	controlplanephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane"
@@ -541,22 +540,7 @@ func getConfig(version, certsDir, etcdDataDir string) (*kubeadmapi.InitConfigura
 	configBytes := []byte(fmt.Sprintf(testConfiguration, certsDir, etcdDataDir, version))
 
 	// Unmarshal the config
-	cfg, err := configutil.BytesToInternalConfig(configBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	// Applies dynamic defaults to settings not provided with flags
-	if err = configutil.SetInitDynamicDefaults(cfg); err != nil {
-		return nil, err
-	}
-
-	// Validates cfg (flags/configs + defaults + dynamic defaults)
-	if err = validation.ValidateInitConfiguration(cfg).ToAggregate(); err != nil {
-		return nil, err
-	}
-
-	return cfg, nil
+	return configutil.BytesToInitConfiguration(configBytes)
 }
 
 func getTempDir(t *testing.T, name string) (string, func()) {

--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/lithammer/dedent"
@@ -352,20 +350,7 @@ func TestMigrateOldConfigFromFile(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			file, err := ioutil.TempFile("", "")
-			if err != nil {
-				t.Fatalf("could not create temporary test file: %v", err)
-			}
-			fileName := file.Name()
-			defer os.Remove(fileName)
-
-			_, err = file.WriteString(test.oldCfg)
-			file.Close()
-			if err != nil {
-				t.Fatalf("could not write contents of old config: %v", err)
-			}
-
-			b, err := MigrateOldConfigFromFile(fileName)
+			b, err := MigrateOldConfig([]byte(test.oldCfg))
 			if test.expectErr {
 				if err == nil {
 					t.Fatalf("unexpected success:\n%s", b)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

`MigrateOldConfigFromFile` is a function, whose purpose is to migrate one config into another. It is working OK for now, but it has some issues:

- It is incredibly inefficient. It can reload and re-parse a single config file for up to 3 times.

- Because of the reloads, it has to take a file containing the configuration (not a byte slice as most of the rest config functions). However, it returns the migrated config in a byte slice (rather asymmetric from the input method).

- Due to the above points it's difficult to implement a proper interface for deprecated kubeadm config versions.

To fix the issues of `MigrateOldConfigFromFile`, the following is done:

- Re-implement the function by removing the calls to file loading package public APIs and replacing them with newly extracted package private APIs that do the job with pre-provided input data in the form of `map[GroupVersionKind][]byte`.

- Take a byte slice of the input configuration as an argument. This makes the function input symmetric to its output. Also, it's now renamed to `MigrateOldConfig` to represent the change from config file path as an input to byte slice.

- As a bonus (actually forgotten from a previous change) `BytesToInternalConfig` is renamed to the more descriptive `BytesToInitConfiguration`.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refs kubernetes/kubeadm#1296

**Special notes for your reviewer**:

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/assign @neolit123
/assign @fabriziopandini 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
