### PR TITLE
kubeadm: Don't load deprecated configs

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/testdata/diff_master_config.yaml
+++ b/cmd/kubeadm/app/cmd/upgrade/testdata/diff_master_config.yaml
@@ -1,3 +1,3 @@
-apiVersion: kubeadm.k8s.io/v1alpha3
+apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-kubernetesVersion: 1.12.0
+kubernetesVersion: 1.13.0

--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -48,20 +48,35 @@ func MarshalKubeadmConfigObject(obj runtime.Object) ([]byte, error) {
 	}
 }
 
-// ValidateSupportedVersion checks if a supplied GroupVersion is not on the list of unsupported GVs. If it is, an error is returned.
-func ValidateSupportedVersion(gv schema.GroupVersion) error {
+// validateSupportedVersion checks if the supplied GroupVersion is not on the lists of old unsupported or deprecated GVs.
+// If it is, an error is returned.
+func validateSupportedVersion(gv schema.GroupVersion, allowDeprecated bool) error {
 	// The support matrix will look something like this now and in the future:
 	// v1.10 and earlier: v1alpha1
 	// v1.11: v1alpha1 read-only, writes only v1alpha2 config
-	// v1.12: v1alpha2 read-only, writes only v1alpha3 config. Warns if the user tries to use v1alpha1
-	// v1.13: v1alpha3 read-only, writes only v1beta1 config. Warns if the user tries to use v1alpha1 or v1alpha2
+	// v1.12: v1alpha2 read-only, writes only v1alpha3 config. Errors if the user tries to use v1alpha1
+	// v1.13: v1alpha3 read-only, writes only v1beta1 config. Errors if the user tries to use v1alpha1 or v1alpha2
+	// v1.14: v1alpha3 convert only, writes only v1beta1 config. Errors if the user tries to use v1alpha1 or v1alpha2
 	oldKnownAPIVersions := map[string]string{
 		"kubeadm.k8s.io/v1alpha1": "v1.11",
 		"kubeadm.k8s.io/v1alpha2": "v1.12",
 	}
-	if useKubeadmVersion := oldKnownAPIVersions[gv.String()]; useKubeadmVersion != "" {
+
+	// Deprecated API versions are supported by us, but can only be used for migration.
+	deprecatedAPIVersions := map[string]struct{}{
+		"kubeadm.k8s.io/v1alpha3": {}, // Can be migrated with kubeadm 1.13+
+	}
+
+	gvString := gv.String()
+
+	if useKubeadmVersion := oldKnownAPIVersions[gvString]; useKubeadmVersion != "" {
 		return errors.Errorf("your configuration file uses an old API spec: %q. Please use kubeadm %s instead and run 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.", gv.String(), useKubeadmVersion)
 	}
+
+	if _, present := deprecatedAPIVersions[gvString]; present && !allowDeprecated {
+		return errors.Errorf("your configuration file uses a deprecated API spec: %q. Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.", gv.String())
+	}
+
 	return nil
 }
 
@@ -154,7 +169,7 @@ func MigrateOldConfig(oldConfig []byte) ([]byte, error) {
 
 	// Migrate InitConfiguration and ClusterConfiguration if there are any in the config
 	if kubeadmutil.GroupVersionKindsHasInitConfiguration(gvks...) || kubeadmutil.GroupVersionKindsHasClusterConfiguration(gvks...) {
-		o, err := documentMapToInitConfiguration(gvkmap)
+		o, err := documentMapToInitConfiguration(gvkmap, true)
 		if err != nil {
 			return []byte{}, err
 		}
@@ -167,7 +182,7 @@ func MigrateOldConfig(oldConfig []byte) ([]byte, error) {
 
 	// Migrate JoinConfiguration if there is any
 	if kubeadmutil.GroupVersionKindsHasJoinConfiguration(gvks...) {
-		o, err := documentMapToJoinConfiguration(gvkmap)
+		o, err := documentMapToJoinConfiguration(gvkmap, true)
 		if err != nil {
 			return []byte{}, err
 		}

--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/lithammer/dedent"
@@ -27,12 +28,13 @@ import (
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
-func TestValidateSupportedVersion(t *testing.T) {
-	const KubeadmGroupName = "kubeadm.k8s.io"
+const KubeadmGroupName = "kubeadm.k8s.io"
 
+func TestValidateSupportedVersion(t *testing.T) {
 	tests := []struct {
-		gv          schema.GroupVersion
-		expectedErr bool
+		gv              schema.GroupVersion
+		allowDeprecated bool
+		expectedErr     bool
 	}{
 		{
 			gv: schema.GroupVersion{
@@ -53,6 +55,14 @@ func TestValidateSupportedVersion(t *testing.T) {
 				Group:   KubeadmGroupName,
 				Version: "v1alpha3",
 			},
+			expectedErr: true,
+		},
+		{
+			gv: schema.GroupVersion{
+				Group:   KubeadmGroupName,
+				Version: "v1alpha3",
+			},
+			allowDeprecated: true,
 		},
 		{
 			gv: schema.GroupVersion{
@@ -69,8 +79,8 @@ func TestValidateSupportedVersion(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		t.Run(rt.gv.String(), func(t *testing.T) {
-			err := ValidateSupportedVersion(rt.gv)
+		t.Run(fmt.Sprintf("%s/allowDeprecated:%t", rt.gv, rt.allowDeprecated), func(t *testing.T) {
+			err := validateSupportedVersion(rt.gv, rt.allowDeprecated)
 			if rt.expectedErr && err == nil {
 				t.Error("unexpected success")
 			} else if !rt.expectedErr && err != nil {

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -84,12 +84,12 @@ func LoadJoinConfigurationFromFile(cfgPath string) (*kubeadmapi.JoinConfiguratio
 		return nil, err
 	}
 
-	return documentMapToJoinConfiguration(gvkmap)
+	return documentMapToJoinConfiguration(gvkmap, false)
 }
 
 // documentMapToJoinConfiguration takes a map between GVKs and YAML documents (as returned by SplitYAMLDocuments),
 // finds a JoinConfiguration, decodes it, dynamically defaults it and then validates it prior to return.
-func documentMapToJoinConfiguration(gvkmap map[schema.GroupVersionKind][]byte) (*kubeadmapi.JoinConfiguration, error) {
+func documentMapToJoinConfiguration(gvkmap map[schema.GroupVersionKind][]byte, allowDeprecated bool) (*kubeadmapi.JoinConfiguration, error) {
 	joinBytes := []byte{}
 	for gvk, bytes := range gvkmap {
 		// not interested in anything other than JoinConfiguration
@@ -97,8 +97,8 @@ func documentMapToJoinConfiguration(gvkmap map[schema.GroupVersionKind][]byte) (
 			continue
 		}
 
-		// check if this version is supported one
-		if err := ValidateSupportedVersion(gvk.GroupVersion()); err != nil {
+		// check if this version is supported and possibly not deprecated
+		if err := validateSupportedVersion(gvk.GroupVersion(), allowDeprecated); err != nil {
 			return nil, err
 		}
 

--- a/cmd/kubeadm/app/util/config/joinconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration_test.go
@@ -46,22 +46,15 @@ func TestLoadJoinConfigurationFromFile(t *testing.T) {
 		// These tests are reading one file, loading it using LoadJoinConfigurationFromFile that all of kubeadm is using for unmarshal of our API types,
 		// and then marshals the internal object to the expected groupVersion
 		{ // v1alpha3 -> internal
-			name:         "v1alpha3ToInternal",
-			in:           nodeV1alpha3YAML,
-			out:          nodeInternalYAML,
-			groupVersion: kubeadm.SchemeGroupVersion,
+			name:        "v1alpha3IsDeprecated",
+			in:          nodeV1alpha3YAML,
+			expectedErr: true,
 		},
 		{ // v1beta1 -> internal
 			name:         "v1beta1ToInternal",
 			in:           nodeV1beta1YAML,
 			out:          nodeInternalYAML,
 			groupVersion: kubeadm.SchemeGroupVersion,
-		},
-		{ // v1alpha3 -> internal -> v1beta1
-			name:         "v1alpha3Tov1beta1",
-			in:           nodeV1alpha3YAML,
-			out:          nodeV1beta1YAML,
-			groupVersion: kubeadmapiv1beta1.SchemeGroupVersion,
 		},
 		{ // v1beta1 -> internal -> v1beta1
 			name:         "v1beta1Tov1beta1",
@@ -77,7 +70,7 @@ func TestLoadJoinConfigurationFromFile(t *testing.T) {
 			out:          nodeDefaultedYAML,
 			groupVersion: kubeadmapiv1beta1.SchemeGroupVersion,
 		},
-		{ // v1alpha3 -> validation should fail
+		{ // v1beta1 -> validation should fail
 			name:        "invalidYAMLShouldFail",
 			in:          nodeInvalidYAML,
 			expectedErr: true,

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/node/incomplete.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/node/incomplete.yaml
@@ -1,11 +1,11 @@
-apiVersion: kubeadm.k8s.io/v1alpha3
-discoveryToken: abcdef.0123456789abcdef
-discoveryTokenAPIServers:
-- kube-apiserver:6443
-discoveryTokenUnsafeSkipCAVerification: true
+apiVersion: kubeadm.k8s.io/v1beta1
+discovery:
+  bootstrapToken:
+    apiServerEndpoint: kube-apiserver:6443
+    token: abcdef.0123456789abcdef
+    unsafeSkipCAVerification: true
+  tlsBootstrapToken: abcdef.0123456789abcdef
 kind: JoinConfiguration
 nodeRegistration:
   criSocket: /var/run/dockershim.sock
   name: thegopher
-tlsBootstrapToken: abcdef.0123456789abcdef
-token: abcdef.0123456789abcdef

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -146,19 +146,19 @@ func TestCmdInitConfig(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "can't load v1alpha1 config",
+			name:     "can't load old v1alpha1 config",
 			args:     "--config=testdata/init/v1alpha1.yaml",
 			expected: false,
 		},
 		{
-			name:     "can't load v1alpha2 config",
+			name:     "can't load old v1alpha2 config",
 			args:     "--config=testdata/init/v1alpha2.yaml",
 			expected: false,
 		},
 		{
-			name:     "can load v1alpha3 config",
+			name:     "can't load deprecated v1alpha3 config",
 			args:     "--config=testdata/init/v1alpha3.yaml",
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "can load v1beta1 config",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Currently kubeadm supports a couple of configuration versions - v1alpha3 and v1beta1. The former is deprecated, but still supported.
    
To discourage users from using it and to speedup conversion to newer versions, we disable the loading of deprecated configurations by all kubeadm sub-commands, but "kubeadm config migrate".
    
v1alpha3 is still present and supported at source level, but cannot be used directly with kubeadm and some of its internal APIs.
    
The added benefit to this is, that users won't need to lookup for an old kubeadm binary after upgrade, just because they were stuck with a deprecated config version for too long.
    
To achieve this, the following was done:
    
- ValidateSupportedVersion now has an allowDeprecated boolean parameter, that controls if the function should return an error upon detecting deprecated config version. Currently the only deprecated version is v1alpha3.
    
- ValidateSupportedVersion is made package private, because it's not used outside of the package anyway.
    
- `BytesToInitConfiguration` and `LoadJoinConfigurationFromFile` are modified to disallow loading of deprecated kubeadm config versions. An error message, that points users to kubeadm config migrate is returned.
    
- `MigrateOldConfig` is still allowed to load deprecated kubeadm config versions.
    
- A bunch of tests were fixed to not expect success if v1alpha3 config is supplied.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refs kubernetes/kubeadm#1296

**Special notes for your reviewer**:

Depends on #74024 . Please, review only the last commit here.

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/assign @neolit123
/assign @fabriziopandini

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm no longer allows using v1alpha3 configs for anything else than converting them to v1beta1.
```
