### PR TITLE
Add missing VisitArbitrary methods in kubectl explain

### DIFF
--- a/pkg/kubectl/explain/field_lookup.go
+++ b/pkg/kubectl/explain/field_lookup.go
@@ -89,6 +89,10 @@ func (f *fieldLookup) VisitKind(k *proto.Kind) {
 	subSchema.Accept(f)
 }
 
+func (f *fieldLookup) VisitArbitrary(a *proto.Arbitrary) {
+	f.Schema = a
+}
+
 // VisitReference is mostly a passthrough.
 func (f *fieldLookup) VisitReference(r proto.Reference) {
 	if f.SaveLeafSchema(r) {

--- a/pkg/kubectl/explain/field_lookup_test.go
+++ b/pkg/kubectl/explain/field_lookup_test.go
@@ -87,3 +87,48 @@ func TestFindField(t *testing.T) {
 		})
 	}
 }
+func TestCrdFindField(t *testing.T) {
+	schema := resources.LookupResource(schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "CrdKind",
+	})
+	if schema == nil {
+		t.Fatal("Counldn't find schema v1.CrdKind")
+	}
+
+	tests := []struct {
+		name string
+		path []string
+
+		err          string
+		expectedPath string
+	}{
+		{
+			name:         "test1",
+			path:         []string{},
+			expectedPath: "CrdKind",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := LookupSchemaForField(schema, tt.path)
+
+			gotErr := ""
+			if err != nil {
+				gotErr = err.Error()
+			}
+
+			gotPath := ""
+			if path != nil {
+				gotPath = path.GetPath().String()
+			}
+
+			if gotErr != tt.err || gotPath != tt.expectedPath {
+				t.Errorf("LookupSchemaForField(schema, %v) = (path: %q, err: %q), expected (path: %q, err: %q)",
+					tt.path, gotPath, gotErr, tt.expectedPath, tt.err)
+			}
+		})
+	}
+}

--- a/pkg/kubectl/explain/model_printer.go
+++ b/pkg/kubectl/explain/model_printer.go
@@ -56,10 +56,12 @@ func (m *modelPrinter) PrintDescription(schema proto.Schema) error {
 	if err := m.Writer.Write("DESCRIPTION:"); err != nil {
 		return err
 	}
+	empty := true
 	for i, desc := range append(m.Descriptions, schema.GetDescription()) {
 		if desc == "" {
 			continue
 		}
+		empty = false
 		if i != 0 {
 			if err := m.Writer.Write(""); err != nil {
 				return err
@@ -68,6 +70,9 @@ func (m *modelPrinter) PrintDescription(schema proto.Schema) error {
 		if err := m.Writer.Indent(descriptionIndentLevel).WriteWrapped(desc); err != nil {
 			return err
 		}
+	}
+	if empty {
+		return m.Writer.Indent(descriptionIndentLevel).WriteWrapped("<empty>")
 	}
 	return nil
 }
@@ -132,6 +137,15 @@ func (m *modelPrinter) VisitPrimitive(p *proto.Primitive) {
 		return
 	}
 	m.Error = m.PrintDescription(p)
+}
+
+func (m *modelPrinter) VisitArbitrary(a *proto.Arbitrary) {
+	if err := m.PrintKindAndVersion(); err != nil {
+		m.Error = err
+		return
+	}
+
+	m.Error = m.PrintDescription(a)
 }
 
 // VisitReference recurses inside the subtype, while collecting the description.

--- a/pkg/kubectl/explain/model_printer_test.go
+++ b/pkg/kubectl/explain/model_printer_test.go
@@ -133,3 +133,40 @@ DESCRIPTION:
 		}
 	}
 }
+func TestCRDModel(t *testing.T) {
+	gvk := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "CrdKind",
+	}
+	schema := resources.LookupResource(gvk)
+	if schema == nil {
+		t.Fatal("Couldn't find schema v1.CrdKind")
+	}
+
+	tests := []struct {
+		path []string
+		want string
+	}{
+		{
+			path: []string{},
+			want: `KIND:     CrdKind
+VERSION:  v1
+
+DESCRIPTION:
+     <empty>
+`,
+		},
+	}
+
+	for _, test := range tests {
+		buf := bytes.Buffer{}
+		if err := PrintModelDescription(test.path, &buf, schema, gvk, false); err != nil {
+			t.Fatalf("Failed to PrintModelDescription for path %v: %v", test.path, err)
+		}
+		got := buf.String()
+		if got != test.want {
+			t.Errorf("Got:\n%v\nWant:\n%v\n", buf.String(), test.want)
+		}
+	}
+}

--- a/pkg/kubectl/explain/test-swagger.json
+++ b/pkg/kubectl/explain/test-swagger.json
@@ -73,6 +73,15 @@
           "$ref": "#/definitions/PrimitiveDef"
         }
       }
+    },
+    "CrdKind": {
+      "x-kubernetes-group-version-kind": [
+        {
+         "group": "",
+         "kind": "CrdKind",
+         "version": "v1"
+        }
+       ]
     }
   }
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/priority important-longterm
/sig cli

**What this PR does / why we need it**:
This is alternative approach to https://github.com/kubernetes/kubernetes/pull/73817 and I think is a better one. 

**Which issue(s) this PR fixes**:
This was noticed in https://github.com/kubernetes/kubernetes/pull/71192

**Special notes for your reviewer**:
/assign @liggitt @sttts @roycaihw @apelisse 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
