### PR TITLE
Use Set to check whether flag name is allowed flag

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -416,23 +416,18 @@ func ValidateMixedArguments(flag *pflag.FlagSet) error {
 }
 
 func isAllowedFlag(flagName string) bool {
-	isAllowed := false
-	switch flagName {
-	case kubeadmcmdoptions.CfgPath,
+	knownFlags := sets.NewString(kubeadmcmdoptions.CfgPath,
 		kubeadmcmdoptions.IgnorePreflightErrors,
 		kubeadmcmdoptions.DryRun,
 		kubeadmcmdoptions.KubeconfigPath,
 		kubeadmcmdoptions.NodeName,
 		kubeadmcmdoptions.NodeCRISocket,
 		kubeadmcmdoptions.KubeconfigDir,
-		"print-join-command", "rootfs", "v":
-		isAllowed = true
-	default:
-		if strings.HasPrefix(flagName, "skip-") {
-			isAllowed = true
-		}
+		"print-join-command", "rootfs", "v")
+	if knownFlags.Has(flagName) {
+		return true
 	}
-	return isAllowed
+	return strings.HasPrefix(flagName, "skip-")
 }
 
 // ValidateFeatureGates validates provided feature gates


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Set is used for known flags so that the check of flag name can be done faster.

**Special notes for your reviewer**:

```release-note
NONE
```
See discussion at the tail of #73998
