### PR TITLE
Automated cherry pick of #73016: Bump the pod memory to higher levels to work on power

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -112,9 +112,9 @@ var _ = framework.KubeDescribe("Summary API", func() {
 				"Time": recent(maxStatsAge),
 				// Pods are limited by Node Allocatable
 				"AvailableBytes":  bounded(1*framework.Kb, memoryLimit),
-				"UsageBytes":      bounded(10*framework.Kb, 20*framework.Mb),
-				"WorkingSetBytes": bounded(10*framework.Kb, 20*framework.Mb),
-				"RSSBytes":        bounded(1*framework.Kb, 20*framework.Mb),
+				"UsageBytes":      bounded(10*framework.Kb, 400*framework.Mb),
+				"WorkingSetBytes": bounded(10*framework.Kb, 400*framework.Mb),
+				"RSSBytes":        bounded(1*framework.Kb, 160*framework.Mb),
 				"PageFaults":      bounded(0, 1000000),
 				"MajorPageFaults": bounded(0, 10),
 			})
@@ -155,10 +155,10 @@ var _ = framework.KubeDescribe("Summary API", func() {
 						}),
 						"Memory": ptrMatchAllFields(gstruct.Fields{
 							"Time":            recent(maxStatsAge),
-							"AvailableBytes":  bounded(1*framework.Kb, 10*framework.Mb),
-							"UsageBytes":      bounded(10*framework.Kb, 20*framework.Mb),
-							"WorkingSetBytes": bounded(10*framework.Kb, 20*framework.Mb),
-							"RSSBytes":        bounded(1*framework.Kb, framework.Mb),
+							"AvailableBytes":  bounded(1*framework.Kb, 80*framework.Mb),
+							"UsageBytes":      bounded(10*framework.Kb, 80*framework.Mb),
+							"WorkingSetBytes": bounded(10*framework.Kb, 80*framework.Mb),
+							"RSSBytes":        bounded(1*framework.Kb, 80*framework.Mb),
 							"PageFaults":      bounded(100, 1000000),
 							"MajorPageFaults": bounded(0, 10),
 						}),
@@ -202,10 +202,10 @@ var _ = framework.KubeDescribe("Summary API", func() {
 				}),
 				"Memory": ptrMatchAllFields(gstruct.Fields{
 					"Time":            recent(maxStatsAge),
-					"AvailableBytes":  bounded(1*framework.Kb, 10*framework.Mb),
-					"UsageBytes":      bounded(10*framework.Kb, 20*framework.Mb),
-					"WorkingSetBytes": bounded(10*framework.Kb, 20*framework.Mb),
-					"RSSBytes":        bounded(1*framework.Kb, framework.Mb),
+					"AvailableBytes":  bounded(1*framework.Kb, 80*framework.Mb),
+					"UsageBytes":      bounded(10*framework.Kb, 80*framework.Mb),
+					"WorkingSetBytes": bounded(10*framework.Kb, 80*framework.Mb),
+					"RSSBytes":        bounded(1*framework.Kb, 80*framework.Mb),
 					"PageFaults":      bounded(0, 1000000),
 					"MajorPageFaults": bounded(0, 10),
 				}),
@@ -328,7 +328,7 @@ func getSummaryTestPods(f *framework.Framework, numRestarts int32, names ...stri
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
 								// Must set memory limit to get MemoryStats.AvailableBytes
-								v1.ResourceMemory: resource.MustParse("10M"),
+								v1.ResourceMemory: resource.MustParse("80M"),
 							},
 						},
 						VolumeMounts: []v1.VolumeMount{


### PR DESCRIPTION
Cherry pick of #73016 on release-1.10.

#73016: Bump the pod memory to higher levels to work on power