### PR TITLE
Add NOTE for StorageObjectInUseProtection

### DIFF
--- a/test/e2e/storage/pv_protection.go
+++ b/test/e2e/storage/pv_protection.go
@@ -85,6 +85,8 @@ var _ = utils.SIGDescribe("PV Protection", func() {
 		By("Checking that PV Protection finalizer is set")
 		pv, err = client.CoreV1().PersistentVolumes().Get(pv.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(), "While getting PV status")
+
+		// NOTE: If the following Expect is failed, please check StorageObjectInUseProtection plugin of admission controller on k8s cluster.
 		Expect(slice.ContainsString(pv.ObjectMeta.Finalizers, volumeutil.PVProtectionFinalizer, nil)).To(BeTrue(), "PV Protection finalizer(%v) is not set in %v", volumeutil.PVProtectionFinalizer, pv.ObjectMeta.Finalizers)
 	})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

StorageObjectInUseProtection plugin is disabled by default on
admission controller, and the PV protection e2e tests can be
failed flakily if disabling the plugin.
This adds NOTE for letting testers know this reason for debugging.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #74038 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note-none

```
