### PR TITLE
Request network plugin in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -22,4 +22,5 @@ labels: kind/bug
 - OS (e.g. from /etc/os-release):
 - Kernel (e.g. `uname -a`):
 - Install tools:
+- Network plugin and version (if this is a network-related bug):
 - Others:


### PR DESCRIPTION
People often file networking-related bug reports that are partly or fully network-plugin-dependent, but they don't mention what network plugin they're using. It would be useful if they did. (Right, @kubernetes/sig-network-bugs?)

The "`(if this is a network-related bug)`" makes the line kind of long so maybe we should get rid of that and just let people provide irrelevant information even for non-networking-related bugs?

OTOH maybe other SIGs (storage?) have the same problem and we should ask about something more generic like "relevant plugins or extensions" or something?

/kind cleanup
/sig network
```release-note
NONE
```