### PR TITLE
kubeadm cleanup: master -> control-plane (cont.1)

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -43,7 +43,7 @@ type InitConfiguration struct {
 	// BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
 	BootstrapTokens []BootstrapToken
 
-	// NodeRegistration holds fields that relate to registering the new master node to the cluster
+	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster
 	NodeRegistration NodeRegistrationOptions
 
 	// LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
@@ -208,7 +208,7 @@ type APIEndpoint struct {
 	BindPort int32
 }
 
-// NodeRegistrationOptions holds fields that relate to registering a new master or node to the cluster, either via "kubeadm init" or "kubeadm join"
+// NodeRegistrationOptions holds fields that relate to registering a new control-plane or node to the cluster, either via "kubeadm init" or "kubeadm join"
 type NodeRegistrationOptions struct {
 
 	// Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm joiń` operation.
@@ -220,7 +220,7 @@ type NodeRegistrationOptions struct {
 	CRISocket string
 
 	// Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
-	// it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your master node, set this field to an
+	// it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
 	// empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
 	Taints []v1.Taint
 
@@ -244,7 +244,7 @@ type Networking struct {
 // TODO: The BootstrapToken object should move out to either k8s.io/client-go or k8s.io/api in the future
 // (probably as part of Bootstrap Tokens going GA). It should not be staged under the kubeadm API as it is now.
 type BootstrapToken struct {
-	// Token is used for establishing bidirectional trust between nodes and masters.
+	// Token is used for establishing bidirectional trust between nodes and control-planes.
 	// Used for joining nodes in the cluster.
 	Token *BootstrapTokenString
 	// Description sets a human-friendly message why this token exists and what it's used
@@ -315,11 +315,11 @@ type ExternalEtcd struct {
 type JoinConfiguration struct {
 	metav1.TypeMeta
 
-	// NodeRegistration holds fields that relate to registering the new master node to the cluster
+	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster
 	NodeRegistration NodeRegistrationOptions
 
 	// CACertPath is the path to the SSL certificate authority used to
-	// secure comunications between node and master.
+	// secure comunications between node and control-plane.
 	// Defaults to "/etc/kubernetes/pki/ca.crt".
 	CACertPath string
 
@@ -359,7 +359,7 @@ type Discovery struct {
 // BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery
 type BootstrapTokenDiscovery struct {
 	// Token is a token used to validate cluster information
-	// fetched from the master.
+	// fetched from the control-plane.
 	Token string
 
 	// APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
@@ -377,7 +377,7 @@ type BootstrapTokenDiscovery struct {
 
 	// UnsafeSkipCAVerification allows token-based discovery
 	// without CA verification via CACertHashes. This can weaken
-	// the security of kubeadm since other nodes can impersonate the master.
+	// the security of kubeadm since other nodes can impersonate the control-plane.
 	UnsafeSkipCAVerification bool
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/types.go
@@ -42,7 +42,7 @@ type InitConfiguration struct {
 	// This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
 	BootstrapTokens []BootstrapToken `json:"bootstrapTokens,omitempty"`
 
-	// NodeRegistration holds fields that relate to registering the new master node to the cluster
+	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster
 	NodeRegistration NodeRegistrationOptions `json:"nodeRegistration,omitempty"`
 
 	// APIEndpoint represents the endpoint of the instance of the API server to be deployed on this node.
@@ -144,7 +144,7 @@ type APIEndpoint struct {
 	BindPort int32 `json:"bindPort"`
 }
 
-// NodeRegistrationOptions holds fields that relate to registering a new master or node to the cluster, either via "kubeadm init" or "kubeadm join"
+// NodeRegistrationOptions holds fields that relate to registering a new control-plane or node to the cluster, either via "kubeadm init" or "kubeadm join"
 type NodeRegistrationOptions struct {
 
 	// Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm joiń` operation.
@@ -156,7 +156,7 @@ type NodeRegistrationOptions struct {
 	CRISocket string `json:"criSocket,omitempty"`
 
 	// Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
-	// it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your master node, set this field to an
+	// it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
 	// empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
 	Taints []v1.Taint `json:"taints,omitempty"`
 
@@ -178,7 +178,7 @@ type Networking struct {
 
 // BootstrapToken describes one bootstrap token, stored as a Secret in the cluster
 type BootstrapToken struct {
-	// Token is used for establishing bidirectional trust between nodes and masters.
+	// Token is used for establishing bidirectional trust between nodes and control-planes.
 	// Used for joining nodes in the cluster.
 	Token *BootstrapTokenString `json:"token"`
 	// Description sets a human-friendly message why this token exists and what it's used
@@ -251,18 +251,18 @@ type ExternalEtcd struct {
 type JoinConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// NodeRegistration holds fields that relate to registering the new master node to the cluster
+	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster
 	NodeRegistration NodeRegistrationOptions `json:"nodeRegistration"`
 
 	// CACertPath is the path to the SSL certificate authority used to
-	// secure comunications between node and master.
+	// secure comunications between node and control-plane.
 	// Defaults to "/etc/kubernetes/pki/ca.crt".
 	CACertPath string `json:"caCertPath"`
 	// DiscoveryFile is a file or url to a kubeconfig file from which to
 	// load cluster information.
 	DiscoveryFile string `json:"discoveryFile"`
 	// DiscoveryToken is a token used to validate cluster information
-	// fetched from the master.
+	// fetched from the control-plane.
 	DiscoveryToken string `json:"discoveryToken"`
 	// DiscoveryTokenAPIServers is a set of IPs to API servers from which info
 	// will be fetched. Currently we only pay attention to one API server but
@@ -291,7 +291,7 @@ type JoinConfiguration struct {
 
 	// DiscoveryTokenUnsafeSkipCAVerification allows token-based discovery
 	// without CA verification via DiscoveryTokenCACertHashes. This can weaken
-	// the security of kubeadm since other nodes can impersonate the master.
+	// the security of kubeadm since other nodes can impersonate the control-plane.
 	DiscoveryTokenUnsafeSkipCAVerification bool `json:"discoveryTokenUnsafeSkipCAVerification"`
 
 	// ControlPlane flag specifies that the joining node should host an additional

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/types.go
@@ -42,7 +42,7 @@ type InitConfiguration struct {
 	// This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
 	BootstrapTokens []BootstrapToken `json:"bootstrapTokens,omitempty"`
 
-	// NodeRegistration holds fields that relate to registering the new master node to the cluster
+	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster
 	NodeRegistration NodeRegistrationOptions `json:"nodeRegistration,omitempty"`
 
 	// LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
@@ -191,7 +191,7 @@ type APIEndpoint struct {
 	BindPort int32 `json:"bindPort"`
 }
 
-// NodeRegistrationOptions holds fields that relate to registering a new master or node to the cluster, either via "kubeadm init" or "kubeadm join"
+// NodeRegistrationOptions holds fields that relate to registering a new control-plane or node to the cluster, either via "kubeadm init" or "kubeadm join"
 type NodeRegistrationOptions struct {
 
 	// Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm joiń` operation.
@@ -203,7 +203,7 @@ type NodeRegistrationOptions struct {
 	CRISocket string `json:"criSocket,omitempty"`
 
 	// Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
-	// it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your master node, set this field to an
+	// it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
 	// empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
 	Taints []v1.Taint `json:"taints,omitempty"`
 
@@ -225,7 +225,7 @@ type Networking struct {
 
 // BootstrapToken describes one bootstrap token, stored as a Secret in the cluster
 type BootstrapToken struct {
-	// Token is used for establishing bidirectional trust between nodes and masters.
+	// Token is used for establishing bidirectional trust between nodes and control-planes.
 	// Used for joining nodes in the cluster.
 	Token *BootstrapTokenString `json:"token"`
 	// Description sets a human-friendly message why this token exists and what it's used
@@ -301,11 +301,11 @@ type ExternalEtcd struct {
 type JoinConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// NodeRegistration holds fields that relate to registering the new master node to the cluster
+	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster
 	NodeRegistration NodeRegistrationOptions `json:"nodeRegistration"`
 
 	// CACertPath is the path to the SSL certificate authority used to
-	// secure comunications between node and master.
+	// secure comunications between node and control-plane.
 	// Defaults to "/etc/kubernetes/pki/ca.crt".
 	CACertPath string `json:"caCertPath"`
 
@@ -345,7 +345,7 @@ type Discovery struct {
 // BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery
 type BootstrapTokenDiscovery struct {
 	// Token is a token used to validate cluster information
-	// fetched from the master.
+	// fetched from the control-plane.
 	Token string `json:"token"`
 
 	// APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
@@ -363,7 +363,7 @@ type BootstrapTokenDiscovery struct {
 
 	// UnsafeSkipCAVerification allows token-based discovery
 	// without CA verification via CACertHashes. This can weaken
-	// the security of kubeadm since other nodes can impersonate the master.
+	// the security of kubeadm since other nodes can impersonate the control-plane.
 	UnsafeSkipCAVerification bool `json:"unsafeSkipCAVerification"`
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -354,7 +354,7 @@ func TestValidateInitConfiguration(t *testing.T) {
 		s        *kubeadm.InitConfiguration
 		expected bool
 	}{
-		{"invalid missing master configuration",
+		{"invalid missing InitConfiguration",
 			&kubeadm.InitConfiguration{}, false},
 		{"invalid missing token with IPv4 service subnet",
 			&kubeadm.InitConfiguration{
@@ -400,7 +400,7 @@ func TestValidateInitConfiguration(t *testing.T) {
 					CertificatesDir: "/some/other/cert/dir",
 				},
 			}, false},
-		{"valid master configuration with incorrect IPv4 pod subnet",
+		{"valid InitConfiguration with incorrect IPv4 pod subnet",
 			&kubeadm.InitConfiguration{
 				LocalAPIEndpoint: kubeadm.APIEndpoint{
 					AdvertiseAddress: "1.2.3.4",
@@ -416,7 +416,7 @@ func TestValidateInitConfiguration(t *testing.T) {
 				},
 				NodeRegistration: kubeadm.NodeRegistrationOptions{Name: nodename, CRISocket: "/some/path"},
 			}, false},
-		{"valid master configuration with IPv4 service subnet",
+		{"valid InitConfiguration with IPv4 service subnet",
 			&kubeadm.InitConfiguration{
 				LocalAPIEndpoint: kubeadm.APIEndpoint{
 					AdvertiseAddress: "1.2.3.4",
@@ -463,7 +463,7 @@ func TestValidateInitConfiguration(t *testing.T) {
 				},
 				NodeRegistration: kubeadm.NodeRegistrationOptions{Name: nodename, CRISocket: "/some/path"},
 			}, true},
-		{"valid master configuration using IPv6 service subnet",
+		{"valid InitConfiguration using IPv6 service subnet",
 			&kubeadm.InitConfiguration{
 				LocalAPIEndpoint: kubeadm.APIEndpoint{
 					AdvertiseAddress: "1:2:3::4",

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -171,7 +171,7 @@ func NewCmdJoin(out io.Writer, joinOptions *joinOptions) *cobra.Command {
 			err = data.Run()
 			kubeadmutil.CheckErr(err)
 		},
-		// We accept the master location as an optional positional argument
+		// We accept the control-plane location as an optional positional argument
 		Args: cobra.MaximumNArgs(1),
 	}
 
@@ -452,7 +452,7 @@ func (j *joinData) Run() error {
 	return nil
 }
 
-// PostInstallControlPlane marks the new node as master and update the cluster status with information about current node
+// PostInstallControlPlane marks the new node as control-plane and update the cluster status with information about current node
 func (j *joinData) PostInstallControlPlane(initConfiguration *kubeadmapi.InitConfiguration) error {
 	kubeConfigFile := filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.AdminKubeConfigFileName)
 

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -101,7 +101,7 @@ const (
 	// TokenDescription flag sets the description of the token
 	TokenDescription = "description"
 
-	// TLSBootstrapToken flag sets the token used to temporarily authenticate with the Kubernetes Master to submit a certificate signing request (CSR) for a locally created key pair
+	// TLSBootstrapToken flag sets the token used to temporarily authenticate with the Kubernetes Control Plane to submit a certificate signing request (CSR) for a locally created key pair
 	TLSBootstrapToken = "tls-bootstrap-token"
 
 	// TokenDiscovery flag sets the token used to validate cluster information fetched from the API server (for token-based discovery)

--- a/cmd/kubeadm/app/cmd/phases/init/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubelet.go
@@ -72,9 +72,9 @@ func runKubeletStart(c workflow.RunData) error {
 		kubeletphase.TryStopKubelet()
 	}
 
-	// Write env file with flags for the kubelet to use. We do not need to write the --register-with-taints for the master,
-	// as we handle that ourselves in the markmaster phase
-	// TODO: Maybe we want to do that some time in the future, in order to remove some logic from the markmaster phase?
+	// Write env file with flags for the kubelet to use. We do not need to write the --register-with-taints for the control-plane,
+	// as we handle that ourselves in the mark-control-plane phase
+	// TODO: Maybe we want to do that some time in the future, in order to remove some logic from the mark-control-plane phase?
 	if err := kubeletphase.WriteKubeletDynamicEnvFile(&data.Cfg().ClusterConfiguration, &data.Cfg().NodeRegistration, false, data.KubeletDir()); err != nil {
 		return errors.Wrap(err, "error writing a dynamic environment file for the kubelet")
 	}

--- a/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
@@ -56,7 +56,7 @@ func NewMarkControlPlanePhase() workflow.Phase {
 	}
 }
 
-// runMarkControlPlane executes markcontrolplane checks logic.
+// runMarkControlPlane executes mark-control-plane checks logic.
 func runMarkControlPlane(c workflow.RunData) error {
 	data, ok := c.(markControlPlaneData)
 	if !ok {

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -144,7 +144,7 @@ func runKubeletStartJoinPhase(c workflow.RunData) error {
 
 	// Write env file with flags for the kubelet to use. We only want to
 	// register the joining node with the specified taints if the node
-	// is not a master. The markmaster phase will register the taints otherwise.
+	// is not a control-plane. The mark-control-plane phase will register the taints otherwise.
 	registerTaintsUsingFlags := cfg.ControlPlane == nil
 	if err := kubeletphase.WriteKubeletDynamicEnvFile(&initCfg.ClusterConfiguration, &initCfg.NodeRegistration, registerTaintsUsingFlags, kubeadmconstants.KubeletRunDirectory); err != nil {
 		return err

--- a/cmd/kubeadm/app/cmd/phases/workflow/doc.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/doc.go
@@ -22,7 +22,7 @@ Composable kubeadm workflows are built by an ordered sequence of phases;
 each phase can have it's own, nested, ordered sequence of sub phases.
 For instance
 
-	preflight     	Run master pre-flight checks
+	preflight     	Run control-plane pre-flight checks
 	certs         	Generates all PKI assets necessary to establish the control plane
 		/ca             Generates a self-signed Kubernetes CA to provision identities for Kubernetes components
 		/apiserver      Generates an API server serving certificate and key

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -140,7 +140,7 @@ func NewCmdApply(apf *applyPlanFlags) *cobra.Command {
 // - Gets the configuration from the kubeadm-config ConfigMap in the cluster
 // - Enforces all version skew policies
 // - Asks the user if they really want to upgrade
-// - Makes sure the control plane images are available locally on the master(s)
+// - Makes sure the control plane images are available locally on the control-plane(s)
 // - Upgrades the control plane components
 // - Applies the other resources that'd be created with kubeadm init as well, like
 //   - Creating the RBAC rules for the bootstrap tokens and the cluster-info ConfigMap


### PR DESCRIPTION
This PR continuation of [#73987](https://github.com/kubernetes/kubernetes/pull/73987)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
/assign @neolit123 