### PR TITLE
parse 88888Gi and 99999Gi

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -325,7 +325,7 @@ func ParseQuantity(str string) (Quantity, error) {
 						return Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format, s: str}, nil
 					}
 				}
-				return Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format}, nil
+				return Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format, s: str}, nil
 			}
 		}
 	}


### PR DESCRIPTION
/kind bug

Different behavior when parsing 88888Gi and 99999Gi.
The expression `value&0x07 != 0` at line 320 is true when parsing 99999Gi, but become false when parse 88888Gi.
As a result, invoke `OriginalString()` after parse 88888Gi will get empty string.
invoke `OriginalString()` after parse 99999Gi then get "99999Gi" is as expected.

```release-note
NONE
```
