### PR TITLE
kubeadm cleanup: master -> control-plane (cont.2)

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/init/preflight.go
@@ -68,7 +68,7 @@ func runPreflight(c workflow.RunData) error {
 	}
 
 	fmt.Println("[preflight] Running pre-flight checks")
-	if err := preflight.RunInitMasterChecks(utilsexec.New(), data.Cfg(), data.IgnorePreflightErrors()); err != nil {
+	if err := preflight.RunInitNodeChecks(utilsexec.New(), data.Cfg(), data.IgnorePreflightErrors()); err != nil {
 		return err
 	}
 

--- a/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
@@ -126,7 +126,7 @@ func printFilesIfDryRunning(data waitControlPlaneData) error {
 	// Print the contents of the upgraded manifests and pretend like they were in /etc/kubernetes/manifests
 	files := []dryrunutil.FileToPrint{}
 	// Print static pod manifests
-	for _, component := range kubeadmconstants.MasterComponents {
+	for _, component := range kubeadmconstants.ControlPlaneComponents {
 		realPath := kubeadmconstants.GetStaticPodFilepath(component, manifestDir)
 		outputPath := kubeadmconstants.GetStaticPodFilepath(component, kubeadmconstants.GetStaticPodDirectory())
 		files = append(files, dryrunutil.NewFileToPrint(realPath, outputPath))

--- a/cmd/kubeadm/app/cmd/phases/join/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/join/preflight.go
@@ -125,7 +125,7 @@ func runPreflight(c workflow.RunData) error {
 
 		// run kubeadm init preflight checks for checking all the prequisites
 		fmt.Println("[preflight] Running pre-flight checks before initializing the new control plane instance")
-		if err := preflight.RunInitMasterChecks(utilsexec.New(), initCfg, j.IgnorePreflightErrors()); err != nil {
+		if err := preflight.RunInitNodeChecks(utilsexec.New(), initCfg, j.IgnorePreflightErrors()); err != nil {
 			return err
 		}
 

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -196,7 +196,7 @@ func runApply(flags *applyFlags) error {
 	// and block until all DaemonSets are ready; then we know for sure that all control plane images are cached locally
 	klog.V(1).Infof("[upgrade/apply] creating prepuller")
 	prepuller := upgrade.NewDaemonSetPrepuller(client, waiter, &cfg.ClusterConfiguration)
-	componentsToPrepull := constants.MasterComponents
+	componentsToPrepull := constants.ControlPlaneComponents
 	if cfg.Etcd.External == nil && flags.etcdUpgrade {
 		componentsToPrepull = append(componentsToPrepull, constants.Etcd)
 	}
@@ -310,7 +310,7 @@ func DryRunStaticPodUpgrade(internalcfg *kubeadmapi.InitConfiguration) error {
 
 	// Print the contents of the upgraded manifests and pretend like they were in /etc/kubernetes/manifests
 	files := []dryrunutil.FileToPrint{}
-	for _, component := range constants.MasterComponents {
+	for _, component := range constants.ControlPlaneComponents {
 		realPath := constants.GetStaticPodFilepath(component, dryRunManifestDir)
 		outputPath := constants.GetStaticPodFilepath(component, constants.GetStaticPodDirectory())
 		files = append(files, dryrunutil.NewFileToPrint(realPath, outputPath))

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -143,7 +143,7 @@ const (
 	// the TLS bootstrap to get itself an unique credential
 	KubeletBootstrapKubeConfigFileName = "bootstrap-kubelet.conf"
 
-	// KubeletKubeConfigFileName defines the file name for the kubeconfig that the master kubelet will use for talking
+	// KubeletKubeConfigFileName defines the file name for the kubeconfig that the control-plane kubelet will use for talking
 	// to the API server
 	KubeletKubeConfigFileName = "kubelet.conf"
 	// ControllerManagerKubeConfigFileName defines the file name for the controller manager's kubeconfig file
@@ -157,9 +157,9 @@ const (
 	ControllerManagerUser = "system:kube-controller-manager"
 	// SchedulerUser defines the well-known user the scheduler should be authenticated as
 	SchedulerUser = "system:kube-scheduler"
-	// MastersGroup defines the well-known group for the apiservers. This group is also superuser by default
+	// SystemPrivilegedGroup defines the well-known group for the apiservers. This group is also superuser by default
 	// (i.e. bound to the cluster-admin ClusterRole)
-	MastersGroup = "system:masters"
+	SystemPrivilegedGroup = "system:masters"
 	// NodesGroup defines the well-known group for all nodes.
 	NodesGroup = "system:nodes"
 	// NodesUserPrefix defines the user name prefix as requested by the Node authorizer.
@@ -171,9 +171,9 @@ const (
 
 	// APICallRetryInterval defines how long kubeadm should wait before retrying a failed API operation
 	APICallRetryInterval = 500 * time.Millisecond
-	// DiscoveryRetryInterval specifies how long kubeadm should wait before retrying to connect to the master when doing discovery
+	// DiscoveryRetryInterval specifies how long kubeadm should wait before retrying to connect to the control-plane when doing discovery
 	DiscoveryRetryInterval = 5 * time.Second
-	// PatchNodeTimeout specifies how long kubeadm should wait for applying the label and taint on the master before timing out
+	// PatchNodeTimeout specifies how long kubeadm should wait for applying the label and taint on the control-plane before timing out
 	PatchNodeTimeout = 2 * time.Minute
 	// UpdateNodeTimeout specifies how long kubeadm should wait for updating node with the initial remote configuration of kubelet before timing out
 	UpdateNodeTimeout = 2 * time.Minute
@@ -198,7 +198,7 @@ const (
 	// CertificateKeySize specifies the size of the key used to encrypt certificates on uploadcerts phase
 	CertificateKeySize = 32
 
-	// LabelNodeRoleMaster specifies that a node is a master
+	// LabelNodeRoleMaster specifies that a node is a control-plane
 	// This is a duplicate definition of the constant in pkg/controller/service/service_controller.go
 	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
 
@@ -357,22 +357,22 @@ const (
 	// DefaultAPIServerBindAddress is the default bind address for the API Server
 	DefaultAPIServerBindAddress = "0.0.0.0"
 
-	// MasterNumCPU is the number of CPUs required on master
-	MasterNumCPU = 2
+	// ControlPlaneNumCPU is the number of CPUs required on control-plane
+	ControlPlaneNumCPU = 2
 
 	// KubeadmCertsSecret specifies in what Secret in the kube-system namespace the certificates should be stored
 	KubeadmCertsSecret = "kubeadm-certs"
 )
 
 var (
-	// MasterTaint is the taint to apply on the PodSpec for being able to run that Pod on the master
-	MasterTaint = v1.Taint{
+	// ControlPlaneTaint is the taint to apply on the PodSpec for being able to run that Pod on the control-plane
+	ControlPlaneTaint = v1.Taint{
 		Key:    LabelNodeRoleMaster,
 		Effect: v1.TaintEffectNoSchedule,
 	}
 
-	// MasterToleration is the toleration to apply on the PodSpec for being able to run that Pod on the master
-	MasterToleration = v1.Toleration{
+	// ControlPlaneToleration is the toleration to apply on the PodSpec for being able to run that Pod on the control-plane
+	ControlPlaneToleration = v1.Toleration{
 		Key:    LabelNodeRoleMaster,
 		Effect: v1.TaintEffectNoSchedule,
 	}
@@ -383,8 +383,8 @@ var (
 	// DefaultTokenGroups specifies the default groups that this token will authenticate as when used for authentication
 	DefaultTokenGroups = []string{NodeBootstrapTokenAuthGroup}
 
-	// MasterComponents defines the master component names
-	MasterComponents = []string{KubeAPIServer, KubeControllerManager, KubeScheduler}
+	// ControlPlaneComponents defines the control-plane component names
+	ControlPlaneComponents = []string{KubeAPIServer, KubeControllerManager, KubeScheduler}
 
 	// MinimumControlPlaneVersion specifies the minimum control plane version kubeadm can deploy
 	MinimumControlPlaneVersion = version.MustParseSemantic("v1.12.0")

--- a/cmd/kubeadm/app/phases/certs/certlist.go
+++ b/cmd/kubeadm/app/phases/certs/certlist.go
@@ -265,7 +265,7 @@ var (
 		CAName:   "ca",
 		config: certutil.Config{
 			CommonName:   kubeadmconstants.APIServerKubeletClientCertCommonName,
-			Organization: []string{kubeadmconstants.MastersGroup},
+			Organization: []string{kubeadmconstants.SystemPrivilegedGroup},
 			Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		},
 	}
@@ -341,7 +341,7 @@ var (
 		CAName:   "etcd-ca",
 		config: certutil.Config{
 			CommonName:   kubeadmconstants.EtcdHealthcheckClientCertCommonName,
-			Organization: []string{kubeadmconstants.MastersGroup},
+			Organization: []string{kubeadmconstants.SystemPrivilegedGroup},
 			Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		},
 	}
@@ -353,7 +353,7 @@ var (
 		CAName:   "etcd-ca",
 		config: certutil.Config{
 			CommonName:   kubeadmconstants.APIServerEtcdClientCertCommonName,
-			Organization: []string{kubeadmconstants.MastersGroup},
+			Organization: []string{kubeadmconstants.SystemPrivilegedGroup},
 			Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		},
 	}

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -147,7 +147,7 @@ func getKubeConfigSpecs(cfg *kubeadmapi.InitConfiguration) (map[string]*kubeConf
 			ClientName: "kubernetes-admin",
 			ClientCertAuth: &clientCertAuth{
 				CAKey:         caKey,
-				Organizations: []string{kubeadmconstants.MastersGroup},
+				Organizations: []string{kubeadmconstants.SystemPrivilegedGroup},
 			},
 		},
 		kubeadmconstants.KubeletKubeConfigFileName: {

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -118,7 +118,7 @@ func TestGetKubeConfigSpecs(t *testing.T) {
 			{
 				kubeConfigFile: kubeadmconstants.AdminKubeConfigFileName,
 				clientName:     "kubernetes-admin",
-				organizations:  []string{kubeadmconstants.MastersGroup},
+				organizations:  []string{kubeadmconstants.SystemPrivilegedGroup},
 			},
 			{
 				kubeConfigFile: kubeadmconstants.KubeletKubeConfigFileName,

--- a/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane_test.go
+++ b/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane_test.go
@@ -49,7 +49,7 @@ func TestMarkControlPlane(t *testing.T) {
 			"control-plane label and taint missing",
 			"",
 			nil,
-			[]v1.Taint{kubeadmconstants.MasterTaint},
+			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
 			"{\"metadata\":{\"labels\":{\"node-role.kubernetes.io/master\":\"\"}},\"spec\":{\"taints\":[{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\"}]}}",
 		},
 		{
@@ -62,22 +62,22 @@ func TestMarkControlPlane(t *testing.T) {
 		{
 			"control-plane label missing",
 			"",
-			[]v1.Taint{kubeadmconstants.MasterTaint},
-			[]v1.Taint{kubeadmconstants.MasterTaint},
+			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
+			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
 			"{\"metadata\":{\"labels\":{\"node-role.kubernetes.io/master\":\"\"}}}",
 		},
 		{
 			"control-plane taint missing",
 			kubeadmconstants.LabelNodeRoleMaster,
 			nil,
-			[]v1.Taint{kubeadmconstants.MasterTaint},
+			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
 			"{\"spec\":{\"taints\":[{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\"}]}}",
 		},
 		{
 			"nothing missing",
 			kubeadmconstants.LabelNodeRoleMaster,
-			[]v1.Taint{kubeadmconstants.MasterTaint},
-			[]v1.Taint{kubeadmconstants.MasterTaint},
+			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
+			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
 			"{}",
 		},
 		{
@@ -101,7 +101,7 @@ func TestMarkControlPlane(t *testing.T) {
 					Effect: v1.TaintEffectNoSchedule,
 				},
 			},
-			[]v1.Taint{kubeadmconstants.MasterTaint},
+			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
 			"{\"spec\":{\"taints\":[{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\"},{\"effect\":\"NoSchedule\",\"key\":\"node.cloudprovider.kubernetes.io/uninitialized\"}]}}",
 		},
 	}

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
@@ -95,11 +95,11 @@ func addNodeSelectorToPodSpec(podSpec *v1.PodSpec) {
 // setMasterTolerationOnPodSpec makes the Pod tolerate the master taint
 func setMasterTolerationOnPodSpec(podSpec *v1.PodSpec) {
 	if podSpec.Tolerations == nil {
-		podSpec.Tolerations = []v1.Toleration{kubeadmconstants.MasterToleration}
+		podSpec.Tolerations = []v1.Toleration{kubeadmconstants.ControlPlaneToleration}
 		return
 	}
 
-	podSpec.Tolerations = append(podSpec.Tolerations, kubeadmconstants.MasterToleration)
+	podSpec.Tolerations = append(podSpec.Tolerations, kubeadmconstants.ControlPlaneToleration)
 }
 
 // setHostIPOnPodSpec sets the environment variable HOST_IP using downward API

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
@@ -69,7 +69,7 @@ func TestMutatePodSpec(t *testing.T) {
 					kubeadmconstants.LabelNodeRoleMaster: "",
 				},
 				Tolerations: []v1.Toleration{
-					kubeadmconstants.MasterToleration,
+					kubeadmconstants.ControlPlaneToleration,
 				},
 				DNSPolicy: v1.DNSClusterFirstWithHostNet,
 			},
@@ -83,7 +83,7 @@ func TestMutatePodSpec(t *testing.T) {
 					kubeadmconstants.LabelNodeRoleMaster: "",
 				},
 				Tolerations: []v1.Toleration{
-					kubeadmconstants.MasterToleration,
+					kubeadmconstants.ControlPlaneToleration,
 				},
 				DNSPolicy: v1.DNSClusterFirstWithHostNet,
 			},
@@ -97,7 +97,7 @@ func TestMutatePodSpec(t *testing.T) {
 					kubeadmconstants.LabelNodeRoleMaster: "",
 				},
 				Tolerations: []v1.Toleration{
-					kubeadmconstants.MasterToleration,
+					kubeadmconstants.ControlPlaneToleration,
 				},
 				DNSPolicy: v1.DNSClusterFirstWithHostNet,
 			},
@@ -168,7 +168,7 @@ func TestSetMasterTolerationOnPodSpec(t *testing.T) {
 			podSpec: &v1.PodSpec{},
 			expected: v1.PodSpec{
 				Tolerations: []v1.Toleration{
-					kubeadmconstants.MasterToleration,
+					kubeadmconstants.ControlPlaneToleration,
 				},
 			},
 		},
@@ -182,7 +182,7 @@ func TestSetMasterTolerationOnPodSpec(t *testing.T) {
 			expected: v1.PodSpec{
 				Tolerations: []v1.Toleration{
 					{Key: "foo", Value: "bar"},
-					kubeadmconstants.MasterToleration,
+					kubeadmconstants.ControlPlaneToleration,
 				},
 			},
 		},

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
@@ -75,7 +75,7 @@ func CreateSelfHostedControlPlane(manifestsDir, kubeConfigDir string, cfg *kubea
 		}
 	}
 
-	for _, componentName := range kubeadmconstants.MasterComponents {
+	for _, componentName := range kubeadmconstants.ControlPlaneComponents {
 		start := time.Now()
 		manifestPath := kubeadmconstants.GetStaticPodFilepath(componentName, manifestsDir)
 

--- a/cmd/kubeadm/app/phases/upgrade/health.go
+++ b/cmd/kubeadm/app/phases/upgrade/health.go
@@ -126,7 +126,7 @@ func masterNodesReady(client clientset.Interface) error {
 // staticPodManifestHealth makes sure the required static pods are presents
 func staticPodManifestHealth(_ clientset.Interface) error {
 	nonExistentManifests := []string{}
-	for _, component := range constants.MasterComponents {
+	for _, component := range constants.ControlPlaneComponents {
 		manifestFile := constants.GetStaticPodFilepath(component, constants.GetStaticPodDirectory())
 		if _, err := os.Stat(manifestFile); os.IsNotExist(err) {
 			nonExistentManifests = append(nonExistentManifests, manifestFile)
@@ -152,7 +152,7 @@ func IsControlPlaneSelfHosted(client clientset.Interface) bool {
 // getNotReadyDaemonSets gets the amount of Ready control plane DaemonSets
 func getNotReadyDaemonSets(client clientset.Interface) ([]error, error) {
 	notReadyDaemonSets := []error{}
-	for _, component := range constants.MasterComponents {
+	for _, component := range constants.ControlPlaneComponents {
 		dsName := constants.AddSelfHostedPrefix(component)
 		ds, err := client.AppsV1().DaemonSets(metav1.NamespaceSystem).Get(dsName, metav1.GetOptions{})
 		if err != nil {

--- a/cmd/kubeadm/app/phases/upgrade/prepull.go
+++ b/cmd/kubeadm/app/phases/upgrade/prepull.go
@@ -42,7 +42,7 @@ type Prepuller interface {
 	DeleteFunc(string) error
 }
 
-// DaemonSetPrepuller makes sure the control plane images are available on all masters
+// DaemonSetPrepuller makes sure the control-plane images are available on all masters
 type DaemonSetPrepuller struct {
 	client clientset.Interface
 	cfg    *kubeadmapi.ClusterConfiguration
@@ -181,7 +181,7 @@ func buildPrePullDaemonSet(component, image string) *apps.DaemonSet {
 					NodeSelector: map[string]string{
 						constants.LabelNodeRoleMaster: "",
 					},
-					Tolerations:                   []v1.Toleration{constants.MasterToleration},
+					Tolerations:                   []v1.Toleration{constants.ControlPlaneToleration},
 					TerminationGracePeriodSeconds: &gracePeriodSecs,
 				},
 			},

--- a/cmd/kubeadm/app/phases/upgrade/prepull_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/prepull_test.go
@@ -141,7 +141,7 @@ func TestPrepullImagesInParallel(t *testing.T) {
 
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			actualErr := PrepullImagesInParallel(rt.p, rt.timeout, append(constants.MasterComponents, constants.Etcd))
+			actualErr := PrepullImagesInParallel(rt.p, rt.timeout, append(constants.ControlPlaneComponents, constants.Etcd))
 			if (actualErr != nil) != rt.expectedErr {
 				t.Errorf(
 					"failed TestPrepullImagesInParallel\n\texpected error: %t\n\tgot: %t",

--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -436,7 +436,7 @@ func StaticPodControlPlane(client clientset.Interface, waiter apiclient.Waiter, 
 		return errors.Wrap(err, "error creating init static pod manifest files")
 	}
 
-	for _, component := range constants.MasterComponents {
+	for _, component := range constants.ControlPlaneComponents {
 		if err = upgradeComponent(component, waiter, pathMgr, cfg, beforePodHashMap[component], recoverManifests); err != nil {
 			return err
 		}

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -871,8 +871,8 @@ func (ncc NumCPUCheck) Check() (warnings, errorList []error) {
 	return warnings, errorList
 }
 
-// RunInitMasterChecks executes all individual, applicable to Master node checks.
-func RunInitMasterChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfiguration, ignorePreflightErrors sets.String) error {
+// RunInitNodeChecks executes all individual, applicable to control-plane node checks.
+func RunInitNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfiguration, ignorePreflightErrors sets.String) error {
 	// First, check if we're root separately from the other preflight checks and fail fast
 	if err := RunRootCheckOnly(ignorePreflightErrors); err != nil {
 		return err
@@ -880,7 +880,7 @@ func RunInitMasterChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfigu
 
 	manifestsDir := filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.ManifestsSubDirName)
 	checks := []Checker{
-		NumCPUCheck{NumCPU: kubeadmconstants.MasterNumCPU},
+		NumCPUCheck{NumCPU: kubeadmconstants.ControlPlaneNumCPU},
 		KubernetesVersionCheck{KubernetesVersion: cfg.KubernetesVersion, KubeadmVersion: kubeadmversion.Get().GitVersion},
 		FirewalldCheck{ports: []int{int(cfg.LocalAPIEndpoint.BindPort), 10250}},
 		PortOpenCheck{port: int(cfg.LocalAPIEndpoint.BindPort)},

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -184,7 +184,7 @@ func (pfct preflightCheckTest) Check() (warning, errorList []error) {
 	return
 }
 
-func TestRunInitMasterChecks(t *testing.T) {
+func TestRunInitNodeChecks(t *testing.T) {
 	var tests = []struct {
 		name     string
 		cfg      *kubeadmapi.InitConfiguration
@@ -231,11 +231,11 @@ func TestRunInitMasterChecks(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		// TODO: Make RunInitMasterChecks accept a ClusterConfiguration object instead of InitConfiguration
-		actual := RunInitMasterChecks(exec.New(), rt.cfg, sets.NewString())
+		// TODO: Make RunInitNodeChecks accept a ClusterConfiguration object instead of InitConfiguration
+		actual := RunInitNodeChecks(exec.New(), rt.cfg, sets.NewString())
 		if (actual == nil) != rt.expected {
 			t.Errorf(
-				"failed RunInitMasterChecks:\n\texpected: %t\n\t  actual: %t\n\t error: %v",
+				"failed RunInitNodeChecks:\n\texpected: %t\n\t  actual: %t\n\t error: %v",
 				rt.expected,
 				(actual == nil),
 				actual,

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -187,7 +187,7 @@ func (w *KubeWaiter) WaitForStaticPodControlPlaneHashes(nodeName string) (map[st
 	componentHash := ""
 	var err error
 	mirrorPodHashes := map[string]string{}
-	for _, component := range constants.MasterComponents {
+	for _, component := range constants.ControlPlaneComponents {
 		err = wait.PollImmediate(constants.APICallRetryInterval, w.timeout, func() (bool, error) {
 			componentHash, err = getStaticPodSingleHash(w.client, nodeName, component)
 			if err != nil {

--- a/cmd/kubeadm/app/util/config/cluster.go
+++ b/cmd/kubeadm/app/util/config/cluster.go
@@ -59,7 +59,6 @@ func FetchInitConfigurationFromCluster(client clientset.Interface, w io.Writer, 
 
 // getInitConfigurationFromCluster is separate only for testing purposes, don't call it directly, use FetchInitConfigurationFromCluster instead
 func getInitConfigurationFromCluster(kubeconfigDir string, client clientset.Interface, newControlPlane bool) (*kubeadmapi.InitConfiguration, error) {
-	// TODO: This code should support reading the MasterConfiguration key as well for backwards-compat
 	// Also, the config map really should be KubeadmConfigConfigMap...
 	configMap, err := client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(constants.KubeadmConfigConfigMap, metav1.GetOptions{})
 	if err != nil {

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -268,7 +268,7 @@ func TestGetNodeRegistration(t *testing.T) {
 					},
 				},
 				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{kubeadmconstants.MasterTaint},
+					Taints: []v1.Taint{kubeadmconstants.ControlPlaneTaint},
 				},
 			},
 		},
@@ -551,7 +551,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{kubeadmconstants.MasterTaint},
+					Taints: []v1.Taint{kubeadmconstants.ControlPlaneTaint},
 				},
 			},
 		},
@@ -611,7 +611,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{kubeadmconstants.MasterTaint},
+					Taints: []v1.Taint{kubeadmconstants.ControlPlaneTaint},
 				},
 			},
 		},

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -85,16 +85,16 @@ func SetBootstrapTokensDynamicDefaults(cfg *[]kubeadmapi.BootstrapToken) error {
 }
 
 // SetNodeRegistrationDynamicDefaults checks and sets configuration values for the NodeRegistration object
-func SetNodeRegistrationDynamicDefaults(cfg *kubeadmapi.NodeRegistrationOptions, masterTaint bool) error {
+func SetNodeRegistrationDynamicDefaults(cfg *kubeadmapi.NodeRegistrationOptions, ControlPlaneTaint bool) error {
 	var err error
 	cfg.Name, err = nodeutil.GetHostname(cfg.Name)
 	if err != nil {
 		return err
 	}
 
-	// Only if the slice is nil, we should append the master taint. This allows the user to specify an empty slice for no default master taint
-	if masterTaint && cfg.Taints == nil {
-		cfg.Taints = []v1.Taint{kubeadmconstants.MasterTaint}
+	// Only if the slice is nil, we should append the control-plane taint. This allows the user to specify an empty slice for no default control-plane taint
+	if ControlPlaneTaint && cfg.Taints == nil {
+		cfg.Taints = []v1.Taint{kubeadmconstants.ControlPlaneTaint}
 	}
 
 	if cfg.CRISocket == "" {


### PR DESCRIPTION
This PR continuation of [#73987](https://github.com/kubernetes/kubernetes/pull/73987)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
/assign @neolit123 