### PR TITLE
Don't return CSI driver unregistration error

### DIFF
--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -147,20 +147,16 @@ func (h *RegistrationHandler) RegisterPlugin(pluginName string, endpoint string,
 
 	driverNodeID, maxVolumePerNode, accessibleTopology, err := csi.NodeGetInfo(ctx)
 	if err != nil {
-		klog.Error(log("registrationHandler.RegisterPlugin failed at CSI.NodeGetInfo: %v", err))
 		if unregErr := unregisterDriver(pluginName); unregErr != nil {
 			klog.Error(log("registrationHandler.RegisterPlugin failed to unregister plugin due to previous error: %v", unregErr))
-			return unregErr
 		}
 		return err
 	}
 
 	err = nim.InstallCSIDriver(pluginName, driverNodeID, maxVolumePerNode, accessibleTopology)
 	if err != nil {
-		klog.Error(log("registrationHandler.RegisterPlugin failed at AddNodeInfo: %v", err))
 		if unregErr := unregisterDriver(pluginName); unregErr != nil {
 			klog.Error(log("registrationHandler.RegisterPlugin failed to unregister plugin due to previous error: %v", unregErr))
-			return unregErr
 		}
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR prevents the Kubelet from returning a CSI unregistration error if it happened during the registration phase.

This is what the user sees in the registrar logs when trying to install a CSI driver. This error happened because no `CSINodeInfo` and `CSIDriver` CRDs were created beforehand:

```
I0214 12:59:42.025030       1 main.go:111] Received GetInfo call: &InfoRequest{}
I0214 12:59:42.954549       1 main.go:121] Received NotifyRegistrationStatus call: &RegistrationStatus{PluginRegistered:false,Error:plugin registration failed with err: error uninstalling CSI driver from CSINodeInfo object error updating CSINodeInfo: timed out waiting for the condition; caused by: the server could not find the requested resource (get csinodeinfos.csi.storage.k8s.io ip-172-18-6-39.ec2.internal),}
E0214 12:59:42.954638       1 main.go:123] Registration process failed with error: plugin registration failed with err: error uninstalling CSI driver from CSINodeInfo object error updating CSINodeInfo: timed out waiting for the condition; caused by: the server could not find the requested resource (get csinodeinfos.csi.storage.k8s.io ip-172-18-6-39.ec2.internal), restarting registration container.
```

Note that the message states the error happened when **uninstalling** the driver.

After applying this PR:

```
I0214 12:36:29.014606       1 node_register.go:86] Starting Registration Server at: /registration/ebs.csi.aws.com-reg.sock
I0214 12:36:29.014772       1 node_register.go:93] Registration Server started at: /registration/ebs.csi.aws.com-reg.sock
I0214 12:36:29.344794       1 main.go:111] Received GetInfo call: &InfoRequest{}
I0214 12:36:30.616599       1 main.go:121] Received NotifyRegistrationStatus call: &RegistrationStatus{PluginRegistered:false,Error:plugin registration failed with err: error updating CSINodeInfo object with CSI driver node info: error updating CSINodeInfo: timed out waiting for the condition; caused by: the server could not find the requested resource (post csinodeinfos.csi.storage.k8s.io),}
E0214 12:36:30.616694       1 main.go:123] Registration process failed with error: plugin registration failed with err: error updating CSINodeInfo object with CSI driver node info: error updating CSINodeInfo: timed out waiting for the condition; caused by: the server could not find the requested resource (post csinodeinfos.csi.storage.k8s.io), restarting registration container.
```

The unregistration error can still be seen in the logs.

**Which issue(s) this PR fixes**:

Fixes #74075

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
/sig storage
/assign @vladimirvivien
CC @jsafrane, @msau42 
