### PR TITLE
Add throttle latency metric to client-go

### DIFF
--- a/pkg/client/metrics/prometheus/prometheus.go
+++ b/pkg/client/metrics/prometheus/prometheus.go
@@ -61,6 +61,7 @@ var (
 
 func init() {
 	prometheus.MustRegister(requestLatency)
+	prometheus.MustRegister(throttleLatency)
 	prometheus.MustRegister(requestResult)
 	metrics.Register(&latencyAdapter{requestLatency}, &latencyAdapter{throttleLatency}, &resultAdapter{requestResult})
 }

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -526,7 +526,9 @@ func (r *Request) tryThrottle() {
 	if r.throttle != nil {
 		r.throttle.Accept()
 	}
-	if latency := time.Since(now); latency > longThrottleLatency {
+	latency := time.Since(now)
+	metrics.ThrottleLatency.Observe(r.verb, r.finalURLTemplate(), latency)
+	if latency > longThrottleLatency {
 		klog.V(4).Infof("Throttling request took %v, request: %s:%s", latency, r.verb, r.URL().String())
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/metrics/metrics.go
+++ b/staging/src/k8s.io/client-go/tools/metrics/metrics.go
@@ -39,15 +39,18 @@ type ResultMetric interface {
 var (
 	// RequestLatency is the latency metric that rest clients will update.
 	RequestLatency LatencyMetric = noopLatency{}
+	// ThrottleLatency is the throttle latency metric that rest clients will update.
+	ThrottleLatency LatencyMetric = noopLatency{}
 	// RequestResult is the result metric that rest clients will update.
 	RequestResult ResultMetric = noopResult{}
 )
 
 // Register registers metrics for the rest client to use. This can
 // only be called once.
-func Register(lm LatencyMetric, rm ResultMetric) {
+func Register(lm LatencyMetric, tm LatencyMetric, rm ResultMetric) {
 	registerMetrics.Do(func() {
 		RequestLatency = lm
+		ThrottleLatency = tm
 		RequestResult = rm
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds a throttle latency metric to `client-go`. This measures the component of request latency caused by throttling. At Monzo we are looking for a way of detecting throttling (eg in the controllers) without having to parse verbose logs. This will allow us to set alerts if throttle latencies increase.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
