### PR TITLE
Fix testing if an interface is the loopback

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -547,12 +547,15 @@ func getLocalIP() ([]v1.NodeAddress, error) {
 		return nil, err
 	}
 	for _, i := range ifaces {
+		if i.Flags&net.FlagLoopback != 0 {
+			continue
+		}
 		localAddrs, err := i.Addrs()
 		if err != nil {
 			klog.Warningf("Failed to extract addresses for NodeAddresses - %v", err)
 		} else {
 			for _, addr := range localAddrs {
-				if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+				if ipnet, ok := addr.(*net.IPNet); ok {
 					if ipnet.IP.To4() != nil {
 						// Filter external IP by MAC address OUIs from vCenter and from ESX
 						vmMACAddr := strings.ToLower(i.HardwareAddr.String())


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
#73721 introduced a change that causes an error to occur when a non-loopback interface is found that doesn't have a valid MAC address. The problem is that the method for determining whether the interface is loopback or not is flawed: interfaces can have multiple IP addresses, and in our case our loopback interface has a 169 address assigned to as well as the 127 one.

**Which issue(s) this PR fixes**:
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
If we can make it into the same release as #73721 we shouldn't need to amend the release notes
```release-note
NONE
```

/sig cloud-provider
/sig vmware

cc @astrieanna