### PR TITLE
Error message has incorrect pluralization

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
@@ -127,7 +127,7 @@ func (c *AggregationController) sync(key string) (syncAction, error) {
 		return syncRequeueRateLimited, err
 	case httpStatus == http.StatusNotModified:
 	case httpStatus == http.StatusNotFound || returnSpec == nil:
-		return syncRequeueRateLimited, fmt.Errorf("OpenAPI spec does not exists")
+		return syncRequeueRateLimited, fmt.Errorf("OpenAPI spec does not exist")
 	case httpStatus == http.StatusOK:
 		if err := c.openAPIAggregationManager.UpdateAPIServiceSpec(key, returnSpec, newEtag); err != nil {
 			return syncRequeueRateLimited, err


### PR DESCRIPTION
Shows up to end users:

```
loading OpenAPI spec for "v1beta1.metrics.k8s.io" failed with: OpenAPI spec does not exists
```

/kind bug

```release-note
NONE
```