### PR TITLE
Add readonly volume tests for windows

### DIFF
--- a/test/e2e/windows/BUILD
+++ b/test/e2e/windows/BUILD
@@ -8,6 +8,7 @@ go_library(
         "density.go",
         "framework.go",
         "networking.go",
+        "volumes.go",
     ],
     importpath = "k8s.io/kubernetes/test/e2e/windows",
     visibility = ["//visibility:public"],

--- a/test/e2e/windows/volumes.go
+++ b/test/e2e/windows/volumes.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package windows
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	emptyDirVolumePath = "C:\\test-volume"
+	hostMapPath        = "C:\\tmp"
+	containerName      = "test-container"
+	volumeName         = "test-volume"
+)
+
+var (
+	image = imageutils.GetE2EImage(imageutils.Pause)
+)
+
+var _ = SIGDescribe("Windows volume mounts ", func() {
+	f := framework.NewDefaultFramework("windows-volumes")
+	var (
+		emptyDirSource = v1.VolumeSource{
+			EmptyDir: &v1.EmptyDirVolumeSource{
+				Medium: v1.StorageMediumDefault,
+			},
+		}
+
+		hostMapSource = v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: hostMapPath,
+			},
+		}
+	)
+	BeforeEach(func() {
+		framework.SkipUnlessNodeOSDistroIs("windows")
+	})
+
+	Context("check volume mount permissions", func() {
+
+		It("container should have readOnly permissions on emptyDir", func() {
+
+			By("creating a container with readOnly permissions on emptyDir volume")
+			doReadOnlyTest(f, emptyDirSource, emptyDirVolumePath)
+
+			By("creating two containers, one with readOnly permissions the other with read-write permissions on emptyDir volume")
+			doReadWriteReadOnlyTest(f, emptyDirSource, emptyDirVolumePath)
+		})
+
+		It("container should have readOnly permissions on hostMapPath", func() {
+
+			By("creating a container with readOnly permissions on hostMap volume")
+			doReadOnlyTest(f, hostMapSource, hostMapPath)
+
+			By("creating two containers, one with readOnly permissions the other with read-write permissions on hostMap volume")
+			doReadWriteReadOnlyTest(f, hostMapSource, hostMapPath)
+		})
+
+	})
+
+})
+
+func doReadOnlyTest(f *framework.Framework, source v1.VolumeSource, volumePath string) {
+	var (
+		filePath = volumePath + "\\test-file.txt"
+		podName  = "pod-" + string(uuid.NewUUID())
+		pod      = testPodWithROVolume(podName, source, volumePath)
+	)
+
+	f.PodClient().CreateSync(pod)
+	cmd := []string{"cmd", "/c", "echo windows-volume-test", ">", filePath}
+
+	_, stderr, _ := f.ExecCommandInContainerWithFullOutput(podName, containerName, cmd...)
+
+	Expect(stderr).To(Equal("Access is denied."))
+
+}
+
+func doReadWriteReadOnlyTest(f *framework.Framework, source v1.VolumeSource, volumePath string) {
+	var (
+		filePath        = volumePath + "\\test-file"
+		podName         = "pod-" + string(uuid.NewUUID())
+		pod             = testPodWithROVolume(podName, source, volumePath)
+		rwcontainerName = containerName + "-rw"
+	)
+
+	rwcontainer := v1.Container{
+		Name:  containerName + "-rw",
+		Image: image,
+		VolumeMounts: []v1.VolumeMount{
+			{
+				Name:      volumeName,
+				MountPath: volumePath,
+			},
+		},
+	}
+
+	pod.Spec.Containers = append(pod.Spec.Containers, rwcontainer)
+	f.PodClient().CreateSync(pod)
+
+	cmd := []string{"cmd", "/c", "echo windows-volume-test", ">", filePath}
+
+	stdout_rw, stderr_rw, err_rw := f.ExecCommandInContainerWithFullOutput(podName, rwcontainerName, cmd...)
+	msg := fmt.Sprintf("cmd: %v, stdout: %q, stderr: %q", cmd, stdout_rw, stderr_rw)
+	Expect(err_rw).NotTo(HaveOccurred(), msg)
+
+	_, stderr, _ := f.ExecCommandInContainerWithFullOutput(podName, containerName, cmd...)
+	Expect(stderr).To(Equal("Access is denied."))
+
+	readcmd := []string{"cmd", "/c", "type", filePath}
+	readout, readerr, err := f.ExecCommandInContainerWithFullOutput(podName, containerName, readcmd...)
+	readmsg := fmt.Sprintf("cmd: %v, stdout: %q, stderr: %q", readcmd, readout, readerr)
+	Expect(readout).To(Equal("windows-volume-test"))
+	Expect(err).NotTo(HaveOccurred(), readmsg)
+}
+
+func testPodWithROVolume(podName string, source v1.VolumeSource, path string) *v1.Pod {
+	return &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: podName,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  containerName,
+					Image: image,
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      volumeName,
+							MountPath: path,
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+			Volumes: []v1.Volume{
+				{
+					Name:         volumeName,
+					VolumeSource: source,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/sig testing
/sig windows

**What this PR does / why we need it**:
This PR adds test cases for volume mapping readonly permissions for windows containers

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related issue: #69904

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
