### PR TITLE
As a maintainer of staging godeps repos, the PR job should take away some of my pain

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
@@ -127,7 +127,7 @@ func (c *AggregationController) sync(key string) (syncAction, error) {
 		return syncRequeueRateLimited, err
 	case httpStatus == http.StatusNotModified:
 	case httpStatus == http.StatusNotFound || returnSpec == nil:
-		return syncRequeueRateLimited, fmt.Errorf("OpenAPI spec does not exists")
+		return syncRequeueRateLimited, fmt.Errorf("OpenAPI spec does not exist")
 	case httpStatus == http.StatusOK:
 		if err := c.openAPIAggregationManager.UpdateAPIServiceSpec(key, returnSpec, newEtag); err != nil {
 			return syncRequeueRateLimited, err


### PR DESCRIPTION
verify-staging-godeps is a very slow, annoying to run locally, action that machines can do more efficiently than me. When I have to update staging godeps, I would prefer the machines (PR job) to do the tedious task of telling me in one go all of the staging godeps that should be updated, instead of failing fast.

This task is only necessary when staging/ is changed, so trying to save time by failing fast on the machine wastes programmer time. Other options include fixing staging-godeps to not be so darn slow, but that's mostly an artifact of programmer time.

/kind makes-me-not-hate-changing-staging-godeps

```release-note
NONE
```