### PR TITLE
prevent unhandled errors on colliding poststarthook registration

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -198,11 +198,11 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		crdHandler,
 	)
 
-	s.GenericAPIServer.AddPostStartHook("start-apiextensions-informers", func(context genericapiserver.PostStartHookContext) error {
+	s.GenericAPIServer.AddPostStartHookOrDie("start-apiextensions-informers", func(context genericapiserver.PostStartHookContext) error {
 		s.Informers.Start(context.StopCh)
 		return nil
 	})
-	s.GenericAPIServer.AddPostStartHook("start-apiextensions-controllers", func(context genericapiserver.PostStartHookContext) error {
+	s.GenericAPIServer.AddPostStartHookOrDie("start-apiextensions-controllers", func(context genericapiserver.PostStartHookContext) error {
 		go crdController.Run(context.StopCh)
 		go namingController.Run(context.StopCh)
 		go establishingController.Run(context.StopCh)

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -57,7 +57,7 @@ func TestNewWithDelegate(t *testing.T) {
 	})
 
 	delegatePostStartHookChan := make(chan struct{})
-	delegateServer.AddPostStartHook("delegate-post-start-hook", func(context PostStartHookContext) error {
+	delegateServer.AddPostStartHookOrDie("delegate-post-start-hook", func(context PostStartHookContext) error {
 		defer close(delegatePostStartHookChan)
 		return nil
 	})
@@ -85,7 +85,7 @@ func TestNewWithDelegate(t *testing.T) {
 	})
 
 	wrappingPostStartHookChan := make(chan struct{})
-	wrappingServer.AddPostStartHook("wrapping-post-start-hook", func(context PostStartHookContext) error {
+	wrappingServer.AddPostStartHookOrDie("wrapping-post-start-hook", func(context PostStartHookContext) error {
 		defer close(wrappingPostStartHookChan)
 		return nil
 	})

--- a/staging/src/k8s.io/apiserver/pkg/server/hooks.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/hooks.go
@@ -92,7 +92,9 @@ func (s *GenericAPIServer) AddPostStartHook(name string, hook PostStartHookFunc)
 	// done is closed when the poststarthook is finished.  This is used by the health check to be able to indicate
 	// that the poststarthook is finished
 	done := make(chan struct{})
-	s.AddHealthzChecks(postStartHookHealthz{name: "poststarthook/" + name, done: done})
+	if err := s.AddHealthzChecks(postStartHookHealthz{name: "poststarthook/" + name, done: done}); err != nil {
+		return err
+	}
 	s.postStartHooks[name] = postStartHookEntry{hook: hook, done: done}
 
 	return nil

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -496,7 +496,7 @@ func TestServerRunWithSNI(t *testing.T) {
 
 			// add poststart hook to know when the server is up.
 			startedCh := make(chan struct{})
-			s.AddPostStartHook("test-notifier", func(context PostStartHookContext) error {
+			s.AddPostStartHookOrDie("test-notifier", func(context PostStartHookContext) error {
 				close(startedCh)
 				return nil
 			})

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -191,16 +191,16 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		s.serviceResolver,
 	)
 
-	s.GenericAPIServer.AddPostStartHook("start-kube-aggregator-informers", func(context genericapiserver.PostStartHookContext) error {
+	s.GenericAPIServer.AddPostStartHookOrDie("start-kube-aggregator-informers", func(context genericapiserver.PostStartHookContext) error {
 		informerFactory.Start(context.StopCh)
 		c.GenericConfig.SharedInformerFactory.Start(context.StopCh)
 		return nil
 	})
-	s.GenericAPIServer.AddPostStartHook("apiservice-registration-controller", func(context genericapiserver.PostStartHookContext) error {
+	s.GenericAPIServer.AddPostStartHookOrDie("apiservice-registration-controller", func(context genericapiserver.PostStartHookContext) error {
 		go apiserviceRegistrationController.Run(context.StopCh)
 		return nil
 	})
-	s.GenericAPIServer.AddPostStartHook("apiservice-status-available-controller", func(context genericapiserver.PostStartHookContext) error {
+	s.GenericAPIServer.AddPostStartHookOrDie("apiservice-status-available-controller", func(context genericapiserver.PostStartHookContext) error {
 		// if we end up blocking for long periods of time, we may need to increase threadiness.
 		go availableController.Run(5, context.StopCh)
 		return nil
@@ -219,7 +219,7 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		}
 		s.openAPIAggregationController = openapicontroller.NewAggregationController(&specDownloader, openAPIAggregator)
 
-		s.GenericAPIServer.AddPostStartHook("apiservice-openapi-controller", func(context genericapiserver.PostStartHookContext) error {
+		s.GenericAPIServer.AddPostStartHookOrDie("apiservice-openapi-controller", func(context genericapiserver.PostStartHookContext) error {
 			go s.openAPIAggregationController.Run(context.StopCh)
 			return nil
 		})

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -142,7 +142,7 @@ func (o WardleServerOptions) RunWardleServer(stopCh <-chan struct{}) error {
 		return err
 	}
 
-	server.GenericAPIServer.AddPostStartHook("start-sample-server-informers", func(context genericapiserver.PostStartHookContext) error {
+	server.GenericAPIServer.AddPostStartHookOrDie("start-sample-server-informers", func(context genericapiserver.PostStartHookContext) error {
 		config.GenericConfig.SharedInformerFactory.Start(context.StopCh)
 		o.SharedInformerFactory.Start(context.StopCh)
 		return nil


### PR DESCRIPTION
We were ignoring some error conditions that don't usually matter, but when they do get really hard to debug.

/kind bug
/priority important-soon

@kubernetes/sig-api-machinery-bugs 

```release-note
NONE
```