### PR TITLE
Divide by runtime.NumCPU in CPU usage calculation.

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -560,7 +561,8 @@ func (p *criStatsProvider) getContainerUsageNanoCores(stats *runtimeapi.Containe
 	}
 
 	nanoSeconds := stats.Cpu.Timestamp - cached.Timestamp
-	usageNanoCores := (stats.Cpu.UsageCoreNanoSeconds.Value - cached.UsageCoreNanoSeconds.Value) * uint64(time.Second/time.Nanosecond) / uint64(nanoSeconds)
+	usagePerCPU := (stats.Cpu.UsageCoreNanoSeconds.Value - cached.UsageCoreNanoSeconds.Value) / uint64(runtime.NumCPU())
+	usageNanoCores := usagePerCPU * uint64(time.Second/time.Nanosecond) / uint64(nanoSeconds)
 	return &usageNanoCores
 }
 

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -19,6 +19,7 @@ package stats
 import (
 	"math/rand"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -648,7 +649,7 @@ func makeFakeLogStats(seed int) *volume.Metrics {
 
 func TestGetContainerUsageNanoCores(t *testing.T) {
 	var value0 uint64
-	var value1 uint64 = 10000000000
+	var value1 = 10000000000 / uint64(runtime.NumCPU())
 
 	tests := []struct {
 		desc          string
@@ -749,6 +750,10 @@ func TestGetContainerUsageNanoCores(t *testing.T) {
 	for _, test := range tests {
 		provider := &criStatsProvider{cpuUsageCache: test.cpuUsageCache}
 		real := provider.getContainerUsageNanoCores(test.stats)
-		assert.Equal(t, test.expected, real, test.desc)
+		if test.expected == nil {
+			assert.Equal(t, test.expected, real, test.desc)
+		} else {
+			assert.Equal(t, strconv.FormatUint(*test.expected, 10), strconv.FormatUint(*real, 10), test.desc)
+		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Because the UsageCoreNanoSeconds values that are used to calculate
usageNanoCores are total CPU usage numbers, the maximum difference
between them for a time period is the number of CPUs times the number of
nanoseconds of wallclock time. Dividing by CPU yields a proper
percentage, and makes the stats in `kubectl top` for Windows pods line
up with local measurements on the nodes of the containers' CPU usage.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Needed for #73489

**Does this PR introduce a user-facing change?**:
```release-note
Windows CPU usage stats are accurately scaled to number of CPUs
```
/sig windows