### PR TITLE
Lowers the default nodelocaldns denial cache TTL

### DIFF
--- a/cluster/addons/dns/nodelocaldns/README.md
+++ b/cluster/addons/dns/nodelocaldns/README.md
@@ -35,3 +35,7 @@ spec:
   - Ingress
   - Egress
 ```
+
+### Negative caching
+
+The `denial` cache TTL has been reduced to the minimum of 5 seconds [here](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml#L37). In the unlikely event that this impacts performance, setting this TTL to a higher value make help alleviate issues, but be aware that operations that rely on DNS polling for orchestration may fail (for example operators with StatefulSets).

--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -34,7 +34,10 @@ data:
   Corefile: |
     __PILLAR__DNS__DOMAIN__:53 {
         errors
-        cache 30
+        cache {
+                success 10000 30
+                denial 10000 5
+        }
         reload
         loop
         bind __PILLAR__LOCAL__DNS__

--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -35,8 +35,8 @@ data:
     __PILLAR__DNS__DOMAIN__:53 {
         errors
         cache {
-                success 10000 30
-                denial 10000 5
+                success 9984 30
+                denial 9984 5
         }
         reload
         loop


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Similar to `--no-negcache` on dnsmasq, this prevents issues which poll DNS for orchestration such as operators with StatefulSets. It can also be very confusing for users when negative caching results in a change they just made seeming to be broken until the cache expires. This assumes that 5 seconds is reasonable and will still catch repeated AAAA negative responses. We could also set the denial cache size to zero which should effectively fully disable it like dnsmasq in kube-dns but testing shows this approach seems to work well in our (albeit small) test clusters.

**Which issue(s) this PR fixes**:

Fixes #74092

**Does this PR introduce a user-facing change?**:
```release-note
Reduces the cache TTL for negative responses to 5s minimum.
```
