### PR TITLE
Remove unused GetDefaultBackendNodePort()

### DIFF
--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -733,14 +733,6 @@ func (j *IngressTestJig) pollServiceNodePort(ns, name string, port int) error {
 	return framework.PollURL(u, "", 30*time.Second, j.PollInterval, &http.Client{Timeout: IngressReqTimeout}, false)
 }
 
-func (j *IngressTestJig) GetDefaultBackendNodePort() (int32, error) {
-	defaultSvc, err := j.Client.CoreV1().Services(metav1.NamespaceSystem).Get(defaultBackendName, metav1.GetOptions{})
-	if err != nil {
-		return 0, err
-	}
-	return defaultSvc.Spec.Ports[0].NodePort, nil
-}
-
 // GetIngressNodePorts returns related backend services' nodePorts.
 // Current GCE ingress controller allows traffic to the default HTTP backend
 // by default, so retrieve its nodePort if includeDefaultBackend is true.


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Since the commit f5bb5234c1225a7150d426e596d0dba02af36e5e
the method has never been used. This just removes it for cleanup.


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note-none

```
