### PR TITLE
> fix pod container status image name display not match deployment

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -385,7 +385,7 @@ func (ds *dockerService) ContainerStatus(_ context.Context, req *runtimeapi.Cont
 
 	labels, annotations := extractLabels(r.Config.Labels)
 	imageName := r.Config.Image
-	if len(ir.RepoTags) > 0 {
+	if len(ir.RepoTags) == 1 {
 		imageName = ir.RepoTags[0]
 	}
 	status := &runtimeapi.ContainerStatus{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

If a docker image has many tags, the pod container status display image name maybe not match the deployment. So, I think use the image name in container config json  will be less misunderstanding.

**Which issue(s) this PR fixes**:

Fixes #https://github.com/kubernetes/kubernetes/issues/74081

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

```release-note
NONE
```
