### PR TITLE
Fix typo and formats

### DIFF
--- a/test/kubemark/pre-existing/README.md
+++ b/test/kubemark/pre-existing/README.md
@@ -11,39 +11,39 @@
 
 Every running Kubemark setup looks like the following:
  1) A running Kubernetes cluster pointed to by the local kubeconfig
- 2) A separate VM where the kubemark master is running
+ 2) A separate VM where the Kubemark Master is running
  3) Some hollow-nodes that run on the Kubernetes Cluster from #1
- 4) The hollow-nodes are configured to talk with the kubemark master at #2
+ 4) The hollow-nodes are configured to talk with the Kubemark Master at #2
 
 When using the pre-existing provider, the developer is responsible for creating
-#1 and #2.  Therefore, the kubemark scripts will not create any infrastructure
-or start a kubemark master like in other providers. Instead, the existing
-resources provided by the VM at $MASTER_IP will serve as the kubemark master.
+#1 and #2.  Therefore, the Kubemark scripts will not create any infrastructure
+or start a Kubemark Master like in other providers. Instead, the existing
+resources provided by the VM at $MASTER_IP will serve as the Kubemark Master.
 
 ## Use Case
 
-The goal of the pre-existing provider is to use the kubemark tools with an
+The goal of the pre-existing provider is to use the Kubemark tools with an
 existing kubermark master. It's meant to provide the developer with
 additional flexibility to customize the cluster infrastructure and still use
-the kubemark setup tools.  The pre-existing provider is an **advanced** use
-case that requires the developer to have knowledge of setting up a kubemark
-master.
+the Kubemark setup tools.  The pre-existing provider is an **advanced** use
+case that requires the developer to have knowledge of setting up a Kubemark
+Master.
 
 ## Requirements
 
-To use the pre-existing provider, the expectation is that there's a kubemark
-master that is rechable at $MASTER_IP. The machine that the kubemark master is
-on has to be ssh able from the host that's executing the kubemark scripts. And
+To use the pre-existing provider, the expectation is that there's a Kubemark
+Master that is reachable at $MASTER_IP. The machine that the Kubemark Master is
+on has to be ssh able from the host that's executing the Kubemark scripts. And
 the user on that machine has to be 'kubernetes'.
 
 Requirement checklist:
-- Set MASTER_IP to ip address to the kubemark master
-- The host where you execute the kubemark scripts must be able to ssh to
+- Set MASTER_IP to ip address to the Kubemark Master
+- The host where you execute the Kubemark scripts must be able to ssh to
   kubernetes@$MASTER_IP
 
 ## Example Configuration
 
-_test/kubemark/cloud-provider-config.sh_
+_test/Kubemark/cloud-provider-config.sh_
 
 ```
 CLOUD_PROVIDER="pre-existing"

--- a/test/kubemark/pre-existing/README.md
+++ b/test/kubemark/pre-existing/README.md
@@ -43,7 +43,7 @@ Requirement checklist:
 
 ## Example Configuration
 
-_test/Kubemark/cloud-provider-config.sh_
+_test/kubemark/cloud-provider-config.sh_
 
 ```
 CLOUD_PROVIDER="pre-existing"


### PR DESCRIPTION
Improve the rechable/README.md by typo and formats and  the capitalization of the initials of Kubemark and Master is not uniform：
1. rechable ->reachable
2.  kubemark -> Kubemark
3. kubemark master -> Kubemark Master



**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
fix a typo and some formats

```release-note
None
```
