### PR TITLE
remove the redundant "the"

### DIFF
--- a/test/images/net/README.md
+++ b/test/images/net/README.md
@@ -14,7 +14,7 @@ some "trivial" set of actions on a socket.
   should return the disposition of the test.
 
 Runners can be executed into two different ways, either through the
-the command-line or via an HTTP request:
+command-line or via an HTTP request:
 
 ## Command-line
 


### PR DESCRIPTION
Here there are two "the" in the doc. So remove the redundant one.

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
remove redundant "the"

```release-note
None
```
