### PR TITLE
refactor: use FilterActivePods instead in replicaset controller

### DIFF
--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -595,12 +595,7 @@ func (rsc *ReplicaSetController) syncReplicaSet(key string) error {
 		return err
 	}
 	// Ignore inactive pods.
-	var filteredPods []*v1.Pod
-	for _, pod := range allPods {
-		if controller.IsPodActive(pod) {
-			filteredPods = append(filteredPods, pod)
-		}
-	}
+	filteredPods := controller.FilterActivePods(allPods)
 
 	// NOTE: filteredPods are pointing to objects from cache - if you need to
 	// modify them, you need to copy it first.


### PR DESCRIPTION
/kind design

**What this PR does / why we need it**:

Use existing `FilterActivePods` instead

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
