### PR TITLE
Cluster Autoscaler 1.3.7

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.5",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.7",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
```release-note:
Update Cluster Autoscaler to version 1.3.7.
```
CA 1.3.7 release notes:
https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.3.7

/kind bug