### PR TITLE
Add security warning back to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -5,7 +5,10 @@ labels: kind/bug
 
 ---
 
-<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!-->
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+
+If the matter is security related, please disclose it privately via https://kubernetes.io/security/
+-->
 
 
 **What happened**:


### PR DESCRIPTION
Looks like this warning got lost when we switched to multiple issue templates. It was added in response to a sensitive security issue that was filed publicly, and still has value for pointing reporters to the correct disclosure process.

```release-note
NONE
```

/assign @liggitt 