### PR TITLE
add -k flag in cli-runtime and kubectl to process kustomization directories

### DIFF
--- a/hack/testdata/kustomize/configmap.yaml
+++ b/hack/testdata/kustomize/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: the-map
+data:
+  altGreeting: "Good Morning!"
+  enableRisky: "false"

--- a/hack/testdata/kustomize/deployment.yaml
+++ b/hack/testdata/kustomize/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: the-deployment
+  labels:
+    deployment: hello
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      deployment: hello
+  template:
+    metadata:
+      labels:
+        deployment: hello
+    spec:
+      containers:
+      - name: the-container
+        image: monopole/hello:1
+        command: ["/hello",
+                  "--port=8080",
+                  "--enableRiskyFeature=$(ENABLE_RISKY)"]
+        ports:
+        - containerPort: 8080
+        env:
+        - name: ALT_GREETING
+          valueFrom:
+            configMapKeyRef:
+              name: the-map
+              key: altGreeting
+        - name: ENABLE_RISKY
+          valueFrom:
+            configMapKeyRef:
+              name: the-map
+              key: enableRisky

--- a/hack/testdata/kustomize/kustomization.yaml
+++ b/hack/testdata/kustomize/kustomization.yaml
@@ -1,0 +1,5 @@
+nameprefix: test-
+resources:
+- deployment.yaml
+- service.yaml
+- configmap.yaml

--- a/hack/testdata/kustomize/service.yaml
+++ b/hack/testdata/kustomize/service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: the-service
+spec:
+  selector:
+    deployment: hello
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 8666
+    targetPort: 8080

--- a/pkg/kubectl/cmd/annotate/annotate.go
+++ b/pkg/kubectl/cmd/annotate/annotate.go
@@ -208,7 +208,7 @@ func (o AnnotateOptions) Validate() error {
 	if o.all && len(o.fieldSelector) > 0 {
 		return fmt.Errorf("cannot set --all and --field-selector at the same time")
 	}
-	if len(o.resources) < 1 && cmdutil.IsFilenameSliceEmpty(o.Filenames) {
+	if len(o.resources) < 1 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		return fmt.Errorf("one or more resources must be specified as <resource> <name> or <resource>/<name>")
 	}
 	if len(o.newAnnotations) < 1 && len(o.removeAnnotations) < 1 {

--- a/pkg/kubectl/cmd/auth/reconcile.go
+++ b/pkg/kubectl/cmd/auth/reconcile.go
@@ -107,13 +107,16 @@ func NewCmdReconcile(f cmdutil.Factory, streams genericclioptions.IOStreams) *co
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "If true, display results but do not submit changes")
 	cmd.Flags().BoolVar(&o.RemoveExtraPermissions, "remove-extra-permissions", o.RemoveExtraPermissions, "If true, removes extra permissions added to roles")
 	cmd.Flags().BoolVar(&o.RemoveExtraSubjects, "remove-extra-subjects", o.RemoveExtraSubjects, "If true, removes extra subjects added to rolebindings")
-	cmd.MarkFlagRequired("filename")
 
 	return cmd
 }
 
 // Complete completes all the required options
 func (o *ReconcileOptions) Complete(cmd *cobra.Command, f cmdutil.Factory, args []string) error {
+	if err := o.FilenameOptions.RequireFilenameOrKustomize(); err != nil {
+		return err
+	}
+
 	if len(args) > 0 {
 		return errors.New("no arguments are allowed")
 	}

--- a/pkg/kubectl/cmd/certificates/certificates.go
+++ b/pkg/kubectl/cmd/certificates/certificates.go
@@ -104,7 +104,7 @@ func (o *CertificateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, arg
 }
 
 func (o *CertificateOptions) Validate() error {
-	if len(o.csrNames) < 1 && cmdutil.IsFilenameSliceEmpty(o.Filenames) {
+	if len(o.csrNames) < 1 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		return fmt.Errorf("one or more CSRs must be specified as <name> or -f <filename>")
 	}
 	return nil

--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -107,12 +107,15 @@ func NewCmdConvert(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "to need to get converted.")
-	cmd.MarkFlagRequired("filename")
 	return cmd
 }
 
 // Complete collects information required to run Convert command from command line.
 func (o *ConvertOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) (err error) {
+	err = o.FilenameOptions.RequireFilenameOrKustomize()
+	if err != nil {
+		return err
+	}
 	o.builder = f.NewBuilder
 
 	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()

--- a/pkg/kubectl/cmd/create/create.go
+++ b/pkg/kubectl/cmd/create/create.go
@@ -103,7 +103,8 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 		Long:                  createLong,
 		Example:               createExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			if cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames) {
+			if cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames, o.FilenameOptions.Kustomize) {
+				ioStreams.ErrOut.Write([]byte("Error: must specify one of -f and -k\n\n"))
 				defaultRunFunc := cmdutil.DefaultSubCommandRun(ioStreams.ErrOut)
 				defaultRunFunc(cmd, args)
 				return
@@ -119,7 +120,6 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 
 	usage := "to use to create the resource"
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
-	cmd.MarkFlagRequired("filename")
 	cmdutil.AddValidateFlags(cmd)
 	cmd.Flags().BoolVar(&o.EditBeforeCreate, "edit", o.EditBeforeCreate, "Edit the API resource before creating")
 	cmd.Flags().Bool("windows-line-endings", runtime.GOOS == "windows",
@@ -184,7 +184,6 @@ func (o *CreateOptions) ValidateArgs(cmd *cobra.Command, args []string) error {
 // Complete completes all the required options
 func (o *CreateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 	var err error
-
 	o.RecordFlags.Complete(cmd)
 	o.Recorder, err = o.RecordFlags.ToRecorder()
 	if err != nil {

--- a/pkg/kubectl/cmd/delete/delete.go
+++ b/pkg/kubectl/cmd/delete/delete.go
@@ -71,6 +71,9 @@ var (
 		# Delete a pod using the type and name specified in pod.json.
 		kubectl delete -f ./pod.json
 
+		# Delete resources from a directory containing kustomization.yaml - e.g. dir/kustomization.yaml.
+		kubectl delete -k dir
+
 		# Delete a pod based on the type and name in the JSON passed into stdin.
 		cat pod.json | kubectl delete -f -
 
@@ -119,7 +122,7 @@ func NewCmdDelete(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 	deleteFlags := NewDeleteCommandFlags("containing the resource to delete.")
 
 	cmd := &cobra.Command{
-		Use:                   "delete ([-f FILENAME] | TYPE [(NAME | -l label | --all)])",
+		Use:                   "delete ([-f FILENAME] | [-k DIRECTORY] | TYPE [(NAME | -l label | --all)])",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Delete resources by filenames, stdin, resources and names, or by resources and label selector"),
 		Long:                  deleteLong,

--- a/pkg/kubectl/cmd/delete/delete_flags.go
+++ b/pkg/kubectl/cmd/delete/delete_flags.go
@@ -156,9 +156,11 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 
 	filenames := []string{}
 	recursive := false
+	kustomize := ""
 
 	return &DeleteFlags{
-		FileNameFlags: &genericclioptions.FileNameFlags{Usage: usage, Filenames: &filenames, Recursive: &recursive},
+		// Not using helpers.go since it provides function to add '-k' for FileNameOptions, but not FileNameFlags
+		FileNameFlags: &genericclioptions.FileNameFlags{Usage: usage, Filenames: &filenames, Kustomize: &kustomize, Recursive: &recursive},
 		LabelSelector: &labelSelector,
 		FieldSelector: &fieldSelector,
 
@@ -186,10 +188,11 @@ func NewDeleteFlags(usage string) *DeleteFlags {
 	wait := false
 
 	filenames := []string{}
+	kustomize := ""
 	recursive := false
 
 	return &DeleteFlags{
-		FileNameFlags: &genericclioptions.FileNameFlags{Usage: usage, Filenames: &filenames, Recursive: &recursive},
+		FileNameFlags: &genericclioptions.FileNameFlags{Usage: usage, Filenames: &filenames, Kustomize: &kustomize, Recursive: &recursive},
 
 		Cascade:     &cascade,
 		GracePeriod: &gracePeriod,

--- a/pkg/kubectl/cmd/describe/describe.go
+++ b/pkg/kubectl/cmd/describe/describe.go
@@ -131,7 +131,7 @@ func (o *DescribeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 		o.EnforceNamespace = false
 	}
 
-	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames) {
+	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames, o.FilenameOptions.Kustomize) {
 		return fmt.Errorf("You must specify the type of resource to describe. %s\n", cmdutil.SuggestAPIResources(o.CmdParent))
 	}
 

--- a/pkg/kubectl/cmd/diff/diff.go
+++ b/pkg/kubectl/cmd/diff/diff.go
@@ -118,7 +118,6 @@ func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 	usage := "contains the configuration to diff"
 	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
 	cmdutil.AddServerSideApplyFlags(cmd)
-	cmd.MarkFlagRequired("filename")
 
 	return cmd
 }
@@ -394,6 +393,11 @@ func isConflict(err error) bool {
 
 func (o *DiffOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 	var err error
+
+	err = o.FilenameOptions.RequireFilenameOrKustomize()
+	if err != nil {
+		return err
+	}
 
 	o.ServerSideApply = cmdutil.GetServerSideApplyFlag(cmd)
 	o.ForceConflicts = cmdutil.GetForceConflictsFlag(cmd)

--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -115,6 +115,9 @@ var (
 		# List a pod identified by type and name specified in "pod.yaml" in JSON output format.
 		kubectl get -f pod.yaml -o json
 
+		# List resources from a directory with kustomization.yaml - e.g. dir/kustomization.yaml.
+		kubectl get -k dir/
+
 		# Return only the phase value of the specified pod.
 		kubectl get -o template pod/web-pod-13je7 --template={{.status.phase}}
 
@@ -257,7 +260,7 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 	switch {
 	case o.Watch || o.WatchOnly:
 	default:
-		if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames) {
+		if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 			fmt.Fprintf(o.ErrOut, "You must specify the type of resource to get. %s\n\n", cmdutil.SuggestAPIResources(o.CmdParent))
 			fullCmdName := cmd.Parent().CommandPath()
 			usageString := "Required resource not specified."

--- a/pkg/kubectl/cmd/label/label.go
+++ b/pkg/kubectl/cmd/label/label.go
@@ -205,7 +205,7 @@ func (o *LabelOptions) Validate() error {
 	if o.all && len(o.fieldSelector) > 0 {
 		return fmt.Errorf("cannot set --all and --field-selector at the same time")
 	}
-	if len(o.resources) < 1 && cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames) {
+	if len(o.resources) < 1 && cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames, o.FilenameOptions.Kustomize) {
 		return fmt.Errorf("one or more resources must be specified as <resource> <name> or <resource>/<name>")
 	}
 	if len(o.newLabels) < 1 && len(o.removeLabels) < 1 && !o.list {

--- a/pkg/kubectl/cmd/replace/replace.go
+++ b/pkg/kubectl/cmd/replace/replace.go
@@ -117,7 +117,6 @@ func NewCmdReplace(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 	o.DeleteFlags.AddFlags(cmd)
 	o.RecordFlags.AddFlags(cmd)
 
-	cmd.MarkFlagRequired("filename")
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddApplyAnnotationFlags(cmd)
 
@@ -163,6 +162,11 @@ func (o *ReplaceOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	}
 	o.DeleteOptions = deleteOpts
 
+	err = o.DeleteOptions.FilenameOptions.RequireFilenameOrKustomize()
+	if err != nil {
+		return err
+	}
+
 	schema, err := f.Validator(o.validate)
 	if err != nil {
 		return err
@@ -189,7 +193,7 @@ func (o *ReplaceOptions) Validate(cmd *cobra.Command) error {
 		return fmt.Errorf("--timeout must have --force specified")
 	}
 
-	if cmdutil.IsFilenameSliceEmpty(o.DeleteOptions.FilenameOptions.Filenames) {
+	if cmdutil.IsFilenameSliceEmpty(o.DeleteOptions.FilenameOptions.Filenames, o.DeleteOptions.FilenameOptions.Kustomize) {
 		return cmdutil.UsageErrorf(cmd, "Must specify --filename to replace")
 	}
 

--- a/pkg/kubectl/cmd/rollout/rollout_history.go
+++ b/pkg/kubectl/cmd/rollout/rollout_history.go
@@ -123,7 +123,7 @@ func (o *RolloutHistoryOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, 
 
 // Validate makes sure all the provided values for command-line options are valid
 func (o *RolloutHistoryOptions) Validate() error {
-	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames) {
+	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		return fmt.Errorf("required resource not specified")
 	}
 	if o.Revision < 0 {

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -117,7 +117,7 @@ func (o *PauseOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 }
 
 func (o *PauseOptions) Validate() error {
-	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames) {
+	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		return fmt.Errorf("required resource not specified")
 	}
 	return nil

--- a/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -121,7 +121,7 @@ func (o *ResumeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 }
 
 func (o *ResumeOptions) Validate() error {
-	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames) {
+	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		return fmt.Errorf("required resource not specified")
 	}
 	return nil

--- a/pkg/kubectl/cmd/rollout/rollout_status.go
+++ b/pkg/kubectl/cmd/rollout/rollout_status.go
@@ -148,7 +148,7 @@ func (o *RolloutStatusOptions) Complete(f cmdutil.Factory, args []string) error 
 
 // Validate makes sure all the provided values for command-line options are valid
 func (o *RolloutStatusOptions) Validate() error {
-	if len(o.BuilderArgs) == 0 && cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames) {
+	if len(o.BuilderArgs) == 0 && cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames, o.FilenameOptions.Kustomize) {
 		return fmt.Errorf("required resource not specified")
 	}
 

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -126,7 +126,7 @@ func (o *UndoOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 }
 
 func (o *UndoOptions) Validate() error {
-	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames) {
+	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		return fmt.Errorf("required resource not specified")
 	}
 	return nil

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -198,7 +198,7 @@ func (o *SetImageOptions) Validate() error {
 	if o.All && len(o.Selector) > 0 {
 		errors = append(errors, fmt.Errorf("cannot set --all and --selector at the same time"))
 	}
-	if len(o.Resources) < 1 && cmdutil.IsFilenameSliceEmpty(o.Filenames) {
+	if len(o.Resources) < 1 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		errors = append(errors, fmt.Errorf("one or more resources must be specified as <resource> <name> or <resource>/<name>"))
 	}
 	if len(o.ContainerImages) < 1 {

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -291,8 +291,8 @@ func UsageErrorf(cmd *cobra.Command, format string, args ...interface{}) error {
 	return fmt.Errorf("%s\nSee '%s -h' for help and examples", msg, cmd.CommandPath())
 }
 
-func IsFilenameSliceEmpty(filenames []string) bool {
-	return len(filenames) == 0
+func IsFilenameSliceEmpty(filenames []string, directory string) bool {
+	return len(filenames) == 0 && directory == ""
 }
 
 func GetFlagString(cmd *cobra.Command, flag string) string {
@@ -382,6 +382,7 @@ func AddValidateOptionFlags(cmd *cobra.Command, options *ValidateOptions) {
 
 func AddFilenameOptionFlags(cmd *cobra.Command, options *resource.FilenameOptions, usage string) {
 	AddJsonFilenameFlag(cmd.Flags(), &options.Filenames, "Filename, directory, or URL to files "+usage)
+	AddKustomizeFlag(cmd.Flags(), &options.Kustomize)
 	cmd.Flags().BoolVarP(&options.Recursive, "recursive", "R", options.Recursive, "Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
 }
 
@@ -392,6 +393,11 @@ func AddJsonFilenameFlag(flags *pflag.FlagSet, value *[]string, usage string) {
 		annotations = append(annotations, strings.TrimLeft(ext, "."))
 	}
 	flags.SetAnnotation("filename", cobra.BashCompFilenameExt, annotations)
+}
+
+// AddKustomizeFlag adds kustomize flag to a command
+func AddKustomizeFlag(flags *pflag.FlagSet, value *string) {
+	flags.StringVarP(value, "kustomize", "k", *value, "Process the kustomization directory. This flag can't be used together with -f or -R.")
 }
 
 // AddDryRunFlag adds dry-run flag to a command. Usually used by mutations.

--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -27,6 +27,7 @@
   - k8s.io/api/core/v1
   - k8s.io/cli-runtime/pkg/genericclioptions/printers
   - k8s.io/cli-runtime/pkg/genericclioptions/resource
+  - k8s.io/cli-runtime/pkg/kustomize
 
 - baseImportPath: "./vendor/k8s.io/apimachinery/"
   allowedImports:

--- a/staging/src/k8s.io/cli-runtime/artifacts/kustomization/configMap.yaml
+++ b/staging/src/k8s.io/cli-runtime/artifacts/kustomization/configMap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: the-map
+data:
+  altGreeting: "Good Morning!"
+  enableRisky: "false"

--- a/staging/src/k8s.io/cli-runtime/artifacts/kustomization/deployment.yaml
+++ b/staging/src/k8s.io/cli-runtime/artifacts/kustomization/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: the-deployment
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        deployment: hello
+    spec:
+      containers:
+      - name: the-container
+        image: monopole/hello:1
+        command: ["/hello",
+                  "--port=8080",
+                  "--enableRiskyFeature=$(ENABLE_RISKY)"]
+        ports:
+        - containerPort: 8080
+        env:
+        - name: ALT_GREETING
+          valueFrom:
+            configMapKeyRef:
+              name: the-map
+              key: altGreeting
+        - name: ENABLE_RISKY
+          valueFrom:
+            configMapKeyRef:
+              name: the-map
+              key: enableRisky

--- a/staging/src/k8s.io/cli-runtime/artifacts/kustomization/kustomization.yaml
+++ b/staging/src/k8s.io/cli-runtime/artifacts/kustomization/kustomization.yaml
@@ -1,0 +1,5 @@
+nameprefix: test-
+resources:
+- deployment.yaml
+- service.yaml
+- configMap.yaml

--- a/staging/src/k8s.io/cli-runtime/artifacts/kustomization/service.yaml
+++ b/staging/src/k8s.io/cli-runtime/artifacts/kustomization/service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: the-service
+spec:
+  selector:
+    deployment: hello
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 8666
+    targetPort: 8080

--- a/staging/src/k8s.io/cli-runtime/artifacts/kustomization/should-not-create.yaml
+++ b/staging/src/k8s.io/cli-runtime/artifacts/kustomization/should-not-create.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: should-not-create-map
+data:
+  altGreeting: "Good Morning!"
+  enableRisky: "false"

--- a/staging/src/k8s.io/cli-runtime/artifacts/kustomization/should-not-load.yaml
+++ b/staging/src/k8s.io/cli-runtime/artifacts/kustomization/should-not-load.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameprefix: test-
+resources:
+- deployment.yaml
+- service.yaml
+- configMap.yaml

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go
@@ -32,6 +32,7 @@ type FileNameFlags struct {
 	Usage string
 
 	Filenames *[]string
+	Kustomize *string
 	Recursive *bool
 }
 
@@ -47,6 +48,9 @@ func (o *FileNameFlags) ToOptions() resource.FilenameOptions {
 	}
 	if o.Filenames != nil {
 		options.Filenames = *o.Filenames
+	}
+	if o.Kustomize != nil {
+		options.Kustomize = *o.Kustomize
 	}
 
 	return options
@@ -67,5 +71,9 @@ func (o *FileNameFlags) AddFlags(flags *pflag.FlagSet) {
 			annotations = append(annotations, strings.TrimLeft(ext, "."))
 		}
 		flags.SetAnnotation("filename", cobra.BashCompFilenameExt, annotations)
+	}
+	if o.Kustomize != nil {
+		flags.StringVarP(o.Kustomize, "kustomize", "k", *o.Kustomize,
+			"Process a kustomization directory. This flag can't be used together with -f or -R.")
 	}
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/BUILD
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/BUILD
@@ -35,12 +35,14 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//staging/src/k8s.io/cli-runtime/pkg/kustomize:go_default_library",
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/restmapper:go_default_library",
         "//vendor/golang.org/x/text/encoding/unicode:go_default_library",
         "//vendor/golang.org/x/text/transform:go_default_library",
+        "//vendor/sigs.k8s.io/kustomize/pkg/fs:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
@@ -130,7 +130,26 @@ func IsUsageError(err error) bool {
 
 type FilenameOptions struct {
 	Filenames []string
+	Kustomize string
 	Recursive bool
+}
+
+func (o *FilenameOptions) validate() []error {
+	var errs []error
+	if len(o.Filenames) > 0 && len(o.Kustomize) > 0 {
+		errs = append(errs, fmt.Errorf("only one of -f or -k can be specified"))
+	}
+	if len(o.Kustomize) > 0 && o.Recursive {
+		errs = append(errs, fmt.Errorf("-R is not allowed to work with -k"))
+	}
+	return errs
+}
+
+func (o *FilenameOptions) RequireFilenameOrKustomize() error {
+	if len(o.Filenames) == 0 && len(o.Kustomize) == 0 {
+		return fmt.Errorf("must specify one of -f and -k")
+	}
+	return nil
 }
 
 type resourceTuple struct {
@@ -195,6 +214,10 @@ func (b *Builder) AddError(err error) *Builder {
 // If ContinueOnError() is set prior to this method, objects on the path that are not
 // recognized will be ignored (but logged at V(2)).
 func (b *Builder) FilenameParam(enforceNamespace bool, filenameOptions *FilenameOptions) *Builder {
+	if errs := filenameOptions.validate(); len(errs) > 0 {
+		b.errs = append(b.errs, errs...)
+		return b
+	}
 	recursive := filenameOptions.Recursive
 	paths := filenameOptions.Filenames
 	for _, s := range paths {
@@ -214,6 +237,10 @@ func (b *Builder) FilenameParam(enforceNamespace bool, filenameOptions *Filename
 			}
 			b.Path(recursive, s)
 		}
+	}
+	if filenameOptions.Kustomize != "" {
+		b.paths = append(b.paths, &KustomizeVisitor{filenameOptions.Kustomize,
+			NewStreamVisitor(nil, b.mapper, filenameOptions.Kustomize, b.schema)})
 	}
 
 	if enforceNamespace {

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
@@ -140,7 +140,7 @@ func (o *FilenameOptions) validate() []error {
 		errs = append(errs, fmt.Errorf("only one of -f or -k can be specified"))
 	}
 	if len(o.Kustomize) > 0 && o.Recursive {
-		errs = append(errs, fmt.Errorf("-R is not allowed to work with -k"))
+		errs = append(errs, fmt.Errorf("the -k flag can't be used with -f or -R"))
 	}
 	return errs
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder_test.go
@@ -392,7 +392,7 @@ func TestFilenameOptionsValidate(t *testing.T) {
 			kustomize: "dir",
 			recursive: true,
 			errExp:    true,
-			msgExp:    "-R is not allowed to work with -k",
+			msgExp:    "the -k flag can't be used with -f or -R",
 		},
 		{
 			filenames: []string{"file"},
@@ -672,6 +672,11 @@ func TestKustomizeDirectoryBuilder(t *testing.T) {
 			directory:     dir,
 			expectErr:     false,
 			expectedNames: []string{"test-the-map", "test-the-deployment", "test-the-service"},
+		},
+		{
+			directory: filepath.Join(dir, "kustomization.yaml"),
+			expectErr: true,
+			errMsg:    "must be a directory to be a root",
 		},
 		{
 			directory: "../../../artifacts/kustomization/should-not-load.yaml",

--- a/staging/src/k8s.io/sample-cli-plugin/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-cli-plugin/Godeps/Godeps.json
@@ -7,12 +7,48 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "github.com/PuerkitoBio/purell",
+			"Rev": "8a290539e2e8629dbc4e6bad948158f790ec31f4"
+		},
+		{
+			"ImportPath": "github.com/PuerkitoBio/urlesc",
+			"Rev": "5bd2802263f21d8788851d5305584c82a5c75d7e"
+		},
+		{
 			"ImportPath": "github.com/davecgh/go-spew/spew",
 			"Rev": "782f4967f2dc4564575ca782fe2d04090b5faca8"
 		},
 		{
+			"ImportPath": "github.com/emicklei/go-restful",
+			"Rev": "ff4f55a206334ef123e4f79bbf348980da81ca46"
+		},
+		{
+			"ImportPath": "github.com/emicklei/go-restful/log",
+			"Rev": "ff4f55a206334ef123e4f79bbf348980da81ca46"
+		},
+		{
 			"ImportPath": "github.com/evanphx/json-patch",
 			"Rev": "5858425f75500d40c52783dce87d085a483ce135"
+		},
+		{
+			"ImportPath": "github.com/ghodss/yaml",
+			"Rev": "c7ce16629ff4cd059ed96ed06419dd3856fd3577"
+		},
+		{
+			"ImportPath": "github.com/go-openapi/jsonpointer",
+			"Rev": "ef5f0afec364d3b9396b7b77b43dbe26bf1f8004"
+		},
+		{
+			"ImportPath": "github.com/go-openapi/jsonreference",
+			"Rev": "8483a886a90412cd6858df4ea3483dce9c8e35a3"
+		},
+		{
+			"ImportPath": "github.com/go-openapi/spec",
+			"Rev": "5bae59e25b21498baea7f9d46e9c147ec106a42e"
+		},
+		{
+			"ImportPath": "github.com/go-openapi/swag",
+			"Rev": "5899d5c5e619fda5fa86e14795a835f473ca284c"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",
@@ -83,6 +119,18 @@
 			"Rev": "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
 		},
 		{
+			"ImportPath": "github.com/mailru/easyjson/buffer",
+			"Rev": "2f5df55504ebc322e4d52d34df6a1f5b503bf26d"
+		},
+		{
+			"ImportPath": "github.com/mailru/easyjson/jlexer",
+			"Rev": "2f5df55504ebc322e4d52d34df6a1f5b503bf26d"
+		},
+		{
+			"ImportPath": "github.com/mailru/easyjson/jwriter",
+			"Rev": "2f5df55504ebc322e4d52d34df6a1f5b503bf26d"
+		},
+		{
 			"ImportPath": "github.com/modern-go/concurrent",
 			"Rev": "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
 		},
@@ -93,6 +141,10 @@
 		{
 			"ImportPath": "github.com/peterbourgon/diskv",
 			"Rev": "5f041e8faa004a95c88a202771f4cc3e991971e6"
+		},
+		{
+			"ImportPath": "github.com/pkg/errors",
+			"Rev": "645ef00459ed84a119197bfb8d8205042c6df63d"
 		},
 		{
 			"ImportPath": "github.com/spf13/cobra",
@@ -143,6 +195,10 @@
 			"Rev": "95c6576299259db960f6c5b9b69ea52422860fce"
 		},
 		{
+			"ImportPath": "golang.org/x/text/cases",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
 			"ImportPath": "golang.org/x/text/encoding",
 			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
 		},
@@ -159,7 +215,19 @@
 			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
 		},
 		{
+			"ImportPath": "golang.org/x/text/internal",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/internal/tag",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
 			"ImportPath": "golang.org/x/text/internal/utf8internal",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/language",
 			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
 		},
 		{
@@ -168,6 +236,10 @@
 		},
 		{
 			"ImportPath": "golang.org/x/text/secure/bidirule",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/secure/precis",
 			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
 		},
 		{
@@ -180,6 +252,10 @@
 		},
 		{
 			"ImportPath": "golang.org/x/text/unicode/norm",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/width",
 			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
 		},
 		{
@@ -327,6 +403,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
@@ -339,6 +419,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/api/validation",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
@@ -348,6 +432,10 @@
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/validation",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
@@ -431,6 +519,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/mergepatch",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/naming",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
@@ -444,6 +536,10 @@
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/strategicpatch",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
@@ -467,6 +563,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/json",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
@@ -480,6 +580,42 @@
 		},
 		{
 			"ImportPath": "k8s.io/cli-runtime/pkg/genericclioptions/resource",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/cli-runtime/pkg/kustomize",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/cli-runtime/pkg/kustomize/k8sdeps",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/cli-runtime/pkg/kustomize/k8sdeps/configmapandsecret",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/cli-runtime/pkg/kustomize/k8sdeps/kunstruct",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/cli-runtime/pkg/kustomize/k8sdeps/kv",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/hash",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/patch",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/cli-runtime/pkg/kustomize/k8sdeps/validator",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
@@ -583,8 +719,104 @@
 			"Rev": "8139d8cb77af419532b33dfa7dd09fbc5f1d344f"
 		},
 		{
+			"ImportPath": "k8s.io/kube-openapi/pkg/common",
+			"Rev": "d7c86cdc46e3a4fcf892b32dd7bc3aa775e0870e"
+		},
+		{
+			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
+			"Rev": "d7c86cdc46e3a4fcf892b32dd7bc3aa775e0870e"
+		},
+		{
 			"ImportPath": "k8s.io/utils/integer",
 			"Rev": "ed37f7428a91fc2a81070808937195dcd46d320e"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/commands/build",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/constants",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/expansion",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/factory",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/fs",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/git",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/gvk",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/ifc",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/ifc/transformer",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/image",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/internal/error",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/loader",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/patch",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/patch/transformer",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/resid",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/resmap",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/resource",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/target",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/transformers",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/transformers/config",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/transformers/config/defaultconfig",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
+		},
+		{
+			"ImportPath": "sigs.k8s.io/kustomize/pkg/types",
+			"Rev": "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
 		},
 		{
 			"ImportPath": "sigs.k8s.io/yaml",

--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -223,6 +223,21 @@ __EOF__
   # cleanup
   kubectl delete -f hack/testdata/service-revision2.yaml "${kube_flags[@]}"
 
+  ## kubectl apply -k somedir
+  kubectl apply -k hack/testdata/kustomize
+  kube::test::get_object_assert 'configmap test-the-map' "{{${id_field}}}" 'test-the-map'
+  kube::test::get_object_assert 'deployment test-the-deployment' "{{${id_field}}}" 'test-the-deployment'
+  kube::test::get_object_assert 'service test-the-service' "{{${id_field}}}" 'test-the-service'
+  # cleanup
+  kubectl delete configmap/test-the-map deployment/test-the-deployment service/test-the-service
+
+  ## kubectl apply --kustomize somedir
+  kubectl apply --kustomize hack/testdata/kustomize
+  kube::test::get_object_assert 'configmap test-the-map' "{{${id_field}}}" 'test-the-map'
+  kube::test::get_object_assert 'deployment test-the-deployment' "{{${id_field}}}" 'test-the-deployment'
+  kube::test::get_object_assert 'service test-the-service' "{{${id_field}}}" 'test-the-service'
+  # cleanup
+  kubectl delete -k hack/testdata/kustomize
 
   set +o nounset
   set +o errexit

--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -229,7 +229,7 @@ __EOF__
   kube::test::get_object_assert 'deployment test-the-deployment' "{{${id_field}}}" 'test-the-deployment'
   kube::test::get_object_assert 'service test-the-service' "{{${id_field}}}" 'test-the-service'
   # cleanup
-  kubectl delete configmap/test-the-map deployment/test-the-deployment service/test-the-service
+  kubectl delete -k hack/testdata/kustomize
 
   ## kubectl apply --kustomize somedir
   kubectl apply --kustomize hack/testdata/kustomize
@@ -237,7 +237,7 @@ __EOF__
   kube::test::get_object_assert 'deployment test-the-deployment' "{{${id_field}}}" 'test-the-deployment'
   kube::test::get_object_assert 'service test-the-service' "{{${id_field}}}" 'test-the-service'
   # cleanup
-  kubectl delete -k hack/testdata/kustomize
+  kubectl delete --kustomize hack/testdata/kustomize
 
   set +o nounset
   set +o errexit

--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -108,3 +108,28 @@ run_create_job_tests() {
     set +o nounset
     set +o errexit
 }
+
+run_kubectl_create_kustomization_directory_tests() {
+  set -o nounset
+  set -o errexit
+
+  ## kubectl create -k <dir> for kustomization directory
+  # Pre-condition: no ConfigMap, Deployment, Service exist
+  kube::test::get_object_assert configmaps "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::get_object_assert services "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  kubectl create -k hack/testdata/kustomize
+  # Post-condition: test-the-map, test-the-deployment, test-the-service exist
+
+  # Check that all items in the list are printed
+  kube::test::get_object_assert 'configmap test-the-map' "{{${id_field}}}" 'test-the-map'
+  kube::test::get_object_assert 'deployment test-the-deployment' "{{${id_field}}}" 'test-the-deployment'
+  kube::test::get_object_assert 'service test-the-service' "{{${id_field}}}" 'test-the-service'
+
+  # cleanup
+  kubectl delete -k hack/testdata/kustomize
+
+  set +o nounset
+  set +o errexit
+}

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -202,6 +202,29 @@ run_kubectl_get_tests() {
   # cleanup
   kubectl delete pods redis-master valid-pod "${kube_flags[@]}"
 
+  ### Test 'kubectl get -k <dir>' prints all the items built from a kustomization directory
+  # Pre-condition: no ConfigMap, Deployment, Service exist
+  kube::test::get_object_assert configmaps "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::get_object_assert services "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  kubectl apply -k hack/testdata/kustomize
+  # Post-condition: test-the-map, test-the-deployment, test-the-service exist
+
+  # Check that all items in the list are printed
+  output_message=$(kubectl get -k hack/testdata/kustomize -o jsonpath="{..metadata.name}" "${kube_flags[@]}")
+  kube::test::if_has_string "${output_message}" "test-the-map"
+  kube::test::if_has_string "${output_message}" "test-the-deployment"
+  kube::test::if_has_string "${output_message}" "test-the-service"
+
+  # cleanup
+  kubectl delete -k hack/testdata/kustomize
+
+  # Check that all items in the list are deleted
+  kube::test::get_object_assert configmaps "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::get_object_assert services "{{range.items}}{{$id_field}}:{{end}}" ''
+
   set +o nounset
   set +o errexit
 }

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -492,6 +492,9 @@ runTests() {
   if kube::test::if_supports_resource "${secrets}" ; then
     record_command run_create_secret_tests
   fi
+  if kube::test::if_supports_resource "${deployments}"; then
+    record_command run_kubectl_create_kustomization_directory_tests
+  fi
 
   ######################
   # Delete             #


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR implements the 2nd Customize integration [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/kustomize-file-processing-integration.md)

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/enhancements/issues/633

**Special notes for your reviewer**:
This PR adds `-k` flag into `FilenameFlags` in cli-runtime.
Kubectl consumes `FilenameFlags` in different sub commands. 

**Does this PR introduce a user-facing change?**:
yes


```release-note
The examples in kubectl apply/get/delete are updated to support `-k` which uses a `kustomization.yaml` file
```
