### PR TITLE
disable xfs localvolume test

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1643,7 +1643,7 @@ var (
 			"ext2",
 			"ext3",
 			"ext4",
-			"xfs",
+			//"xfs", disabled see issue https://github.com/kubernetes/kubernetes/issues/74095
 		),
 	}
 	// max file size


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**: currently aws kops e2e tests are failing, see issue

**Which issue(s) this PR fixes**:
Fixes #74095

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
