### PR TITLE
cleanup: reuse the same util in kube-openapi

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/openapi/openapi.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/openapi/openapi.go
@@ -30,10 +30,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kube-openapi/pkg/util"
+	openapiutil "k8s.io/kube-openapi/pkg/util"
 )
 
-var verbs = util.NewTrie([]string{"get", "log", "read", "replace", "patch", "delete", "deletecollection", "watch", "connect", "proxy", "list", "create", "patch"})
+var verbs = openapiutil.NewTrie([]string{"get", "log", "read", "replace", "patch", "delete", "deletecollection", "watch", "connect", "proxy", "list", "create", "patch"})
 
 const (
 	extensionGVK = "x-kubernetes-group-version-kind"
@@ -133,19 +133,6 @@ func gvkConvert(gvk schema.GroupVersionKind) v1.GroupVersionKind {
 	}
 }
 
-func friendlyName(name string) string {
-	nameParts := strings.Split(name, "/")
-	// Reverse first part. e.g., io.k8s... instead of k8s.io...
-	if len(nameParts) > 0 && strings.Contains(nameParts[0], ".") {
-		parts := strings.Split(nameParts[0], ".")
-		for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
-			parts[i], parts[j] = parts[j], parts[i]
-		}
-		nameParts[0] = strings.Join(parts, ".")
-	}
-	return strings.Join(nameParts, ".")
-}
-
 func typeName(t reflect.Type) string {
 	path := t.PkgPath()
 	if strings.Contains(path, "/vendor/") {
@@ -183,9 +170,9 @@ func NewDefinitionNamer(schemes ...*runtime.Scheme) *DefinitionNamer {
 // GetDefinitionName returns the name and tags for a given definition
 func (d *DefinitionNamer) GetDefinitionName(name string) (string, spec.Extensions) {
 	if groupVersionKinds, ok := d.typeGroupVersionKinds[name]; ok {
-		return friendlyName(name), spec.Extensions{
+		return openapiutil.ToRESTFriendlyName(name), spec.Extensions{
 			extensionGVK: groupVersionKinds.JSON(),
 		}
 	}
-	return friendlyName(name), nil
+	return openapiutil.ToRESTFriendlyName(name), nil
 }


### PR DESCRIPTION
Reuse the [same util in kube-openapi](https://github.com/kubernetes/kubernetes/blob/07da603b59052036c00b4cb369b837c7336b50ee/vendor/k8s.io/kube-openapi/pkg/util/util.go#L45-L67) to convert Golang package/type canonical name into REST friendly OpenAPI name.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/kind cleanup
/assign @mbohlool 