### PR TITLE
kubectl: fix a bug where "describe" cannot obtain the event messages for a static pod

### DIFF
--- a/pkg/kubectl/describe/versioned/describe.go
+++ b/pkg/kubectl/describe/versioned/describe.go
@@ -642,6 +642,9 @@ func (d *PodDescriber) Describe(namespace, name string, describerSettings descri
 			klog.Errorf("Unable to construct reference to '%#v': %v", pod, err)
 		} else {
 			ref.Kind = ""
+			if _, isMirrorPod := pod.Annotations[corev1.MirrorPodAnnotationKey]; isMirrorPod {
+				ref.UID = types.UID(pod.Annotations[corev1.MirrorPodAnnotationKey])
+			}
 			events, _ = d.Core().Events(namespace).Search(scheme.Scheme, ref)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:


static pods expose status to apiserver via a mirror pod, but events are reported with the uid of the static pod. Thus `kubectl describe` will never show events for static pods because the uid of the event's `involvedObject` doesn't match the uid of the mirror pod. It's always hard to know/debug what happened to static pod without event message.

This PR fixes this by replacing the `involvedObject.uid` selector's value from mirror pod's uid to static pod's uid when getting static pod's events

```shell
<=========before fix===========>
[root@k8s-test-master01 ~]# kubectl describe pods -v 6
I0201 06:23:49.957611   92145 loader.go:359] Config loaded from file /root/.kube/config
I0201 06:23:49.975236   92145 round_trippers.go:438] GET http://127.0.0.1:8080/api/v1/namespaces/default/pods 200 OK in 5 milliseconds
I0201 06:23:49.978377   92145 round_trippers.go:438] GET http://127.0.0.1:8080/api/v1/namespaces/default/pods/nginx-node1 200 OK in 2 milliseconds
I0201 06:23:49.984808   92145 round_trippers.go:438] GET http://127.0.0.1:8080/api/v1/namespaces/default/events?fieldSelector=involvedObject.uid%3Dab4d703a-25a6-11e9-a7b5-000c292d53d3%2CinvolvedObject.name%3Dnginx-node1%2CinvolvedObject.namespace%3Ddefault 200 OK in 1 milliseconds
Name:         nginx-node1
Namespace:    default
Node:         node1/172.16.68.129
Start Time:   Fri, 01 Feb 2019 06:22:17 +0800
Labels:       <none>
Annotations:  kubernetes.io/config.hash: 565abcacf87dff516e54628c975847d9
              kubernetes.io/config.mirror: 565abcacf87dff516e54628c975847d9
              kubernetes.io/config.seen: 2019-02-01T06:22:17.863203231+08:00
              kubernetes.io/config.source: file
Status:       Running
IP:           172.17.0.34
Containers:
  nginx:
    Container ID:   docker://7189bb66fa0dabcc677fc78ffc78879193d5228170b323158ad124c3c2e612d9
    Image:          nginx
    Image ID:       docker-pullable://nginx@sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
    Port:           <none>
    Host Port:      <none>
    State:          Running
      Started:      Fri, 01 Feb 2019 06:22:39 +0800
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:         <none>
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:            <none>
QoS Class:          BestEffort
Node-Selectors:     <none>
Tolerations:        :NoExecute
Events:             <none>


<=================after fix=================>
[root@k8s-test-master01 ~]# ./kubectl describe pods -v 6
I0201 06:24:14.694813   92150 loader.go:359] Config loaded from file /root/.kube/config
I0201 06:24:14.711071   92150 round_trippers.go:438] GET http://127.0.0.1:8080/api/v1/namespaces/default/pods 200 OK in 7 milliseconds
I0201 06:24:14.717407   92150 round_trippers.go:438] GET http://127.0.0.1:8080/api/v1/namespaces/default/pods/nginx-node1 200 OK in 4 milliseconds
I0201 06:24:14.724278   92150 round_trippers.go:438] GET http://127.0.0.1:8080/api/v1/namespaces/default/events?fieldSelector=involvedObject.name%3Dnginx-node1%2CinvolvedObject.namespace%3Ddefault%2CinvolvedObject.uid%3D565abcacf87dff516e54628c975847d9 200 OK in 2 milliseconds
Name:         nginx-node1
Namespace:    default
Node:         node1/172.16.68.129
Start Time:   Fri, 01 Feb 2019 06:22:17 +0800
Labels:       <none>
Annotations:  kubernetes.io/config.hash: 565abcacf87dff516e54628c975847d9
              kubernetes.io/config.mirror: 565abcacf87dff516e54628c975847d9
              kubernetes.io/config.seen: 2019-02-01T06:22:17.863203231+08:00
              kubernetes.io/config.source: file
Status:       Running
IP:           172.17.0.34
Containers:
  nginx:
    Container ID:   docker://7189bb66fa0dabcc677fc78ffc78879193d5228170b323158ad124c3c2e612d9
    Image:          nginx
    Image ID:       docker-pullable://nginx@sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
    Port:           <none>
    Host Port:      <none>
    State:          Running
      Started:      Fri, 01 Feb 2019 06:22:39 +0800
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:         <none>
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:            <none>
QoS Class:          BestEffort
Node-Selectors:     <none>
Tolerations:        :NoExecute
Events:
  Type     Reason             Age                From            Message
  ----     ------             ----               ----            -------
  Normal   Pulling            115s               kubelet, node1  pulling image "nginx"
  Normal   Pulled             98s                kubelet, node1  Successfully pulled image "nginx"
  Normal   Created            97s                kubelet, node1  Created container
  Normal   Started            95s                kubelet, node1  Started container


```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubectl: fix a bug where "describe" cannot obtain the event messages for a static pod
```
