### PR TITLE
delete the mirror pod with uid precondition in mirror pod manager

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1614,14 +1614,13 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 
 	// Create Mirror Pod for Static Pod if it doesn't already exist
 	if kubepod.IsStaticPod(pod) {
-		podFullName := kubecontainer.GetPodFullName(pod)
 		deleted := false
 		if mirrorPod != nil {
 			if mirrorPod.DeletionTimestamp != nil || !kl.podManager.IsMirrorPodOf(mirrorPod, pod) {
 				// The mirror pod is semantically different from the static pod. Remove
 				// it. The mirror pod will get recreated later.
 				klog.Warningf("Deleting mirror pod %q because it is outdated", format.Pod(mirrorPod))
-				if err := kl.podManager.DeleteMirrorPod(podFullName); err != nil {
+				if err := kl.podManager.DeleteMirrorPod(mirrorPod); err != nil {
 					klog.Errorf("Failed deleting mirror pod %q: %v", format.Pod(mirrorPod), err)
 				} else {
 					deleted = true

--- a/pkg/kubelet/pod/pod_manager.go
+++ b/pkg/kubelet/pod/pod_manager.go
@@ -303,22 +303,22 @@ func (pm *basicManager) GetUIDTranslations() (podToMirror map[kubetypes.Resolved
 	return podToMirror, mirrorToPod
 }
 
-func (pm *basicManager) getOrphanedMirrorPodNames() []string {
+func (pm *basicManager) getOrphanedMirrorPods() []*v1.Pod {
 	pm.lock.RLock()
 	defer pm.lock.RUnlock()
-	var podFullNames []string
-	for podFullName := range pm.mirrorPodByFullName {
+	var pods []*v1.Pod
+	for podFullName, pod := range pm.mirrorPodByFullName {
 		if _, ok := pm.podByFullName[podFullName]; !ok {
-			podFullNames = append(podFullNames, podFullName)
+			pods = append(pods, pod)
 		}
 	}
-	return podFullNames
+	return pods
 }
 
 func (pm *basicManager) DeleteOrphanedMirrorPods() {
-	podFullNames := pm.getOrphanedMirrorPodNames()
-	for _, podFullName := range podFullNames {
-		pm.MirrorClient.DeleteMirrorPod(podFullName)
+	pods := pm.getOrphanedMirrorPods()
+	for _, p := range pods {
+		pm.MirrorClient.DeleteMirrorPod(p)
 	}
 }
 

--- a/pkg/kubelet/pod/pod_manager_test.go
+++ b/pkg/kubelet/pod/pod_manager_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/kubelet/configmap"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	podtest "k8s.io/kubernetes/pkg/kubelet/pod/testing"
 	"k8s.io/kubernetes/pkg/kubelet/secret"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -158,14 +159,14 @@ func TestDeletePods(t *testing.T) {
 		t.Fatalf("Run DeletePod() error, expected %d pods, got %d pods; ", len(expectedPods)-1, len(actualPods))
 	}
 
-	orphanedMirrorPodNames := podManager.getOrphanedMirrorPodNames()
+	orphanedMirrorPods := podManager.getOrphanedMirrorPods()
 	expectedOrphanedMirrorPodNameNum := 1
-	if len(orphanedMirrorPodNames) != expectedOrphanedMirrorPodNameNum {
-		t.Fatalf("Run getOrphanedMirrorPodNames() error, expected %d orphaned mirror pods, got %d orphaned mirror pods; ", expectedOrphanedMirrorPodNameNum, len(orphanedMirrorPodNames))
+	if len(orphanedMirrorPods) != expectedOrphanedMirrorPodNameNum {
+		t.Fatalf("Run getOrphanedMirrorPodNames() error, expected %d orphaned mirror pods, got %d orphaned mirror pods; ", expectedOrphanedMirrorPodNameNum, len(orphanedMirrorPods))
 	}
 
 	expectedOrphanedMirrorPodName := mirrorPod.Name + "_" + mirrorPod.Namespace
-	if orphanedMirrorPodNames[0] != expectedOrphanedMirrorPodName {
-		t.Fatalf("Run getOrphanedMirrorPodNames() error, expected orphaned mirror pod name : %s, got orphaned mirror pod name %s; ", expectedOrphanedMirrorPodName, orphanedMirrorPodNames[0])
+	if kubecontainer.GetPodFullName(orphanedMirrorPods[0]) != expectedOrphanedMirrorPodName {
+		t.Fatalf("Run getOrphanedMirrorPodNames() error, expected orphaned mirror pod name : %s, got orphaned mirror pod name %s; ", expectedOrphanedMirrorPodName, kubecontainer.GetPodFullName(orphanedMirrorPods[0]))
 	}
 }

--- a/pkg/kubelet/pod/testing/fake_mirror_client.go
+++ b/pkg/kubelet/pod/testing/fake_mirror_client.go
@@ -52,9 +52,10 @@ func (fmc *FakeMirrorClient) CreateMirrorPod(pod *v1.Pod) error {
 	return nil
 }
 
-func (fmc *FakeMirrorClient) DeleteMirrorPod(podFullName string) error {
+func (fmc *FakeMirrorClient) DeleteMirrorPod(pod *v1.Pod) error {
 	fmc.mirrorPodLock.Lock()
 	defer fmc.mirrorPodLock.Unlock()
+	podFullName := kubecontainer.GetPodFullName(pod)
 	fmc.mirrorPods.Delete(podFullName)
 	fmc.deleteCounts[podFullName]++
 	return nil

--- a/pkg/kubelet/pod/testing/mock_manager.go
+++ b/pkg/kubelet/pod/testing/mock_manager.go
@@ -47,13 +47,13 @@ func (_m *MockManager) CreateMirrorPod(_a0 *v1.Pod) error {
 	return r0
 }
 
-// DeleteMirrorPod provides a mock function with given fields: podFullName
-func (_m *MockManager) DeleteMirrorPod(podFullName string) error {
-	ret := _m.Called(podFullName)
+// DeleteMirrorPod provides a mock function with given fields: _a0
+func (_m *MockManager) DeleteMirrorPod(_a0 *v1.Pod) error {
+	ret := _m.Called(_a0)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(podFullName)
+	if rf, ok := ret.Get(0).(func(*v1.Pod) error); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
If the mirror pod of static pod be deleted from apiserver, the mirror pod status would swing between "Pending" and "Running". After executing `watch -d kubectl get pods xxxxx -o yaml`, I found the pod uid is changeing continuously, which means the mirror pod is recreated over and over again.  After diving into the kubelet log, I found it was caused by kubelet deleting mirror pod without `uid` precondition and there was a race condtion when we create a pod with the same name and namespace soon after deleting the previsous one, the new created pod will be deleted by kubelet accidentally. 

kubelet's log can been seen in [kubelet.INFO.log](https://github.com/kubernetes/kubernetes/files/2871777/kubelet.INFO.log)


This PR fixes this bug by deleting the mirror pod with uid precondition, which is also a remaining TODO for a long time.

https://github.com/kubernetes/kubernetes/blob/07a5488b2a8f67add543da72e8819407d8314204/pkg/kubelet/pod/mirror_client.go#L86 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
