### PR TITLE
Fix shellcheck lint errors in test/images/* scripts

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -114,7 +114,6 @@
 ./test/e2e_node/jenkins/copy-e2e-image.sh
 ./test/e2e_node/jenkins/e2e-node-jenkins.sh
 ./test/e2e_node/jenkins/ubuntu-14.04-nvidia-install.sh
-./test/images/volume/rbd/osd.sh
 ./third_party/forked/shell2junit/sh2ju.sh
 ./third_party/intemp/intemp.sh
 ./third_party/multiarch/qemu-user-static/register/qemu-binfmt-conf.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -114,7 +114,6 @@
 ./test/e2e_node/jenkins/copy-e2e-image.sh
 ./test/e2e_node/jenkins/e2e-node-jenkins.sh
 ./test/e2e_node/jenkins/ubuntu-14.04-nvidia-install.sh
-./test/images/volume/rbd/create_block.sh
 ./test/images/volume/rbd/mon.sh
 ./test/images/volume/rbd/osd.sh
 ./third_party/forked/shell2junit/sh2ju.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -114,7 +114,6 @@
 ./test/e2e_node/jenkins/copy-e2e-image.sh
 ./test/e2e_node/jenkins/e2e-node-jenkins.sh
 ./test/e2e_node/jenkins/ubuntu-14.04-nvidia-install.sh
-./test/images/pets/zookeeper-installer/install.sh
 ./test/images/pets/zookeeper-installer/on-start.sh
 ./test/images/volume/gluster/run_gluster.sh
 ./test/images/volume/iscsi/create_block.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -114,7 +114,6 @@
 ./test/e2e_node/jenkins/copy-e2e-image.sh
 ./test/e2e_node/jenkins/e2e-node-jenkins.sh
 ./test/e2e_node/jenkins/ubuntu-14.04-nvidia-install.sh
-./test/images/pets/redis-installer/on-start.sh
 ./test/images/pets/zookeeper-installer/install.sh
 ./test/images/pets/zookeeper-installer/on-start.sh
 ./test/images/volume/gluster/run_gluster.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -114,7 +114,6 @@
 ./test/e2e_node/jenkins/copy-e2e-image.sh
 ./test/e2e_node/jenkins/e2e-node-jenkins.sh
 ./test/e2e_node/jenkins/ubuntu-14.04-nvidia-install.sh
-./test/images/volume/gluster/run_gluster.sh
 ./test/images/volume/iscsi/create_block.sh
 ./test/images/volume/nfs/run_nfs.sh
 ./test/images/volume/rbd/bootstrap.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -114,7 +114,6 @@
 ./test/e2e_node/jenkins/copy-e2e-image.sh
 ./test/e2e_node/jenkins/e2e-node-jenkins.sh
 ./test/e2e_node/jenkins/ubuntu-14.04-nvidia-install.sh
-./test/images/volume/rbd/mon.sh
 ./test/images/volume/rbd/osd.sh
 ./third_party/forked/shell2junit/sh2ju.sh
 ./third_party/intemp/intemp.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -114,7 +114,6 @@
 ./test/e2e_node/jenkins/copy-e2e-image.sh
 ./test/e2e_node/jenkins/e2e-node-jenkins.sh
 ./test/e2e_node/jenkins/ubuntu-14.04-nvidia-install.sh
-./test/images/pets/zookeeper-installer/on-start.sh
 ./test/images/volume/gluster/run_gluster.sh
 ./test/images/volume/iscsi/create_block.sh
 ./test/images/volume/nfs/run_nfs.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -114,7 +114,6 @@
 ./test/e2e_node/jenkins/copy-e2e-image.sh
 ./test/e2e_node/jenkins/e2e-node-jenkins.sh
 ./test/e2e_node/jenkins/ubuntu-14.04-nvidia-install.sh
-./test/images/volume/iscsi/create_block.sh
 ./test/images/volume/nfs/run_nfs.sh
 ./test/images/volume/rbd/bootstrap.sh
 ./test/images/volume/rbd/create_block.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -114,7 +114,6 @@
 ./test/e2e_node/jenkins/copy-e2e-image.sh
 ./test/e2e_node/jenkins/e2e-node-jenkins.sh
 ./test/e2e_node/jenkins/ubuntu-14.04-nvidia-install.sh
-./test/images/volume/nfs/run_nfs.sh
 ./test/images/volume/rbd/bootstrap.sh
 ./test/images/volume/rbd/create_block.sh
 ./test/images/volume/rbd/mon.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -114,7 +114,6 @@
 ./test/e2e_node/jenkins/copy-e2e-image.sh
 ./test/e2e_node/jenkins/e2e-node-jenkins.sh
 ./test/e2e_node/jenkins/ubuntu-14.04-nvidia-install.sh
-./test/images/volume/rbd/bootstrap.sh
 ./test/images/volume/rbd/create_block.sh
 ./test/images/volume/rbd/mon.sh
 ./test/images/volume/rbd/osd.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -114,7 +114,6 @@
 ./test/e2e_node/jenkins/copy-e2e-image.sh
 ./test/e2e_node/jenkins/e2e-node-jenkins.sh
 ./test/e2e_node/jenkins/ubuntu-14.04-nvidia-install.sh
-./test/images/image-util.sh
 ./test/images/pets/redis-installer/on-start.sh
 ./test/images/pets/zookeeper-installer/install.sh
 ./test/images/pets/zookeeper-installer/on-start.sh

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -21,7 +21,7 @@ set -o pipefail
 TASK=$1
 IMAGE=$2
 
-KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE}")/../.." && pwd -P)"
+KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
 # Mapping of go ARCH to actual architectures shipped part of multiarch/qemu-user-static project
@@ -29,13 +29,13 @@ declare -A QEMUARCHS=( ["amd64"]="x86_64" ["arm"]="arm" ["arm64"]="aarch64" ["pp
 
 # Returns list of all supported architectures from BASEIMAGE file
 listArchs() {
-  cut -d "=" -f 1 ${IMAGE}/BASEIMAGE
+  cut -d "=" -f 1 "${IMAGE}/BASEIMAGE" | (mapfile -t; echo "${MAPFILE[@]}")
 }
 
 # Returns baseimage need to used in Dockerfile for any given architecture
 getBaseImage() {
   arch=$1
-  echo $(grep "${arch}=" BASEIMAGE | cut -d= -f2)
+  grep "${arch}=" BASEIMAGE | cut -d= -f2
 }
 
 # This function will build test image for all the architectures
@@ -43,41 +43,41 @@ getBaseImage() {
 # it will build for all the supported arch list - amd64, arm,
 # arm64, ppc64le, s390x
 build() {
-  if [[ -f ${IMAGE}/BASEIMAGE ]]; then
-    archs=$(listArchs)
+  if [[ -f "${IMAGE}/BASEIMAGE" ]]; then
+    archs=( "$(listArchs)" )
   else
-    archs=${!QEMUARCHS[@]}
+    archs=( "${!QEMUARCHS[@]}" )
   fi
 
   kube::util::ensure-gnu-sed
 
-  for arch in ${archs}; do
+  for arch in "${archs[@]}"; do
     echo "Building image for ${IMAGE} ARCH: ${arch}..."
 
     # Create a temporary directory for every architecture and copy the image content
     # and build the image from temporary directory
-    mkdir -p ${KUBE_ROOT}/_tmp
-    temp_dir=$(mktemp -d ${KUBE_ROOT}/_tmp/test-images-build.XXXXXX)
+    mkdir -p "${KUBE_ROOT}/_tmp"
+    temp_dir=$(mktemp -d "${KUBE_ROOT}/_tmp/test-images-build.XXXXXX")
     kube::util::trap_add "rm -rf ${temp_dir}" EXIT
 
-    cp -r ${IMAGE}/* ${temp_dir}
+    cp -r "${IMAGE}/*" "${temp_dir}"
     if [[ -f ${IMAGE}/Makefile ]]; then
       # make bin will take care of all the prerequisites needed
       # for building the docker image
-      make -C ${IMAGE} bin ARCH=${arch} TARGET=${temp_dir}
+      make -C "${IMAGE}" bin ARCH="${arch}" TARGET="${temp_dir}"
     fi
-    pushd ${temp_dir}
+    pushd "${temp_dir}"
     # image tag
     TAG=$(<VERSION)
 
     if [[ -f BASEIMAGE ]]; then
-      BASEIMAGE=$(getBaseImage ${arch})
+      BASEIMAGE=$(getBaseImage "${arch}")
       ${SED} -i "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
       ${SED} -i "s|BASEARCH|${arch}|g" Dockerfile
     fi
 
     # copy the qemu-*-static binary to docker image to build the multi architecture image on x86 platform
-    if [[ $(grep "CROSS_BUILD_" Dockerfile) ]]; then
+    if grep "CROSS_BUILD_" -q Dockerfile; then
       if [[ "${arch}" == "amd64" ]]; then
         ${SED} -i "/CROSS_BUILD_/d" Dockerfile
       else
@@ -89,14 +89,14 @@ build() {
           sudo=sudo
         fi
         "${sudo}" "${KUBE_ROOT}/third_party/multiarch/qemu-user-static/register/register.sh" --reset
-        curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/${QEMUVERSION}/x86_64_qemu-${QEMUARCHS[$arch]}-static.tar.gz | tar -xz -C ${temp_dir}
+        curl -sSL "https://github.com/multiarch/qemu-user-static/releases/download/${QEMUVERSION}/x86_64_qemu-${QEMUARCHS[$arch]}-static.tar.gz" | tar -xz -C "${temp_dir}"
         # Ensure we don't get surprised by umask settings
         chmod 0755 "${temp_dir}/qemu-${QEMUARCHS[$arch]}-static"
         ${SED} -i "s/CROSS_BUILD_//g" Dockerfile
       fi
     fi
 
-    docker build --pull -t ${REGISTRY}/${IMAGE}-${arch}:${TAG} .
+    docker build --pull -t "${REGISTRY}/${IMAGE}-${arch}:${TAG}" .
 
     popd
   done
@@ -115,14 +115,14 @@ docker_version_check() {
 # This function will push the docker images
 push() {
   docker_version_check
-  TAG=$(<${IMAGE}/VERSION)
+  TAG=$(<"${IMAGE}/VERSION")
   if [[ -f ${IMAGE}/BASEIMAGE ]]; then
-    archs=$(listArchs)
+    archs=( "$(listArchs)" )
   else
-    archs=${!QEMUARCHS[@]}
+    archs=( "${!QEMUARCHS[@]}" )
   fi
-  for arch in ${archs}; do
-    docker push ${REGISTRY}/${IMAGE}-${arch}:${TAG}
+  for arch in "${archs[@]}"; do
+    docker push "${REGISTRY}/${IMAGE}-${arch}:${TAG}"
   done
 
   kube::util::ensure-gnu-sed
@@ -130,26 +130,27 @@ push() {
   # The manifest command is still experimental as of Docker 18.09.2
   export DOCKER_CLI_EXPERIMENTAL="enabled"
   # Make archs list into image manifest. Eg: 'amd64 ppc64le' to '${REGISTRY}/${IMAGE}-amd64:${TAG} ${REGISTRY}/${IMAGE}-ppc64le:${TAG}'
-  manifest=$(echo $archs | ${SED} -e "s~[^ ]*~$REGISTRY\/$IMAGE\-&:$TAG~g")
-  docker manifest create --amend ${REGISTRY}/${IMAGE}:${TAG} ${manifest}
-  for arch in ${archs}; do
-    docker manifest annotate --arch ${arch} ${REGISTRY}/${IMAGE}:${TAG} ${REGISTRY}/${IMAGE}-${arch}:${TAG}
+  manifest=$(echo "${archs[*]}" | ${SED} -e "s~[^ ]*~$REGISTRY\/$IMAGE\-&:$TAG~g")
+  docker manifest create --amend "${REGISTRY}/${IMAGE}:${TAG}" "${manifest}"
+  for arch in "${archs[@]}"; do
+    docker manifest annotate --arch "${arch}" "${REGISTRY}/${IMAGE}:${TAG}" "${REGISTRY}/${IMAGE}-${arch}:${TAG}"
   done
-  docker manifest push --purge ${REGISTRY}/${IMAGE}:${TAG}
+  docker manifest push --purge "${REGISTRY}/${IMAGE}:${TAG}"
 }
 
 # This function is for building the go code
 bin() {
-  for SRC in $@;
+  for SRC in "$@";
   do
-  docker run --rm -it -v ${TARGET}:${TARGET}:Z -v ${KUBE_ROOT}:/go/src/k8s.io/kubernetes:Z \
-        golang:${GOLANG_VERSION} \
+  # shellcheck disable=SC2153 # Shellcheck believes "ARCH" is referring to "arch"
+  docker run --rm -it -v "${TARGET}:${TARGET}:Z" -v "${KUBE_ROOT}:/go/src/k8s.io/kubernetes:Z" \
+        "golang:${GOLANG_VERSION}" \
         /bin/bash -c "\
                 cd /go/src/k8s.io/kubernetes/test/images/${SRC_DIR} && \
-                CGO_ENABLED=0 GOARM=${GOARM} GOARCH=${ARCH} go build -a -installsuffix cgo --ldflags '-w' -o ${TARGET}/${SRC} ./$(dirname ${SRC})"
+                CGO_ENABLED=0 GOARM=${GOARM} GOARCH=${ARCH} go build -a -installsuffix cgo --ldflags '-w' -o ${TARGET}/${SRC} ./$(dirname "${SRC}")"
   done
 }
 
 shift
 
-eval ${TASK} "$@"
+eval "${TASK} $*"

--- a/test/images/pets/redis-installer/on-start.sh
+++ b/test/images/pets/redis-installer/on-start.sh
@@ -27,7 +27,7 @@ PORT=6379
 while read -ra LINE; do
     if [[ "${LINE}" == *"${HOSTNAME}"* ]]; then
         sed -i -e "s|^bind.*$|bind ${LINE}|" ${CFG}
-    elif [ "$(/opt/redis/redis-cli -h $LINE info | grep role | sed 's,\r$,,')" = "role:master" ]; then
+    elif [ "$(/opt/redis/redis-cli -h "$LINE" info | grep role | sed 's,\r$,,')" = "role:master" ]; then
         # TODO: More restrictive regex?
         sed -i -e "s|^# slaveof.*$|slaveof ${LINE} ${PORT}|" ${CFG}
     fi

--- a/test/images/pets/zookeeper-installer/install.sh
+++ b/test/images/pets/zookeeper-installer/install.sh
@@ -55,10 +55,10 @@ cp "${INSTALL_VOLUME}"/zookeeper/conf/zoo_sample.cfg "${INSTALL_VOLUME}"/zookeep
 
 # TODO: Should dynamic config be tied to the version?
 IFS="." read -ra RELEASE <<< "${VERSION}"
-if [ $(expr "${RELEASE[1]}") -gt 4 ]; then
+if [ "${RELEASE[1]}" -gt 4 ]; then
     echo zookeeper-"${VERSION}" supports dynamic reconfiguration, enabling it
-    echo "standaloneEnabled=false" >> "${INSTALL_VOLUME}"/zookeeper/conf/zoo.cfg
-    echo "dynamicConfigFile="${INSTALL_VOLUME}"/zookeeper/conf/zoo.cfg.dynamic" >> "${INSTALL_VOLUME}"/zookeeper/conf/zoo.cfg
+    echo "standaloneEnabled=false" >> "${INSTALL_VOLUME}/zookeeper/conf/zoo.cfg"
+    echo "dynamicConfigFile=${INSTALL_VOLUME}/zookeeper/conf/zoo.cfg.dynamic" >> "${INSTALL_VOLUME}/zookeeper/conf/zoo.cfg"
 fi
 
 # TODO: This is a hack, netcat is convenient to have in the zookeeper container

--- a/test/images/pets/zookeeper-installer/on-start.sh
+++ b/test/images/pets/zookeeper-installer/on-start.sh
@@ -36,7 +36,7 @@ MY_ID_FILE=/tmp/zookeeper/myid
 HOSTNAME=$(hostname)
 
 while read -ra LINE; do
-    PEERS=("${PEERS[@]}" $LINE)
+    PEERS=("${PEERS[@]}" "$LINE")
 done
 
 # Don't add the first member as an observer
@@ -56,7 +56,7 @@ echo "" > "${CFG_BAK}"
 i=0
 LEADER=$HOSTNAME
 for peer in "${PEERS[@]}"; do
-    let i=i+1
+    (( i+=1 ))
     if [[ "${peer}" == *"${HOSTNAME}"* ]]; then
       MY_ID=$i
       MY_NAME=${peer}
@@ -94,10 +94,10 @@ ADD_SERVER="server.$MY_ID=$MY_NAME:2888:3888:participant;0.0.0.0:2181"
 
 # Prove that we've actually joined the running cluster
 ITERATION=0
-until $(echo config | /opt/nc localhost 2181 | grep "${ADD_SERVER}" > /dev/null); do
+until echo config | /opt/nc localhost 2181 | grep "${ADD_SERVER}" > /dev/null; do
   echo $ITERATION] waiting for updated config to sync back to localhost
   sleep 1
-  let ITERATION=ITERATION+1
+  (( ITERATION+=1 ))
   if [ $ITERATION -eq 20 ]; then
     exit 1
   fi

--- a/test/images/volume/gluster/run_gluster.sh
+++ b/test/images/volume/gluster/run_gluster.sh
@@ -14,24 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIR=`mktemp -d`
+DIR="$(mktemp -d)"
 
 function start()
 {
-    mount -t tmpfs test $DIR
-    chmod 755 $DIR
-    cp /vol/* $DIR/
+    mount -t tmpfs test "$DIR"
+    chmod 755 "$DIR"
+    cp /vol/* "$DIR/"
     /usr/sbin/glusterd -p /run/glusterd.pid
-    gluster volume create test_vol `hostname -i`:$DIR force
+    gluster volume create test_vol "$(hostname -i):$DIR" force
     gluster volume start test_vol
 }
 
 function stop()
 {
     gluster --mode=script volume stop test_vol force
-    kill $(cat /run/glusterd.pid)
-    umount $DIR
-    rm -rf $DIR
+    kill "$(cat /run/glusterd.pid)"
+    umount "$DIR"
+    rm -rf "$DIR"
     exit 0
 }
 

--- a/test/images/volume/iscsi/create_block.sh
+++ b/test/images/volume/iscsi/create_block.sh
@@ -17,7 +17,7 @@
 # Exit on the first error.
 set -e
 
-MNTDIR=`mktemp -d`
+MNTDIR="$(mktemp -d)"
 
 cleanup()
 {
@@ -25,8 +25,8 @@ cleanup()
     RET=$?
     # Silently remove everything and ignore errors
     set +e
-    /bin/umount $MNTDIR 2>/dev/null
-    /bin/rmdir $MNTDIR 2>/dev/null
+    /bin/umount "$MNTDIR" 2>/dev/null
+    /bin/rmdir "$MNTDIR" 2>/dev/null
     /bin/rm block 2>/dev/null
     exit $RET
 }
@@ -39,9 +39,9 @@ dd if=/dev/zero of=block seek=120 count=1 bs=1M
 mkfs.ext2 block
 
 # Add index.html to it
-mount -o loop block $MNTDIR
-echo "Hello from iSCSI" > $MNTDIR/index.html
-umount $MNTDIR
+mount -o loop block "$MNTDIR"
+echo "Hello from iSCSI" > "$MNTDIR/index.html"
+umount "$MNTDIR"
 
 rm block.tar.gz 2>/dev/null || :
 tar cfz block.tar.gz block

--- a/test/images/volume/nfs/run_nfs.sh
+++ b/test/images/volume/nfs/run_nfs.sh
@@ -22,21 +22,22 @@ function start()
     while getopts "G:" opt; do
         case ${opt} in
             G) gid=${OPTARG};;
+            *):;;
         esac
     done
-    shift $(($OPTIND - 1))
+    shift $((OPTIND - 1))
 
     # prepare /etc/exports
     for i in "$@"; do
         # fsid=0: needed for NFSv4
         echo "$i *(rw,fsid=0,insecure,no_root_squash)" >> /etc/exports
         if [ -v gid ] ; then
-            chmod 070 $i
-            chgrp $gid $i
+            chmod 070 "$i"
+            chgrp "$gid" "$i"
         fi
         # move index.html to here
-        /bin/cp /tmp/index.html $i/
-        chmod 644 $i/index.html
+        /bin/cp /tmp/index.html "$i/"
+        chmod 644 "$i/index.html"
         echo "Serving $i"
     done
 
@@ -67,7 +68,7 @@ function stop()
     /usr/sbin/exportfs -au
     /usr/sbin/exportfs -f
 
-    kill $( pidof rpc.mountd )
+    kill "$( pidof rpc.mountd )"
     umount /proc/fs/nfsd
     echo > /etc/exports
     exit 0

--- a/test/images/volume/rbd/bootstrap.sh
+++ b/test/images/volume/rbd/bootstrap.sh
@@ -25,10 +25,10 @@
 
 
 # Create /etc/ceph/ceph.conf
-sh ./ceph.conf.sh `hostname -i`
+sh ./ceph.conf.sh "$(hostname -i)"
 
 # Configure and start ceph-mon
-sh ./mon.sh `hostname -i`
+sh ./mon.sh "$(hostname -i)"
 
 # Configure and start 2x ceph-osd
 mkdir -p /var/lib/ceph/osd/ceph-0 /var/lib/ceph/osd/ceph-1
@@ -51,7 +51,7 @@ ceph fs new cephfs cephfs_metadata cephfs_data
 # It takes a while until the volume created above is mountable,
 # 1 second is usually enough, but try indefinetily.
 sleep 1
-while ! ceph-fuse -m `hostname -i`:6789 /mnt; do
+while ! ceph-fuse -m "$(hostname -i):6789" /mnt; do
     echo "Waiting for cephfs to be up"
     sleep 1
 done

--- a/test/images/volume/rbd/create_block.sh
+++ b/test/images/volume/rbd/create_block.sh
@@ -20,7 +20,7 @@
 # Exit on the first error.
 set -e
 
-MNTDIR=`mktemp -d`
+MNTDIR="$(mktemp -d)"
 
 cleanup()
 {
@@ -28,8 +28,8 @@ cleanup()
     RET=$?
     # Silently remove everything and ignore errors
     set +e
-    /bin/umount $MNTDIR 2>/dev/null
-    /bin/rmdir $MNTDIR 2>/dev/null
+    /bin/umount "$MNTDIR" 2>/dev/null
+    /bin/rmdir "$MNTDIR" 2>/dev/null
     /bin/rm block 2>/dev/null
     exit $RET
 }
@@ -42,9 +42,9 @@ dd if=/dev/zero of=block seek=120 count=1 bs=1M
 mkfs.ext2 block
 
 # Add index.html to it
-mount -o loop block $MNTDIR
-echo "Hello from RBD" > $MNTDIR/index.html
-umount $MNTDIR
+mount -o loop block "$MNTDIR"
+echo "Hello from RBD" > "$MNTDIR/index.html"
+umount "$MNTDIR"
 
 rm block.tar.gz 2>/dev/null || :
 tar cfz block.tar.gz block

--- a/test/images/volume/rbd/mon.sh
+++ b/test/images/volume/rbd/mon.sh
@@ -19,7 +19,7 @@
 #
 
 # monitor setup
-monmaptool --create --clobber --fsid `uuidgen` --add a $1:6789 /etc/ceph/monmap
+monmaptool --create --clobber --fsid "$(uuidgen)" --add a "$1:6789" /etc/ceph/monmap
 mkdir /var/lib/ceph/mon/ceph-a
 ceph-mon -i a --mkfs --monmap /etc/ceph/monmap -k /var/lib/ceph/mon/keyring
 cp /var/lib/ceph/mon/keyring /var/lib/ceph/mon/ceph-a

--- a/test/images/volume/rbd/osd.sh
+++ b/test/images/volume/rbd/osd.sh
@@ -19,7 +19,7 @@
 #
 
 ceph osd create
-ceph-osd -i $1 --mkfs --mkkey
-ceph auth add osd.$1 osd 'allow *' mon 'allow rwx' -i /var/lib/ceph/osd/ceph-$1/keyring
-ceph osd crush add $1 1 root=default host=cephbox
-ceph-osd -i $1 -k /var/lib/ceph/osd/ceph-$1/keyring
+ceph-osd -i "$1" --mkfs --mkkey
+ceph auth add "osd.$1" osd 'allow *' mon 'allow rwx' -i "/var/lib/ceph/osd/ceph-$1/keyring"
+ceph osd crush add "$1" 1 root=default host=cephbox
+ceph-osd -i "$1" -k "/var/lib/ceph/osd/ceph-$1/keyring"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Ensures all  scripts under test/images/* pass hack/verify-shellcheck.sh

**Which issue(s) this PR fixes**:
Working towards #72956

**Special notes for your reviewer**:
None :)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig testing