### PR TITLE
Add applier flag

### DIFF
--- a/pkg/kubectl/cmd/apply/apply.go
+++ b/pkg/kubectl/cmd/apply/apply.go
@@ -68,6 +68,7 @@ type ApplyOptions struct {
 
 	ServerSideApply bool
 	ForceConflicts  bool
+	ApplyManager    string
 	Selector        string
 	DryRun          bool
 	ServerDryRun    bool
@@ -194,6 +195,7 @@ func NewCmdApply(baseName string, f cmdutil.Factory, ioStreams genericclioptions
 func (o *ApplyOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 	o.ServerSideApply = cmdutil.GetServerSideApplyFlag(cmd)
 	o.ForceConflicts = cmdutil.GetForceConflictsFlag(cmd)
+	o.ApplyManager = cmdutil.GetApplyManagerFlag(cmd)
 	o.DryRun = cmdutil.GetDryRunFlag(cmd)
 
 	if o.ForceConflicts && !o.ServerSideApply {
@@ -387,7 +389,8 @@ func (o *ApplyOptions) Run() error {
 				return cmdutil.AddSourceToErr("serverside-apply", info.Source, err)
 			}
 			options := metav1.PatchOptions{
-				Force: &o.ForceConflicts,
+				Force:        &o.ForceConflicts,
+				ApplyManager: o.ApplyManager,
 			}
 			if o.ServerDryRun {
 				options.DryRun = []string{metav1.DryRunAll}

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -402,6 +402,7 @@ func AddDryRunFlag(cmd *cobra.Command) {
 func AddServerSideApplyFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("server-side", false, "If true, apply runs in the server instead of the client. This is an alpha feature and flag.")
 	cmd.Flags().Bool("force-conflicts", false, "If true, server-side apply will force the changes against conflicts. This is an alpha feature and flag.")
+	cmd.Flags().String("apply-manager", "kubectl", "Name of the manager used to track applied field ownership. This is an alpha feature and flag.")
 }
 
 func AddIncludeUninitializedFlag(cmd *cobra.Command) {
@@ -483,6 +484,10 @@ func GetServerSideApplyFlag(cmd *cobra.Command) bool {
 
 func GetForceConflictsFlag(cmd *cobra.Command) bool {
 	return GetFlagBool(cmd, "force-conflicts")
+}
+
+func GetApplyManagerFlag(cmd *cobra.Command) string {
+	return GetFlagString(cmd, "apply-manager")
 }
 
 func GetDryRunFlag(cmd *cobra.Command) bool {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/apply_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/apply_test.go
@@ -71,6 +71,7 @@ values:
 	result, err := rest.Patch(types.ApplyPatchType).
 		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 		Name("mytest").
+		Param("applyManager", "apply").
 		Body(yamlBody).
 		DoRaw()
 	if err != nil {
@@ -90,6 +91,7 @@ values:
 	result, err = rest.Patch(types.ApplyPatchType).
 		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 		Name("mytest").
+		Param("applyManager", "apply").
 		Body(yamlBody).
 		DoRaw()
 	if err == nil {
@@ -108,6 +110,7 @@ values:
 		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 		Name("mytest").
 		Param("force", "true").
+		Param("applyManager", "apply").
 		Body(yamlBody).
 		DoRaw()
 	if err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -528,6 +528,12 @@ type PatchOptions struct {
 	// flag must be unset for non-apply patch requests.
 	// +optional
 	Force *bool `json:"force,omitempty" protobuf:"varint,2,opt,name=force"`
+
+	// ApplyManager is the name of the applier. This field is required
+	// for apply requests (application/apply-patch) but forbidden
+	// for non-apply patch types (jsonpatch, mergepatch, smp).
+	// +optional
+	ApplyManager string `json:"applyManager,omitempty" protobuf:"bytes,3,name=applyManager"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -100,8 +100,17 @@ func ValidateUpdateOptions(options *metav1.UpdateOptions) field.ErrorList {
 
 func ValidatePatchOptions(options *metav1.PatchOptions, patchType types.PatchType) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if patchType != types.ApplyPatchType && options.Force != nil {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("force"), "may not be specified for non-apply patch"))
+	if patchType != types.ApplyPatchType {
+		if options.Force != nil {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("force"), "may not be specified for non-apply patch"))
+		}
+		if options.ApplyManager != "" {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("applyManager"), "may not be specified for non-apply patch"))
+		}
+	} else {
+		if options.ApplyManager == "" {
+			allErrs = append(allErrs, field.Required(field.NewPath("applyManager"), "is required for apply patch"))
+		}
 	}
 	allErrs = append(allErrs, validateDryRun(field.NewPath("dryRun"), options.DryRun)...)
 	return allErrs

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -30,8 +30,6 @@ import (
 	"sigs.k8s.io/structured-merge-diff/merge"
 )
 
-const applyManager = "apply"
-
 // FieldManager updates the managed fields and merge applied
 // configurations.
 type FieldManager struct {
@@ -141,7 +139,7 @@ func (f *FieldManager) Update(liveObj, newObj runtime.Object, manager string) (r
 
 // Apply is used when server-side apply is called, as it merges the
 // object and update the managed fields.
-func (f *FieldManager) Apply(liveObj runtime.Object, patch []byte, force bool) (runtime.Object, error) {
+func (f *FieldManager) Apply(liveObj runtime.Object, patch []byte, applyManager string, force bool) (runtime.Object, error) {
 	// If the object doesn't have metadata, apply isn't allowed.
 	if _, err := meta.Accessor(liveObj); err != nil {
 		return nil, fmt.Errorf("couldn't get accessor: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -91,7 +91,7 @@ func TestApplyStripsFields(t *testing.T) {
 			"uid": "b",
 			"resourceVersion": "b"
 		}
-	}`), false)
+	}`), "apply", false)
 	if err != nil {
 		t.Fatalf("failed to apply object: %v", err)
 	}
@@ -105,6 +105,7 @@ func TestApplyStripsFields(t *testing.T) {
 		t.Fatalf("fields did not get stripped on apply: %v", m)
 	}
 }
+
 func TestApplyDoesNotStripLabels(t *testing.T) {
 	f := NewTestFieldManager(t)
 
@@ -125,7 +126,7 @@ func TestApplyDoesNotStripLabels(t *testing.T) {
 				"a": "b"
 			},
 		}
-	}`), false)
+	}`), "apply", false)
 	if err != nil {
 		t.Fatalf("failed to apply object: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -414,7 +414,7 @@ func (p *applyPatcher) applyPatchToCurrentObject(obj runtime.Object) (runtime.Ob
 	if p.fieldManager == nil {
 		panic("FieldManager must be installed to run apply")
 	}
-	return p.fieldManager.Apply(obj, p.patch, force)
+	return p.fieldManager.Apply(obj, p.patch, p.options.ApplyManager, force)
 }
 
 func (p *applyPatcher) createNewObject() (runtime.Object, error) {

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -106,6 +106,7 @@ func TestApplyAlsoCreates(t *testing.T) {
 			Namespace("default").
 			Resource(tc.resource).
 			Name(tc.name).
+			Param("applyManager", "apply").
 			Body([]byte(tc.body)).
 			Do().
 			Get()
@@ -132,6 +133,7 @@ func TestCreateOnApplyFailsWithUID(t *testing.T) {
 		Namespace("default").
 		Resource("pods").
 		Name("test-pod-uid").
+		Param("applyManager", "apply").
 		Body([]byte(`{
 			"apiVersion": "v1",
 			"kind": "Pod",
@@ -194,6 +196,7 @@ func TestApplyUpdateApplyConflictForced(t *testing.T) {
 		Namespace("default").
 		Resource("deployments").
 		Name("deployment").
+		Param("applyManager", "apply").
 		Body(obj).Do().Get()
 	if err != nil {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
@@ -214,6 +217,7 @@ func TestApplyUpdateApplyConflictForced(t *testing.T) {
 		Namespace("default").
 		Resource("deployments").
 		Name("deployment").
+		Param("applyManager", "apply").
 		Body([]byte(obj)).Do().Get()
 	if err == nil {
 		t.Fatalf("Expecting to get conflicts when applying object")
@@ -232,6 +236,7 @@ func TestApplyUpdateApplyConflictForced(t *testing.T) {
 		Resource("deployments").
 		Name("deployment").
 		Param("force", "true").
+		Param("applyManager", "apply").
 		Body([]byte(obj)).Do().Get()
 	if err != nil {
 		t.Fatalf("Failed to apply object with force: %v", err)
@@ -249,6 +254,7 @@ func TestApplyManagedFields(t *testing.T) {
 		Namespace("default").
 		Resource("configmaps").
 		Name("test-cm").
+		Param("applyManager", "apply").
 		Body([]byte(`{
 			"apiVersion": "v1",
 			"kind": "ConfigMap",
@@ -360,6 +366,7 @@ func TestApplyRemovesEmptyManagedFields(t *testing.T) {
 		Namespace("default").
 		Resource("configmaps").
 		Name("test-cm").
+		Param("applyManager", "apply").
 		Body(obj).
 		Do().
 		Get()
@@ -371,6 +378,7 @@ func TestApplyRemovesEmptyManagedFields(t *testing.T) {
 		Namespace("default").
 		Resource("configmaps").
 		Name("test-cm").
+		Param("applyManager", "apply").
 		Body(obj).Do().Get()
 	if err != nil {
 		t.Fatalf("Failed to patch object: %v", err)
@@ -388,5 +396,106 @@ func TestApplyRemovesEmptyManagedFields(t *testing.T) {
 
 	if managed := accessor.GetManagedFields(); managed != nil {
 		t.Fatalf("Object contains unexpected managedFields: %v", managed)
+	}
+}
+
+func TestApplyRequiresApplyManager(t *testing.T) {
+	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
+
+	_, client, closeFn := setup(t)
+	defer closeFn()
+
+	obj := []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "test-cm",
+			"namespace": "default"
+		}
+	}`)
+
+	_, err := client.CoreV1().RESTClient().Patch(types.ApplyPatchType).
+		Namespace("default").
+		Resource("configmaps").
+		Name("test-cm").
+		Body(obj).
+		Do().
+		Get()
+	if err == nil {
+		t.Fatalf("Apply should fail to create without applyManager")
+	}
+
+	_, err = client.CoreV1().RESTClient().Patch(types.ApplyPatchType).
+		Namespace("default").
+		Resource("configmaps").
+		Name("test-cm").
+		Param("applyManager", "apply").
+		Body(obj).
+		Do().
+		Get()
+	if err != nil {
+		t.Fatalf("Apply failed to create with applyManager: %v", err)
+	}
+}
+
+func TestApplyForbiddenMergePatch(t *testing.T) {
+	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
+
+	_, client, closeFn := setup(t)
+	defer closeFn()
+
+	obj := []byte(`{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"name": "test-cm",
+			"namespace": "default"
+		}
+	}`)
+
+	_, err := client.CoreV1().RESTClient().Patch(types.ApplyPatchType).
+		Namespace("default").
+		Resource("configmaps").
+		Name("test-cm").
+		Body(obj).
+		Do().
+		Get()
+	if err == nil {
+		t.Fatalf("Apply should fail to create without applyManager")
+	}
+
+	_, err = client.CoreV1().RESTClient().Patch(types.ApplyPatchType).
+		Namespace("default").
+		Resource("configmaps").
+		Name("test-cm").
+		Param("applyManager", "apply").
+		Body(obj).
+		Do().
+		Get()
+	if err != nil {
+		t.Fatalf("Apply failed to create object: %v", err)
+	}
+
+	_, err = client.CoreV1().RESTClient().Patch(types.MergePatchType).
+		Namespace("default").
+		Resource("configmaps").
+		Name("test-cm").
+		Body([]byte(`{"data":{"key": "value"}}`)).
+		Do().
+		Get()
+	if err != nil {
+		t.Fatalf("MergePatch failed to update without applyManager: %v", err)
+	}
+
+	_, err = client.CoreV1().RESTClient().Patch(types.MergePatchType).
+		Namespace("default").
+		Resource("configmaps").
+		Name("test-cm").
+		Param("applyManager", "apply").
+		Body([]byte(`{"data":{"key": "value"}}`)).
+		Do().
+		Get()
+	if err == nil {
+		t.Fatalf("MergePatch succeeded to update with applyManager")
 	}
 }

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -574,6 +574,9 @@ func TestRBAC(t *testing.T) {
 			if r.verb == "PATCH" {
 				// For patch operations, use the apply content type
 				req.Header.Add("Content-Type", string(types.ApplyPatchType))
+				q := req.URL.Query()
+				q.Add("applyManager", "apply")
+				req.URL.RawQuery = q.Encode()
 			}
 
 			if err != nil {


### PR DESCRIPTION
Add mandatory "applier" to apply workflow  …
And add a corresponding flag in kubectl, even though the value is
defaulted in kubectl with "kubectl".

The flag is required for Apply patch-type, but entirely forbidden for
non-apply patch types.

**What type of PR is this?**
/kind feature
/sig api-machinery
/priority important-soon

/assign @jennybuckley @kwiesmueller 

Since we talked about this, I think you should like it.
/cc @smarterclayton @liggitt 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
