### PR TITLE
Fix shellcheck lint errors in third_party/* scripts

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -96,7 +96,6 @@
 ./test/images/volume/gluster/run_gluster.sh
 ./test/images/volume/iscsi/create_block.sh
 ./test/images/volume/nfs/run_nfs.sh
-./third_party/forked/shell2junit/sh2ju.sh
 ./third_party/intemp/intemp.sh
 ./third_party/multiarch/qemu-user-static/register/qemu-binfmt-conf.sh
 ./third_party/multiarch/qemu-user-static/register/register.sh


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Ensures all scripts under third_party/* pass hack/verify-shellcheck.sh

**Which issue(s) this PR fixes**:
Working towards #72956

**Special notes for your reviewer**:
None :)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig testing