### PR TITLE
Replacing 'HTTP' by 'HTTPS' for securing kubernetes links

### DIFF
--- a/staging/src/k8s.io/csi-api/README.md
+++ b/staging/src/k8s.io/csi-api/README.md
@@ -9,7 +9,7 @@ implementations of the APIs.
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community
-page](http://kubernetes.io/community/).
+page](https://kubernetes.io/community/).
 
 You can reach the maintainers of this repository at:
 

--- a/staging/src/k8s.io/csi-translation-lib/README.md
+++ b/staging/src/k8s.io/csi-translation-lib/README.md
@@ -10,7 +10,7 @@ Consumers of this repository can make use of functions like `TranslateToCSI` and
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community
-page](http://kubernetes.io/community/).
+page](https://kubernetes.io/community/).
 
 You can reach the maintainers of this repository at:
 

--- a/staging/src/k8s.io/metrics/README.md
+++ b/staging/src/k8s.io/metrics/README.md
@@ -52,7 +52,7 @@ APIs, and will follow Kubernetes releases.
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community
-page](http://kubernetes.io/community/).
+page](https://kubernetes.io/community/).
 
 You can reach the maintainers of this repository at:
 

--- a/staging/src/k8s.io/node-api/README.md
+++ b/staging/src/k8s.io/node-api/README.md
@@ -10,7 +10,7 @@ implementations of the APIs.
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community
-page](http://kubernetes.io/community/).
+page](https://kubernetes.io/community/).
 
 You can reach the maintainers of this repository at:
 


### PR DESCRIPTION
Currently, when we access **kubernetes.io/community** with **HTTP**, it is
redirected to **HTTPS** automatically. So this commit aims to
replace **http://kubernetes.io/community/** by **https://kubernetes.io/community/**
for security.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
For secure accessibility in **kubernetes.io/community**
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note

```
