### PR TITLE
kubeadm: use non-formatting constructor for new error

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -52,7 +52,7 @@ func enforceRequirements(flags *applyPlanFlags, dryRun bool, newK8sVersion strin
 
 	// Check if the cluster is self-hosted
 	if upgrade.IsControlPlaneSelfHosted(client) {
-		return nil, nil, nil, errors.Errorf("cannot upgrade a self-hosted control plane")
+		return nil, nil, nil, errors.New("cannot upgrade a self-hosted control plane")
 	}
 
 	// Run healthchecks against the cluster


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
`errors.Errorf()` expects a format string and arguments, but at this line we don't produce a formatted error message. It's enough to use the simplest constructor function here.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
