### PR TITLE
kubeadm: unhide version non-emptiness check

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -109,9 +109,9 @@ func NewCmdApply(apf *applyPlanFlags) *cobra.Command {
 				flags.newK8sVersionStr = args[0]
 			}
 
-			// Default the flags dynamically, based on each others' value
-			err = SetImplicitFlags(flags)
-			kubeadmutil.CheckErr(err)
+			if len(flags.newK8sVersionStr) == 0 {
+				kubeadmutil.CheckErr(errors.New("version string can't be empty"))
+			}
 
 			err = runApply(flags)
 			kubeadmutil.CheckErr(err)
@@ -227,15 +227,6 @@ func runApply(flags *applyFlags) error {
 	fmt.Printf("[upgrade/successful] SUCCESS! Your cluster was upgraded to %q. Enjoy!\n", flags.newK8sVersionStr)
 	fmt.Println("")
 	fmt.Println("[upgrade/kubelet] Now that your control plane is upgraded, please proceed with upgrading your kubelets if you haven't already done so.")
-
-	return nil
-}
-
-// SetImplicitFlags handles dynamically defaulting flags based on each other's value
-func SetImplicitFlags(flags *applyFlags) error {
-	if len(flags.newK8sVersionStr) == 0 {
-		return errors.New("version string can't be empty")
-	}
 
 	return nil
 }

--- a/cmd/kubeadm/app/cmd/upgrade/apply_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply_test.go
@@ -19,57 +19,11 @@ package upgrade
 import (
 	"io/ioutil"
 	"os"
-	"reflect"
 	"testing"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
-
-func TestSetImplicitFlags(t *testing.T) {
-	var tests = []struct {
-		name          string
-		flags         *applyFlags
-		expectedFlags applyFlags
-		errExpected   bool
-	}{
-		{
-			name: "if the new version is empty; it should error out",
-			flags: &applyFlags{
-				newK8sVersionStr: "",
-			},
-			expectedFlags: applyFlags{
-				newK8sVersionStr: "",
-			},
-			errExpected: true,
-		},
-	}
-	for _, rt := range tests {
-		t.Run(rt.name, func(t *testing.T) {
-			actualErr := SetImplicitFlags(rt.flags)
-
-			// If an error was returned; make newK8sVersion nil so it's easy to match using reflect.DeepEqual later (instead of a random pointer)
-			if actualErr != nil {
-				rt.flags.newK8sVersion = nil
-			}
-
-			if !reflect.DeepEqual(*rt.flags, rt.expectedFlags) {
-				t.Errorf(
-					"failed SetImplicitFlags:\n\texpected flags: %v\n\t  actual: %v",
-					rt.expectedFlags,
-					*rt.flags,
-				)
-			}
-			if (actualErr != nil) != rt.errExpected {
-				t.Errorf(
-					"failed SetImplicitFlags:\n\texpected error: %t\n\t  actual: %t",
-					rt.errExpected,
-					(actualErr != nil),
-				)
-			}
-		})
-	}
-}
 
 func TestSessionIsInteractive(t *testing.T) {
 	var tcases = []struct {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
The name of the function `SetImplicitFlags()` doesn't reflect its purpose any more. Basically it's just a check for string emptiness which would be more readable if not hidden inside the function. Thus remove the function.

**Special notes for your reviewer**:
This is a part of the PR series splitting https://github.com/kubernetes/kubernetes/pull/73135

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
