### PR TITLE
add more fields to be stripped from managedFields

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
@@ -42,7 +42,6 @@ go_test(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -233,8 +233,12 @@ var stripSet = fieldpath.NewSet(
 	fieldpath.MakePathOrDie("metadata", "name"),
 	fieldpath.MakePathOrDie("metadata", "namespace"),
 	fieldpath.MakePathOrDie("metadata", "creationTimestamp"),
+	fieldpath.MakePathOrDie("metadata", "deletionTimestamp"),
 	fieldpath.MakePathOrDie("metadata", "selfLink"),
 	fieldpath.MakePathOrDie("metadata", "uid"),
+	fieldpath.MakePathOrDie("metadata", "clusterName"),
+	fieldpath.MakePathOrDie("metadata", "generation"),
+	fieldpath.MakePathOrDie("metadata", "managedFields"),
 	fieldpath.MakePathOrDie("metadata", "resourceVersion"),
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -233,7 +233,6 @@ var stripSet = fieldpath.NewSet(
 	fieldpath.MakePathOrDie("metadata", "name"),
 	fieldpath.MakePathOrDie("metadata", "namespace"),
 	fieldpath.MakePathOrDie("metadata", "creationTimestamp"),
-	fieldpath.MakePathOrDie("metadata", "deletionTimestamp"),
 	fieldpath.MakePathOrDie("metadata", "selfLink"),
 	fieldpath.MakePathOrDie("metadata", "uid"),
 	fieldpath.MakePathOrDie("metadata", "clusterName"),

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -78,7 +78,6 @@ func TestApplyStripsFields(t *testing.T) {
 			"name": "b",
 			"namespace": "b",
 			"creationTimestamp": "2016-05-19T09:59:00Z",
-			"deletionTimestamp": "2016-05-19T09:59:00Z",
 			"selfLink": "b",
 			"uid": "b",
 			"clusterName": "b",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -82,7 +82,18 @@ func TestApplyStripsFields(t *testing.T) {
 			"uid": "b",
 			"clusterName": "b",
 			"generation": 0,
-			"managedFields": [],
+			"managedFields": [{
+					"manager": "apply",
+					"operation": "Apply",
+					"apiVersion": "v1",
+					"fields": {
+						"f:metadata": {
+							"f:labels": {
+								"f:test-label": {}
+							}
+						}
+					}
+				}],
 			"resourceVersion": "b"
 		}
 	}`), false)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -19,11 +19,9 @@ package fieldmanager_test
 import (
 	"errors"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
@@ -71,14 +69,7 @@ func TestFieldManagerCreation(t *testing.T) {
 func TestApplyStripsFields(t *testing.T) {
 	f := NewTestFieldManager(t)
 
-	obj := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "a",
-			Namespace:         "a",
-			CreationTimestamp: metav1.Time{Time: time.Time{}},
-			SelfLink:          "a",
-		},
-	}
+	obj := &corev1.Pod{}
 
 	newObj, err := f.Apply(obj, []byte(`{
 		"apiVersion": "v1",
@@ -87,8 +78,12 @@ func TestApplyStripsFields(t *testing.T) {
 			"name": "b",
 			"namespace": "b",
 			"creationTimestamp": "2016-05-19T09:59:00Z",
+			"deletionTimestamp": "2016-05-19T09:59:00Z",
 			"selfLink": "b",
 			"uid": "b",
+			"clusterName": "b",
+			"generation": 0,
+			"managedFields": [],
 			"resourceVersion": "b"
 		}
 	}`), false)
@@ -108,14 +103,7 @@ func TestApplyStripsFields(t *testing.T) {
 func TestApplyDoesNotStripLabels(t *testing.T) {
 	f := NewTestFieldManager(t)
 
-	obj := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "a",
-			Namespace:         "a",
-			CreationTimestamp: metav1.Time{Time: time.Time{}},
-			SelfLink:          "a",
-		},
-	}
+	obj := &corev1.Pod{}
 
 	newObj, err := f.Apply(obj, []byte(`{
 		"apiVersion": "v1",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds more fields to get stripped from managedFields
As requested by @lavalamp in https://github.com/kubernetes/kubernetes/pull/73681

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
