### PR TITLE
kubeadm: drop applyFlags.newK8sVersion field

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply_test.go
@@ -48,11 +48,6 @@ func TestSetImplicitFlags(t *testing.T) {
 		t.Run(rt.name, func(t *testing.T) {
 			actualErr := SetImplicitFlags(rt.flags)
 
-			// If an error was returned; make newK8sVersion nil so it's easy to match using reflect.DeepEqual later (instead of a random pointer)
-			if actualErr != nil {
-				rt.flags.newK8sVersion = nil
-			}
-
 			if !reflect.DeepEqual(*rt.flags, rt.expectedFlags) {
 				t.Errorf(
 					"failed SetImplicitFlags:\n\texpected flags: %v\n\t  actual: %v",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Drop applyFlags.newK8sVersion field since it's not a command line flag. Use a variable instead.

**Special notes for your reviewer**:
This is a part of the PR series splitting #73135

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
