### PR TITLE
Add code comments to guard inadvertent removal of insecure-bind-address

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go
@@ -69,11 +69,13 @@ func (s *DeprecatedInsecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.IPVar(&s.BindAddress, "insecure-bind-address", s.BindAddress, ""+
 		"The IP address on which to serve the --insecure-port (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces).")
+	// Though this flag is deprecated, we discovered security concerns over how to do health checks without it e.g. #43784
 	fs.MarkDeprecated("insecure-bind-address", "This flag will be removed in a future version.")
 	fs.Lookup("insecure-bind-address").Hidden = false
 
 	fs.IntVar(&s.BindPort, "insecure-port", s.BindPort, ""+
 		"The port on which to serve unsecured, unauthenticated access.")
+	// Though this flag is deprecated, we discovered security concerns over how to do health checks without it e.g. #43784
 	fs.MarkDeprecated("insecure-port", "This flag will be removed in a future version.")
 	fs.Lookup("insecure-port").Hidden = false
 }
@@ -130,7 +132,8 @@ func (o *DeprecatedInsecureServingOptions) WithLoopback() *DeprecatedInsecureSer
 }
 
 // DeprecatedInsecureServingOptionsWithLoopback adds loopback functionality to the DeprecatedInsecureServingOptions.
-// DEPRECATED: all insecure serving options are removed in a future version
+// DEPRECATED: all insecure serving options will be removed in a future version, however note that
+// there are security concerns over how health checks can work here - see e.g. #43784
 type DeprecatedInsecureServingOptionsWithLoopback struct {
 	*DeprecatedInsecureServingOptions
 }


### PR DESCRIPTION
Though the flags are deprecated, the deprecation process revealed that
the flag is important for health checks in more secure environments.
Add a link to #43784 to help developers understand why the flags have
not yet been removed.

Issue #43784
Issue #74172
Issue #59018


/kind documentation

```release-note
NONE
```