### PR TITLE
remove unnecessary scheme from config struct

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/config.go
@@ -87,7 +87,6 @@ func ReadAdmissionConfiguration(pluginNames []string, configFilePath string, con
 		}
 		return configProvider{
 			config: decodedConfig,
-			scheme: configScheme,
 		}, nil
 	}
 	// we got an error where the decode wasn't related to a missing type
@@ -127,13 +126,11 @@ func ReadAdmissionConfiguration(pluginNames []string, configFilePath string, con
 	}
 	return configProvider{
 		config: internalConfig,
-		scheme: configScheme,
 	}, nil
 }
 
 type configProvider struct {
 	config *apiserver.AdmissionConfiguration
-	scheme *runtime.Scheme
 }
 
 // GetAdmissionPluginConfigurationFor returns a reader that holds the admission plugin configuration.


### PR DESCRIPTION
Trying to find a different bug, I ran into this and wasted some time.  It's just a dead scheme we shouldn't have.

/kind cleanup
/priority important-longterm
@kubernetes/sig-api-machinery-pr-reviews 

```release-note
NONE
```