### PR TITLE
Fix to #74223 , leaderelection.go affirming creation of new log and l…

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -314,7 +314,7 @@ func (le *LeaderElector) tryAcquireOrRenew() bool {
 		}
 		le.observedRecord = leaderElectionRecord
 		le.observedTime = le.clock.Now()
-		klog.Info("Created a new lock, and acquired it succesfully at time: %v", le.observedTime)
+		klog.Info("Created a new lock, and acquired it successfully at time: %v", le.observedTime)
 		return true
 	}
 

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -219,7 +219,7 @@ func (le *LeaderElector) acquire(ctx context.Context) bool {
 		succeeded = le.tryAcquireOrRenew()
 		le.maybeReportTransition()
 		if !succeeded {
-			klog.V(4).Infof("Attempt %v, failed to acquire lease %v", le.tries, desc)
+			klog.V(4).Infof("Failed to acquire lease %v", desc)
 			return
 		}
 		le.config.Lock.RecordEvent("became leader")

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -215,15 +215,12 @@ func (le *LeaderElector) acquire(ctx context.Context) bool {
 	defer cancel()
 	succeeded := false
 	desc := le.config.Lock.Describe()
-	klog.Infof("attempting to acquire leader lease  %v...", desc)
+	klog.Infof("Attempting to acquire leader lease  %v.  Note that failures will be retried, and logged at level V(4)", desc)
 	wait.JitterUntil(func() {
 		succeeded = le.tryAcquireOrRenew()
 		le.maybeReportTransition()
 		if !succeeded {
-			le.tries = le.tries + 1
-			if le.tries % 10 == 0 {
-				klog.Infof("Attempt %v, failed to acquire lease %v", le.tries, desc)
-			}
+			klog.V(4).Infof("Attempt %v, failed to acquire lease %v", le.tries, desc)
 			return
 		}
 		le.config.Lock.RecordEvent("became leader")

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -222,7 +222,7 @@ func (le *LeaderElector) acquire(ctx context.Context) bool {
 		if !succeeded {
 			le.tries = le.tries + 1
 			if le.tries % 10 == 0 {
-				klog.Infof("Attempt %v, failed to acquire lease %v", tries, desc)
+				klog.Infof("Attempt %v, failed to acquire lease %v", le.tries, desc)
 			}
 			return
 		}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -305,7 +305,6 @@ func (le *LeaderElector) tryAcquireOrRenew() bool {
 
 	// 1. obtain or create the ElectionRecord
 	oldLeaderElectionRecord, err := le.config.Lock.Get()
-
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			klog.Errorf("error retrieving resource lock %v: %v", le.config.Lock.Describe(), err)

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -150,7 +150,6 @@ type LeaderCallbacks struct {
 
 // LeaderElector is a leader election client.
 type LeaderElector struct {
-	tries int
 	config LeaderElectionConfig
 	// internal bookkeeping
 	observedRecord rl.LeaderElectionRecord

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -214,12 +214,12 @@ func (le *LeaderElector) acquire(ctx context.Context) bool {
 	defer cancel()
 	succeeded := false
 	desc := le.config.Lock.Describe()
-	klog.Infof("Attempting to acquire leader lease  %v.  Note that failures will be retried, and logged at level V(4)", desc)
+	klog.Infof("attempting to acquire leader lease  %v.  Note that failures will be retried, and logged at level V(4)", desc)
 	wait.JitterUntil(func() {
 		succeeded = le.tryAcquireOrRenew()
 		le.maybeReportTransition()
 		if !succeeded {
-			klog.V(4).Infof("Failed to acquire lease %v", desc)
+			klog.V(4).Infof("failed to acquire lease %v", desc)
 			return
 		}
 		le.config.Lock.RecordEvent("became leader")
@@ -279,7 +279,7 @@ func (le *LeaderElector) release() bool {
 		LeaderTransitions: le.observedRecord.LeaderTransitions,
 	}
 	if err := le.config.Lock.Update(leaderElectionRecord); err != nil {
-		klog.Errorf("Failed to release lock: %v", err)
+		klog.Errorf("failed to release lock: %v", err)
 		return false
 	}
 	le.observedRecord = leaderElectionRecord


### PR DESCRIPTION
…eveled log of acquire trial 

**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

Ideally, the leader elect should show that its creating a new lock, so that logs aren't 100% negative when looking at a cluster that is healthy / became corrupt.

**Which issue(s) this PR fixes**:

Fixes #74223  

**Special notes for your reviewer**:

This ones a Quickie :) 

**Does this PR introduce a user-facing change?**:
```release-note
Improved leaderelection lock logging for DR/failure forensics scenarios
```
