### PR TITLE
Remove unused wrong image config

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -99,7 +99,6 @@ var (
 	BusyBox                  = Config{dockerLibraryRegistry, "busybox", "1.29"}
 	CheckMetadataConcealment = Config{e2eRegistry, "metadata-concealment", "1.2"}
 	CudaVectorAdd            = Config{e2eRegistry, "cuda-vector-add", "1.0"}
-	CudaVectorAdd2           = Config{e2eRegistry, "cuda-vector-add", "2.0"}
 	Dnsutils                 = Config{e2eRegistry, "dnsutils", "1.1"}
 	EchoServer               = Config{e2eRegistry, "echoserver", "2.2"}
 	EntrypointTester         = Config{e2eRegistry, "entrypoint-tester", "1.0"}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove unused wrong image config.
The variable `CudaVectorAdd2` is not used globally.
And the image `gcr.io/kubernetes-e2e-test-images/cuda-vector-add:2.0` doesn't exist.

**Which issue(s) this PR fixes**:
Fixes #74215

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
