### PR TITLE
Fix duplicate container query param on exec pod command

### DIFF
--- a/pkg/kubectl/cmd/exec/exec.go
+++ b/pkg/kubectl/cmd/exec/exec.go
@@ -311,8 +311,7 @@ func (p *ExecOptions) Run() error {
 			Resource("pods").
 			Name(pod.Name).
 			Namespace(pod.Namespace).
-			SubResource("exec").
-			Param("container", containerName)
+			SubResource("exec")
 		req.VersionedParams(&corev1.PodExecOptions{
 			Container: containerName,
 			Command:   p.Command,

--- a/pkg/kubectl/cmd/exec/exec_test.go
+++ b/pkg/kubectl/cmd/exec/exec_test.go
@@ -244,6 +244,10 @@ func TestExec(t *testing.T) {
 				t.Errorf("%s: Did not get expected path for exec request", test.name)
 				return
 			}
+			if strings.Count(ex.url.RawQuery, "container=bar") != 1 {
+				t.Errorf("%s: Did not get expected container query param for exec request", test.name)
+				return
+			}
 			if ex.method != "POST" {
 				t.Errorf("%s: Did not get method for exec request: %s", test.name, ex.method)
 			}


### PR DESCRIPTION
Signed-off-by: He Xiaoxi <xxhe@alauda.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fix duplicate container query param on exec pod command

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #74231

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
