### PR TITLE
kube-aggregator: fix typo aggregator_unavailable_api{server -> service}_{gauge,}

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/metrics.go
@@ -30,7 +30,7 @@ var (
 	)
 	unavailableGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "aggregator_unavailable_apiserver_gauge",
+			Name: "aggregator_unavailable_apiservice",
 			Help: "Gauge of APIServices which are marked as unavailable broken down by APIService name.",
 		},
 		[]string{"name"},


### PR DESCRIPTION
Note we don't have to follow the deprecation process as this was merged after 1.13 and is not out in the wild yet.

Fix for https://github.com/kubernetes/kubernetes/pull/71380.