### PR TITLE
Fix shellcheck errors for some scripts in hack/

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -118,7 +118,6 @@
 ./hack/update-workspace-mirror.sh
 ./hack/verify-all.sh
 ./hack/verify-api-groups.sh
-./hack/verify-bazel.sh
 ./hack/verify-boilerplate.sh
 ./hack/verify-cli-conventions.sh
 ./hack/verify-codegen.sh
@@ -132,13 +131,9 @@
 ./hack/verify-generated-protobuf.sh
 ./hack/verify-generated-runtime.sh
 ./hack/verify-generated-swagger-docs.sh
-./hack/verify-godep-licenses.sh
-./hack/verify-godeps.sh
-./hack/verify-gofmt.sh
 ./hack/verify-golint.sh
 ./hack/verify-govet.sh
 ./hack/verify-import-boss.sh
-./hack/verify-imports.sh
 ./hack/verify-linkcheck.sh
 ./hack/verify-no-vendor-cycles.sh
 ./hack/verify-openapi-spec.sh

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -17,7 +17,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+export KUBE_ROOT
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 if [[ ! -f "${KUBE_ROOT}/vendor/BUILD" ]]; then
@@ -31,7 +32,7 @@ fi
 # TODO(spxtr): Remove this line once Bazel is the only way to build.
 rm -f "${KUBE_ROOT}/pkg/generated/openapi/zz_generated.openapi.go"
 
-_tmpdir="$(kube::realpath $(mktemp -d -t verify-bazel.XXXXXX))"
+_tmpdir="$(kube::realpath "$(mktemp -d -t verify-bazel.XXXXXX)")"
 kube::util::trap_add "rm -rf ${_tmpdir}" EXIT
 
 _tmp_gopath="${_tmpdir}/go"

--- a/hack/verify-godep-licenses.sh
+++ b/hack/verify-godep-licenses.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
@@ -48,7 +48,7 @@ ln -s "${KUBE_ROOT}/vendor" "${_tmpdir}"
 LICENSE_ROOT="${_tmpdir}" "${KUBE_ROOT}/hack/update-godep-licenses.sh"
 
 # Compare Godep Licenses
-if ! _out="$(diff -Naupr ${KUBE_ROOT}/Godeps/LICENSES ${_tmpdir}/Godeps/LICENSES)"; then
+if ! _out="$(diff -Naupr "${KUBE_ROOT}/Godeps/LICENSES" "${_tmpdir}/Godeps/LICENSES")"; then
   echo "Your godep licenses file is out of date. Run hack/update-godep-licenses.sh and commit the results." >&2
   echo "${_out}" >&2
   exit 1

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
@@ -35,7 +35,7 @@ kube::util::ensure_godep_version
 
 if [[ -z ${TMP_GOPATH:-} ]]; then
   # Create a nice clean place to put our new godeps
-  _tmpdir="$(kube::realpath $(mktemp -d -t gopath.XXXXXX))"
+  _tmpdir="$(kube::realpath "$(mktemp -d -t gopath.XXXXXX)")"
 else
   # reuse what we might have saved previously
   _tmpdir="${TMP_GOPATH}"
@@ -58,7 +58,7 @@ trap cleanup EXIT
 _kubetmp="${_tmpdir}/src/k8s.io"
 mkdir -p "${_kubetmp}"
 # should create ${_kubectmp}/kubernetes
-git archive --format=tar --prefix=kubernetes/ $(git write-tree) | (cd "${_kubetmp}" && tar xf -)
+git archive --format=tar --prefix=kubernetes/ "$(git write-tree)" | (cd "${_kubetmp}" && tar xf -)
 _kubetmp="${_kubetmp}/kubernetes"
 
 # Do all our work in the new GOPATH
@@ -84,7 +84,7 @@ ret=0
 
 pushd "${KUBE_ROOT}" > /dev/null 2>&1
   # Test for diffs
-  if ! _out="$(diff -Naupr --ignore-matching-lines='^\s*\"GoVersion\":' Godeps/Godeps.json ${_kubetmp}/Godeps/Godeps.json)"; then
+  if ! _out="$(diff -Naupr --ignore-matching-lines='^\s*\"GoVersion\":' Godeps/Godeps.json "${_kubetmp}/Godeps/Godeps.json")"; then
     echo "Your Godeps.json is different:" >&2
     echo "${_out}" >&2
     echo "Godeps Verify failed." >&2
@@ -101,7 +101,7 @@ pushd "${KUBE_ROOT}" > /dev/null 2>&1
     ret=1
   fi
 
-  if ! _out="$(diff -Naupr -x "BUILD" -x "AUTHORS*" -x "CONTRIBUTORS*" vendor ${_kubetmp}/vendor)"; then
+  if ! _out="$(diff -Naupr -x "BUILD" -x "AUTHORS*" -x "CONTRIBUTORS*" vendor "${_kubetmp}/vendor")"; then
     echo "Your vendored results are different:" >&2
     echo "${_out}" >&2
     echo "Godeps Verify failed." >&2

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 cd "${KUBE_ROOT}"
@@ -53,7 +53,7 @@ find_files() {
 # formatting (e.g., a file does not parse correctly). Without "|| true" this
 # would have led to no useful error message from gofmt, because the script would
 # have failed before getting to the "echo" in the block below.
-diff=$(find_files | xargs ${gofmt} -d -s 2>&1) || true
+diff=$(find_files | xargs "${gofmt}" -d -s 2>&1) || true
 if [[ -n "${diff}" ]]; then
   echo "${diff}" >&2
   echo >&2

--- a/hack/verify-imports.sh
+++ b/hack/verify-imports.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Five more of the hack/verify-* scripts now pass shellcheck and have been
removed from hack/.shellcheck_failures. Part of the effort tracked in https://github.com/kubernetes/kubernetes/issues/72956.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
