### PR TITLE
Ensure Docker experimental features are enabled before creating manifest

### DIFF
--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -127,6 +127,8 @@ push() {
 
   kube::util::ensure-gnu-sed
 
+  # The manifest command is still experimental as of Docker 18.09.2
+  export DOCKER_CLI_EXPERIMENTAL="enabled"
   # Make archs list into image manifest. Eg: 'amd64 ppc64le' to '${REGISTRY}/${IMAGE}-amd64:${TAG} ${REGISTRY}/${IMAGE}-ppc64le:${TAG}'
   manifest=$(echo $archs | ${SED} -e "s~[^ ]*~$REGISTRY\/$IMAGE\-&:$TAG~g")
   docker manifest create --amend ${REGISTRY}/${IMAGE}:${TAG} ${manifest}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: When building and pushing new e2e images, `make all-push` can fail to create/push the manifest list if experimental features are not enabled in the Docker client.

We've fixed this in some of the other Makefiles by setting the `DOCKER_CLI_EXPERIMENTAL` environment variable, so let's do this in `image-util.sh` as well.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig testing
/priority important-soon
/assign @mkumatag 
cc @jiayingz 
