### PR TITLE
Audit test utils fix 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/scheme.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/scheme.go
@@ -38,4 +38,5 @@ func init() {
 	utilruntime.Must(v1alpha1.AddToScheme(Scheme))
 	utilruntime.Must(v1beta1.AddToScheme(Scheme))
 	utilruntime.Must(auditinternal.AddToScheme(Scheme))
+	utilruntime.Must(Scheme.SetVersionPriority(v1.SchemeGroupVersion, v1beta1.SchemeGroupVersion, v1alpha1.SchemeGroupVersion))
 }

--- a/staging/src/k8s.io/apiserver/pkg/audit/scheme.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/scheme.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/apis/audit/v1"
 	"k8s.io/apiserver/pkg/apis/audit/v1alpha1"
 	"k8s.io/apiserver/pkg/apis/audit/v1beta1"
@@ -33,6 +34,7 @@ var Codecs = serializer.NewCodecFactory(Scheme)
 
 func init() {
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(auditinternal.AddToScheme(Scheme))
 	utilruntime.Must(v1.AddToScheme(Scheme))
 	utilruntime.Must(v1alpha1.AddToScheme(Scheme))
 	utilruntime.Must(v1beta1.AddToScheme(Scheme))

--- a/staging/src/k8s.io/apiserver/pkg/audit/scheme.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/scheme.go
@@ -34,8 +34,8 @@ var Codecs = serializer.NewCodecFactory(Scheme)
 
 func init() {
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
-	utilruntime.Must(auditinternal.AddToScheme(Scheme))
 	utilruntime.Must(v1.AddToScheme(Scheme))
 	utilruntime.Must(v1alpha1.AddToScheme(Scheme))
 	utilruntime.Must(v1beta1.AddToScheme(Scheme))
+	utilruntime.Must(auditinternal.AddToScheme(Scheme))
 }

--- a/test/e2e/auth/BUILD
+++ b/test/e2e/auth/BUILD
@@ -43,7 +43,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/audit:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/apis/audit/v1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1:go_default_library",

--- a/test/e2e/auth/audit.go
+++ b/test/e2e/auth/audit.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
-	"k8s.io/apiserver/pkg/apis/audit/v1beta1"
+	"k8s.io/apiserver/pkg/apis/audit/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -734,7 +734,7 @@ func expectEvents(f *framework.Framework, expectedEvents []utils.AuditEvent) {
 			return false, err
 		}
 		defer stream.Close()
-		missing, err := utils.CheckAuditLines(stream, expectedEvents, v1beta1.SchemeGroupVersion)
+		missing, err := utils.CheckAuditLines(stream, expectedEvents, v1.SchemeGroupVersion)
 		if err != nil {
 			framework.Logf("Failed to observe audit events: %v", err)
 		} else if len(missing) > 0 {

--- a/test/e2e/auth/audit.go
+++ b/test/e2e/auth/audit.go
@@ -734,13 +734,13 @@ func expectEvents(f *framework.Framework, expectedEvents []utils.AuditEvent) {
 			return false, err
 		}
 		defer stream.Close()
-		missing, err := utils.CheckAuditLines(stream, expectedEvents, v1.SchemeGroupVersion)
+		missingReport, err := utils.CheckAuditLines(stream, expectedEvents, v1.SchemeGroupVersion)
 		if err != nil {
 			framework.Logf("Failed to observe audit events: %v", err)
-		} else if len(missing) > 0 {
-			framework.Logf("Events %#v not found!", missing)
+		} else if len(missingReport.MissingEvents) > 0 {
+			framework.Logf(missingReport.String())
 		}
-		return len(missing) == 0, nil
+		return len(missingReport.MissingEvents) == 0, nil
 	})
 	framework.ExpectNoError(err, "after %v failed to observe audit events", pollingTimeout)
 }

--- a/test/integration/master/audit_test.go
+++ b/test/integration/master/audit_test.go
@@ -214,12 +214,12 @@ func testAudit(t *testing.T, version string) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	defer stream.Close()
-	missing, err := utils.CheckAuditLines(stream, expectedEvents, versions[version])
+	missingReport, err := utils.CheckAuditLines(stream, expectedEvents, versions[version])
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if len(missing) > 0 {
-		t.Errorf("Failed to match all expected events, events %#v not found!", missing)
+	if len(missingReport.MissingEvents) > 0 {
+		t.Errorf(missingReport.String())
 	}
 }
 

--- a/test/utils/audit.go
+++ b/test/utils/audit.go
@@ -56,6 +56,7 @@ type MissingEventsReport struct {
 	MissingEvents     []AuditEvent
 }
 
+// String returns a human readable string representation of the report
 func (m *MissingEventsReport) String() string {
 	return fmt.Sprintf(`missing %d events
 

--- a/test/utils/audit.go
+++ b/test/utils/audit.go
@@ -49,13 +49,13 @@ type AuditEvent struct {
 }
 
 // CheckAuditLines searches the audit log for the expected audit lines.
-// if includeID is true the event ids will also be verified
 func CheckAuditLines(stream io.Reader, expected []AuditEvent, version schema.GroupVersion) (missing []AuditEvent, err error) {
 	expectations := buildEventExpectations(expected)
 
 	scanner := bufio.NewScanner(stream)
 	for scanner.Scan() {
 		line := scanner.Text()
+
 		e := &auditinternal.Event{}
 		decoder := audit.Codecs.UniversalDecoder(version)
 		if err := runtime.DecodeInto(decoder, []byte(line), e); err != nil {
@@ -81,7 +81,6 @@ func CheckAuditLines(stream io.Reader, expected []AuditEvent, version schema.Gro
 }
 
 // CheckAuditList searches an audit event list for the expected audit events.
-// if includeID is true the event ids will also be verified
 func CheckAuditList(el auditinternal.EventList, expected []AuditEvent) (missing []AuditEvent, err error) {
 	expectations := buildEventExpectations(expected)
 
@@ -133,7 +132,6 @@ func buildEventExpectations(expected []AuditEvent) map[AuditEvent]bool {
 }
 
 // testEventFromInternal takes an internal audit event and returns a test event
-// if includeID is true the event id will be included
 func testEventFromInternal(e *auditinternal.Event) (AuditEvent, error) {
 	event := AuditEvent{
 		Level:      e.Level,

--- a/test/utils/audit.go
+++ b/test/utils/audit.go
@@ -48,23 +48,53 @@ type AuditEvent struct {
 	AuthorizeDecision  string
 }
 
+// MissingEventsReport provides an analysis if any events are missing
+type MissingEventsReport struct {
+	FirstEventChecked *auditinternal.Event
+	LastEventChecked  *auditinternal.Event
+	NumEventsChecked  int
+	MissingEvents     []AuditEvent
+}
+
+func (m *MissingEventsReport) String() string {
+	return fmt.Sprintf(`missing %d events
+
+- first event checked: %#v
+
+- last event checked: %#v
+
+- number of events checked: %d
+
+- missing events: %#v`, len(m.MissingEvents), m.FirstEventChecked, m.LastEventChecked, m.NumEventsChecked, m.MissingEvents)
+}
+
 // CheckAuditLines searches the audit log for the expected audit lines.
-func CheckAuditLines(stream io.Reader, expected []AuditEvent, version schema.GroupVersion) (missing []AuditEvent, err error) {
+func CheckAuditLines(stream io.Reader, expected []AuditEvent, version schema.GroupVersion) (missingReport *MissingEventsReport, err error) {
 	expectations := buildEventExpectations(expected)
 
 	scanner := bufio.NewScanner(stream)
-	for scanner.Scan() {
+
+	missingReport = &MissingEventsReport{
+		MissingEvents: expected,
+	}
+
+	var i int
+	for i = 0; scanner.Scan(); i++ {
 		line := scanner.Text()
 
 		e := &auditinternal.Event{}
 		decoder := audit.Codecs.UniversalDecoder(version)
 		if err := runtime.DecodeInto(decoder, []byte(line), e); err != nil {
-			return expected, fmt.Errorf("failed decoding buf: %s, apiVersion: %s", line, version)
+			return missingReport, fmt.Errorf("failed decoding buf: %s, apiVersion: %s", line, version)
 		}
+		if i == 0 {
+			missingReport.FirstEventChecked = e
+		}
+		missingReport.LastEventChecked = e
 
 		event, err := testEventFromInternal(e)
 		if err != nil {
-			return expected, err
+			return missingReport, err
 		}
 
 		// If the event was expected, mark it as found.
@@ -73,11 +103,13 @@ func CheckAuditLines(stream io.Reader, expected []AuditEvent, version schema.Gro
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return expected, err
+		return missingReport, err
 	}
 
-	missing = findMissing(expectations)
-	return missing, nil
+	missingEvents := findMissing(expectations)
+	missingReport.MissingEvents = missingEvents
+	missingReport.NumEventsChecked = i
+	return missingReport, nil
 }
 
 // CheckAuditList searches an audit event list for the expected audit events.


### PR DESCRIPTION
Fixing up audit test utils related to https://storage.googleapis.com/k8s-gubernator/triage/index.html?date=2019-01-25&pr=1&job=pull-kubernetes-e2e-gce&test=Advanced%20Audit test flake

* adds audit internal type to common scheme
* changes e2e test to decode events in v1
* Returns a missing events report when events are not found that denotes the first and last event checked as well as the total number.

/kind failing-test
/sig auth

```release-note
NONE
```
