### PR TITLE
kubeadm/join: expose the KubeConfigPath() method to joinData

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -173,7 +173,7 @@ func NewCmdJoin(out io.Writer, joinOptions *joinOptions) *cobra.Command {
 				}
 
 				ctx := map[string]string{
-					"KubeConfigPath": kubeadmconstants.GetAdminKubeConfigPath(),
+					"KubeConfigPath": data.KubeConfigPath(),
 					"etcdMessage":    etcdMessage,
 				}
 				joinControPlaneDoneTemp.Execute(data.outputWriter, ctx)
@@ -378,6 +378,11 @@ func newJoinData(cmd *cobra.Command, args []string, options *joinOptions, out io
 // Cfg returns the JoinConfiguration.
 func (j *joinData) Cfg() *kubeadmapi.JoinConfiguration {
 	return j.cfg
+}
+
+// KubeConfigPath returns the default kubeconfig path.
+func (j *joinData) KubeConfigPath() string {
+	return kubeadmconstants.GetAdminKubeConfigPath()
 }
 
 // TLSBootstrapCfg returns the cluster-info (kubeconfig).


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the following error:
"error execution phase control-plane-join/etcd:
control-plane-join phase invoked with an invalid data struct"

The problem here is that joinData cannot be type-asserted
to the interface type under controlplanejoin.go (controlPlaneJoinData)
because joinData lacks KubeConfigPath.

Given we use KubeConfigPath in more than one place for join
it makes sense to define the method and make it return:
kubeadmconstants.GetAdminKubeConfigPath()

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-all#kubeadm-kind-master

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/kind bug
/priority critical-urgent
cc @fabriziopandini @RA489 
cc @kubernetes/sig-cluster-lifecycle-pr-reviews 
