### PR TITLE
Fix shellcheck lint errors in ./hack/...

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -95,17 +95,8 @@
 ./hack/update-all.sh
 ./hack/update-bazel.sh
 ./hack/update-codegen.sh
-./hack/update-generated-device-plugin-dockerized.sh
-./hack/update-generated-device-plugin.sh
-./hack/update-generated-docs.sh
 ./hack/update-generated-kms-dockerized.sh
-./hack/update-generated-kms.sh
-./hack/update-generated-kubelet-plugin-registration-dockerized.sh
-./hack/update-generated-kubelet-plugin-registration.sh
-./hack/update-generated-pod-resources-dockerized.sh
-./hack/update-generated-pod-resources.sh
 ./hack/update-generated-protobuf-dockerized.sh
-./hack/update-generated-protobuf.sh
 ./hack/update-generated-runtime-dockerized.sh
 ./hack/update-generated-runtime.sh
 ./hack/update-generated-swagger-docs.sh

--- a/hack/update-generated-device-plugin-dockerized.sh
+++ b/hack/update-generated-device-plugin-dockerized.sh
@@ -18,10 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE}")/../" && pwd -P)"
+KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd -P)"
 DEVICE_PLUGIN_ALPHA="${KUBE_ROOT}/pkg/kubelet/apis/deviceplugin/v1alpha/"
 DEVICE_PLUGIN_V1BETA1="${KUBE_ROOT}/pkg/kubelet/apis/deviceplugin/v1beta1/"
 
 source "${KUBE_ROOT}/hack/lib/protoc.sh"
-kube::protoc::generate_proto ${DEVICE_PLUGIN_ALPHA}
-kube::protoc::generate_proto ${DEVICE_PLUGIN_V1BETA1}
+kube::protoc::generate_proto "${DEVICE_PLUGIN_ALPHA}"
+kube::protoc::generate_proto "${DEVICE_PLUGIN_V1BETA1}"

--- a/hack/update-generated-device-plugin.sh
+++ b/hack/update-generated-device-plugin.sh
@@ -18,10 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # NOTE: All output from this script needs to be copied back to the calling
 # source tree.  This is managed in kube::build::copy_output in build/common.sh.
 # If the output set is changed update that function.
 
-${KUBE_ROOT}/build/run.sh hack/update-generated-device-plugin-dockerized.sh "$@"
+"${KUBE_ROOT}/build/run.sh" hack/update-generated-device-plugin-dockerized.sh "$@"

--- a/hack/update-generated-docs.sh
+++ b/hack/update-generated-docs.sh
@@ -22,7 +22,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env

--- a/hack/update-generated-kms.sh
+++ b/hack/update-generated-kms.sh
@@ -18,12 +18,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # NOTE: All output from this script needs to be copied back to the calling
 # source tree.  This is managed in kube::build::copy_output in build/common.sh.
 # If the output set is changed update that function.
 
-${KUBE_ROOT}/build/run.sh hack/update-generated-kms-dockerized.sh "$@"
+"${KUBE_ROOT}/build/run.sh" hack/update-generated-kms-dockerized.sh "$@"
 
 # ex: ts=2 sw=2 et filetype=sh

--- a/hack/update-generated-kubelet-plugin-registration-dockerized.sh
+++ b/hack/update-generated-kubelet-plugin-registration-dockerized.sh
@@ -18,14 +18,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE}")/../" && pwd -P)"
+KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd -P)"
 KUBELET_PLUGIN_REGISTRATION_V1ALPHA="${KUBE_ROOT}/pkg/kubelet/apis/pluginregistration/v1alpha1/"
 KUBELET_PLUGIN_REGISTRATION_V1BETA="${KUBE_ROOT}/pkg/kubelet/apis/pluginregistration/v1beta1/"
 KUBELET_EXAMPLE_PLUGIN_V1BETA1="${KUBE_ROOT}/pkg/kubelet/util/pluginwatcher/example_plugin_apis/v1beta1/"
 KUBELET_EXAMPLE_PLUGIN_V1BETA2="${KUBE_ROOT}/pkg/kubelet/util/pluginwatcher/example_plugin_apis/v1beta2/"
 
 source "${KUBE_ROOT}/hack/lib/protoc.sh"
-kube::protoc::generate_proto ${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}
-kube::protoc::generate_proto ${KUBELET_PLUGIN_REGISTRATION_V1BETA}
-kube::protoc::generate_proto ${KUBELET_EXAMPLE_PLUGIN_V1BETA1}
-kube::protoc::generate_proto ${KUBELET_EXAMPLE_PLUGIN_V1BETA2}
+kube::protoc::generate_proto "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}"
+kube::protoc::generate_proto "${KUBELET_PLUGIN_REGISTRATION_V1BETA}"
+kube::protoc::generate_proto "${KUBELET_EXAMPLE_PLUGIN_V1BETA1}"
+kube::protoc::generate_proto "${KUBELET_EXAMPLE_PLUGIN_V1BETA2}"

--- a/hack/update-generated-kubelet-plugin-registration.sh
+++ b/hack/update-generated-kubelet-plugin-registration.sh
@@ -18,10 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # NOTE: All output from this script needs to be copied back to the calling
 # source tree.  This is managed in kube::build::copy_output in build/common.sh.
 # If the output set is changed update that function.
 
-${KUBE_ROOT}/build/run.sh hack/update-generated-kubelet-plugin-registration-dockerized.sh "$@"
+"${KUBE_ROOT}/build/run.sh" hack/update-generated-kubelet-plugin-registration-dockerized.sh "$@"

--- a/hack/update-generated-pod-resources-dockerized.sh
+++ b/hack/update-generated-pod-resources-dockerized.sh
@@ -18,8 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE}")/../" && pwd -P)"
+KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd -P)"
 POD_RESOURCES_ALPHA="${KUBE_ROOT}/pkg/kubelet/apis/podresources/v1alpha1/"
 
 source "${KUBE_ROOT}/hack/lib/protoc.sh"
-kube::protoc::generate_proto ${POD_RESOURCES_ALPHA}
+kube::protoc::generate_proto "${POD_RESOURCES_ALPHA}"

--- a/hack/update-generated-pod-resources.sh
+++ b/hack/update-generated-pod-resources.sh
@@ -18,10 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # NOTE: All output from this script needs to be copied back to the calling
 # source tree.  This is managed in kube::build::copy_output in build/common.sh.
 # If the output set is changed update that function.
 
-${KUBE_ROOT}/build/run.sh hack/update-generated-pod-resources-dockerized.sh "$@"
+"${KUBE_ROOT}/build/run.sh" hack/update-generated-pod-resources-dockerized.sh "$@"

--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # NOTE: All output from this script needs to be copied back to the calling
 # source tree.  This is managed in kube::build::copy_output in build/common.sh.


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```