### PR TITLE
Fix e2e network policy tests

### DIFF
--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -560,7 +560,7 @@ func createNetworkClientPod(f *framework.Framework, namespace *v1.Namespace, pod
 					Args: []string{
 						"/bin/sh",
 						"-c",
-						fmt.Sprintf("for i in $(seq 1 5); do wget -q -T 8 %s.%s:%d && exit 0 || sleep 1; done; exit 1",
+						fmt.Sprintf("for i in $(seq 1 5); do nc -vz -w 8 %s.%s %d && exit 0 || sleep 1; done; exit 1",
 							targetService.Name, targetService.Namespace, targetPort),
 					},
 				},

--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -17,7 +17,7 @@ limitations under the License.
 package network
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -560,7 +560,7 @@ func createNetworkClientPod(f *framework.Framework, namespace *v1.Namespace, pod
 					Args: []string{
 						"/bin/sh",
 						"-c",
-						fmt.Sprintf("for i in $(seq 1 5); do curl -s -m 8 %s.%s:%d && exit 0 || sleep 1; done; exit 1",
+						fmt.Sprintf("for i in $(seq 1 5); do wget -q -T 8 %s.%s:%d && exit 0 || sleep 1; done; exit 1",
 							targetService.Name, targetService.Namespace, targetPort),
 					},
 				},


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

This PR uses wget instead of curl (because curl is missing in the busybox image) to make the network policy tests pass.

**Which issue(s) this PR fixes**:

Fixes #74289
Fixes #71728

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
