### PR TITLE
Fix conformance daemon_set test failing in local cluster

### DIFF
--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -377,7 +377,6 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 		if framework.TestContext.CloudConfig.NumNodes < 2 {
 			framework.Logf("Conformance test suite needs a cluster with at least 2 nodes.")
 		}
-
 		framework.Logf("Create a RollingUpdate DaemonSet")
 		label := map[string]string{daemonsetNameLabel: dsName}
 		ds := newDaemonSet(dsName, image, label)
@@ -415,7 +414,11 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 				framework.Failf("unexpected pod found, image = %s", image)
 			}
 		}
-		Expect(len(existingPods)).NotTo(Equal(0))
+		if framework.TestContext.CloudConfig.NumNodes < 2 {
+			Expect(len(existingPods)).To(Equal(0))
+		} else {
+			Expect(len(existingPods)).NotTo(Equal(0))
+		}
 		Expect(len(newPods)).NotTo(Equal(0))
 
 		framework.Logf("Roll back the DaemonSet before rollout is complete")


### PR DESCRIPTION
Fixing up conformance test related to:
1, ci-k8s-conformance-arm64-aws-cluster
https://storage.googleapis.com/k8s-conformance-arm/logs/ci-k8s-conformance-arm64-aws-cluster/84/build-log.txt

2, conformance test results for ppc64le
https://storage.googleapis.com/ppc64le-kubernetes/logs/ci-conformance-kubernetes/2809/build-log.txt

Signed-off-by: Bin Lu <bin.lu@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind failing-test


**What this PR does / why we need it**:
Fix conformance daemon_set test failing in local cluster

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Fix conformance daemon_set test failing in local cluster

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```
