### PR TITLE
Clear EndpointsLastChangeTriggerTime when there is no new trigger time to be exported

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -522,6 +522,8 @@ func (e *EndpointController) syncService(key string) error {
 	if !endpointsLastChangeTriggerTime.IsZero() {
 		newEndpoints.Annotations[v1.EndpointsLastChangeTriggerTime] =
 			endpointsLastChangeTriggerTime.Format(time.RFC3339Nano)
+	} else { // No new trigger time, clear the annotation.
+		delete(newEndpoints.Annotations, v1.EndpointsLastChangeTriggerTime)
 	}
 
 	klog.V(4).Infof("Update endpoints for %v/%v, ready: %d not ready: %d", service.Namespace, service.Name, totalReadyEps, totalNotReadyEps)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
We should clean the EndpointsLastChangeTriggerTime annotation when there is no new trigger time to be exported. 
Not clearing the may result in kube-proxy exporting the wrong Network Programming Latency SLI.

An example here is when pods are being deleted, currently we're not able to compute trigger time for pod deletions (there is a TODO to tackle that).
Therefore when pods are being deleted, the trigger time doesn't change and we update an Endpoints object with the old annotation value. This results in a wrong Network Programming Latency SLI being exported in kube-proxy as we use an old EndpointsLastChangeTriggerTime value which faultly bumps the SLI up. 
Below is the graph for two consecutive runs of the load test that visualizes the issue.

![rcvkfo6cu5a](https://user-images.githubusercontent.com/2604887/53087112-b38dc780-3506-11e9-85a2-a3af1f55a5fd.png)


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
