### PR TITLE
Refactor finding datastore during volume creation to vsphere_util

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -1164,18 +1164,10 @@ func (vs *VSphere) DisksAreAttached(nodeVolumes map[k8stypes.NodeName][]string) 
 func (vs *VSphere) CreateVolume(volumeOptions *vclib.VolumeOptions) (canonicalVolumePath string, err error) {
 	klog.V(1).Infof("Starting to create a vSphere volume with volumeOptions: %+v", volumeOptions)
 	createVolumeInternal := func(volumeOptions *vclib.VolumeOptions) (canonicalVolumePath string, err error) {
-		var datastore string
-		var dsList []*vclib.DatastoreInfo
-		// If datastore not specified, then use default datastore
-		if volumeOptions.Datastore == "" {
-			datastore = vs.cfg.Workspace.DefaultDatastore
-		} else {
-			datastore = volumeOptions.Datastore
-		}
-		datastore = strings.TrimSpace(datastore)
 		// Create context
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		vsi, err := vs.getVSphereInstanceForServer(vs.cfg.Workspace.VCenterIP, ctx)
 		if err != nil {
 			return "", err
@@ -1184,30 +1176,9 @@ func (vs *VSphere) CreateVolume(volumeOptions *vclib.VolumeOptions) (canonicalVo
 		if err != nil {
 			return "", err
 		}
+
 		var vmOptions *vclib.VMOptions
 		if volumeOptions.VSANStorageProfileData != "" || volumeOptions.StoragePolicyName != "" {
-			// If datastore and zone are specified, first validate if the datastore is in the provided zone.
-			if len(volumeOptions.Zone) != 0 && volumeOptions.Datastore != "" {
-				klog.V(4).Infof("Specified zone : %s, datastore : %s", volumeOptions.Zone, volumeOptions.Datastore)
-				dsList, err = getDatastoresForZone(ctx, dc, vs.nodeManager, volumeOptions.Zone)
-				if err != nil {
-					return "", err
-				}
-
-				// Validate if the datastore provided belongs to the zone. If not, fail the operation.
-				found := false
-				for _, ds := range dsList {
-					if ds.Info.Name == volumeOptions.Datastore {
-						found = true
-						break
-					}
-				}
-				if !found {
-					err := fmt.Errorf("The specified datastore %s does not match the provided zones : %s", volumeOptions.Datastore, volumeOptions.Zone)
-					klog.Error(err)
-					return "", err
-				}
-			}
 			// Acquire a read lock to ensure multiple PVC requests can be processed simultaneously.
 			cleanUpDummyVMLock.RLock()
 			defer cleanUpDummyVMLock.RUnlock()
@@ -1226,97 +1197,17 @@ func (vs *VSphere) CreateVolume(volumeOptions *vclib.VolumeOptions) (canonicalVo
 				return "", err
 			}
 		}
-		if volumeOptions.StoragePolicyName != "" && volumeOptions.Datastore == "" {
-			if len(volumeOptions.Zone) == 0 {
-				klog.V(4).Infof("Selecting a shared datastore as per the storage policy %s", volumeOptions.StoragePolicyName)
-				datastore, err = getPbmCompatibleDatastore(ctx, dc, volumeOptions.StoragePolicyName, vs.nodeManager)
-			} else {
-				// If zone is specified, first get the datastores in the zone.
-				dsList, err = getDatastoresForZone(ctx, dc, vs.nodeManager, volumeOptions.Zone)
 
-				if err != nil {
-					klog.Errorf("Failed to find a shared datastore matching zone %s. err: %+v", volumeOptions.Zone, err)
-					return "", err
-				}
-				// If unable to get any datastore, fail the operation.
-				if len(dsList) == 0 {
-					err := fmt.Errorf("Failed to find a shared datastore matching zone %s", volumeOptions.Zone)
-					klog.Error(err)
-					return "", err
-				}
-
-				klog.V(4).Infof("Specified zone : %s. Picking a datastore as per the storage policy %s among the zoned datastores : %s", volumeOptions.Zone,
-					volumeOptions.StoragePolicyName, dsList)
-				// Among the compatible datastores, select the one based on the maximum free space.
-				datastore, err = getPbmCompatibleZonedDatastore(ctx, dc, volumeOptions.StoragePolicyName, dsList)
-			}
-			klog.V(1).Infof("Datastore selected as per policy : %s", datastore)
-			if err != nil {
-				klog.Errorf("Failed to get pbm compatible datastore with storagePolicy: %s. err: %+v", volumeOptions.StoragePolicyName, err)
-				return "", err
-			}
-		} else {
-			// If zone is specified, pick the datastore in the zone with maximum free space within the zone.
-			if volumeOptions.Datastore == "" && len(volumeOptions.Zone) != 0 {
-				klog.V(4).Infof("Specified zone : %s", volumeOptions.Zone)
-				dsList, err = getDatastoresForZone(ctx, dc, vs.nodeManager, volumeOptions.Zone)
-
-				if err != nil {
-					klog.Errorf("Failed to find a shared datastore matching zone %s. err: %+v", volumeOptions.Zone, err)
-					return "", err
-				}
-				// If unable to get any datastore, fail the operation
-				if len(dsList) == 0 {
-					err := fmt.Errorf("Failed to find a shared datastore matching zone %s", volumeOptions.Zone)
-					klog.Error(err)
-					return "", err
-				}
-
-				datastore, err = getMostFreeDatastoreName(ctx, nil, dsList)
-				if err != nil {
-					klog.Errorf("Failed to get shared datastore: %+v", err)
-					return "", err
-				}
-				klog.V(1).Infof("Specified zone : %s. Selected datastore : %s", volumeOptions.StoragePolicyName, datastore)
-			} else {
-				var sharedDsList []*vclib.DatastoreInfo
-				var err error
-				if len(volumeOptions.Zone) == 0 {
-					// If zone is not provided, get the shared datastore across all node VMs.
-					klog.V(4).Infof("Validating if datastore %s is shared across all node VMs", datastore)
-					sharedDsList, err = getSharedDatastoresInK8SCluster(ctx, dc, vs.nodeManager)
-					if err != nil {
-						klog.Errorf("Failed to get shared datastore: %+v", err)
-						return "", err
-					}
-					// Prepare error msg to be used later, if required.
-					err = fmt.Errorf("The specified datastore %s is not a shared datastore across node VMs", datastore)
-				} else {
-					// If zone is provided, get the shared datastores in that zone.
-					klog.V(4).Infof("Validating if datastore %s is in zone %s ", datastore, volumeOptions.Zone)
-					sharedDsList, err = getDatastoresForZone(ctx, dc, vs.nodeManager, volumeOptions.Zone)
-					if err != nil {
-						klog.Errorf("Failed to find a shared datastore matching zone %s. err: %+v", volumeOptions.Zone, err)
-						return "", err
-					}
-					// Prepare error msg to be used later, if required.
-					err = fmt.Errorf("The specified datastore %s does not match the provided zones : %s", datastore, volumeOptions.Zone)
-				}
-				found := false
-				// Check if the selected datastore belongs to the list of shared datastores computed.
-				for _, sharedDs := range sharedDsList {
-					if datastore == sharedDs.Info.Name {
-						klog.V(4).Infof("Datastore validation succeeded")
-						found = true
-						break
-					}
-				}
-				if !found {
-					klog.Error(err)
-					return "", err
-				}
-			}
+		datastoreFinder, err := NewDatastoreFinder(vs.cfg.Workspace.DefaultDatastore, dc, vs.nodeManager, volumeOptions)
+		if err != nil {
+			return "", err
 		}
+
+		datastore, err := datastoreFinder.GetDatastoreForVolume(ctx)
+		if err != nil {
+			return "", err
+		}
+
 		ds, err := dc.GetDatastoreByName(ctx, datastore)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Rewrites the logic of finding and/or validating the datastore on which a volume is to be created. There are three inputs considered from the user:
1. Datastore name itself
2. Storage Policy namge
3. Zones specified in allowedTopologies

Any combination of these three inputs can be given by the user, for a total of 8 cases to be handled here. Each of these 8 cases needs a different handler to validate the input and come up with the datastore on which to place the volume.

This is currently handled in nested conditions which makes the code unreadable. This change proposes to clean up this code into a simple table look up to dispatch to the correct handler.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Looking to get some feedback whether this is a desirable change.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
