### PR TITLE
Fix some shellcheck failures in hack

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -39,9 +39,6 @@
 ./cluster/test-smoke.sh
 ./cluster/update-storage-objects.sh
 ./cluster/validate-cluster.sh
-./hack/benchmark-go.sh
-./hack/build-cross.sh
-./hack/build-go.sh
 ./hack/cherry_pick_pull.sh
 ./hack/generate-bindata.sh
 ./hack/generate-docs.sh
@@ -79,10 +76,8 @@
 ./hack/make-rules/update.sh
 ./hack/make-rules/verify.sh
 ./hack/make-rules/vet.sh
-./hack/test-go.sh
 ./hack/test-integration.sh
 ./hack/test-update-storage-objects.sh
-./hack/update-all.sh
 ./hack/update-bazel.sh
 ./hack/update-codegen.sh
 ./hack/update-generated-device-plugin-dockerized.sh
@@ -106,7 +101,6 @@
 ./hack/update-staging-godeps.sh
 ./hack/update-translations.sh
 ./hack/update-workspace-mirror.sh
-./hack/verify-all.sh
 ./hack/verify-api-groups.sh
 ./hack/verify-boilerplate.sh
 ./hack/verify-cli-conventions.sh

--- a/hack/benchmark-go.sh
+++ b/hack/benchmark-go.sh
@@ -18,8 +18,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-
 make test \
     WHAT="$*" \
     KUBE_COVER="" \

--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 echo "NOTE: $0 has been replaced by 'make cross'"
 echo

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -20,12 +20,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # For help output
 ARGHELP=""
 if [[ "$#" -gt 0 ]]; then
-    ARGHELP="WHAT='$@'"
+    ARGHELP="WHAT='$*'"
 fi
 
 echo "NOTE: $0 has been replaced by 'make' or 'make all'"

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -20,12 +20,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # For help output
 ARGHELP=""
 if [[ "$#" -gt 0 ]]; then
-    ARGHELP="WHAT='$@'"
+    ARGHELP="WHAT='$*'"
 fi
 
 echo "NOTE: $0 has been replaced by 'make test'"

--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 echo "NOTE: $0 has been replaced by 'make update'"
 echo

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # For help output
 ARGHELP=""


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix some shellcheck failures in hack :
- hack/benchmark-go.sh
- hack/verify-all.sh
- hack/build-cross.sh
- hack/update-all.sh
- hack/test-go.sh
- hack/build-go.sh

**Which issue(s) this PR fixes**:
Ref #72956

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
