### PR TITLE
Expose kube-proxy metrics on 0.0.0.0 by default

### DIFF
--- a/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted.yaml
@@ -69,7 +69,7 @@ ipvs:
   scheduler: ""
   syncPeriod: 30s
 kind: KubeProxyConfiguration
-metricsBindAddress: 127.0.0.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: ""
 nodePortAddresses: null
 oomScoreAdj: -999

--- a/pkg/proxy/apis/config/v1alpha1/defaults.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults.go
@@ -43,7 +43,7 @@ func SetDefaults_KubeProxyConfiguration(obj *kubeproxyconfigv1alpha1.KubeProxyCo
 		obj.HealthzBindAddress += fmt.Sprintf(":%v", ports.ProxyHealthzPort)
 	}
 	if obj.MetricsBindAddress == "" {
-		obj.MetricsBindAddress = fmt.Sprintf("127.0.0.1:%v", ports.ProxyStatusPort)
+		obj.MetricsBindAddress = fmt.Sprintf("0.0.0.0:%v", ports.ProxyStatusPort)
 	} else if !strings.Contains(obj.MetricsBindAddress, ":") {
 		obj.MetricsBindAddress += fmt.Sprintf(":%v", ports.ProxyStatusPort)
 	}

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -91,7 +91,7 @@ type KubeProxyConfiguration struct {
 	// defaulting to 0.0.0.0:10256
 	HealthzBindAddress string `json:"healthzBindAddress"`
 	// metricsBindAddress is the IP address and port for the metrics server to serve on,
-	// defaulting to 127.0.0.1:10249 (set to 0.0.0.0 for all interfaces)
+	// defaulting to 0.0.0.0:10249
 	MetricsBindAddress string `json:"metricsBindAddress"`
 	// enableProfiling enables profiling via web interface on /debug/pprof handler.
 	// Profiling handlers will be handled by metrics server.


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR exposes changes the default metrics-bind-address to 0.0.0.0.
Currently the kube-proxy metrics are exposed by default on 127.0.0.1 interface. It makes it hard to collect those metrics for monitoring purposes, e.g. via prometheus.
Other components (e.g. [kube-scheduler](https://github.com/kubernetes/kubernetes/blob/a7966022d78bce63fa8212ea2519c99f49c2570e/pkg/scheduler/apis/config/v1alpha1/defaults.go#L78)) use 0.0.0.0 as the default metrics bind address.


**Which issue(s) this PR fixes**: 
Fixes https://github.com/kubernetes/kubernetes/issues/74011


**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
From now on the kube-proxy metrics will be exposed by default on 0.0.0.0 instead of 127.0.0.1
```
