### PR TITLE
Do not return error on invalid MAC address in vSphere Cloud Provider

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -569,7 +569,8 @@ func getLocalIP() ([]v1.NodeAddress, error) {
 						vmMACAddr := strings.ToLower(i.HardwareAddr.String())
 						// Making sure that the MAC address is long enough
 						if len(vmMACAddr) < 17 {
-							return addrs, fmt.Errorf("MAC address %q is invalid", vmMACAddr)
+							klog.V(4).Infof("Skipping invalid MAC address: %q", vmMACAddr)
+							continue
 						}
 						if vmwareOUI[vmMACAddr[:8]] {
 							nodehelpers.AddToNodeAddresses(&addrs,


### PR DESCRIPTION
This PR fixes an erratic behavior of the vSphere Cloud Provider when running with flannel where it would return error if `flannel0` interface is parsed when patching the node IP

/sig vmware
/sig cloud-provider

/kind bug