### PR TITLE
WIP: Translate one API call to use v1.Node instead of NodeName

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -434,7 +434,7 @@ type Volumes interface {
 	// Attach the disk to the node with the specified NodeName
 	// nodeName can be empty to mean "the instance on which we are running"
 	// Returns the device (e.g. /dev/xvdf) where we attached the volume
-	AttachDisk(diskName KubernetesVolumeID, nodeName types.NodeName) (string, error)
+	AttachDisk(diskName KubernetesVolumeID, node *v1.Node) (string, error)
 	// Detach the disk from the node with the specified NodeName
 	// nodeName can be empty to mean "the instance on which we are running"
 	// Returns the device where the volume was attached
@@ -2093,11 +2093,13 @@ func wrapAttachError(err error, disk *awsDisk, instance string) error {
 }
 
 // AttachDisk implements Volumes.AttachDisk
-func (c *Cloud) AttachDisk(diskName KubernetesVolumeID, nodeName types.NodeName) (string, error) {
+func (c *Cloud) AttachDisk(diskName KubernetesVolumeID, node *v1.Node) (string, error) {
 	disk, err := newAWSDisk(c, diskName)
 	if err != nil {
 		return "", err
 	}
+
+	nodeName := types.NodeName(node.Name)
 
 	awsInstance, info, err := c.getFullInstance(nodeName)
 	if err != nil {

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -362,7 +362,7 @@ func (adc *attachDetachController) populateActualStateOfWorld() error {
 				continue
 			}
 			adc.processVolumesInUse(nodeName, node.Status.VolumesInUse)
-			adc.addNodeToDswp(node, types.NodeName(node.Name))
+			adc.addNodeToDswp(node)
 		}
 	}
 	return nil
@@ -529,7 +529,7 @@ func (adc *attachDetachController) nodeUpdate(oldObj, newObj interface{}) {
 	}
 
 	nodeName := types.NodeName(node.Name)
-	adc.addNodeToDswp(node, nodeName)
+	adc.addNodeToDswp(node)
 	adc.processVolumesInUse(nodeName, node.Status.VolumesInUse)
 }
 
@@ -739,7 +739,7 @@ func (adc *attachDetachController) GetExec(pluginName string) mount.Exec {
 	return mount.NewOsExec()
 }
 
-func (adc *attachDetachController) addNodeToDswp(node *v1.Node, nodeName types.NodeName) {
+func (adc *attachDetachController) addNodeToDswp(node *v1.Node) {
 	if _, exists := node.Annotations[volumeutil.ControllerManagedAttachAnnotation]; exists {
 		keepTerminatedPodVolumes := false
 
@@ -749,7 +749,7 @@ func (adc *attachDetachController) addNodeToDswp(node *v1.Node, nodeName types.N
 
 		// Node specifies annotation indicating it should be managed by attach
 		// detach controller. Add it to desired state of world.
-		adc.desiredStateOfWorld.AddNode(nodeName, keepTerminatedPodVolumes)
+		adc.desiredStateOfWorld.AddNode(node, keepTerminatedPodVolumes)
 	}
 }
 

--- a/pkg/volume/awsebs/attacher.go
+++ b/pkg/volume/awsebs/attacher.go
@@ -67,7 +67,7 @@ func (plugin *awsElasticBlockStorePlugin) GetDeviceMountRefs(deviceMountPath str
 	return mounter.GetMountRefs(deviceMountPath)
 }
 
-func (attacher *awsElasticBlockStoreAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string, error) {
+func (attacher *awsElasticBlockStoreAttacher) Attach(spec *volume.Spec, node *v1.Node) (string, error) {
 	volumeSource, _, err := getVolumeSource(spec)
 	if err != nil {
 		return "", err
@@ -77,9 +77,9 @@ func (attacher *awsElasticBlockStoreAttacher) Attach(spec *volume.Spec, nodeName
 
 	// awsCloud.AttachDisk checks if disk is already attached to node and
 	// succeeds in that case, so no need to do that separately.
-	devicePath, err := attacher.awsVolumes.AttachDisk(volumeID, nodeName)
+	devicePath, err := attacher.awsVolumes.AttachDisk(volumeID, node)
 	if err != nil {
-		klog.Errorf("Error attaching volume %q to node %q: %+v", volumeID, nodeName, err)
+		klog.Errorf("Error attaching volume %q to node %q: %+v", volumeID, node.Name, err)
 		return "", err
 	}
 

--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -59,7 +59,9 @@ var _ volume.DeviceUnmounter = &azureDiskDetacher{}
 var getLunMutex = keymutex.NewHashed(0)
 
 // Attach attaches a volume.Spec to an Azure VM referenced by NodeName, returning the disk's LUN
-func (a *azureDiskAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string, error) {
+func (a *azureDiskAttacher) Attach(spec *volume.Spec, node *v1.Node) (string, error) {
+	nodeName := types.NodeName(node.Name) // FIXME(justinsb): pass node through
+
 	volumeSource, _, err := getVolumeSource(spec)
 	if err != nil {
 		klog.Warningf("failed to get azure disk spec (%v)", err)

--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -127,7 +127,9 @@ func (attacher *cinderDiskAttacher) waitDiskAttached(instanceID, volumeID string
 	return err
 }
 
-func (attacher *cinderDiskAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string, error) {
+func (attacher *cinderDiskAttacher) Attach(spec *volume.Spec, node *v1.Node) (string, error) {
+	nodeName := types.NodeName(node.Name) // FIXME(justinsb): pass node through
+
 	volumeID, _, _, err := getVolumeInfo(spec)
 	if err != nil {
 		return "", err

--- a/pkg/volume/fc/attacher.go
+++ b/pkg/volume/fc/attacher.go
@@ -62,7 +62,7 @@ func (plugin *fcPlugin) GetDeviceMountRefs(deviceMountPath string) ([]string, er
 	return mounter.GetMountRefs(deviceMountPath)
 }
 
-func (attacher *fcAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string, error) {
+func (attacher *fcAttacher) Attach(spec *volume.Spec, node *v1.Node) (string, error) {
 	return "", nil
 }
 

--- a/pkg/volume/flexvolume/attacher.go
+++ b/pkg/volume/flexvolume/attacher.go
@@ -34,7 +34,8 @@ var _ volume.Attacher = &flexVolumeAttacher{}
 var _ volume.DeviceMounter = &flexVolumeAttacher{}
 
 // Attach is part of the volume.Attacher interface
-func (a *flexVolumeAttacher) Attach(spec *volume.Spec, hostName types.NodeName) (string, error) {
+func (a *flexVolumeAttacher) Attach(spec *volume.Spec, node *v1.Node) (string, error) {
+	hostName := types.NodeName(node.Name) // FIXME(justinsb): pass node through
 
 	call := a.plugin.NewDriverCall(attachCmd)
 	call.AppendSpec(spec, a.plugin.host, nil)

--- a/pkg/volume/gcepd/attacher.go
+++ b/pkg/volume/gcepd/attacher.go
@@ -75,7 +75,9 @@ func (plugin *gcePersistentDiskPlugin) GetDeviceMountRefs(deviceMountPath string
 // Callers are responsible for retrying on failure.
 // Callers are responsible for thread safety between concurrent attach and
 // detach operations.
-func (attacher *gcePersistentDiskAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string, error) {
+func (attacher *gcePersistentDiskAttacher) Attach(spec *volume.Spec, node *v1.Node) (string, error) {
+	nodeName := types.NodeName(node.Name) // FIXME(justinsb): pass node through
+
 	volumeSource, readOnly, err := getVolumeSource(spec)
 	if err != nil {
 		return "", err

--- a/pkg/volume/iscsi/attacher.go
+++ b/pkg/volume/iscsi/attacher.go
@@ -63,7 +63,7 @@ func (plugin *iscsiPlugin) GetDeviceMountRefs(deviceMountPath string) ([]string,
 	return mounter.GetMountRefs(deviceMountPath)
 }
 
-func (attacher *iscsiAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string, error) {
+func (attacher *iscsiAttacher) Attach(spec *volume.Spec, node *v1.Node) (string, error) {
 	return "", nil
 }
 

--- a/pkg/volume/photon_pd/attacher.go
+++ b/pkg/volume/photon_pd/attacher.go
@@ -70,7 +70,9 @@ func (plugin *photonPersistentDiskPlugin) NewDeviceMounter() (volume.DeviceMount
 // Callers are responsible for retryinging on failure.
 // Callers are responsible for thread safety between concurrent attach and
 // detach operations.
-func (attacher *photonPersistentDiskAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string, error) {
+func (attacher *photonPersistentDiskAttacher) Attach(spec *volume.Spec, node *v1.Node) (string, error) {
+	nodeName := types.NodeName(node.Name) // FIXME(justinsb): pass node through
+
 	hostName := string(nodeName)
 	volumeSource, _, err := getVolumeSource(spec)
 	if err != nil {

--- a/pkg/volume/rbd/attacher.go
+++ b/pkg/volume/rbd/attacher.go
@@ -91,7 +91,7 @@ var _ volume.DeviceMounter = &rbdAttacher{}
 // access external `rbd` utility. And there is no need since AttachDetach
 // controller will not try to attach RWO volumes which are already attached to
 // other nodes.
-func (attacher *rbdAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string, error) {
+func (attacher *rbdAttacher) Attach(spec *volume.Spec, node *v1.Node) (string, error) {
 	return "", nil
 }
 

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -267,7 +267,7 @@ type VolumeToAttach struct {
 
 	// NodeName is the identifier for the node that the volume should be
 	// attached to.
-	NodeName types.NodeName
+	Node *v1.Node
 
 	// scheduledPods is a map containing the set of pods that reference this
 	// volume and are scheduled to the underlying node. The key in the map is
@@ -278,7 +278,7 @@ type VolumeToAttach struct {
 
 // GenerateMsgDetailed returns detailed msgs for volumes to attach
 func (volume *VolumeToAttach) GenerateMsgDetailed(prefixMsg, suffixMsg string) (detailedMsg string) {
-	detailedStr := fmt.Sprintf("(UniqueName: %q) from node %q", volume.VolumeName, volume.NodeName)
+	detailedStr := fmt.Sprintf("(UniqueName: %q) from node %q", volume.VolumeName, volume.Node.Name)
 	volumeSpecName := "nil"
 	if volume.VolumeSpec != nil {
 		volumeSpecName = volume.VolumeSpec.Name()
@@ -288,7 +288,7 @@ func (volume *VolumeToAttach) GenerateMsgDetailed(prefixMsg, suffixMsg string) (
 
 // GenerateMsg returns simple and detailed msgs for volumes to attach
 func (volume *VolumeToAttach) GenerateMsg(prefixMsg, suffixMsg string) (simpleMsg, detailedMsg string) {
-	detailedStr := fmt.Sprintf("(UniqueName: %q) from node %q", volume.VolumeName, volume.NodeName)
+	detailedStr := fmt.Sprintf("(UniqueName: %q) from node %q", volume.VolumeName, volume.Node.Name)
 	volumeSpecName := "nil"
 	if volume.VolumeSpec != nil {
 		volumeSpecName = volume.VolumeSpec.Name()

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -336,7 +336,7 @@ func (og *operationGenerator) GenerateAttachVolumeFunc(
 	attachVolumeFunc := func() (error, error) {
 		// Execute attach
 		devicePath, attachErr := volumeAttacher.Attach(
-			volumeToAttach.VolumeSpec, volumeToAttach.NodeName)
+			volumeToAttach.VolumeSpec, volumeToAttach.Node)
 
 		if attachErr != nil {
 			if derr, ok := attachErr.(*volerr.DanglingAttachError); ok {
@@ -352,7 +352,7 @@ func (og *operationGenerator) GenerateAttachVolumeFunc(
 
 			} else {
 				addErr := actualStateOfWorld.MarkVolumeAsUncertain(
-					v1.UniqueVolumeName(""), originalSpec, volumeToAttach.NodeName)
+					v1.UniqueVolumeName(""), originalSpec, types.NodeName(volumeToAttach.Node.Name))
 				if addErr != nil {
 					klog.Errorf("AttachVolume.MarkVolumeAsUncertain fail to add the volume %q to actual state with %s", volumeToAttach.VolumeName, addErr)
 				}
@@ -370,7 +370,7 @@ func (og *operationGenerator) GenerateAttachVolumeFunc(
 
 		// Update actual state of world
 		addVolumeNodeErr := actualStateOfWorld.MarkVolumeAsAttached(
-			v1.UniqueVolumeName(""), originalSpec, volumeToAttach.NodeName, devicePath)
+			v1.UniqueVolumeName(""), originalSpec, types.NodeName(volumeToAttach.Node.Name), devicePath)
 		if addVolumeNodeErr != nil {
 			// On failure, return error. Caller will log and retry.
 			return volumeToAttach.GenerateError("AttachVolume.MarkVolumeAsAttached failed", addVolumeNodeErr)

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -209,7 +209,7 @@ type Attacher interface {
 	// Attaches the volume specified by the given spec to the node with the given Name.
 	// On success, returns the device path where the device was attached on the
 	// node.
-	Attach(spec *Spec, nodeName types.NodeName) (string, error)
+	Attach(spec *Spec, node *v1.Node) (string, error)
 
 	// VolumesAreAttached checks whether the list of volumes still attached to the specified
 	// node. It returns a map which maps from the volume spec to the checking result.

--- a/pkg/volume/vsphere_volume/attacher.go
+++ b/pkg/volume/vsphere_volume/attacher.go
@@ -70,7 +70,9 @@ func (plugin *vsphereVolumePlugin) NewDeviceMounter() (volume.DeviceMounter, err
 // Callers are responsible for retryinging on failure.
 // Callers are responsible for thread safety between concurrent attach and
 // detach operations.
-func (attacher *vsphereVMDKAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string, error) {
+func (attacher *vsphereVMDKAttacher) Attach(spec *volume.Spec, node *v1.Node) (string, error) {
+	nodeName := types.NodeName(node.Name) // FIXME(justinsb): pass node through
+
 	volumeSource, _, err := getVolumeSource(spec)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
(Looks bad, but the second one should be much easier!)


/kind design

```release-note
NONE
```