### PR TITLE
Fix scanning of failed targets

### DIFF
--- a/pkg/volume/util/device_util_linux.go
+++ b/pkg/volume/util/device_util_linux.go
@@ -21,10 +21,11 @@ package util
 import (
 	"errors"
 	"fmt"
-	"k8s.io/klog"
 	"path"
 	"strconv"
 	"strings"
+
+	"k8s.io/klog"
 )
 
 // FindMultipathDeviceForDevice given a device name like /dev/sdx, find the devicemapper parent
@@ -135,7 +136,8 @@ func (handler *deviceHandler) GetISCSIPortalHostMapForTarget(targetIqn string) (
 			targetNamePath := sessionPath + "/iscsi_session/" + sessionName + "/targetname"
 			targetName, err := io.ReadFile(targetNamePath)
 			if err != nil {
-				return nil, err
+				klog.Infof("Failed to process session %s, assuming this session is unavailable: %s", sessionName, err)
+				continue
 			}
 
 			// Ignore hosts that don't matchthe target we were looking for.
@@ -147,7 +149,8 @@ func (handler *deviceHandler) GetISCSIPortalHostMapForTarget(targetIqn string) (
 			// for the iSCSI connection.
 			dirs2, err := io.ReadDir(sessionPath)
 			if err != nil {
-				return nil, err
+				klog.Infof("Failed to process session %s, assuming this session is unavailable: %s", sessionName, err)
+				continue
 			}
 			for _, dir2 := range dirs2 {
 				// Skip over files that aren't the connection
@@ -164,25 +167,29 @@ func (handler *deviceHandler) GetISCSIPortalHostMapForTarget(targetIqn string) (
 				addrPath := connectionPath + "/address"
 				addr, err := io.ReadFile(addrPath)
 				if err != nil {
-					return nil, err
+					klog.Infof("Failed to process connection %s, assuming this connection is unavailable: %s", dirName, err)
+					continue
 				}
 
 				portPath := connectionPath + "/port"
 				port, err := io.ReadFile(portPath)
 				if err != nil {
-					return nil, err
+					klog.Infof("Failed to process connection %s, assuming this connection is unavailable: %s", dirName, err)
+					continue
 				}
 
 				persistentAddrPath := connectionPath + "/persistent_address"
 				persistentAddr, err := io.ReadFile(persistentAddrPath)
 				if err != nil {
-					return nil, err
+					klog.Infof("Failed to process connection %s, assuming this connection is unavailable: %s", dirName, err)
+					continue
 				}
 
 				persistentPortPath := connectionPath + "/persistent_port"
 				persistentPort, err := io.ReadFile(persistentPortPath)
 				if err != nil {
-					return nil, err
+					klog.Infof("Failed to process connection %s, assuming this connection is unavailable: %s", dirName, err)
+					continue
 				}
 
 				// Add entries to the map for both the current and persistent portals


### PR DESCRIPTION
If a iSCSI target is down while a volume is attached, reading from `/sys/class/iscsi_host/host415/device/session383/connection383:0/iscsi_connection/connection383:0/address` fails with an error. Kubelet should assume that such target is not available / logged in and try to relogin. Eventually, if such error persists, it should continue mounting the volume if the other paths are healthy instead of failing whole `WaitForAttach()`.

**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #74305

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed scanning of failed iSCSI targets.
```
