### PR TITLE
Removing many redundant words in comment

### DIFF
--- a/pkg/volume/csi/csiv0/csi.pb.go
+++ b/pkg/volume/csi/csiv0/csi.pb.go
@@ -1498,7 +1498,7 @@ type TopologyRequirement struct {
 	//   {"region": "R1", "zone": "Z3"}
 	// preferred =
 	//   {"region": "R1", "zone": "Z3"}
-	// then the the SP SHOULD first attempt to make the provisioned volume
+	// then the SP SHOULD first attempt to make the provisioned volume
 	// available from "zone" "Z3" in the "region" "R1" and fall back to
 	// "zone" "Z2" in the "region" "R1" if that is not possible.
 	//
@@ -1512,7 +1512,7 @@ type TopologyRequirement struct {
 	// preferred =
 	//   {"region": "R1", "zone": "Z4"},
 	//   {"region": "R1", "zone": "Z2"}
-	// then the the SP SHOULD first attempt to make the provisioned volume
+	// then the SP SHOULD first attempt to make the provisioned volume
 	// accessible from "zone" "Z4" in the "region" "R1" and fall back to
 	// "zone" "Z2" in the "region" "R1" if that is not possible. If that
 	// is not possible, the SP may choose between either the "zone"
@@ -1531,7 +1531,7 @@ type TopologyRequirement struct {
 	// preferred =
 	//   {"region": "R1", "zone": "Z5"},
 	//   {"region": "R1", "zone": "Z3"}
-	// then the the SP SHOULD first attempt to make the provisioned volume
+	// then the SP SHOULD first attempt to make the provisioned volume
 	// accessible from the combination of the two "zones" "Z5" and "Z3" in
 	// the "region" "R1". If that's not possible, it should fall back to
 	// a combination of "Z5" and other possibilities from the list of

--- a/pkg/windows/service/service.go
+++ b/pkg/windows/service/service.go
@@ -83,7 +83,7 @@ Loop:
 				s <- c.CurrentStatus
 			case svc.Stop, svc.Shutdown:
 				klog.Infof("Service stopping")
-				// We need to translate this request into a signal that can be handled by the the signal handler
+				// We need to translate this request into a signal that can be handled by the signal handler
 				// handling shutdowns normally (currently apiserver/pkg/server/signal.go).
 				// If we do not do this, our main threads won't be notified of the upcoming shutdown.
 				// Since Windows services do not use any console, we cannot simply generate a CTRL_BREAK_EVENT

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields.go
@@ -127,8 +127,8 @@ func decodeVersionedSet(encodedVersionedSet *metav1.ManagedFieldsEntry) (version
 	return versionedSet, nil
 }
 
-// encodeManagedFields converts ManagedFields from the the format used by
-// sigs.k8s.io/structured-merge-diff to the the wire format (api format)
+// encodeManagedFields converts ManagedFields from the format used by
+// sigs.k8s.io/structured-merge-diff to the wire format (api format)
 func encodeManagedFields(managedFields fieldpath.ManagedFields) (encodedManagedFields []metav1.ManagedFieldsEntry, err error) {
 	// Sort the keys so a predictable order will be used.
 	managers := []string{}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor_test.go
@@ -76,7 +76,7 @@ func TestLeaderElectionHealthChecker(t *testing.T) {
 			elector:        nil,
 		},
 		{
-			description:    "call check when the the lease is far expired",
+			description:    "call check when the lease is far expired",
 			expected:       fmt.Errorf("failed election to renew leadership on lease %s", "foo"),
 			adaptorTimeout: time.Second * 20,
 			elector: &LeaderElector{
@@ -93,7 +93,7 @@ func TestLeaderElectionHealthChecker(t *testing.T) {
 			},
 		},
 		{
-			description:    "call check when the the lease is far expired but held by another server",
+			description:    "call check when the lease is far expired but held by another server",
 			expected:       nil,
 			adaptorTimeout: time.Second * 20,
 			elector: &LeaderElector{
@@ -110,7 +110,7 @@ func TestLeaderElectionHealthChecker(t *testing.T) {
 			},
 		},
 		{
-			description:    "call check when the the lease is not expired",
+			description:    "call check when the lease is not expired",
 			expected:       nil,
 			adaptorTimeout: time.Second * 20,
 			elector: &LeaderElector{
@@ -127,7 +127,7 @@ func TestLeaderElectionHealthChecker(t *testing.T) {
 			},
 		},
 		{
-			description:    "call check when the the lease is expired but inside the timeout",
+			description:    "call check when the lease is expired but inside the timeout",
 			expected:       nil,
 			adaptorTimeout: time.Second * 20,
 			elector: &LeaderElector{


### PR DESCRIPTION
Although it is trivial fix, it might make source codes be
read more easily.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
This PR removes the redundant word in comments of source codes.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
