### PR TITLE
Ensure ownership when deleting a load balancer security group

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -4231,16 +4231,16 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
 			sgID := aws.StringValue(sg.GroupId)
 
 			if sgID == c.cfg.Global.ElbSecurityGroup {
-				//We don't want to delete a security group that was defined in the Cloud Configurationn.
+				//We don't want to delete a security group that was defined in the Cloud Configuration.
 				continue
 			}
 			if sgID == "" {
-				klog.Warning("Ignoring empty security group in ", service.Name)
+				klog.Warningf("Ignoring empty security group in %s", service.Name)
 				continue
 			}
 
 			if !c.tagging.hasClusterTag(sg.Tags) {
-				klog.Warning("Ignoring security group with no cluster tag in", service.Name)
+				klog.Warningf("Ignoring security group with no cluster tag in %s", service.Name)
 				continue
 			}
 

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -4221,7 +4221,7 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
 		describeRequest.Filters = c.tagging.addFilters(filters)
 		response, err := c.ec2.DescribeSecurityGroups(describeRequest)
 		if err != nil {
-			return fmt.Errorf("Error querying security groups for ELB: %q", err)
+			return fmt.Errorf("error querying security groups for ELB: %q", err)
 		}
 
 		// Collect the security groups to delete

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -4212,18 +4212,39 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
 		// Note that this is annoying: the load balancer disappears from the API immediately, but it is still
 		// deleting in the background.  We get a DependencyViolation until the load balancer has deleted itself
 
+		var loadBalancerSGs = aws.StringValueSlice(lb.SecurityGroups)
+
+		describeRequest := &ec2.DescribeSecurityGroupsInput{}
+		filters := []*ec2.Filter{
+			newEc2Filter("group-id", loadBalancerSGs...),
+		}
+		describeRequest.Filters = c.tagging.addFilters(filters)
+		response, err := c.ec2.DescribeSecurityGroups(describeRequest)
+		if err != nil {
+			return fmt.Errorf("Error querying security groups for ELB: %q", err)
+		}
+
 		// Collect the security groups to delete
 		securityGroupIDs := map[string]struct{}{}
-		for _, securityGroupID := range lb.SecurityGroups {
-			if *securityGroupID == c.cfg.Global.ElbSecurityGroup {
+
+		for _, sg := range response {
+			sgID := aws.StringValue(sg.GroupId)
+
+			if sgID == c.cfg.Global.ElbSecurityGroup {
 				//We don't want to delete a security group that was defined in the Cloud Configurationn.
 				continue
 			}
-			if aws.StringValue(securityGroupID) == "" {
+			if sgID == "" {
 				klog.Warning("Ignoring empty security group in ", service.Name)
 				continue
 			}
-			securityGroupIDs[*securityGroupID] = struct{}{}
+
+			if !c.tagging.hasClusterTag(sg.Tags) {
+				klog.Warning("Ignoring security group with no cluster tag in", service.Name)
+				continue
+			}
+
+			securityGroupIDs[sgID] = struct{}{}
 		}
 
 		// Loop through and try to delete them


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes the behavior of a load balancer deletion.
When deleting a load balancer, there is no check for ownership.
Given this, when attaching an extra security group to a load balancer with the annotation `service.beta.kubernetes.io/aws-load-balancer-extra-security-groups`, the security group is deleted along with it. Even if there are no cluster tags in the security group.

With this fix, when there is a security group attached to a load balancer that has no cluster tags, after the load balancer deletion the security group should be kept alive.

**Which issue(s) this PR fixes**:

Fixes #62204
Fixes #62489

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Ensure ownership when deleting a load balancer security group
```