### PR TITLE
Fix golint failures on e2e/[..]/(aws|azure)

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -674,8 +674,6 @@ test/e2e/cloud
 test/e2e/common
 test/e2e/framework
 test/e2e/framework/ingress
-test/e2e/framework/providers/aws
-test/e2e/framework/providers/azure
 test/e2e/framework/providers/gce
 test/e2e/framework/providers/kubemark
 test/e2e/instrumentation

--- a/test/e2e/framework/providers/azure/azure.go
+++ b/test/e2e/framework/providers/azure/azure.go
@@ -28,10 +28,10 @@ import (
 )
 
 func init() {
-	framework.RegisterProvider("azure", NewProvider)
+	framework.RegisterProvider("azure", newProvider)
 }
 
-func NewProvider() (framework.ProviderInterface, error) {
+func newProvider() (framework.ProviderInterface, error) {
 	if framework.TestContext.CloudConfig.ConfigFile == "" {
 		return nil, fmt.Errorf("config-file must be specified for Azure")
 	}
@@ -47,16 +47,19 @@ func NewProvider() (framework.ProviderInterface, error) {
 	}, err
 }
 
+//Provider is a structure to handle Azure clouds for e2e testing
 type Provider struct {
 	framework.NullProvider
 
 	azureCloud *azure.Cloud
 }
 
+// DeleteNode deletes a node which is specified as the argument
 func (p *Provider) DeleteNode(node *v1.Node) error {
 	return errors.New("not implemented yet")
 }
 
+// CreatePD creates a persistent volume
 func (p *Provider) CreatePD(zone string) (string, error) {
 	pdName := fmt.Sprintf("%s-%s", framework.TestContext.Prefix, string(uuid.NewUUID()))
 	_, diskURI, _, err := p.azureCloud.CreateVolume(pdName, "" /* account */, "" /* sku */, "" /* location */, 1 /* sizeGb */)
@@ -66,6 +69,7 @@ func (p *Provider) CreatePD(zone string) (string, error) {
 	return diskURI, nil
 }
 
+// DeletePD deletes a persistent volume
 func (p *Provider) DeletePD(pdName string) error {
 	if err := p.azureCloud.DeleteVolume(pdName); err != nil {
 		framework.Logf("failed to delete Azure volume %q: %v", pdName, err)
@@ -74,6 +78,7 @@ func (p *Provider) DeletePD(pdName string) error {
 	return nil
 }
 
+// EnableAndDisableInternalLB returns functions for both enabling and disabling internal Load Balancer
 func (p *Provider) EnableAndDisableInternalLB() (enable, disable func(svc *v1.Service)) {
 	enable = func(svc *v1.Service) {
 		svc.ObjectMeta.Annotations = map[string]string{azure.ServiceAnnotationLoadBalancerInternal: "true"}


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This fixes golint failures under test/e2e/framework/providers/aws and test/e2e/framework/providers/azure.

ref: https://github.com/kubernetes/kubernetes/issues/68026

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note-none

```
