### PR TITLE
Add ExpectError() to e2e test framework

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2038,6 +2038,11 @@ func RandomSuffix() string {
 	return strconv.Itoa(r.Int() % 10000)
 }
 
+// ExpectError expects an error happens, otherwise an exception raises
+func ExpectError(err error, explain ...interface{}) {
+	gomega.Expect(err).To(gomega.HaveOccurred(), explain...)
+}
+
 // ExpectNoError checks if "err" is set, and if so, fails assertion while logging the error.
 func ExpectNoError(err error, explain ...interface{}) {
 	ExpectNoErrorWithOffset(1, err, explain...)

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -484,7 +484,7 @@ func (t StorageClassTest) TestBindingWaitForFirstConsumerMultiPVC(claims []*v1.P
 	// Wait for ClaimProvisionTimeout (across all PVCs in parallel) and make sure the phase did not become Bound i.e. the Wait errors out
 	By("checking the claims are in pending state")
 	err = framework.WaitForPersistentVolumeClaimsPhase(v1.ClaimBound, t.Client, namespace, claimNames, 2*time.Second /* Poll */, framework.ClaimProvisionShortTimeout, true)
-	Expect(err).To(HaveOccurred())
+	framework.ExpectError(err)
 	verifyPVCsPending(t.Client, createdClaims)
 
 	By("creating a pod referring to the claims")


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

There is a lot of gomega.Expect(err).To(gomega.HaveOccurred()) callers which expect an error happens in e2e tests.
However these test code seems confusing because the code readers need to take care of To() or NotTo() on each test scenario.
This adds ExpectError() for more readable test code.
In addition, this applies ExpectError() to e2e provisioning.go as a sample.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note-none
NONE
```
