### PR TITLE
use cache size to signal undecorated storage

### DIFF
--- a/pkg/registry/cachesize/cachesize.go
+++ b/pkg/registry/cachesize/cachesize.go
@@ -39,6 +39,7 @@ func NewHeuristicWatchCacheSizes(expectedRAMCapacityMB int) map[schema.GroupReso
 	watchCacheSizes[schema.GroupResource{Resource: "nodes"}] = maxInt(5*clusterSize, 1000)
 	watchCacheSizes[schema.GroupResource{Resource: "pods"}] = maxInt(50*clusterSize, 1000)
 	watchCacheSizes[schema.GroupResource{Resource: "services"}] = maxInt(5*clusterSize, 1000)
+	watchCacheSizes[schema.GroupResource{Resource: "events"}] = 0
 	watchCacheSizes[schema.GroupResource{Resource: "apiservices", Group: "apiregistration.k8s.io"}] = maxInt(5*clusterSize, 1000)
 	return watchCacheSizes
 }

--- a/pkg/registry/core/event/storage/storage.go
+++ b/pkg/registry/core/event/storage/storage.go
@@ -40,10 +40,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter, ttl uint64) *REST {
 		panic(err) // TODO: Propagate error up
 	}
 
-	// We explicitly do NOT do any decoration here - switching on Cacher
-	// for events will lead to too high memory consumption.
-	opts.Decorator = generic.UndecoratedStorage // TODO use watchCacheSize=-1 to signal UndecoratedStorage
-
 	store := &genericregistry.Store{
 		NewFunc:       func() runtime.Object { return &api.Event{} },
 		NewListFunc:   func() runtime.Object { return &api.EventList{} },

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
@@ -42,7 +42,7 @@ func StorageWithCacher(capacity int) generic.StorageDecorator {
 		triggerFunc storage.TriggerPublisherFunc) (storage.Interface, factory.DestroyFunc) {
 
 		s, d := generic.NewRawStorage(storageConfig)
-		if capacity == 0 {
+		if capacity <= 0 {
 			klog.V(5).Infof("Storage caching is disabled for %T", objectType)
 			return s, d
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -229,6 +229,7 @@ func (f *SimpleRestOptionsFactory) GetRESTOptions(resource schema.GroupResource)
 		if !ok {
 			cacheSize = f.Options.DefaultWatchCacheSize
 		}
+		// depending on cache size this might return an undecorated storage
 		ret.Decorator = genericregistry.StorageWithCacher(cacheSize)
 	}
 	return ret, nil
@@ -262,6 +263,7 @@ func (f *StorageFactoryRestOptionsFactory) GetRESTOptions(resource schema.GroupR
 		if !ok {
 			cacheSize = f.Options.DefaultWatchCacheSize
 		}
+		// depending on cache size this might return an undecorated storage
 		ret.Decorator = genericregistry.StorageWithCacher(cacheSize)
 	}
 
@@ -285,7 +287,6 @@ func ParseWatchCacheSizes(cacheSizes []string) (map[schema.GroupResource]int, er
 		if size < 0 {
 			return nil, fmt.Errorf("watch cache size cannot be negative: %s", c)
 		}
-
 		watchCacheSizes[schema.ParseGroupResource(tokens[0])] = size
 	}
 	return watchCacheSizes, nil


### PR DESCRIPTION
**What type of PR is this?**

**What this PR does / why we need it**:

As part of kubernetes/enhancements#383 we need to be able to signal if storage is decorated with cacher or not through external parameters (e.g. watch cache size). This enables it for events and keeps the default behavior (disable watch cache for events by default)

**Which issue(s) this PR fixes**:

Fixes #74271

**Special notes for your reviewer**:

/assign @wojtek-t 

**Does this PR introduce a user-facing change?**:

```release-note
watch can now be enabled  for events using the flag --watch-cache-sizes on kube-apiserver
```
