### PR TITLE
Partially cherry pick of #67622: Call RepackSubsets() only once instead of for each pod

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -476,9 +476,9 @@ func (e *EndpointController) syncService(key string) error {
 				totalReadyEps = totalReadyEps + readyEps
 				totalNotReadyEps = totalNotReadyEps + notReadyEps
 			}
-			subsets = endpoints.RepackSubsets(subsets)
 		}
 	}
+	subsets = endpoints.RepackSubsets(subsets)
 
 	// See if there's actually an update here.
 	currentEndpoints, err := e.endpointsLister.Endpoints(service.Namespace).Get(service.Name)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This is partially cherry picking #67622. It fixes a regression introduced by #62497 that the endpoint controller calls `RepackSubsets()` too often and sometimes unnecessarily. The regression has negative impact on endpoint update performance, especially under large scale.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
/assign @prameshj @freehan 

```release-note
Fix a regression in endpoint controller to improve endpoint update performance.
```
