### PR TITLE
Fix hash if statement

### DIFF
--- a/cluster/gce/win1803/common.psm1
+++ b/cluster/gce/win1803/common.psm1
@@ -129,7 +129,7 @@ function MustDownload-File {
         continue
       }
       # Attempt to validate the hash
-      if ($Hash -ne $null) {
+      if ($Hash) {
         Try {
             Validate-SHA1 -Hash $Hash -Path $OutFile
         } Catch {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
I thought the unspecified argument would be $null in PowerShell, but it turns out to be the empty string in practice. This updated version checks for both.

```release-note
NONE
```

@pjh @yujuhong 
