### PR TITLE
Fix shellcheck for godep scripts in hack

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -26,8 +26,6 @@
 ./cluster/validate-cluster.sh
 ./hack/cherry_pick_pull.sh
 ./hack/ginkgo-e2e.sh
-./hack/godep-restore.sh
-./hack/godep-save.sh
 ./hack/grab-profiles.sh
 ./hack/jenkins/benchmark-dockerized.sh
 ./hack/jenkins/build.sh

--- a/hack/godep-restore.sh
+++ b/hack/godep-restore.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::log::status "Restoring kubernetes godeps"

--- a/hack/godep-save.sh
+++ b/hack/godep-save.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::log::status "Ensuring prereqs"
@@ -88,11 +88,13 @@ kube::log::status "Running godep save - this might take a while"
 # This uses $(pwd) rather than ${KUBE_ROOT} because KUBE_ROOT will be
 # realpath'ed, and godep barfs ("... is not using a known version control
 # system") on our staging dirs.
-GOPATH="${GOPATH}:$(pwd)/staging" ${KUBE_GODEP:?} save -i $(IFS=,; echo "${IGNORED_PACKAGES[*]}") "${REQUIRED_BINS[@]}"
+GOPATH="${GOPATH}:$(pwd)/staging" ${KUBE_GODEP:?} save -i "$(IFS=,; echo "${IGNORED_PACKAGES[*]}")" "${REQUIRED_BINS[@]}"
 
 # create a symlink in vendor directory pointing to the staging client. This
 # let other packages use the staging client as if it were vendored.
-for repo in $(ls staging/src/k8s.io); do
+for full_repo_path in staging/src/k8s.io/*; do
+  repo=$(basename "${full_repo_path}")
+
   if [ ! -e "vendor/k8s.io/${repo}" ]; then
     ln -s "../../staging/src/k8s.io/${repo}" "vendor/k8s.io/${repo}"
   fi


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix errors highlighted by `shellcheck` for `hack/godep-restore.sh` and
`hack/godep-save.sh`. Part of the effort tracked in https://github.com/kubernetes/kubernetes/issues/72956.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
