### PR TITLE
support namespace in output of kubectl run

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -355,6 +355,7 @@ func (o *RunOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 	names := generator.ParamNames()
 	params := generate.MakeParams(cmd, names)
 	params["name"] = args[0]
+	params["namespace"] = namespace
 	if len(args) > 1 {
 		params["args"] = args[1:]
 	}

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/run.go
@@ -42,6 +42,7 @@ func (DeploymentV1Beta1) ParamNames() []generate.GeneratorParam {
 		{Name: "labels", Required: false},
 		{Name: "default-name", Required: false},
 		{Name: "name", Required: true},
+		{Name: "namespace", Required: true},
 		{Name: "replicas", Required: true},
 		{Name: "image", Required: true},
 		{Name: "image-pull-policy", Required: false},
@@ -120,6 +121,12 @@ func (DeploymentV1Beta1) Generate(genericParams map[string]interface{}) (runtime
 			},
 		},
 	}
+
+	namespace := getNamespace(params)
+	if len(namespace) > 0 {
+		deployment.ObjectMeta.Namespace = namespace
+	}
+
 	return &deployment, nil
 }
 
@@ -130,6 +137,7 @@ func (DeploymentAppsV1Beta1) ParamNames() []generate.GeneratorParam {
 		{Name: "labels", Required: false},
 		{Name: "default-name", Required: false},
 		{Name: "name", Required: true},
+		{Name: "namespace", Required: true},
 		{Name: "replicas", Required: true},
 		{Name: "image", Required: true},
 		{Name: "image-pull-policy", Required: false},
@@ -208,6 +216,12 @@ func (DeploymentAppsV1Beta1) Generate(genericParams map[string]interface{}) (run
 			},
 		},
 	}
+
+	namespace := getNamespace(params)
+	if len(namespace) > 0 {
+		deployment.ObjectMeta.Namespace = namespace
+	}
+
 	return &deployment, nil
 }
 
@@ -218,6 +232,7 @@ func (DeploymentAppsV1) ParamNames() []generate.GeneratorParam {
 		{Name: "labels", Required: false},
 		{Name: "default-name", Required: false},
 		{Name: "name", Required: true},
+		{Name: "namespace", Required: true},
 		{Name: "replicas", Required: true},
 		{Name: "image", Required: true},
 		{Name: "image-pull-policy", Required: false},
@@ -296,6 +311,12 @@ func (DeploymentAppsV1) Generate(genericParams map[string]interface{}) (runtime.
 			},
 		},
 	}
+
+	namespace := getNamespace(params)
+	if len(namespace) > 0 {
+		deployment.ObjectMeta.Namespace = namespace
+	}
+
 	return &deployment, nil
 }
 
@@ -327,6 +348,12 @@ func getName(params map[string]string) (string, error) {
 		}
 	}
 	return name, nil
+}
+
+// getNamespace returns the namespace of newly created resource.
+func getNamespace(params map[string]string) string {
+	namespace, _ := params["namespace"]
+	return namespace
 }
 
 // getParams returns map of generic parameters.
@@ -383,6 +410,7 @@ func (JobV1) ParamNames() []generate.GeneratorParam {
 		{Name: "labels", Required: false},
 		{Name: "default-name", Required: false},
 		{Name: "name", Required: true},
+		{Name: "namespace", Required: true},
 		{Name: "image", Required: true},
 		{Name: "image-pull-policy", Required: false},
 		{Name: "port", Required: false},
@@ -467,6 +495,11 @@ func (JobV1) Generate(genericParams map[string]interface{}) (runtime.Object, err
 		},
 	}
 
+	namespace := getNamespace(params)
+	if len(namespace) > 0 {
+		job.ObjectMeta.Namespace = namespace
+	}
+
 	return &job, nil
 }
 
@@ -477,6 +510,7 @@ func (CronJobV2Alpha1) ParamNames() []generate.GeneratorParam {
 		{Name: "labels", Required: false},
 		{Name: "default-name", Required: false},
 		{Name: "name", Required: true},
+		{Name: "namespace", Required: true},
 		{Name: "image", Required: true},
 		{Name: "image-pull-policy", Required: false},
 		{Name: "port", Required: false},
@@ -568,6 +602,11 @@ func (CronJobV2Alpha1) Generate(genericParams map[string]interface{}) (runtime.O
 		},
 	}
 
+	namespace := getNamespace(params)
+	if len(namespace) > 0 {
+		cronJob.ObjectMeta.Namespace = namespace
+	}
+
 	return &cronJob, nil
 }
 
@@ -578,6 +617,7 @@ func (CronJobV1Beta1) ParamNames() []generate.GeneratorParam {
 		{Name: "labels", Required: false},
 		{Name: "default-name", Required: false},
 		{Name: "name", Required: true},
+		{Name: "namespace", Required: true},
 		{Name: "image", Required: true},
 		{Name: "image-pull-policy", Required: false},
 		{Name: "port", Required: false},
@@ -669,6 +709,11 @@ func (CronJobV1Beta1) Generate(genericParams map[string]interface{}) (runtime.Ob
 		},
 	}
 
+	namespace := getNamespace(params)
+	if len(namespace) > 0 {
+		cronJob.ObjectMeta.Namespace = namespace
+	}
+
 	return &cronJob, nil
 }
 
@@ -679,6 +724,7 @@ func (BasicReplicationController) ParamNames() []generate.GeneratorParam {
 		{Name: "labels", Required: false},
 		{Name: "default-name", Required: false},
 		{Name: "name", Required: true},
+		{Name: "namespace", Required: true},
 		{Name: "replicas", Required: true},
 		{Name: "image", Required: true},
 		{Name: "image-pull-policy", Required: false},
@@ -831,6 +877,12 @@ func (BasicReplicationController) Generate(genericParams map[string]interface{})
 			},
 		},
 	}
+
+	namespace := getNamespace(params)
+	if len(namespace) > 0 {
+		controller.ObjectMeta.Namespace = namespace
+	}
+
 	return &controller, nil
 }
 
@@ -901,6 +953,7 @@ func (BasicPod) ParamNames() []generate.GeneratorParam {
 		{Name: "labels", Required: false},
 		{Name: "default-name", Required: false},
 		{Name: "name", Required: true},
+		{Name: "namespace", Required: true},
 		{Name: "image", Required: true},
 		{Name: "image-pull-policy", Required: false},
 		{Name: "port", Required: false},
@@ -988,6 +1041,12 @@ func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, 
 			RestartPolicy: restartPolicy,
 		},
 	}
+
+	namespace := getNamespace(params)
+	if len(namespace) > 0 {
+		pod.ObjectMeta.Namespace = namespace
+	}
+
 	imagePullPolicy := v1.PullPolicy(params["image-pull-policy"])
 	if err = updatePodContainers(params, args, envs, imagePullPolicy, &pod.Spec); err != nil {
 		return nil, err

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/run_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/run_test.go
@@ -42,6 +42,7 @@ func TestGenerate(t *testing.T) {
 			name: "test1",
 			params: map[string]interface{}{
 				"name":              "foo",
+				"namespace":         "bar",
 				"image":             "someimage",
 				"image-pull-policy": "Always",
 				"replicas":          "1",
@@ -49,8 +50,9 @@ func TestGenerate(t *testing.T) {
 			},
 			expected: &v1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"run": "foo"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"run": "foo"},
 				},
 				Spec: v1.ReplicationControllerSpec{
 					Replicas: &one,
@@ -76,16 +78,18 @@ func TestGenerate(t *testing.T) {
 		{
 			name: "test2",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"port":     "",
-				"env":      []string{"a=b", "c=d"},
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"replicas":  "1",
+				"port":      "",
+				"env":       []string{"a=b", "c=d"},
 			},
 			expected: &v1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"run": "foo"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"run": "foo"},
 				},
 				Spec: v1.ReplicationControllerSpec{
 					Replicas: &one,
@@ -121,6 +125,7 @@ func TestGenerate(t *testing.T) {
 			name: "test3",
 			params: map[string]interface{}{
 				"name":              "foo",
+				"namespace":         "bar",
 				"image":             "someimage",
 				"image-pull-policy": "Never",
 				"replicas":          "1",
@@ -129,8 +134,9 @@ func TestGenerate(t *testing.T) {
 			},
 			expected: &v1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"run": "foo"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"run": "foo"},
 				},
 				Spec: v1.ReplicationControllerSpec{
 					Replicas: &one,
@@ -156,17 +162,19 @@ func TestGenerate(t *testing.T) {
 		{
 			name: "test3",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"port":     "",
-				"args":     []string{"bar", "baz", "blah"},
-				"command":  "true",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"replicas":  "1",
+				"port":      "",
+				"args":      []string{"bar", "baz", "blah"},
+				"command":   "true",
 			},
 			expected: &v1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"run": "foo"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"run": "foo"},
 				},
 				Spec: v1.ReplicationControllerSpec{
 					Replicas: &one,
@@ -191,15 +199,17 @@ func TestGenerate(t *testing.T) {
 		{
 			name: "test4",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"port":     "80",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"replicas":  "1",
+				"port":      "80",
 			},
 			expected: &v1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"run": "foo"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"run": "foo"},
 				},
 				Spec: v1.ReplicationControllerSpec{
 					Replicas: &one,
@@ -229,6 +239,7 @@ func TestGenerate(t *testing.T) {
 			name: "test5",
 			params: map[string]interface{}{
 				"name":              "foo",
+				"namespace":         "bar",
 				"image":             "someimage",
 				"image-pull-policy": "IfNotPresent",
 				"replicas":          "1",
@@ -237,8 +248,9 @@ func TestGenerate(t *testing.T) {
 			},
 			expected: &v1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"run": "foo"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"run": "foo"},
 				},
 				Spec: v1.ReplicationControllerSpec{
 					Replicas: &one,
@@ -269,10 +281,11 @@ func TestGenerate(t *testing.T) {
 		{
 			name: "test6",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"hostport": "80",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"replicas":  "1",
+				"hostport":  "80",
 			},
 			expected:  nil,
 			expectErr: true,
@@ -280,15 +293,17 @@ func TestGenerate(t *testing.T) {
 		{
 			name: "test7",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"labels":   "foo=bar,baz=blah",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"replicas":  "1",
+				"labels":    "foo=bar,baz=blah",
 			},
 			expected: &v1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"foo": "bar", "baz": "blah"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"foo": "bar", "baz": "blah"},
 				},
 				Spec: v1.ReplicationControllerSpec{
 					Replicas: &one,
@@ -312,10 +327,11 @@ func TestGenerate(t *testing.T) {
 		{
 			name: "test8",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"hostport": "80",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"replicas":  "1",
+				"hostport":  "80",
 			},
 			expected:  nil,
 			expectErr: true,
@@ -323,11 +339,12 @@ func TestGenerate(t *testing.T) {
 		{
 			name: "test9",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"labels":   "foo=bar,baz=blah",
-				"requests": "cpu100m,memory=100Mi",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"replicas":  "1",
+				"labels":    "foo=bar,baz=blah",
+				"requests":  "cpu100m,memory=100Mi",
 			},
 			expected:  nil,
 			expectErr: true,
@@ -335,11 +352,12 @@ func TestGenerate(t *testing.T) {
 		{
 			name: "test10",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"labels":   "foo=bar,baz=blah",
-				"requests": "cpu=100m&memory=100Mi",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"replicas":  "1",
+				"labels":    "foo=bar,baz=blah",
+				"requests":  "cpu=100m&memory=100Mi",
 			},
 			expected:  nil,
 			expectErr: true,
@@ -347,11 +365,12 @@ func TestGenerate(t *testing.T) {
 		{
 			name: "test11",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"labels":   "foo=bar,baz=blah",
-				"requests": "cpu=",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"replicas":  "1",
+				"labels":    "foo=bar,baz=blah",
+				"requests":  "cpu=",
 			},
 			expected:  nil,
 			expectErr: true,
@@ -359,17 +378,19 @@ func TestGenerate(t *testing.T) {
 		{
 			name: "test12",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"labels":   "foo=bar,baz=blah",
-				"requests": "cpu=100m,memory=100Mi",
-				"limits":   "cpu=400m,memory=200Mi",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"replicas":  "1",
+				"labels":    "foo=bar,baz=blah",
+				"requests":  "cpu=100m,memory=100Mi",
+				"limits":    "cpu=400m,memory=200Mi",
 			},
 			expected: &v1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"foo": "bar", "baz": "blah"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"foo": "bar", "baz": "blah"},
 				},
 				Spec: v1.ReplicationControllerSpec{
 					Replicas: &one,
@@ -393,6 +414,40 @@ func TestGenerate(t *testing.T) {
 											v1.ResourceMemory: resource.MustParse("200Mi"),
 										},
 									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "test13",
+			params: map[string]interface{}{
+				"name":              "foo",
+				"image":             "someimage",
+				"image-pull-policy": "Always",
+				"replicas":          "1",
+				"port":              "",
+			},
+			expected: &v1.ReplicationController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "foo",
+					Labels: map[string]string{"run": "foo"},
+				},
+				Spec: v1.ReplicationControllerSpec{
+					Replicas: &one,
+					Selector: map[string]string{"run": "foo"},
+					Template: &v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"run": "foo"},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:            "foo",
+									Image:           "someimage",
+									ImagePullPolicy: v1.PullAlways,
 								},
 							},
 						},
@@ -430,14 +485,16 @@ func TestGeneratePod(t *testing.T) {
 		{
 			name: "test1",
 			params: map[string]interface{}{
-				"name":  "foo",
-				"image": "someimage",
-				"port":  "",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"port":      "",
 			},
 			expected: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"run": "foo"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"run": "foo"},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -454,9 +511,10 @@ func TestGeneratePod(t *testing.T) {
 		{
 			name: "test2",
 			params: map[string]interface{}{
-				"name":  "foo",
-				"image": "someimage",
-				"env":   []string{"a", "c"},
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"env":       []string{"a", "c"},
 			},
 
 			expected:  nil,
@@ -466,14 +524,16 @@ func TestGeneratePod(t *testing.T) {
 			name: "test3",
 			params: map[string]interface{}{
 				"name":              "foo",
+				"namespace":         "bar",
 				"image":             "someimage",
 				"image-pull-policy": "Always",
 				"env":               []string{"a=b", "c=d"},
 			},
 			expected: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"run": "foo"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"run": "foo"},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -501,14 +561,16 @@ func TestGeneratePod(t *testing.T) {
 		{
 			name: "test4",
 			params: map[string]interface{}{
-				"name":  "foo",
-				"image": "someimage",
-				"port":  "80",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"port":      "80",
 			},
 			expected: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"run": "foo"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"run": "foo"},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -530,15 +592,17 @@ func TestGeneratePod(t *testing.T) {
 		{
 			name: "test5",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"port":     "80",
-				"hostport": "80",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"port":      "80",
+				"hostport":  "80",
 			},
 			expected: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"run": "foo"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"run": "foo"},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -561,9 +625,10 @@ func TestGeneratePod(t *testing.T) {
 		{
 			name: "test6",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"hostport": "80",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"hostport":  "80",
 			},
 			expected:  nil,
 			expectErr: true,
@@ -571,15 +636,17 @@ func TestGeneratePod(t *testing.T) {
 		{
 			name: "test7",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"labels":   "foo=bar,baz=blah",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"replicas":  "1",
+				"labels":    "foo=bar,baz=blah",
 			},
 			expected: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"foo": "bar", "baz": "blah"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"foo": "bar", "baz": "blah"},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -596,16 +663,18 @@ func TestGeneratePod(t *testing.T) {
 		{
 			name: "test8",
 			params: map[string]interface{}{
-				"name":     "foo",
-				"image":    "someimage",
-				"replicas": "1",
-				"labels":   "foo=bar,baz=blah",
-				"stdin":    "true",
+				"name":      "foo",
+				"namespace": "bar",
+				"image":     "someimage",
+				"replicas":  "1",
+				"labels":    "foo=bar,baz=blah",
+				"stdin":     "true",
 			},
 			expected: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"foo": "bar", "baz": "blah"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"foo": "bar", "baz": "blah"},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -625,6 +694,7 @@ func TestGeneratePod(t *testing.T) {
 			name: "test9",
 			params: map[string]interface{}{
 				"name":             "foo",
+				"namespace":        "bar",
 				"image":            "someimage",
 				"replicas":         "1",
 				"labels":           "foo=bar,baz=blah",
@@ -633,8 +703,9 @@ func TestGeneratePod(t *testing.T) {
 			},
 			expected: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"foo": "bar", "baz": "blah"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"foo": "bar", "baz": "blah"},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -681,6 +752,7 @@ func TestGenerateDeployment(t *testing.T) {
 			params: map[string]interface{}{
 				"labels":            "foo=bar,baz=blah",
 				"name":              "foo",
+				"namespace":         "bar",
 				"replicas":          "3",
 				"image":             "someimage",
 				"image-pull-policy": "Always",
@@ -695,8 +767,9 @@ func TestGenerateDeployment(t *testing.T) {
 			},
 			expected: &extensionsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"foo": "bar", "baz": "blah"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"foo": "bar", "baz": "blah"},
 				},
 				Spec: extensionsv1beta1.DeploymentSpec{
 					Replicas: &three,
@@ -778,6 +851,7 @@ func TestGenerateAppsDeployment(t *testing.T) {
 			params: map[string]interface{}{
 				"labels":            "foo=bar,baz=blah",
 				"name":              "foo",
+				"namespace":         "bar",
 				"replicas":          "3",
 				"image":             "someimage",
 				"image-pull-policy": "Always",
@@ -792,8 +866,9 @@ func TestGenerateAppsDeployment(t *testing.T) {
 			},
 			expected: &appsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"foo": "bar", "baz": "blah"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"foo": "bar", "baz": "blah"},
 				},
 				Spec: appsv1beta1.DeploymentSpec{
 					Replicas: &three,
@@ -874,6 +949,7 @@ func TestGenerateJob(t *testing.T) {
 			params: map[string]interface{}{
 				"labels":           "foo=bar,baz=blah",
 				"name":             "foo",
+				"namespace":        "bar",
 				"image":            "someimage",
 				"port":             "80",
 				"hostport":         "80",
@@ -888,8 +964,9 @@ func TestGenerateJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"foo": "bar", "baz": "blah"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"foo": "bar", "baz": "blah"},
 				},
 				Spec: batchv1.JobSpec{
 					Template: v1.PodTemplateSpec{
@@ -969,6 +1046,7 @@ func TestGenerateCronJobAlpha(t *testing.T) {
 			params: map[string]interface{}{
 				"labels":           "foo=bar,baz=blah",
 				"name":             "foo",
+				"namespace":        "bar",
 				"image":            "someimage",
 				"port":             "80",
 				"hostport":         "80",
@@ -984,8 +1062,9 @@ func TestGenerateCronJobAlpha(t *testing.T) {
 			},
 			expected: &batchv2alpha1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"foo": "bar", "baz": "blah"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"foo": "bar", "baz": "blah"},
 				},
 				Spec: batchv2alpha1.CronJobSpec{
 					Schedule:          "0/5 * * * ?",
@@ -1071,6 +1150,7 @@ func TestGenerateCronJobBeta(t *testing.T) {
 			params: map[string]interface{}{
 				"labels":           "foo=bar,baz=blah",
 				"name":             "foo",
+				"namespace":        "bar",
 				"image":            "someimage",
 				"port":             "80",
 				"hostport":         "80",
@@ -1086,8 +1166,9 @@ func TestGenerateCronJobBeta(t *testing.T) {
 			},
 			expected: &batchv1beta1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"foo": "bar", "baz": "blah"},
+					Name:      "foo",
+					Namespace: "bar",
+					Labels:    map[string]string{"foo": "bar", "baz": "blah"},
 				},
 				Spec: batchv1beta1.CronJobSpec{
 					Schedule:          "0/5 * * * ?",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Below run command does consider namespace. It creates and save configuration without namespace in output file.
`kubectl run test-nginx --image=nginx --namespace=dev --dry-run -o yaml >> test-nginx.yaml`

If without checking output file someone create resource using create or apply command, resource always get created in default namespace.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #73781

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support namespace in output of kubectl run.
```
