### PR TITLE
make test/cmd/delete.sh pass shellcheck

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -139,7 +139,6 @@
 ./test/cmd/core.sh
 ./test/cmd/crd.sh
 ./test/cmd/create.sh
-./test/cmd/delete.sh
 ./test/cmd/diff.sh
 ./test/cmd/discovery.sh
 ./test/cmd/generic-resources.sh

--- a/test/cmd/delete.sh
+++ b/test/cmd/delete.sh
@@ -36,9 +36,9 @@ run_kubectl_delete_allnamespaces_tests() {
 
   # no configmaps should be in either of those namespaces
   kubectl config set-context "${CONTEXT}" --namespace="${ns_one}"
-  kube::test::get_object_assert configmap "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::get_object_assert configmap "{{range.items}}{{${id_field:?}}}:{{end}}" ''
   kubectl config set-context "${CONTEXT}" --namespace="${ns_two}"
-  kube::test::get_object_assert configmap "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::get_object_assert configmap "{{range.items}}{{${id_field:?}}}:{{end}}" ''
 
   set +o nounset
   set +o errexit


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: makes more of our shell pass the verify-shellcheck lint.

**Which issue(s) this PR fixes**: this is work towards #72956 
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**: see https://github.com/koalaman/shellcheck/wiki/SC2154#exceptions `${var:?}` will fail if the variable is unset or empty, which satisfies shellcheck and denotes variables read from outside the script.

We can likely apply this pattern to the other test/cmd/*.sh scripts.

Getting them to pass will help us catch bugs in the future once they are removed from the linter exceptions file, unfortunately the pattern we used to implement these makes it difficult to analyze them for correctness.
 
**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
