### PR TITLE
Follow-up #72676: Fixes potential nil panic uncovered by unstructured conversion

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -401,6 +401,9 @@ func (s *Scheme) Default(src Object) {
 func (s *Scheme) Convert(in, out interface{}, context interface{}) error {
 	unstructuredIn, okIn := in.(Unstructured)
 	unstructuredOut, okOut := out.(Unstructured)
+	// Check if the underlying value of conversion in&out is nil to prevent nil panic
+	okIn = okIn && !reflect.ValueOf(in).IsNil()
+	okOut = okOut && !reflect.ValueOf(out).IsNil()
 	switch {
 	case okIn && okOut:
 		// converting unstructured input to an unstructured output is a straight copy - unstructured


### PR DESCRIPTION
/kind cleanup
/sig api-machinery
/assign @sttts @liggitt 

ref: #72676

Check if unstructured conversion in&out 🍔 is a nil value via reflection.


Panic traces:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
  panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1393d7a]

goroutine 21 [running]:
testing.tRunner.func1(0xc4201c41e0)
  /usr/local/Cellar/go/1.10.3/libexec/src/testing/testing.go:742 +0x29d
panic(0x14ccc40, 0x1868ab0)
  /usr/local/Cellar/go/1.10.3/libexec/src/runtime/panic.go:502 +0x229
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.(*Unstructured).GetAPIVersion(0x0, 0x0, 0x0)
  /Users/zuoxiu.jm/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go:200 +0x3a
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.(*Unstructured).GroupVersionKind(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
  /Users/zuoxiu.jm/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go:396 +0x5b
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime.(*Scheme).ObjectKinds(0xc4201b3260, 0x15bd120, 0x0, 0x15bd120, 0x0, 0x1679f70, 0x1679fb0, 0xf, 0x182e5f0)
  /Users/zuoxiu.jm/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:240 +0x318
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime.(*Scheme).unstructuredToTyped(0xc4201b3260, 0x1b28298, 0x0, 0x0, 0x0, 0x200, 0x150ee00)
  /Users/zuoxiu.jm/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:579 +0x7e
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime.(*Scheme).Convert(0xc4201b3260, 0x15543e0, 0x0, 0x1552ba0, 0xc4201a9200, 0x0, 0x0, 0x3a, 0x2d2)
  /Users/zuoxiu.jm/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:455 +0x30f
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/conversion/unstructured.TestUnstructuredToObjectConversion.func2(0xc4201c41e0)
  /Users/zuoxiu.jm/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/conversion/unstructured/unstructured_conversion_test.go:152 +0xae
testing.tRunner(0xc4201c41e0, 0xc42019dd00)
  /usr/local/Cellar/go/1.10.3/libexec/src/testing/testing.go:777 +0xd0
created by testing.(*T).Run
  /usr/local/Cellar/go/1.10.3/libexec/src/testing/testing.go:824 +0x2e0
```
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
