### PR TITLE
Fix GetFirstPod watch issues

### DIFF
--- a/pkg/kubectl/polymorphichelpers/BUILD
+++ b/pkg/kubectl/polymorphichelpers/BUILD
@@ -44,6 +44,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
     ],
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/milestone v1.14
/priority important-longterm

**What this PR does / why we need it**:
`GetFirstPod` was using raw WATCH call and wasn't able to restart it, nor re-list leading to failures before the timeout would have been reached. Now it is back by an informer and resilient to WATCH failures.

Split from https://github.com/kubernetes/kubernetes/pull/50102

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

needs fixed `logsForObjectWithClient`'s unit tests first https://github.com/kubernetes/kubernetes/pull/74347