### PR TITLE
Fix logsForObjectWithClient tests

### DIFF
--- a/pkg/kubectl/polymorphichelpers/BUILD
+++ b/pkg/kubectl/polymorphichelpers/BUILD
@@ -81,7 +81,9 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
+        "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/BUILD
@@ -47,6 +47,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
@@ -19,6 +19,7 @@ package fake
 import (
 	"k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
+	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 	core "k8s.io/client-go/testing"
 )
@@ -54,7 +55,15 @@ func (c *FakePods) GetLogs(name string, opts *v1.PodLogOptions) *restclient.Requ
 	action.Value = opts
 
 	_, _ = c.Fake.Invokes(action, &v1.Pod{})
-	return &restclient.Request{}
+
+	r := &restclient.Request{}
+	r.Name(name)
+	r.Namespace(c.ns)
+	r.Resource(podsResource.Resource)
+	r.SubResource("log")
+	r.SpecificallyVersionedParams(opts, scheme.ParameterCodec, podsResource.GroupVersion())
+
+	return r
 }
 
 func (c *FakePods) Evict(eviction *policy.Eviction) error {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
(for https://github.com/kubernetes/kubernetes/pull/74346 fixing a bug that need this fixed)

/kind cleanup

**What this PR does / why we need it**:
Prereq to https://github.com/kubernetes/kubernetes/pull/74346 but I wanted the test change to go through CI separately proving it works with the existing `GetPodLogs` behaviour before shipping new version of that function which could also change the outputs.

**Special notes for your reviewer**:
We should not test client actions, but the result. Client actions are flake if you use asynchronous processing and properly handle all the watch issues like doing LIST+WATCH. Doing that asynchronously and comparing actions is a flake trap. Also testing the actual resulls seems more correct to me.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @soltysh 