### PR TITLE
Fix shellcheck for hack/verify-generated-*

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -89,14 +89,6 @@
 ./hack/verify-cli-conventions.sh
 ./hack/verify-codegen.sh
 ./hack/verify-description.sh
-./hack/verify-generated-device-plugin.sh
-./hack/verify-generated-docs.sh
-./hack/verify-generated-files.sh
-./hack/verify-generated-kms.sh
-./hack/verify-generated-kubelet-plugin-registration.sh
-./hack/verify-generated-pod-resources.sh
-./hack/verify-generated-protobuf.sh
-./hack/verify-generated-runtime.sh
 ./hack/verify-golint.sh
 ./hack/verify-govet.sh
 ./hack/verify-import-boss.sh

--- a/hack/verify-generated-device-plugin.sh
+++ b/hack/verify-generated-device-plugin.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 ERROR="Device plugin api is out of date. Please run hack/update-generated-device-plugin.sh"
 DEVICE_PLUGIN_ALPHA="${KUBE_ROOT}/pkg/kubelet/apis/deviceplugin/v1alpha/"
 DEVICE_PLUGIN_V1BETA1="${KUBE_ROOT}/pkg/kubelet/apis/deviceplugin/v1beta1/"
@@ -27,19 +27,19 @@ source "${KUBE_ROOT}/hack/lib/protoc.sh"
 kube::golang::setup_env
 
 function cleanup {
-	rm -rf ${DEVICE_PLUGIN_ALPHA}/_tmp/
-	rm -rf ${DEVICE_PLUGIN_V1BETA1}/_tmp/
+	rm -rf "${DEVICE_PLUGIN_ALPHA}/_tmp/"
+	rm -rf "${DEVICE_PLUGIN_V1BETA1}/_tmp/"
 }
 
 trap cleanup EXIT
 
-mkdir -p ${DEVICE_PLUGIN_ALPHA}/_tmp
-cp ${DEVICE_PLUGIN_ALPHA}/api.pb.go ${DEVICE_PLUGIN_ALPHA}/_tmp/
-mkdir -p ${DEVICE_PLUGIN_V1BETA1}/_tmp
-cp ${DEVICE_PLUGIN_V1BETA1}/api.pb.go ${DEVICE_PLUGIN_V1BETA1}/_tmp/
+mkdir -p "${DEVICE_PLUGIN_ALPHA}/_tmp"
+cp "${DEVICE_PLUGIN_ALPHA}/api.pb.go" "${DEVICE_PLUGIN_ALPHA}/_tmp/"
+mkdir -p "${DEVICE_PLUGIN_V1BETA1}/_tmp"
+cp "${DEVICE_PLUGIN_V1BETA1}/api.pb.go" "${DEVICE_PLUGIN_V1BETA1}/_tmp/"
 
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-device-plugin.sh"
-kube::protoc::diff "${DEVICE_PLUGIN_ALPHA}/api.pb.go" "${DEVICE_PLUGIN_ALPHA}/_tmp/api.pb.go" ${ERROR}
+kube::protoc::diff "${DEVICE_PLUGIN_ALPHA}/api.pb.go" "${DEVICE_PLUGIN_ALPHA}/_tmp/api.pb.go" "${ERROR}"
 echo "Generated device plugin alpha api is up to date."
-kube::protoc::diff "${DEVICE_PLUGIN_V1BETA1}/api.pb.go" "${DEVICE_PLUGIN_V1BETA1}/_tmp/api.pb.go" ${ERROR}
+kube::protoc::diff "${DEVICE_PLUGIN_V1BETA1}/api.pb.go" "${DEVICE_PLUGIN_V1BETA1}/_tmp/api.pb.go" "${ERROR}"
 echo "Generated device plugin beta api is up to date."

--- a/hack/verify-generated-docs.sh
+++ b/hack/verify-generated-docs.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env

--- a/hack/verify-generated-files.sh
+++ b/hack/verify-generated-files.sh
@@ -18,12 +18,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+export KUBE_ROOT
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::util::ensure_clean_working_dir
 
-_tmpdir="$(kube::realpath $(mktemp -d -t verify-generated-files.XXXXXX))"
+_tmpdir="$(kube::realpath "$(mktemp -d -t verify-generated-files.XXXXXX)")"
 kube::util::trap_add "rm -rf ${_tmpdir}" EXIT
 
 _tmp_gopath="${_tmpdir}/go"

--- a/hack/verify-generated-kms.sh
+++ b/hack/verify-generated-kms.sh
@@ -18,27 +18,27 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 KUBE_KMS_GRPC_ROOT="${KUBE_ROOT}/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1/"
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
 function cleanup {
-	rm -rf ${KUBE_KMS_GRPC_ROOT}/_tmp/
+	rm -rf "${KUBE_KMS_GRPC_ROOT}/_tmp/"
 }
 
 trap cleanup EXIT
 
-mkdir -p ${KUBE_KMS_GRPC_ROOT}/_tmp
-cp ${KUBE_KMS_GRPC_ROOT}/service.pb.go ${KUBE_KMS_GRPC_ROOT}/_tmp/
+mkdir -p "${KUBE_KMS_GRPC_ROOT}/_tmp"
+cp "${KUBE_KMS_GRPC_ROOT}/service.pb.go" "${KUBE_KMS_GRPC_ROOT}/_tmp/"
 
 ret=0
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-kms.sh"
-diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr ${KUBE_KMS_GRPC_ROOT}/_tmp/service.pb.go ${KUBE_KMS_GRPC_ROOT}/service.pb.go || ret=$?
+diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr "${KUBE_KMS_GRPC_ROOT}/_tmp/service.pb.go" "${KUBE_KMS_GRPC_ROOT}/service.pb.go" || ret=$?
 if [[ $ret -eq 0 ]]; then
     echo "Generated KMS gRPC is up to date."
-    cp ${KUBE_KMS_GRPC_ROOT}/_tmp/service.pb.go ${KUBE_KMS_GRPC_ROOT}/
+    cp "${KUBE_KMS_GRPC_ROOT}/_tmp/service.pb.go" "${KUBE_KMS_GRPC_ROOT}/"
 else
     echo "Generated KMS gRPC is out of date. Please run hack/update-generated-kms.sh"
     exit 1

--- a/hack/verify-generated-kubelet-plugin-registration.sh
+++ b/hack/verify-generated-kubelet-plugin-registration.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 ERROR="Kubelet Plugin Registration api is out of date. Please run hack/update-generated-kubelet-plugin-registration.sh"
 KUBELET_PLUGIN_REGISTRATION_V1ALPHA="${KUBE_ROOT}/pkg/kubelet/apis/pluginregistration/v1alpha1/"
 KUBELET_PLUGIN_REGISTRATION_V1BETA="${KUBE_ROOT}/pkg/kubelet/apis/pluginregistration/v1beta1/"
@@ -27,24 +27,24 @@ source "${KUBE_ROOT}/hack/lib/protoc.sh"
 kube::golang::setup_env
 
 function cleanup {
-	rm -rf ${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp/
-	rm -rf ${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp/
+	rm -rf "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp/"
+	rm -rf "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp/"
 }
 
 trap cleanup EXIT
 
-mkdir -p ${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp
-mkdir -p ${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp
+mkdir -p "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp"
+mkdir -p "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp"
 
-cp ${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/api.pb.go ${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp/
-cp ${KUBELET_PLUGIN_REGISTRATION_V1BETA}/api.pb.go ${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp/
+cp "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/api.pb.go" "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp/"
+cp "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/api.pb.go" "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp/"
 
 # Check V1Alpha
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-kubelet-plugin-registration.sh"
-kube::protoc::diff "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/api.pb.go" "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp/api.pb.go" ${ERROR}
+kube::protoc::diff "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/api.pb.go" "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}/_tmp/api.pb.go" "${ERROR}"
 echo "Generated Kubelet Plugin Registration api is up to date."
 
 # Check V1Beta
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-kubelet-plugin-registration.sh"
-kube::protoc::diff "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/api.pb.go" "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp/api.pb.go" ${ERROR}
+kube::protoc::diff "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/api.pb.go" "${KUBELET_PLUGIN_REGISTRATION_V1BETA}/_tmp/api.pb.go" "${ERROR}"
 echo "Generated Kubelet Plugin Registration api is up to date."

--- a/hack/verify-generated-pod-resources.sh
+++ b/hack/verify-generated-pod-resources.sh
@@ -18,27 +18,27 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 KUBE_REMOTE_RUNTIME_ROOT="${KUBE_ROOT}/pkg/kubelet/apis/podresources/v1alpha1"
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
 function cleanup {
-	rm -rf ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/
+	rm -rf "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/"
 }
 
 trap cleanup EXIT
 
-mkdir -p ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp
-cp ${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/
+mkdir -p "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp"
+cp "${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/"
 
 ret=0
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-pod-resources.sh"
-diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go ${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go || ret=$?
+diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go" || ret=$?
 if [[ $ret -eq 0 ]]; then
     echo "Generated pod resources api is up to date."
-    cp ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go ${KUBE_REMOTE_RUNTIME_ROOT}/
+    cp "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/"
 else
     echo "Generated pod resources api is out of date. Please run hack/update-generated-pod-resources.sh"
     exit 1

--- a/hack/verify-generated-protobuf.sh
+++ b/hack/verify-generated-protobuf.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env

--- a/hack/verify-generated-runtime.sh
+++ b/hack/verify-generated-runtime.sh
@@ -18,27 +18,27 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 KUBE_REMOTE_RUNTIME_ROOT="${KUBE_ROOT}/pkg/kubelet/apis/cri/runtime/v1alpha2"
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
 function cleanup {
-	rm -rf ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/
+	rm -rf "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/"
 }
 
 trap cleanup EXIT
 
-mkdir -p ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp
-cp ${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/
+mkdir -p "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp"
+cp "${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/"
 
 ret=0
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-runtime.sh"
-diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go ${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go || ret=$?
+diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go" || ret=$?
 if [[ $ret -eq 0 ]]; then
     echo "Generated container runtime api is up to date."
-    cp ${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go ${KUBE_REMOTE_RUNTIME_ROOT}/
+    cp "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/"
 else
     echo "Generated container runtime api is out of date. Please run hack/update-generated-runtime.sh"
     exit 1


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
All of the `hack/verify-generated-*` files now pass shellcheck and are
removed from `hack/.shellcheck_failures`. Part of the effort tracked in https://github.com/kubernetes/kubernetes/issues/72956.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
