### PR TITLE
Add volume expansion support in StorageOS

### DIFF
--- a/pkg/volume/storageos/storageos_test.go
+++ b/pkg/volume/storageos/storageos_test.go
@@ -83,10 +83,16 @@ type fakePDManager struct {
 	unmountCalled      bool
 	createCalled       bool
 	deleteCalled       bool
+	expandCalled       bool
 }
 
 func (fake *fakePDManager) NewAPI(apiCfg *storageosAPIConfig) error {
 	fake.api = fakeAPI{}
+	return nil
+}
+
+func (fake *fakePDManager) ExpandVolume(volumeName, volumeNamespace string, size int) error {
+	fake.expandCalled = true
 	return nil
 }
 

--- a/pkg/volume/storageos/storageos_util.go
+++ b/pkg/volume/storageos/storageos_util.go
@@ -69,6 +69,7 @@ type apiImplementer interface {
 	VolumeMount(opts storageostypes.VolumeMountOptions) error
 	VolumeUnmount(opts storageostypes.VolumeUnmountOptions) error
 	VolumeDelete(opt storageostypes.DeleteOptions) error
+	VolumeUpdate(opt storageostypes.VolumeUpdateOptions) (*storageostypes.Volume, error)
 	Node(ref string) (*storageostypes.Node, error)
 }
 
@@ -303,6 +304,17 @@ func (u *storageosUtil) DeviceDir(b *storageosMounter) string {
 		return defaultDeviceDir
 	}
 	return ctrl.DeviceDir
+}
+
+// ExpandVolume expands a volume to a new size(in GiB).
+func (u *storageosUtil) ExpandVolume(volumeName, volumeNamespace string, size int) error {
+	opts := storageostypes.VolumeUpdateOptions{
+		Name:      volumeName,
+		Namespace: volumeNamespace,
+		Size:      size,
+	}
+	_, err := u.api.VolumeUpdate(opts)
+	return err
 }
 
 // pathMode returns the FileMode for a path.

--- a/pkg/volume/storageos/storageos_util_test.go
+++ b/pkg/volume/storageos/storageos_util_test.go
@@ -108,6 +108,9 @@ func (f fakeAPI) VolumeUnmount(opts storageostypes.VolumeUnmountOptions) error {
 func (f fakeAPI) VolumeDelete(opts storageostypes.DeleteOptions) error {
 	return nil
 }
+func (f fakeAPI) VolumeUpdate(opts storageostypes.VolumeUpdateOptions) (*storageostypes.Volume, error) {
+	return nil, nil
+}
 func (f fakeAPI) Node(ref string) (*storageostypes.Node, error) {
 	return &storageostypes.Node{}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
>
/kind feature

**What this PR does / why we need it**:
This PR adds volume expansion support in StorageOS volume plugin. It is needed to perform volume expansion of the PVCs created by StorageOS through kubernetes.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #74350

<!--
**Does this PR introduce a user-facing change?**:
  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
StorageOS volume plugin updated to support volume expansion.
```
