### PR TITLE
Narrow k8s.io/api auto-labeling

### DIFF
--- a/staging/src/k8s.io/api/OWNERS
+++ b/staging/src/k8s.io/api/OWNERS
@@ -3,10 +3,13 @@
 # Disable inheritance as this is an api owners file
 options:
   no_parent_owners: true
-approvers:
-- api-approvers
-reviewers:
-- api-reviewers
-labels:
-- sig/architecture
-- kind/api-change
+filters:
+  ".*":
+    approvers:
+      - api-approvers
+    reviewers:
+      - api-reviewers
+  # only auto-label go file changes as kind/api-change
+  "\\.go$":
+    labels:
+      - kind/api-change


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

The auto-labeling at the root of the staging k8s.io/api dir was flagging Godeps.json changes as api changes. We're using that label as a signal to comment on PRs pointing people to the API review process, so avoiding false positives would be nice.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
