### PR TITLE
Turn off command echoing in test to avoid illegal bytes in XML

### DIFF
--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -232,7 +232,6 @@ __EOF__
 run_kubectl_apply_tests() {
   set -o nounset
   set -o errexit
-  set -x
 
   create_and_use_new_namespace
   kube::log::status "Testing kubectl apply --server-side"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
#73866 introduced this test and included `set -x`, which causes bash to echo the commands being executed. Unfortunately, these commands contain literal ANSI colour codes, which are not valid UTF-8. This leads to generating invalid XML for JUnit files, which renders our tools [unable to read them](https://gubernator.k8s.io/build/kubernetes-jenkins/pr-logs/pull/74354/pull-kubernetes-integration/45737/).

This PR removes `set -x`, and should result in our JUnit files once more being valid.

```release-note
NONE
```
