### PR TITLE
client-go/rest: fix finalURLTemplate for url base == "/"

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -511,13 +511,23 @@ func (r Request) finalURLTemplate() url.URL {
 	}
 	r.params = newParams
 	url := r.URL()
-	segments := strings.Split(r.URL().Path, "/")
+
+	segments := strings.Split(url.Path, "/")
 	groupIndex := 0
 	index := 0
-	if r.URL() != nil && r.c.base != nil && strings.Contains(r.URL().Path, r.c.base.Path) {
-		groupIndex += len(strings.Split(r.c.base.Path, "/"))
+	trimmedBasePath := ""
+	if url != nil && r.c.base != nil && strings.Contains(url.Path, r.c.base.Path) {
+		p := strings.TrimPrefix(url.Path, r.c.base.Path)
+		if !strings.HasPrefix(p, "/") {
+			p = "/" + p
+		}
+		// store the base path that we have trimmed so we can append it
+		// before returning the URL
+		trimmedBasePath = r.c.base.Path
+		segments = strings.Split(p, "/")
+		groupIndex = 1
 	}
-	if groupIndex >= len(segments) {
+	if len(segments) <= 2 {
 		return *url
 	}
 
@@ -563,7 +573,7 @@ func (r Request) finalURLTemplate() url.URL {
 			segments[index+3] = "{name}"
 		}
 	}
-	url.Path = path.Join(segments...)
+	url.Path = path.Join(trimmedBasePath, path.Join(segments...))
 	return *url
 }
 


### PR DESCRIPTION
In some environments, where url base is "/", it can cause all paths to
be presented in metrics with "{prefix}" as `groupIndex` is with the wrong
index. To fix the behavior in such environments, it was added a 
conditional branch to check if the URL base is "/" and, thus, print the
metrics with the correct path, for example "api/v1/nodes/{name}" instead
of "{prefix}".

Fixes: 99248b8fe1fe ("Rewrite finalURLTemplate used only for metrics because of dynamic client change")

/kind bug

```release-note
Fix client-go prometheus metrics to correctly present the API path accessed in some environments.
```