### PR TITLE
Automated cherry pick of #74301: do not return error on invalid mac address in vsphere cloud

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -554,7 +554,8 @@ func getLocalIP() ([]v1.NodeAddress, error) {
 						vmMACAddr := strings.ToLower(i.HardwareAddr.String())
 						// Making sure that the MAC address is long enough
 						if len(vmMACAddr) < 17 {
-							return addrs, fmt.Errorf("MAC address %q is invalid", vmMACAddr)
+							klog.V(4).Infof("Skipping invalid MAC address: %q", vmMACAddr)
+							continue
 						}
 						if vmwareOUI[vmMACAddr[:8]] {
 							v1helper.AddToNodeAddresses(&addrs,


### PR DESCRIPTION
Cherry pick of #74301 on release-1.13.

#74301: do not return error on invalid mac address in vsphere cloud