### PR TITLE
fake client object tracker: support merge patch

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
@@ -181,11 +181,11 @@ func TestPatch(t *testing.T) {
 			patchBytes: []byte(`[{"op": "add", "path": "/spec/newvalue", "value": "dummy"}]`),
 			wantErrMsg: "invalid JSON document",
 		}, {
-			name:       "merge patch fails as unsupported",
-			object:     newUnstructured(testAPIVersion, testKind, testNamespace, testName),
-			patchType:  types.MergePatchType,
-			patchBytes: []byte(`{}`),
-			wantErrMsg: "PatchType is not supported",
+			name:                  "merge patch works with simple replacement",
+			object:                newUnstructuredWithSpec(map[string]interface{}{"foo": "bar"}),
+			patchType:             types.MergePatchType,
+			patchBytes:            []byte(`{ "spec": { "foo": "baz" } }`),
+			expectedPatchedObject: newUnstructuredWithSpec(map[string]interface{}{"foo": "baz"}),
 		},
 		// TODO: Add tests for strategic merge using v1.Pod for example to ensure the test cases
 		// demonstrate expected use cases.

--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,7 +138,7 @@ func ObjectReaction(tracker ObjectTracker) ReactionFunc {
 			if err != nil {
 				return true, nil, err
 			}
-			// Only supports strategic merge patch and JSONPatch as coded.
+
 			switch action.GetPatchType() {
 			case types.JSONPatchType:
 				patch, err := jsonpatch.DecodePatch(action.GetPatch())
@@ -150,6 +150,15 @@ func ObjectReaction(tracker ObjectTracker) ReactionFunc {
 					return true, nil, err
 				}
 				if err = json.Unmarshal(modified, obj); err != nil {
+					return true, nil, err
+				}
+			case types.MergePatchType:
+				modified, err := jsonpatch.MergePatch(old, action.GetPatch())
+				if err != nil {
+					return true, nil, err
+				}
+
+				if err := json.Unmarshal(modified, obj); err != nil {
 					return true, nil, err
 				}
 			case types.StrategicMergePatchType:


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Add support for merge patch types to the client-go fake used for testing.  Previously they were supported (although they were treated as strategic merge patches), but recent code changes removed any support for them.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
