### PR TITLE
Register openstack provider for e2e test

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -67,6 +67,7 @@ go_library(
         "//test/e2e/framework/providers/azure:go_default_library",
         "//test/e2e/framework/providers/gce:go_default_library",
         "//test/e2e/framework/providers/kubemark:go_default_library",
+        "//test/e2e/framework/providers/openstack:go_default_library",
         "//test/e2e/framework/testfiles:go_default_library",
         "//test/e2e/manifest:go_default_library",
         "//test/utils:go_default_library",

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -50,6 +50,7 @@ import (
 	_ "k8s.io/kubernetes/test/e2e/framework/providers/azure"
 	_ "k8s.io/kubernetes/test/e2e/framework/providers/gce"
 	_ "k8s.io/kubernetes/test/e2e/framework/providers/kubemark"
+	_ "k8s.io/kubernetes/test/e2e/framework/providers/openstack"
 )
 
 var (

--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -170,6 +170,7 @@ filegroup(
         "//test/e2e/framework/providers/azure:all-srcs",
         "//test/e2e/framework/providers/gce:all-srcs",
         "//test/e2e/framework/providers/kubemark:all-srcs",
+        "//test/e2e/framework/providers/openstack:all-srcs",
         "//test/e2e/framework/testfiles:all-srcs",
         "//test/e2e/framework/timer:all-srcs",
         "//test/e2e/framework/viperconfig:all-srcs",

--- a/test/e2e/framework/providers/openstack/BUILD
+++ b/test/e2e/framework/providers/openstack/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["openstack.go"],
+    importpath = "k8s.io/kubernetes/test/e2e/framework/providers/openstack",
+    visibility = ["//visibility:public"],
+    deps = ["//test/e2e/framework:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/framework/providers/openstack/openstack.go
+++ b/test/e2e/framework/providers/openstack/openstack.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func init() {
+	framework.RegisterProvider("openstack", newProvider)
+}
+
+func newProvider() (framework.ProviderInterface, error) {
+	return &Provider{}, nil
+}
+
+// Provider is a structure to handle OpenStack clouds for e2e testing
+type Provider struct {
+	framework.NullProvider
+}


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Since the commit f3d79e152eaac1cd1c5ac79e0a0bbd0997abdb17
openstack provider has been denied on e2e test runner.
However there are storage e2e tests which are related to
openstack. So this adds the registration of openstack
provider for e2e test.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #74326

**Special notes for your reviewer**:

This change is tested on my local OpenStack environment.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note-none

```
