### PR TITLE
Add health plugin for CoreDNS in the DNS tests

### DIFF
--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -66,6 +66,7 @@ func (t *dnsFederationsConfigMapTest) run() {
 		t.labels = []string{"abc", "ghi"}
 		valid1 := map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
+        health
         kubernetes %v in-addr.arpa ip6.arpa {
             pods insecure
             upstream
@@ -74,12 +75,13 @@ func (t *dnsFederationsConfigMapTest) run() {
         federation %v {
            abc def.com
         }
-        proxy . /etc/resolv.conf
+        forward . /etc/resolv.conf
     }`, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterDNSDomain)}
 		valid1m := map[string]string{t.labels[0]: "def.com"}
 
 		valid2 := map[string]string{
 			"Corefile": fmt.Sprintf(`:53 {
+        health
         kubernetes %v in-addr.arpa ip6.arpa {
             pods insecure
             upstream
@@ -88,7 +90,7 @@ func (t *dnsFederationsConfigMapTest) run() {
         federation %v {
            ghi xyz.com
         }
-        proxy . /etc/resolv.conf
+        forward . /etc/resolv.conf
     }`, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterDNSDomain)}
 		valid2m := map[string]string{t.labels[1]: "xyz.com"}
 
@@ -228,15 +230,16 @@ func (t *dnsNameserverTest) run(isIPv6 bool) {
 	if t.name == "coredns" {
 		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
+        health
         kubernetes %v in-addr.arpa ip6.arpa {
            pods insecure
            upstream
            fallthrough in-addr.arpa ip6.arpa
         }
-        proxy . %v
+        forward . %v
     }
      acme.local:53 {
-       proxy . %v
+       forward . %v
     }`, framework.TestContext.ClusterDNSDomain, t.dnsServerPod.Status.PodIP, t.dnsServerPod.Status.PodIP),
 		}})
 
@@ -325,12 +328,13 @@ func (t *dnsPtrFwdTest) run(isIPv6 bool) {
 	if t.name == "coredns" {
 		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
+        health
         kubernetes %v in-addr.arpa ip6.arpa {
            pods insecure
            upstream
            fallthrough in-addr.arpa ip6.arpa
         }
-        proxy . %v
+        forward . %v
     }`, framework.TestContext.ClusterDNSDomain, t.dnsServerPod.Status.PodIP),
 		}})
 
@@ -434,12 +438,13 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
 	if t.name == "coredns" {
 		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
+        health
         kubernetes %v in-addr.arpa ip6.arpa {
            pods insecure
            upstream
            fallthrough in-addr.arpa ip6.arpa
         }
-        proxy . %v
+        forward . %v
     }`, framework.TestContext.ClusterDNSDomain, t.dnsServerPod.Status.PodIP),
 		}})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Following https://github.com/kubernetes/kubernetes/pull/74137, where CoreDNS now has the `readinessProbe` checks, the health plugin is added to report that CoreDNS is healthy.

Also, update the `proxy` plugin to `forward` since `forward` is now the default.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Failing DNS tests in https://k8s-testgrid.appspot.com/sig-network-gce#gci-gce-serial

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
