### PR TITLE
Fix some shellcheck failures in hack

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -38,13 +38,10 @@
 ./cluster/update-storage-objects.sh
 ./cluster/validate-cluster.sh
 ./hack/cherry_pick_pull.sh
-./hack/generate-bindata.sh
-./hack/generate-docs.sh
 ./hack/ginkgo-e2e.sh
 ./hack/godep-restore.sh
 ./hack/godep-save.sh
 ./hack/grab-profiles.sh
-./hack/install-etcd.sh
 ./hack/jenkins/benchmark-dockerized.sh
 ./hack/jenkins/build.sh
 ./hack/jenkins/test-dockerized.sh
@@ -76,7 +73,6 @@
 ./hack/make-rules/vet.sh
 ./hack/test-integration.sh
 ./hack/test-update-storage-objects.sh
-./hack/update-bazel.sh
 ./hack/update-codegen.sh
 ./hack/update-generated-kms-dockerized.sh
 ./hack/update-generated-protobuf-dockerized.sh

--- a/hack/generate-bindata.sh
+++ b/hack/generate-bindata.sh
@@ -18,7 +18,8 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+export KUBE_ROOT
 source "${KUBE_ROOT}/hack/lib/init.sh"
 source "${KUBE_ROOT}/hack/lib/logging.sh"
 

--- a/hack/generate-docs.sh
+++ b/hack/generate-docs.sh
@@ -22,7 +22,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_HACK_ROOT=$(dirname "${BASH_SOURCE}")
+KUBE_HACK_ROOT=$(dirname "${BASH_SOURCE[0]}")
 
 echo "WARNING: hack/generate-docs.sh is an alias for hack/update-generated-docs.sh"
 echo "and will be removed in a future version."

--- a/hack/install-etcd.sh
+++ b/hack/install-etcd.sh
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::etcd::install

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -17,7 +17,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+export KUBE_ROOT
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 # Ensure that we find the binaries we build before anything else.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix some shellcheck failures in hack :
- hack/generate-bindata.sh
- hack/generate-docs.sh
- hack/install-etcd.sh
- hack/update-bazel.sh

**Which issue(s) this PR fixes**:
Ref #72956

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```