### PR TITLE
fix negative slice index error in keymutex in 1.13

### DIFF
--- a/pkg/util/keymutex/hashed.go
+++ b/pkg/util/keymutex/hashed.go
@@ -45,20 +45,20 @@ type hashedKeyMutex struct {
 // Acquires a lock associated with the specified ID.
 func (km *hashedKeyMutex) LockKey(id string) {
 	klog.V(5).Infof("hashedKeyMutex.LockKey(...) called for id %q\r\n", id)
-	km.mutexes[km.hash(id)%len(km.mutexes)].Lock()
+	km.mutexes[km.hash(id)%uint32(len(km.mutexes))].Lock()
 	klog.V(5).Infof("hashedKeyMutex.LockKey(...) for id %q completed.\r\n", id)
 }
 
 // Releases the lock associated with the specified ID.
 func (km *hashedKeyMutex) UnlockKey(id string) error {
 	klog.V(5).Infof("hashedKeyMutex.UnlockKey(...) called for id %q\r\n", id)
-	km.mutexes[km.hash(id)%len(km.mutexes)].Unlock()
+	km.mutexes[km.hash(id)%uint32(len(km.mutexes))].Unlock()
 	klog.V(5).Infof("hashedKeyMutex.UnlockKey(...) for id %q completed.\r\n", id)
 	return nil
 }
 
-func (km *hashedKeyMutex) hash(id string) int {
+func (km *hashedKeyMutex) hash(id string) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(id))
-	return int(h.Sum32())
+	return h.Sum32()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This issue https://github.com/kubernetes/kubernetes/issues/73858 report that the generated index for slice in `keymutex` maybe negative in some platform (like arm).

This PR aims to fix this issue. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #73858

**Special notes for your reviewer**:

Already fixed it in master branch by https://github.com/kubernetes/utils/pull/84.
But in before `1.14`, keymutex code is in k/k, so I submit this PR to fix it in `1.13`, and then will cherrypick to `1.12`.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix keymutex issues which may crash in some platforms.
```
