### PR TITLE
kubeadm cleanup: master -> control-plane (cont.3)

### DIFF
--- a/cmd/kubeadm/app/phases/addons/proxy/proxy.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy.go
@@ -52,8 +52,8 @@ func EnsureProxyAddon(cfg *kubeadmapi.ClusterConfiguration, localEndpoint *kubea
 		return errors.Wrap(err, "error when creating kube-proxy service account")
 	}
 
-	// Generate Master Enpoint kubeconfig file
-	masterEndpoint, err := kubeadmutil.GetMasterEndpoint(cfg.ControlPlaneEndpoint, localEndpoint)
+	// Generate ControlPlane Enpoint kubeconfig file
+	controlPlaneEndpoint, err := kubeadmutil.GetControlPlaneEndpoint(cfg.ControlPlaneEndpoint, localEndpoint)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func EnsureProxyAddon(cfg *kubeadmapi.ClusterConfiguration, localEndpoint *kubea
 			ProxyConfigMap    string
 			ProxyConfigMapKey string
 		}{
-			MasterEndpoint:    masterEndpoint,
+			MasterEndpoint:    controlPlaneEndpoint,
 			ProxyConfig:       prefixBytes.String(),
 			ProxyConfigMap:    constants.KubeProxyConfigMap,
 			ProxyConfigMapKey: constants.KubeProxyConfigMapKey,

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -135,7 +135,7 @@ func getKubeConfigSpecs(cfg *kubeadmapi.InitConfiguration) (map[string]*kubeConf
 		return nil, errors.Wrap(err, "couldn't create a kubeconfig; the CA files couldn't be loaded")
 	}
 
-	masterEndpoint, err := kubeadmutil.GetMasterEndpoint(cfg.ControlPlaneEndpoint, &cfg.LocalAPIEndpoint)
+	masterEndpoint, err := kubeadmutil.GetControlPlaneEndpoint(cfg.ControlPlaneEndpoint, &cfg.LocalAPIEndpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func WriteKubeConfigWithClientCert(out io.Writer, cfg *kubeadmapi.InitConfigurat
 		return errors.Wrap(err, "couldn't create a kubeconfig; the CA files couldn't be loaded")
 	}
 
-	masterEndpoint, err := kubeadmutil.GetMasterEndpoint(cfg.ControlPlaneEndpoint, &cfg.LocalAPIEndpoint)
+	masterEndpoint, err := kubeadmutil.GetControlPlaneEndpoint(cfg.ControlPlaneEndpoint, &cfg.LocalAPIEndpoint)
 	if err != nil {
 		return err
 	}
@@ -312,7 +312,7 @@ func WriteKubeConfigWithToken(out io.Writer, cfg *kubeadmapi.InitConfiguration, 
 		return errors.Wrap(err, "couldn't create a kubeconfig; the CA files couldn't be loaded")
 	}
 
-	masterEndpoint, err := kubeadmutil.GetMasterEndpoint(cfg.ControlPlaneEndpoint, &cfg.LocalAPIEndpoint)
+	masterEndpoint, err := kubeadmutil.GetControlPlaneEndpoint(cfg.ControlPlaneEndpoint, &cfg.LocalAPIEndpoint)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -162,7 +162,7 @@ func TestGetKubeConfigSpecs(t *testing.T) {
 			}
 
 			// Asserts InitConfiguration values injected into spec
-			masterEndpoint, err := kubeadmutil.GetMasterEndpoint(cfg.ControlPlaneEndpoint, &cfg.LocalAPIEndpoint)
+			masterEndpoint, err := kubeadmutil.GetControlPlaneEndpoint(cfg.ControlPlaneEndpoint, &cfg.LocalAPIEndpoint)
 			if err != nil {
 				t.Error(err)
 			}

--- a/cmd/kubeadm/app/util/apiclient/init_dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/init_dryrun.go
@@ -40,18 +40,18 @@ import (
 // - GET /nodes/<node-name> -- must return a valid Node
 // - ...all other, unknown GETs/LISTs will be logged
 type InitDryRunGetter struct {
-	masterName    string
-	serviceSubnet string
+	controlPlaneName string
+	serviceSubnet    string
 }
 
 // InitDryRunGetter should implement the DryRunGetter interface
 var _ DryRunGetter = &InitDryRunGetter{}
 
 // NewInitDryRunGetter creates a new instance of the InitDryRunGetter struct
-func NewInitDryRunGetter(masterName string, serviceSubnet string) *InitDryRunGetter {
+func NewInitDryRunGetter(controlPlaneName string, serviceSubnet string) *InitDryRunGetter {
 	return &InitDryRunGetter{
-		masterName:    masterName,
-		serviceSubnet: serviceSubnet,
+		controlPlaneName: controlPlaneName,
+		serviceSubnet:    serviceSubnet,
 	}
 }
 
@@ -122,16 +122,16 @@ func (idr *InitDryRunGetter) handleKubernetesService(action core.GetAction) (boo
 
 // handleGetNode returns a fake node object for the purpose of moving kubeadm init forwards.
 func (idr *InitDryRunGetter) handleGetNode(action core.GetAction) (bool, runtime.Object, error) {
-	if action.GetName() != idr.masterName || action.GetResource().Resource != "nodes" {
+	if action.GetName() != idr.controlPlaneName || action.GetResource().Resource != "nodes" {
 		// We can't handle this event
 		return false, nil, nil
 	}
 
 	return true, &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: idr.masterName,
+			Name: idr.controlPlaneName,
 			Labels: map[string]string{
-				"kubernetes.io/hostname": idr.masterName,
+				"kubernetes.io/hostname": idr.controlPlaneName,
 			},
 			Annotations: map[string]string{},
 		},

--- a/cmd/kubeadm/app/util/apiclient/init_dryrun_test.go
+++ b/cmd/kubeadm/app/util/apiclient/init_dryrun_test.go
@@ -27,9 +27,9 @@ import (
 )
 
 func TestHandleGetAction(t *testing.T) {
-	masterName := "master-foo"
+	controlPlaneName := "control-plane-foo"
 	serviceSubnet := "10.96.0.1/12"
-	idr := NewInitDryRunGetter(masterName, serviceSubnet)
+	idr := NewInitDryRunGetter(controlPlaneName, serviceSubnet)
 
 	var tests = []struct {
 		name               string
@@ -47,9 +47,9 @@ func TestHandleGetAction(t *testing.T) {
 		},
 		{
 			name:               "get nodes",
-			action:             core.NewRootGetAction(schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, masterName),
+			action:             core.NewRootGetAction(schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, controlPlaneName),
 			expectedHandled:    true,
-			expectedObjectJSON: []byte(`{"metadata":{"name":"master-foo","creationTimestamp":null,"labels":{"kubernetes.io/hostname":"master-foo"}},"spec":{},"status":{"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"","osImage":"","containerRuntimeVersion":"","kubeletVersion":"","kubeProxyVersion":"","operatingSystem":"","architecture":""}}}`),
+			expectedObjectJSON: []byte(`{"metadata":{"name":"control-plane-foo","creationTimestamp":null,"labels":{"kubernetes.io/hostname":"control-plane-foo"}},"spec":{},"status":{"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"","osImage":"","containerRuntimeVersion":"","kubeletVersion":"","kubeProxyVersion":"","operatingSystem":"","architecture":""}}}`),
 			expectedErr:        false,
 		},
 		{
@@ -80,7 +80,7 @@ func TestHandleGetAction(t *testing.T) {
 			expectedObjectJSON: []byte(``),
 			expectedErr:        false,
 		},
-		{ // an ask for an other node than the master should not be answered
+		{ // an ask for an other node than the control-plane should not be answered
 			name:               "get other-node",
 			action:             core.NewRootGetAction(schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, "other-node"),
 			expectedHandled:    false,

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -34,11 +34,11 @@ import (
 
 // SetJoinDynamicDefaults checks and sets configuration values for the JoinConfiguration object
 func SetJoinDynamicDefaults(cfg *kubeadmapi.JoinConfiguration) error {
-	addMasterTaint := false
+	addControlPlaneTaint := false
 	if cfg.ControlPlane != nil {
-		addMasterTaint = true
+		addControlPlaneTaint = true
 	}
-	if err := SetNodeRegistrationDynamicDefaults(&cfg.NodeRegistration, addMasterTaint); err != nil {
+	if err := SetNodeRegistrationDynamicDefaults(&cfg.NodeRegistration, addControlPlaneTaint); err != nil {
 		return err
 	}
 

--- a/cmd/kubeadm/app/util/endpoint.go
+++ b/cmd/kubeadm/app/util/endpoint.go
@@ -28,11 +28,11 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
-// GetMasterEndpoint returns a properly formatted endpoint for the control plane built according following rules:
+// GetControlPlaneEndpoint returns a properly formatted endpoint for the control plane built according following rules:
 // - If the controlPlaneEndpoint is defined, use it.
 // - if the controlPlaneEndpoint is defined but without a port number, use the controlPlaneEndpoint + localEndpoint.BindPort is used.
 // - Otherwise, in case the controlPlaneEndpoint is not defined, use the localEndpoint.AdvertiseAddress + the localEndpoint.BindPort.
-func GetMasterEndpoint(controlPlaneEndpoint string, localEndpoint *kubeadmapi.APIEndpoint) (string, error) {
+func GetControlPlaneEndpoint(controlPlaneEndpoint string, localEndpoint *kubeadmapi.APIEndpoint) (string, error) {
 	// parse the bind port
 	bindPortString := strconv.Itoa(int(localEndpoint.BindPort))
 	if _, err := ParsePort(bindPortString); err != nil {
@@ -45,8 +45,8 @@ func GetMasterEndpoint(controlPlaneEndpoint string, localEndpoint *kubeadmapi.AP
 		return "", errors.Errorf("invalid value `%s` given for api.advertiseAddress", localEndpoint.AdvertiseAddress)
 	}
 
-	// set the master url using localEndpoint.AdvertiseAddress + the localEndpoint.BindPort
-	masterURL := &url.URL{
+	// set the control-plane url using localEndpoint.AdvertiseAddress + the localEndpoint.BindPort
+	controlPlaneURL := &url.URL{
 		Scheme: "https",
 		Host:   net.JoinHostPort(ip.String(), bindPortString),
 	}
@@ -69,14 +69,14 @@ func GetMasterEndpoint(controlPlaneEndpoint string, localEndpoint *kubeadmapi.AP
 			port = bindPortString
 		}
 
-		// overrides the master url using the controlPlaneAddress (and eventually the bindport)
-		masterURL = &url.URL{
+		// overrides the control-plane url using the controlPlaneAddress (and eventually the bindport)
+		controlPlaneURL = &url.URL{
 			Scheme: "https",
 			Host:   net.JoinHostPort(host, port),
 		}
 	}
 
-	return masterURL.String(), nil
+	return controlPlaneURL.String(), nil
 }
 
 // ParseHostPort parses a network address of the form "host:port", "ipv4:port", "[ipv6]:port" into host and port;

--- a/cmd/kubeadm/app/util/endpoint_test.go
+++ b/cmd/kubeadm/app/util/endpoint_test.go
@@ -22,7 +22,7 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
-func TestGetMasterEndpoint(t *testing.T) {
+func TestGetControlPlaneEndpoint(t *testing.T) {
 	var tests = []struct {
 		name             string
 		cfg              *kubeadmapi.InitConfiguration
@@ -198,7 +198,7 @@ func TestGetMasterEndpoint(t *testing.T) {
 
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			actualEndpoint, actualError := GetMasterEndpoint(rt.cfg.ControlPlaneEndpoint, &rt.cfg.LocalAPIEndpoint)
+			actualEndpoint, actualError := GetControlPlaneEndpoint(rt.cfg.ControlPlaneEndpoint, &rt.cfg.LocalAPIEndpoint)
 
 			if (actualError != nil) && !rt.expectedError {
 				t.Errorf("%s unexpected failure: %v", rt.name, actualError)


### PR DESCRIPTION
This PR continuation of [#73987](https://github.com/kubernetes/kubernetes/pull/73987)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
/assign @neolit123 