### PR TITLE
kubeadm: simplify creating etcdClient

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -98,22 +98,17 @@ func runPlan(flags *planFlags, userVersion string) error {
 	// external etcd vs static pod etcd
 	isExternalEtcd := cfg.Etcd.External != nil
 	if isExternalEtcd {
-		client, err := etcdutil.New(
+		etcdClient, err = etcdutil.New(
 			cfg.Etcd.External.Endpoints,
 			cfg.Etcd.External.CAFile,
 			cfg.Etcd.External.CertFile,
 			cfg.Etcd.External.KeyFile)
-		if err != nil {
-			return err
-		}
-		etcdClient = client
 	} else {
 		// Connects to local/stacked etcd existing in the cluster
-		client, err := etcdutil.NewFromCluster(client, cfg.CertificatesDir)
-		if err != nil {
-			return err
-		}
-		etcdClient = client
+		etcdClient, err = etcdutil.NewFromCluster(client, cfg.CertificatesDir)
+	}
+	if err != nil {
+		return err
 	}
 
 	// Compute which upgrade possibilities there are


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There is no need to overshadow `client` with a transitive variable used solely for transfering its value to `etcdClient`.

**Special notes for your reviewer**:
This is a part of the PR series splitting #73135

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
