### PR TITLE
clean nonexistent metrics in e2e test

### DIFF
--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -184,6 +184,7 @@ var InterestingControllerManagerMetrics = []string{
 }
 
 var InterestingKubeletMetrics = []string{
+	"kubelet_docker_operations_errors_total",
 	"kubelet_docker_operations_duration_seconds",
 	"kubelet_pod_start_duration_seconds",
 	"kubelet_pod_worker_duration_seconds",

--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -184,14 +184,10 @@ var InterestingControllerManagerMetrics = []string{
 }
 
 var InterestingKubeletMetrics = []string{
-	"kubelet_container_manager_latency_microseconds",
-	"kubelet_docker_errors",
 	"kubelet_docker_operations_duration_seconds",
-	"kubelet_generate_pod_status_latency_microseconds",
 	"kubelet_pod_start_duration_seconds",
 	"kubelet_pod_worker_duration_seconds",
 	"kubelet_pod_worker_start_duration_seconds",
-	"kubelet_sync_pods_latency_microseconds",
 }
 
 var InterestingClusterAutoscalerMetrics = []string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
/sig test
/sig instrumentation

**What this PR does / why we need it**:

The following four metrics can not be found now:
```
kubelet_container_manager_latency_microseconds
kubelet_docker_errors
kubelet_generate_pod_status_latency_microseconds
kubelet_sync_pods_latency_microseconds
```

If they are really nonexistent, then we should remove them in e2e tests.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
