### PR TITLE
kubeadm: reduce the number of fetch configuration when reset

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -84,6 +84,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/v1beta1:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/validation:go_default_library",
         "//cmd/kubeadm/app/cmd/options:go_default_library",

--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/lithammer/dedent"
 
-	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -275,38 +275,38 @@ func TestGetEtcdDataDir(t *testing.T) {
 		podYaml       string
 		expectErr     bool
 		writeManifest bool
-		validClient   bool
+		validConfig   bool
 	}{
 		"non-existent file returns error": {
 			expectErr:     true,
 			writeManifest: false,
-			validClient:   true,
+			validConfig:   true,
 		},
 		"return etcd data dir": {
 			dataDir:       "/path/to/etcd",
 			podYaml:       etcdPod,
 			expectErr:     false,
 			writeManifest: true,
-			validClient:   true,
+			validConfig:   true,
 		},
 		"invalid etcd pod": {
 			podYaml:       etcdPodInvalid,
 			expectErr:     true,
 			writeManifest: true,
-			validClient:   true,
+			validConfig:   true,
 		},
 		"etcd pod spec without data volume": {
 			podYaml:       etcdPodWithoutDataVolume,
 			expectErr:     true,
 			writeManifest: true,
-			validClient:   true,
+			validConfig:   true,
 		},
 		"kubeconfig file doesn't exist": {
 			dataDir:       "/path/to/etcd",
 			podYaml:       etcdPod,
 			expectErr:     false,
 			writeManifest: true,
-			validClient:   false,
+			validConfig:   false,
 		},
 	}
 
@@ -325,9 +325,9 @@ func TestGetEtcdDataDir(t *testing.T) {
 
 			var dataDir string
 			var err error
-			if test.validClient {
-				client := clientsetfake.NewSimpleClientset()
-				dataDir, err = getEtcdDataDir(manifestPath, client)
+			if test.validConfig {
+				cfg := &kubeadmapi.InitConfiguration{}
+				dataDir, err = getEtcdDataDir(manifestPath, cfg)
 			} else {
 				dataDir, err = getEtcdDataDir(manifestPath, nil)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind cleanup

**What this PR does / why we need it**:

When run reset command will invoke the `FetchInitConfigurationFromCluster` function that fetch the cluster configuration three times in reset.go, it should only fetch the configuration from the Kubernetes cluster once.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/1417

**Special notes for your reviewer**:

This PR is work in progress, and it only my first commit about it. I'm not sure if there are other related things that need to be attention. If there is, hope point out. Thanks.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
