### PR TITLE
Fix shellcheck for more scripts in hack

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -100,15 +100,10 @@
 ./hack/verify-golint.sh
 ./hack/verify-govet.sh
 ./hack/verify-import-boss.sh
-./hack/verify-linkcheck.sh
 ./hack/verify-no-vendor-cycles.sh
 ./hack/verify-openapi-spec.sh
-./hack/verify-pkg-names.sh
 ./hack/verify-readonly-packages.sh
-./hack/verify-spelling.sh
-./hack/verify-staging-godeps.sh
 ./hack/verify-staging-meta-files.sh
-./hack/verify-symbols.sh
 ./hack/verify-test-featuregates.sh
 ./test/cmd/apply.sh
 ./test/cmd/apps.sh

--- a/hack/verify-linkcheck.sh
+++ b/hack/verify-linkcheck.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
@@ -38,7 +38,7 @@ mkdir -p "$OUTPUT"
 APIROOT="${KUBE_ROOT}/pkg/api/"
 APISROOT="${KUBE_ROOT}/pkg/apis/"
 DOCROOT="${KUBE_ROOT}/docs/"
-ROOTS=($APIROOT $APISROOT $DOCROOT)
+ROOTS=("$APIROOT" "$APISROOT" "$DOCROOT")
 found_invalid=false
 for root in "${ROOTS[@]}"; do
   "${linkcheck}" "--root-dir=${root}" 2> >(tee -a "${OUTPUT}/error" >&2) && ret=0 || ret=$?
@@ -54,7 +54,7 @@ done
 
 if [ ${found_invalid} = true ]; then
   echo "Summary of invalid links:"
-  cat ${OUTPUT}/error
+  cat "${OUTPUT}/error"
   exit 1
 fi
 

--- a/hack/verify-pkg-names.sh
+++ b/hack/verify-pkg-names.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::verify_go_version

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -17,7 +17,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+export KUBE_ROOT
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 # Ensure that we find the binaries we build before anything else.
@@ -30,5 +31,5 @@ go install k8s.io/kubernetes/vendor/github.com/client9/misspell/cmd/misspell
 # Spell checking
 # All the skipping files are defined in hack/.spelling_failures
 skipping_file="${KUBE_ROOT}/hack/.spelling_failures"
-failing_packages=$(echo `cat ${skipping_file}` | sed "s| | -e |g")
-git ls-files | grep -v -e ${failing_packages} | xargs misspell -i "Creater,creater,ect" -error -o stderr
+failing_packages=$(sed "s| | -e |g" "${skipping_file}")
+git ls-files | grep -v -e "${failing_packages}" | xargs misspell -i "Creater,creater,ect" -error -o stderr

--- a/hack/verify-staging-godeps.sh
+++ b/hack/verify-staging-godeps.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
@@ -32,4 +32,4 @@ if ! [[ ${KUBE_FORCE_VERIFY_CHECKS:-} =~ ^[yY]$ ]] && \
   exit 0
 fi
 
-KUBE_VERBOSE="${KUBE_VERBOSE:-3}" KUBE_RUN_COPY_OUTPUT=N ${KUBE_ROOT}/hack/update-staging-godeps.sh -d -f "$@"
+KUBE_VERBOSE="${KUBE_VERBOSE:-3}" KUBE_RUN_COPY_OUTPUT=N "${KUBE_ROOT}/hack/update-staging-godeps.sh" -d -f "$@"

--- a/hack/verify-symbols.sh
+++ b/hack/verify-symbols.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
@@ -33,7 +33,7 @@ BADSYMBOLS=(
 )
 
 # b/c hyperkube binds everything simply check that for bad symbols
-SYMBOLS="$(nm ${KUBE_OUTPUT_HOSTBIN}/hyperkube)"
+SYMBOLS="$(nm "${KUBE_OUTPUT_HOSTBIN}/hyperkube")"
 
 RESULT=0
 for BADSYMBOL in "${BADSYMBOLS[@]}"; do


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Making more of the scripts in hack pass the shellcheck linter. Part of the https://github.com/kubernetes/kubernetes/issues/72956 effort to make all shell scripts pass shellcheck.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
