### PR TITLE
Remove deprecated versionless client interface methods

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/idempotency_test.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency_test.go
@@ -62,7 +62,7 @@ func TestPatchNodeNonErrorCases(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset()
-			_, err := client.Core().Nodes().Create(&tc.node)
+			_, err := client.CoreV1().Nodes().Create(&tc.node)
 			if err != nil {
 				t.Fatalf("failed to create node to fake client: %v", err)
 			}

--- a/pkg/controller/certificates/certificate_controller_test.go
+++ b/pkg/controller/certificates/certificate_controller_test.go
@@ -47,7 +47,7 @@ func TestCertificateController(t *testing.T) {
 			Reason:  "test reason",
 			Message: "test message",
 		})
-		_, err := client.Certificates().CertificateSigningRequests().UpdateApproval(csr)
+		_, err := client.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(csr)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
@@ -66,7 +66,7 @@ func TestFinalizeNamespaceFunc(t *testing.T) {
 		},
 	}
 	d := namespacedResourcesDeleter{
-		nsClient:       mockClient.Core().Namespaces(),
+		nsClient:       mockClient.CoreV1().Namespaces(),
 		finalizerToken: v1.FinalizerKubernetes,
 	}
 	d.finalizeNamespace(testNamespace)
@@ -180,7 +180,7 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *metav1.APIVersio
 		fn := func() ([]*metav1.APIResourceList, error) {
 			return resources, nil
 		}
-		d := NewNamespacedResourcesDeleter(mockClient.Core().Namespaces(), dynamicClient, mockClient.Core(), fn, v1.FinalizerKubernetes, true)
+		d := NewNamespacedResourcesDeleter(mockClient.CoreV1().Namespaces(), dynamicClient, mockClient.CoreV1(), fn, v1.FinalizerKubernetes, true)
 		if err := d.Delete(testInput.testNamespace.Name); err != nil {
 			t.Errorf("scenario %s - Unexpected error when synching namespace %v", scenario, err)
 		}
@@ -219,7 +219,7 @@ func TestRetryOnConflictError(t *testing.T) {
 	}
 	namespace := &v1.Namespace{}
 	d := namespacedResourcesDeleter{
-		nsClient: mockClient.Core().Namespaces(),
+		nsClient: mockClient.CoreV1().Namespaces(),
 	}
 	_, err := d.retryOnConflictError(namespace, retryOnce)
 	if err != nil {
@@ -255,7 +255,7 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 	fn := func() ([]*metav1.APIResourceList, error) {
 		return testResources(), nil
 	}
-	d := NewNamespacedResourcesDeleter(mockClient.Core().Namespaces(), nil, mockClient.Core(),
+	d := NewNamespacedResourcesDeleter(mockClient.CoreV1().Namespaces(), nil, mockClient.CoreV1(),
 		fn, v1.FinalizerKubernetes, true)
 	err := d.Delete(testNamespace.Name)
 	if err != nil {

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -665,9 +665,9 @@ func (tc *testCase) setupController(t *testing.T) (*HorizontalController, inform
 	defaultDownscalestabilizationWindow := 5 * time.Minute
 
 	hpaController := NewHorizontalController(
-		eventClient.Core(),
+		eventClient.CoreV1(),
 		testScaleClient,
-		testClient.Autoscaling(),
+		testClient.AutoscalingV1(),
 		testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme),
 		metricsClient,
 		informerFactory.Autoscaling().V1().HorizontalPodAutoscalers(),

--- a/pkg/controller/podautoscaler/legacy_horizontal_test.go
+++ b/pkg/controller/podautoscaler/legacy_horizontal_test.go
@@ -494,9 +494,9 @@ func (tc *legacyTestCase) runTest(t *testing.T) {
 	defaultDownscaleStabilisationWindow := 5 * time.Minute
 
 	hpaController := NewHorizontalController(
-		eventClient.Core(),
+		eventClient.CoreV1(),
 		testScaleClient,
-		testClient.Autoscaling(),
+		testClient.AutoscalingV1(),
 		testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme),
 		metricsClient,
 		informerFactory.Autoscaling().V1().HorizontalPodAutoscalers(),

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -672,7 +672,7 @@ func TestControllerUpdateStatusWithFailure(t *testing.T) {
 	fakeClient.AddReactor("*", "*", func(action core.Action) (bool, runtime.Object, error) {
 		return true, &apps.ReplicaSet{}, fmt.Errorf("Fake error")
 	})
-	fakeRSClient := fakeClient.Apps().ReplicaSets("default")
+	fakeRSClient := fakeClient.AppsV1().ReplicaSets("default")
 	numReplicas := int32(10)
 	newStatus := apps.ReplicaSetStatus{Replicas: numReplicas}
 	updateReplicaSetStatus(fakeRSClient, rs, newStatus)

--- a/pkg/controller/testutil/test_utils.go
+++ b/pkg/controller/testutil/test_utils.go
@@ -96,7 +96,7 @@ func (m *FakeNodeHandler) GetUpdatedNodesCopy() []*v1.Node {
 
 // Core returns fake CoreInterface.
 func (m *FakeNodeHandler) Core() v1core.CoreV1Interface {
-	return &FakeLegacyHandler{m.Clientset.Core(), m}
+	return &FakeLegacyHandler{m.Clientset.CoreV1(), m}
 }
 
 // CoreV1 returns fake CoreV1Interface

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -156,7 +156,7 @@ func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2
 
 	stopCh := make(chan struct{})
 
-	pods, err := fakeKubeClient.Core().Pods(v1.NamespaceAll).List(metav1.ListOptions{})
+	pods, err := fakeKubeClient.CoreV1().Pods(v1.NamespaceAll).List(metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("Run failed with error. Expected: <no error> Actual: %v", err)
 	}
@@ -166,7 +166,7 @@ func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2
 		podInformer.GetIndexer().Add(&podToAdd)
 		podsNum++
 	}
-	nodes, err := fakeKubeClient.Core().Nodes().List(metav1.ListOptions{})
+	nodes, err := fakeKubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("Run failed with error. Expected: <no error> Actual: %v", err)
 	}

--- a/pkg/kubectl/cmd/cp/cp.go
+++ b/pkg/kubectl/cmd/cp/cp.go
@@ -499,7 +499,7 @@ func (o *CopyOptions) execute(options *exec.ExecOptions) error {
 	}
 
 	options.Config = o.ClientConfig
-	options.PodClient = o.Clientset.Core()
+	options.PodClient = o.Clientset.CoreV1()
 
 	if err := options.Validate(); err != nil {
 		return err

--- a/pkg/kubectl/cmd/scale/scale.go
+++ b/pkg/kubectl/cmd/scale/scale.go
@@ -228,7 +228,7 @@ func (o *ScaleOptions) RunScale() error {
 			// go down the legacy jobs path.  This can be removed in 3.14  For now, contain it.
 			fmt.Fprintf(o.ErrOut, "%s scale job is DEPRECATED and will be removed in a future version.\n", o.parent)
 
-			if err := ScaleJob(info, o.clientSet.Batch(), uint(o.Replicas), precondition, retry, waitForReplicas); err != nil {
+			if err := ScaleJob(info, o.clientSet.BatchV1(), uint(o.Replicas), precondition, retry, waitForReplicas); err != nil {
 				return err
 			}
 

--- a/pkg/kubectl/cmd/scale/scalejob_test.go
+++ b/pkg/kubectl/cmd/scale/scalejob_test.go
@@ -69,7 +69,7 @@ func (c *errorJobClient) Jobs(namespace string) batchclient.JobInterface {
 }
 
 func TestJobScaleRetry(t *testing.T) {
-	fake := &errorJobClient{JobsGetter: fake.NewSimpleClientset().Batch(), conflict: true}
+	fake := &errorJobClient{JobsGetter: fake.NewSimpleClientset().BatchV1(), conflict: true}
 	scaler := &JobPsuedoScaler{JobsClient: fake}
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
@@ -103,7 +103,7 @@ func job() *batch.Job {
 
 func TestJobScale(t *testing.T) {
 	fakeClientset := fake.NewSimpleClientset(job())
-	scaler := &JobPsuedoScaler{JobsClient: fakeClientset.Batch()}
+	scaler := &JobPsuedoScaler{JobsClient: fakeClientset.BatchV1()}
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
 	name := "foo"
@@ -122,7 +122,7 @@ func TestJobScale(t *testing.T) {
 }
 
 func TestJobScaleInvalid(t *testing.T) {
-	fake := &errorJobClient{JobsGetter: fake.NewSimpleClientset().Batch(), invalid: true}
+	fake := &errorJobClient{JobsGetter: fake.NewSimpleClientset().BatchV1(), invalid: true}
 	scaler := &JobPsuedoScaler{JobsClient: fake}
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
@@ -150,7 +150,7 @@ func TestJobScaleFailsPreconditions(t *testing.T) {
 			Parallelism: &ten,
 		},
 	})
-	scaler := &JobPsuedoScaler{JobsClient: fake.Batch()}
+	scaler := &JobPsuedoScaler{JobsClient: fake.BatchV1()}
 	preconditions := ScalePrecondition{2, ""}
 	count := uint(3)
 	name := "foo"

--- a/pkg/kubectl/cmd/top/top_node.go
+++ b/pkg/kubectl/cmd/top/top_node.go
@@ -219,7 +219,7 @@ func (o TopNodeOptions) RunTopNode() error {
 func getNodeMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, resourceName string, selector labels.Selector) (*metricsapi.NodeMetricsList, error) {
 	var err error
 	versionedMetrics := &metricsV1beta1api.NodeMetricsList{}
-	mc := metricsClient.Metrics()
+	mc := metricsClient.MetricsV1beta1()
 	nm := mc.NodeMetricses()
 	if resourceName != "" {
 		m, err := nm.Get(resourceName, metav1.GetOptions{})

--- a/pkg/kubectl/cmd/top/top_pod.go
+++ b/pkg/kubectl/cmd/top/top_pod.go
@@ -205,13 +205,13 @@ func getMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, namespac
 	}
 	versionedMetrics := &metricsv1beta1api.PodMetricsList{}
 	if resourceName != "" {
-		m, err := metricsClient.Metrics().PodMetricses(ns).Get(resourceName, metav1.GetOptions{})
+		m, err := metricsClient.MetricsV1beta1().PodMetricses(ns).Get(resourceName, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
 		versionedMetrics.Items = []metricsv1beta1api.PodMetrics{*m}
 	} else {
-		versionedMetrics, err = metricsClient.Metrics().PodMetricses(ns).List(metav1.ListOptions{LabelSelector: selector.String()})
+		versionedMetrics, err = metricsClient.MetricsV1beta1().PodMetricses(ns).List(metav1.ListOptions{LabelSelector: selector.String()})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kubectl/drain/cordon.go
+++ b/pkg/kubectl/drain/cordon.go
@@ -73,7 +73,7 @@ func (c *CordonHelper) UpdateIfRequired(desired bool) bool {
 // JSON, or if either patch or update calls fail; it will also return a second error
 // whenever creating a patch has failed
 func (c *CordonHelper) PatchOrReplace(clientset kubernetes.Interface) (error, error) {
-	client := clientset.Core().Nodes()
+	client := clientset.CoreV1().Nodes()
 
 	oldData, err := json.Marshal(c.node)
 	if err != nil {

--- a/pkg/kubectl/polymorphichelpers/helpers_test.go
+++ b/pkg/kubectl/polymorphichelpers/helpers_test.go
@@ -174,7 +174,7 @@ func TestGetFirstPod(t *testing.T) {
 		}
 		selector := labels.Set(labelSet).AsSelector()
 
-		pod, numPods, err := GetFirstPod(fake.Core(), metav1.NamespaceDefault, selector.String(), 1*time.Minute, test.sortBy)
+		pod, numPods, err := GetFirstPod(fake.CoreV1(), metav1.NamespaceDefault, selector.String(), 1*time.Minute, test.sortBy)
 		pod.Spec.SecurityContext = nil
 		if !test.expectedErr && err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)

--- a/pkg/kubectl/rolling_updater_test.go
+++ b/pkg/kubectl/rolling_updater_test.go
@@ -903,8 +903,8 @@ func TestUpdate_assignOriginalAnnotation(t *testing.T) {
 	newRc := newRc(1, 1)
 	fake := fake.NewSimpleClientset(oldRc)
 	updater := &RollingUpdater{
-		rcClient:  fake.Core(),
-		podClient: fake.Core(),
+		rcClient:  fake.CoreV1(),
+		podClient: fake.CoreV1(),
 		ns:        "default",
 		scaleAndWait: func(rc *corev1.ReplicationController, retry *RetryParams, wait *RetryParams) (*corev1.ReplicationController, error) {
 			return rc, nil
@@ -1101,7 +1101,7 @@ func TestRollingUpdater_multipleContainersInPod(t *testing.T) {
 				Container:     tt.container,
 				DeploymentKey: tt.deploymentKey,
 			}
-			updatedRc, err := CreateNewControllerFromCurrentController(fake.Core(), codec, config)
+			updatedRc, err := CreateNewControllerFromCurrentController(fake.CoreV1(), codec, config)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -1177,8 +1177,8 @@ func TestRollingUpdater_cleanupWithClients(t *testing.T) {
 			fake := fake.NewSimpleClientset(objs...)
 			updater := &RollingUpdater{
 				ns:        "default",
-				rcClient:  fake.Core(),
-				podClient: fake.Core(),
+				rcClient:  fake.CoreV1(),
+				podClient: fake.CoreV1(),
 			}
 			config := &RollingUpdaterConfig{
 				Out:           ioutil.Discard,
@@ -1227,7 +1227,7 @@ func TestRollingUpdater_cleanupWithClients_Rename(t *testing.T) {
 		return false, nil, nil
 	})
 
-	err := Rename(fake.Core(), rcExisting, rc.Name)
+	err := Rename(fake.CoreV1(), rcExisting, rc.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1315,7 +1315,7 @@ func TestFindSourceController(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(tt.list)
-			ctrl, err := FindSourceController(fakeClient.Core(), "default", tt.name)
+			ctrl, err := FindSourceController(fakeClient.CoreV1(), "default", tt.name)
 			if tt.expectError && err == nil {
 				t.Errorf("unexpected non-error")
 			}
@@ -1425,7 +1425,7 @@ func TestUpdateExistingReplicationController(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			fakeClient := fake.NewSimpleClientset(tt.expectedRc)
-			rc, err := UpdateExistingReplicationController(fakeClient.Core(), fakeClient.Core(), tt.rc, "default", tt.name, tt.deploymentKey, tt.deploymentValue, buffer)
+			rc, err := UpdateExistingReplicationController(fakeClient.CoreV1(), fakeClient.CoreV1(), tt.rc, "default", tt.name, tt.deploymentKey, tt.deploymentValue, buffer)
 			if !reflect.DeepEqual(rc, tt.expectedRc) {
 				t.Errorf("expected:\n%#v\ngot:\n%#v\n", tt.expectedRc, rc)
 			}
@@ -1832,8 +1832,8 @@ func TestRollingUpdater_readyPods(t *testing.T) {
 
 			updater := &RollingUpdater{
 				ns:        "default",
-				rcClient:  client.Core(),
-				podClient: client.Core(),
+				rcClient:  client.CoreV1(),
+				podClient: client.CoreV1(),
 				nowFn:     tt.nowFn,
 			}
 			oldReady, newReady, err := updater.readyPods(tt.oldRc, tt.newRc, tt.minReadySeconds)

--- a/pkg/master/client_ca_hook_test.go
+++ b/pkg/master/client_ca_hook_test.go
@@ -215,7 +215,7 @@ func TestWriteClientCAs(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.preexistingObjs...)
-			test.hook.tryToWriteClientCAs(client.Core())
+			test.hook.tryToWriteClientCAs(client.CoreV1())
 
 			actualConfigMaps, updated := getFinalConfigMaps(client)
 			if !reflect.DeepEqual(test.expectedConfigMaps, actualConfigMaps) {

--- a/pkg/master/controller_test.go
+++ b/pkg/master/controller_test.go
@@ -392,7 +392,7 @@ func TestReconcileEndpoints(t *testing.T) {
 		if test.endpoints != nil {
 			fakeClient = fake.NewSimpleClientset(test.endpoints)
 		}
-		reconciler := reconcilers.NewMasterCountEndpointReconciler(test.additionalMasters+1, fakeClient.Core())
+		reconciler := reconcilers.NewMasterCountEndpointReconciler(test.additionalMasters+1, fakeClient.CoreV1())
 		err := reconciler.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, true)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
@@ -510,7 +510,7 @@ func TestReconcileEndpoints(t *testing.T) {
 		if test.endpoints != nil {
 			fakeClient = fake.NewSimpleClientset(test.endpoints)
 		}
-		reconciler := reconcilers.NewMasterCountEndpointReconciler(test.additionalMasters+1, fakeClient.Core())
+		reconciler := reconcilers.NewMasterCountEndpointReconciler(test.additionalMasters+1, fakeClient.CoreV1())
 		err := reconciler.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, false)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
@@ -593,7 +593,7 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 	for _, test := range create_tests {
 		master := Controller{}
 		fakeClient := fake.NewSimpleClientset()
-		master.ServiceClient = fakeClient.Core()
+		master.ServiceClient = fakeClient.CoreV1()
 		master.CreateOrUpdateMasterServiceIfNeeded(test.serviceName, net.ParseIP("1.2.3.4"), test.servicePorts, test.serviceType, false)
 		creates := []core.CreateAction{}
 		for _, action := range fakeClient.Actions() {
@@ -875,7 +875,7 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 	for _, test := range reconcile_tests {
 		master := Controller{}
 		fakeClient := fake.NewSimpleClientset(test.service)
-		master.ServiceClient = fakeClient.Core()
+		master.ServiceClient = fakeClient.CoreV1()
 		err := master.CreateOrUpdateMasterServiceIfNeeded(test.serviceName, net.ParseIP("1.2.3.4"), test.servicePorts, test.serviceType, true)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
@@ -934,7 +934,7 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 	for _, test := range non_reconcile_tests {
 		master := Controller{}
 		fakeClient := fake.NewSimpleClientset(test.service)
-		master.ServiceClient = fakeClient.Core()
+		master.ServiceClient = fakeClient.CoreV1()
 		err := master.CreateOrUpdateMasterServiceIfNeeded(test.serviceName, net.ParseIP("1.2.3.4"), test.servicePorts, test.serviceType, false)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -237,7 +237,7 @@ func makeNodeList(nodes []string, nodeResources apiv1.NodeResources) *apiv1.Node
 func TestGetNodeAddresses(t *testing.T) {
 	assert := assert.New(t)
 
-	fakeNodeClient := fake.NewSimpleClientset(makeNodeList([]string{"node1", "node2"}, apiv1.NodeResources{})).Core().Nodes()
+	fakeNodeClient := fake.NewSimpleClientset(makeNodeList([]string{"node1", "node2"}, apiv1.NodeResources{})).CoreV1().Nodes()
 	addressProvider := nodeAddressProvider{fakeNodeClient}
 
 	// Fail case (no addresses associated with nodes)
@@ -261,7 +261,7 @@ func TestGetNodeAddresses(t *testing.T) {
 func TestGetNodeAddressesWithOnlySomeExternalIP(t *testing.T) {
 	assert := assert.New(t)
 
-	fakeNodeClient := fake.NewSimpleClientset(makeNodeList([]string{"node1", "node2", "node3"}, apiv1.NodeResources{})).Core().Nodes()
+	fakeNodeClient := fake.NewSimpleClientset(makeNodeList([]string{"node1", "node2", "node3"}, apiv1.NodeResources{})).CoreV1().Nodes()
 	addressProvider := nodeAddressProvider{fakeNodeClient}
 
 	// Pass case with 1 External type IP (index == 1) and nodes (indexes 0 & 2) have no External IP.

--- a/pkg/registry/core/service/ipallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair_test.go
@@ -56,7 +56,7 @@ func TestRepair(t *testing.T) {
 		item: &api.RangeAllocation{Range: "192.168.1.0/24"},
 	}
 	_, cidr, _ := net.ParseCIDR(ipregistry.item.Range)
-	r := NewRepair(0, fakeClient.Core(), fakeClient.Core(), cidr, ipregistry)
+	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.CoreV1(), cidr, ipregistry)
 
 	if err := r.RunOnce(); err != nil {
 		t.Fatal(err)
@@ -69,7 +69,7 @@ func TestRepair(t *testing.T) {
 		item:      &api.RangeAllocation{Range: "192.168.1.0/24"},
 		updateErr: fmt.Errorf("test error"),
 	}
-	r = NewRepair(0, fakeClient.Core(), fakeClient.Core(), cidr, ipregistry)
+	r = NewRepair(0, fakeClient.CoreV1(), fakeClient.CoreV1(), cidr, ipregistry)
 	if err := r.RunOnce(); !strings.Contains(err.Error(), ": test error") {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestRepairLeak(t *testing.T) {
 		},
 	}
 
-	r := NewRepair(0, fakeClient.Core(), fakeClient.Core(), cidr, ipregistry)
+	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.CoreV1(), cidr, ipregistry)
 	// Run through the "leak detection holdoff" loops.
 	for i := 0; i < (numRepairsBeforeLeakCleanup - 1); i++ {
 		if err := r.RunOnce(); err != nil {
@@ -170,7 +170,7 @@ func TestRepairWithExisting(t *testing.T) {
 			Data:  dst.Data,
 		},
 	}
-	r := NewRepair(0, fakeClient.Core(), fakeClient.Core(), cidr, ipregistry)
+	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.CoreV1(), cidr, ipregistry)
 	if err := r.RunOnce(); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/registry/core/service/portallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/portallocator/controller/repair_test.go
@@ -56,7 +56,7 @@ func TestRepair(t *testing.T) {
 		item: &api.RangeAllocation{Range: "100-200"},
 	}
 	pr, _ := net.ParsePortRange(registry.item.Range)
-	r := NewRepair(0, fakeClient.Core(), fakeClient.Core(), *pr, registry)
+	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.CoreV1(), *pr, registry)
 
 	if err := r.RunOnce(); err != nil {
 		t.Fatal(err)
@@ -69,7 +69,7 @@ func TestRepair(t *testing.T) {
 		item:      &api.RangeAllocation{Range: "100-200"},
 		updateErr: fmt.Errorf("test error"),
 	}
-	r = NewRepair(0, fakeClient.Core(), fakeClient.Core(), *pr, registry)
+	r = NewRepair(0, fakeClient.CoreV1(), fakeClient.CoreV1(), *pr, registry)
 	if err := r.RunOnce(); !strings.Contains(err.Error(), ": test error") {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestRepairLeak(t *testing.T) {
 		},
 	}
 
-	r := NewRepair(0, fakeClient.Core(), fakeClient.Core(), *pr, registry)
+	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.CoreV1(), *pr, registry)
 	// Run through the "leak detection holdoff" loops.
 	for i := 0; i < (numRepairsBeforeLeakCleanup - 1); i++ {
 		if err := r.RunOnce(); err != nil {
@@ -182,7 +182,7 @@ func TestRepairWithExisting(t *testing.T) {
 			Data:  dst.Data,
 		},
 	}
-	r := NewRepair(0, fakeClient.Core(), fakeClient.Core(), *pr, registry)
+	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.CoreV1(), *pr, registry)
 	if err := r.RunOnce(); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
@@ -605,7 +605,7 @@ func TestInstallCSIDriverExistingAnnotation(t *testing.T) {
 		}
 
 		// Assert
-		nodeInfo, err := csiClient.Csi().CSINodeInfos().Get(nodeName, metav1.GetOptions{})
+		nodeInfo, err := csiClient.CsiV1alpha1().CSINodeInfos().Get(nodeName, metav1.GetOptions{})
 		if err != nil {
 			t.Errorf("error getting CSINodeInfo: %v", err)
 			continue
@@ -1018,7 +1018,7 @@ func test(t *testing.T, addNodeInfo bool, csiNodeInfoEnabled bool, testcases []t
 			}
 
 			/* CSINodeInfo validation */
-			nodeInfo, err := csiClient.Csi().CSINodeInfos().Get(nodeName, metav1.GetOptions{})
+			nodeInfo, err := csiClient.CsiV1alpha1().CSINodeInfos().Get(nodeName, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("error getting CSINodeInfo: %v", err)
 				continue

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -153,7 +153,7 @@ func (plugin *glusterfsPlugin) NewMounter(spec *volume.Spec, pod *v1.Pod, _ volu
 	if kubeClient == nil {
 		return nil, fmt.Errorf("failed to get kube client to initialize mounter")
 	}
-	ep, err := kubeClient.Core().Endpoints(epNamespace).Get(epName, metav1.GetOptions{})
+	ep, err := kubeClient.CoreV1().Endpoints(epNamespace).Get(epName, metav1.GetOptions{})
 
 	if err != nil {
 		klog.Errorf("failed to get endpoint %s: %v", epName, err)

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -472,7 +472,7 @@ func (plugin *rbdPlugin) NewBlockVolumeMapper(spec *volume.Spec, pod *v1.Pod, _ 
 			if kubeClient == nil {
 				return nil, fmt.Errorf("Cannot get kube client")
 			}
-			secrets, err := kubeClient.Core().Secrets(secretNs).Get(secretName, metav1.GetOptions{})
+			secrets, err := kubeClient.CoreV1().Secrets(secretNs).Get(secretName, metav1.GetOptions{})
 			if err != nil {
 				err = fmt.Errorf("Couldn't get secret %v/%v err: %v", secretNs, secretName, err)
 				return nil, err

--- a/pkg/volume/storageos/storageos_test.go
+++ b/pkg/volume/storageos/storageos_test.go
@@ -171,7 +171,7 @@ func TestPlugin(t *testing.T) {
 
 	client := fake.NewSimpleClientset()
 
-	client.Core().Secrets("default").Create(&v1.Secret{
+	client.CoreV1().Secrets("default").Create(&v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: "default",

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -89,7 +89,7 @@ func (p *Provision) Admit(a admission.Attributes, o admission.ObjectInterfaces) 
 		Status: corev1.NamespaceStatus{},
 	}
 
-	_, err = p.client.Core().Namespaces().Create(namespace)
+	_, err = p.client.CoreV1().Namespaces().Create(namespace)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return admission.NewForbidden(a, err)
 	}

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -75,7 +75,7 @@ func (e *Exists) Validate(a admission.Attributes, o admission.ObjectInterfaces) 
 	}
 
 	// in case of latency in our caches, make a call direct to storage to verify that it truly exists or not
-	_, err = e.client.Core().Namespaces().Get(a.GetNamespace(), metav1.GetOptions{})
+	_, err = e.client.CoreV1().Namespaces().Get(a.GetNamespace(), metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return err

--- a/plugin/pkg/admission/podnodeselector/admission.go
+++ b/plugin/pkg/admission/podnodeselector/admission.go
@@ -216,7 +216,7 @@ func (p *podNodeSelector) ValidateInitialization() error {
 }
 
 func (p *podNodeSelector) defaultGetNamespace(name string) (*corev1.Namespace, error) {
-	namespace, err := p.client.Core().Namespaces().Get(name, metav1.GetOptions{})
+	namespace, err := p.client.CoreV1().Namespaces().Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("namespace %s does not exist", name)
 	}

--- a/plugin/pkg/admission/resourcequota/resource_access.go
+++ b/plugin/pkg/admission/resourcequota/resource_access.go
@@ -125,7 +125,7 @@ func (e *quotaAccessor) GetQuotas(namespace string) ([]corev1.ResourceQuota, err
 			// If there is already in-flight List() for a given namespace, we should wait until
 			// it is finished and cache is updated instead of doing the same, also to avoid
 			// throttling - see #22422 for details.
-			liveList, err := e.client.Core().ResourceQuotas(namespace).List(metav1.ListOptions{})
+			liveList, err := e.client.CoreV1().ResourceQuotas(namespace).List(metav1.ListOptions{})
 			if err != nil {
 				return nil, err
 			}

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -304,7 +304,7 @@ func (s *serviceAccount) getServiceAccount(namespace string, name string) (*core
 		if i != 0 {
 			time.Sleep(retryInterval)
 		}
-		serviceAccount, err := s.client.Core().ServiceAccounts(namespace).Get(name, metav1.GetOptions{})
+		serviceAccount, err := s.client.CoreV1().ServiceAccounts(namespace).Get(name, metav1.GetOptions{})
 		if err == nil {
 			return serviceAccount, nil
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
@@ -28,8 +28,6 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	CrV1() crv1.CrV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Cr() crv1.CrV1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -41,12 +39,6 @@ type Clientset struct {
 
 // CrV1 retrieves the CrV1Client
 func (c *Clientset) CrV1() crv1.CrV1Interface {
-	return c.crV1
-}
-
-// Deprecated: Cr retrieves the default version of CrClient.
-// Please explicitly pick a version.
-func (c *Clientset) Cr() crv1.CrV1Interface {
 	return c.crV1
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -75,8 +75,3 @@ var _ clientset.Interface = &Clientset{}
 func (c *Clientset) CrV1() crv1.CrV1Interface {
 	return &fakecrv1.FakeCrV1{Fake: &c.Fake}
 }
-
-// Cr retrieves the CrV1Client
-func (c *Clientset) Cr() crv1.CrV1Interface {
-	return &fakecrv1.FakeCrV1{Fake: &c.Fake}
-}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
@@ -28,8 +28,6 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1beta1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Apiextensions() apiextensionsv1beta1.ApiextensionsV1beta1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -41,12 +39,6 @@ type Clientset struct {
 
 // ApiextensionsV1beta1 retrieves the ApiextensionsV1beta1Client
 func (c *Clientset) ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1beta1Interface {
-	return c.apiextensionsV1beta1
-}
-
-// Deprecated: Apiextensions retrieves the default version of ApiextensionsClient.
-// Please explicitly pick a version.
-func (c *Clientset) Apiextensions() apiextensionsv1beta1.ApiextensionsV1beta1Interface {
 	return c.apiextensionsV1beta1
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
@@ -75,8 +75,3 @@ var _ clientset.Interface = &Clientset{}
 func (c *Clientset) ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1beta1Interface {
 	return &fakeapiextensionsv1beta1.FakeApiextensionsV1beta1{Fake: &c.Fake}
 }
-
-// Apiextensions retrieves the ApiextensionsV1beta1Client
-func (c *Clientset) Apiextensions() apiextensionsv1beta1.ApiextensionsV1beta1Interface {
-	return &fakeapiextensionsv1beta1.FakeApiextensionsV1beta1{Fake: &c.Fake}
-}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
@@ -355,7 +355,7 @@ func isWatchCachePrimed(crd *apiextensionsv1beta1.CustomResourceDefinition, dyna
 
 // DeleteCustomResourceDefinition deletes a CRD and waits until it disappears from discovery.
 func DeleteCustomResourceDefinition(crd *apiextensionsv1beta1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) error {
-	if err := apiExtensionsClient.Apiextensions().CustomResourceDefinitions().Delete(crd.Name, nil); err != nil {
+	if err := apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(crd.Name, nil); err != nil {
 		return err
 	}
 	for _, version := range servedVersions(crd) {

--- a/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
+++ b/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
@@ -61,7 +61,7 @@ func TestFakeClient(t *testing.T) {
 
 	// Inject an event into the fake client.
 	p := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "my-pod"}}
-	_, err := client.Core().Pods("test-ns").Create(p)
+	_, err := client.CoreV1().Pods("test-ns").Create(p)
 	if err != nil {
 		t.Errorf("error injecting pod add: %v", err)
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -61,74 +61,38 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	AdmissionregistrationV1beta1() admissionregistrationv1beta1.AdmissionregistrationV1beta1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Admissionregistration() admissionregistrationv1beta1.AdmissionregistrationV1beta1Interface
 	AppsV1() appsv1.AppsV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Apps() appsv1.AppsV1Interface
 	AppsV1beta1() appsv1beta1.AppsV1beta1Interface
 	AppsV1beta2() appsv1beta2.AppsV1beta2Interface
 	AuditregistrationV1alpha1() auditregistrationv1alpha1.AuditregistrationV1alpha1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Auditregistration() auditregistrationv1alpha1.AuditregistrationV1alpha1Interface
 	AuthenticationV1() authenticationv1.AuthenticationV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Authentication() authenticationv1.AuthenticationV1Interface
 	AuthenticationV1beta1() authenticationv1beta1.AuthenticationV1beta1Interface
 	AuthorizationV1() authorizationv1.AuthorizationV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Authorization() authorizationv1.AuthorizationV1Interface
 	AuthorizationV1beta1() authorizationv1beta1.AuthorizationV1beta1Interface
 	AutoscalingV1() autoscalingv1.AutoscalingV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Autoscaling() autoscalingv1.AutoscalingV1Interface
 	AutoscalingV2beta1() autoscalingv2beta1.AutoscalingV2beta1Interface
 	AutoscalingV2beta2() autoscalingv2beta2.AutoscalingV2beta2Interface
 	BatchV1() batchv1.BatchV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Batch() batchv1.BatchV1Interface
 	BatchV1beta1() batchv1beta1.BatchV1beta1Interface
 	BatchV2alpha1() batchv2alpha1.BatchV2alpha1Interface
 	CertificatesV1beta1() certificatesv1beta1.CertificatesV1beta1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Certificates() certificatesv1beta1.CertificatesV1beta1Interface
 	CoordinationV1beta1() coordinationv1beta1.CoordinationV1beta1Interface
 	CoordinationV1() coordinationv1.CoordinationV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Coordination() coordinationv1.CoordinationV1Interface
 	CoreV1() corev1.CoreV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Core() corev1.CoreV1Interface
 	EventsV1beta1() eventsv1beta1.EventsV1beta1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Events() eventsv1beta1.EventsV1beta1Interface
 	ExtensionsV1beta1() extensionsv1beta1.ExtensionsV1beta1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Extensions() extensionsv1beta1.ExtensionsV1beta1Interface
 	NetworkingV1() networkingv1.NetworkingV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Networking() networkingv1.NetworkingV1Interface
 	NetworkingV1beta1() networkingv1beta1.NetworkingV1beta1Interface
 	PolicyV1beta1() policyv1beta1.PolicyV1beta1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Policy() policyv1beta1.PolicyV1beta1Interface
 	RbacV1() rbacv1.RbacV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Rbac() rbacv1.RbacV1Interface
 	RbacV1beta1() rbacv1beta1.RbacV1beta1Interface
 	RbacV1alpha1() rbacv1alpha1.RbacV1alpha1Interface
 	SchedulingV1alpha1() schedulingv1alpha1.SchedulingV1alpha1Interface
 	SchedulingV1beta1() schedulingv1beta1.SchedulingV1beta1Interface
 	SchedulingV1() schedulingv1.SchedulingV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Scheduling() schedulingv1.SchedulingV1Interface
 	SettingsV1alpha1() settingsv1alpha1.SettingsV1alpha1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Settings() settingsv1alpha1.SettingsV1alpha1Interface
 	StorageV1beta1() storagev1beta1.StorageV1beta1Interface
 	StorageV1() storagev1.StorageV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Storage() storagev1.StorageV1Interface
 	StorageV1alpha1() storagev1alpha1.StorageV1alpha1Interface
 }
 
@@ -177,20 +141,8 @@ func (c *Clientset) AdmissionregistrationV1beta1() admissionregistrationv1beta1.
 	return c.admissionregistrationV1beta1
 }
 
-// Deprecated: Admissionregistration retrieves the default version of AdmissionregistrationClient.
-// Please explicitly pick a version.
-func (c *Clientset) Admissionregistration() admissionregistrationv1beta1.AdmissionregistrationV1beta1Interface {
-	return c.admissionregistrationV1beta1
-}
-
 // AppsV1 retrieves the AppsV1Client
 func (c *Clientset) AppsV1() appsv1.AppsV1Interface {
-	return c.appsV1
-}
-
-// Deprecated: Apps retrieves the default version of AppsClient.
-// Please explicitly pick a version.
-func (c *Clientset) Apps() appsv1.AppsV1Interface {
 	return c.appsV1
 }
 
@@ -209,20 +161,8 @@ func (c *Clientset) AuditregistrationV1alpha1() auditregistrationv1alpha1.Auditr
 	return c.auditregistrationV1alpha1
 }
 
-// Deprecated: Auditregistration retrieves the default version of AuditregistrationClient.
-// Please explicitly pick a version.
-func (c *Clientset) Auditregistration() auditregistrationv1alpha1.AuditregistrationV1alpha1Interface {
-	return c.auditregistrationV1alpha1
-}
-
 // AuthenticationV1 retrieves the AuthenticationV1Client
 func (c *Clientset) AuthenticationV1() authenticationv1.AuthenticationV1Interface {
-	return c.authenticationV1
-}
-
-// Deprecated: Authentication retrieves the default version of AuthenticationClient.
-// Please explicitly pick a version.
-func (c *Clientset) Authentication() authenticationv1.AuthenticationV1Interface {
 	return c.authenticationV1
 }
 
@@ -236,12 +176,6 @@ func (c *Clientset) AuthorizationV1() authorizationv1.AuthorizationV1Interface {
 	return c.authorizationV1
 }
 
-// Deprecated: Authorization retrieves the default version of AuthorizationClient.
-// Please explicitly pick a version.
-func (c *Clientset) Authorization() authorizationv1.AuthorizationV1Interface {
-	return c.authorizationV1
-}
-
 // AuthorizationV1beta1 retrieves the AuthorizationV1beta1Client
 func (c *Clientset) AuthorizationV1beta1() authorizationv1beta1.AuthorizationV1beta1Interface {
 	return c.authorizationV1beta1
@@ -249,12 +183,6 @@ func (c *Clientset) AuthorizationV1beta1() authorizationv1beta1.AuthorizationV1b
 
 // AutoscalingV1 retrieves the AutoscalingV1Client
 func (c *Clientset) AutoscalingV1() autoscalingv1.AutoscalingV1Interface {
-	return c.autoscalingV1
-}
-
-// Deprecated: Autoscaling retrieves the default version of AutoscalingClient.
-// Please explicitly pick a version.
-func (c *Clientset) Autoscaling() autoscalingv1.AutoscalingV1Interface {
 	return c.autoscalingV1
 }
 
@@ -273,12 +201,6 @@ func (c *Clientset) BatchV1() batchv1.BatchV1Interface {
 	return c.batchV1
 }
 
-// Deprecated: Batch retrieves the default version of BatchClient.
-// Please explicitly pick a version.
-func (c *Clientset) Batch() batchv1.BatchV1Interface {
-	return c.batchV1
-}
-
 // BatchV1beta1 retrieves the BatchV1beta1Client
 func (c *Clientset) BatchV1beta1() batchv1beta1.BatchV1beta1Interface {
 	return c.batchV1beta1
@@ -294,12 +216,6 @@ func (c *Clientset) CertificatesV1beta1() certificatesv1beta1.CertificatesV1beta
 	return c.certificatesV1beta1
 }
 
-// Deprecated: Certificates retrieves the default version of CertificatesClient.
-// Please explicitly pick a version.
-func (c *Clientset) Certificates() certificatesv1beta1.CertificatesV1beta1Interface {
-	return c.certificatesV1beta1
-}
-
 // CoordinationV1beta1 retrieves the CoordinationV1beta1Client
 func (c *Clientset) CoordinationV1beta1() coordinationv1beta1.CoordinationV1beta1Interface {
 	return c.coordinationV1beta1
@@ -310,20 +226,8 @@ func (c *Clientset) CoordinationV1() coordinationv1.CoordinationV1Interface {
 	return c.coordinationV1
 }
 
-// Deprecated: Coordination retrieves the default version of CoordinationClient.
-// Please explicitly pick a version.
-func (c *Clientset) Coordination() coordinationv1.CoordinationV1Interface {
-	return c.coordinationV1
-}
-
 // CoreV1 retrieves the CoreV1Client
 func (c *Clientset) CoreV1() corev1.CoreV1Interface {
-	return c.coreV1
-}
-
-// Deprecated: Core retrieves the default version of CoreClient.
-// Please explicitly pick a version.
-func (c *Clientset) Core() corev1.CoreV1Interface {
 	return c.coreV1
 }
 
@@ -332,31 +236,13 @@ func (c *Clientset) EventsV1beta1() eventsv1beta1.EventsV1beta1Interface {
 	return c.eventsV1beta1
 }
 
-// Deprecated: Events retrieves the default version of EventsClient.
-// Please explicitly pick a version.
-func (c *Clientset) Events() eventsv1beta1.EventsV1beta1Interface {
-	return c.eventsV1beta1
-}
-
 // ExtensionsV1beta1 retrieves the ExtensionsV1beta1Client
 func (c *Clientset) ExtensionsV1beta1() extensionsv1beta1.ExtensionsV1beta1Interface {
 	return c.extensionsV1beta1
 }
 
-// Deprecated: Extensions retrieves the default version of ExtensionsClient.
-// Please explicitly pick a version.
-func (c *Clientset) Extensions() extensionsv1beta1.ExtensionsV1beta1Interface {
-	return c.extensionsV1beta1
-}
-
 // NetworkingV1 retrieves the NetworkingV1Client
 func (c *Clientset) NetworkingV1() networkingv1.NetworkingV1Interface {
-	return c.networkingV1
-}
-
-// Deprecated: Networking retrieves the default version of NetworkingClient.
-// Please explicitly pick a version.
-func (c *Clientset) Networking() networkingv1.NetworkingV1Interface {
 	return c.networkingV1
 }
 
@@ -370,20 +256,8 @@ func (c *Clientset) PolicyV1beta1() policyv1beta1.PolicyV1beta1Interface {
 	return c.policyV1beta1
 }
 
-// Deprecated: Policy retrieves the default version of PolicyClient.
-// Please explicitly pick a version.
-func (c *Clientset) Policy() policyv1beta1.PolicyV1beta1Interface {
-	return c.policyV1beta1
-}
-
 // RbacV1 retrieves the RbacV1Client
 func (c *Clientset) RbacV1() rbacv1.RbacV1Interface {
-	return c.rbacV1
-}
-
-// Deprecated: Rbac retrieves the default version of RbacClient.
-// Please explicitly pick a version.
-func (c *Clientset) Rbac() rbacv1.RbacV1Interface {
 	return c.rbacV1
 }
 
@@ -412,20 +286,8 @@ func (c *Clientset) SchedulingV1() schedulingv1.SchedulingV1Interface {
 	return c.schedulingV1
 }
 
-// Deprecated: Scheduling retrieves the default version of SchedulingClient.
-// Please explicitly pick a version.
-func (c *Clientset) Scheduling() schedulingv1.SchedulingV1Interface {
-	return c.schedulingV1
-}
-
 // SettingsV1alpha1 retrieves the SettingsV1alpha1Client
 func (c *Clientset) SettingsV1alpha1() settingsv1alpha1.SettingsV1alpha1Interface {
-	return c.settingsV1alpha1
-}
-
-// Deprecated: Settings retrieves the default version of SettingsClient.
-// Please explicitly pick a version.
-func (c *Clientset) Settings() settingsv1alpha1.SettingsV1alpha1Interface {
 	return c.settingsV1alpha1
 }
 
@@ -436,12 +298,6 @@ func (c *Clientset) StorageV1beta1() storagev1beta1.StorageV1beta1Interface {
 
 // StorageV1 retrieves the StorageV1Client
 func (c *Clientset) StorageV1() storagev1.StorageV1Interface {
-	return c.storageV1
-}
-
-// Deprecated: Storage retrieves the default version of StorageClient.
-// Please explicitly pick a version.
-func (c *Clientset) Storage() storagev1.StorageV1Interface {
 	return c.storageV1
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
@@ -142,18 +142,8 @@ func (c *Clientset) AdmissionregistrationV1beta1() admissionregistrationv1beta1.
 	return &fakeadmissionregistrationv1beta1.FakeAdmissionregistrationV1beta1{Fake: &c.Fake}
 }
 
-// Admissionregistration retrieves the AdmissionregistrationV1beta1Client
-func (c *Clientset) Admissionregistration() admissionregistrationv1beta1.AdmissionregistrationV1beta1Interface {
-	return &fakeadmissionregistrationv1beta1.FakeAdmissionregistrationV1beta1{Fake: &c.Fake}
-}
-
 // AppsV1 retrieves the AppsV1Client
 func (c *Clientset) AppsV1() appsv1.AppsV1Interface {
-	return &fakeappsv1.FakeAppsV1{Fake: &c.Fake}
-}
-
-// Apps retrieves the AppsV1Client
-func (c *Clientset) Apps() appsv1.AppsV1Interface {
 	return &fakeappsv1.FakeAppsV1{Fake: &c.Fake}
 }
 
@@ -172,18 +162,8 @@ func (c *Clientset) AuditregistrationV1alpha1() auditregistrationv1alpha1.Auditr
 	return &fakeauditregistrationv1alpha1.FakeAuditregistrationV1alpha1{Fake: &c.Fake}
 }
 
-// Auditregistration retrieves the AuditregistrationV1alpha1Client
-func (c *Clientset) Auditregistration() auditregistrationv1alpha1.AuditregistrationV1alpha1Interface {
-	return &fakeauditregistrationv1alpha1.FakeAuditregistrationV1alpha1{Fake: &c.Fake}
-}
-
 // AuthenticationV1 retrieves the AuthenticationV1Client
 func (c *Clientset) AuthenticationV1() authenticationv1.AuthenticationV1Interface {
-	return &fakeauthenticationv1.FakeAuthenticationV1{Fake: &c.Fake}
-}
-
-// Authentication retrieves the AuthenticationV1Client
-func (c *Clientset) Authentication() authenticationv1.AuthenticationV1Interface {
 	return &fakeauthenticationv1.FakeAuthenticationV1{Fake: &c.Fake}
 }
 
@@ -197,11 +177,6 @@ func (c *Clientset) AuthorizationV1() authorizationv1.AuthorizationV1Interface {
 	return &fakeauthorizationv1.FakeAuthorizationV1{Fake: &c.Fake}
 }
 
-// Authorization retrieves the AuthorizationV1Client
-func (c *Clientset) Authorization() authorizationv1.AuthorizationV1Interface {
-	return &fakeauthorizationv1.FakeAuthorizationV1{Fake: &c.Fake}
-}
-
 // AuthorizationV1beta1 retrieves the AuthorizationV1beta1Client
 func (c *Clientset) AuthorizationV1beta1() authorizationv1beta1.AuthorizationV1beta1Interface {
 	return &fakeauthorizationv1beta1.FakeAuthorizationV1beta1{Fake: &c.Fake}
@@ -209,11 +184,6 @@ func (c *Clientset) AuthorizationV1beta1() authorizationv1beta1.AuthorizationV1b
 
 // AutoscalingV1 retrieves the AutoscalingV1Client
 func (c *Clientset) AutoscalingV1() autoscalingv1.AutoscalingV1Interface {
-	return &fakeautoscalingv1.FakeAutoscalingV1{Fake: &c.Fake}
-}
-
-// Autoscaling retrieves the AutoscalingV1Client
-func (c *Clientset) Autoscaling() autoscalingv1.AutoscalingV1Interface {
 	return &fakeautoscalingv1.FakeAutoscalingV1{Fake: &c.Fake}
 }
 
@@ -232,11 +202,6 @@ func (c *Clientset) BatchV1() batchv1.BatchV1Interface {
 	return &fakebatchv1.FakeBatchV1{Fake: &c.Fake}
 }
 
-// Batch retrieves the BatchV1Client
-func (c *Clientset) Batch() batchv1.BatchV1Interface {
-	return &fakebatchv1.FakeBatchV1{Fake: &c.Fake}
-}
-
 // BatchV1beta1 retrieves the BatchV1beta1Client
 func (c *Clientset) BatchV1beta1() batchv1beta1.BatchV1beta1Interface {
 	return &fakebatchv1beta1.FakeBatchV1beta1{Fake: &c.Fake}
@@ -252,11 +217,6 @@ func (c *Clientset) CertificatesV1beta1() certificatesv1beta1.CertificatesV1beta
 	return &fakecertificatesv1beta1.FakeCertificatesV1beta1{Fake: &c.Fake}
 }
 
-// Certificates retrieves the CertificatesV1beta1Client
-func (c *Clientset) Certificates() certificatesv1beta1.CertificatesV1beta1Interface {
-	return &fakecertificatesv1beta1.FakeCertificatesV1beta1{Fake: &c.Fake}
-}
-
 // CoordinationV1beta1 retrieves the CoordinationV1beta1Client
 func (c *Clientset) CoordinationV1beta1() coordinationv1beta1.CoordinationV1beta1Interface {
 	return &fakecoordinationv1beta1.FakeCoordinationV1beta1{Fake: &c.Fake}
@@ -267,18 +227,8 @@ func (c *Clientset) CoordinationV1() coordinationv1.CoordinationV1Interface {
 	return &fakecoordinationv1.FakeCoordinationV1{Fake: &c.Fake}
 }
 
-// Coordination retrieves the CoordinationV1Client
-func (c *Clientset) Coordination() coordinationv1.CoordinationV1Interface {
-	return &fakecoordinationv1.FakeCoordinationV1{Fake: &c.Fake}
-}
-
 // CoreV1 retrieves the CoreV1Client
 func (c *Clientset) CoreV1() corev1.CoreV1Interface {
-	return &fakecorev1.FakeCoreV1{Fake: &c.Fake}
-}
-
-// Core retrieves the CoreV1Client
-func (c *Clientset) Core() corev1.CoreV1Interface {
 	return &fakecorev1.FakeCoreV1{Fake: &c.Fake}
 }
 
@@ -287,28 +237,13 @@ func (c *Clientset) EventsV1beta1() eventsv1beta1.EventsV1beta1Interface {
 	return &fakeeventsv1beta1.FakeEventsV1beta1{Fake: &c.Fake}
 }
 
-// Events retrieves the EventsV1beta1Client
-func (c *Clientset) Events() eventsv1beta1.EventsV1beta1Interface {
-	return &fakeeventsv1beta1.FakeEventsV1beta1{Fake: &c.Fake}
-}
-
 // ExtensionsV1beta1 retrieves the ExtensionsV1beta1Client
 func (c *Clientset) ExtensionsV1beta1() extensionsv1beta1.ExtensionsV1beta1Interface {
 	return &fakeextensionsv1beta1.FakeExtensionsV1beta1{Fake: &c.Fake}
 }
 
-// Extensions retrieves the ExtensionsV1beta1Client
-func (c *Clientset) Extensions() extensionsv1beta1.ExtensionsV1beta1Interface {
-	return &fakeextensionsv1beta1.FakeExtensionsV1beta1{Fake: &c.Fake}
-}
-
 // NetworkingV1 retrieves the NetworkingV1Client
 func (c *Clientset) NetworkingV1() networkingv1.NetworkingV1Interface {
-	return &fakenetworkingv1.FakeNetworkingV1{Fake: &c.Fake}
-}
-
-// Networking retrieves the NetworkingV1Client
-func (c *Clientset) Networking() networkingv1.NetworkingV1Interface {
 	return &fakenetworkingv1.FakeNetworkingV1{Fake: &c.Fake}
 }
 
@@ -322,18 +257,8 @@ func (c *Clientset) PolicyV1beta1() policyv1beta1.PolicyV1beta1Interface {
 	return &fakepolicyv1beta1.FakePolicyV1beta1{Fake: &c.Fake}
 }
 
-// Policy retrieves the PolicyV1beta1Client
-func (c *Clientset) Policy() policyv1beta1.PolicyV1beta1Interface {
-	return &fakepolicyv1beta1.FakePolicyV1beta1{Fake: &c.Fake}
-}
-
 // RbacV1 retrieves the RbacV1Client
 func (c *Clientset) RbacV1() rbacv1.RbacV1Interface {
-	return &fakerbacv1.FakeRbacV1{Fake: &c.Fake}
-}
-
-// Rbac retrieves the RbacV1Client
-func (c *Clientset) Rbac() rbacv1.RbacV1Interface {
 	return &fakerbacv1.FakeRbacV1{Fake: &c.Fake}
 }
 
@@ -362,18 +287,8 @@ func (c *Clientset) SchedulingV1() schedulingv1.SchedulingV1Interface {
 	return &fakeschedulingv1.FakeSchedulingV1{Fake: &c.Fake}
 }
 
-// Scheduling retrieves the SchedulingV1Client
-func (c *Clientset) Scheduling() schedulingv1.SchedulingV1Interface {
-	return &fakeschedulingv1.FakeSchedulingV1{Fake: &c.Fake}
-}
-
 // SettingsV1alpha1 retrieves the SettingsV1alpha1Client
 func (c *Clientset) SettingsV1alpha1() settingsv1alpha1.SettingsV1alpha1Interface {
-	return &fakesettingsv1alpha1.FakeSettingsV1alpha1{Fake: &c.Fake}
-}
-
-// Settings retrieves the SettingsV1alpha1Client
-func (c *Clientset) Settings() settingsv1alpha1.SettingsV1alpha1Interface {
 	return &fakesettingsv1alpha1.FakeSettingsV1alpha1{Fake: &c.Fake}
 }
 
@@ -384,11 +299,6 @@ func (c *Clientset) StorageV1beta1() storagev1beta1.StorageV1beta1Interface {
 
 // StorageV1 retrieves the StorageV1Client
 func (c *Clientset) StorageV1() storagev1.StorageV1Interface {
-	return &fakestoragev1.FakeStorageV1{Fake: &c.Fake}
-}
-
-// Storage retrieves the StorageV1Client
-func (c *Clientset) Storage() storagev1.StorageV1Interface {
 	return &fakestoragev1.FakeStorageV1{Fake: &c.Fake}
 }
 

--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher_test.go
@@ -182,10 +182,10 @@ func TestNewInformerWatcher(t *testing.T) {
 
 			lw := &cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					return fake.Core().Secrets("").List(options)
+					return fake.CoreV1().Secrets("").List(options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return fake.Core().Secrets("").Watch(options)
+					return fake.CoreV1().Secrets("").Watch(options)
 				},
 			}
 			_, _, w, done := NewIndexerInformerWatcher(lw, &corev1.Secret{})

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/clientset.go
@@ -28,8 +28,6 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	ExampleV1() examplev1.ExampleV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Example() examplev1.ExampleV1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -41,12 +39,6 @@ type Clientset struct {
 
 // ExampleV1 retrieves the ExampleV1Client
 func (c *Clientset) ExampleV1() examplev1.ExampleV1Interface {
-	return c.exampleV1
-}
-
-// Deprecated: Example retrieves the default version of ExampleClient.
-// Please explicitly pick a version.
-func (c *Clientset) Example() examplev1.ExampleV1Interface {
 	return c.exampleV1
 }
 

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/fake/clientset_generated.go
@@ -75,8 +75,3 @@ var _ clientset.Interface = &Clientset{}
 func (c *Clientset) ExampleV1() examplev1.ExampleV1Interface {
 	return &fakeexamplev1.FakeExampleV1{Fake: &c.Fake}
 }
-
-// Example retrieves the ExampleV1Client
-func (c *Clientset) Example() examplev1.ExampleV1Interface {
-	return &fakeexamplev1.FakeExampleV1{Fake: &c.Fake}
-}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/clientset.go
@@ -29,11 +29,7 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	ExampleV1() examplev1.ExampleV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Example() examplev1.ExampleV1Interface
 	SecondExampleV1() secondexamplev1.SecondExampleV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	SecondExample() secondexamplev1.SecondExampleV1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -49,20 +45,8 @@ func (c *Clientset) ExampleV1() examplev1.ExampleV1Interface {
 	return c.exampleV1
 }
 
-// Deprecated: Example retrieves the default version of ExampleClient.
-// Please explicitly pick a version.
-func (c *Clientset) Example() examplev1.ExampleV1Interface {
-	return c.exampleV1
-}
-
 // SecondExampleV1 retrieves the SecondExampleV1Client
 func (c *Clientset) SecondExampleV1() secondexamplev1.SecondExampleV1Interface {
-	return c.secondExampleV1
-}
-
-// Deprecated: SecondExample retrieves the default version of SecondExampleClient.
-// Please explicitly pick a version.
-func (c *Clientset) SecondExample() secondexamplev1.SecondExampleV1Interface {
 	return c.secondExampleV1
 }
 

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/fake/clientset_generated.go
@@ -78,17 +78,7 @@ func (c *Clientset) ExampleV1() examplev1.ExampleV1Interface {
 	return &fakeexamplev1.FakeExampleV1{Fake: &c.Fake}
 }
 
-// Example retrieves the ExampleV1Client
-func (c *Clientset) Example() examplev1.ExampleV1Interface {
-	return &fakeexamplev1.FakeExampleV1{Fake: &c.Fake}
-}
-
 // SecondExampleV1 retrieves the SecondExampleV1Client
 func (c *Clientset) SecondExampleV1() secondexamplev1.SecondExampleV1Interface {
-	return &fakesecondexamplev1.FakeSecondExampleV1{Fake: &c.Fake}
-}
-
-// SecondExample retrieves the SecondExampleV1Client
-func (c *Clientset) SecondExample() secondexamplev1.SecondExampleV1Interface {
 	return &fakesecondexamplev1.FakeSecondExampleV1{Fake: &c.Fake}
 }

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/clientset.go
@@ -29,11 +29,7 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	ExampleV1() examplev1.ExampleV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Example() examplev1.ExampleV1Interface
 	SecondExampleV1() secondexamplev1.SecondExampleV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	SecondExample() secondexamplev1.SecondExampleV1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -49,20 +45,8 @@ func (c *Clientset) ExampleV1() examplev1.ExampleV1Interface {
 	return c.exampleV1
 }
 
-// Deprecated: Example retrieves the default version of ExampleClient.
-// Please explicitly pick a version.
-func (c *Clientset) Example() examplev1.ExampleV1Interface {
-	return c.exampleV1
-}
-
 // SecondExampleV1 retrieves the SecondExampleV1Client
 func (c *Clientset) SecondExampleV1() secondexamplev1.SecondExampleV1Interface {
-	return c.secondExampleV1
-}
-
-// Deprecated: SecondExample retrieves the default version of SecondExampleClient.
-// Please explicitly pick a version.
-func (c *Clientset) SecondExample() secondexamplev1.SecondExampleV1Interface {
 	return c.secondExampleV1
 }
 

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/fake/clientset_generated.go
@@ -78,17 +78,7 @@ func (c *Clientset) ExampleV1() examplev1.ExampleV1Interface {
 	return &fakeexamplev1.FakeExampleV1{Fake: &c.Fake}
 }
 
-// Example retrieves the ExampleV1Client
-func (c *Clientset) Example() examplev1.ExampleV1Interface {
-	return &fakeexamplev1.FakeExampleV1{Fake: &c.Fake}
-}
-
 // SecondExampleV1 retrieves the SecondExampleV1Client
 func (c *Clientset) SecondExampleV1() secondexamplev1.SecondExampleV1Interface {
-	return &fakesecondexamplev1.FakeSecondExampleV1{Fake: &c.Fake}
-}
-
-// SecondExample retrieves the SecondExampleV1Client
-func (c *Clientset) SecondExample() secondexamplev1.SecondExampleV1Interface {
 	return &fakesecondexamplev1.FakeSecondExampleV1{Fake: &c.Fake}
 }

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
@@ -102,10 +102,6 @@ func (g *genClientset) GenerateType(c *generator.Context, t *types.Type, w io.Wr
 		}
 
 		sw.Do(clientsetInterfaceImplTemplate, m)
-		// don't generated the default method if generating internalversion clientset
-		if group.IsDefaultVersion && group.Version != "" {
-			sw.Do(clientsetInterfaceDefaultVersionImpl, m)
-		}
 	}
 
 	return sw.Error()

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
@@ -88,10 +88,6 @@ func (g *genClientset) GenerateType(c *generator.Context, t *types.Type, w io.Wr
 	sw.Do(clientsetTemplate, m)
 	for _, g := range allGroups {
 		sw.Do(clientsetInterfaceImplTemplate, g)
-		// don't generated the default method if generating internalversion clientset
-		if g.IsDefaultVersion && g.Version != "" {
-			sw.Do(clientsetInterfaceDefaultVersionImpl, g)
-		}
 	}
 	sw.Do(getDiscoveryTemplate, m)
 	sw.Do(newClientsetForConfigTemplate, m)
@@ -105,9 +101,7 @@ var clientsetInterface = `
 type Interface interface {
 	Discovery() $.DiscoveryInterface|raw$
     $range .allGroups$$.GroupGoName$$.Version$() $.PackageAlias$.$.GroupGoName$$.Version$Interface
-	$if .IsDefaultVersion$// Deprecated: please explicitly pick a version if possible.
-	$.GroupGoName$() $.PackageAlias$.$.GroupGoName$$.Version$Interface
-	$end$$end$
+	$end$
 }
 `
 
@@ -124,14 +118,6 @@ type Clientset struct {
 var clientsetInterfaceImplTemplate = `
 // $.GroupGoName$$.Version$ retrieves the $.GroupGoName$$.Version$Client
 func (c *Clientset) $.GroupGoName$$.Version$() $.PackageAlias$.$.GroupGoName$$.Version$Interface {
-	return c.$.LowerCaseGroupGoName$$.Version$
-}
-`
-
-var clientsetInterfaceDefaultVersionImpl = `
-// Deprecated: $.GroupGoName$ retrieves the default version of $.GroupGoName$Client.
-// Please explicitly pick a version.
-func (c *Clientset) $.GroupGoName$() $.PackageAlias$.$.GroupGoName$$.Version$Interface {
 	return c.$.LowerCaseGroupGoName$$.Version$
 }
 `

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/types/helpers.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/types/helpers.go
@@ -73,7 +73,7 @@ func (a sortableSliceOfVersions) Less(i, j int) bool {
 }
 
 // Determine the default version among versions. If a user calls a group client
-// without specifying the version (e.g., c.Core(), instead of c.CoreV1()), the
+// without specifying the version (e.g., c.CoreV1(), instead of c.CoreV1()), the
 // default version will be returned.
 func defaultVersion(versions []PackageVersion) Version {
 	var versionStrings []string

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/types/helpers.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/types/helpers.go
@@ -88,14 +88,12 @@ func defaultVersion(versions []PackageVersion) Version {
 func ToGroupVersionInfo(groups []GroupVersions, groupGoNames map[GroupVersion]string) []GroupVersionInfo {
 	var groupVersionPackages []GroupVersionInfo
 	for _, group := range groups {
-		defaultVersion := defaultVersion(group.Versions)
 		for _, version := range group.Versions {
 			groupGoName := groupGoNames[GroupVersion{Group: group.Group, Version: version.Version}]
 			groupVersionPackages = append(groupVersionPackages, GroupVersionInfo{
 				Group:                Group(namer.IC(group.Group.NonEmpty())),
 				Version:              Version(namer.IC(version.Version.String())),
 				PackageAlias:         strings.ToLower(groupGoName + version.Version.NonEmpty()),
-				IsDefaultVersion:     version.Version == defaultVersion && version.Version != "",
 				GroupGoName:          groupGoName,
 				LowerCaseGroupGoName: namer.IL(groupGoName),
 			})

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/types/types.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/types/types.go
@@ -62,11 +62,8 @@ type GroupVersions struct {
 
 // GroupVersionInfo contains all the info around a group version.
 type GroupVersionInfo struct {
-	Group   Group
-	Version Version
-	// If a user calls a group client without specifying the version (e.g.,
-	// c.Core(), instead of c.CoreV1()), the default version will be returned.
-	IsDefaultVersion     bool
+	Group                Group
+	Version              Version
 	PackageAlias         string
 	GroupGoName          string
 	LowerCaseGroupGoName string

--- a/staging/src/k8s.io/csi-api/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/csi-api/pkg/client/clientset/versioned/clientset.go
@@ -28,8 +28,6 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	CsiV1alpha1() csiv1alpha1.CsiV1alpha1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Csi() csiv1alpha1.CsiV1alpha1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -41,12 +39,6 @@ type Clientset struct {
 
 // CsiV1alpha1 retrieves the CsiV1alpha1Client
 func (c *Clientset) CsiV1alpha1() csiv1alpha1.CsiV1alpha1Interface {
-	return c.csiV1alpha1
-}
-
-// Deprecated: Csi retrieves the default version of CsiClient.
-// Please explicitly pick a version.
-func (c *Clientset) Csi() csiv1alpha1.CsiV1alpha1Interface {
 	return c.csiV1alpha1
 }
 

--- a/staging/src/k8s.io/csi-api/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/csi-api/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -75,8 +75,3 @@ var _ clientset.Interface = &Clientset{}
 func (c *Clientset) CsiV1alpha1() csiv1alpha1.CsiV1alpha1Interface {
 	return &fakecsiv1alpha1.FakeCsiV1alpha1{Fake: &c.Fake}
 }
-
-// Csi retrieves the CsiV1alpha1Client
-func (c *Clientset) Csi() csiv1alpha1.CsiV1alpha1Interface {
-	return &fakecsiv1alpha1.FakeCsiV1alpha1{Fake: &c.Fake}
-}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
@@ -30,8 +30,6 @@ type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	ApiregistrationV1beta1() apiregistrationv1beta1.ApiregistrationV1beta1Interface
 	ApiregistrationV1() apiregistrationv1.ApiregistrationV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Apiregistration() apiregistrationv1.ApiregistrationV1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -49,12 +47,6 @@ func (c *Clientset) ApiregistrationV1beta1() apiregistrationv1beta1.Apiregistrat
 
 // ApiregistrationV1 retrieves the ApiregistrationV1Client
 func (c *Clientset) ApiregistrationV1() apiregistrationv1.ApiregistrationV1Interface {
-	return c.apiregistrationV1
-}
-
-// Deprecated: Apiregistration retrieves the default version of ApiregistrationClient.
-// Please explicitly pick a version.
-func (c *Clientset) Apiregistration() apiregistrationv1.ApiregistrationV1Interface {
 	return c.apiregistrationV1
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
@@ -82,8 +82,3 @@ func (c *Clientset) ApiregistrationV1beta1() apiregistrationv1beta1.Apiregistrat
 func (c *Clientset) ApiregistrationV1() apiregistrationv1.ApiregistrationV1Interface {
 	return &fakeapiregistrationv1.FakeApiregistrationV1{Fake: &c.Fake}
 }
-
-// Apiregistration retrieves the ApiregistrationV1Client
-func (c *Clientset) Apiregistration() apiregistrationv1.ApiregistrationV1Interface {
-	return &fakeapiregistrationv1.FakeApiregistrationV1{Fake: &c.Fake}
-}

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
@@ -30,8 +30,6 @@ type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	MetricsV1alpha1() metricsv1alpha1.MetricsV1alpha1Interface
 	MetricsV1beta1() metricsv1beta1.MetricsV1beta1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Metrics() metricsv1beta1.MetricsV1beta1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -49,12 +47,6 @@ func (c *Clientset) MetricsV1alpha1() metricsv1alpha1.MetricsV1alpha1Interface {
 
 // MetricsV1beta1 retrieves the MetricsV1beta1Client
 func (c *Clientset) MetricsV1beta1() metricsv1beta1.MetricsV1beta1Interface {
-	return c.metricsV1beta1
-}
-
-// Deprecated: Metrics retrieves the default version of MetricsClient.
-// Please explicitly pick a version.
-func (c *Clientset) Metrics() metricsv1beta1.MetricsV1beta1Interface {
 	return c.metricsV1beta1
 }
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -82,8 +82,3 @@ func (c *Clientset) MetricsV1alpha1() metricsv1alpha1.MetricsV1alpha1Interface {
 func (c *Clientset) MetricsV1beta1() metricsv1beta1.MetricsV1beta1Interface {
 	return &fakemetricsv1beta1.FakeMetricsV1beta1{Fake: &c.Fake}
 }
-
-// Metrics retrieves the MetricsV1beta1Client
-func (c *Clientset) Metrics() metricsv1beta1.MetricsV1beta1Interface {
-	return &fakemetricsv1beta1.FakeMetricsV1beta1{Fake: &c.Fake}
-}

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/clientset.go
@@ -28,8 +28,6 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	NodeV1alpha1() nodev1alpha1.NodeV1alpha1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Node() nodev1alpha1.NodeV1alpha1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -41,12 +39,6 @@ type Clientset struct {
 
 // NodeV1alpha1 retrieves the NodeV1alpha1Client
 func (c *Clientset) NodeV1alpha1() nodev1alpha1.NodeV1alpha1Interface {
-	return c.nodeV1alpha1
-}
-
-// Deprecated: Node retrieves the default version of NodeClient.
-// Please explicitly pick a version.
-func (c *Clientset) Node() nodev1alpha1.NodeV1alpha1Interface {
 	return c.nodeV1alpha1
 }
 

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -75,8 +75,3 @@ var _ clientset.Interface = &Clientset{}
 func (c *Clientset) NodeV1alpha1() nodev1alpha1.NodeV1alpha1Interface {
 	return &fakenodev1alpha1.FakeNodeV1alpha1{Fake: &c.Fake}
 }
-
-// Node retrieves the NodeV1alpha1Client
-func (c *Clientset) Node() nodev1alpha1.NodeV1alpha1Interface {
-	return &fakenodev1alpha1.FakeNodeV1alpha1{Fake: &c.Fake}
-}

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/clientset.go
@@ -30,8 +30,6 @@ type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	WardleV1alpha1() wardlev1alpha1.WardleV1alpha1Interface
 	WardleV1beta1() wardlev1beta1.WardleV1beta1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Wardle() wardlev1beta1.WardleV1beta1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -49,12 +47,6 @@ func (c *Clientset) WardleV1alpha1() wardlev1alpha1.WardleV1alpha1Interface {
 
 // WardleV1beta1 retrieves the WardleV1beta1Client
 func (c *Clientset) WardleV1beta1() wardlev1beta1.WardleV1beta1Interface {
-	return c.wardleV1beta1
-}
-
-// Deprecated: Wardle retrieves the default version of WardleClient.
-// Please explicitly pick a version.
-func (c *Clientset) Wardle() wardlev1beta1.WardleV1beta1Interface {
 	return c.wardleV1beta1
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/fake/clientset_generated.go
@@ -82,8 +82,3 @@ func (c *Clientset) WardleV1alpha1() wardlev1alpha1.WardleV1alpha1Interface {
 func (c *Clientset) WardleV1beta1() wardlev1beta1.WardleV1beta1Interface {
 	return &fakewardlev1beta1.FakeWardleV1beta1{Fake: &c.Fake}
 }
-
-// Wardle retrieves the WardleV1beta1Client
-func (c *Clientset) Wardle() wardlev1beta1.WardleV1beta1Interface {
-	return &fakewardlev1beta1.FakeWardleV1beta1{Fake: &c.Fake}
-}

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
@@ -28,8 +28,6 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	SamplecontrollerV1alpha1() samplecontrollerv1alpha1.SamplecontrollerV1alpha1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Samplecontroller() samplecontrollerv1alpha1.SamplecontrollerV1alpha1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -41,12 +39,6 @@ type Clientset struct {
 
 // SamplecontrollerV1alpha1 retrieves the SamplecontrollerV1alpha1Client
 func (c *Clientset) SamplecontrollerV1alpha1() samplecontrollerv1alpha1.SamplecontrollerV1alpha1Interface {
-	return c.samplecontrollerV1alpha1
-}
-
-// Deprecated: Samplecontroller retrieves the default version of SamplecontrollerClient.
-// Please explicitly pick a version.
-func (c *Clientset) Samplecontroller() samplecontrollerv1alpha1.SamplecontrollerV1alpha1Interface {
 	return c.samplecontrollerV1alpha1
 }
 

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/fake/clientset_generated.go
@@ -75,8 +75,3 @@ var _ clientset.Interface = &Clientset{}
 func (c *Clientset) SamplecontrollerV1alpha1() samplecontrollerv1alpha1.SamplecontrollerV1alpha1Interface {
 	return &fakesamplecontrollerv1alpha1.FakeSamplecontrollerV1alpha1{Fake: &c.Fake}
 }
-
-// Samplecontroller retrieves the SamplecontrollerV1alpha1Client
-func (c *Clientset) Samplecontroller() samplecontrollerv1alpha1.SamplecontrollerV1alpha1Interface {
-	return &fakesamplecontrollerv1alpha1.FakeSamplecontrollerV1alpha1{Fake: &c.Fake}
-}

--- a/test/e2e/framework/podlogs/podlogs.go
+++ b/test/e2e/framework/podlogs/podlogs.go
@@ -27,13 +27,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"os"
 	"path"
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/pkg/errors"
 
 	"k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +47,7 @@ import (
 //    rpc error: code = Unknown desc = Error: No such container: 41a...
 // when the pod gets deleted while streaming.
 func LogsForPod(ctx context.Context, cs clientset.Interface, ns, pod string, opts *v1.PodLogOptions) (io.ReadCloser, error) {
-	req := cs.Core().Pods(ns).GetLogs(pod, opts)
+	req := cs.CoreV1().Pods(ns).GetLogs(pod, opts)
 	return req.Context(ctx).Stream()
 }
 
@@ -78,7 +79,7 @@ var expectedErrors = regexp.MustCompile(`container .* in pod .* is (terminated|w
 // running pods, but that then would have the disadvantage that
 // already deleted pods aren't covered.
 func CopyAllLogs(ctx context.Context, cs clientset.Interface, ns string, to LogOutput) error {
-	watcher, err := cs.Core().Pods(ns).Watch(meta.ListOptions{})
+	watcher, err := cs.CoreV1().Pods(ns).Watch(meta.ListOptions{})
 	if err != nil {
 		return errors.Wrap(err, "cannot create Pod event watcher")
 	}
@@ -90,7 +91,7 @@ func CopyAllLogs(ctx context.Context, cs clientset.Interface, ns string, to LogO
 			m.Lock()
 			defer m.Unlock()
 
-			pods, err := cs.Core().Pods(ns).List(meta.ListOptions{})
+			pods, err := cs.CoreV1().Pods(ns).List(meta.ListOptions{})
 			if err != nil {
 				if to.StatusWriter != nil {
 					fmt.Fprintf(to.StatusWriter, "ERROR: get pod list in %s: %s\n", ns, err)
@@ -213,7 +214,7 @@ func CopyAllLogs(ctx context.Context, cs clientset.Interface, ns string, to LogO
 // WatchPods prints pod status events for a certain namespace or all namespaces
 // when namespace name is empty.
 func WatchPods(ctx context.Context, cs clientset.Interface, ns string, to io.Writer) error {
-	watcher, err := cs.Core().Pods(ns).Watch(meta.ListOptions{})
+	watcher, err := cs.CoreV1().Pods(ns).Watch(meta.ListOptions{})
 	if err != nil {
 		return errors.Wrap(err, "cannot create Pod event watcher")
 	}

--- a/test/integration/defaulttolerationseconds/defaulttolerationseconds_test.go
+++ b/test/integration/defaulttolerationseconds/defaulttolerationseconds_test.go
@@ -57,7 +57,7 @@ func TestAdmission(t *testing.T) {
 		},
 	}
 
-	updatedPod, err := client.Core().Pods(pod.Namespace).Create(&pod)
+	updatedPod, err := client.CoreV1().Pods(pod.Namespace).Create(&pod)
 	if err != nil {
 		t.Fatalf("error creating pod: %v", err)
 	}

--- a/test/integration/evictions/evictions_test.go
+++ b/test/integration/evictions/evictions_test.go
@@ -19,6 +19,7 @@ package evictions
 import (
 	"fmt"
 	"net/http/httptest"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -37,7 +38,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/controller/disruption"
 	"k8s.io/kubernetes/test/integration/framework"
-	"reflect"
 )
 
 const (
@@ -89,7 +89,7 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 	waitToObservePods(t, informers.Core().V1().Pods().Informer(), numOfEvictions, v1.PodRunning)
 
 	pdb := newPDB()
-	if _, err := clientSet.Policy().PodDisruptionBudgets(ns.Name).Create(pdb); err != nil {
+	if _, err := clientSet.PolicyV1beta1().PodDisruptionBudgets(ns.Name).Create(pdb); err != nil {
 		t.Errorf("Failed to create PodDisruptionBudget: %v", err)
 	}
 
@@ -107,7 +107,7 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 			eviction := newEviction(ns.Name, podName, deleteOption)
 
 			err := wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
-				e := clientSet.Policy().Evictions(ns.Name).Evict(eviction)
+				e := clientSet.PolicyV1beta1().Evictions(ns.Name).Evict(eviction)
 				switch {
 				case errors.IsTooManyRequests(e):
 					return false, nil
@@ -151,7 +151,7 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 
 	close(errCh)
 	var errList []error
-	if err := clientSet.Policy().PodDisruptionBudgets(ns.Name).Delete(pdb.Name, deleteOption); err != nil {
+	if err := clientSet.PolicyV1beta1().PodDisruptionBudgets(ns.Name).Delete(pdb.Name, deleteOption); err != nil {
 		errList = append(errList, fmt.Errorf("Failed to delete PodDisruptionBudget: %v", err))
 	}
 	for err := range errCh {
@@ -202,20 +202,20 @@ func TestTerminalPodEviction(t *testing.T) {
 	waitToObservePods(t, informers.Core().V1().Pods().Informer(), 1, v1.PodSucceeded)
 
 	pdb := newPDB()
-	if _, err := clientSet.Policy().PodDisruptionBudgets(ns.Name).Create(pdb); err != nil {
+	if _, err := clientSet.PolicyV1beta1().PodDisruptionBudgets(ns.Name).Create(pdb); err != nil {
 		t.Errorf("Failed to create PodDisruptionBudget: %v", err)
 	}
 
 	waitPDBStable(t, clientSet, 1, ns.Name, pdb.Name)
 
-	pdbList, err := clientSet.Policy().PodDisruptionBudgets(ns.Name).List(metav1.ListOptions{})
+	pdbList, err := clientSet.PolicyV1beta1().PodDisruptionBudgets(ns.Name).List(metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("Error while listing pod disruption budget")
 	}
 	oldPdb := pdbList.Items[0]
 	eviction := newEviction(ns.Name, pod.Name, deleteOption)
 	err = wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
-		e := clientSet.Policy().Evictions(ns.Name).Evict(eviction)
+		e := clientSet.PolicyV1beta1().Evictions(ns.Name).Evict(eviction)
 		switch {
 		case errors.IsTooManyRequests(e):
 			return false, nil
@@ -230,7 +230,7 @@ func TestTerminalPodEviction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Eviction of pod failed %v", err)
 	}
-	pdbList, err = clientSet.Policy().PodDisruptionBudgets(ns.Name).List(metav1.ListOptions{})
+	pdbList, err = clientSet.PolicyV1beta1().PodDisruptionBudgets(ns.Name).List(metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("Error while listing pod disruption budget")
 	}
@@ -240,7 +240,7 @@ func TestTerminalPodEviction(t *testing.T) {
 		t.Fatalf("Expected the pdb generation to be of same value %v but got %v", newPdb.Status.ObservedGeneration, oldPdb.Status.ObservedGeneration)
 	}
 
-	if err := clientSet.Policy().PodDisruptionBudgets(ns.Name).Delete(pdb.Name, deleteOption); err != nil {
+	if err := clientSet.PolicyV1beta1().PodDisruptionBudgets(ns.Name).Delete(pdb.Name, deleteOption); err != nil {
 		t.Fatalf("Failed to delete pod disruption budget")
 	}
 }
@@ -364,7 +364,7 @@ func waitToObservePods(t *testing.T, podInformer cache.SharedIndexInformer, podN
 
 func waitPDBStable(t *testing.T, clientSet clientset.Interface, podNum int32, ns, pdbName string) {
 	if err := wait.PollImmediate(2*time.Second, 60*time.Second, func() (bool, error) {
-		pdb, err := clientSet.Policy().PodDisruptionBudgets(ns).Get(pdbName, metav1.GetOptions{})
+		pdb, err := clientSet.PolicyV1beta1().PodDisruptionBudgets(ns).Get(pdbName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/integration/metrics/metrics_test.go
+++ b/test/integration/metrics/metrics_test.go
@@ -111,7 +111,7 @@ func TestApiserverMetrics(t *testing.T) {
 	// Make a request to the apiserver to ensure there's at least one data point
 	// for the metrics we're expecting -- otherwise, they won't be exported.
 	client := clientset.NewForConfigOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
-	if _, err := client.Core().Pods(metav1.NamespaceDefault).List(metav1.ListOptions{}); err != nil {
+	if _, err := client.CoreV1().Pods(metav1.NamespaceDefault).List(metav1.ListOptions{}); err != nil {
 		t.Fatalf("unexpected error getting pods: %v", err)
 	}
 

--- a/test/integration/objectmeta/objectmeta_test.go
+++ b/test/integration/objectmeta/objectmeta_test.go
@@ -41,12 +41,12 @@ func TestIgnoreClusterName(t *testing.T) {
 			ClusterName: "cluster-name-to-ignore",
 		},
 	}
-	nsNew, err := client.Core().Namespaces().Create(&ns)
+	nsNew, err := client.CoreV1().Namespaces().Create(&ns)
 	assert.Nil(t, err)
 	assert.Equal(t, ns.Name, nsNew.Name)
 	assert.Empty(t, nsNew.ClusterName)
 
-	nsNew, err = client.Core().Namespaces().Update(&ns)
+	nsNew, err = client.CoreV1().Namespaces().Update(&ns)
 	assert.Nil(t, err)
 	assert.Equal(t, ns.Name, nsNew.Name)
 	assert.Empty(t, nsNew.ClusterName)

--- a/test/integration/pods/pods_test.go
+++ b/test/integration/pods/pods_test.go
@@ -129,13 +129,13 @@ func TestPodUpdateActiveDeadlineSeconds(t *testing.T) {
 		pod.Spec.ActiveDeadlineSeconds = tc.original
 		pod.ObjectMeta.Name = fmt.Sprintf("activedeadlineseconds-test-%v", i)
 
-		if _, err := client.Core().Pods(ns.Name).Create(pod); err != nil {
+		if _, err := client.CoreV1().Pods(ns.Name).Create(pod); err != nil {
 			t.Errorf("Failed to create pod: %v", err)
 		}
 
 		pod.Spec.ActiveDeadlineSeconds = tc.update
 
-		_, err := client.Core().Pods(ns.Name).Update(pod)
+		_, err := client.CoreV1().Pods(ns.Name).Update(pod)
 		if tc.valid && err != nil {
 			t.Errorf("%v: failed to update pod: %v", tc.name, err)
 		} else if !tc.valid && err == nil {
@@ -173,7 +173,7 @@ func TestPodReadOnlyFilesystem(t *testing.T) {
 		},
 	}
 
-	if _, err := client.Core().Pods(ns.Name).Create(pod); err != nil {
+	if _, err := client.CoreV1().Pods(ns.Name).Create(pod); err != nil {
 		t.Errorf("Failed to create pod: %v", err)
 	}
 

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -103,7 +103,7 @@ func TestQuota(t *testing.T) {
 	qc := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource)
 	informersStarted := make(chan struct{})
 	resourceQuotaControllerOptions := &resourcequotacontroller.ResourceQuotaControllerOptions{
-		QuotaClient:               clientset.Core(),
+		QuotaClient:               clientset.CoreV1(),
 		ResourceQuotaInformer:     informers.Core().V1().ResourceQuotas(),
 		ResyncPeriod:              controller.NoResyncPeriodFunc,
 		InformerFactory:           informers,
@@ -151,12 +151,12 @@ func TestQuota(t *testing.T) {
 }
 
 func waitForQuota(t *testing.T, quota *v1.ResourceQuota, clientset *clientset.Clientset) {
-	w, err := clientset.Core().ResourceQuotas(quota.Namespace).Watch(metav1.SingleObject(metav1.ObjectMeta{Name: quota.Name}))
+	w, err := clientset.CoreV1().ResourceQuotas(quota.Namespace).Watch(metav1.SingleObject(metav1.ObjectMeta{Name: quota.Name}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, err := clientset.Core().ResourceQuotas(quota.Namespace).Create(quota); err != nil {
+	if _, err := clientset.CoreV1().ResourceQuotas(quota.Namespace).Create(quota); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -210,12 +210,12 @@ func scale(t *testing.T, namespace string, clientset *clientset.Clientset) {
 		},
 	}
 
-	w, err := clientset.Core().ReplicationControllers(namespace).Watch(metav1.SingleObject(metav1.ObjectMeta{Name: rc.Name}))
+	w, err := clientset.CoreV1().ReplicationControllers(namespace).Watch(metav1.SingleObject(metav1.ObjectMeta{Name: rc.Name}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, err := clientset.Core().ReplicationControllers(namespace).Create(rc); err != nil {
+	if _, err := clientset.CoreV1().ReplicationControllers(namespace).Create(rc); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -239,7 +239,7 @@ func scale(t *testing.T, namespace string, clientset *clientset.Clientset) {
 		return false, nil
 	})
 	if err != nil {
-		pods, _ := clientset.Core().Pods(namespace).List(metav1.ListOptions{LabelSelector: labels.Everything().String(), FieldSelector: fields.Everything().String()})
+		pods, _ := clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: labels.Everything().String(), FieldSelector: fields.Everything().String()})
 		t.Fatalf("unexpected error: %v, ended with %v pods", err, len(pods.Items))
 	}
 }
@@ -301,7 +301,7 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 	qc := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource)
 	informersStarted := make(chan struct{})
 	resourceQuotaControllerOptions := &resourcequotacontroller.ResourceQuotaControllerOptions{
-		QuotaClient:               clientset.Core(),
+		QuotaClient:               clientset.CoreV1(),
 		ResourceQuotaInformer:     informers.Core().V1().ResourceQuotas(),
 		ResyncPeriod:              controller.NoResyncPeriodFunc,
 		InformerFactory:           informers,
@@ -339,7 +339,7 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 			},
 		},
 	}
-	if _, err := clientset.Core().Pods(ns.Name).Create(pod); err == nil {
+	if _, err := clientset.CoreV1().Pods(ns.Name).Create(pod); err == nil {
 		t.Fatalf("expected error for insufficient quota")
 	}
 
@@ -362,7 +362,7 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 	// attempt to create a new pod once the quota is propagated
 	err = wait.PollImmediate(5*time.Second, time.Minute, func() (bool, error) {
 		// retry until we succeed (to allow time for all changes to propagate)
-		if _, err := clientset.Core().Pods(ns.Name).Create(pod); err == nil {
+		if _, err := clientset.CoreV1().Pods(ns.Name).Create(pod); err == nil {
 			return true, nil
 		}
 		return false, nil

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -72,7 +72,7 @@ func TestServiceAccountAutoCreate(t *testing.T) {
 	ns := "test-service-account-creation"
 
 	// Create namespace
-	_, err = c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	_, err = c.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
 	if err != nil {
 		t.Fatalf("could not create namespace: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestServiceAccountAutoCreate(t *testing.T) {
 	}
 
 	// Delete service account
-	err = c.Core().ServiceAccounts(ns).Delete(defaultUser.Name, nil)
+	err = c.CoreV1().ServiceAccounts(ns).Delete(defaultUser.Name, nil)
 	if err != nil {
 		t.Fatalf("Could not delete default serviceaccount: %v", err)
 	}
@@ -110,13 +110,13 @@ func TestServiceAccountTokenAutoCreate(t *testing.T) {
 	name := "my-service-account"
 
 	// Create namespace
-	_, err = c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	_, err = c.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
 	if err != nil {
 		t.Fatalf("could not create namespace: %v", err)
 	}
 
 	// Create service account
-	serviceAccount, err := c.Core().ServiceAccounts(ns).Create(&v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name}})
+	serviceAccount, err := c.CoreV1().ServiceAccounts(ns).Create(&v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name}})
 	if err != nil {
 		t.Fatalf("Service Account not created: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestServiceAccountTokenAutoCreate(t *testing.T) {
 	}
 
 	// Delete token
-	err = c.Core().Secrets(ns).Delete(token1Name, nil)
+	err = c.CoreV1().Secrets(ns).Delete(token1Name, nil)
 	if err != nil {
 		t.Fatalf("Could not delete token: %v", err)
 	}
@@ -146,12 +146,12 @@ func TestServiceAccountTokenAutoCreate(t *testing.T) {
 	}
 
 	// Trigger creation of a new referenced token
-	serviceAccount, err = c.Core().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
+	serviceAccount, err = c.CoreV1().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	serviceAccount.Secrets = []v1.ObjectReference{}
-	_, err = c.Core().ServiceAccounts(ns).Update(serviceAccount)
+	_, err = c.CoreV1().ServiceAccounts(ns).Update(serviceAccount)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestServiceAccountTokenAutoCreate(t *testing.T) {
 	}
 
 	// Delete service account
-	err = c.Core().ServiceAccounts(ns).Delete(name, nil)
+	err = c.CoreV1().ServiceAccounts(ns).Delete(name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +178,7 @@ func TestServiceAccountTokenAutoCreate(t *testing.T) {
 	tokensToCleanup := sets.NewString(token1Name, token2Name, token3Name)
 	err = wait.Poll(time.Second, 10*time.Second, func() (bool, error) {
 		// Get all secrets in the namespace
-		secrets, err := c.Core().Secrets(ns).List(metav1.ListOptions{})
+		secrets, err := c.CoreV1().Secrets(ns).List(metav1.ListOptions{})
 		// Retrieval errors should fail
 		if err != nil {
 			return false, err
@@ -207,7 +207,7 @@ func TestServiceAccountTokenAutoMount(t *testing.T) {
 	ns := "auto-mount-ns"
 
 	// Create "my" namespace
-	_, err = c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	_, err = c.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		t.Fatalf("could not create namespace: %v", err)
 	}
@@ -261,7 +261,7 @@ func TestServiceAccountTokenAutoMount(t *testing.T) {
 	}
 	expectedContainer2VolumeMounts := protoPod.Spec.Containers[1].VolumeMounts
 
-	createdPod, err := c.Core().Pods(ns).Create(&protoPod)
+	createdPod, err := c.CoreV1().Pods(ns).Create(&protoPod)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,19 +290,19 @@ func TestServiceAccountTokenAuthentication(t *testing.T) {
 	otherns := "other-ns"
 
 	// Create "my" namespace
-	_, err = c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: myns}})
+	_, err = c.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: myns}})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		t.Fatalf("could not create namespace: %v", err)
 	}
 
 	// Create "other" namespace
-	_, err = c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: otherns}})
+	_, err = c.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: otherns}})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		t.Fatalf("could not create namespace: %v", err)
 	}
 
 	// Create "ro" user in myns
-	_, err = c.Core().ServiceAccounts(myns).Create(&v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: readOnlyServiceAccountName}})
+	_, err = c.CoreV1().ServiceAccounts(myns).Create(&v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: readOnlyServiceAccountName}})
 	if err != nil {
 		t.Fatalf("Service Account not created: %v", err)
 	}
@@ -315,13 +315,13 @@ func TestServiceAccountTokenAuthentication(t *testing.T) {
 	roClient := clientset.NewForConfigOrDie(&roClientConfig)
 	doServiceAccountAPIRequests(t, roClient, myns, true, true, false)
 	doServiceAccountAPIRequests(t, roClient, otherns, true, false, false)
-	err = c.Core().Secrets(myns).Delete(roTokenName, nil)
+	err = c.CoreV1().Secrets(myns).Delete(roTokenName, nil)
 	if err != nil {
 		t.Fatalf("could not delete token: %v", err)
 	}
 	// wait for delete to be observed and reacted to via watch
 	wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-		sa, err := c.Core().ServiceAccounts(myns).Get(readOnlyServiceAccountName, metav1.GetOptions{})
+		sa, err := c.CoreV1().ServiceAccounts(myns).Get(readOnlyServiceAccountName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -335,7 +335,7 @@ func TestServiceAccountTokenAuthentication(t *testing.T) {
 	doServiceAccountAPIRequests(t, roClient, myns, false, false, false)
 
 	// Create "rw" user in myns
-	_, err = c.Core().ServiceAccounts(myns).Create(&v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: readWriteServiceAccountName}})
+	_, err = c.CoreV1().ServiceAccounts(myns).Create(&v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: readWriteServiceAccountName}})
 	if err != nil {
 		t.Fatalf("Service Account not created: %v", err)
 	}
@@ -489,13 +489,13 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 
 func getServiceAccount(c *clientset.Clientset, ns string, name string, shouldWait bool) (*v1.ServiceAccount, error) {
 	if !shouldWait {
-		return c.Core().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
+		return c.CoreV1().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
 	}
 
 	var user *v1.ServiceAccount
 	var err error
 	err = wait.Poll(time.Second, 10*time.Second, func() (bool, error) {
-		user, err = c.Core().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
+		user, err = c.CoreV1().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return false, nil
 		}
@@ -512,7 +512,7 @@ func getReferencedServiceAccountToken(c *clientset.Clientset, ns string, name st
 	token := ""
 
 	findToken := func() (bool, error) {
-		user, err := c.Core().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
+		user, err := c.CoreV1().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return false, nil
 		}
@@ -521,7 +521,7 @@ func getReferencedServiceAccountToken(c *clientset.Clientset, ns string, name st
 		}
 
 		for _, ref := range user.Secrets {
-			secret, err := c.Core().Secrets(ns).Get(ref.Name, metav1.GetOptions{})
+			secret, err := c.CoreV1().Secrets(ns).Get(ref.Name, metav1.GetOptions{})
 			if errors.IsNotFound(err) {
 				continue
 			}
@@ -571,17 +571,17 @@ func doServiceAccountAPIRequests(t *testing.T, c *clientset.Clientset, ns string
 
 	readOps := []testOperation{
 		func() error {
-			_, err := c.Core().Secrets(ns).List(metav1.ListOptions{})
+			_, err := c.CoreV1().Secrets(ns).List(metav1.ListOptions{})
 			return err
 		},
 		func() error {
-			_, err := c.Core().Pods(ns).List(metav1.ListOptions{})
+			_, err := c.CoreV1().Pods(ns).List(metav1.ListOptions{})
 			return err
 		},
 	}
 	writeOps := []testOperation{
-		func() error { _, err := c.Core().Secrets(ns).Create(testSecret); return err },
-		func() error { return c.Core().Secrets(ns).Delete(testSecret.Name, nil) },
+		func() error { _, err := c.CoreV1().Secrets(ns).Create(testSecret); return err },
+		func() error { return c.CoreV1().Secrets(ns).Delete(testSecret.Name, nil) },
 	}
 
 	for _, op := range readOps {

--- a/test/integration/statefulset/statefulset_test.go
+++ b/test/integration/statefulset/statefulset_test.go
@@ -85,7 +85,7 @@ func TestDeletingAndFailedPods(t *testing.T) {
 	waitSTSStable(t, c, sts)
 
 	// Verify STS creates 2 pods
-	podClient := c.Core().Pods(ns.Name)
+	podClient := c.CoreV1().Pods(ns.Name)
 	pods := getPods(t, podClient, labelMap)
 	if len(pods.Items) != 2 {
 		t.Fatalf("len(pods) = %d, want 2", len(pods.Items))
@@ -97,7 +97,7 @@ func TestDeletingAndFailedPods(t *testing.T) {
 	updatePod(t, podClient, deletingPod.Name, func(pod *v1.Pod) {
 		pod.Finalizers = []string{"fake.example.com/blockDeletion"}
 	})
-	if err := c.Core().Pods(ns.Name).Delete(deletingPod.Name, &metav1.DeleteOptions{}); err != nil {
+	if err := c.CoreV1().Pods(ns.Name).Delete(deletingPod.Name, &metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("error deleting pod %s: %v", deletingPod.Name, err)
 	}
 

--- a/test/integration/statefulset/util.go
+++ b/test/integration/statefulset/util.go
@@ -199,7 +199,7 @@ func runControllerAndInformers(sc *statefulset.StatefulSetController, informers 
 }
 
 func createHeadlessService(t *testing.T, clientSet clientset.Interface, headlessService *v1.Service) {
-	_, err := clientSet.Core().Services(headlessService.Namespace).Create(headlessService)
+	_, err := clientSet.CoreV1().Services(headlessService.Namespace).Create(headlessService)
 	if err != nil {
 		t.Fatalf("failed creating headless service: %v", err)
 	}
@@ -216,7 +216,7 @@ func createSTSsPods(t *testing.T, clientSet clientset.Interface, stss []*appsv1.
 		createdSTSs = append(createdSTSs, createdSTS)
 	}
 	for _, pod := range pods {
-		createdPod, err := clientSet.Core().Pods(pod.Namespace).Create(pod)
+		createdPod, err := clientSet.CoreV1().Pods(pod.Namespace).Create(pod)
 		if err != nil {
 			t.Fatalf("failed to create pod %s: %v", pod.Name, err)
 		}

--- a/test/integration/ttlcontroller/ttlcontroller_test.go
+++ b/test/integration/ttlcontroller/ttlcontroller_test.go
@@ -59,7 +59,7 @@ func createNodes(t *testing.T, client *clientset.Clientset, startIndex, endIndex
 					Name: fmt.Sprintf("node-%d", idx),
 				},
 			}
-			if _, err := client.Core().Nodes().Create(node); err != nil {
+			if _, err := client.CoreV1().Nodes().Create(node); err != nil {
 				t.Fatalf("Failed to create node: %v", err)
 			}
 		}(i)
@@ -74,7 +74,7 @@ func deleteNodes(t *testing.T, client *clientset.Clientset, startIndex, endIndex
 		go func(idx int) {
 			defer wg.Done()
 			name := fmt.Sprintf("node-%d", idx)
-			if err := client.Core().Nodes().Delete(name, &metav1.DeleteOptions{}); err != nil {
+			if err := client.CoreV1().Nodes().Delete(name, &metav1.DeleteOptions{}); err != nil {
 				t.Fatalf("Failed to delete node: %v", err)
 			}
 		}(i)

--- a/test/integration/volume/attach_detach_test.go
+++ b/test/integration/volume/attach_detach_test.go
@@ -162,13 +162,13 @@ func TestPodDeletionWithDswp(t *testing.T) {
 	pod := fakePodWithVol(namespaceName)
 	podStopCh := make(chan struct{})
 
-	if _, err := testClient.Core().Nodes().Create(node); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Create(node); err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
 	go informers.Core().V1().Nodes().Informer().Run(podStopCh)
 
-	if _, err := testClient.Core().Pods(ns.Name).Create(pod); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).Create(pod); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -229,13 +229,13 @@ func TestPodUpdateWithWithADC(t *testing.T) {
 	pod := fakePodWithVol(namespaceName)
 	podStopCh := make(chan struct{})
 
-	if _, err := testClient.Core().Nodes().Create(node); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Create(node); err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
 	go informers.Core().V1().Nodes().Informer().Run(podStopCh)
 
-	if _, err := testClient.Core().Pods(ns.Name).Create(pod); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).Create(pod); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -264,7 +264,7 @@ func TestPodUpdateWithWithADC(t *testing.T) {
 
 	pod.Status.Phase = v1.PodSucceeded
 
-	if _, err := testClient.Core().Pods(ns.Name).UpdateStatus(pod); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).UpdateStatus(pod); err != nil {
 		t.Errorf("Failed to update pod : %v", err)
 	}
 
@@ -297,13 +297,13 @@ func TestPodUpdateWithKeepTerminatedPodVolumes(t *testing.T) {
 	pod := fakePodWithVol(namespaceName)
 	podStopCh := make(chan struct{})
 
-	if _, err := testClient.Core().Nodes().Create(node); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Create(node); err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
 	go informers.Core().V1().Nodes().Informer().Run(podStopCh)
 
-	if _, err := testClient.Core().Pods(ns.Name).Create(pod); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).Create(pod); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -332,7 +332,7 @@ func TestPodUpdateWithKeepTerminatedPodVolumes(t *testing.T) {
 
 	pod.Status.Phase = v1.PodSucceeded
 
-	if _, err := testClient.Core().Pods(ns.Name).UpdateStatus(pod); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).UpdateStatus(pod); err != nil {
 		t.Errorf("Failed to update pod : %v", err)
 	}
 
@@ -474,13 +474,13 @@ func TestPodAddedByDswp(t *testing.T) {
 	pod := fakePodWithVol(namespaceName)
 	podStopCh := make(chan struct{})
 
-	if _, err := testClient.Core().Nodes().Create(node); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Create(node); err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
 	go informers.Core().V1().Nodes().Informer().Run(podStopCh)
 
-	if _, err := testClient.Core().Pods(ns.Name).Create(pod); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).Create(pod); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -549,7 +549,7 @@ func TestPVCBoundWithADC(t *testing.T) {
 			},
 		},
 	}
-	if _, err := testClient.Core().Nodes().Create(node); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Create(node); err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
@@ -557,10 +557,10 @@ func TestPVCBoundWithADC(t *testing.T) {
 	pvcs := []*v1.PersistentVolumeClaim{}
 	for i := 0; i < 3; i++ {
 		pod, pvc := fakePodWithPVC(fmt.Sprintf("fakepod-pvcnotbound-%d", i), fmt.Sprintf("fakepvc-%d", i), namespaceName)
-		if _, err := testClient.Core().Pods(pod.Namespace).Create(pod); err != nil {
+		if _, err := testClient.CoreV1().Pods(pod.Namespace).Create(pod); err != nil {
 			t.Errorf("Failed to create pod : %v", err)
 		}
-		if _, err := testClient.Core().PersistentVolumeClaims(pvc.Namespace).Create(pvc); err != nil {
+		if _, err := testClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc); err != nil {
 			t.Errorf("Failed to create pvc : %v", err)
 		}
 		pvcs = append(pvcs, pvc)
@@ -568,7 +568,7 @@ func TestPVCBoundWithADC(t *testing.T) {
 	// pod with no pvc
 	podNew := fakePodWithVol(namespaceName)
 	podNew.SetName("fakepod")
-	if _, err := testClient.Core().Pods(podNew.Namespace).Create(podNew); err != nil {
+	if _, err := testClient.CoreV1().Pods(podNew.Namespace).Create(podNew); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -608,7 +608,7 @@ func createPVForPVC(t *testing.T, testClient *clientset.Clientset, pvc *v1.Persi
 			StorageClassName: *pvc.Spec.StorageClassName,
 		},
 	}
-	if _, err := testClient.Core().PersistentVolumes().Create(pv); err != nil {
+	if _, err := testClient.CoreV1().PersistentVolumes().Create(pv); err != nil {
 		t.Errorf("Failed to create pv : %v", err)
 	}
 }

--- a/test/integration/volume/persistent_volumes_test.go
+++ b/test/integration/volume/persistent_volumes_test.go
@@ -116,7 +116,7 @@ func TestPersistentVolumeRecycler(t *testing.T) {
 
 	// NOTE: This test cannot run in parallel, because it is creating and deleting
 	// non-namespaced objects (PersistenceVolumes).
-	defer testClient.Core().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
+	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
 
 	stopCh := make(chan struct{})
 	informers.Start(stopCh)
@@ -171,7 +171,7 @@ func TestPersistentVolumeDeleter(t *testing.T) {
 
 	// NOTE: This test cannot run in parallel, because it is creating and deleting
 	// non-namespaced objects (PersistenceVolumes).
-	defer testClient.Core().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
+	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
 
 	stopCh := make(chan struct{})
 	informers.Start(stopCh)
@@ -231,7 +231,7 @@ func TestPersistentVolumeBindRace(t *testing.T) {
 
 	// NOTE: This test cannot run in parallel, because it is creating and deleting
 	// non-namespaced objects (PersistenceVolumes).
-	defer testClient.Core().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
+	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
 
 	stopCh := make(chan struct{})
 	informers.Start(stopCh)
@@ -301,7 +301,7 @@ func TestPersistentVolumeClaimLabelSelector(t *testing.T) {
 
 	// NOTE: This test cannot run in parallel, because it is creating and deleting
 	// non-namespaced objects (PersistenceVolumes).
-	defer testClient.Core().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
+	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
 
 	stopCh := make(chan struct{})
 	informers.Start(stopCh)
@@ -382,7 +382,7 @@ func TestPersistentVolumeClaimLabelSelectorMatchExpressions(t *testing.T) {
 
 	// NOTE: This test cannot run in parallel, because it is creating and deleting
 	// non-namespaced objects (PersistenceVolumes).
-	defer testClient.Core().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
+	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
 
 	stopCh := make(chan struct{})
 	informers.Start(stopCh)
@@ -482,7 +482,7 @@ func TestPersistentVolumeMultiPVs(t *testing.T) {
 
 	// NOTE: This test cannot run in parallel, because it is creating and deleting
 	// non-namespaced objects (PersistenceVolumes).
-	defer testClient.Core().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
+	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
 
 	stopCh := make(chan struct{})
 	informers.Start(stopCh)
@@ -572,7 +572,7 @@ func TestPersistentVolumeMultiPVsPVCs(t *testing.T) {
 
 	// NOTE: This test cannot run in parallel, because it is creating and deleting
 	// non-namespaced objects (PersistenceVolumes).
-	defer testClient.Core().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
+	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
 
 	controllerStopCh := make(chan struct{})
 	informers.Start(controllerStopCh)
@@ -862,7 +862,7 @@ func TestPersistentVolumeProvisionMultiPVCs(t *testing.T) {
 
 	// NOTE: This test cannot run in parallel, because it is creating and deleting
 	// non-namespaced objects (PersistenceVolumes and StorageClasses).
-	defer testClient.Core().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
+	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
 	defer testClient.StorageV1().StorageClasses().DeleteCollection(nil, metav1.ListOptions{})
 
 	storageClass := storage.StorageClass{
@@ -957,7 +957,7 @@ func TestPersistentVolumeMultiPVsDiffAccessModes(t *testing.T) {
 
 	// NOTE: This test cannot run in parallel, because it is creating and deleting
 	// non-namespaced objects (PersistenceVolumes).
-	defer testClient.Core().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
+	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(nil, metav1.ListOptions{})
 
 	stopCh := make(chan struct{})
 	informers.Start(stopCh)
@@ -1025,7 +1025,7 @@ func TestPersistentVolumeMultiPVsDiffAccessModes(t *testing.T) {
 
 func waitForPersistentVolumePhase(client *clientset.Clientset, pvName string, w watch.Interface, phase v1.PersistentVolumePhase) {
 	// Check if the volume is already in requested phase
-	volume, err := client.Core().PersistentVolumes().Get(pvName, metav1.GetOptions{})
+	volume, err := client.CoreV1().PersistentVolumes().Get(pvName, metav1.GetOptions{})
 	if err == nil && volume.Status.Phase == phase {
 		return
 	}
@@ -1046,7 +1046,7 @@ func waitForPersistentVolumePhase(client *clientset.Clientset, pvName string, w 
 
 func waitForPersistentVolumeClaimPhase(client *clientset.Clientset, claimName, namespace string, w watch.Interface, phase v1.PersistentVolumeClaimPhase) {
 	// Check if the claim is already in requested phase
-	claim, err := client.Core().PersistentVolumeClaims(namespace).Get(claimName, metav1.GetOptions{})
+	claim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(claimName, metav1.GetOptions{})
 	if err == nil && claim.Status.Phase == phase {
 		return
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes the long-deprecated versionless external client interfaces.

As new versions of API groups are added, the version these accessors targets shifts, which can silently make an application target an unintended version when recompiled with a newer client-go library.

**Does this PR introduce a user-facing change?**:
```release-note
client-go: the deprecated versionless API group accessors (like `clientset.Apps()` have been removed). Use an explicit version instead (like `clientset.AppsV1()`)
```

/sig api-machinery
/cc @sttts @lavalamp 