### PR TITLE
kubeadm: fix TestInitConfigurationMarshallingFromFile on Mac

### DIFF
--- a/cmd/kubeadm/app/util/config/initconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration_test.go
@@ -42,6 +42,7 @@ const (
 	masterInternalYAMLNonLinux  = "testdata/conversion/master/internal_non_linux.yaml"
 	masterIncompleteYAML        = "testdata/defaulting/master/incomplete.yaml"
 	masterDefaultedYAML         = "testdata/defaulting/master/defaulted.yaml"
+	masterDefaultedYAMLDarwin   = "testdata/defaulting/master/defaulted_darwin.yaml"
 	masterDefaultedYAMLNonLinux = "testdata/defaulting/master/defaulted_non_linux.yaml"
 	masterInvalidYAML           = "testdata/validation/invalid_mastercfg.yaml"
 )
@@ -145,7 +146,9 @@ func TestInitConfigurationMarshallingFromFile(t *testing.T) {
 	masterV1beta1YAMLAbstracted := masterV1beta1YAML
 	masterInternalYAMLAbstracted := masterInternalYAML
 	masterDefaultedYAMLAbstracted := masterDefaultedYAML
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS == "darwin" {
+		masterDefaultedYAMLAbstracted = masterDefaultedYAMLDarwin
+	} else if runtime.GOOS != "linux" {
 		masterV1alpha3YAMLAbstracted = masterV1alpha3YAMLNonLinux
 		masterV1beta1YAMLAbstracted = masterV1beta1YAMLNonLinux
 		masterInternalYAMLAbstracted = masterInternalYAMLNonLinux

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted_darwin.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted_darwin.yaml
@@ -1,0 +1,155 @@
+apiVersion: kubeadm.k8s.io/v1beta1
+bootstrapTokens:
+- groups:
+  - system:bootstrappers:kubeadm:default-node-token
+  token: s73ybu.6tw6wnqgp5z0wb77
+  ttl: 24h0m0s
+  usages:
+  - signing
+  - authentication
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 192.168.2.2
+  bindPort: 6443
+nodeRegistration:
+  criSocket: /var/run/criruntime.sock
+  name: master-1
+  taints:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+---
+apiServer:
+  timeoutForControlPlane: 4m0s
+apiVersion: kubeadm.k8s.io/v1beta1
+certificatesDir: /var/lib/kubernetes/pki
+clusterName: kubernetes
+controlPlaneEndpoint: ""
+controllerManager: {}
+dns:
+  type: CoreDNS
+etcd:
+  local:
+    dataDir: /var/lib/etcd
+imageRepository: my-company.com
+kind: ClusterConfiguration
+kubernetesVersion: v1.13.0
+networking:
+  dnsDomain: cluster.global
+  podSubnet: 10.148.0.0/16
+  serviceSubnet: 10.196.0.0/12
+scheduler: {}
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+bindAddress: 0.0.0.0
+clientConnection:
+  acceptContentTypes: ""
+  burst: 10
+  contentType: application/vnd.kubernetes.protobuf
+  kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+  qps: 5
+clusterCIDR: 10.148.0.0/16
+configSyncPeriod: 15m0s
+conntrack:
+  max: null
+  maxPerCore: 32768
+  min: 131072
+  tcpCloseWaitTimeout: 1h0m0s
+  tcpEstablishedTimeout: 24h0m0s
+enableProfiling: false
+healthzBindAddress: 0.0.0.0:10256
+hostnameOverride: ""
+iptables:
+  masqueradeAll: false
+  masqueradeBit: 14
+  minSyncPeriod: 0s
+  syncPeriod: 30s
+ipvs:
+  excludeCIDRs: null
+  minSyncPeriod: 0s
+  scheduler: ""
+  syncPeriod: 30s
+kind: KubeProxyConfiguration
+metricsBindAddress: 127.0.0.1:10249
+mode: ""
+nodePortAddresses: null
+oomScoreAdj: -999
+portRange: ""
+resourceContainer: /kube-proxy
+udpIdleTimeout: 250ms
+winkernel:
+  enableDSR: false
+  networkName: ""
+  sourceVip: ""
+---
+address: 0.0.0.0
+apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  anonymous:
+    enabled: false
+  webhook:
+    cacheTTL: 2m0s
+    enabled: true
+  x509:
+    clientCAFile: /etc/kubernetes/pki/ca.crt
+authorization:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: 5m0s
+    cacheUnauthorizedTTL: 30s
+cgroupDriver: cgroupfs
+cgroupsPerQOS: true
+clusterDNS:
+- 10.192.0.10
+clusterDomain: cluster.global
+configMapAndSecretChangeDetectionStrategy: Watch
+containerLogMaxFiles: 5
+containerLogMaxSize: 10Mi
+contentType: application/vnd.kubernetes.protobuf
+cpuCFSQuota: true
+cpuCFSQuotaPeriod: 100ms
+cpuManagerPolicy: none
+cpuManagerReconcilePeriod: 10s
+enableControllerAttachDetach: true
+enableDebuggingHandlers: true
+enforceNodeAllocatable:
+- pods
+eventBurst: 10
+eventRecordQPS: 5
+evictionHard:
+  imagefs.available: 15%
+  memory.available: 100Mi
+  nodefs.available: 10%
+evictionPressureTransitionPeriod: 5m0s
+failSwapOn: true
+fileCheckFrequency: 20s
+hairpinMode: promiscuous-bridge
+healthzBindAddress: 127.0.0.1
+healthzPort: 10248
+httpCheckFrequency: 20s
+imageGCHighThresholdPercent: 85
+imageGCLowThresholdPercent: 80
+imageMinimumGCAge: 2m0s
+iptablesDropBit: 15
+iptablesMasqueradeBit: 14
+kind: KubeletConfiguration
+kubeAPIBurst: 10
+kubeAPIQPS: 5
+makeIPTablesUtilChains: true
+maxOpenFiles: 1000000
+maxPods: 110
+nodeLeaseDurationSeconds: 40
+nodeStatusReportFrequency: 1m0s
+nodeStatusUpdateFrequency: 10s
+oomScoreAdj: -999
+podPidsLimit: -1
+port: 10250
+registryBurst: 10
+registryPullQPS: 5
+resolvConf: /etc/resolv.conf
+rotateCertificates: true
+runtimeRequestTimeout: 2m0s
+serializeImagePulls: true
+staticPodPath: /etc/kubernetes/manifests
+streamingConnectionIdleTimeout: 4h0m0s
+syncFrequency: 1m0s
+volumeStatsAggPeriod: 1m0s


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

3 test cases of TestInitConfigurationMarshallingFromFile fail showing
this difference between expected and actual output:
```
   --- expected
   +++ actual
   @@ -67,6 +67,10 @@
        PortRange: ""
        ResourceContainer: /kube-proxy
        UDPIdleTimeout: 250ms
   +    Winkernel:
   +      EnableDSR: false
   +      NetworkName: ""
   +      SourceVip: ""
      Kubelet:
        Address: 1.2.3.4
        Authentication:
```

Fixed test code and added one test YAML specific to Mac to solve this.

**Special notes for your reviewer**:
Surprisingly the rest of kubeadm tests worked just fine on Mac, which makes it a great platform for developing kubernetes and kubeadm in particular.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```