### PR TITLE
Promote spiffxp to approver for cluster/

### DIFF
--- a/cluster/OWNERS
+++ b/cluster/OWNERS
@@ -4,15 +4,16 @@ reviewers:
   - bentheelder
   - eparis
   - jbeda
+  - Katharine
   - mikedanese
   - roberthbailey
-  - spiffxp
   - zmerlynn
 approvers:
   - eparis
   - jbeda
   - mikedanese
   - roberthbailey
+  - spiffxp
   - zmerlynn
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
I've been a reviewer for ~6 months, I think it's time I move on to
approver. My goal is to get more review bandwidth on this dir, and IMO
at least some of it should be coming from sig-testing.

Since I'm going up I'd like to mentor someone behind and am nominating
Katharine as a reviewer

/release-note-none
/kind cleanup
/sig testing
/sig cluster-lifecycle