### PR TITLE
Disable Windows Defender on Windows nodes.

### DIFF
--- a/cluster/gce/windows/common.psm1
+++ b/cluster/gce/windows/common.psm1
@@ -146,5 +146,20 @@ function MustDownload-File {
   }
 }
 
+# Returns true if this node is part of a test cluster (see
+# cluster/gce/config-test.sh). $KubeEnv is a hash table containing the kube-env
+# metadata keys+values.
+function Test-IsTestCluster {
+  param (
+    [parameter(Mandatory=$true)] [hashtable]$KubeEnv
+  )
+
+  if ($KubeEnv.Contains('TEST_CLUSTER') -and `
+      ($KubeEnv['TEST_CLUSTER'] -eq 'true')) {
+    return $true
+  }
+  return $false
+}
+
 # Export all public functions:
 Export-ModuleMember -Function *-*

--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -77,18 +77,6 @@ function FetchAndImport-ModuleFromMetadata {
   Import-Module -Force C:\$Filename
 }
 
-# Returns true if this node is part of a test cluster (see
-# cluster/gce/config-test.sh).
-#
-# $kube_env must be set before calling this function.
-function Test-IsTestCluster {
-  if ($kube_env.Contains('TEST_CLUSTER') -and `
-      ($kube_env['TEST_CLUSTER'] -eq 'true')) {
-    return $true
-  }
-  return $false
-}
-
 try {
   # Don't use FetchAndImport-ModuleFromMetadata for common.psm1 - the common
   # module includes variables and functions that any other function may depend
@@ -104,8 +92,9 @@ try {
 
   Set-PrerequisiteOptions
   $kube_env = Fetch-KubeEnv
+  Disable-WindowsDefender
 
-  if (Test-IsTestCluster) {
+  if (Test-IsTestCluster $kube_env) {
     Log-Output 'Test cluster detected, installing OpenSSH.'
     FetchAndImport-ModuleFromMetadata 'install-ssh-psm1' 'install-ssh.psm1'
     InstallAndStart-OpenSsh


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
This PR disables Windows Defender on the Windows nodes in test clusters on GCE. Windows Defender's behavior is unpredictable and it has caused flakiness in our test clusters, including Windows crashes and node reboots in severe cases.

Windows Defender is only disabled if the node is detected to be part of an e2e test cluster. For these clusters we assume that the GCP firewall is sufficient. Disabling Windows Defender may or may not be advisable for production clusters.

We've been running a variant of this code in our fork (https://github.com/pjh/kubernetes/tree/windows-up) for a few days: https://testgrid.k8s.io/google-windows#windows-prototype&width=20.

```release-note
NONE
```