### PR TITLE
Explicitly set GVK when sending objects to webhooks

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion.go
@@ -37,5 +37,7 @@ func ConvertToGVK(obj runtime.Object, gvk schema.GroupVersionKind, o admission.O
 	if err != nil {
 		return nil, err
 	}
+	// Explicitly set the GVK
+	out.GetObjectKind().SetGroupVersionKind(gvk)
 	return out, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion_test.go
@@ -62,6 +62,10 @@ func TestConvertToGVK(t *testing.T) {
 			},
 			gvk: examplev1.SchemeGroupVersion.WithKind("Pod"),
 			expectedObj: &examplev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "example.apiserver.k8s.io/v1",
+					Kind:       "Pod",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod1",
 					Labels: map[string]string{
@@ -87,6 +91,10 @@ func TestConvertToGVK(t *testing.T) {
 			},
 			gvk: example2v1.SchemeGroupVersion.WithKind("ReplicaSet"),
 			expectedObj: &example2v1.ReplicaSet{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "example2.apiserver.k8s.io/v1",
+					Kind:       "ReplicaSet",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "rs1",
 					Labels: map[string]string{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When sending typed objects (e.g. pods, configmaps, etc) to admission webhooks, the object/oldObject was missing an apiVersion/kind field.

**Which issue(s) this PR fixes**:
Fixes #74373 

(will pick to release branches after review/merge)

**Does this PR introduce a user-facing change?**:
```release-note
Fixes an issue with missing apiVersion/kind in object data sent to admission webhooks
```

/sig api-machinery
/cc @mbohlool 