### PR TITLE
kubeadm: fix url validation code

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -321,11 +321,15 @@ func ValidateURLs(urls []string, requireHTTPS bool, fldPath *field.Path) field.E
 	allErrs := field.ErrorList{}
 	for _, urlstr := range urls {
 		u, err := url.Parse(urlstr)
-		if err != nil || u.Scheme == "" {
-			allErrs = append(allErrs, field.Invalid(fldPath, urlstr, "not a valid URL"))
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath, urlstr, fmt.Sprintf("URL parse error: %v", err)))
+			continue
 		}
 		if requireHTTPS && u.Scheme != "https" {
 			allErrs = append(allErrs, field.Invalid(fldPath, urlstr, "the URL must be using the HTTPS scheme"))
+		}
+		if u.Scheme == "" {
+			allErrs = append(allErrs, field.Invalid(fldPath, urlstr, "the URL without scheme is not allowed"))
 		}
 	}
 	return allErrs
@@ -476,7 +480,7 @@ func ValidateSocketPath(socket string, fldPath *field.Path) field.ErrorList {
 
 	u, err := url.Parse(socket)
 	if err != nil {
-		return append(allErrs, field.Invalid(fldPath, socket, fmt.Sprintf("url parsing error: %v", err)))
+		return append(allErrs, field.Invalid(fldPath, socket, fmt.Sprintf("URL parsing error: %v", err)))
 	}
 
 	if u.Scheme == "" {
@@ -484,7 +488,7 @@ func ValidateSocketPath(socket string, fldPath *field.Path) field.ErrorList {
 			return append(allErrs, field.Invalid(fldPath, socket, fmt.Sprintf("path is not absolute: %s", socket)))
 		}
 	} else if u.Scheme != kubeadmapiv1beta1.DefaultUrlScheme {
-		return append(allErrs, field.Invalid(fldPath, socket, fmt.Sprintf("url scheme %s is not supported", u.Scheme)))
+		return append(allErrs, field.Invalid(fldPath, socket, fmt.Sprintf("URL scheme %s is not supported", u.Scheme)))
 	}
 
 	return allErrs


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixed nil pointer dereference in url validation code that
caused kubeamd panic:

  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xa7930c]

  goroutine 1 [running]:
  kubeadm/validation.ValidateURLs(0x40000bafe0, 0x2, 0x2, 0x1, 0x40002967b0, 0x0, 0x40002967b0, 0xf302a0)
    kubeadm/validation/validation.go:324 +0xcc
  kubeadm/validation.ValidateEtcd(0x400000b490, 0x4000296720, 0x0, 0x0, 0x0)
    kubeadm/validation/validation.go:291 +0x1f0
      ...

**Which issue(s) this PR fixes**:

Fixes kubernetes/kubeadm#1419

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: fixed nil pointer dereference caused by a bug in url parsing
```