### PR TITLE
Fix shellcheck lint errors in cluster and hack scripts

### DIFF
--- a/cluster/gce/gci/node-helper.sh
+++ b/cluster/gce/gci/node-helper.sh
@@ -33,9 +33,13 @@ function get-node-instance-metadata-from-file {
   echo "${metadata}"
 }
 
-# $1: template name (required).
+# Assumed vars:
+#   scope_flags
+# Parameters:
+#   $1: template name (required).
 function create-linux-node-instance-template {
   local template_name="$1"
   ensure-gci-metadata-files
+  # shellcheck disable=2154 # 'scope_flags' is assigned by upstream
   create-node-template "${template_name}" "${scope_flags[*]}" "$(get-node-instance-metadata-from-file)" "" "linux"
 }

--- a/cluster/update-storage-objects.sh
+++ b/cluster/update-storage-objects.sh
@@ -25,7 +25,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 KUBECTL="${KUBE_OUTPUT_HOSTBIN}/kubectl"
@@ -57,7 +57,7 @@ declare -a resources=(
 )
 
 # Find all the namespaces.
-namespaces=( $("${KUBECTL}" get namespaces -o go-template="{{range.items}}{{.metadata.name}} {{end}}"))
+IFS=" " read -r -a namespaces <<< "$("${KUBECTL}" get namespaces -o go-template="{{range.items}}{{.metadata.name}} {{end}}")"
 if [ -z "${namespaces:-}" ]
 then
   echo "Unexpected: No namespace found. Nothing to do."
@@ -74,7 +74,7 @@ do
     # TODO hopefully we can remove this once we use dynamic discovery of gettable/updateable
     # resources.
     set +e
-    instances=( $("${KUBECTL}" get "${resource}" --namespace="${namespace}" -o go-template="{{range.items}}{{.metadata.name}} {{end}}"))
+    IFS=" " read -r -a instances <<< "$("${KUBECTL}" get "${resource}" --namespace="${namespace}" -o go-template="{{range.items}}{{.metadata.name}} {{end}}")"
     result=$?
     set -e
 

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -12,7 +12,6 @@
 ./cluster/gce/gci/health-monitor.sh
 ./cluster/gce/gci/master-helper.sh
 ./cluster/gce/gci/mounter/stage-upload.sh
-./cluster/gce/gci/node-helper.sh
 ./cluster/gce/gci/shutdown.sh
 ./cluster/gce/list-resources.sh
 ./cluster/gce/upgrade-aliases.sh
@@ -34,7 +33,6 @@
 ./cluster/test-e2e.sh
 ./cluster/test-network.sh
 ./cluster/test-smoke.sh
-./cluster/update-storage-objects.sh
 ./cluster/validate-cluster.sh
 ./hack/cherry_pick_pull.sh
 ./hack/generate-bindata.sh
@@ -79,7 +77,6 @@
 ./hack/update-generated-kms-dockerized.sh
 ./hack/update-generated-protobuf-dockerized.sh
 ./hack/update-generated-runtime-dockerized.sh
-./hack/update-generated-runtime.sh
 ./hack/update-godep-licenses.sh
 ./hack/update-gofmt.sh
 ./hack/update-openapi-spec.sh

--- a/hack/update-generated-runtime.sh
+++ b/hack/update-generated-runtime.sh
@@ -18,12 +18,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # NOTE: All output from this script needs to be copied back to the calling
 # source tree.  This is managed in kube::build::copy_output in build/common.sh.
 # If the output set is changed update that function.
 
-${KUBE_ROOT}/build/run.sh hack/update-generated-runtime-dockerized.sh "$@"
+"${KUBE_ROOT}/build/run.sh" hack/update-generated-runtime-dockerized.sh "$@"
 
 # ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix shellcheck lint errors in cluster and hack scripts:
```
cluster/gce/gci/node-helper.sh
cluster/update-storage-objects.sh
hack/update-generated-runtime.sh
```

**Which issue(s) this PR fixes**:
Ref #72956

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```