### PR TITLE
kubeadm: fix issue with missing kubeproxy fields in test data

### DIFF
--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/internal_non_linux.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/internal_non_linux.yaml
@@ -67,6 +67,10 @@ ComponentConfigs:
     PortRange: ""
     ResourceContainer: /kube-proxy
     UDPIdleTimeout: 250ms
+    Winkernel:
+      EnableDSR: false
+      NetworkName: ""
+      SourceVip: ""
   Kubelet:
     Address: 1.2.3.4
     Authentication:

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha3.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha3.yaml
@@ -89,6 +89,10 @@ oomScoreAdj: -999
 portRange: ""
 resourceContainer: /kube-proxy
 udpIdleTimeout: 250ms
+winkernel:
+  enableDSR: false
+  networkName: ""
+  sourceVip: ""
 ---
 address: 1.2.3.4
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha3_non_linux.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha3_non_linux.yaml
@@ -89,6 +89,10 @@ oomScoreAdj: -999
 portRange: ""
 resourceContainer: /kube-proxy
 udpIdleTimeout: 250ms
+winkernel:
+  enableDSR: false
+  networkName: ""
+  sourceVip: ""
 ---
 address: 1.2.3.4
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/v1beta1_non_linux.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/v1beta1_non_linux.yaml
@@ -90,6 +90,10 @@ oomScoreAdj: -999
 portRange: ""
 resourceContainer: /kube-proxy
 udpIdleTimeout: 250ms
+winkernel:
+  enableDSR: false
+  networkName: ""
+  sourceVip: ""
 ---
 address: 1.2.3.4
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted_non_linux.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted_non_linux.yaml
@@ -76,6 +76,10 @@ oomScoreAdj: -999
 portRange: ""
 resourceContainer: /kube-proxy
 udpIdleTimeout: 250ms
+winkernel:
+  enableDSR: false
+  networkName: ""
+  sourceVip: ""
 ---
 address: 0.0.0.0
 apiVersion: kubelet.config.k8s.io/v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch introduced changes in kubeproxy's v1alpha1 that did were not reflected completely in our test data files for non-linux platforms:
https://github.com/kubernetes/kubernetes/commit/164f79e2d4321dbf00c56345b20b015e856a497e

The change should be applied for both linux and non-linux platforms.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @bart0sh @yagonobre 
please test if this works for you on OSX.

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/kind bug
/priority important-longterm
