### PR TITLE
bazel: create genrules to produce debs and RPMs without arch-specific names

### DIFF
--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -21,32 +21,38 @@ release_filegroup(
     name = "debs",
     conditioned_srcs = for_platforms(
         default = [],
-        for_client = [":kubectl-{ARCH}.deb"],
+        for_client = [":kubectl.deb"],
         for_node = [
-            ":cri-tools-{ARCH}.deb",
-            ":kubeadm-{ARCH}.deb",
-            ":kubelet-{ARCH}.deb",
-            ":kubernetes-cni-{ARCH}.deb",
+            ":cri-tools.deb",
+            ":kubeadm.deb",
+            ":kubelet.deb",
+            ":kubernetes-cni.deb",
         ],
         only_os = "linux",
     ),
 )
 
-# Create aliases from the non-arch names to the arch-specific names for backwards compatibility
-alias(
+# Create genrules to copy the arch-specific debs to debs without the arch in their filename.
+genrule(
     name = "kubectl",
-    actual = select(for_platforms(
-        for_client = ":kubectl-{ARCH}",
+    srcs = select(for_platforms(
+        for_client = [":kubectl-{ARCH}.deb"],
         only_os = "linux",
     )),
+    outs = ["kubectl.deb"],
+    cmd = "cp $< $@",
+    output_to_bindir = True,
 )
 
-[alias(
+[genrule(
     name = pkg,
-    actual = select(for_platforms(
-        for_node = ":%s-{ARCH}" % pkg,
+    srcs = select(for_platforms(
+        for_node = [":%s-{ARCH}.deb" % pkg],
         only_os = "linux",
     )),
+    outs = ["%s.deb" % pkg],
+    cmd = "cp $< $@",
+    output_to_bindir = True,
 ) for pkg in [
     "cri-tools",
     "kubeadm",

--- a/build/rpms/BUILD
+++ b/build/rpms/BUILD
@@ -9,12 +9,12 @@ release_filegroup(
     name = "rpms",
     conditioned_srcs = for_platforms(
         default = [],
-        for_client = [":kubectl-{ARCH}"],
+        for_client = [":kubectl.rpm"],
         for_node = [
-            ":cri-tools-{ARCH}",
-            ":kubeadm-{ARCH}",
-            ":kubelet-{ARCH}",
-            ":kubernetes-cni-{ARCH}",
+            ":cri-tools.rpm",
+            ":kubeadm.rpm",
+            ":kubelet.rpm",
+            ":kubernetes-cni.rpm",
         ],
         only_os = "linux",
     ),
@@ -22,21 +22,27 @@ release_filegroup(
     visibility = ["//visibility:public"],
 )
 
-# Create aliases from the non-arch names to the arch-specific names for backwards compatibility
-alias(
+# Create genrules to copy the arch-specific RPMs to RPMs without the arch in their filename.
+genrule(
     name = "kubectl",
-    actual = select(for_platforms(
-        for_client = ":kubectl-{ARCH}",
+    srcs = select(for_platforms(
+        for_client = [":kubectl-{ARCH}.rpm"],
         only_os = "linux",
     )),
+    outs = ["kubectl.rpm"],
+    cmd = "cp $< $@",
+    output_to_bindir = True,
 )
 
-[alias(
+[genrule(
     name = pkg,
-    actual = select(for_platforms(
-        for_client = ":%s-{ARCH}" % pkg,
+    srcs = select(for_platforms(
+        for_client = [":%s-{ARCH}.rpm" % pkg],
         only_os = "linux",
     )),
+    outs = ["%s.rpm" % pkg],
+    cmd = "cp $< $@",
+    output_to_bindir = True,
 ) for pkg in [
     "cri-tools",
     "kubeadm",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**: this is a follow-up to #73930.

In that PR I implemented support for cross-compilation using Bazel.

One issue I ran into is that the `pkg_deb` and `pkg_rpm` rules have an `architecture` attribute which is used in their package metadata, but is also used in the output filenames. (For example, `pkg_deb` actually creates both a `$NAME.deb` and a `$NAME-$ARCH.deb`.) Bazel disallows output filenames to be configured - you can't do something like
```python
  out = select(...),
```
and similarly disallows configuring attributes which affect output filenames (like `architecture`).

To work around this, instead of configuring the `architecture` attribute, I used macros and list comprehensions to create multiple rules, each with a `-$ARCHITECTURE` suffix in their name.
This meant that the debs and RPMs now had different filenames.

I created `alias`es to maintain the old target names, but these `alias`es had no effect on the output filenames. Thus downstream projects like Kind were broken, as the debs had new filenames.

In this PR I'm basically restoring the old end-user functionality by replacing the `alias`es with simple `genrule`s that copy to the non-arched filename. The arch-specific outputs still exist, but are generally to be used indirectly.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kind/issues/336

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @BenTheElder 
cc @neolit123 