### PR TITLE
[WIP]Use k8s's own function to provide data for resource metrics endpoint rather than cAdvisor

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -84,6 +84,7 @@ go_library(
         "//pkg/kubelet/server/portforward:go_default_library",
         "//pkg/kubelet/server/remotecommand:go_default_library",
         "//pkg/kubelet/server/stats:go_default_library",
+        "//pkg/kubelet/server/stats/resourcemetrics:go_default_library",
         "//pkg/kubelet/server/streaming:go_default_library",
         "//pkg/kubelet/stats:go_default_library",
         "//pkg/kubelet/status:go_default_library",

--- a/pkg/kubelet/cm/BUILD
+++ b/pkg/kubelet/cm/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/github.com/opencontainers/runc/libcontainer/cgroups:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
@@ -84,7 +85,6 @@ go_library(
             "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
             "//staging/src/k8s.io/client-go/tools/record:go_default_library",
             "//vendor/github.com/docker/go-units:go_default_library",
-            "//vendor/github.com/opencontainers/runc/libcontainer/cgroups:go_default_library",
             "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
             "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd:go_default_library",
             "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",

--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -591,3 +591,13 @@ func (m *cgroupManagerImpl) GetResourceStats(name CgroupName) (*ResourceStats, e
 	}
 	return toResourceStats(stats), nil
 }
+
+func (m *cgroupManagerImpl) GetResourceMetrics(cgroupName CgroupName) (*libcontainercgroups.Stats, time.Time, error) {
+	stats := libcontainercgroups.NewStats()
+	memMountPoint := path.Join(m.subsystems.MountPoints["memory"], m.Name(cgroupName))
+	cpuMountPoint := path.Join(m.subsystems.MountPoints["cpu"], m.Name(cgroupName))
+	startTime := time.Now()
+	(&cgroupfs.MemoryGroup{}).GetStats(memMountPoint, stats)
+	(&cgroupfs.CpuacctGroup{}).GetStats(cpuMountPoint, stats)
+	return stats, startTime, nil
+}

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	// TODO: Migrate kubelet to either use its own internal objects or client library.
+	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	"k8s.io/api/core/v1"
 	internalapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
 	podresourcesapi "k8s.io/kubernetes/pkg/kubelet/apis/podresources/v1alpha1"
@@ -104,6 +105,8 @@ type ContainerManager interface {
 
 	// GetDevices returns information about the devices assigned to pods and containers
 	GetDevices(podUID, containerName string) []*podresourcesapi.ContainerDevices
+
+	GetResourceMetrics(cgroupName CgroupName) (*libcontainercgroups.Stats, time.Time, error)
 }
 
 type NodeConfig struct {

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -897,3 +897,7 @@ func (cm *containerManagerImpl) GetDevicePluginResourceCapacity() (v1.ResourceLi
 func (cm *containerManagerImpl) GetDevices(podUID, containerName string) []*podresourcesapi.ContainerDevices {
 	return cm.deviceManager.GetDevices(podUID, containerName)
 }
+
+func (cm *containerManagerImpl) GetResourceMetrics(cgroupName CgroupName) (*cgroups.Stats, time.Time, error) {
+	return cm.cgroupManager.GetResourceMetrics(cgroupName)
+}

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -17,9 +17,12 @@ limitations under the License.
 package cm
 
 import (
+	"time"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/klog"
 
+	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	"k8s.io/apimachinery/pkg/api/resource"
 	internalapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
 	podresourcesapi "k8s.io/kubernetes/pkg/kubelet/apis/podresources/v1alpha1"
@@ -76,6 +79,10 @@ func (cm *containerManagerStub) GetCapacity() v1.ResourceList {
 			resource.BinarySI),
 	}
 	return c
+}
+
+func (cm *containerManagerStub) GetResourceMetrics(cgroupName CgroupName) (*libcontainercgroups.Stats, time.Time, error) {
+	return nil, time.Now(), nil
 }
 
 func (cm *containerManagerStub) GetPluginRegistrationHandler() pluginwatcher.PluginHandler {

--- a/pkg/kubelet/cm/pod_container_manager_stub.go
+++ b/pkg/kubelet/cm/pod_container_manager_stub.go
@@ -53,3 +53,7 @@ func (m *podContainerManagerStub) GetAllPodsFromCgroups() (map[types.UID]CgroupN
 func (m *podContainerManagerStub) IsPodCgroup(cgroupfs string) (bool, types.UID) {
 	return false, types.UID("")
 }
+
+func (m *podContainerManagerStub) GetAllPodsContainersFromCgroups() ([]CgroupName, error) {
+	return nil, nil
+}

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package cm
 
 import (
+	"time"
+
+	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -92,6 +95,7 @@ type CgroupManager interface {
 	ReduceCPULimits(cgroupName CgroupName) error
 	// GetResourceStats returns statistics of the specified cgroup as read from the cgroup fs.
 	GetResourceStats(name CgroupName) (*ResourceStats, error)
+	GetResourceMetrics(cgroupName CgroupName) (*libcontainercgroups.Stats, time.Time, error)
 }
 
 // QOSContainersInfo stores the names of containers per qos
@@ -124,6 +128,8 @@ type PodContainerManager interface {
 
 	// GetAllPodsFromCgroups enumerates the set of pod uids to their associated cgroup based on state of cgroupfs system.
 	GetAllPodsFromCgroups() (map[types.UID]CgroupName, error)
+
+	GetAllPodsContainersFromCgroups() ([]CgroupName, error)
 
 	// IsPodCgroup returns true if the literal cgroupfs name corresponds to a pod
 	IsPodCgroup(cgroupfs string) (bool, types.UID)

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -291,7 +291,7 @@ func (s *Server) InstallDefaultHandlers() {
 		Operation("getPods"))
 	s.restfulCont.Add(ws)
 
-	s.restfulCont.Add(stats.CreateHandlers(statsPath, s.host, s.resourceAnalyzer))
+	s.restfulCont.Add(stats.CreateHandlers(statsPath, s.host, s.resourceAnalyzer, s.resourceAnalyzer))
 	s.restfulCont.Handle(metricsPath, prometheus.Handler())
 
 	// cAdvisor metrics are exposed under the secured handler as well
@@ -313,7 +313,7 @@ func (s *Server) InstallDefaultHandlers() {
 	)
 
 	v1alpha1ResourceRegistry := prometheus.NewRegistry()
-	v1alpha1ResourceRegistry.MustRegister(stats.NewPrometheusResourceMetricCollector(s.resourceAnalyzer, v1alpha1.Config()))
+	v1alpha1ResourceRegistry.MustRegister(stats.NewPrometheusCoreCollector(s.resourceAnalyzer, v1alpha1.Config()))
 	s.restfulCont.Handle(path.Join(resourceMetricsPathPrefix, v1alpha1.Version),
 		promhttp.HandlerFor(v1alpha1ResourceRegistry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}),
 	)

--- a/pkg/kubelet/server/stats/BUILD
+++ b/pkg/kubelet/server/stats/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/kubelet/apis/stats/v1alpha1:go_default_library",
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/container:go_default_library",
+        "//pkg/kubelet/server/stats/resourcemetrics:go_default_library",
         "//pkg/kubelet/util:go_default_library",
         "//pkg/kubelet/util/format:go_default_library",
         "//pkg/volume:go_default_library",
@@ -113,6 +114,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/kubelet/server/stats/resourcemetrics:all-srcs",
         "//pkg/kubelet/server/stats/testing:all-srcs",
     ],
     tags = ["automanaged"],

--- a/pkg/kubelet/server/stats/prometheus_resource_metrics_test.go
+++ b/pkg/kubelet/server/stats/prometheus_resource_metrics_test.go
@@ -295,7 +295,7 @@ func TestCollectResourceMetrics(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			provider := &mockSummaryProvider{}
 			provider.On("GetCPUAndMemoryStats").Return(tc.summary, tc.summaryErr)
-			collector := NewPrometheusResourceMetricCollector(provider, tc.config)
+			collector := NewPrometheusCoreCollector(provider, tc.config)
 			metrics := collectMetrics(t, collector, len(tc.expectedMetrics))
 			for i := range metrics {
 				assertEqual(t, metrics[i], tc.expectedMetrics[i])

--- a/pkg/kubelet/server/stats/resource_analyzer.go
+++ b/pkg/kubelet/server/stats/resource_analyzer.go
@@ -18,6 +18,8 @@ package stats
 
 import (
 	"time"
+
+	"k8s.io/kubernetes/pkg/kubelet/server/stats/resourcemetrics"
 )
 
 // ResourceAnalyzer provides statistics on node resource consumption
@@ -26,21 +28,23 @@ type ResourceAnalyzer interface {
 
 	fsResourceAnalyzerInterface
 	SummaryProvider
+	resourcemetrics.ResourceMetricsProvider
 }
 
 // resourceAnalyzer implements ResourceAnalyzer
 type resourceAnalyzer struct {
 	*fsResourceAnalyzer
 	SummaryProvider
+	resourcemetrics.ResourceMetricsProvider
 }
 
 var _ ResourceAnalyzer = &resourceAnalyzer{}
 
 // NewResourceAnalyzer returns a new ResourceAnalyzer
-func NewResourceAnalyzer(statsProvider Provider, calVolumeFrequency time.Duration) ResourceAnalyzer {
+func NewResourceAnalyzer(statsProvider Provider, mp resourcemetrics.ResourceMetricsProvider, calVolumeFrequency time.Duration) ResourceAnalyzer {
 	fsAnalyzer := newFsResourceAnalyzer(statsProvider, calVolumeFrequency)
 	summaryProvider := NewSummaryProvider(statsProvider)
-	return &resourceAnalyzer{fsAnalyzer, summaryProvider}
+	return &resourceAnalyzer{fsAnalyzer, summaryProvider, mp}
 }
 
 // Start starts background functions necessary for the ResourceAnalyzer to function

--- a/pkg/kubelet/server/stats/resourcemetrics/BUILD
+++ b/pkg/kubelet/server/stats/resourcemetrics/BUILD
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "cri_resource_metrics.go",
+        "helper.go",
+        "resource_metrics.go",
+    ],
+    importpath = "k8s.io/kubernetes/pkg/kubelet/server/stats/resourcemetrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/kubelet/apis/cri:go_default_library",
+        "//pkg/kubelet/apis/cri/runtime/v1alpha2:go_default_library",
+        "//pkg/kubelet/apis/stats/v1alpha1:go_default_library",
+        "//pkg/kubelet/cm:go_default_library",
+        "//pkg/kubelet/leaky:go_default_library",
+        "//pkg/kubelet/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
+        "//vendor/github.com/google/cadvisor/info/v2:go_default_library",
+        "//vendor/github.com/opencontainers/runc/libcontainer/cgroups:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/kubelet/server/stats/resourcemetrics/cri_resource_metrics.go
+++ b/pkg/kubelet/server/stats/resourcemetrics/cri_resource_metrics.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package resourcemetrics
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	internalapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+	summary "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
+	"k8s.io/kubernetes/pkg/kubelet/leaky"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+)
+
+type criCoreMetricsProvider struct {
+	cm             cm.ContainerManager
+	runtimeService internalapi.RuntimeService
+}
+
+func NewCRIMetricsProvider(cm cm.ContainerManager, rs internalapi.RuntimeService) ResourceMetricsProvider {
+	return &criCoreMetricsProvider{cm, rs}
+}
+
+func (cp *criCoreMetricsProvider) GetMetrics() (*summary.Summary, error) {
+	resp, err := cp.runtimeService.ListContainerStats(&runtimeapi.ContainerStatsFilter{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list all container stats: %v", err)
+	}
+
+	podToStats := map[summary.PodReference]*summary.PodStats{}
+	for _, stats := range resp {
+		containerName := kubetypes.GetContainerName(stats.Attributes.Labels)
+		if containerName == leaky.PodInfraContainerName || containerName == "" {
+			//jump infrastructure container
+			continue
+		}
+		cpuStats := &summary.CPUStats{
+			UsageCoreNanoSeconds: uint64Ptr(stats.Cpu.UsageCoreNanoSeconds.Value),
+			Time:                 metav1.NewTime(time.Unix(0, stats.Cpu.Timestamp)),
+		}
+		memoryStats := &summary.MemoryStats{
+			WorkingSetBytes: uint64Ptr(stats.Memory.WorkingSetBytes.Value),
+			Time:            metav1.NewTime(time.Unix(0, stats.Memory.Timestamp)),
+		}
+
+		ref := buildPodRef(stats.Attributes.Labels)
+		podStats, found := podToStats[ref]
+		if !found {
+			podStats = &summary.PodStats{PodRef: ref}
+			podToStats[ref] = podStats
+		}
+
+		podStats.Containers = append(podStats.Containers, summary.ContainerStats{
+			// TODO: which timestamp should we use?
+			StartTime: metav1.NewTime(time.Unix(0, stats.Cpu.Timestamp)),
+			Name:      containerName,
+			CPU:       cpuStats,
+			Memory:    memoryStats,
+		})
+	}
+
+	// Extract node info from root cgroup
+	cpu, memory, time, err := extractContainerInfo(cm.CgroupName([]string{}), cp.cm)
+	if err != nil {
+		return nil, err
+	}
+	nodeStats := summary.NodeStats{
+		CPU:       cpu,
+		Memory:    memory,
+		StartTime: metav1.NewTime(time),
+	}
+
+	p := []summary.PodStats{}
+	for _, ps := range podToStats {
+		p = append(p, *ps)
+	}
+	return &summary.Summary{Pods: p, Node: nodeStats}, nil
+}

--- a/pkg/kubelet/server/stats/resourcemetrics/helper.go
+++ b/pkg/kubelet/server/stats/resourcemetrics/helper.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcemetrics
+
+import (
+	"k8s.io/klog"
+	"regexp"
+	"time"
+
+	infov1 "github.com/google/cadvisor/info/v1"
+	info "github.com/google/cadvisor/info/v2"
+	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	summary "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+)
+
+func containerNameToDockerId(cn cm.CgroupName) string {
+	var dockerCgroupRegexp = regexp.MustCompile(`([a-z0-9]{64})`)
+	if matches := dockerCgroupRegexp.FindStringSubmatch(cn.ToCgroupfs()); matches != nil {
+		return matches[1]
+	}
+	return cn.ToCgroupfs()
+}
+
+func isPodManagedContainer(labels map[string]string) bool {
+	podName := kubetypes.GetPodName(labels)
+	podNamespace := kubetypes.GetPodNamespace(labels)
+	managed := podName != "" && podNamespace != ""
+	if !managed && podName != podNamespace {
+		klog.Warningf(
+			"Expect container to have either both podName (%s) and podNamespace (%s) labels, or neither.",
+			podName, podNamespace)
+	}
+	return managed
+}
+func setCpuStats(s *libcontainercgroups.Stats, ret *infov1.CpuStats) {
+	ret.Usage.User = s.CpuStats.CpuUsage.UsageInUsermode
+	ret.Usage.System = s.CpuStats.CpuUsage.UsageInKernelmode
+	ret.Usage.Total = s.CpuStats.CpuUsage.TotalUsage
+	ret.CFS.Periods = s.CpuStats.ThrottlingData.Periods
+	ret.CFS.ThrottledPeriods = s.CpuStats.ThrottlingData.ThrottledPeriods
+	ret.CFS.ThrottledTime = s.CpuStats.ThrottlingData.ThrottledTime
+}
+
+func setMemoryStats(s *libcontainercgroups.Stats, ret *infov1.MemoryStats) {
+	ret.Usage = s.MemoryStats.Usage.Usage
+	ret.MaxUsage = s.MemoryStats.Usage.MaxUsage
+	ret.Failcnt = s.MemoryStats.Usage.Failcnt
+
+	if s.MemoryStats.UseHierarchy {
+		ret.Cache = s.MemoryStats.Stats["total_cache"]
+		ret.RSS = s.MemoryStats.Stats["total_rss"]
+		ret.Swap = s.MemoryStats.Stats["total_swap"]
+		ret.MappedFile = s.MemoryStats.Stats["total_mapped_file"]
+	} else {
+		ret.Cache = s.MemoryStats.Stats["cache"]
+		ret.RSS = s.MemoryStats.Stats["rss"]
+		ret.Swap = s.MemoryStats.Stats["swap"]
+		ret.MappedFile = s.MemoryStats.Stats["mapped_file"]
+	}
+	if v, ok := s.MemoryStats.Stats["pgfault"]; ok {
+		ret.ContainerData.Pgfault = v
+		ret.HierarchicalData.Pgfault = v
+	}
+	if v, ok := s.MemoryStats.Stats["pgmajfault"]; ok {
+		ret.ContainerData.Pgmajfault = v
+		ret.HierarchicalData.Pgmajfault = v
+	}
+
+	workingSet := ret.Usage
+	if v, ok := s.MemoryStats.Stats["total_inactive_file"]; ok {
+		if workingSet < v {
+			workingSet = 0
+		} else {
+			workingSet -= v
+		}
+	}
+	ret.WorkingSet = workingSet
+}
+
+func cadvisorInfoToCPUandMemoryStats(stats *info.ContainerStats) (*summary.CPUStats, *summary.MemoryStats) {
+	var cpuStats *summary.CPUStats
+	var memoryStats *summary.MemoryStats
+	cpuStats = &summary.CPUStats{
+		Time: metav1.NewTime(stats.Timestamp),
+	}
+	if stats.CpuInst != nil {
+		cpuStats.UsageNanoCores = &stats.CpuInst.Usage.Total
+	}
+	if stats.Cpu != nil {
+		cpuStats.UsageCoreNanoSeconds = &stats.Cpu.Usage.Total
+	}
+
+	pageFaults := stats.Memory.ContainerData.Pgfault
+	majorPageFaults := stats.Memory.ContainerData.Pgmajfault
+	memoryStats = &summary.MemoryStats{
+		Time:            metav1.NewTime(stats.Timestamp),
+		UsageBytes:      &stats.Memory.Usage,
+		WorkingSetBytes: &stats.Memory.WorkingSet,
+		RSSBytes:        &stats.Memory.RSS,
+		PageFaults:      &pageFaults,
+		MajorPageFaults: &majorPageFaults,
+	}
+
+	return cpuStats, memoryStats
+}
+
+func buildPodRef(containerLabels map[string]string) summary.PodReference {
+	podName := kubetypes.GetPodName(containerLabels)
+	podNamespace := kubetypes.GetPodNamespace(containerLabels)
+	podUID := kubetypes.GetPodUID(containerLabels)
+	return summary.PodReference{Name: podName, Namespace: podNamespace, UID: podUID}
+}
+
+func extractContainerInfo(cg cm.CgroupName, cm cm.ContainerManager) (*summary.CPUStats, *summary.MemoryStats, time.Time, error) {
+	s, time, err := cm.GetResourceMetrics(cg)
+	if err != nil {
+		return nil, nil, time, err
+	}
+
+	ret := &info.ContainerStats{
+		Timestamp: time,
+	}
+
+	ret.Cpu = &infov1.CpuStats{}
+	ret.Memory = &infov1.MemoryStats{}
+	setCpuStats(s, ret.Cpu)
+	setMemoryStats(s, ret.Memory)
+	cpu, memory := cadvisorInfoToCPUandMemoryStats(ret)
+	return cpu, memory, time, nil
+}
+
+func uint64Ptr(u uint64) *uint64 {
+	return &u
+}

--- a/pkg/kubelet/server/stats/resourcemetrics/resource_metrics.go
+++ b/pkg/kubelet/server/stats/resourcemetrics/resource_metrics.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcemetrics
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	internalapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
+	summary "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
+	"k8s.io/kubernetes/pkg/kubelet/leaky"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+)
+
+type ResourceMetricsProvider interface {
+	GetMetrics() (*summary.Summary, error)
+}
+
+type coreMetricsProvider struct {
+	cm             cm.ContainerManager
+	runtimeService internalapi.RuntimeService
+}
+
+func NewCoreMetrics(cm cm.ContainerManager, rs internalapi.RuntimeService) ResourceMetricsProvider {
+	return &coreMetricsProvider{cm, rs}
+}
+
+func (self *coreMetricsProvider) GetMetrics() (*summary.Summary, error) {
+	containerCgroups, err := self.cm.NewPodContainerManager().GetAllPodsContainersFromCgroups()
+	if err != nil {
+		return nil, err
+	}
+
+	podToStats := map[summary.PodReference]*summary.PodStats{}
+	for _, cg := range containerCgroups {
+		id := containerNameToDockerId(cg)
+		status, err := self.runtimeService.ContainerStatus(id)
+		if err != nil {
+			continue
+		}
+		if !isPodManagedContainer(status.Labels) {
+			continue
+		}
+		containerName := kubetypes.GetContainerName(status.Labels)
+		if containerName == leaky.PodInfraContainerName || containerName == "" {
+			//jump infrastructure container
+			continue
+		}
+		cpu, memory, time, err := extractContainerInfo(cg, self.cm)
+		if err != nil {
+			return nil, err
+		}
+		ref := buildPodRef(status.Labels)
+		podStats, found := podToStats[ref]
+		if !found {
+			podStats = &summary.PodStats{PodRef: ref}
+			podToStats[ref] = podStats
+		}
+
+		podStats.Containers = append(podStats.Containers, summary.ContainerStats{
+			StartTime: metav1.NewTime(time),
+			Name:      containerName,
+			CPU:       cpu,
+			Memory:    memory,
+		})
+	}
+
+	// Extract node info from root cgroup
+	cpu, memory, time, err := extractContainerInfo(cm.CgroupName([]string{}), self.cm)
+	if err != nil {
+		return nil, err
+	}
+	nodeStats := summary.NodeStats{
+		CPU:       cpu,
+		Memory:    memory,
+		StartTime: metav1.NewTime(time),
+	}
+
+	p := []summary.PodStats{}
+	for _, ps := range podToStats {
+		p = append(p, *ps)
+	}
+	return &summary.Summary{Pods: p, Node: nodeStats}, nil
+}


### PR DESCRIPTION

 /kind feature
> /kind flake

**What this PR does / why we need it**:
This patch intends to replace cAdvisor which play a important role in k8s monitor system. Currently, it exposes cpu/memory data via summay-style api. Doing like this is to make it easier to compare with legacy summary endpoint to make sure we are doing collecting thing correctly.
It would migrate to prometheus-style endpoint after patch #73946 merged.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #68522 


```release-note
Use k8s's own function to provide data for resource metrics endpoint rather than cAdvisor
```
