### PR TITLE
Only set TLS cert callback if credentials plugin returns with cert

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -182,7 +182,13 @@ func (a *Authenticator) UpdateTransportConfig(c *transport.Config) error {
 	if c.TLS.GetCert != nil {
 		return errors.New("can't add TLS certificate callback: transport.Config.TLS.GetCert already set")
 	}
-	c.TLS.GetCert = a.cert
+	cert, err := a.cert() // test if a.cert() returns an actual certificate
+	if err != nil {
+		return errors.New("cert generation failed")
+	}
+	if cert != nil {
+		c.TLS.GetCert = a.cert
+	}
 
 	var dial func(ctx context.Context, network, addr string) (net.Conn, error)
 	if c.Dial != nil {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> 
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

According to https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins the credentials plugin can return either with a bearer token or with TLS cert data.

This change ensures that the HasCertCallback() (https://github.com/kubernetes/client-go/blob/b831b8de7155117e51afaffeb647007a756ddc92/transport/config.go#L100) will only return True if the plugin actually generates a client certificate. In case it returns a Bearer token the return value should be False.

This change helps with successful calls to `kubernetes.NewForConfig(config)` when using bearer token authentication as it won't fail on this line:
https://github.com/kubernetes/client-go/blob/b831b8de7155117e51afaffeb647007a756ddc92/transport/transport.go#L33

A quick example to demonstrate the original bad behavior:

```
package main

import (
	"crypto/tls"
	"fmt"
	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
	"k8s.io/client-go/kubernetes"
	"k8s.io/client-go/rest"
	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
	"net/http"
)

func main() {
	host := "<redacted>"
	eks_cluster_name := "<redacted>"

	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}

	config := &rest.Config{
		Host:      host,
		Transport: http.DefaultTransport,
		ExecProvider: &clientcmdapi.ExecConfig{
			APIVersion: "client.authentication.k8s.io/v1alpha1",
			Command:    "aws-iam-authenticator",
			Args:       []string{"token", "-i", eks_cluster_name},
		},
	}

	clientset, err := kubernetes.NewForConfig(config)
	if err != nil {
		panic(err.Error())
	}
	pods, err := clientset.CoreV1().Pods("").List(metav1.ListOptions{})
	if err != nil {
		panic(err.Error())
	}
	fmt.Printf("There are %d pods in the cluster\n", len(pods.Items))
}
```

Without the change the above command returns with:

> panic: using a custom transport with TLS certificate options or the insecure flag is not allowed
> 
> goroutine 1 [running]:
> main.main()
> 	/tmp/example.go:26 +0x2d9
> exit status 2

With the proposed change the output is as expected:

> There are 42 pods in the cluster

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
In this proposed change I call the a.cert() method earlier in the program flow, but as the results are cached I don't consider this a large drawback. I had to restructure the tests a bit to make sure test fixtures are already available when the first cert() function call happens.

The real world motivation for this change is that I want to use Prometheus to monitor an EKS cluster from outside the cluster and therefore I want to be able to use the credentials plugin together with a custom transport RoundTripper implementation here:
https://github.com/prometheus/prometheus/blob/e72c875e63df1af15df40fa218a9068a91c6a432/discovery/kubernetes/kubernetes.go#L197-L200

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
