### PR TITLE
HPA controller preserve the spec.metrics order

### DIFF
--- a/pkg/apis/autoscaling/annotations.go
+++ b/pkg/apis/autoscaling/annotations.go
@@ -20,6 +20,10 @@ package autoscaling
 // specs when converting the `Metrics` field from autoscaling/v2beta1
 const MetricSpecsAnnotation = "autoscaling.alpha.kubernetes.io/metrics"
 
+// CPUMetricIndexAnnotation is the annotation which holds CPU-utilization HPA metric
+// index when converting the `Metrics` field from autoscaling/v2beta2
+const CPUMetricIndexAnnotation = "autoscaling.alpha.kubernetes.io/cpu-metric-index"
+
 // MetricStatusesAnnotation is the annotation which holds non-CPU-utilization HPA metric
 // statuses when converting the `CurrentMetrics` field from autoscaling/v2beta1
 const MetricStatusesAnnotation = "autoscaling.alpha.kubernetes.io/current-metrics"

--- a/pkg/apis/autoscaling/v1/conversion.go
+++ b/pkg/apis/autoscaling/v1/conversion.go
@@ -390,7 +390,7 @@ func Convert_v1_HorizontalPodAutoscaler_To_autoscaling_HorizontalPodAutoscaler(i
 
 		// the normal Spec conversion could have populated out.Spec.Metrics with a single element, so deal with that
 		outMetrics := make([]autoscaling.MetricSpec, len(otherMetrics)+len(out.Spec.Metrics))
-		if out.Spec.Metrics != nil && cpuMetricIndex < len(outMetrics){
+		if out.Spec.Metrics != nil && cpuMetricIndex < len(outMetrics) {
 			outMetrics[cpuMetricIndex] = out.Spec.Metrics[0]
 		}
 		for i, metric := range otherMetrics {

--- a/pkg/apis/autoscaling/v1/conversion.go
+++ b/pkg/apis/autoscaling/v1/conversion.go
@@ -394,10 +394,11 @@ func Convert_v1_HorizontalPodAutoscaler_To_autoscaling_HorizontalPodAutoscaler(i
 			outMetrics[cpuMetricIndex] = out.Spec.Metrics[0]
 		}
 		for i, metric := range otherMetrics {
+			outIndex := i
 			if out.Spec.Metrics != nil && i >= cpuMetricIndex {
-				i = i + 1
+				outIndex++
 			}
-			if err := Convert_v1_MetricSpec_To_autoscaling_MetricSpec(&metric, &outMetrics[i], s); err != nil {
+			if err := Convert_v1_MetricSpec_To_autoscaling_MetricSpec(&metric, &outMetrics[outIndex], s); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
cc @DirectXMan12

**What this PR does / why we need it**:
Fixes #74099

When convert from v1, we just append `out.Spec.Metrics[0]` to `otherMetrics` which  reorders the spec.metrics list.
```golang
func Convert_v1_HorizontalPodAutoscaler_To_autoscaling_HorizontalPodAutoscaler(in *autoscalingv1.HorizontalPodAutoscaler, out *autoscaling.HorizontalPodAutoscaler, s conversion.Scope) error {
	if err := autoConvert_v1_HorizontalPodAutoscaler_To_autoscaling_HorizontalPodAutoscaler(in, out, s); err != nil {
		return err
	}

	if otherMetricsEnc, hasOtherMetrics := out.Annotations[autoscaling.MetricSpecsAnnotation]; hasOtherMetrics {
		var otherMetrics []autoscalingv1.MetricSpec
		if err := json.Unmarshal([]byte(otherMetricsEnc), &otherMetrics); err != nil {
			return err
		}

		// the normal Spec conversion could have populated out.Spec.Metrics with a single element, so deal with that
		outMetrics := make([]autoscaling.MetricSpec, len(otherMetrics)+len(out.Spec.Metrics))
		for i, metric := range otherMetrics {
			if err := Convert_v1_MetricSpec_To_autoscaling_MetricSpec(&metric, &outMetrics[i], s); err != nil {
				return err
			}
		}
		if out.Spec.Metrics != nil {
                         //  append out.Spec.Metrics[0] to otherMetrics which reorders the spec.metrics list
			outMetrics[len(otherMetrics)] = out.Spec.Metrics[0]
		}
		out.Spec.Metrics = outMetrics
		delete(out.Annotations, autoscaling.MetricSpecsAnnotation)
	}
   
       ....
}
```
As we know, `out.Spec.Metrics[0]`  is CPU metric. So, I use annotation to record CPU metric and delete this annotation after finishing conversion.

```release-note
NONE
```
