### PR TITLE
Change to unblock e2e tests for vsphere provider

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -69,6 +69,7 @@ go_library(
         "//test/e2e/framework/providers/gce:go_default_library",
         "//test/e2e/framework/providers/kubemark:go_default_library",
         "//test/e2e/framework/providers/openstack:go_default_library",
+        "//test/e2e/framework/providers/vsphere:go_default_library",
         "//test/e2e/framework/testfiles:go_default_library",
         "//test/e2e/manifest:go_default_library",
         "//test/utils:go_default_library",

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -51,6 +51,7 @@ import (
 	_ "k8s.io/kubernetes/test/e2e/framework/providers/gce"
 	_ "k8s.io/kubernetes/test/e2e/framework/providers/kubemark"
 	_ "k8s.io/kubernetes/test/e2e/framework/providers/openstack"
+	_ "k8s.io/kubernetes/test/e2e/framework/providers/vsphere"
 )
 
 var (

--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -171,6 +171,7 @@ filegroup(
         "//test/e2e/framework/providers/gce:all-srcs",
         "//test/e2e/framework/providers/kubemark:all-srcs",
         "//test/e2e/framework/providers/openstack:all-srcs",
+        "//test/e2e/framework/providers/vsphere:all-srcs",
         "//test/e2e/framework/testfiles:all-srcs",
         "//test/e2e/framework/timer:all-srcs",
         "//test/e2e/framework/viperconfig:all-srcs",

--- a/test/e2e/framework/providers/vsphere/BUILD
+++ b/test/e2e/framework/providers/vsphere/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["vsphere.go"],
+    importpath = "k8s.io/kubernetes/test/e2e/framework/providers/vsphere",
+    visibility = ["//visibility:public"],
+    deps = ["//test/e2e/framework:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/framework/providers/vsphere/OWNERS
+++ b/test/e2e/framework/providers/vsphere/OWNERS
@@ -1,0 +1,31 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- pmorie
+- saad-ali
+- thockin
+- matchstick
+- SandeepPissay
+- divyenpatel
+- BaluDontu
+- abrarshivani
+- imkin
+- frapposelli
+- dougm
+- sandeeppsunny
+reviewers:
+- abithap
+- abrarshivani
+- saad-ali
+- justinsb
+- jsafrane
+- rootfs
+- jingxu97
+- msau42
+- SandeepPissay
+- divyenpatel
+- BaluDontu
+- imkin
+- frapposelli
+- dougm
+- sandeeppsunny

--- a/test/e2e/framework/providers/vsphere/vsphere.go
+++ b/test/e2e/framework/providers/vsphere/vsphere.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func init() {
+	framework.RegisterProvider("vsphere", newProvider)
+}
+
+func newProvider() (framework.ProviderInterface, error) {
+	return &framework.NullProvider{}, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, vsphere e2e tests fail to start with the following error:

> Unknown provider "vsphere". The following providers are known: aws azure gce gke kubemark local skeleton

This is a minimal change to unblock e2e testing for vsphere cloud provider.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


