### PR TITLE
Make the annotation of ListContainerStats keep consistent with the in…

### DIFF
--- a/pkg/kubelet/remote/fake/fake_runtime.go
+++ b/pkg/kubelet/remote/fake/fake_runtime.go
@@ -245,7 +245,7 @@ func (f *RemoteRuntime) ContainerStats(ctx context.Context, req *kubeapi.Contain
 	return &kubeapi.ContainerStatsResponse{Stats: stats}, nil
 }
 
-// ListContainerStats returns stats of all running containers.
+// ListContainerStats returns stats of all existing containers.
 func (f *RemoteRuntime) ListContainerStats(ctx context.Context, req *kubeapi.ListContainerStatsRequest) (*kubeapi.ListContainerStatsResponse, error) {
 	stats, err := f.RuntimeService.ListContainerStats(req.Filter)
 	if err != nil {

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.pb.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.pb.go
@@ -3864,7 +3864,7 @@ type RuntimeServiceClient interface {
 	// ContainerStats returns stats of the container. If the container does not
 	// exist, the call returns an error.
 	ContainerStats(ctx context.Context, in *ContainerStatsRequest, opts ...grpc.CallOption) (*ContainerStatsResponse, error)
-	// ListContainerStats returns stats of all running containers.
+	// ListContainerStats returns stats of all existing containers.
 	ListContainerStats(ctx context.Context, in *ListContainerStatsRequest, opts ...grpc.CallOption) (*ListContainerStatsResponse, error)
 	// UpdateRuntimeConfig updates the runtime configuration based on the given request.
 	UpdateRuntimeConfig(ctx context.Context, in *UpdateRuntimeConfigRequest, opts ...grpc.CallOption) (*UpdateRuntimeConfigResponse, error)
@@ -4144,7 +4144,7 @@ type RuntimeServiceServer interface {
 	// ContainerStats returns stats of the container. If the container does not
 	// exist, the call returns an error.
 	ContainerStats(context.Context, *ContainerStatsRequest) (*ContainerStatsResponse, error)
-	// ListContainerStats returns stats of all running containers.
+	// ListContainerStats returns stats of all existing containers.
 	ListContainerStats(context.Context, *ListContainerStatsRequest) (*ListContainerStatsResponse, error)
 	// UpdateRuntimeConfig updates the runtime configuration based on the given request.
 	UpdateRuntimeConfig(context.Context, *UpdateRuntimeConfigRequest) (*UpdateRuntimeConfigResponse, error)

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.proto
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.proto
@@ -99,7 +99,7 @@ service RuntimeService {
     // ContainerStats returns stats of the container. If the container does not
     // exist, the call returns an error.
     rpc ContainerStats(ContainerStatsRequest) returns (ContainerStatsResponse) {}
-    // ListContainerStats returns stats of all running containers.
+    // ListContainerStats returns stats of all existing containers.
     rpc ListContainerStats(ListContainerStatsRequest) returns (ListContainerStatsResponse) {}
 
     // UpdateRuntimeConfig updates the runtime configuration based on the given request.

--- a/staging/src/k8s.io/cri-api/pkg/apis/services.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/services.go
@@ -84,7 +84,7 @@ type ContainerStatsManager interface {
 	// ContainerStats returns stats of the container. If the container does not
 	// exist, the call returns an error.
 	ContainerStats(containerID string) (*runtimeapi.ContainerStats, error)
-	// ListContainerStats returns stats of all running containers.
+	// ListContainerStats returns stats of all existing containers.
 	ListContainerStats(filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error)
 }
 


### PR DESCRIPTION
Make the annotation of ListContainerStats keep consistent with the interface implementation.

Signed-off-by: Lu Fengqi <lufq.fnst@cn.fujitsu.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
From Issue #53514 ListContainerStats return the stats of all containers (include non-running containers), then improve the corresponding annotation to avoid confusion.

**Special notes for your reviewer**:
/cc @Random-Liu @yguo0905 @yujuhong @dashpole 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
