### PR TITLE
Fix some golint failures for pkg/kubelet/apis/...

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -81,7 +81,6 @@ pkg/capabilities
 pkg/cloudprovider/providers/fake
 pkg/cloudprovider/providers/photon
 pkg/cloudprovider/providers/vsphere
-pkg/cloudprovider/providers/vsphere/vclib
 pkg/controller
 pkg/controller/apis/config/v1alpha1
 pkg/controller/bootstrap
@@ -171,10 +170,7 @@ pkg/kubelet/apis
 pkg/kubelet/apis/config
 pkg/kubelet/apis/config/v1beta1
 pkg/kubelet/apis/cri/testing
-pkg/kubelet/apis/deviceplugin/v1alpha
 pkg/kubelet/apis/deviceplugin/v1beta1
-pkg/kubelet/apis/pluginregistration/v1alpha1
-pkg/kubelet/apis/pluginregistration/v1beta1
 pkg/kubelet/cadvisor
 pkg/kubelet/cadvisor/testing
 pkg/kubelet/checkpoint

--- a/pkg/cloudprovider/providers/vsphere/vclib/connection_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/connection_test.go
@@ -85,7 +85,7 @@ func TestWithValidCaCert(t *testing.T) {
 
 	server, _ := createTestServer(t, fixtures.CaCertPath, fixtures.ServerCertPath, fixtures.ServerKeyPath, handler)
 	server.StartTLS()
-	u := mustParseUrl(t, server.URL)
+	u := mustParseURL(t, server.URL)
 
 	connection := &vclib.VSphereConnection{
 		Hostname: u.Hostname(),
@@ -104,7 +104,7 @@ func TestWithVerificationWithWrongThumbprint(t *testing.T) {
 
 	server, _ := createTestServer(t, fixtures.CaCertPath, fixtures.ServerCertPath, fixtures.ServerKeyPath, handler)
 	server.StartTLS()
-	u := mustParseUrl(t, server.URL)
+	u := mustParseURL(t, server.URL)
 
 	connection := &vclib.VSphereConnection{
 		Hostname:   u.Hostname(),
@@ -124,7 +124,7 @@ func TestWithVerificationWithoutCaCertOrThumbprint(t *testing.T) {
 
 	server, _ := createTestServer(t, fixtures.CaCertPath, fixtures.ServerCertPath, fixtures.ServerKeyPath, handler)
 	server.StartTLS()
-	u := mustParseUrl(t, server.URL)
+	u := mustParseURL(t, server.URL)
 
 	connection := &vclib.VSphereConnection{
 		Hostname: u.Hostname(),
@@ -142,7 +142,7 @@ func TestWithValidThumbprint(t *testing.T) {
 	server, thumbprint :=
 		createTestServer(t, fixtures.CaCertPath, fixtures.ServerCertPath, fixtures.ServerKeyPath, handler)
 	server.StartTLS()
-	u := mustParseUrl(t, server.URL)
+	u := mustParseURL(t, server.URL)
 
 	connection := &vclib.VSphereConnection{
 		Hostname:   u.Hostname(),
@@ -213,7 +213,7 @@ func getRequestVerifier(t *testing.T) (http.HandlerFunc, func()) {
 	return handler, checker
 }
 
-func mustParseUrl(t *testing.T, i string) *url.URL {
+func mustParseURL(t *testing.T, i string) *url.URL {
 	u, err := url.Parse(i)
 	if err != nil {
 		t.Fatalf("Cannot parse URL: %v", err)

--- a/pkg/kubelet/apis/deviceplugin/v1alpha/constants.go
+++ b/pkg/kubelet/apis/deviceplugin/v1alpha/constants.go
@@ -22,7 +22,7 @@ const (
 	// Unhealthy means that the device is unhealthy
 	Unhealthy = "Unhealthy"
 
-	// Current version of the API supported by kubelet
+	// Version is the current version of the API supported by kubelet
 	Version = "v1alpha2"
 	// DevicePluginPath is the folder the Device Plugin is expecting sockets to be on
 	// Only privileged pods have access to this path

--- a/pkg/kubelet/apis/pluginregistration/v1alpha1/constants.go
+++ b/pkg/kubelet/apis/pluginregistration/v1alpha1/constants.go
@@ -17,6 +17,8 @@ limitations under the License.
 package pluginregistration
 
 const (
-	CSIPlugin    = "CSIPlugin"
+	// CSIPlugin identifier for registered CSI plugins
+	CSIPlugin = "CSIPlugin"
+	// DevicePlugin identifier for registered device plugins
 	DevicePlugin = "DevicePlugin"
 )

--- a/pkg/kubelet/apis/pluginregistration/v1beta1/constants.go
+++ b/pkg/kubelet/apis/pluginregistration/v1beta1/constants.go
@@ -17,6 +17,8 @@ limitations under the License.
 package pluginregistration
 
 const (
-	CSIPlugin    = "CSIPlugin"
+	// CSIPlugin identifier for registered CSI plugins
+	CSIPlugin = "CSIPlugin"
+	// DevicePlugin identifier for registered device plugins
 	DevicePlugin = "DevicePlugin"
 )


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
Fix golint failures on :
- pkg/cloudprovider/providers/vsphere/vclib
- pkg/kubelet/apis/deviceplugin/v1alpha
- pkg/kubelet/apis/pluginregistration/v1alpha1
- pkg/kubelet/apis/pluginregistration/v1beta1

**Which issue(s) this PR fixes**:
Refs #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
