### PR TITLE
kubeadm: move duplicated code into enforceRequirements()

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply_test.go
@@ -25,30 +25,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
-func TestAssertVersionStringIsEmpty(t *testing.T) {
-	var tcases = []struct {
-		name        string
-		version     string
-		expectedErr bool
-	}{
-		{
-			name:    "Version string is not empty",
-			version: "some string",
-		},
-		{
-			name:        "Version string is empty",
-			expectedErr: true,
-		},
-	}
-	for _, tt := range tcases {
-		t.Run(tt.name, func(t *testing.T) {
-			if assertVersionStringIsEmpty(tt.version) == nil && tt.expectedErr {
-				t.Errorf("No error triggered for string '%s'", tt.version)
-			}
-		})
-	}
-}
-
 func TestSessionIsInteractive(t *testing.T) {
 	var tcases = []struct {
 		name     string

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -18,10 +18,133 @@ package upgrade
 
 import (
 	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
+	"time"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
+
+const (
+	validConfig = `apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+kubernetesVersion: 1.13.0
+`
+)
+
+func TestGetK8sVersionFromUserInput(t *testing.T) {
+	var tcases = []struct {
+		name               string
+		isVersionMandatory bool
+		clusterConfig      string
+		args               []string
+		expectedErr        bool
+		expectedVersion    string
+	}{
+		{
+			name:               "No config and version as an argument",
+			isVersionMandatory: true,
+			args:               []string{"v1.13.1"},
+			expectedVersion:    "v1.13.1",
+		},
+		{
+			name:               "Neither config nor version specified",
+			isVersionMandatory: true,
+			expectedErr:        true,
+		},
+		{
+			name:               "No config and empty version as an argument",
+			isVersionMandatory: true,
+			args:               []string{""},
+			expectedErr:        true,
+		},
+		{
+			name:               "Valid config, but no version specified",
+			isVersionMandatory: true,
+			clusterConfig:      validConfig,
+			expectedVersion:    "v1.13.0",
+		},
+		{
+			name:               "Valid config and different version specified",
+			isVersionMandatory: true,
+			clusterConfig:      validConfig,
+			args:               []string{"v1.13.1"},
+			expectedVersion:    "v1.13.1",
+		},
+		{
+			name: "Version is optional",
+		},
+	}
+	for tnum, tt := range tcases {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := &applyPlanFlags{}
+			if len(tt.clusterConfig) > 0 {
+				tmpfile := fmt.Sprintf("/tmp/kubeadm-upgrade-common-test-%d-%d.yaml", tnum, time.Now().Unix())
+				if err := ioutil.WriteFile(tmpfile, []byte(tt.clusterConfig), 0666); err != nil {
+					t.Fatalf("Failed to create test config file: %+v", err)
+				}
+				defer os.Remove(tmpfile)
+
+				flags.cfgPath = tmpfile
+			}
+
+			userVersion, err := getK8sVersionFromUserInput(flags, tt.args, tt.isVersionMandatory)
+
+			if err == nil && tt.expectedErr {
+				t.Error("Expected error, but got success")
+			}
+			if err != nil && !tt.expectedErr {
+				t.Errorf("Unexpected error: %+v", err)
+			}
+			if userVersion != tt.expectedVersion {
+				t.Errorf("Expected '%s', but got '%s'", tt.expectedVersion, userVersion)
+			}
+		})
+	}
+}
+
+func TestEnforceRequirements(t *testing.T) {
+	tcases := []struct {
+		name          string
+		newK8sVersion string
+		dryRun        bool
+		flags         applyPlanFlags
+		expectedErr   bool
+	}{
+		{
+			name:        "Fail pre-flight check",
+			expectedErr: true,
+		},
+		{
+			name: "Bogus preflight check disabled when also 'all' is specified",
+			flags: applyPlanFlags{
+				ignorePreflightErrors: []string{"bogusvalue", "all"},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "Fail to create client",
+			flags: applyPlanFlags{
+				ignorePreflightErrors: []string{"all"},
+			},
+			expectedErr: true,
+		},
+	}
+	for _, tt := range tcases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, err := enforceRequirements(&tt.flags, tt.dryRun, tt.newK8sVersion)
+
+			if err == nil && tt.expectedErr {
+				t.Error("Expected error, but got success")
+			}
+			if err != nil && !tt.expectedErr {
+				t.Errorf("Unexpected error: %+v", err)
+			}
+		})
+	}
+}
 
 func TestPrintConfiguration(t *testing.T) {
 	var tests = []struct {

--- a/cmd/kubeadm/app/cmd/upgrade/upgrade.go
+++ b/cmd/kubeadm/app/cmd/upgrade/upgrade.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -39,7 +38,6 @@ type applyPlanFlags struct {
 	allowRCUpgrades           bool
 	printConfig               bool
 	ignorePreflightErrors     []string
-	ignorePreflightErrorsSet  sets.String
 	out                       io.Writer
 }
 
@@ -52,7 +50,6 @@ func NewCmdUpgrade(out io.Writer) *cobra.Command {
 		allowExperimentalUpgrades: false,
 		allowRCUpgrades:           false,
 		printConfig:               false,
-		ignorePreflightErrorsSet:  sets.NewString(),
 		out:                       out,
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Move duplicated code into `enforceRequirements()` and to a new function `getK8sVersionFromUserInput()`.

Also drop `applyPlanFlags.ignorePreflightErrorsSet` field which is not a command line option.

**Special notes for your reviewer**:
This is a part of the PR series splitting #73135.

**XXX**: This PR increases code coverage, but the new tests reveal some unexpected behaviour. The current logic of handling user input is that if a user specifies a `ClusterConfiguration` file without `KubernetesVersion` specified in it and no version is given as an argument then there's no failure. Because the function `LoadInitConfigurationFromFile()` returns a config with some default version already defined which is taken from the release server and is not known at test time.
Thus when a new release of K8s is finalized the tests will start to fail.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
