### PR TITLE
Adding ownerReferences.uid as a selector for pods api

### DIFF
--- a/pkg/apis/core/v1/conversion.go
+++ b/pkg/apis/core/v1/conversion.go
@@ -60,6 +60,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 			switch label {
 			case "metadata.name",
 				"metadata.namespace",
+				"metadata.ownerReferences.uid",
 				"spec.nodeName",
 				"spec.restartPolicy",
 				"spec.schedulerName",

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -206,7 +206,7 @@ func PodToSelectableFields(pod *api.Pod) fields.Set {
 	// amount of allocations needed to create the fields.Set. If you add any
 	// field here or the number of object-meta related fields changes, this should
 	// be adjusted.
-	podSpecificFieldsSet := make(fields.Set, 9)
+	podSpecificFieldsSet := make(fields.Set, 10)
 	podSpecificFieldsSet["spec.nodeName"] = pod.Spec.NodeName
 	podSpecificFieldsSet["spec.restartPolicy"] = string(pod.Spec.RestartPolicy)
 	podSpecificFieldsSet["spec.schedulerName"] = string(pod.Spec.SchedulerName)
@@ -214,6 +214,7 @@ func PodToSelectableFields(pod *api.Pod) fields.Set {
 	podSpecificFieldsSet["status.phase"] = string(pod.Status.Phase)
 	podSpecificFieldsSet["status.podIP"] = string(pod.Status.PodIP)
 	podSpecificFieldsSet["status.nominatedNodeName"] = string(pod.Status.NominatedNodeName)
+	podSpecificFieldsSet["metadata.ownerReferences.uid"] = ExtractOwnerUID(pod.GetOwnerReferences())
 	return generic.AddObjectMetaFieldsSet(podSpecificFieldsSet, &pod.ObjectMeta, true)
 }
 
@@ -534,4 +535,13 @@ func PortForwardLocation(
 		RawQuery: params.Encode(),
 	}
 	return loc, nodeInfo.Transport, nil
+}
+
+// ExtractOwnerUID concats all ownerReferences uid to a string
+func ExtractOwnerUID(m []metav1.OwnerReference) (fmtStr string) {
+	for _, ownerRef := range m {
+		fmtStr += fmt.Sprintf("%v\n", string(ownerRef.UID))
+	}
+	fmtStr = strings.TrimSuffix(fmtStr, "\n")
+	return
 }

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -141,6 +141,42 @@ func TestMatchPod(t *testing.T) {
 			},
 			fieldSelector: fields.ParseSelectorOrDie("status.nominatedNodeName=node2"),
 			expectMatch:   false,
+		},
+		{
+			in: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{UID: "owner"}},
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("metadata.ownerReferences.uid=owner"),
+			expectMatch:   true,
+		},
+		{
+			in: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{UID: "owner"}},
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("metadata.ownerReferences.uid=nonowner"),
+			expectMatch:   false,
+		},
+		{
+			in: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{UID: "owner"}},
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("metadata.ownerReferences.uid="),
+			expectMatch:   false,
+		},
+		{
+			in: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{},
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("metadata.ownerReferences.uid="),
+			expectMatch:   true,
 		}}
 	for _, testCase := range testCases {
 		m := MatchPod(labels.Everything(), testCase.fieldSelector)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind api-change
/kind feature


**What this PR does / why we need it**:
This PR enables user to query pods  based on ownerReferences' uid as a selector. This will enable to fetch specific pods for a given owner object instead of fetching all pods and iterating over them.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: 
yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Pods API now accepts metadata.ownerReferences.uid as a value for selector fields.
```
