### PR TITLE
Use upload-config phase in `kubeadm config upload`

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -86,6 +86,7 @@ go_test(
         "//cmd/kubeadm/app/apis/kubeadm/v1beta1:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/validation:go_default_library",
         "//cmd/kubeadm/app/cmd/options:go_default_library",
+        "//cmd/kubeadm/app/cmd/phases/workflow:go_default_library",
         "//cmd/kubeadm/app/componentconfigs:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/features:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

In 1.13 the upload-config phase got graduated. This means, that the old `kubeadm config upload from-*` commands are no longer necessary in the form in which they exist now.

Also, `kubeadm config upload` did not share any code with the graduated upload-config phase and this means, that we have the same functionality implemented twice.

To overcome this, the following changes are done:

- Redirect `kubeadm config upload` to `kubeadm init phase upload-config`, thus, support all of the `kubeadm init phase upload-config` sub-commands. At the moment these are `kubeadm`, `kubelet` and `all`.

- Delete the code of the old `kubeadm config upload from-file` command and introduce an alias to `kubeadm init phase upload-config kubeadm` in its place. This does not introduce an user facing change (all existing user commands that use `kubeadm config upload from-file` will now simply go to `kubeadm init phase upload-config kubeadm` and work in the same way).

- Mark `kubeadm config upload from-flags` as deprecated. This command is dangerous in that it's easy for an user to trash the cluster config by specifying wrong command line parameters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#988

**Special notes for your reviewer**:
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/priority important-longterm
/assign @neolit123
/assign @fabriziopandini

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm config upload is now a redirector to kubeadm init phase upload-config. Old from-file and from-flags sub-commands are deprecated.
```
