### PR TITLE
Update RBAC roles for networking.k8s.io ingresses

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -284,7 +284,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(Write...).Groups(policyGroup).Resources("poddisruptionbudgets").RuleOrDie(),
 
-				rbacv1helpers.NewRule(Write...).Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
+				rbacv1helpers.NewRule(Write...).Groups(networkingGroup).Resources("networkpolicies", "ingresses").RuleOrDie(),
 			},
 		},
 		{
@@ -317,7 +317,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(Read...).Groups(policyGroup).Resources("poddisruptionbudgets").RuleOrDie(),
 
-				rbacv1helpers.NewRule(Read...).Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
+				rbacv1helpers.NewRule(Read...).Groups(networkingGroup).Resources("networkpolicies", "ingresses").RuleOrDie(),
 			},
 		},
 		{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -211,6 +211,7 @@ items:
   - apiGroups:
     - networking.k8s.io
     resources:
+    - ingresses
     - networkpolicies
     verbs:
     - create
@@ -326,6 +327,7 @@ items:
   - apiGroups:
     - networking.k8s.io
     resources:
+    - ingresses
     - networkpolicies
     verbs:
     - get


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Updates RBAC roles that grant permissions to ingress objects to include the new networking.k8s.io API group

follow up to https://github.com/kubernetes/kubernetes/pull/74057

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
