### PR TITLE
Fix golint under test/e2e/framework/ingress

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -667,7 +667,6 @@ test/e2e/chaosmonkey
 test/e2e/cloud
 test/e2e/common
 test/e2e/framework
-test/e2e/framework/ingress
 test/e2e/framework/providers/gce
 test/e2e/framework/providers/kubemark
 test/e2e/instrumentation

--- a/test/e2e/network/scale/ingress.go
+++ b/test/e2e/network/scale/ingress.go
@@ -62,7 +62,7 @@ var (
 // IngressScaleFramework defines the framework for ingress scale testing.
 type IngressScaleFramework struct {
 	Clientset     clientset.Interface
-	Jig           *ingress.IngressTestJig
+	Jig           *ingress.TestJig
 	GCEController *gce.GCEIngressController
 	CloudConfig   framework.CloudConfig
 	Logger        ingress.TestLogger

--- a/test/e2e/upgrades/ingress.go
+++ b/test/e2e/upgrades/ingress.go
@@ -44,7 +44,7 @@ type IngressUpgradeTest struct {
 	gceController *gce.GCEIngressController
 	// holds GCP resources pre-upgrade
 	resourceStore *GCPResourceStore
-	jig           *ingress.IngressTestJig
+	jig           *ingress.TestJig
 	httpClient    *http.Client
 	ip            string
 	ipName        string


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This fixes golint failures under test/e2e/framework/ingress

ref: https://github.com/kubernetes/kubernetes/issues/68026

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note-none

```
