### PR TITLE
Fix test-cmd kubectl_run flake

### DIFF
--- a/test/cmd/run.sh
+++ b/test/cmd/run.sh
@@ -36,7 +36,7 @@ run_kubectl_run_tests() {
   # Clean up
   kubectl delete jobs pi "${kube_flags[@]}"
   # Post-condition: no pods exist.
-  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::wait_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
 
   # Pre-Condition: no Deployment exists
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
/area deflake
/priority critical-urgent
/sig cli

**What this PR does / why we need it**:
Removes a flake-prone anti-pattern from `test-cmd run_kubectl_run_tests`

It is unrealistic to expect a cascading delete to immediately take
effect. Somehow this test got away with it for a while, but we
have finally reached a point where apiserver performance has changed
just enough to expsoe this flaky expectation.

**Which issue(s) this PR fixes**:
Fixes #74431

**Special notes for your reviewer**:
I tested locally by running just this test case 100 times in a row,
no flakes. As far as I can tell, no other `test-cmd` testcases use
this anti-pattern of delete-then-get.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/cc @liggitt  @apelisse
since you two helped weigh in on the flake

/milestone v1.14