### PR TITLE
GCE: switch to using e2eteam/pause:3.1 for pause containers

### DIFF
--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -106,7 +106,6 @@ try {
   Download-HelperScripts
 
   Create-DockerRegistryKey
-  Create-PauseImage
   DownloadAndInstall-KubernetesBinaries
   Create-NodePki
   Create-KubeletKubeconfig

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -45,7 +45,7 @@
 #  - Document functions using proper syntax:
 #    https://technet.microsoft.com/en-us/library/hh847834(v=wps.620).aspx
 
-$INFRA_CONTAINER = "kubeletwin/pause"
+$INFRA_CONTAINER = "e2eteam/pause:3.1"
 $GCE_METADATA_SERVER = "169.254.169.254"
 # The "management" interface is used by the kubelet and by Windows pods to talk
 # to the rest of the Kubernetes cluster *without NAT*. This interface does not
@@ -285,41 +285,6 @@ function Get_ContainerVersionLabel {
   }
   Throw ("Unknown Windows version $WinVersion, don't know its container " +
          "version label")
-}
-
-# Builds the pause image with name $INFRA_CONTAINER.
-function Create-PauseImage {
-  $win_version = $(Get-InstanceMetadataValue 'win-version')
-  if ($win_version -match '2019') {
-    # TODO(pjh): update this function to properly support 2019 vs. 1809 vs.
-    # future Windows versions. For example, Windows Server 2019 does not
-    # support the nanoserver container
-    # (https://blogs.technet.microsoft.com/virtualization/2018/11/13/windows-server-2019-now-available/).
-    Log_NotImplemented "Need to update Create-PauseImage for WS2019"
-  }
-
-  $version_label = Get_ContainerVersionLabel $win_version
-  $pause_dir = "${env:K8S_DIR}\pauseimage"
-  $dockerfile = "$pause_dir\Dockerfile"
-  mkdir -Force $pause_dir
-  if (ShouldWrite-File $dockerfile) {
-    New-Item -Force -ItemType file $dockerfile | Out-Null
-    Set-Content `
-        $dockerfile `
-        ("FROM mcr.microsoft.com/windows/nanoserver:${version_label}`n`n" +
-         "CMD cmd /c ping -t localhost > nul")
-  }
-
-  if (($(docker images -a) -like "*${INFRA_CONTAINER}*") -and
-      (-not $REDO_STEPS)) {
-    Log-Output "Skip: ${INFRA_CONTAINER} already built"
-    return
-  }
-  docker build -t ${INFRA_CONTAINER} $pause_dir
-  if ($LastExitCode -ne 0) {
-    Log-Output -Fatal `
-        "docker build -t ${INFRA_CONTAINER} $pause_dir failed"
-  }
 }
 
 # Downloads the Kubernetes binaries from kube-env's NODE_BINARY_TAR_URL and


### PR DESCRIPTION
Stop building pause images on node startup.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
