### PR TITLE
Add cross-OS test for service connectivity

### DIFF
--- a/test/e2e/windows/BUILD
+++ b/test/e2e/windows/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = [
         "density.go",
         "framework.go",
+        "hybrid_network.go",
         "networking.go",
         "volumes.go",
     ],

--- a/test/e2e/windows/hybrid_network.go
+++ b/test/e2e/windows/hybrid_network.go
@@ -123,7 +123,6 @@ func createTestPod(f *framework.Framework, image string, os string) *v1.Pod {
 	if os == linuxOS {
 		pod.Spec.Tolerations = []v1.Toleration{
 			{
-				Key:      "key",
 				Operator: v1.TolerationOpExists,
 				Effect:   v1.TaintEffectNoSchedule,
 			},

--- a/test/e2e/windows/hybrid_network.go
+++ b/test/e2e/windows/hybrid_network.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package windows
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	linuxOS   = "linux"
+	windowsOS = "windows"
+)
+
+var (
+	windowsBusyBoximage = imageutils.GetE2EImage(imageutils.TestWebserver)
+	linuxBusyBoxImage   = "docker.io/library/nginx:1.15-alpine"
+)
+
+var _ = SIGDescribe("Hybrid cluster network", func() {
+	f := framework.NewDefaultFramework("hybrid-network")
+
+	BeforeEach(func() {
+		framework.SkipUnlessNodeOSDistroIs("windows")
+	})
+
+	Context("for all supported CNIs", func() {
+
+		It("should have stable external networking for linux and windows pods", func() {
+
+			By("creating a linux pod with external requests")
+			linuxPod := CreateTestPod(f, linuxBusyBoxImage, linuxOS)
+			cmd := []string{"/bin/sh", "-c", "nc -vz 8.8.8.8 53", "||", "nc -vz 8.8.4.4 53"}
+			checkExternal(f, linuxPod, linuxOS, cmd)
+
+			By("creating a windows pod with external requests")
+			windowsPod := CreateTestPod(f, windowsBusyBoximage, windowsOS)
+			cmd = []string{"powershell", "-command", "$r=invoke-webrequest www.google.com -usebasicparsing; echo $r.StatusCode"}
+			out, msg := checkExternal(f, windowsPod, windowsOS, cmd)
+			Expect(out).To(Equal("200"), msg)
+		})
+
+	})
+})
+
+func checkExternal(f *framework.Framework, podName string, os string, cmd []string]) (string, string) {
+	By(fmt.Sprintf("checking external connectivity of %s-container in %s pod", os, podName))
+	out, stderr, err := f.ExecCommandInContainerWithFullOutput(podName, os + "-container", cmd...)
+	msg := fmt.Sprintf("cmd: %v, stdout: %q, stderr: %q", cmd, out, stderr)
+	Expect(err).NotTo(HaveOccurred(), msg)
+	return out, msg
+}
+
+func CreateTestPod(f *framework.Framework, image string, os string) string {
+	ns := f.Namespace.Name
+	cs := f.ClientSet
+
+	podName := "pod-" + string(uuid.NewUUID())
+	pod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: podName,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  os + "-container",
+					Image: image,
+				},
+			},
+			NodeSelector: map[string]string{
+				"beta.kubernetes.io/os": os,
+			},
+		},
+	}
+	if os == linuxOS {
+		pod.Spec.Tolerations = []v1.Toleration{
+			{
+				Key:      "key",
+				Operator: v1.TolerationOpExists,
+				Effect:   v1.TaintEffectNoSchedule,
+			},
+		}
+	}
+	_, err := cs.CoreV1().Pods(ns).Create(pod)
+	framework.ExpectNoError(err)
+	framework.ExpectNoError(f.WaitForPodRunning(podName))
+	return podName
+}

--- a/test/e2e/windows/hybrid_network.go
+++ b/test/e2e/windows/hybrid_network.go
@@ -71,9 +71,9 @@ var _ = SIGDescribe("Hybrid cluster network", func() {
 })
 
 var (
-	duration      = "10s"
-	poll_interval = "1s"
-	timeout       = 10 // seconds
+	duration     = "10s"
+	pollInterval = "1s"
+	timeout      = 10 // seconds
 )
 
 func assertConsistentConnectivity(f *framework.Framework, podName string, os string, cmd []string) {
@@ -81,7 +81,7 @@ func assertConsistentConnectivity(f *framework.Framework, podName string, os str
 		By(fmt.Sprintf("checking connectivity of %s-container in %s", os, podName))
 		_, _, err := f.ExecCommandInContainerWithFullOutput(podName, os+"-container", cmd...)
 		return err
-	}, duration, poll_interval).ShouldNot(HaveOccurred())
+	}, duration, pollInterval).ShouldNot(HaveOccurred())
 }
 
 func linuxCheck(address string, port int) []string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/sig windows
/sig testing

**What this PR does / why we need it**:
Tests connectivity of cross OS pods

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Related issue #74377

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
