### PR TITLE
Automated cherry pick of #69548: Fix find-binary to locate bazel e2e tests

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -163,11 +163,11 @@ kube::util::find-binary-for-platform() {
     "${KUBE_ROOT}/platforms/${platform}/${lookfor}"
   )
   # Also search for binary in bazel build tree.
-  # The bazel go rules place binaries in subtrees like
+  # The bazel go rules place some binaries in subtrees like
   # "bazel-bin/source/path/linux_amd64_pure_stripped/binaryname", so make sure
   # the platform name is matched in the path.
   locations+=($(find "${KUBE_ROOT}/bazel-bin/" -type f -executable \
-    -path "*/${platform/\//_}*/${lookfor}" 2>/dev/null || true) )
+    \( -path "*/${platform/\//_}*/${lookfor}" -o -path "*/${lookfor}" \) 2>/dev/null || true) )
 
   # List most recently-updated location.
   local -r bin=$( (ls -t "${locations[@]}" 2>/dev/null || true) | head -1 )


### PR DESCRIPTION
Cherry pick of #69548 on release-1.12.

#69548: Fix find-binary to locate bazel e2e tests

fixes kubernetes/test-infra#11503
