### PR TITLE
Trivial fix typo

### DIFF
--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -176,7 +176,7 @@ type ExtenderTLSConfig struct {
 	// Server should be accessed without verifying the TLS certificate. For testing only.
 	Insecure bool
 	// ServerName is passed to the server for SNI and is used in the client to check server
-	// ceritificates against. If ServerName is empty, the hostname used to contact the
+	// certificates against. If ServerName is empty, the hostname used to contact the
 	// server is used.
 	ServerName string
 

--- a/pkg/scheduler/api/v1/types.go
+++ b/pkg/scheduler/api/v1/types.go
@@ -156,7 +156,7 @@ type ExtenderTLSConfig struct {
 	// Server should be accessed without verifying the TLS certificate. For testing only.
 	Insecure bool `json:"insecure,omitempty"`
 	// ServerName is passed to the server for SNI and is used in the client to check server
-	// ceritificates against. If ServerName is empty, the hostname used to contact the
+	// certificates against. If ServerName is empty, the hostname used to contact the
 	// server is used.
 	ServerName string `json:"serverName,omitempty"`
 


### PR DESCRIPTION
Although it is spelling mistakes, it might make an effect while reading.

```release-note
NONE
```
