### PR TITLE
discovery: fill group and version in resource list

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
@@ -74,7 +74,6 @@ func NewDiscoveryController(crdInformer informers.CustomResourceDefinitionInform
 }
 
 func (c *DiscoveryController) sync(version schema.GroupVersion) error {
-
 	apiVersionsForDiscovery := []metav1.GroupVersionForDiscovery{}
 	apiResourcesForDiscovery := []metav1.APIResource{}
 	versionsForDiscoveryMap := map[metav1.GroupVersion]bool{}
@@ -130,6 +129,8 @@ func (c *DiscoveryController) sync(version schema.GroupVersion) error {
 			Name:         crd.Status.AcceptedNames.Plural,
 			SingularName: crd.Status.AcceptedNames.Singular,
 			Namespaced:   crd.Spec.Scope == apiextensions.NamespaceScoped,
+			Group:        crd.Spec.Group,
+			Version:      version.Version,
 			Kind:         crd.Status.AcceptedNames.Kind,
 			Verbs:        verbs,
 			ShortNames:   crd.Status.AcceptedNames.ShortNames,
@@ -142,21 +143,25 @@ func (c *DiscoveryController) sync(version schema.GroupVersion) error {
 		}
 		if subresources != nil && subresources.Status != nil {
 			apiResourcesForDiscovery = append(apiResourcesForDiscovery, metav1.APIResource{
-				Name:       crd.Status.AcceptedNames.Plural + "/status",
-				Namespaced: crd.Spec.Scope == apiextensions.NamespaceScoped,
-				Kind:       crd.Status.AcceptedNames.Kind,
-				Verbs:      metav1.Verbs([]string{"get", "patch", "update"}),
+				Name:         crd.Status.AcceptedNames.Plural + "/status",
+				SingularName: "",
+				Namespaced:   crd.Spec.Scope == apiextensions.NamespaceScoped,
+				Group:        crd.Spec.Group,
+				Version:      version.Version,
+				Kind:         crd.Status.AcceptedNames.Kind,
+				Verbs:        metav1.Verbs([]string{"get", "patch", "update"}),
 			})
 		}
 
 		if subresources != nil && subresources.Scale != nil {
 			apiResourcesForDiscovery = append(apiResourcesForDiscovery, metav1.APIResource{
-				Group:      autoscaling.GroupName,
-				Version:    "v1",
-				Kind:       "Scale",
-				Name:       crd.Status.AcceptedNames.Plural + "/scale",
-				Namespaced: crd.Spec.Scope == apiextensions.NamespaceScoped,
-				Verbs:      metav1.Verbs([]string{"get", "patch", "update"}),
+				Name:         crd.Status.AcceptedNames.Plural + "/scale",
+				SingularName: "",
+				Namespaced:   crd.Spec.Scope == apiextensions.NamespaceScoped,
+				Group:        autoscaling.GroupName,
+				Version:      "v1",
+				Kind:         "Scale",
+				Verbs:        metav1.Verbs([]string{"get", "patch", "update"}),
 			})
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -381,6 +381,8 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			resourcePath = itemPath
 			resourceParams = nameParams
 		}
+		apiResource.Group = a.group.GroupVersion.Group
+		apiResource.Version = a.group.GroupVersion.Version
 		apiResource.Name = path
 		apiResource.Namespaced = false
 		apiResource.Kind = resourceKind
@@ -430,6 +432,8 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			resourcePath = itemPath
 			resourceParams = nameParams
 		}
+		apiResource.Group = a.group.GroupVersion.Group
+		apiResource.Version = a.group.GroupVersion.Version
 		apiResource.Name = path
 		apiResource.Namespaced = true
 		apiResource.Kind = resourceKind


### PR DESCRIPTION
For some reason we did not fill the group and version fields in the /apis/group/version discovery info.

```release-note
Fill group and version fields in GroupVersion discovery info.
```