### PR TITLE
Fix shellcheck lint errors in test/images/* scripts

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -86,6 +86,5 @@
 ./test/e2e_node/environment/setup_host.sh
 ./test/e2e_node/gubernator.sh
 ./test/images/image-util.sh
-./test/images/volume/gluster/run_gluster.sh
 ./test/images/volume/iscsi/create_block.sh
 ./test/images/volume/nfs/run_nfs.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -86,5 +86,4 @@
 ./test/e2e_node/environment/setup_host.sh
 ./test/e2e_node/gubernator.sh
 ./test/images/image-util.sh
-./test/images/volume/iscsi/create_block.sh
 ./test/images/volume/nfs/run_nfs.sh

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -86,4 +86,3 @@
 ./test/e2e_node/environment/setup_host.sh
 ./test/e2e_node/gubernator.sh
 ./test/images/image-util.sh
-./test/images/volume/nfs/run_nfs.sh

--- a/test/images/volume/gluster/run_gluster.sh
+++ b/test/images/volume/gluster/run_gluster.sh
@@ -14,24 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIR=`mktemp -d`
+DIR="$(mktemp -d)"
 
 function start()
 {
-    mount -t tmpfs test $DIR
-    chmod 755 $DIR
-    cp /vol/* $DIR/
+    mount -t tmpfs test "$DIR"
+    chmod 755 "$DIR"
+    cp /vol/* "$DIR/"
     /usr/sbin/glusterd -p /run/glusterd.pid
-    gluster volume create test_vol `hostname -i`:$DIR force
+    gluster volume create test_vol "$(hostname -i):$DIR" force
     gluster volume start test_vol
 }
 
 function stop()
 {
     gluster --mode=script volume stop test_vol force
-    kill $(cat /run/glusterd.pid)
-    umount $DIR
-    rm -rf $DIR
+    kill "$(cat /run/glusterd.pid)"
+    umount "$DIR"
+    rm -rf "$DIR"
     exit 0
 }
 

--- a/test/images/volume/iscsi/create_block.sh
+++ b/test/images/volume/iscsi/create_block.sh
@@ -17,7 +17,7 @@
 # Exit on the first error.
 set -e
 
-MNTDIR=`mktemp -d`
+MNTDIR="$(mktemp -d)"
 
 cleanup()
 {
@@ -25,8 +25,8 @@ cleanup()
     RET=$?
     # Silently remove everything and ignore errors
     set +e
-    /bin/umount $MNTDIR 2>/dev/null
-    /bin/rmdir $MNTDIR 2>/dev/null
+    /bin/umount "$MNTDIR" 2>/dev/null
+    /bin/rmdir "$MNTDIR" 2>/dev/null
     /bin/rm block 2>/dev/null
     exit $RET
 }
@@ -39,9 +39,9 @@ dd if=/dev/zero of=block seek=120 count=1 bs=1M
 mkfs.ext2 block
 
 # Add index.html to it
-mount -o loop block $MNTDIR
-echo "Hello from iscsi" > $MNTDIR/index.html
-umount $MNTDIR
+mount -o loop block "$MNTDIR"
+echo "Hello from iscsi" > "$MNTDIR/index.html"
+umount "$MNTDIR"
 
 rm block.tar.gz 2>/dev/null || :
 tar cfz block.tar.gz block

--- a/test/images/volume/nfs/run_nfs.sh
+++ b/test/images/volume/nfs/run_nfs.sh
@@ -22,21 +22,22 @@ function start()
     while getopts "G:" opt; do
         case ${opt} in
             G) gid=${OPTARG};;
+            *):;;
         esac
     done
-    shift $(($OPTIND - 1))
+    shift $((OPTIND - 1))
 
     # prepare /etc/exports
     for i in "$@"; do
         # fsid=0: needed for NFSv4
         echo "$i *(rw,fsid=0,insecure,no_root_squash)" >> /etc/exports
         if [ -v gid ] ; then
-            chmod 070 $i
-            chgrp $gid $i
+            chmod 070 "$i"
+            chgrp "$gid" "$i"
         fi
         # move index.html to here
-        /bin/cp /tmp/index.html $i/
-        chmod 644 $i/index.html
+        /bin/cp /tmp/index.html "$i/"
+        chmod 644 "$i/index.html"
         echo "Serving $i"
     done
 
@@ -67,7 +68,7 @@ function stop()
     /usr/sbin/exportfs -au
     /usr/sbin/exportfs -f
 
-    kill $( pidof rpc.mountd )
+    kill "$( pidof rpc.mountd )"
     umount /proc/fs/nfsd
     echo > /etc/exports
     exit 0


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Ensures all scripts under test/images/* pass hack/verify-shellcheck.sh
**EDIT:**  Most of the scripts have been updated in other PRs. This is now limited to:
```
test/images/volume/gluster/run_gluster.sh
test/images/volume/iscsi/create_block.sh
test/images/volume/nfs/run_nfs.sh
```

**Which issue(s) this PR fixes**:
Working towards #72956

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig testing
/priority important-longterm
