### PR TITLE
make audit metadata work for custom resources

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/audit/BUILD
@@ -19,6 +19,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/audit",
     importpath = "k8s.io/apiserver/pkg/audit",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -20,13 +20,13 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"reflect"
 	"time"
 
 	"github.com/pborman/uuid"
 	"k8s.io/klog"
 
-	"reflect"
-
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -117,8 +117,9 @@ func LogRequestObject(ae *auditinternal.Event, obj runtime.Object, gvr schema.Gr
 	if ae.ObjectRef == nil {
 		ae.ObjectRef = &auditinternal.ObjectReference{}
 	}
-	if acc, ok := obj.(metav1.ObjectMetaAccessor); ok {
-		meta := acc.GetObjectMeta()
+
+	// meta.Accessor is more general than ObjectMetaAccessor, but if it fails, we can just skip setting these bits
+	if meta, err := meta.Accessor(obj); err == nil {
 		if len(ae.ObjectRef.Namespace) == 0 {
 			ae.ObjectRef.Namespace = meta.GetNamespace()
 		}


### PR DESCRIPTION
customresources are represented as unstructured.Unstructured which are not part of the metav1.ObjectMetaAccessor, but are metav1.Object .  Switch to use the accessor to ensure we always set the appropriate metadata.

/kind bug

```release-note
NONE
```

@kubernetes/sig-api-machinery-bugs 