### PR TITLE
Cleanup container and image of kube-build after

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -738,3 +738,12 @@ function kube::build::copy_output() {
 
   kube::build::stop_rsyncd_container
 }
+
+# Clean up kube-build container and image after building.
+function kube::build::delete_kubebuild() {
+  kube::log::status "Deleting kube-build container ${KUBE_DATA_CONTAINER_NAME}"
+  "${DOCKER[@]}" rm "${KUBE_DATA_CONTAINER_NAME}" &>/dev/null || true
+
+  kube::log::status "Deleting kube-build image ${KUBE_BUILD_IMAGE}"
+  "${DOCKER[@]}" rmi "${KUBE_BUILD_IMAGE}" &>/dev/null || true
+}

--- a/build/release.sh
+++ b/build/release.sh
@@ -43,3 +43,5 @@ fi
 kube::build::copy_output
 
 kube::release::package_tarballs
+
+kube::build::delete_kubebuild


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

After building e2e binary, container and image of kube-build still
exist and they waste disk space after building multiple times.
This adds cleanup of them for fixing it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #74623

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
