### PR TITLE
Refactor the node perf tests to run on non-amd64 cluster

### DIFF
--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -53,8 +53,8 @@ var NodeImageWhiteList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.Nonewprivs),
 	imageutils.GetPauseImageName(),
 	framework.GetGPUDevicePluginImage(),
-	"gcr.io/kubernetes-e2e-test-images/node-perf/npb-is-amd64:1.0",
-	"gcr.io/kubernetes-e2e-test-images/node-perf/npb-ep-amd64:1.0",
+	"gcr.io/kubernetes-e2e-test-images/node-perf/npb-is:1.0",
+	"gcr.io/kubernetes-e2e-test-images/node-perf/npb-ep:1.0",
 	"gcr.io/kubernetes-e2e-test-images/node-perf/tf-wide-deep-amd64:1.0",
 )
 

--- a/test/e2e_node/perf/workloads/npb_ep.go
+++ b/test/e2e_node/perf/workloads/npb_ep.go
@@ -43,7 +43,7 @@ func (w npbEPWorkload) PodSpec() corev1.PodSpec {
 	var containers []corev1.Container
 	ctn := corev1.Container{
 		Name:  fmt.Sprintf("%s-ctn", w.Name()),
-		Image: "gcr.io/kubernetes-e2e-test-images/node-perf/npb-ep-amd64:1.0",
+		Image: "gcr.io/kubernetes-e2e-test-images/node-perf/npb-ep:1.0",
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceName(corev1.ResourceCPU):    resource.MustParse("15000m"),

--- a/test/e2e_node/perf/workloads/npb_is.go
+++ b/test/e2e_node/perf/workloads/npb_is.go
@@ -41,7 +41,7 @@ func (w npbISWorkload) PodSpec() corev1.PodSpec {
 	var containers []corev1.Container
 	ctn := corev1.Container{
 		Name:  fmt.Sprintf("%s-ctn", w.Name()),
-		Image: "gcr.io/kubernetes-e2e-test-images/node-perf/npb-is-amd64:1.0",
+		Image: "gcr.io/kubernetes-e2e-test-images/node-perf/npb-is:1.0",
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceName(corev1.ResourceCPU):    resource.MustParse("16000m"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes: https://github.com/kubernetes/kubernetes/issues/73367

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/73367

**Special notes for your reviewer**:

- This will give more clarity on which test is failing on given hardware
- All the tests will run irrespective of the running sequence.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
