### PR TITLE
tests: Adds gcr.io Windows image test case

### DIFF
--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -359,6 +359,7 @@ while true; do sleep 1; done
 
 			It("should be able to pull image from docker hub [NodeConformance]", func() {
 				framework.SkipUnlessNodeOSDistroIs("windows")
+				// TODO(claudiub): Switch to nanoserver image manifest list.
 				image := "e2eteam/busybox:1.29"
 				imagePullTest(image, false, v1.PodRunning, false, true)
 			})

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -372,6 +372,12 @@ while true; do sleep 1; done
 				image := "gcr.io/authenticated-image-pulling/alpine:3.7"
 				imagePullTest(image, true, v1.PodRunning, false, false)
 			})
+
+			It("should be able to pull from private registry with secret [NodeConformance]", func() {
+				framework.SkipUnlessNodeOSDistroIs("windows")
+				image := "gcr.io/authenticated-image-pulling/windows-nanoserver:v1"
+				imagePullTest(image, true, v1.PodRunning, false, true)
+			})
 		})
 	})
 })

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -357,7 +357,7 @@ while true; do sleep 1; done
 				imagePullTest(image, false, v1.PodRunning, false, false)
 			})
 
-			It("should be able to pull image from docker hub [WindowsOnly] [NodeConformance]", func() {
+			It("should be able to pull image from docker hub [NodeConformance]", func() {
 				framework.SkipUnlessNodeOSDistroIs("windows")
 				image := "e2eteam/busybox:1.29"
 				imagePullTest(image, false, v1.PodRunning, false, true)

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -230,13 +230,18 @@ while true; do sleep 1; done
 			// Images used for ConformanceContainer are not added into NodeImageWhiteList, because this test is
 			// testing image pulling, these images don't need to be prepulled. The ImagePullPolicy
 			// is v1.PullAlways, so it won't be blocked by framework image white list check.
-			imagePullTest := func(image string, hasSecret bool, expectedPhase v1.PodPhase, expectedPullStatus bool) {
+			imagePullTest := func(image string, hasSecret bool, expectedPhase v1.PodPhase, expectedPullStatus bool, windowsImage bool) {
+				command := []string{"/bin/sh", "-c", "while true; do sleep 1; done"}
+				if windowsImage {
+					// -t: Ping the specified host until stopped.
+					command = []string{"ping", "-t", "localhost"}
+				}
 				container := ConformanceContainer{
 					PodClient: f.PodClient(),
 					Container: v1.Container{
 						Name:            "image-pull-test",
 						Image:           image,
-						Command:         []string{"/bin/sh", "-c", "while true; do sleep 1; done"},
+						Command:         command,
 						ImagePullPolicy: v1.PullAlways,
 					},
 					RestartPolicy: v1.RestartPolicyNever,
@@ -328,39 +333,44 @@ while true; do sleep 1; done
 
 			It("should not be able to pull image from invalid registry [NodeConformance]", func() {
 				image := "invalid.com/invalid/alpine:3.1"
-				imagePullTest(image, false, v1.PodPending, true)
+				imagePullTest(image, false, v1.PodPending, true, false)
 			})
 
 			It("should not be able to pull non-existing image from gcr.io [NodeConformance]", func() {
 				image := "k8s.gcr.io/invalid-image:invalid-tag"
-				imagePullTest(image, false, v1.PodPending, true)
+				imagePullTest(image, false, v1.PodPending, true, false)
 			})
 
-			// TODO(claudiub): Add a Windows equivalent test.
 			It("should be able to pull image from gcr.io [LinuxOnly] [NodeConformance]", func() {
 				image := "gcr.io/google-containers/debian-base:0.4.1"
-				imagePullTest(image, false, v1.PodRunning, false)
+				imagePullTest(image, false, v1.PodRunning, false, false)
+			})
+
+			It("should be able to pull image from gcr.io [NodeConformance]", func() {
+				framework.SkipUnlessNodeOSDistroIs("windows")
+				image := "gcr.io/kubernetes-e2e-test-images/windows-nanoserver:v1"
+				imagePullTest(image, false, v1.PodRunning, false, true)
 			})
 
 			It("should be able to pull image from docker hub [LinuxOnly] [NodeConformance]", func() {
 				image := "alpine:3.7"
-				imagePullTest(image, false, v1.PodRunning, false)
+				imagePullTest(image, false, v1.PodRunning, false, false)
 			})
 
 			It("should be able to pull image from docker hub [WindowsOnly] [NodeConformance]", func() {
 				framework.SkipUnlessNodeOSDistroIs("windows")
 				image := "e2eteam/busybox:1.29"
-				imagePullTest(image, false, v1.PodRunning, false)
+				imagePullTest(image, false, v1.PodRunning, false, true)
 			})
 
 			It("should not be able to pull from private registry without secret [NodeConformance]", func() {
 				image := "gcr.io/authenticated-image-pulling/alpine:3.7"
-				imagePullTest(image, false, v1.PodPending, true)
+				imagePullTest(image, false, v1.PodPending, true, false)
 			})
 
 			It("should be able to pull from private registry with secret [LinuxOnly] [NodeConformance]", func() {
 				image := "gcr.io/authenticated-image-pulling/alpine:3.7"
-				imagePullTest(image, true, v1.PodRunning, false)
+				imagePullTest(image, true, v1.PodRunning, false, false)
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

/sig windows
/sig testing

**What this PR does / why we need it**:

Adds the test "should be able to pull image from gcr.io [NodeConformance]",
which will pull the the image "gcr.io/kubernetes-e2e-test-images/windows-nanoserver:v1".
The mentioned image is a manifest list, and it works for both
Windows Server 1803 and Windows Server 2019. The manifest list
will have to be amended when a new Windows Server is released.

Adds the test "should be able to pull from private registry with secret [NodeConformance]"
which will pull the image "gcr.io/authenticated-image-pulling/windows-nanoserver:v1".
The mentioned image is a manifest list, and it works for both
Windows Server 1803 and Windows Server 2019. The manifest list
will have to be amended when a new Windows Server is released.

The command passed to the Windows Container has been changed to
"ping -t localhost", which will keep the container in the Running state,
which is required and checked by the test.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #74134 
Fixes #74740

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
