### PR TITLE
Automated cherry pick of #74636: Remove reflector metrics as they currently cause a memory

### DIFF
--- a/pkg/util/reflector/prometheus/prometheus.go
+++ b/pkg/util/reflector/prometheus/prometheus.go
@@ -85,8 +85,6 @@ func init() {
 	prometheus.MustRegister(watchDuration)
 	prometheus.MustRegister(itemsPerWatch)
 	prometheus.MustRegister(lastResourceVersion)
-
-	cache.SetReflectorMetricsProvider(prometheusMetricsProvider{})
 }
 
 type prometheusMetricsProvider struct{}


### PR DESCRIPTION
Cherry pick of #74636 on release-1.13.

#74636: Remove reflector metrics as they currently cause a memory