### PR TITLE
Updated the code to handle divide by zero panic

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -545,6 +545,9 @@ func (p *criStatsProvider) getContainerUsageNanoCores(stats *runtimeapi.Containe
 	}
 
 	nanoSeconds := stats.Cpu.Timestamp - cached.Timestamp
+	if nanoSeconds == 0 {
+		nanoSeconds = 1
+	}
 	usageNanoCores := (stats.Cpu.UsageCoreNanoSeconds.Value - cached.UsageCoreNanoSeconds.Value) * uint64(time.Second/time.Nanosecond) / uint64(nanoSeconds)
 	return &usageNanoCores
 }


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

This fixes the bug where there can be a Panic when `nanoSeconds` value is zero

**Which issue(s) this PR fixes**:

Fixes #74667 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
