### PR TITLE
Fix flag template when both visible and explicit flags are specified

### DIFF
--- a/pkg/kubectl/util/templates/templates.go
+++ b/pkg/kubectl/util/templates/templates.go
@@ -49,7 +49,8 @@ const (
 
 	// SectionFlags is the help template section that displays the command's flags.
 	SectionFlags = `{{ if or $visibleFlags.HasFlags $explicitlyExposedFlags.HasFlags}}Options:
-{{ if $visibleFlags.HasFlags}}{{trimRight (flagsUsages $visibleFlags)}}{{end}}{{ if $explicitlyExposedFlags.HasFlags}}{{trimRight (flagsUsages $explicitlyExposedFlags)}}{{end}}
+{{ if $visibleFlags.HasFlags}}{{trimRight (flagsUsages $visibleFlags)}}{{end}}{{ if $explicitlyExposedFlags.HasFlags}}{{ if $visibleFlags.HasFlags}}
+{{end}}{{trimRight (flagsUsages $explicitlyExposedFlags)}}{{end}}
 
 {{end}}`
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Before the change the help might end up looking like this:
```
Options:
  -u, --username='': Username, will prompt if not providedn      --certificate-authority='': Path to a cert file for
the certificate authority
```
Notice no newline after `--username` flag description because `trimRight` is removing this. With this change we conditionally add new line after `visibleFlags`, which results in following output:
```
Options:
  -u, --username='': Username, will prompt if not provided
      --certificate-authority='': Path to a cert file for the certificate authority
```

**Special notes for your reviewer**:
/assign @juanvallejo 

**Does this PR introduce a user-facing change?**:
```release-note
Fix --help flag parsing 
```
