### PR TITLE
Bump debian-iptables to v11.0.2

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -85,7 +85,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 #
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
-  debian_iptables_version=v10.2
+  debian_iptables_version=v11.0.2
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD.
   case $1 in

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -18,7 +18,7 @@ REGISTRY ?= staging-k8s.gcr.io
 IMAGE ?= debian-base
 BUILD_IMAGE ?= debian-build
 
-TAG ?= 0.3.2
+TAG ?= v1.0.0
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,11 +16,11 @@
 
 REGISTRY?="staging-k8s.gcr.io"
 IMAGE=debian-iptables
-TAG=v10.2
+TAG=v11.0.2
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.2
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):v1.0.0
 
 build:
 	cp ./* $(TEMP_DIR)

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -86,10 +86,10 @@ http_file(
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:0987db7ce42949d20ed2647a65d4bee0b616b4d40c7ea54769cc24b7ad003677",
+    digest = "sha256:adc40e9ec817c15d35b26d1d6aa4d0f8096fba4c99e26a026159bb0bc98c6a89",
     registry = "k8s.gcr.io",
     repository = "debian-iptables-amd64",
-    tag = "v10.2",  # ignored, but kept here for documentation
+    tag = "v11.0.2",  # ignored, but kept here for documentation
 )
 
 docker_pull(


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/priority critical-urgent
/sig release
/sig network

**What this PR does / why we need it**:
Follow up of https://github.com/kubernetes/kubernetes/pull/75845 to use debian-iptables:v11.0.2 as a manual cherrypick of https://github.com/kubernetes/kubernetes/pull/75997 for 1.11.

**Which issue(s) this PR fixes**:
Fixes #NONE

**Special notes for your reviewer**:
/assign @tallclair 

**Does this PR introduce a user-facing change?**:
```release-note
None
```
