### PR TITLE
Use EPOLL_CLOEXEC to prevent fd leaks.

### DIFF
--- a/pkg/kubelet/eviction/threshold_notifier_linux.go
+++ b/pkg/kubelet/eviction/threshold_notifier_linux.go
@@ -48,12 +48,12 @@ var _ CgroupNotifier = &linuxCgroupNotifier{}
 func NewCgroupNotifier(path, attribute string, threshold int64) (CgroupNotifier, error) {
 	var watchfd, eventfd, epfd, controlfd int
 	var err error
-	watchfd, err = unix.Open(fmt.Sprintf("%s/%s", path, attribute), unix.O_RDONLY, 0)
+	watchfd, err = unix.Open(fmt.Sprintf("%s/%s", path, attribute), unix.O_RDONLY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}
 	defer unix.Close(watchfd)
-	controlfd, err = unix.Open(fmt.Sprintf("%s/cgroup.event_control", path), unix.O_WRONLY, 0)
+	controlfd, err = unix.Open(fmt.Sprintf("%s/cgroup.event_control", path), unix.O_WRONLY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func NewCgroupNotifier(path, attribute string, threshold int64) (CgroupNotifier,
 			unix.Close(eventfd)
 		}
 	}()
-	epfd, err = unix.EpollCreate1(0)
+	epfd, err = unix.EpollCreate1(unix.EPOLL_CLOEXEC)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/flock/flock_unix.go
+++ b/pkg/util/flock/flock_unix.go
@@ -23,7 +23,7 @@ import "golang.org/x/sys/unix"
 // Acquire acquires a lock on a file for the duration of the process. This method
 // is reentrant.
 func Acquire(path string) error {
-	fd, err := unix.Open(path, unix.O_CREAT|unix.O_RDWR, 0600)
+	fd, err := unix.Open(path, unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -497,7 +497,7 @@ func ExclusiveOpenFailsOnDevice(pathname string) (bool, error) {
 		klog.Errorf("Path %q is not referring to a device.", pathname)
 		return false, nil
 	}
-	fd, errno := unix.Open(pathname, unix.O_RDONLY|unix.O_EXCL, 0)
+	fd, errno := unix.Open(pathname, unix.O_RDONLY|unix.O_EXCL|unix.O_CLOEXEC, 0)
 	// If the device is in use, open will return an invalid fd.
 	// When this happens, it is expected that Close will fail and throw an error.
 	defer unix.Close(fd)

--- a/pkg/volume/util/subpath/subpath_linux.go
+++ b/pkg/volume/util/subpath/subpath_linux.go
@@ -398,7 +398,7 @@ func doSafeMakeDir(pathname string, base string, perm os.FileMode) error {
 			return fmt.Errorf("cannot create directory %s: %s", currentPath, err)
 		}
 		// Dive into the created directory
-		childFD, err = syscall.Openat(parentFD, dir, nofollowFlags, 0)
+		childFD, err = syscall.Openat(parentFD, dir, nofollowFlags|unix.O_CLOEXEC, 0)
 		if err != nil {
 			return fmt.Errorf("cannot open %s: %s", currentPath, err)
 		}
@@ -454,7 +454,7 @@ func findExistingPrefix(base, pathname string) (string, []string, error) {
 	// This should be faster than looping through all dirs and calling os.Stat()
 	// on each of them, as the symlinks are resolved only once with OpenAt().
 	currentPath := base
-	fd, err := syscall.Open(currentPath, syscall.O_RDONLY, 0)
+	fd, err := syscall.Open(currentPath, syscall.O_RDONLY|syscall.O_CLOEXEC, 0)
 	if err != nil {
 		return pathname, nil, fmt.Errorf("error opening %s: %s", currentPath, err)
 	}
@@ -466,7 +466,7 @@ func findExistingPrefix(base, pathname string) (string, []string, error) {
 	for i, dir := range dirs {
 		// Using O_PATH here will prevent hangs in case user replaces directory with
 		// fifo
-		childFD, err := syscall.Openat(fd, dir, unix.O_PATH, 0)
+		childFD, err := syscall.Openat(fd, dir, unix.O_PATH|unix.O_CLOEXEC, 0)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return currentPath, dirs[i:], nil
@@ -499,7 +499,7 @@ func doSafeOpen(pathname string, base string) (int, error) {
 
 	// Assumption: base is the only directory that we have under control.
 	// Base dir is not allowed to be a symlink.
-	parentFD, err := syscall.Open(base, nofollowFlags, 0)
+	parentFD, err := syscall.Open(base, nofollowFlags|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return -1, fmt.Errorf("cannot open directory %s: %s", base, err)
 	}
@@ -531,7 +531,7 @@ func doSafeOpen(pathname string, base string) (int, error) {
 		}
 
 		klog.V(5).Infof("Opening path %s", currentPath)
-		childFD, err = syscall.Openat(parentFD, seg, openFDFlags, 0)
+		childFD, err = syscall.Openat(parentFD, seg, openFDFlags|unix.O_CLOEXEC, 0)
 		if err != nil {
 			return -1, fmt.Errorf("cannot open %s: %s", currentPath, err)
 		}

--- a/pkg/volume/util/subpath/subpath_nsenter_test.go
+++ b/pkg/volume/util/subpath/subpath_nsenter_test.go
@@ -83,7 +83,7 @@ func TestCheckDeviceInode(t *testing.T) {
 			continue
 		}
 
-		fd, err := unix.Open(test.srcPath, unix.O_CREAT, 0644)
+		fd, err := unix.Open(test.srcPath, unix.O_CREAT|unix.O_CLOEXEC, 0644)
 		if err != nil {
 			t.Errorf("Test %q: cannot open srcPath %s: %s", test.name, test.srcPath, err)
 			continue


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug

**What this PR does / why we need it**:

Use EPOLL_CLOEXEC to prevent fd leaks.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

There's still an issue with fsnotify which is used in other places.
Reaching out to the maintainer, but he backed out of the project some
time ago and there's no active committers AFAIK.

**Does this PR introduce a user-facing change?**:

```release-note
Use O_CLOEXEC to ensure file descriptors do not leak to subprocesses.
```
