### PR TITLE
refactor NLB securityGroup handling

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer_test.go
@@ -17,11 +17,9 @@ limitations under the License.
 package aws
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/stretchr/testify/assert"
 )
@@ -163,66 +161,6 @@ func TestIsNLB(t *testing.T) {
 			t.Errorf("Incorrect value for isNLB() case %s. Got %t, expected %t.", test.name, got, test.want)
 		}
 	}
-}
-
-func TestSecurityGroupFiltering(t *testing.T) {
-	grid := []struct {
-		in          []*ec2.SecurityGroup
-		name        string
-		expected    int
-		description string
-	}{
-		{
-			in: []*ec2.SecurityGroup{
-				{
-					IpPermissions: []*ec2.IpPermission{
-						{
-							IpRanges: []*ec2.IpRange{
-								{
-									Description: aws.String("an unmanaged"),
-								},
-							},
-						},
-					},
-				},
-			},
-			name:        "unmanaged",
-			expected:    0,
-			description: "An environment without managed LBs should have %d, but found %d SecurityGroups",
-		},
-		{
-			in: []*ec2.SecurityGroup{
-				{
-					IpPermissions: []*ec2.IpPermission{
-						{
-							IpRanges: []*ec2.IpRange{
-								{
-									Description: aws.String("an unmanaged"),
-								},
-								{
-									Description: aws.String(fmt.Sprintf("%s=%s", NLBClientRuleDescription, "managedlb")),
-								},
-								{
-									Description: aws.String(fmt.Sprintf("%s=%s", NLBHealthCheckRuleDescription, "managedlb")),
-								},
-							},
-						},
-					},
-				},
-			},
-			name:        "managedlb",
-			expected:    1,
-			description: "Found %d, but should have %d Security Groups",
-		},
-	}
-
-	for _, g := range grid {
-		actual := len(filterForIPRangeDescription(g.in, g.name))
-		if actual != g.expected {
-			t.Errorf(g.description, actual, g.expected)
-		}
-	}
-
 }
 
 func TestSyncElbListeners(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Refactor securityGroup handling part of NLB

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #57212 

**Special notes for your reviewer**:
This is not intended as an fully securityGroup handling refactor, but just as an intermediary step.
Current approach still have some limitation as before:
1. If same SG rules are required by multiple LB(will be common when we need to add support for POD IP mode).  Future improvements can be use comma seprated description to identify rules are shared by multiple LB. e.g. (NLB=lb1,NLB=lb2). And when add/remove permissions, we update the description as needed, and use an in-process lock for updating shared securityGroup like node securityGroup)
1. Do we really needs to support multiple securityGroup on worker nodes? Is there any k8s distribution on AWS that relies on that?
1. Previous ICMP rules(kubernetes.io/rule/nlb/mtu=LBName) won't be cleaned up. This can be improved by change my IPPermissionMatchDesc to be regex based or add an "IsExactMatch" param.Not sure whether it's needed since NLB is alpha feature.
1. Test done:
   1. create multiple NLB service with different loadBalancerSourceRanges, verified the correct ICMP/client/healthcheck rules been applied.
   1. modify loadBalancerSourceRanges on these NLBs, verified the ICMP/client rules been updated.
   1. delete these NLB services, verified ICMP/client/healthcheck rules been deleted.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
refactor AWS NLB securityGroup handling
```
