### PR TITLE
Fixing a small bug with GMSA support and adding an e2e test on it.

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -153,8 +153,15 @@ if [ ${remote} = true ] ; then
   exit $?
 
 else
-  # Refresh sudo credentials for local run
-  if ! ping -c 1 -q metadata.google.internal &> /dev/null; then
+  # Refresh sudo credentials if needed
+  if ping -c 1 -q metadata.google.internal &> /dev/null; then
+    echo "Running on CGE, not asking for sudo credentials"
+  elif sudo --non-interactive "$(which /bin/bash)" -c true 2> /dev/null; then
+    # if we can run bash without a password, it's a pretty safe bet that either
+    # we can run any commant without a password, or that sudo credentials
+    # are already cached - and they've just been re-cached
+    echo "No need to refresh sudo credentials"
+  else
     echo "Updating sudo credentials"
     sudo -v || exit 1
   fi

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -488,6 +488,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	ProcMountType:                               {Default: false, PreRelease: utilfeature.Alpha},
 	TTLAfterFinished:                            {Default: false, PreRelease: utilfeature.Alpha},
 	KubeletPodResources:                         {Default: false, PreRelease: utilfeature.Alpha},
+	WindowsGMSA:                                 {Default: false, PreRelease: utilfeature.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/kubelet/dockershim/docker_container_unsupported.go
+++ b/pkg/kubelet/dockershim/docker_container_unsupported.go
@@ -23,26 +23,35 @@ import (
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
-type containerCreationCleanupInfo struct{}
+type containerCleanupInfo struct{}
 
 // applyPlatformSpecificDockerConfig applies platform-specific configurations to a dockertypes.ContainerCreateConfig struct.
-// The containerCreationCleanupInfo struct it returns will be passed as is to performPlatformSpecificContainerCreationCleanup
-// after the container has been created.
-func (ds *dockerService) applyPlatformSpecificDockerConfig(*runtimeapi.CreateContainerRequest, *dockertypes.ContainerCreateConfig) (*containerCreationCleanupInfo, error) {
+// The containerCleanupInfo struct it returns will be passed as is to performPlatformSpecificContainerCleanup
+// after either:
+//   * the container creation has failed
+//   * the container has been successfully started
+//   * the container has been removed
+// whichever happens first.
+func (ds *dockerService) applyPlatformSpecificDockerConfig(*runtimeapi.CreateContainerRequest, *dockertypes.ContainerCreateConfig) (*containerCleanupInfo, error) {
 	return nil, nil
 }
 
-// performPlatformSpecificContainerCreationCleanup is responsible for doing any platform-specific cleanup
-// after a container creation. Any errors it returns are simply logged, but do not fail the container
-// creation.
-func (ds *dockerService) performPlatformSpecificContainerCreationCleanup(cleanupInfo *containerCreationCleanupInfo) (errors []error) {
+// performPlatformSpecificContainerCleanup is responsible for doing any platform-specific cleanup
+// after either:
+//   * the container creation has failed
+//   * the container has been successfully started
+//   * the container has been removed
+// whichever happens first.
+// Any errors it returns are simply logged, but do not prevent the container from being started or
+// removed.
+func (ds *dockerService) performPlatformSpecificContainerCleanup(cleanupInfo *containerCleanupInfo) (errors []error) {
 	return
 }
 
-// platformSpecificContainerCreationInitCleanup is called when dockershim
+// platformSpecificContainerInitCleanup is called when dockershim
 // is starting, and is meant to clean up any cruft left by previous runs
 // creating containers.
 // Errors are simply logged, but don't prevent dockershim from starting.
-func (ds *dockerService) platformSpecificContainerCreationInitCleanup() (errors []error) {
+func (ds *dockerService) platformSpecificContainerInitCleanup() (errors []error) {
 	return
 }

--- a/pkg/kubelet/dockershim/docker_container_windows_test.go
+++ b/pkg/kubelet/dockershim/docker_container_windows_test.go
@@ -82,7 +82,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 		defer setRandomReader(randomBytes)()
 
 		createConfig := &dockertypes.ContainerCreateConfig{}
-		cleanupInfo := &containerCreationCleanupInfo{}
+		cleanupInfo := &containerCleanupInfo{}
 		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, createConfig, cleanupInfo)
 
 		assert.Nil(t, err)
@@ -105,7 +105,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 		defer setRegistryCreateKeyFunc(t, &dummyRegistryKey{})()
 
 		createConfig := &dockertypes.ContainerCreateConfig{}
-		cleanupInfo := &containerCreationCleanupInfo{}
+		cleanupInfo := &containerCleanupInfo{}
 		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, createConfig, cleanupInfo)
 
 		assert.Nil(t, err)
@@ -127,7 +127,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 	t.Run("when there's an error generating the random value name", func(t *testing.T) {
 		defer setRandomReader([]byte{})()
 
-		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCreationCleanupInfo{})
+		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCleanupInfo{})
 
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "error when generating gMSA registry value name: unable to generate random string")
@@ -135,7 +135,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 	t.Run("if there's an error opening the registry key", func(t *testing.T) {
 		defer setRegistryCreateKeyFunc(t, &dummyRegistryKey{}, fmt.Errorf("dummy error"))()
 
-		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCreationCleanupInfo{})
+		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCleanupInfo{})
 
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "unable to open registry key")
@@ -145,7 +145,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 		key.setStringValueError = fmt.Errorf("dummy error")
 		defer setRegistryCreateKeyFunc(t, key)()
 
-		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCreationCleanupInfo{})
+		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCleanupInfo{})
 
 		if assert.NotNil(t, err) {
 			assert.Contains(t, err.Error(), "unable to write into registry value")
@@ -155,7 +155,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 	t.Run("if there is no GMSA annotation", func(t *testing.T) {
 		createConfig := &dockertypes.ContainerCreateConfig{}
 
-		err := applyGMSAConfig(&runtimeapi.ContainerConfig{}, createConfig, &containerCreationCleanupInfo{})
+		err := applyGMSAConfig(&runtimeapi.ContainerConfig{}, createConfig, &containerCleanupInfo{})
 
 		assert.Nil(t, err)
 		assert.Nil(t, createConfig.HostConfig)
@@ -164,7 +164,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 
 func TestRemoveGMSARegistryValue(t *testing.T) {
 	valueName := "k8s-cred-spec-1900254518529e2a3dedb85cdec03ce270559647459ab531f07af5eb1c5495fda709435ce82ab89c"
-	cleanupInfoWithValue := &containerCreationCleanupInfo{gMSARegistryValueName: valueName}
+	cleanupInfoWithValue := &containerCleanupInfo{gMSARegistryValueName: valueName}
 
 	t.Run("it does remove the registry value", func(t *testing.T) {
 		key := &dummyRegistryKey{}
@@ -204,7 +204,7 @@ func TestRemoveGMSARegistryValue(t *testing.T) {
 		key := &dummyRegistryKey{}
 		defer setRegistryCreateKeyFunc(t, key)()
 
-		err := removeGMSARegistryValue(&containerCreationCleanupInfo{})
+		err := removeGMSARegistryValue(&containerCleanupInfo{})
 
 		assert.Nil(t, err)
 		assert.Equal(t, 0, len(key.deleteValueArgs))

--- a/test/e2e/windows/BUILD
+++ b/test/e2e/windows/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = [
         "density.go",
         "framework.go",
+        "gmsa.go",
         "hybrid_network.go",
         "networking.go",
         "volumes.go",

--- a/test/e2e/windows/framework.go
+++ b/test/e2e/windows/framework.go
@@ -16,8 +16,22 @@ limitations under the License.
 
 package windows
 
-import "github.com/onsi/ginkgo"
+import (
+	. "github.com/onsi/ginkgo"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// it seems we can't use k8s.io/kubernetes/test/utils/image.GetPauseImageName() as it does not
+// contain a windows image?
+const winPauseImageName = "kubeletwin/pause:latest"
 
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-windows] "+text, body)
+	return Describe("[sig-windows] "+text, func() {
+		BeforeEach(func() {
+			// all tests in this package are Windows specific
+			framework.SkipUnlessNodeOSDistroIs("windows")
+		})
+
+		body()
+	})
 }

--- a/test/e2e/windows/gmsa.go
+++ b/test/e2e/windows/gmsa.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package windows
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// We need an image that packs the `nltest` command for this - and the `winPauseImageName` one doesn't.
+// I'm afraid this is the smallest one that does.
+const gMSATestImageName = "mcr.microsoft.com/powershell"
+
+var _ = SIGDescribe("[Feature:Windows] GMSA [Slow]", func() {
+	f := framework.NewDefaultFramework("gmsa-test-windows")
+
+	Describe("kubelet GMSA support", func() {
+		Context("when creating a pod with correct GMSA credential specs", func() {
+			It("passes the credential specs down to the pod's containers", func() {
+				defer GinkgoRecover()
+
+				podName := "with-correct-gmsa-annotations"
+
+				container1Name := "container1"
+				podDomain := "acme.com"
+
+				container2Name := "container2"
+				container2Domain := "contoso.org"
+
+				containers := make([]corev1.Container, 2)
+				for i, name := range []string{container1Name, container2Name} {
+					containers[i] = corev1.Container{
+						Name:    name,
+						Image:   gMSATestImageName,
+						Command: []string{"powershell"},
+						Args:    []string{"while ($true) { Start-Sleep -Seconds 1 }"},
+					}
+				}
+
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: podName,
+						Annotations: map[string]string{
+							"pod.alpha.windows.kubernetes.io/gmsa-credential-spec":                         generateDummyCredSpecs(podDomain),
+							container2Name + ".container.alpha.windows.kubernetes.io/gmsa-credential-spec": generateDummyCredSpecs(container2Domain),
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: containers,
+					},
+				}
+
+				By("creating a pod with correct GMSA annotations")
+				f.PodClient().Create(pod)
+
+				By("waiting for the pod and its containers to be running")
+				Eventually(func() bool {
+					pod, err := f.PodClient().Get(podName, metav1.GetOptions{})
+					if err != nil && pod.Status.Phase != corev1.PodRunning {
+						return false
+					}
+
+					for _, containerStatus := range pod.Status.ContainerStatuses {
+						if containerStatus.State.Running == nil {
+							return false
+						}
+					}
+
+					return true
+				}, 5*time.Minute, 1*time.Second).Should(BeTrue())
+
+				By("checking the domain reported by nltest in the containers")
+				namespaceOption := fmt.Sprintf("--namespace=%s", f.Namespace.Name)
+				for containerName, domain := range map[string]string{
+					container1Name: podDomain,
+					container2Name: container2Domain,
+				} {
+					var (
+						output string
+						err    error
+					)
+
+					containerOption := fmt.Sprintf("--container=%s", containerName)
+					// even for bogus creds, `nltest /PARENTDOMAIN` simply returns the AD domain, which is enough for our purpose here.
+					// note that the "eventually" part seems to be needed to account for the fact that powershell containers
+					// are a bit slow to become responsive, even when docker reports them as running.
+					Eventually(func() bool {
+						output, err = framework.RunKubectl("exec", namespaceOption, podName, containerOption, "--", "nltest", "/PARENTDOMAIN")
+						return err == nil
+					}, 1*time.Minute, 1*time.Second).Should(BeTrue())
+
+					if !strings.HasPrefix(output, domain) {
+						framework.Failf("Expected %q to start with %q", output, domain)
+					}
+
+					expectedSubstr := "The command completed successfully"
+					if !strings.Contains(output, expectedSubstr) {
+						framework.Failf("Expected %q to contain %q", output, expectedSubstr)
+					}
+				}
+
+				// If this was an e2e_node test, we could also check that the registry keys used to pass down the cred specs to Docker
+				// have been properly cleaned up - but as of right now, e2e_node tests don't support Windows. We should migrate this
+				// test to an e2e_node test when they start supporting Windows.
+			})
+		})
+	})
+})
+
+func generateDummyCredSpecs(domain string) string {
+	shortName := strings.ToUpper(strings.Split(domain, ".")[0])
+
+	return fmt.Sprintf(`{
+       "ActiveDirectoryConfig":{
+          "GroupManagedServiceAccounts":[
+             {
+                "Name":"WebApplication",
+                "Scope":"%s"
+             },
+             {
+                "Name":"WebApplication",
+                "Scope":"%s"
+             }
+          ]
+       },
+       "CmsPlugins":[
+          "ActiveDirectory"
+       ],
+       "DomainJoinConfig":{
+          "DnsName":"%s",
+          "DnsTreeName":"%s",
+          "Guid":"244818ae-87ca-4fcd-92ec-e79e5252348a",
+          "MachineAccountName":"WebApplication",
+          "NetBiosName":"%s",
+          "Sid":"S-1-5-21-2126729477-2524175714-3194792973"
+       }
+    }`, shortName, domain, domain, domain, shortName)
+}

--- a/test/e2e_node/conformance/run_test.sh
+++ b/test/e2e_node/conformance/run_test.sh
@@ -24,8 +24,16 @@
 # TODO(random-liu): Use standard tool to start kubelet in production way (such
 # as systemd, supervisord etc.)
 
-# Refresh sudo credentials if not running on GCE.
-if ! ping -c 1 -q metadata.google.internal &> /dev/null; then
+# Refresh sudo credentials if needed
+if ping -c 1 -q metadata.google.internal &> /dev/null; then
+  echo "Running on CGE, not asking for sudo credentials"
+elif sudo --non-interactive "$(which /bin/bash)" -c true 2> /dev/null; then
+  # if we can run bash without a password, it's a pretty safe bet that either
+  # we can run any commant without a password, or that sudo credentials
+  # are already cached - and they've just been re-cached
+  echo "No need to refresh sudo credentials"
+else
+  echo "Updating sudo credentials"
   sudo -v || exit 1
 fi
 

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -62,7 +62,7 @@ func setDesiredConfiguration(initialConfig *kubeletconfig.KubeletConfiguration) 
 var _ = framework.KubeDescribe("Node Container Manager [Serial]", func() {
 	f := framework.NewDefaultFramework("node-container-manager")
 	Describe("Validate Node Allocatable [NodeFeature:NodeAllocatable]", func() {
-		It("set's up the node and runs the test", func() {
+		It("sets up the node and runs the test", func() {
 			framework.ExpectNoError(runTest(f))
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

A previous PR (https://github.com/kubernetes/kubernetes/pull/73726)
added GMSA support to the dockershim. Unfortunately, there was a
bug in there: the registry keys used to pass the cred specs down
to Docker were being cleaned up too early, right after the containers'
creation - before Docker would ever try to read them, when trying to
actually start the container.

This patch fixes this, and also adds an e2e test on this.

**Which issue(s) this PR fixes**:
@yujuhong requested an e2e test on this at https://github.com/kubernetes/kubernetes/pull/73726#pullrequestreview-206595783.

**Special notes for your reviewer**:
The e2e test has been verified to pass on a cluster with a Windows node with the
`WindowsGMSA=true` feature gate enabled; however, I don't believe that's the case
when running a "regular" build. Would it be possible to:
1) enable that feature gate when running Windows e2e tests in a build?
2) or else enable dynamic Kubelet config for these tests, so that each spec can
set the config it needs?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
