### PR TITLE
Fix golint failures in staging/src/k8s.io/apiserver/pkg/storage/errors, staging/src/k8s.io/apiserver/pkg/storage/etcd

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -522,8 +522,6 @@ staging/src/k8s.io/apiserver/pkg/server/httplog
 staging/src/k8s.io/apiserver/pkg/server/options
 staging/src/k8s.io/apiserver/pkg/server/storage
 staging/src/k8s.io/apiserver/pkg/storage
-staging/src/k8s.io/apiserver/pkg/storage/errors
-staging/src/k8s.io/apiserver/pkg/storage/etcd
 staging/src/k8s.io/apiserver/pkg/storage/etcd/etcdtest
 staging/src/k8s.io/apiserver/pkg/storage/etcd/metrics
 staging/src/k8s.io/apiserver/pkg/storage/etcd/testing

--- a/staging/src/k8s.io/apiserver/pkg/storage/errors/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/errors/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package etcd provides conversion of etcd errors to API errors.
+// Package storage provides conversion of storage errors to API errors.
 package storage // import "k8s.io/apiserver/pkg/storage/errors"

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/api_object_versioner.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/api_object_versioner.go
@@ -101,7 +101,7 @@ func (a APIObjectVersioner) ParseResourceVersion(resourceVersion string) (uint64
 	return version, nil
 }
 
-// APIObjectVersioner implements Versioner
+// Versioner implements Versioner
 var Versioner storage.Versioner = APIObjectVersioner{}
 
 // CompareResourceVersion compares etcd resource versions.  Outside this API they are all strings,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix golint failures in :
staging/src/k8s.io/apiserver/pkg/storage/errors
staging/src/k8s.io/apiserver/pkg/storage/etcd

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
