### PR TITLE
Remove duplicate package import

### DIFF
--- a/pkg/apis/autoscaling/v1/conversion.go
+++ b/pkg/apis/autoscaling/v1/conversion.go
@@ -25,8 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	core "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/core"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
@@ -298,7 +297,7 @@ func Convert_autoscaling_HorizontalPodAutoscaler_To_v1_HorizontalPodAutoscaler(i
 
 	otherMetrics := make([]autoscalingv1.MetricSpec, 0, len(in.Spec.Metrics))
 	for _, metric := range in.Spec.Metrics {
-		if metric.Type == autoscaling.ResourceMetricSourceType && metric.Resource != nil && metric.Resource.Name == api.ResourceCPU && metric.Resource.Target.AverageUtilization != nil {
+		if metric.Type == autoscaling.ResourceMetricSourceType && metric.Resource != nil && metric.Resource.Name == core.ResourceCPU && metric.Resource.Target.AverageUtilization != nil {
 			continue
 		}
 
@@ -411,7 +410,7 @@ func Convert_v1_HorizontalPodAutoscaler_To_autoscaling_HorizontalPodAutoscaler(i
 			{
 				Type: autoscaling.ResourceMetricSourceType,
 				Resource: &autoscaling.ResourceMetricSource{
-					Name: api.ResourceCPU,
+					Name: core.ResourceCPU,
 					Target: autoscaling.MetricTarget{
 						Type: autoscaling.UtilizationMetricType,
 					},
@@ -449,7 +448,7 @@ func Convert_autoscaling_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAutoscal
 	out.MaxReplicas = in.MaxReplicas
 
 	for _, metric := range in.Metrics {
-		if metric.Type == autoscaling.ResourceMetricSourceType && metric.Resource != nil && metric.Resource.Name == api.ResourceCPU {
+		if metric.Type == autoscaling.ResourceMetricSourceType && metric.Resource != nil && metric.Resource.Name == core.ResourceCPU {
 			if metric.Resource.Target.AverageUtilization != nil {
 				out.TargetCPUUtilizationPercentage = new(int32)
 				*out.TargetCPUUtilizationPercentage = *metric.Resource.Target.AverageUtilization
@@ -474,7 +473,7 @@ func Convert_v1_HorizontalPodAutoscalerSpec_To_autoscaling_HorizontalPodAutoscal
 			{
 				Type: autoscaling.ResourceMetricSourceType,
 				Resource: &autoscaling.ResourceMetricSource{
-					Name: api.ResourceCPU,
+					Name: core.ResourceCPU,
 					Target: autoscaling.MetricTarget{
 						Type: autoscaling.UtilizationMetricType,
 					},
@@ -496,7 +495,7 @@ func Convert_autoscaling_HorizontalPodAutoscalerStatus_To_v1_HorizontalPodAutosc
 	out.DesiredReplicas = in.DesiredReplicas
 
 	for _, metric := range in.CurrentMetrics {
-		if metric.Type == autoscaling.ResourceMetricSourceType && metric.Resource != nil && metric.Resource.Name == api.ResourceCPU {
+		if metric.Type == autoscaling.ResourceMetricSourceType && metric.Resource != nil && metric.Resource.Name == core.ResourceCPU {
 			if metric.Resource.Current.AverageUtilization != nil {
 
 				out.CurrentCPUUtilizationPercentage = new(int32)
@@ -519,7 +518,7 @@ func Convert_v1_HorizontalPodAutoscalerStatus_To_autoscaling_HorizontalPodAutosc
 			{
 				Type: autoscaling.ResourceMetricSourceType,
 				Resource: &autoscaling.ResourceMetricStatus{
-					Name: api.ResourceCPU,
+					Name: core.ResourceCPU,
 				},
 			},
 		}


### PR DESCRIPTION

/kind cleanup


**What this PR does / why we need it**:
Clean duplicate package import.
It surprised me that golang doesn't check this kind of duplicate.

```release-note
NONE
```
