### PR TITLE
Automated cherry pick of #74448: Explicitly set GVK when sending objects to webhooks

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion.go
@@ -43,6 +43,8 @@ func (c *convertor) ConvertToGVK(obj runtime.Object, gvk schema.GroupVersionKind
 	if err != nil {
 		return nil, err
 	}
+	// Explicitly set the GVK
+	out.GetObjectKind().SetGroupVersionKind(gvk)
 	return out, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion_test.go
@@ -59,6 +59,10 @@ func TestConvertToGVK(t *testing.T) {
 			},
 			gvk: examplev1.SchemeGroupVersion.WithKind("Pod"),
 			expectedObj: &examplev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "example.apiserver.k8s.io/v1",
+					Kind:       "Pod",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod1",
 					Labels: map[string]string{
@@ -84,6 +88,10 @@ func TestConvertToGVK(t *testing.T) {
 			},
 			gvk: example2v1.SchemeGroupVersion.WithKind("ReplicaSet"),
 			expectedObj: &example2v1.ReplicaSet{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "example2.apiserver.k8s.io/v1",
+					Kind:       "ReplicaSet",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "rs1",
 					Labels: map[string]string{


### PR DESCRIPTION
Cherry pick of #74448 on release-1.11.

#74448: Explicitly set GVK when sending objects to webhooks