### PR TITLE
Move MountsInGlobalPDPath from mount pkg to volume

### DIFF
--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -182,8 +182,8 @@ func (f *FakeMounter) PathIsDevice(pathname string) (bool, error) {
 	return true, nil
 }
 
-func (f *FakeMounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
-	return getDeviceNameFromMount(f, mountPath, pluginDir)
+func (f *FakeMounter) GetDeviceNameFromMount(mountPath, pluginMountDir string) (string, error) {
+	return getDeviceNameFromMount(f, mountPath, pluginMountDir)
 }
 
 func (f *FakeMounter) MakeRShared(path string) error {

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -29,13 +29,12 @@ type FileType string
 
 const (
 	// Default mount command if mounter path is not specified
-	defaultMountCommand           = "mount"
-	MountsInGlobalPDPath          = "mounts"
-	FileTypeDirectory    FileType = "Directory"
-	FileTypeFile         FileType = "File"
-	FileTypeSocket       FileType = "Socket"
-	FileTypeCharDev      FileType = "CharDevice"
-	FileTypeBlockDev     FileType = "BlockDevice"
+	defaultMountCommand          = "mount"
+	FileTypeDirectory   FileType = "Directory"
+	FileTypeFile        FileType = "File"
+	FileTypeSocket      FileType = "Socket"
+	FileTypeCharDev     FileType = "CharDevice"
+	FileTypeBlockDev    FileType = "BlockDevice"
 )
 
 type Interface interface {
@@ -62,8 +61,8 @@ type Interface interface {
 	// PathIsDevice determines if a path is a device.
 	PathIsDevice(pathname string) (bool, error)
 	// GetDeviceNameFromMount finds the device name by checking the mount path
-	// to get the global mount path which matches its plugin directory
-	GetDeviceNameFromMount(mountPath, pluginDir string) (string, error)
+	// to get the global mount path within its plugin directory
+	GetDeviceNameFromMount(mountPath, pluginMountDir string) (string, error)
 	// MakeRShared checks that given path is on a mount with 'rshared' mount
 	// propagation. If not, it bind-mounts the path as rshared.
 	MakeRShared(path string) error

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -304,19 +304,19 @@ func ExclusiveOpenFailsOnDevice(pathname string) (bool, error) {
 }
 
 //GetDeviceNameFromMount: given a mount point, find the device name from its global mount point
-func (mounter *Mounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
-	return GetDeviceNameFromMountLinux(mounter, mountPath, pluginDir)
+func (mounter *Mounter) GetDeviceNameFromMount(mountPath, pluginMountDir string) (string, error) {
+	return GetDeviceNameFromMountLinux(mounter, mountPath, pluginMountDir)
 }
 
-func getDeviceNameFromMount(mounter Interface, mountPath, pluginDir string) (string, error) {
-	return GetDeviceNameFromMountLinux(mounter, mountPath, pluginDir)
+func getDeviceNameFromMount(mounter Interface, mountPath, pluginMountDir string) (string, error) {
+	return GetDeviceNameFromMountLinux(mounter, mountPath, pluginMountDir)
 }
 
 // GetDeviceNameFromMountLinux find the device name from /proc/mounts in which
-// the mount path reference should match the given plugin directory. In case no mount path reference
+// the mount path reference should match the given plugin mount directory. In case no mount path reference
 // matches, returns the volume name taken from its given mountPath
 // This implementation is shared with NsEnterMounter
-func GetDeviceNameFromMountLinux(mounter Interface, mountPath, pluginDir string) (string, error) {
+func GetDeviceNameFromMountLinux(mounter Interface, mountPath, pluginMountDir string) (string, error) {
 	refs, err := mounter.GetMountRefs(mountPath)
 	if err != nil {
 		klog.V(4).Infof("GetMountRefs failed for mount path %q: %v", mountPath, err)
@@ -326,10 +326,9 @@ func GetDeviceNameFromMountLinux(mounter Interface, mountPath, pluginDir string)
 		klog.V(4).Infof("Directory %s is not mounted", mountPath)
 		return "", fmt.Errorf("directory %s is not mounted", mountPath)
 	}
-	basemountPath := path.Join(pluginDir, MountsInGlobalPDPath)
 	for _, ref := range refs {
-		if strings.HasPrefix(ref, basemountPath) {
-			volumeID, err := filepath.Rel(basemountPath, ref)
+		if strings.HasPrefix(ref, pluginMountDir) {
+			volumeID, err := filepath.Rel(pluginMountDir, ref)
 			if err != nil {
 				klog.Errorf("Failed to get volume id from mount %s - %v", mountPath, err)
 				return "", err

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -58,11 +58,11 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, unsupportedErr
 }
 
-func (mounter *Mounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
+func (mounter *Mounter) GetDeviceNameFromMount(mountPath, pluginMountDir string) (string, error) {
 	return "", unsupportedErr
 }
 
-func getDeviceNameFromMount(mounter Interface, mountPath, pluginDir string) (string, error) {
+func getDeviceNameFromMount(mounter Interface, mountPath, pluginMountDir string) (string, error) {
 	return "", unsupportedErr
 }
 

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -196,14 +196,14 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 }
 
 // GetDeviceNameFromMount given a mnt point, find the device
-func (mounter *Mounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
-	return getDeviceNameFromMount(mounter, mountPath, pluginDir)
+func (mounter *Mounter) GetDeviceNameFromMount(mountPath, pluginMountDir string) (string, error) {
+	return getDeviceNameFromMount(mounter, mountPath, pluginMountDir)
 }
 
 // getDeviceNameFromMount find the device(drive) name in which
-// the mount path reference should match the given plugin directory. In case no mount path reference
+// the mount path reference should match the given plugin mount directory. In case no mount path reference
 // matches, returns the volume name taken from its given mountPath
-func getDeviceNameFromMount(mounter Interface, mountPath, pluginDir string) (string, error) {
+func getDeviceNameFromMount(mounter Interface, mountPath, pluginMountDir string) (string, error) {
 	refs, err := mounter.GetMountRefs(mountPath)
 	if err != nil {
 		klog.V(4).Infof("GetMountRefs failed for mount path %q: %v", mountPath, err)
@@ -212,7 +212,7 @@ func getDeviceNameFromMount(mounter Interface, mountPath, pluginDir string) (str
 	if len(refs) == 0 {
 		return "", fmt.Errorf("directory %s is not mounted", mountPath)
 	}
-	basemountPath := normalizeWindowsPath(path.Join(pluginDir, MountsInGlobalPDPath))
+	basemountPath := normalizeWindowsPath(pluginMountDir)
 	for _, ref := range refs {
 		if strings.Contains(ref, basemountPath) {
 			volumeID, err := filepath.Rel(normalizeWindowsPath(basemountPath), ref)

--- a/pkg/volume/awsebs/aws_ebs.go
+++ b/pkg/volume/awsebs/aws_ebs.go
@@ -250,8 +250,8 @@ func getVolumeSource(
 
 func (plugin *awsElasticBlockStorePlugin) ConstructVolumeSpec(volName, mountPath string) (*volume.Spec, error) {
 	mounter := plugin.host.GetMounter(plugin.GetPluginName())
-	pluginDir := plugin.host.GetPluginDir(plugin.GetPluginName())
-	volumeID, err := mounter.GetDeviceNameFromMount(mountPath, pluginDir)
+	pluginMntDir := util.GetPluginMountDir(plugin.host, plugin.GetPluginName())
+	volumeID, err := mounter.GetDeviceNameFromMount(mountPath, pluginMntDir)
 	if err != nil {
 		return nil, err
 	}
@@ -451,7 +451,7 @@ func makeGlobalPDPath(host volume.VolumeHost, volumeID aws.KubernetesVolumeID) s
 	// Clean up the URI to be more fs-friendly
 	name := string(volumeID)
 	name = strings.Replace(name, "://", "/", -1)
-	return filepath.Join(host.GetPluginDir(awsElasticBlockStorePluginName), mount.MountsInGlobalPDPath, name)
+	return filepath.Join(host.GetPluginDir(awsElasticBlockStorePluginName), util.MountsInGlobalPDPath, name)
 }
 
 func (ebs *awsElasticBlockStore) GetPath() string {

--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -199,7 +199,7 @@ func (a *azureDiskAttacher) GetDeviceMountPath(spec *volume.Spec) (string, error
 	}
 
 	if volumeSource.Kind == nil { // this spec was constructed from info on the node
-		pdPath := filepath.Join(a.plugin.host.GetPluginDir(azureDataDiskPluginName), mount.MountsInGlobalPDPath, volumeSource.DataDiskURI)
+		pdPath := filepath.Join(a.plugin.host.GetPluginDir(azureDataDiskPluginName), util.MountsInGlobalPDPath, volumeSource.DataDiskURI)
 		return pdPath, nil
 	}
 

--- a/pkg/volume/azure_dd/azure_common.go
+++ b/pkg/volume/azure_dd/azure_common.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/legacy-cloud-providers/azure"
 	utilstrings "k8s.io/utils/strings"
 )
@@ -80,7 +80,7 @@ func makeGlobalPDPath(host volume.VolumeHost, diskUri string, isManaged bool) (s
 	}
 	// "{m for managed b for blob}{hashed diskUri or DiskId depending on disk kind }"
 	diskName := fmt.Sprintf(uniqueDiskNameTemplate, prefix, hashedDiskUri)
-	pdPath := filepath.Join(host.GetPluginDir(azureDataDiskPluginName), mount.MountsInGlobalPDPath, diskName)
+	pdPath := filepath.Join(host.GetPluginDir(azureDataDiskPluginName), util.MountsInGlobalPDPath, diskName)
 
 	return pdPath, nil
 }

--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -328,8 +328,8 @@ var _ volume.NodeExpandableVolumePlugin = &azureDataDiskPlugin{}
 
 func (plugin *azureDataDiskPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
 	mounter := plugin.host.GetMounter(plugin.GetPluginName())
-	pluginDir := plugin.host.GetPluginDir(plugin.GetPluginName())
-	sourceName, err := mounter.GetDeviceNameFromMount(mountPath, pluginDir)
+	pluginMntDir := util.GetPluginMountDir(plugin.host, plugin.GetPluginName())
+	sourceName, err := mounter.GetDeviceNameFromMount(mountPath, pluginMntDir)
 
 	if err != nil {
 		return nil, err

--- a/pkg/volume/cephfs/cephfs.go
+++ b/pkg/volume/cephfs/cephfs.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -384,7 +384,7 @@ func (cephfsVolume *cephfs) execFuseMount(mountpoint string) error {
 			return err
 		}
 
-		keyringFile = path.Join(keyringPath, fileName)
+		keyringFile = filepath.Join(keyringPath, fileName)
 
 	} else {
 		keyringFile = cephfsVolume.secretFile

--- a/pkg/volume/cephfs/cephfs_test.go
+++ b/pkg/volume/cephfs/cephfs_test.go
@@ -18,7 +18,7 @@ package cephfs
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -83,7 +83,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Got a nil Mounter")
 	}
 	volumePath := mounter.GetPath()
-	volpath := path.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~cephfs/vol1")
+	volpath := filepath.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~cephfs/vol1")
 	if volumePath != volpath {
 		t.Errorf("Got unexpected path: %s", volumePath)
 	}

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -266,8 +266,8 @@ func (plugin *cinderPlugin) getCloudProvider() (BlockStorageProvider, error) {
 
 func (plugin *cinderPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
 	mounter := plugin.host.GetMounter(plugin.GetPluginName())
-	pluginDir := plugin.host.GetPluginDir(plugin.GetPluginName())
-	sourceName, err := mounter.GetDeviceNameFromMount(mountPath, pluginDir)
+	pluginMntDir := util.GetPluginMountDir(plugin.host, plugin.GetPluginName())
+	sourceName, err := mounter.GetDeviceNameFromMount(mountPath, pluginMntDir)
 	if err != nil {
 		return nil, err
 	}
@@ -449,7 +449,7 @@ func (b *cinderVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 }
 
 func makeGlobalPDName(host volume.VolumeHost, devName string) string {
-	return path.Join(host.GetPluginDir(cinderVolumePluginName), mount.MountsInGlobalPDPath, devName)
+	return path.Join(host.GetPluginDir(cinderVolumePluginName), util.MountsInGlobalPDPath, devName)
 }
 
 func (cd *cinderVolume) GetPath() string {

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -449,7 +450,7 @@ func (b *cinderVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 }
 
 func makeGlobalPDName(host volume.VolumeHost, devName string) string {
-	return path.Join(host.GetPluginDir(cinderVolumePluginName), util.MountsInGlobalPDPath, devName)
+	return filepath.Join(host.GetPluginDir(cinderVolumePluginName), util.MountsInGlobalPDPath, devName)
 }
 
 func (cd *cinderVolume) GetPath() string {

--- a/pkg/volume/cinder/cinder_block_test.go
+++ b/pkg/volume/cinder/cinder_block_test.go
@@ -18,7 +18,7 @@ package cinder
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -47,7 +47,7 @@ func TestGetVolumeSpecFromGlobalMapPath(t *testing.T) {
 	//deferred clean up
 	defer os.RemoveAll(tmpVDir)
 
-	expectedGlobalPath := path.Join(tmpVDir, testGlobalPath)
+	expectedGlobalPath := filepath.Join(tmpVDir, testGlobalPath)
 
 	//Bad Path
 	badspec, err := getVolumeSpecFromGlobalMapPath("")
@@ -102,8 +102,8 @@ func TestGetPodAndPluginMapPaths(t *testing.T) {
 	//deferred clean up
 	defer os.RemoveAll(tmpVDir)
 
-	expectedGlobalPath := path.Join(tmpVDir, testGlobalPath)
-	expectedPodPath := path.Join(tmpVDir, testPodPath)
+	expectedGlobalPath := filepath.Join(tmpVDir, testGlobalPath)
+	expectedPodPath := filepath.Join(tmpVDir, testPodPath)
 
 	spec := getTestVolume(false, true /*isBlock*/)
 	plugMgr := volume.VolumePluginMgr{}

--- a/pkg/volume/cinder/cinder_test.go
+++ b/pkg/volume/cinder/cinder_test.go
@@ -19,7 +19,7 @@ package cinder
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -64,7 +64,7 @@ type fakePDManager struct {
 }
 
 func getFakeDeviceName(host volume.VolumeHost, pdName string) string {
-	return path.Join(host.GetPluginDir(cinderVolumePluginName), "device", pdName)
+	return filepath.Join(host.GetPluginDir(cinderVolumePluginName), "device", pdName)
 }
 
 // Real Cinder AttachDisk attaches a cinder volume. If it is not yet mounted,
@@ -160,7 +160,7 @@ func TestPlugin(t *testing.T) {
 	if mounter == nil {
 		t.Errorf("Got a nil Mounter")
 	}
-	volPath := path.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~cinder/vol1")
+	volPath := filepath.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~cinder/vol1")
 	path := mounter.GetPath()
 	if path != volPath {
 		t.Errorf("Got unexpected path: %s", path)

--- a/pkg/volume/configmap/configmap_test.go
+++ b/pkg/volume/configmap/configmap_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -498,14 +498,14 @@ func TestPluginOptional(t *testing.T) {
 		}
 	}
 
-	datadirSymlink := path.Join(volumePath, "..data")
+	datadirSymlink := filepath.Join(volumePath, "..data")
 	datadir, err := os.Readlink(datadirSymlink)
 	if err != nil && os.IsNotExist(err) {
 		t.Fatalf("couldn't find volume path's data dir, %s", datadirSymlink)
 	} else if err != nil {
 		t.Fatalf("couldn't read symlink, %s", datadirSymlink)
 	}
-	datadirPath := path.Join(volumePath, datadir)
+	datadirPath := filepath.Join(volumePath, datadir)
 
 	infos, err := ioutil.ReadDir(volumePath)
 	if err != nil {
@@ -689,7 +689,7 @@ func configMap(namespace, name string) v1.ConfigMap {
 
 func doTestConfigMapDataInVolume(volumePath string, configMap v1.ConfigMap, t *testing.T) {
 	for key, value := range configMap.Data {
-		configMapDataHostPath := path.Join(volumePath, key)
+		configMapDataHostPath := filepath.Join(volumePath, key)
 		if _, err := os.Stat(configMapDataHostPath); err != nil {
 			t.Fatalf("SetUp() failed, couldn't find configMap data on disk: %v", configMapDataHostPath)
 		} else {

--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -598,7 +597,7 @@ func makeDeviceMountPath(plugin *csiPlugin, spec *volume.Spec) (string, error) {
 		return "", fmt.Errorf("makeDeviceMountPath failed, pv name empty")
 	}
 
-	return path.Join(plugin.host.GetPluginDir(plugin.GetPluginName()), persistentVolumeInGlobalPath, pvName, globalMountInGlobalPath), nil
+	return filepath.Join(plugin.host.GetPluginDir(plugin.GetPluginName()), persistentVolumeInGlobalPath, pvName, globalMountInGlobalPath), nil
 }
 
 func getDriverAndVolNameFromDeviceMountPath(k8s kubernetes.Interface, deviceMountPath string) (string, string, error) {

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 
 	"k8s.io/klog"
@@ -63,14 +62,14 @@ func (m *csiBlockMapper) GetGlobalMapPath(spec *volume.Spec) (string, error) {
 // Example: plugins/kubernetes.io/csi/volumeDevices/staging/{pvname}
 func (m *csiBlockMapper) getStagingPath() string {
 	sanitizedSpecVolID := utilstrings.EscapeQualifiedName(m.specName)
-	return path.Join(m.plugin.host.GetVolumeDevicePluginDir(CSIPluginName), "staging", sanitizedSpecVolID)
+	return filepath.Join(m.plugin.host.GetVolumeDevicePluginDir(CSIPluginName), "staging", sanitizedSpecVolID)
 }
 
 // getPublishPath returns a publish path for a file (on the node) that should be used on NodePublishVolume/NodeUnpublishVolume
 // Example: plugins/kubernetes.io/csi/volumeDevices/publish/{pvname}
 func (m *csiBlockMapper) getPublishPath() string {
 	sanitizedSpecVolID := utilstrings.EscapeQualifiedName(m.specName)
-	return path.Join(m.plugin.host.GetVolumeDevicePluginDir(CSIPluginName), "publish", sanitizedSpecVolID)
+	return filepath.Join(m.plugin.host.GetVolumeDevicePluginDir(CSIPluginName), "publish", sanitizedSpecVolID)
 }
 
 // GetPodDeviceMapPath returns pod's device file which will be mapped to a volume

--- a/pkg/volume/csi/csi_block_test.go
+++ b/pkg/volume/csi/csi_block_test.go
@@ -19,7 +19,6 @@ package csi
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -64,12 +63,12 @@ func TestBlockMapperGetGlobalMapPath(t *testing.T) {
 		{
 			name:           "simple specName",
 			specVolumeName: "spec-0",
-			path:           path.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/%s/%s", "spec-0", "dev")),
+			path:           filepath.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/%s/%s", "spec-0", "dev")),
 		},
 		{
 			name:           "specName with dots",
 			specVolumeName: "test.spec.1",
-			path:           path.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/%s/%s", "test.spec.1", "dev")),
+			path:           filepath.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/%s/%s", "test.spec.1", "dev")),
 		},
 	}
 	for _, tc := range testCases {
@@ -104,12 +103,12 @@ func TestBlockMapperGetStagingPath(t *testing.T) {
 		{
 			name:           "simple specName",
 			specVolumeName: "spec-0",
-			path:           path.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/staging/%s", "spec-0")),
+			path:           filepath.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/staging/%s", "spec-0")),
 		},
 		{
 			name:           "specName with dots",
 			specVolumeName: "test.spec.1",
-			path:           path.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/staging/%s", "test.spec.1")),
+			path:           filepath.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/staging/%s", "test.spec.1")),
 		},
 	}
 	for _, tc := range testCases {
@@ -141,12 +140,12 @@ func TestBlockMapperGetPublishPath(t *testing.T) {
 		{
 			name:           "simple specName",
 			specVolumeName: "spec-0",
-			path:           path.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/publish/%s", "spec-0")),
+			path:           filepath.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/publish/%s", "spec-0")),
 		},
 		{
 			name:           "specName with dots",
 			specVolumeName: "test.spec.1",
-			path:           path.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/publish/%s", "test.spec.1")),
+			path:           filepath.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/publish/%s", "test.spec.1")),
 		},
 	}
 	for _, tc := range testCases {
@@ -178,12 +177,12 @@ func TestBlockMapperGetDeviceMapPath(t *testing.T) {
 		{
 			name:           "simple specName",
 			specVolumeName: "spec-0",
-			path:           path.Join(tmpDir, fmt.Sprintf("pods/%s/volumeDevices/kubernetes.io~csi", testPodUID)),
+			path:           filepath.Join(tmpDir, fmt.Sprintf("pods/%s/volumeDevices/kubernetes.io~csi", testPodUID)),
 		},
 		{
 			name:           "specName with dots",
 			specVolumeName: "test.spec.1",
-			path:           path.Join(tmpDir, fmt.Sprintf("pods/%s/volumeDevices/kubernetes.io~csi", testPodUID)),
+			path:           filepath.Join(tmpDir, fmt.Sprintf("pods/%s/volumeDevices/kubernetes.io~csi", testPodUID)),
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"k8s.io/klog"
 
@@ -75,7 +76,7 @@ type csiMountMgr struct {
 var _ volume.Volume = &csiMountMgr{}
 
 func (c *csiMountMgr) GetPath() string {
-	dir := path.Join(getTargetPath(c.podUID, c.specVolumeID, c.plugin.host), "/mount")
+	dir := filepath.Join(getTargetPath(c.podUID, c.specVolumeID, c.plugin.host), "/mount")
 	klog.V(4).Info(log("mounter.GetPath generated [%s]", dir))
 	return dir
 }
@@ -440,7 +441,7 @@ func removeMountDir(plug *csiPlugin, mountPath string) error {
 		}
 		// remove volume data file as well
 		volPath := path.Dir(mountPath)
-		dataFile := path.Join(volPath, volDataFileName)
+		dataFile := filepath.Join(volPath, volDataFileName)
 		klog.V(4).Info(log("also deleting volume info data file [%s]", dataFile))
 		if err := os.Remove(dataFile); err != nil && !os.IsNotExist(err) {
 			klog.Error(log("failed to delete volume data file [%s]: %v", dataFile, err))

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"reflect"
@@ -60,12 +61,12 @@ func TestMounterGetPath(t *testing.T) {
 		{
 			name:           "simple specName",
 			specVolumeName: "spec-0",
-			path:           path.Join(tmpDir, fmt.Sprintf("pods/%s/volumes/kubernetes.io~csi/%s/%s", testPodUID, "spec-0", "/mount")),
+			path:           filepath.Join(tmpDir, fmt.Sprintf("pods/%s/volumes/kubernetes.io~csi/%s/%s", testPodUID, "spec-0", "/mount")),
 		},
 		{
 			name:           "specName with dots",
 			specVolumeName: "test.spec.1",
-			path:           path.Join(tmpDir, fmt.Sprintf("pods/%s/volumes/kubernetes.io~csi/%s/%s", testPodUID, "test.spec.1", "/mount")),
+			path:           filepath.Join(tmpDir, fmt.Sprintf("pods/%s/volumes/kubernetes.io~csi/%s/%s", testPodUID, "test.spec.1", "/mount")),
 		},
 	}
 	for _, tc := range testCases {
@@ -649,7 +650,7 @@ func TestUnmounterTeardown(t *testing.T) {
 	pv := makeTestPV("test-pv", 10, testDriver, testVol)
 
 	// save the data file prior to unmount
-	dir := path.Join(getTargetPath(testPodUID, pv.ObjectMeta.Name, plug.host), "/mount")
+	dir := filepath.Join(getTargetPath(testPodUID, pv.ObjectMeta.Name, plug.host), "/mount")
 	if err := os.MkdirAll(dir, 0755); err != nil && !os.IsNotExist(err) {
 		t.Errorf("failed to create dir [%s]: %v", dir, err)
 	}

--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -756,7 +756,7 @@ func TestPluginNewUnmounter(t *testing.T) {
 	pv := makeTestPV("test-pv", 10, testDriver, testVol)
 
 	// save the data file to re-create client
-	dir := path.Join(getTargetPath(testPodUID, pv.ObjectMeta.Name, plug.host), "/mount")
+	dir := filepath.Join(getTargetPath(testPodUID, pv.ObjectMeta.Name, plug.host), "/mount")
 	if err := os.MkdirAll(dir, 0755); err != nil && !os.IsNotExist(err) {
 		t.Errorf("failed to create dir [%s]: %v", dir, err)
 	}

--- a/pkg/volume/csi/csi_util.go
+++ b/pkg/volume/csi/csi_util.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	api "k8s.io/api/core/v1"
@@ -54,7 +54,7 @@ func getCredentialsFromSecret(k8s kubernetes.Interface, secretRef *api.SecretRef
 
 // saveVolumeData persists parameter data as json file at the provided location
 func saveVolumeData(dir string, fileName string, data map[string]string) error {
-	dataFilePath := path.Join(dir, fileName)
+	dataFilePath := filepath.Join(dir, fileName)
 	klog.V(4).Info(log("saving volume data file [%s]", dataFilePath))
 	file, err := os.Create(dataFilePath)
 	if err != nil {
@@ -73,7 +73,7 @@ func saveVolumeData(dir string, fileName string, data map[string]string) error {
 // loadVolumeData loads volume info from specified json file/location
 func loadVolumeData(dir string, fileName string) (map[string]string, error) {
 	// remove /mount at the end
-	dataFileName := path.Join(dir, fileName)
+	dataFileName := filepath.Join(dir, fileName)
 	klog.V(4).Info(log("loading volume data file [%s]", dataFileName))
 
 	file, err := os.Open(dataFileName)
@@ -114,7 +114,7 @@ func log(msg string, parts ...interface{}) string {
 // path: plugins/kubernetes.io/csi/volumeDevices/{specVolumeID}/dev
 func getVolumeDevicePluginDir(specVolID string, host volume.VolumeHost) string {
 	sanitizedSpecVolID := utilstrings.EscapeQualifiedName(specVolID)
-	return path.Join(host.GetVolumeDevicePluginDir(CSIPluginName), sanitizedSpecVolID, "dev")
+	return filepath.Join(host.GetVolumeDevicePluginDir(CSIPluginName), sanitizedSpecVolID, "dev")
 }
 
 // getVolumeDeviceDataDir returns the path where the CSI plugin keeps the
@@ -122,7 +122,7 @@ func getVolumeDevicePluginDir(specVolID string, host volume.VolumeHost) string {
 // path: plugins/kubernetes.io/csi/volumeDevices/{specVolumeID}/data
 func getVolumeDeviceDataDir(specVolID string, host volume.VolumeHost) string {
 	sanitizedSpecVolID := utilstrings.EscapeQualifiedName(specVolID)
-	return path.Join(host.GetVolumeDevicePluginDir(CSIPluginName), sanitizedSpecVolID, "data")
+	return filepath.Join(host.GetVolumeDevicePluginDir(CSIPluginName), sanitizedSpecVolID, "data")
 }
 
 // hasReadWriteOnce returns true if modes contains v1.ReadWriteOnce

--- a/pkg/volume/csi/csi_util_test.go
+++ b/pkg/volume/csi/csi_util_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	api "k8s.io/api/core/v1"
@@ -104,7 +105,7 @@ func TestSaveVolumeData(t *testing.T) {
 	for i, tc := range testCases {
 		t.Logf("test case: %s", tc.name)
 		specVolID := fmt.Sprintf("spec-volid-%d", i)
-		mountDir := path.Join(getTargetPath(testPodUID, specVolID, plug.host), "/mount")
+		mountDir := filepath.Join(getTargetPath(testPodUID, specVolID, plug.host), "/mount")
 		if err := os.MkdirAll(mountDir, 0755); err != nil && !os.IsNotExist(err) {
 			t.Errorf("failed to create dir [%s]: %v", mountDir, err)
 		}
@@ -116,7 +117,7 @@ func TestSaveVolumeData(t *testing.T) {
 		}
 		// did file get created
 		dataDir := getTargetPath(testPodUID, specVolID, plug.host)
-		file := path.Join(dataDir, volDataFileName)
+		file := filepath.Join(dataDir, volDataFileName)
 		if _, err := os.Stat(file); err != nil {
 			t.Errorf("failed to create data dir: %v", err)
 		}

--- a/pkg/volume/downwardapi/downwardapi_test.go
+++ b/pkg/volume/downwardapi/downwardapi_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -314,7 +314,7 @@ type stepName struct {
 func (step stepName) getName() string { return step.name }
 
 func doVerifyLinesInFile(t *testing.T, volumePath, filename string, expected string) {
-	data, err := ioutil.ReadFile(path.Join(volumePath, filename))
+	data, err := ioutil.ReadFile(filepath.Join(volumePath, filename))
 	if err != nil {
 		t.Errorf(err.Error())
 		return
@@ -350,7 +350,7 @@ type verifyMode struct {
 }
 
 func (step verifyMode) run(test *downwardAPITest) {
-	fileInfo, err := os.Stat(path.Join(test.volumePath, step.name))
+	fileInfo, err := os.Stat(filepath.Join(test.volumePath, step.name))
 	if err != nil {
 		test.t.Errorf(err.Error())
 		return
@@ -374,7 +374,7 @@ func (step reSetUp) run(test *downwardAPITest) {
 		test.pod.ObjectMeta.Labels = step.newLabels
 	}
 
-	currentTarget, err := os.Readlink(path.Join(test.volumePath, downwardAPIDir))
+	currentTarget, err := os.Readlink(filepath.Join(test.volumePath, downwardAPIDir))
 	if err != nil {
 		test.t.Errorf("labels file should be a link... %s\n", err.Error())
 	}
@@ -385,7 +385,7 @@ func (step reSetUp) run(test *downwardAPITest) {
 	}
 
 	// get the link of the link
-	currentTarget2, err := os.Readlink(path.Join(test.volumePath, downwardAPIDir))
+	currentTarget2, err := os.Readlink(filepath.Join(test.volumePath, downwardAPIDir))
 	if err != nil {
 		test.t.Errorf(".current should be a link... %s\n", err.Error())
 	}

--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -19,7 +19,7 @@ package emptydir
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -420,7 +420,7 @@ func (ed *emptyDir) teardownTmpfsOrHugetlbfs(dir string) error {
 }
 
 func (ed *emptyDir) getMetaDir() string {
-	return path.Join(ed.plugin.host.GetPodPluginDir(ed.pod.UID, utilstrings.EscapeQualifiedName(emptyDirPluginName)), ed.volName)
+	return filepath.Join(ed.plugin.host.GetPodPluginDir(ed.pod.UID, utilstrings.EscapeQualifiedName(emptyDirPluginName)), ed.volName)
 }
 
 func getVolumeSource(spec *volume.Spec) (*v1.EmptyDirVolumeSource, bool) {

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -20,7 +20,7 @@ package emptydir
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -107,8 +107,8 @@ func doTestPlugin(t *testing.T, config pluginTestConfig) {
 	defer os.RemoveAll(basePath)
 
 	var (
-		volumePath  = path.Join(basePath, "pods/poduid/volumes/kubernetes.io~empty-dir/test-volume")
-		metadataDir = path.Join(basePath, "pods/poduid/plugins/kubernetes.io~empty-dir/test-volume")
+		volumePath  = filepath.Join(basePath, "pods/poduid/volumes/kubernetes.io~empty-dir/test-volume")
+		metadataDir = filepath.Join(basePath, "pods/poduid/plugins/kubernetes.io~empty-dir/test-volume")
 
 		plug       = makePluginUnderTest(t, "kubernetes.io/empty-dir", basePath)
 		volumeName = "test-volume"
@@ -250,7 +250,7 @@ func TestPluginBackCompat(t *testing.T) {
 	}
 
 	volPath := mounter.GetPath()
-	if volPath != path.Join(basePath, "pods/poduid/volumes/kubernetes.io~empty-dir/vol1") {
+	if volPath != filepath.Join(basePath, "pods/poduid/volumes/kubernetes.io~empty-dir/vol1") {
 		t.Errorf("Got unexpected path: %s", volPath)
 	}
 }

--- a/pkg/volume/fc/fc_util.go
+++ b/pkg/volume/fc/fc_util.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -136,18 +135,18 @@ func scsiHostRescan(io ioHandler) {
 func makePDNameInternal(host volume.VolumeHost, wwns []string, lun string, wwids []string) string {
 	if len(wwns) != 0 {
 		w := strings.Join(wwns, "-")
-		return path.Join(host.GetPluginDir(fcPluginName), w+"-lun-"+lun)
+		return filepath.Join(host.GetPluginDir(fcPluginName), w+"-lun-"+lun)
 	}
-	return path.Join(host.GetPluginDir(fcPluginName), strings.Join(wwids, "-"))
+	return filepath.Join(host.GetPluginDir(fcPluginName), strings.Join(wwids, "-"))
 }
 
 // make a directory like /var/lib/kubelet/plugins/kubernetes.io/fc/volumeDevices/target-lun-0
 func makeVDPDNameInternal(host volume.VolumeHost, wwns []string, lun string, wwids []string) string {
 	if len(wwns) != 0 {
 		w := strings.Join(wwns, "-")
-		return path.Join(host.GetVolumeDevicePluginDir(fcPluginName), w+"-lun-"+lun)
+		return filepath.Join(host.GetVolumeDevicePluginDir(fcPluginName), w+"-lun-"+lun)
 	}
-	return path.Join(host.GetVolumeDevicePluginDir(fcPluginName), strings.Join(wwids, "-"))
+	return filepath.Join(host.GetVolumeDevicePluginDir(fcPluginName), strings.Join(wwids, "-"))
 }
 
 func parsePDName(path string) (wwns []string, lun int32, wwids []string, err error) {
@@ -360,7 +359,7 @@ func (util *fcUtil) DetachBlockFCDisk(c fcDiskUnmapper, mapPath, devicePath stri
 	}
 	for _, fi := range fis {
 		if strings.Contains(fi.Name(), volumeInfo) {
-			devicePath = path.Join(searchPath, fi.Name())
+			devicePath = filepath.Join(searchPath, fi.Name())
 			klog.V(5).Infof("fc: updated devicePath: %s", devicePath)
 			break
 		}

--- a/pkg/volume/flexvolume/flexvolume_test.go
+++ b/pkg/volume/flexvolume/flexvolume_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"text/template"
 
@@ -132,12 +132,12 @@ func installPluginUnderTest(t *testing.T, vendorName, plugName, tmpDir string, e
 	if vendorName != "" {
 		vendoredName = fmt.Sprintf("%s~%s", vendorName, plugName)
 	}
-	pluginDir := path.Join(tmpDir, vendoredName)
+	pluginDir := filepath.Join(tmpDir, vendoredName)
 	err := os.MkdirAll(pluginDir, 0777)
 	if err != nil {
 		t.Errorf("Failed to create plugin: %v", err)
 	}
-	pluginExec := path.Join(pluginDir, plugName)
+	pluginExec := filepath.Join(pluginDir, plugName)
 	f, err := os.Create(pluginExec)
 	if err != nil {
 		t.Errorf("Failed to install plugin")
@@ -149,7 +149,7 @@ func installPluginUnderTest(t *testing.T, vendorName, plugName, tmpDir string, e
 	if execTemplateData == nil {
 		execTemplateData = &map[string]interface{}{
 			"DevicePath": "/dev/sdx",
-			"OutputFile": path.Join(pluginDir, plugName+".out"),
+			"OutputFile": filepath.Join(pluginDir, plugName+".out"),
 		}
 	}
 

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -18,7 +18,7 @@ package flexvolume
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -69,7 +69,7 @@ type PluginFactory interface {
 type pluginFactory struct{}
 
 func (pluginFactory) NewFlexVolumePlugin(pluginDir, name string, runner exec.Interface) (volume.VolumePlugin, error) {
-	execPath := path.Join(pluginDir, name)
+	execPath := filepath.Join(pluginDir, name)
 
 	driverName := utilstrings.UnescapeQualifiedName(name)
 
@@ -105,7 +105,7 @@ func (plugin *flexVolumePlugin) Init(host volume.VolumeHost) error {
 func (plugin *flexVolumePlugin) getExecutable() string {
 	parts := strings.Split(plugin.driverName, "/")
 	execName := parts[len(parts)-1]
-	execPath := path.Join(plugin.execPath, execName)
+	execPath := filepath.Join(plugin.execPath, execName)
 	if runtime.GOOS == "windows" {
 		execPath = util.GetWindowsPath(execPath)
 	}
@@ -315,8 +315,8 @@ func (plugin *flexVolumePlugin) getDeviceMountPath(spec *volume.Spec) (string, e
 		return "", fmt.Errorf("GetVolumeName failed from getDeviceMountPath: %s", err)
 	}
 
-	mountsDir := path.Join(plugin.host.GetPluginDir(flexVolumePluginName), plugin.driverName, "mounts")
-	return path.Join(mountsDir, volumeName), nil
+	mountsDir := filepath.Join(plugin.host.GetPluginDir(flexVolumePluginName), plugin.driverName, "mounts")
+	return filepath.Join(mountsDir, volumeName), nil
 }
 
 func (plugin *flexVolumePlugin) RequiresFSResize() bool {

--- a/pkg/volume/flexvolume/probe_test.go
+++ b/pkg/volume/flexvolume/probe_test.go
@@ -18,7 +18,7 @@ package flexvolume
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/fsnotify/fsnotify"
@@ -71,8 +71,8 @@ func TestProberAddRemoveDriver(t *testing.T) {
 
 	// add driver
 	const driverName2 = "fake-driver2"
-	driverPath := path.Join(pluginDir, driverName2)
-	executablePath := path.Join(driverPath, driverName2)
+	driverPath := filepath.Join(pluginDir, driverName2)
+	executablePath := filepath.Join(driverPath, driverName2)
 	installDriver(driverName2, fs)
 	watcher.TriggerEvent(fsnotify.Create, driverPath)
 	watcher.TriggerEvent(fsnotify.Create, executablePath)
@@ -95,7 +95,7 @@ func TestProberAddRemoveDriver(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Call probe after a non-driver file is added in a subdirectory. should return 1 event.
-	fp := path.Join(driverPath, "dummyfile")
+	fp := filepath.Join(driverPath, "dummyfile")
 	fs.Create(fp)
 	watcher.TriggerEvent(fsnotify.Create, fp)
 
@@ -115,7 +115,7 @@ func TestProberAddRemoveDriver(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Call probe after a subdirectory is added in a driver directory. should return 1 event.
-	subdirPath := path.Join(driverPath, "subdir")
+	subdirPath := filepath.Join(driverPath, "subdir")
 	fs.Create(subdirPath)
 	watcher.TriggerEvent(fsnotify.Create, subdirPath)
 
@@ -196,7 +196,7 @@ func TestRemovePluginDir(t *testing.T) {
 	// Arrange
 	driverPath, fs, watcher, _ := initTestEnvironment(t)
 	fs.RemoveAll(pluginDir)
-	watcher.TriggerEvent(fsnotify.Remove, path.Join(driverPath, driverName))
+	watcher.TriggerEvent(fsnotify.Remove, filepath.Join(driverPath, driverName))
 	watcher.TriggerEvent(fsnotify.Remove, driverPath)
 	watcher.TriggerEvent(fsnotify.Remove, pluginDir)
 
@@ -216,7 +216,7 @@ func TestNestedDriverDir(t *testing.T) {
 
 	// test add testDriverName
 	testDriverName := "testDriverName"
-	testDriverPath := path.Join(pluginDir, testDriverName)
+	testDriverPath := filepath.Join(pluginDir, testDriverName)
 	fs.MkdirAll(testDriverPath, 0666)
 	watcher.TriggerEvent(fsnotify.Create, testDriverPath)
 	// Assert
@@ -227,7 +227,7 @@ func TestNestedDriverDir(t *testing.T) {
 	basePath := testDriverPath
 	for i := 0; i < 10; i++ {
 		subdirName := "subdirName"
-		subdirPath := path.Join(basePath, subdirName)
+		subdirPath := filepath.Join(basePath, subdirName)
 		fs.MkdirAll(subdirPath, 0666)
 		watcher.TriggerEvent(fsnotify.Create, subdirPath)
 		// Assert
@@ -246,9 +246,9 @@ func TestProberMultipleEvents(t *testing.T) {
 	for i := 0; i < iterations; i++ {
 		newDriver := fmt.Sprintf("multi-event-driver%d", 1)
 		installDriver(newDriver, fs)
-		driverPath := path.Join(pluginDir, newDriver)
+		driverPath := filepath.Join(pluginDir, newDriver)
 		watcher.TriggerEvent(fsnotify.Create, driverPath)
-		watcher.TriggerEvent(fsnotify.Create, path.Join(driverPath, newDriver))
+		watcher.TriggerEvent(fsnotify.Create, filepath.Join(driverPath, newDriver))
 	}
 
 	// Act
@@ -284,9 +284,9 @@ func TestProberError(t *testing.T) {
 
 // Installs a mock driver (an empty file) in the mock fs.
 func installDriver(driverName string, fs utilfs.Filesystem) {
-	driverPath := path.Join(pluginDir, driverName)
+	driverPath := filepath.Join(pluginDir, driverName)
 	fs.MkdirAll(driverPath, 0666)
-	fs.Create(path.Join(driverPath, driverName))
+	fs.Create(filepath.Join(driverPath, driverName))
 }
 
 // Initializes mocks, installs a single driver in the mock fs, then initializes prober.
@@ -303,7 +303,7 @@ func initTestEnvironment(t *testing.T) (
 		fs:        fs,
 		factory:   fakePluginFactory{error: false},
 	}
-	driverPath = path.Join(pluginDir, driverName)
+	driverPath = filepath.Join(pluginDir, driverName)
 	installDriver(driverName, fs)
 	prober.Init()
 

--- a/pkg/volume/flocker/flocker.go
+++ b/pkg/volume/flocker/flocker.go
@@ -19,7 +19,7 @@ package flocker
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	flockerapi "github.com/clusterhq/flocker-go"
@@ -81,7 +81,7 @@ func getPath(uid types.UID, volName string, host volume.VolumeHost) string {
 }
 
 func makeGlobalFlockerPath(datasetUUID string) string {
-	return path.Join(defaultMountPath, datasetUUID)
+	return filepath.Join(defaultMountPath, datasetUUID)
 }
 
 func (p *flockerPlugin) Init(host volume.VolumeHost) error {

--- a/pkg/volume/gcepd/attacher.go
+++ b/pkg/volume/gcepd/attacher.go
@@ -104,7 +104,7 @@ func (attacher *gcePersistentDiskAttacher) Attach(spec *volume.Spec, nodeName ty
 		}
 	}
 
-	return path.Join(diskByIDPath, diskGooglePrefix+pdName), nil
+	return filepath.Join(diskByIDPath, diskGooglePrefix+pdName), nil
 }
 
 func (attacher *gcePersistentDiskAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {

--- a/pkg/volume/gcepd/gce_pd.go
+++ b/pkg/volume/gcepd/gce_pd.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -441,7 +441,7 @@ func (b *gcePersistentDiskMounter) SetUpAt(dir string, fsGroup *int64) error {
 }
 
 func makeGlobalPDName(host volume.VolumeHost, devName string) string {
-	return path.Join(host.GetPluginDir(gcePersistentDiskPluginName), util.MountsInGlobalPDPath, devName)
+	return filepath.Join(host.GetPluginDir(gcePersistentDiskPluginName), util.MountsInGlobalPDPath, devName)
 }
 
 func (b *gcePersistentDiskMounter) GetPath() string {

--- a/pkg/volume/gcepd/gce_pd.go
+++ b/pkg/volume/gcepd/gce_pd.go
@@ -302,8 +302,8 @@ var _ volume.NodeExpandableVolumePlugin = &gcePersistentDiskPlugin{}
 
 func (plugin *gcePersistentDiskPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
 	mounter := plugin.host.GetMounter(plugin.GetPluginName())
-	pluginDir := plugin.host.GetPluginDir(plugin.GetPluginName())
-	sourceName, err := mounter.GetDeviceNameFromMount(mountPath, pluginDir)
+	pluginMntDir := util.GetPluginMountDir(plugin.host, plugin.GetPluginName())
+	sourceName, err := mounter.GetDeviceNameFromMount(mountPath, pluginMntDir)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +441,7 @@ func (b *gcePersistentDiskMounter) SetUpAt(dir string, fsGroup *int64) error {
 }
 
 func makeGlobalPDName(host volume.VolumeHost, devName string) string {
-	return path.Join(host.GetPluginDir(gcePersistentDiskPluginName), mount.MountsInGlobalPDPath, devName)
+	return path.Join(host.GetPluginDir(gcePersistentDiskPluginName), util.MountsInGlobalPDPath, devName)
 }
 
 func (b *gcePersistentDiskMounter) GetPath() string {

--- a/pkg/volume/gcepd/gce_pd_block.go
+++ b/pkg/volume/gcepd/gce_pd_block.go
@@ -18,7 +18,6 @@ package gcepd
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"strconv"
 
@@ -163,7 +162,7 @@ func (pd *gcePersistentDisk) GetGlobalMapPath(spec *volume.Spec) (string, error)
 	if err != nil {
 		return "", err
 	}
-	return path.Join(pd.plugin.host.GetVolumeDevicePluginDir(gcePersistentDiskPluginName), string(volumeSource.PDName)), nil
+	return filepath.Join(pd.plugin.host.GetVolumeDevicePluginDir(gcePersistentDiskPluginName), string(volumeSource.PDName)), nil
 }
 
 // GetPodDeviceMapPath returns pod device map path and volume name

--- a/pkg/volume/gcepd/gce_pd_block_test.go
+++ b/pkg/volume/gcepd/gce_pd_block_test.go
@@ -18,7 +18,7 @@ package gcepd
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -47,7 +47,7 @@ func TestGetVolumeSpecFromGlobalMapPath(t *testing.T) {
 	//deferred clean up
 	defer os.RemoveAll(tmpVDir)
 
-	expectedGlobalPath := path.Join(tmpVDir, testGlobalPath)
+	expectedGlobalPath := filepath.Join(tmpVDir, testGlobalPath)
 
 	//Bad Path
 	badspec, err := getVolumeSpecFromGlobalMapPath("")
@@ -102,8 +102,8 @@ func TestGetPodAndPluginMapPaths(t *testing.T) {
 	//deferred clean up
 	defer os.RemoveAll(tmpVDir)
 
-	expectedGlobalPath := path.Join(tmpVDir, testGlobalPath)
-	expectedPodPath := path.Join(tmpVDir, testPodPath)
+	expectedGlobalPath := filepath.Join(tmpVDir, testGlobalPath)
+	expectedPodPath := filepath.Join(tmpVDir, testPodPath)
 
 	spec := getTestVolume(false, tmpVDir, true /*isBlock*/)
 	plugMgr := volume.VolumePluginMgr{}

--- a/pkg/volume/gcepd/gce_pd_test.go
+++ b/pkg/volume/gcepd/gce_pd_test.go
@@ -19,7 +19,7 @@ package gcepd
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -135,7 +135,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Got a nil Mounter")
 	}
 
-	volPath := path.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~gce-pd/vol1")
+	volPath := filepath.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~gce-pd/vol1")
 	path := mounter.GetPath()
 	if path != volPath {
 		t.Errorf("Got unexpected path: %s", path)

--- a/pkg/volume/gcepd/gce_util.go
+++ b/pkg/volume/gcepd/gce_util.go
@@ -18,7 +18,6 @@ package gcepd
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -272,8 +271,8 @@ func parseScsiSerial(output string) (string, error) {
 // Returns list of all /dev/disk/by-id/* paths for given PD.
 func getDiskByIDPaths(pdName string, partition string) []string {
 	devicePaths := []string{
-		path.Join(diskByIDPath, diskGooglePrefix+pdName),
-		path.Join(diskByIDPath, diskScsiGooglePrefix+pdName),
+		filepath.Join(diskByIDPath, diskGooglePrefix+pdName),
+		filepath.Join(diskByIDPath, diskScsiGooglePrefix+pdName),
 	}
 
 	if partition != "" {

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -19,7 +19,6 @@ package git_repo
 import (
 	"fmt"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -225,10 +224,10 @@ func (b *gitRepoVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 	switch {
 	case len(b.target) != 0 && filepath.Clean(b.target) == ".":
 		// if target dir is '.', use the current dir
-		subdir = path.Join(dir)
+		subdir = filepath.Join(dir)
 	case len(files) == 1:
 		// if target is not '.', use the generated folder
-		subdir = path.Join(dir, files[0].Name())
+		subdir = filepath.Join(dir, files[0].Name())
 	default:
 		// if target is not '.', but generated many files, it's wrong
 		return fmt.Errorf("unexpected directory contents: %v", files)
@@ -248,7 +247,7 @@ func (b *gitRepoVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 }
 
 func (b *gitRepoVolumeMounter) getMetaDir() string {
-	return path.Join(b.plugin.host.GetPodPluginDir(b.podUID, utilstrings.EscapeQualifiedName(gitRepoPluginName)), b.volName)
+	return filepath.Join(b.plugin.host.GetPodPluginDir(b.podUID, utilstrings.EscapeQualifiedName(gitRepoPluginName)), b.volName)
 }
 
 func (b *gitRepoVolumeMounter) execCommand(command string, args []string, dir string) ([]byte, error) {

--- a/pkg/volume/git_repo/git_repo_test.go
+++ b/pkg/volume/git_repo/git_repo_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -393,7 +393,7 @@ func doTestSetUp(scenario struct {
 		if expected.cmd[1] == "clone" {
 			fakeOutputs = append(fakeOutputs, func() ([]byte, error) {
 				// git clone, it creates new dir/files
-				os.MkdirAll(path.Join(fcmd.Dirs[0], expected.dir), 0750)
+				os.MkdirAll(filepath.Join(fcmd.Dirs[0], expected.dir), 0750)
 				return []byte{}, nil
 			})
 		} else {

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	dstrings "strings"
@@ -347,7 +347,7 @@ func (b *glusterfsMounter) setUpAtInternal(dir string) error {
 
 	// If logfile has not been provided, create driver specific log file.
 	if !hasLogFile {
-		p := path.Join(b.glusterfs.plugin.host.GetPluginDir(glusterfsPluginName), b.glusterfs.volName)
+		p := filepath.Join(b.glusterfs.plugin.host.GetPluginDir(glusterfsPluginName), b.glusterfs.volName)
 		if err := os.MkdirAll(p, 0750); err != nil {
 			return fmt.Errorf("failed to create directory %v: %v", p, err)
 		}
@@ -355,7 +355,7 @@ func (b *glusterfsMounter) setUpAtInternal(dir string) error {
 		// adding log-level ERROR to remove noise
 		// and more specific log path so each pod has
 		// its own log based on PV + Pod
-		log = path.Join(p, b.pod.Name+"-glusterfs.log")
+		log = filepath.Join(p, b.pod.Name+"-glusterfs.log")
 
 		// Use derived log file in gluster fuse mount
 		options = append(options, "log-file="+log)

--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -186,12 +185,12 @@ func getDevicePrefixRefCount(mounter mount.Interface, deviceNamePrefix string) (
 
 // make a directory like /var/lib/kubelet/plugins/kubernetes.io/iscsi/iface_name/portal-some_iqn-lun-lun_id
 func makePDNameInternal(host volume.VolumeHost, portal string, iqn string, lun string, iface string) string {
-	return path.Join(host.GetPluginDir(iscsiPluginName), "iface-"+iface, portal+"-"+iqn+"-lun-"+lun)
+	return filepath.Join(host.GetPluginDir(iscsiPluginName), "iface-"+iface, portal+"-"+iqn+"-lun-"+lun)
 }
 
 // make a directory like /var/lib/kubelet/plugins/kubernetes.io/iscsi/volumeDevices/iface_name/portal-some_iqn-lun-lun_id
 func makeVDPDNameInternal(host volume.VolumeHost, portal string, iqn string, lun string, iface string) string {
-	return path.Join(host.GetVolumeDevicePluginDir(iscsiPluginName), "iface-"+iface, portal+"-"+iqn+"-lun-"+lun)
+	return filepath.Join(host.GetVolumeDevicePluginDir(iscsiPluginName), "iface-"+iface, portal+"-"+iqn+"-lun-"+lun)
 }
 
 type ISCSIUtil struct{}
@@ -207,7 +206,7 @@ func (util *ISCSIUtil) MakeGlobalVDPDName(iscsi iscsiDisk) string {
 }
 
 func (util *ISCSIUtil) persistISCSI(conf iscsiDisk, mnt string) error {
-	file := path.Join(mnt, "iscsi.json")
+	file := filepath.Join(mnt, "iscsi.json")
 	fp, err := os.Create(file)
 	if err != nil {
 		return fmt.Errorf("iscsi: create %s err %s", file, err)
@@ -221,7 +220,7 @@ func (util *ISCSIUtil) persistISCSI(conf iscsiDisk, mnt string) error {
 }
 
 func (util *ISCSIUtil) loadISCSI(conf *iscsiDisk, mnt string) error {
-	file := path.Join(mnt, "iscsi.json")
+	file := filepath.Join(mnt, "iscsi.json")
 	fp, err := os.Open(file)
 	if err != nil {
 		return fmt.Errorf("iscsi: open %s err %s", file, err)

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -222,7 +222,7 @@ func (plugin *localVolumePlugin) ConstructBlockVolumeSpec(podUID types.UID, volu
 }
 
 func (plugin *localVolumePlugin) generateBlockDeviceBaseGlobalPath() string {
-	return filepath.Join(plugin.host.GetPluginDir(localVolumePluginName), mount.MountsInGlobalPDPath)
+	return filepath.Join(plugin.host.GetPluginDir(localVolumePluginName), util.MountsInGlobalPDPath)
 }
 
 func (plugin *localVolumePlugin) getGlobalLocalPath(spec *volume.Spec) (string, error) {

--- a/pkg/volume/local/local_test.go
+++ b/pkg/volume/local/local_test.go
@@ -21,7 +21,6 @@ package local
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -302,7 +301,7 @@ func TestMountUnmount(t *testing.T) {
 		t.Fatalf("Got a nil Mounter")
 	}
 
-	volPath := path.Join(tmpDir, testMountPath)
+	volPath := filepath.Join(tmpDir, testMountPath)
 	path := mounter.GetPath()
 	if path != volPath {
 		t.Errorf("Got unexpected path: %s", path)
@@ -356,7 +355,7 @@ func TestMapUnmap(t *testing.T) {
 		t.Fatalf("Got a nil Mounter")
 	}
 
-	expectedGlobalPath := path.Join(tmpDir, testGlobalPath)
+	expectedGlobalPath := filepath.Join(tmpDir, testGlobalPath)
 	globalPath, err := mapper.GetGlobalMapPath(volSpec)
 	if err != nil {
 		t.Errorf("Failed to get global path: %v", err)
@@ -364,7 +363,7 @@ func TestMapUnmap(t *testing.T) {
 	if globalPath != expectedGlobalPath {
 		t.Errorf("Got unexpected path: %s, expected %s", globalPath, expectedGlobalPath)
 	}
-	expectedPodPath := path.Join(tmpDir, testPodPath)
+	expectedPodPath := filepath.Join(tmpDir, testPodPath)
 	podPath, volName := mapper.GetPodDeviceMapPath()
 	if podPath != expectedPodPath {
 		t.Errorf("Got unexpected pod path: %s, expected %s", podPath, expectedPodPath)
@@ -407,7 +406,7 @@ func testFSGroupMount(plug volume.VolumePlugin, pod *v1.Pod, tmpDir string, fsGr
 		return fmt.Errorf("Got a nil Mounter")
 	}
 
-	volPath := path.Join(tmpDir, testMountPath)
+	volPath := filepath.Join(tmpDir, testMountPath)
 	path := mounter.GetPath()
 	if path != volPath {
 		return fmt.Errorf("Got unexpected path: %s", path)
@@ -423,7 +422,7 @@ func TestConstructVolumeSpec(t *testing.T) {
 	tmpDir, plug := getPlugin(t)
 	defer os.RemoveAll(tmpDir)
 
-	volPath := path.Join(tmpDir, testMountPath)
+	volPath := filepath.Join(tmpDir, testMountPath)
 	spec, err := plug.ConstructVolumeSpec(testPVName, volPath)
 	if err != nil {
 		t.Errorf("ConstructVolumeSpec() failed: %v", err)
@@ -464,7 +463,7 @@ func TestConstructBlockVolumeSpec(t *testing.T) {
 	tmpDir, plug := getBlockPlugin(t)
 	defer os.RemoveAll(tmpDir)
 
-	podPath := path.Join(tmpDir, testPodPath)
+	podPath := filepath.Join(tmpDir, testPodPath)
 	spec, err := plug.ConstructBlockVolumeSpec(types.UID("poduid"), testPVName, podPath)
 	if err != nil {
 		t.Errorf("ConstructBlockVolumeSpec() failed: %v", err)

--- a/pkg/volume/photon_pd/attacher.go
+++ b/pkg/volume/photon_pd/attacher.go
@@ -95,7 +95,7 @@ func (attacher *photonPersistentDiskAttacher) Attach(spec *volume.Spec, nodeName
 	}
 
 	PdidWithNoHypens := strings.Replace(volumeSource.PdID, "-", "", -1)
-	return path.Join(diskByIDPath, diskPhotonPrefix+PdidWithNoHypens), nil
+	return filepath.Join(diskByIDPath, diskPhotonPrefix+PdidWithNoHypens), nil
 }
 
 func (attacher *photonPersistentDiskAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {

--- a/pkg/volume/photon_pd/photon_pd.go
+++ b/pkg/volume/photon_pd/photon_pd.go
@@ -136,8 +136,8 @@ func (plugin *photonPersistentDiskPlugin) newUnmounterInternal(volName string, p
 
 func (plugin *photonPersistentDiskPlugin) ConstructVolumeSpec(volumeSpecName, mountPath string) (*volume.Spec, error) {
 	mounter := plugin.host.GetMounter(plugin.GetPluginName())
-	pluginDir := plugin.host.GetPluginDir(plugin.GetPluginName())
-	pdID, err := mounter.GetDeviceNameFromMount(mountPath, pluginDir)
+	pluginMntDir := util.GetPluginMountDir(plugin.host, plugin.GetPluginName())
+	pdID, err := mounter.GetDeviceNameFromMount(mountPath, pluginMntDir)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (c *photonPersistentDiskUnmounter) TearDownAt(dir string) error {
 }
 
 func makeGlobalPDPath(host volume.VolumeHost, devName string) string {
-	return path.Join(host.GetPluginDir(photonPersistentDiskPluginName), mount.MountsInGlobalPDPath, devName)
+	return path.Join(host.GetPluginDir(photonPersistentDiskPluginName), util.MountsInGlobalPDPath, devName)
 }
 
 func (ppd *photonPersistentDisk) GetPath() string {

--- a/pkg/volume/photon_pd/photon_pd.go
+++ b/pkg/volume/photon_pd/photon_pd.go
@@ -19,7 +19,7 @@ package photon_pd
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -285,7 +285,7 @@ func (c *photonPersistentDiskUnmounter) TearDownAt(dir string) error {
 }
 
 func makeGlobalPDPath(host volume.VolumeHost, devName string) string {
-	return path.Join(host.GetPluginDir(photonPersistentDiskPluginName), util.MountsInGlobalPDPath, devName)
+	return filepath.Join(host.GetPluginDir(photonPersistentDiskPluginName), util.MountsInGlobalPDPath, devName)
 }
 
 func (ppd *photonPersistentDisk) GetPath() string {

--- a/pkg/volume/photon_pd/photon_pd_test.go
+++ b/pkg/volume/photon_pd/photon_pd_test.go
@@ -19,7 +19,7 @@ package photon_pd
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -122,7 +122,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Got a nil Mounter")
 	}
 
-	volPath := path.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~photon-pd/vol1")
+	volPath := filepath.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~photon-pd/vol1")
 	path := mounter.GetPath()
 	if path != volPath {
 		t.Errorf("Got unexpected path: %s", path)

--- a/pkg/volume/portworx/portworx_test.go
+++ b/pkg/volume/portworx/portworx_test.go
@@ -19,7 +19,7 @@ package portworx
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -157,7 +157,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Got a nil Mounter")
 	}
 
-	volPath := path.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~portworx-volume/vol1")
+	volPath := filepath.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~portworx-volume/vol1")
 	path := mounter.GetPath()
 	if path != volPath {
 		t.Errorf("Got unexpected path: %s", path)

--- a/pkg/volume/projected/projected_test.go
+++ b/pkg/volume/projected/projected_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -1069,14 +1069,14 @@ func TestPluginOptional(t *testing.T) {
 		}
 	}
 
-	datadirSymlink := path.Join(volumePath, "..data")
+	datadirSymlink := filepath.Join(volumePath, "..data")
 	datadir, err := os.Readlink(datadirSymlink)
 	if err != nil && os.IsNotExist(err) {
 		t.Fatalf("couldn't find volume path's data dir, %s", datadirSymlink)
 	} else if err != nil {
 		t.Fatalf("couldn't read symlink, %s", datadirSymlink)
 	}
-	datadirPath := path.Join(volumePath, datadir)
+	datadirPath := filepath.Join(volumePath, datadir)
 
 	infos, err := ioutil.ReadDir(volumePath)
 	if err != nil {
@@ -1227,7 +1227,7 @@ func makeProjection(name string, defaultMode int32, kind string) *v1.ProjectedVo
 
 func doTestSecretDataInVolume(volumePath string, secret v1.Secret, t *testing.T) {
 	for key, value := range secret.Data {
-		secretDataHostPath := path.Join(volumePath, key)
+		secretDataHostPath := filepath.Join(volumePath, key)
 		if _, err := os.Stat(secretDataHostPath); err != nil {
 			t.Fatalf("SetUp() failed, couldn't find secret data on disk: %v", secretDataHostPath)
 		} else {

--- a/pkg/volume/quobyte/quobyte.go
+++ b/pkg/volume/quobyte/quobyte.go
@@ -19,7 +19,7 @@ package quobyte
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	gostrings "strings"
 
 	"github.com/pborman/uuid"
@@ -286,7 +286,7 @@ func (quobyteVolume *quobyte) GetPath() string {
 	// Quobyte has only one mount in the PluginDir where all Volumes are mounted
 	// The Quobyte client does a fixed-user mapping
 	pluginDir := quobyteVolume.plugin.host.GetPluginDir(utilstrings.EscapeQualifiedName(quobytePluginName))
-	return path.Join(pluginDir, fmt.Sprintf("%s#%s@%s", user, group, quobyteVolume.volume))
+	return filepath.Join(pluginDir, fmt.Sprintf("%s#%s@%s", user, group, quobyteVolume.volume))
 }
 
 type quobyteUnmounter struct {

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -374,8 +374,8 @@ func (plugin *rbdPlugin) newUnmounterInternal(volName string, podUID types.UID, 
 
 func (plugin *rbdPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
 	mounter := plugin.host.GetMounter(plugin.GetPluginName())
-	pluginDir := plugin.host.GetPluginDir(plugin.GetPluginName())
-	sourceName, err := mounter.GetDeviceNameFromMount(mountPath, pluginDir)
+	pluginMntDir := volutil.GetPluginMountDir(plugin.host, plugin.GetPluginName())
+	sourceName, err := mounter.GetDeviceNameFromMount(mountPath, pluginMntDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/volume"
+	volutil "k8s.io/kubernetes/pkg/volume/util"
 	utilpath "k8s.io/utils/path"
 )
 
@@ -255,7 +256,7 @@ func makePDNameInternal(host volume.VolumeHost, pool string, image string) strin
 		return deprecatedDir
 	}
 	// Return the canonical format path.
-	return path.Join(host.GetPluginDir(rbdPluginName), mount.MountsInGlobalPDPath, pool+"-image-"+image)
+	return path.Join(host.GetPluginDir(rbdPluginName), volutil.MountsInGlobalPDPath, pool+"-image-"+image)
 }
 
 // Make a directory like /var/lib/kubelet/plugins/kubernetes.io/rbd/volumeDevices/pool-image-image.

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -27,7 +27,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -80,7 +80,7 @@ func getRbdDevFromImageAndPool(pool string, image string) (string, bool) {
 			// https://github.com/torvalds/linux/blob/master/drivers/block/rbd.c
 			name := f.Name()
 			// First match pool, then match name.
-			poolFile := path.Join(sys_path, name, "pool")
+			poolFile := filepath.Join(sys_path, name, "pool")
 			poolBytes, err := ioutil.ReadFile(poolFile)
 			if err != nil {
 				klog.V(4).Infof("error reading %s: %v", poolFile, err)
@@ -90,7 +90,7 @@ func getRbdDevFromImageAndPool(pool string, image string) (string, bool) {
 				klog.V(4).Infof("device %s is not %q: %q", name, pool, string(poolBytes))
 				continue
 			}
-			imgFile := path.Join(sys_path, name, "name")
+			imgFile := filepath.Join(sys_path, name, "name")
 			imgBytes, err := ioutil.ReadFile(imgFile)
 			if err != nil {
 				klog.V(4).Infof("error reading %s: %v", imgFile, err)
@@ -160,12 +160,12 @@ func getNbdDevFromImageAndPool(pool string, image string) (string, bool) {
 			klog.V(4).Infof("error reading nbd info directory %s: %v", nbdPath, err)
 			continue
 		}
-		pidBytes, err := ioutil.ReadFile(path.Join(nbdPath, "pid"))
+		pidBytes, err := ioutil.ReadFile(filepath.Join(nbdPath, "pid"))
 		if err != nil {
 			klog.V(5).Infof("did not find valid pid file in dir %s: %v", nbdPath, err)
 			continue
 		}
-		cmdlineFileName := path.Join("/proc", strings.TrimSpace(string(pidBytes)), "cmdline")
+		cmdlineFileName := filepath.Join("/proc", strings.TrimSpace(string(pidBytes)), "cmdline")
 		rawCmdline, err := ioutil.ReadFile(cmdlineFileName)
 		if err != nil {
 			klog.V(4).Infof("failed to read cmdline file %s: %v", cmdlineFileName, err)
@@ -186,7 +186,7 @@ func getNbdDevFromImageAndPool(pool string, image string) (string, bool) {
 				nbdPath, imgPath, cmdlineArgs[2])
 			continue
 		}
-		devicePath := path.Join("/dev", "nbd"+strconv.Itoa(i))
+		devicePath := filepath.Join("/dev", "nbd"+strconv.Itoa(i))
 		if _, err := os.Lstat(devicePath); err != nil {
 			klog.Warningf("Stat device %s for imgpath %s failed %v", devicePath, imgPath, err)
 			continue
@@ -248,7 +248,7 @@ func checkRbdNbdTools(e mount.Exec) bool {
 // Make a directory like /var/lib/kubelet/plugins/kubernetes.io/rbd/mounts/pool-image-image.
 func makePDNameInternal(host volume.VolumeHost, pool string, image string) string {
 	// Backward compatibility for the deprecated format: /var/lib/kubelet/plugins/kubernetes.io/rbd/rbd/pool-image-image.
-	deprecatedDir := path.Join(host.GetPluginDir(rbdPluginName), "rbd", pool+"-image-"+image)
+	deprecatedDir := filepath.Join(host.GetPluginDir(rbdPluginName), "rbd", pool+"-image-"+image)
 	info, err := os.Stat(deprecatedDir)
 	if err == nil && info.IsDir() {
 		// The device mount path has already been created with the deprecated format, return it.
@@ -256,12 +256,12 @@ func makePDNameInternal(host volume.VolumeHost, pool string, image string) strin
 		return deprecatedDir
 	}
 	// Return the canonical format path.
-	return path.Join(host.GetPluginDir(rbdPluginName), volutil.MountsInGlobalPDPath, pool+"-image-"+image)
+	return filepath.Join(host.GetPluginDir(rbdPluginName), volutil.MountsInGlobalPDPath, pool+"-image-"+image)
 }
 
 // Make a directory like /var/lib/kubelet/plugins/kubernetes.io/rbd/volumeDevices/pool-image-image.
 func makeVDPDNameInternal(host volume.VolumeHost, pool string, image string) string {
-	return path.Join(host.GetVolumeDevicePluginDir(rbdPluginName), pool+"-image-"+image)
+	return filepath.Join(host.GetVolumeDevicePluginDir(rbdPluginName), pool+"-image-"+image)
 }
 
 // RBDUtil implements diskManager interface.
@@ -486,7 +486,7 @@ func (util *RBDUtil) DetachDisk(plugin *rbdPlugin, deviceMountPath string, devic
 
 	// Currently, we don't persist rbd info on the disk, but for backward
 	// compatbility, we need to clean it if found.
-	rbdFile := path.Join(deviceMountPath, "rbd.json")
+	rbdFile := filepath.Join(deviceMountPath, "rbd.json")
 	exists, err := utilpath.Exists(utilpath.CheckFollowSymlink, rbdFile)
 	if err != nil {
 		return err

--- a/pkg/volume/scaleio/sio_client.go
+++ b/pkg/volume/scaleio/sio_client.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -535,5 +534,5 @@ func (c *sioClient) getSdcPath() string {
 }
 
 func (c *sioClient) getSdcCmd() string {
-	return path.Join(c.getSdcPath(), "drv_cfg")
+	return filepath.Join(c.getSdcPath(), "drv_cfg")
 }

--- a/pkg/volume/scaleio/sio_util_test.go
+++ b/pkg/volume/scaleio/sio_util_test.go
@@ -19,7 +19,7 @@ package scaleio
 import (
 	"encoding/gob"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -152,7 +152,7 @@ func TestUtilSaveConfig(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	config := path.Join(tmpDir, testConfigFile)
+	config := filepath.Join(tmpDir, testConfigFile)
 	data := map[string]string{
 		confKey.gateway:    "https://test-gateway/",
 		confKey.secretName: "sio-secret",
@@ -207,7 +207,7 @@ func TestUtilLoadConfig(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	configFile := path.Join(tmpDir, sioConfigFileName)
+	configFile := filepath.Join(tmpDir, sioConfigFileName)
 
 	if err := saveConfig(configFile, config); err != nil {
 		t.Fatalf("failed to save configFile %s error:%v", configFile, err)

--- a/pkg/volume/scaleio/sio_volume.go
+++ b/pkg/volume/scaleio/sio_volume.go
@@ -19,7 +19,7 @@ package scaleio
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -359,7 +359,7 @@ func (v *sioVolume) Provision(selectedNode *api.Node, allowedTopologies []api.To
 func (v *sioVolume) setSioMgr() error {
 	klog.V(4).Info(log("setting up sio mgr for spec  %s", v.volSpecName))
 	podDir := v.plugin.host.GetPodPluginDir(v.podUID, sioPluginName)
-	configName := path.Join(podDir, sioConfigFileName)
+	configName := filepath.Join(podDir, sioConfigFileName)
 	if v.sioMgr == nil {
 		configData, err := loadConfig(configName) // try to load config if exist
 		if err != nil {
@@ -414,7 +414,7 @@ func (v *sioVolume) setSioMgr() error {
 // resetSioMgr creates scaleio manager from existing (cached) config data
 func (v *sioVolume) resetSioMgr() error {
 	podDir := v.plugin.host.GetPodPluginDir(v.podUID, sioPluginName)
-	configName := path.Join(podDir, sioConfigFileName)
+	configName := filepath.Join(podDir, sioConfigFileName)
 	if v.sioMgr == nil {
 		// load config data from disk
 		configData, err := loadConfig(configName)

--- a/pkg/volume/scaleio/sio_volume_test.go
+++ b/pkg/volume/scaleio/sio_volume_test.go
@@ -19,7 +19,7 @@ package scaleio
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -185,7 +185,7 @@ func TestVolumeMounterUnmounter(t *testing.T) {
 	sioVol.sioMgr.client = sio
 	sioVol.sioMgr.CreateVolume(testSioVol, 8) //create vol ahead of time
 
-	volPath := path.Join(tmpDir, fmt.Sprintf("pods/%s/volumes/kubernetes.io~scaleio/%s", podUID, testSioVolName))
+	volPath := filepath.Join(tmpDir, fmt.Sprintf("pods/%s/volumes/kubernetes.io~scaleio/%s", podUID, testSioVolName))
 	path := sioMounter.GetPath()
 	if path != volPath {
 		t.Errorf("Got unexpected path: %s", path)

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
@@ -527,14 +527,14 @@ func TestPluginOptional(t *testing.T) {
 		}
 	}
 
-	datadirSymlink := path.Join(volumePath, "..data")
+	datadirSymlink := filepath.Join(volumePath, "..data")
 	datadir, err := os.Readlink(datadirSymlink)
 	if err != nil && os.IsNotExist(err) {
 		t.Fatalf("couldn't find volume path's data dir, %s", datadirSymlink)
 	} else if err != nil {
 		t.Fatalf("couldn't read symlink, %s", datadirSymlink)
 	}
-	datadirPath := path.Join(volumePath, datadir)
+	datadirPath := filepath.Join(volumePath, datadir)
 
 	infos, err := ioutil.ReadDir(volumePath)
 	if err != nil {
@@ -665,7 +665,7 @@ func secret(namespace, name string) v1.Secret {
 
 func doTestSecretDataInVolume(volumePath string, secret v1.Secret, t *testing.T) {
 	for key, value := range secret.Data {
-		secretDataHostPath := path.Join(volumePath, key)
+		secretDataHostPath := filepath.Join(volumePath, key)
 		if _, err := os.Stat(secretDataHostPath); err != nil {
 			t.Fatalf("SetUp() failed, couldn't find secret data on disk: %v", secretDataHostPath)
 		} else {

--- a/pkg/volume/storageos/storageos.go
+++ b/pkg/volume/storageos/storageos.go
@@ -441,7 +441,7 @@ func (b *storageosMounter) SetUpAt(dir string, fsGroup *int64) error {
 }
 
 func makeGlobalPDName(host volume.VolumeHost, pvName, volNamespace, volName string) string {
-	return path.Join(host.GetPluginDir(utilstrings.EscapeQualifiedName(storageosPluginName)), mount.MountsInGlobalPDPath, pvName+"."+volNamespace+"."+volName)
+	return path.Join(host.GetPluginDir(utilstrings.EscapeQualifiedName(storageosPluginName)), util.MountsInGlobalPDPath, pvName+"."+volNamespace+"."+volName)
 }
 
 // Given the pod id and PV name, finds the volume's namespace and name from the

--- a/pkg/volume/storageos/storageos.go
+++ b/pkg/volume/storageos/storageos.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -441,7 +440,7 @@ func (b *storageosMounter) SetUpAt(dir string, fsGroup *int64) error {
 }
 
 func makeGlobalPDName(host volume.VolumeHost, pvName, volNamespace, volName string) string {
-	return path.Join(host.GetPluginDir(utilstrings.EscapeQualifiedName(storageosPluginName)), util.MountsInGlobalPDPath, pvName+"."+volNamespace+"."+volName)
+	return filepath.Join(host.GetPluginDir(utilstrings.EscapeQualifiedName(storageosPluginName)), util.MountsInGlobalPDPath, pvName+"."+volNamespace+"."+volName)
 }
 
 // Given the pod id and PV name, finds the volume's namespace and name from the

--- a/pkg/volume/storageos/storageos_test.go
+++ b/pkg/volume/storageos/storageos_test.go
@@ -19,7 +19,7 @@ package storageos
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -202,7 +202,7 @@ func TestPlugin(t *testing.T) {
 		t.Fatalf("Got a nil Mounter")
 	}
 
-	expectedPath := path.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~storageos/vol1-pvname.ns1.vol1")
+	expectedPath := filepath.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~storageos/vol1-pvname.ns1.vol1")
 	volPath := mounter.GetPath()
 	if volPath != expectedPath {
 		t.Errorf("Expected path: '%s' got: '%s'", expectedPath, volPath)

--- a/pkg/volume/storageos/storageos_util.go
+++ b/pkg/volume/storageos/storageos_util.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -174,7 +174,7 @@ func (u *storageosUtil) AttachVolume(b *storageosMounter) (string, error) {
 		}
 	}
 
-	srcPath := path.Join(b.deviceDir, vol.ID)
+	srcPath := filepath.Join(b.deviceDir, vol.ID)
 	dt, err := pathDeviceType(srcPath)
 	if err != nil {
 		klog.Warningf("volume source path %q for volume %q not ready (%v)", srcPath, b.volName, err)

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -21,7 +21,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -118,27 +118,27 @@ func NewFakeVolumeHostWithMounterFSType(rootDir string, kubeClient clientset.Int
 }
 
 func (f *fakeVolumeHost) GetPluginDir(podUID string) string {
-	return path.Join(f.rootDir, "plugins", podUID)
+	return filepath.Join(f.rootDir, "plugins", podUID)
 }
 
 func (f *fakeVolumeHost) GetVolumeDevicePluginDir(pluginName string) string {
-	return path.Join(f.rootDir, "plugins", pluginName, "volumeDevices")
+	return filepath.Join(f.rootDir, "plugins", pluginName, "volumeDevices")
 }
 
 func (f *fakeVolumeHost) GetPodsDir() string {
-	return path.Join(f.rootDir, "pods")
+	return filepath.Join(f.rootDir, "pods")
 }
 
 func (f *fakeVolumeHost) GetPodVolumeDir(podUID types.UID, pluginName, volumeName string) string {
-	return path.Join(f.rootDir, "pods", string(podUID), "volumes", pluginName, volumeName)
+	return filepath.Join(f.rootDir, "pods", string(podUID), "volumes", pluginName, volumeName)
 }
 
 func (f *fakeVolumeHost) GetPodVolumeDeviceDir(podUID types.UID, pluginName string) string {
-	return path.Join(f.rootDir, "pods", string(podUID), "volumeDevices", pluginName)
+	return filepath.Join(f.rootDir, "pods", string(podUID), "volumeDevices", pluginName)
 }
 
 func (f *fakeVolumeHost) GetPodPluginDir(podUID types.UID, pluginName string) string {
-	return path.Join(f.rootDir, "pods", string(podUID), "plugins", pluginName)
+	return filepath.Join(f.rootDir, "pods", string(podUID), "plugins", pluginName)
 }
 
 func (f *fakeVolumeHost) GetKubeClient() clientset.Interface {
@@ -789,7 +789,7 @@ func (fv *FakeVolume) GetPath() string {
 }
 
 func (fv *FakeVolume) getPath() string {
-	return path.Join(fv.Plugin.Host.GetPodVolumeDir(fv.PodUID, utilstrings.EscapeQualifiedName(fv.Plugin.PluginName), fv.VolName))
+	return filepath.Join(fv.Plugin.Host.GetPodVolumeDir(fv.PodUID, utilstrings.EscapeQualifiedName(fv.Plugin.PluginName), fv.VolName))
 }
 
 func (fv *FakeVolume) TearDown() error {
@@ -834,7 +834,7 @@ func (fv *FakeVolume) GetGlobalMapPath(spec *Spec) (string, error) {
 
 // Block volume support
 func (fv *FakeVolume) getGlobalMapPath() (string, error) {
-	return path.Join(fv.Plugin.Host.GetVolumeDevicePluginDir(utilstrings.EscapeQualifiedName(fv.Plugin.PluginName)), "pluginDependentPath"), nil
+	return filepath.Join(fv.Plugin.Host.GetVolumeDevicePluginDir(utilstrings.EscapeQualifiedName(fv.Plugin.PluginName)), "pluginDependentPath"), nil
 }
 
 // Block volume support
@@ -854,7 +854,7 @@ func (fv *FakeVolume) GetPodDeviceMapPath() (string, string) {
 
 // Block volume support
 func (fv *FakeVolume) getPodDeviceMapPath() (string, string) {
-	return path.Join(fv.Plugin.Host.GetPodVolumeDeviceDir(fv.PodUID, utilstrings.EscapeQualifiedName(fv.Plugin.PluginName))), fv.VolName
+	return filepath.Join(fv.Plugin.Host.GetPodVolumeDeviceDir(fv.PodUID, utilstrings.EscapeQualifiedName(fv.Plugin.PluginName))), fv.VolName
 }
 
 // Block volume support

--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -126,7 +126,7 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection) error {
 	}
 
 	// (2)
-	dataDirPath := path.Join(w.targetDir, dataDirName)
+	dataDirPath := filepath.Join(w.targetDir, dataDirName)
 	oldTsDir, err := os.Readlink(dataDirPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -137,7 +137,7 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection) error {
 		// empty oldTsDir indicates that it didn't exist
 		oldTsDir = ""
 	}
-	oldTsPath := path.Join(w.targetDir, oldTsDir)
+	oldTsPath := filepath.Join(w.targetDir, oldTsDir)
 
 	var pathsToRemove sets.String
 	// if there was no old version, there's nothing to remove
@@ -183,7 +183,7 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection) error {
 	}
 
 	// (8)
-	newDataDirPath := path.Join(w.targetDir, newDataDirName)
+	newDataDirPath := filepath.Join(w.targetDir, newDataDirName)
 	if err = os.Symlink(tsDirName, newDataDirPath); err != nil {
 		os.RemoveAll(tsDir)
 		klog.Errorf("%s: error creating symbolic link for atomic update: %v", w.logContext, err)
@@ -279,7 +279,7 @@ func validatePath(targetPath string) error {
 // shouldWritePayload returns whether the payload should be written to disk.
 func shouldWritePayload(payload map[string]FileProjection, oldTsDir string) (bool, error) {
 	for userVisiblePath, fileProjection := range payload {
-		shouldWrite, err := shouldWriteFile(path.Join(oldTsDir, userVisiblePath), fileProjection.Data)
+		shouldWrite, err := shouldWriteFile(filepath.Join(oldTsDir, userVisiblePath), fileProjection.Data)
 		if err != nil {
 			return false, err
 		}
@@ -375,7 +375,7 @@ func (w *AtomicWriter) writePayloadToDir(payload map[string]FileProjection, dir 
 	for userVisiblePath, fileProjection := range payload {
 		content := fileProjection.Data
 		mode := os.FileMode(fileProjection.Mode)
-		fullPath := path.Join(dir, userVisiblePath)
+		fullPath := filepath.Join(dir, userVisiblePath)
 		baseDir, _ := filepath.Split(fullPath)
 
 		err := os.MkdirAll(baseDir, os.ModePerm)
@@ -419,11 +419,11 @@ func (w *AtomicWriter) createUserVisibleFiles(payload map[string]FileProjection)
 			slashpos = len(userVisiblePath)
 		}
 		linkname := userVisiblePath[:slashpos]
-		_, err := os.Readlink(path.Join(w.targetDir, linkname))
+		_, err := os.Readlink(filepath.Join(w.targetDir, linkname))
 		if err != nil && os.IsNotExist(err) {
 			// The link into the data directory for this path doesn't exist; create it
-			visibleFile := path.Join(w.targetDir, linkname)
-			dataDirFile := path.Join(dataDirName, linkname)
+			visibleFile := filepath.Join(w.targetDir, linkname)
+			dataDirFile := filepath.Join(dataDirName, linkname)
 
 			err = os.Symlink(dataDirFile, visibleFile)
 			if err != nil {
@@ -444,7 +444,7 @@ func (w *AtomicWriter) removeUserVisiblePaths(paths sets.String) error {
 		if strings.Contains(p, ps) {
 			continue
 		}
-		if err := os.Remove(path.Join(w.targetDir, p)); err != nil {
+		if err := os.Remove(filepath.Join(w.targetDir, p)); err != nil {
 			klog.Errorf("%s: error pruning old user-visible path %s: %v", w.logContext, p, err)
 			lasterr = err
 		}

--- a/pkg/volume/util/atomic_writer_test.go
+++ b/pkg/volume/util/atomic_writer_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/base64"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -235,7 +234,7 @@ func TestPathsToRemove(t *testing.T) {
 			continue
 		}
 
-		dataDirPath := path.Join(targetDir, dataDirName)
+		dataDirPath := filepath.Join(targetDir, dataDirName)
 		oldTsDir, err := os.Readlink(dataDirPath)
 		if err != nil && os.IsNotExist(err) {
 			t.Errorf("Data symlink does not exist: %v", dataDirPath)
@@ -245,7 +244,7 @@ func TestPathsToRemove(t *testing.T) {
 			continue
 		}
 
-		actual, err := writer.pathsToRemove(tc.payload2, path.Join(targetDir, oldTsDir))
+		actual, err := writer.pathsToRemove(tc.payload2, filepath.Join(targetDir, oldTsDir))
 		if err != nil {
 			t.Errorf("%v: unexpected error determining paths to remove: %v", tc.name, err)
 			continue
@@ -751,7 +750,7 @@ func TestMultipleUpdates(t *testing.T) {
 }
 
 func checkVolumeContents(targetDir, tcName string, payload map[string]FileProjection, t *testing.T) {
-	dataDirPath := path.Join(targetDir, dataDirName)
+	dataDirPath := filepath.Join(targetDir, dataDirName)
 	// use filepath.Walk to reconstruct the payload, then deep equal
 	observedPayload := make(map[string]FileProjection)
 	visitor := func(path string, info os.FileInfo, err error) error {
@@ -790,13 +789,13 @@ func checkVolumeContents(targetDir, tcName string, payload map[string]FileProjec
 			continue
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			p := path.Join(targetDir, info.Name())
+			p := filepath.Join(targetDir, info.Name())
 			actual, err := os.Readlink(p)
 			if err != nil {
 				t.Errorf("Unable to read symlink %v: %v", p, err)
 				continue
 			}
-			if err := filepath.Walk(path.Join(targetDir, actual), visitor); err != nil {
+			if err := filepath.Walk(filepath.Join(targetDir, actual), visitor); err != nil {
 				t.Errorf("%v: unexpected error walking directory: %v", tcName, err)
 			}
 		}
@@ -953,7 +952,7 @@ func TestCreateUserVisibleFiles(t *testing.T) {
 		}
 		defer os.RemoveAll(targetDir)
 
-		dataDirPath := path.Join(targetDir, dataDirName)
+		dataDirPath := filepath.Join(targetDir, dataDirName)
 		err = os.MkdirAll(dataDirPath, 0755)
 		if err != nil {
 			t.Fatalf("%v: unexpected error creating data path: %v", tc.name, err)
@@ -970,7 +969,7 @@ func TestCreateUserVisibleFiles(t *testing.T) {
 		}
 
 		for subpath, expectedDest := range tc.expected {
-			visiblePath := path.Join(targetDir, subpath)
+			visiblePath := filepath.Join(targetDir, subpath)
 			destination, err := os.Readlink(visiblePath)
 			if err != nil && os.IsNotExist(err) {
 				t.Fatalf("%v: visible symlink does not exist: %v", tc.name, visiblePath)

--- a/pkg/volume/util/device_util_linux.go
+++ b/pkg/volume/util/device_util_linux.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -77,10 +77,10 @@ func (handler *deviceHandler) FindSlaveDevicesOnMultipath(dm string) []string {
 		return devices
 	}
 	disk := parts[2]
-	slavesPath := path.Join("/sys/block/", disk, "/slaves/")
+	slavesPath := filepath.Join("/sys/block/", disk, "/slaves/")
 	if files, err := io.ReadDir(slavesPath); err == nil {
 		for _, f := range files {
-			devices = append(devices, path.Join("/dev/", f.Name()))
+			devices = append(devices, filepath.Join("/dev/", f.Name()))
 		}
 	}
 	return devices

--- a/pkg/volume/util/exec/exec_mount.go
+++ b/pkg/volume/util/exec/exec_mount.go
@@ -112,8 +112,8 @@ func (m *execMounter) PathIsDevice(pathname string) (bool, error) {
 }
 
 //GetDeviceNameFromMount given a mount point, find the volume id from checking /proc/mounts
-func (m *execMounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
-	return m.wrappedMounter.GetDeviceNameFromMount(mountPath, pluginDir)
+func (m *execMounter) GetDeviceNameFromMount(mountPath, pluginMountDir string) (string, error) {
+	return m.wrappedMounter.GetDeviceNameFromMount(mountPath, pluginMountDir)
 }
 
 func (m *execMounter) IsMountPointMatch(mp mount.MountPoint, dir string) bool {

--- a/pkg/volume/util/exec/exec_mount_unsupported.go
+++ b/pkg/volume/util/exec/exec_mount_unsupported.go
@@ -53,7 +53,7 @@ func (mounter *execMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-func (mounter *execMounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
+func (mounter *execMounter) GetDeviceNameFromMount(mountPath, pluginMountDir string) (string, error) {
 	return "", nil
 }
 

--- a/pkg/volume/util/nested_volumes.go
+++ b/pkg/volume/util/nested_volumes.go
@@ -18,12 +18,12 @@ package util
 
 import (
 	"fmt"
-	"k8s.io/api/core/v1"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"k8s.io/api/core/v1"
 )
 
 // getNestedMountpoints returns a list of mountpoint directories that should be created
@@ -90,7 +90,7 @@ func MakeNestedMountpoints(name, baseDir string, pod v1.Pod) error {
 		return err
 	}
 	for _, dir := range dirs {
-		err := os.MkdirAll(path.Join(baseDir, dir), 0755)
+		err := os.MkdirAll(filepath.Join(baseDir, dir), 0755)
 		if err != nil {
 			return fmt.Errorf("Unable to create nested volume mountpoints: %v", err)
 		}

--- a/pkg/volume/util/nested_volumes_test.go
+++ b/pkg/volume/util/nested_volumes_test.go
@@ -19,7 +19,7 @@ package util
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -206,7 +206,7 @@ func TestGetNestedMountpoints(t *testing.T) {
 		}
 		defer os.RemoveAll(dir)
 
-		rootdir := path.Join(dir, "vol")
+		rootdir := filepath.Join(dir, "vol")
 		err = os.Mkdir(rootdir, 0755)
 		if err != nil {
 			t.Errorf("Unexpected error trying to create temp root directory: %v", err)

--- a/pkg/volume/util/nsenter/nsenter_mount.go
+++ b/pkg/volume/util/nsenter/nsenter_mount.go
@@ -228,8 +228,8 @@ func (n *Mounter) PathIsDevice(pathname string) (bool, error) {
 }
 
 //GetDeviceNameFromMount given a mount point, find the volume id from checking /proc/mounts
-func (n *Mounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
-	return mount.GetDeviceNameFromMountLinux(n, mountPath, pluginDir)
+func (n *Mounter) GetDeviceNameFromMount(mountPath, pluginMountDir string) (string, error) {
+	return mount.GetDeviceNameFromMountLinux(n, mountPath, pluginMountDir)
 }
 
 // MakeRShared checks if path is shared and bind-mounts it as rshared if needed.

--- a/pkg/volume/util/nsenter/nsenter_mount_unsupported.go
+++ b/pkg/volume/util/nsenter/nsenter_mount_unsupported.go
@@ -78,7 +78,7 @@ func (*Mounter) PathIsDevice(pathname string) (bool, error) {
 
 // GetDeviceNameFromMount finds the device name from its global mount point using the
 // given mountpath and plugin location. It is a noop of unsupported platforms
-func (*Mounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
+func (*Mounter) GetDeviceNameFromMount(mountPath, pluginMountDir string) (string, error) {
 	return "", nil
 }
 

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -19,7 +19,7 @@ package operationexecutor
 import (
 	goerrors "errors"
 	"fmt"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -810,7 +810,7 @@ func (og *operationGenerator) GenerateUnmountVolumeFunc(
 		subpather := og.volumePluginMgr.Host.GetSubpather()
 
 		// Remove all bind-mounts for subPaths
-		podDir := path.Join(podsDir, string(volumeToUnmount.PodUID))
+		podDir := filepath.Join(podsDir, string(volumeToUnmount.PodUID))
 		if err := subpather.CleanSubPaths(podDir, volumeToUnmount.InnerVolumeSpecName); err != nil {
 			return volumeToUnmount.GenerateError("error cleaning subPath mounts", err)
 		}

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -58,6 +58,10 @@ const (
 	// that decides if pod volumes are unmounted when pod is terminated
 	KeepTerminatedPodVolumesAnnotation string = "volumes.kubernetes.io/keep-terminated-pod-volumes"
 
+	// MountsInGlobalPDPath is name of the directory appended to a volume plugin
+	// name to create the place for volume mounts in the global PD path.
+	MountsInGlobalPDPath = "mounts"
+
 	// VolumeGidAnnotationKey is the of the annotation on the PersistentVolume
 	// object that specifies a supplemental GID.
 	VolumeGidAnnotationKey = "pv.beta.kubernetes.io/gid"
@@ -529,4 +533,11 @@ func MapBlockVolume(
 	}
 
 	return nil
+}
+
+// GetPluginMountDir returns the global mount directory name appended
+// to the given plugin name's plugin directory
+func GetPluginMountDir(host volume.VolumeHost, name string) string {
+	mntDir := filepath.Join(host.GetPluginDir(name), MountsInGlobalPDPath)
+	return mntDir
 }

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -75,7 +74,7 @@ const (
 // called 'ready' in the given directory and returns
 // true if that file exists.
 func IsReady(dir string) bool {
-	readyFile := path.Join(dir, readyFileName)
+	readyFile := filepath.Join(dir, readyFileName)
 	s, err := os.Stat(readyFile)
 	if err != nil {
 		return false
@@ -98,7 +97,7 @@ func SetReady(dir string) {
 		return
 	}
 
-	readyFile := path.Join(dir, readyFileName)
+	readyFile := filepath.Join(dir, readyFileName)
 	file, err := os.Create(readyFile)
 	if err != nil {
 		klog.Errorf("Can't touch %s: %v", readyFile, err)

--- a/pkg/volume/util/volumepathhandler/volume_path_handler.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 
 	"k8s.io/klog"
@@ -102,7 +101,7 @@ func (v VolumePathHandler) MapDevice(devicePath string, mapPath string, linkName
 	// Remove old symbolic link(or file) then create new one.
 	// This should be done because current symbolic link is
 	// stale across node reboot.
-	linkPath := path.Join(mapPath, string(linkName))
+	linkPath := filepath.Join(mapPath, string(linkName))
 	if err = os.Remove(linkPath); err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -119,7 +118,7 @@ func (v VolumePathHandler) UnmapDevice(mapPath string, linkName string) error {
 	klog.V(5).Infof("UnmapDevice: linkName %s", linkName)
 
 	// Check symbolic link exists
-	linkPath := path.Join(mapPath, string(linkName))
+	linkPath := filepath.Join(mapPath, string(linkName))
 	if islinkExist, checkErr := v.IsSymlinkExist(linkPath); checkErr != nil {
 		return checkErr
 	} else if !islinkExist {
@@ -176,13 +175,13 @@ func (v VolumePathHandler) GetDeviceSymlinkRefs(devPath string, mapPath string) 
 			continue
 		}
 		filename := file.Name()
-		filepath, err := os.Readlink(path.Join(mapPath, filename))
+		fp, err := os.Readlink(filepath.Join(mapPath, filename))
 		if err != nil {
 			return nil, fmt.Errorf("Symbolic link cannot be retrieved %v", err)
 		}
-		klog.V(5).Infof("GetDeviceSymlinkRefs: filepath: %v, devPath: %v", filepath, devPath)
-		if filepath == devPath {
-			refs = append(refs, path.Join(mapPath, filename))
+		klog.V(5).Infof("GetDeviceSymlinkRefs: filepath: %v, devPath: %v", fp, devPath)
+		if fp == devPath {
+			refs = append(refs, filepath.Join(mapPath, filename))
 		}
 	}
 	klog.V(5).Infof("GetDeviceSymlinkRefs: refs %v", refs)

--- a/pkg/volume/vsphere_volume/attacher.go
+++ b/pkg/volume/vsphere_volume/attacher.go
@@ -19,7 +19,7 @@ package vsphere_volume
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -90,7 +90,7 @@ func (attacher *vsphereVMDKAttacher) Attach(spec *volume.Spec, nodeName types.No
 		return "", err
 	}
 
-	return path.Join(diskByIDPath, diskSCSIPrefix+diskUUID), nil
+	return filepath.Join(diskByIDPath, diskSCSIPrefix+diskUUID), nil
 }
 
 func (attacher *vsphereVMDKAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {

--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -145,8 +145,8 @@ func (plugin *vsphereVolumePlugin) newUnmounterInternal(volName string, podUID t
 
 func (plugin *vsphereVolumePlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
 	mounter := plugin.host.GetMounter(plugin.GetPluginName())
-	pluginDir := plugin.host.GetPluginDir(plugin.GetPluginName())
-	volumePath, err := mounter.GetDeviceNameFromMount(mountPath, pluginDir)
+	pluginMntDir := util.GetPluginMountDir(plugin.host, plugin.GetPluginName())
+	volumePath, err := mounter.GetDeviceNameFromMount(mountPath, pluginMntDir)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func (v *vsphereVolumeUnmounter) TearDownAt(dir string) error {
 }
 
 func makeGlobalPDPath(host volume.VolumeHost, devName string) string {
-	return path.Join(host.GetPluginDir(vsphereVolumePluginName), mount.MountsInGlobalPDPath, devName)
+	return path.Join(host.GetPluginDir(vsphereVolumePluginName), util.MountsInGlobalPDPath, devName)
 }
 
 func (vv *vsphereVolume) GetPath() string {

--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -19,7 +19,7 @@ package vsphere_volume
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"k8s.io/api/core/v1"
@@ -294,7 +294,7 @@ func (v *vsphereVolumeUnmounter) TearDownAt(dir string) error {
 }
 
 func makeGlobalPDPath(host volume.VolumeHost, devName string) string {
-	return path.Join(host.GetPluginDir(vsphereVolumePluginName), util.MountsInGlobalPDPath, devName)
+	return filepath.Join(host.GetPluginDir(vsphereVolumePluginName), util.MountsInGlobalPDPath, devName)
 }
 
 func (vv *vsphereVolume) GetPath() string {

--- a/pkg/volume/vsphere_volume/vsphere_volume_block.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_block.go
@@ -18,7 +18,6 @@ package vsphere_volume
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -153,7 +152,7 @@ func (v *vsphereVolume) GetGlobalMapPath(spec *volume.Spec) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(v.plugin.host.GetVolumeDevicePluginDir(vsphereVolumePluginName), string(volumeSource.VolumePath)), nil
+	return filepath.Join(v.plugin.host.GetVolumeDevicePluginDir(vsphereVolumePluginName), string(volumeSource.VolumePath)), nil
 }
 
 func (v *vsphereVolume) GetPodDeviceMapPath() (string, string) {

--- a/pkg/volume/vsphere_volume/vsphere_volume_block_test.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_block_test.go
@@ -18,7 +18,7 @@ package vsphere_volume
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -46,7 +46,7 @@ func TestGetVolumeSpecFromGlobalMapPath(t *testing.T) {
 	// deferred clean up
 	defer os.RemoveAll(tmpVDir)
 
-	expectedGlobalPath := path.Join(tmpVDir, testGlobalPath)
+	expectedGlobalPath := filepath.Join(tmpVDir, testGlobalPath)
 
 	// Bad Path
 	badspec, err := getVolumeSpecFromGlobalMapPath("")
@@ -80,8 +80,8 @@ func TestGetPodAndPluginMapPaths(t *testing.T) {
 	// deferred clean up
 	defer os.RemoveAll(tmpVDir)
 
-	expectedGlobalPath := path.Join(tmpVDir, testGlobalPath)
-	expectedPodPath := path.Join(tmpVDir, testPodPath)
+	expectedGlobalPath := filepath.Join(tmpVDir, testGlobalPath)
+	expectedPodPath := filepath.Join(tmpVDir, testPodPath)
 
 	spec := getTestVolume(true) // block volume
 	pluginMgr := volume.VolumePluginMgr{}

--- a/pkg/volume/vsphere_volume/vsphere_volume_test.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_test.go
@@ -19,7 +19,7 @@ package vsphere_volume
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -117,7 +117,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Got a nil Mounter")
 	}
 
-	mntPath := path.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~vsphere-volume/vol1")
+	mntPath := filepath.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~vsphere-volume/vol1")
 	path := mounter.GetPath()
 	if path != mntPath {
 		t.Errorf("Got unexpected path: %s", path)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Since `pkg/util/mount` is going to move out of k/k, this exported constant
that is Kubernetes specific needs to move somewhere else. Made sense to
move it to `pkg/volume/util`.

For the volume plugins that call `mounter.GetDeviceNameFromMount()`,
rather than changing the signature of `mounter.GetDeviceNameFromMount()`
just have the volume plugins append `MountsInGlobalPDPath` to the volume
pluginDir themselves rather than having `mounter.GetDeviceNameFromMount()`
do it since that code no longer has access to that constant.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This is another step in making #68513 be a lot simpler.

This PR does not attempt to address #74548 at all, just maintain current functionality.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
