### PR TITLE
Simplify package skipping test

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/naming/from_stack_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/naming/from_stack_test.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package naming
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestGetNameFromCallsite(t *testing.T) {
 	tests := []struct {
@@ -26,17 +29,17 @@ func TestGetNameFromCallsite(t *testing.T) {
 	}{
 		{
 			name:     "simple",
-			expected: "k8s.io/apimachinery/pkg/util/naming/from_stack_test.go:50",
+			expected: "k8s.io/apimachinery/pkg/util/naming/from_stack_test.go:",
 		},
 		{
 			name:            "ignore-package",
 			ignoredPackages: []string{"k8s.io/apimachinery/pkg/util/naming"},
-			expected:        "testing/testing.go:827",
+			expected:        "testing/testing.go:",
 		},
 		{
 			name:            "ignore-file",
 			ignoredPackages: []string{"k8s.io/apimachinery/pkg/util/naming/from_stack_test.go"},
-			expected:        "testing/testing.go:827",
+			expected:        "testing/testing.go:",
 		},
 		{
 			name:            "ignore-multiple",
@@ -48,8 +51,8 @@ func TestGetNameFromCallsite(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := GetNameFromCallsite(tc.ignoredPackages...)
-			if tc.expected != actual {
-				t.Fatalf("expected %q, got %q", tc.expected, actual)
+			if !strings.HasPrefix(actual, tc.expected) {
+				t.Fatalf("expected string with prefix %q, got %q", tc.expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
What we really care about is the filename located, not the line number. This simplifies the test to not need rework every time we bump go versions (c.f. https://github.com/kubernetes/kubernetes/pull/74632/files#r261305801)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
