### PR TITLE
Stop setting --hostname-override on Windows kube-proxy and allow args  to be extended remotely if necessary

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -895,14 +895,24 @@ function Configure-Kubelet {
 #   KUBERNETES_MASTER_NAME
 #   CLUSTER_IP_RANGE
 function Start-WorkerServices {
+  # Compute kubelet args
   $kubelet_args_str = ${kube_env}['KUBELET_ARGS']
   $kubelet_args = $kubelet_args_str.Split(" ")
   Log-Output "kubelet_args from metadata: ${kubelet_args}"
-
-  $additional_arg_list = @(`
+  $default_kubelet_args = @(`
       "--pod-infra-container-image=${INFRA_CONTAINER}"
   )
-  $kubelet_args = ${kubelet_args} + ${additional_arg_list}
+  $kubelet_args = ${default_kubelet_args} + ${kubelet_args}
+  Log-Output "Final kubelet_args: ${kubelet_args}"
+
+  # Compute kube-proxy args
+  $kubeproxy_args_str = ${kube_env}['KUBEPROXY_ARGS']
+  Try {
+    $kubeproxy_args = $kubeproxy_args_str.Split(" ")
+  } Catch {
+    $kubeproxy_args = ""
+  }
+  Log-Output "kubeproxy_args from metadata: ${kubeproxy_args}"
 
   # kubeproxy is started on Linux nodes using
   # kube-manifests/kubernetes/gci-trusty/kube-proxy.manifest, which is
@@ -915,12 +925,11 @@ function Start-WorkerServices {
   #   --ipvs-sync-period=1m --ipvs-min-sync-period=10s
   # And also with various volumeMounts and "securityContext: privileged: true".
   $apiserver_address = ${kube_env}['KUBERNETES_MASTER_NAME']
-  $kubeproxy_args = @(`
+  $default_kubeproxy_args = @(`
       "--v=4",
       "--master=https://${apiserver_address}",
       "--kubeconfig=${env:KUBEPROXY_KUBECONFIG}",
       "--proxy-mode=kernelspace",
-      "--hostname-override=$(hostname)",
       "--cluster-cidr=$(${kube_env}['CLUSTER_IP_RANGE'])",
 
       # Configure kube-proxy to run as a windows service.
@@ -941,6 +950,8 @@ function Start-WorkerServices {
       # of string delimiters.
       "--resource-container="
   )
+  $kubeproxy_args = ${default_kubeproxy_args} + ${kubeproxy_args}
+  Log-Output "Final kubeproxy_args: ${kubeproxy_args}"
 
   # TODO(pjh): kubelet is emitting these messages:
   # I1023 23:44:11.761915    2468 kubelet.go:274] Adding pod path:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
--hostname-override should not be necessary, we can rely on kube-proxy
to auto-detect it just like we do in Kubelet.

I also added an optional variable to kube_env, KUBEPROXY_ARGS, that we
can use to remotely extend kube-proxy's command-line if necessary.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig node
/sig windows
/assign @yujuhong 
@pjh