### PR TITLE
Fixing a small bug with GMSA support

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -480,6 +480,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	ProcMountType:                               {Default: false, PreRelease: utilfeature.Alpha},
 	TTLAfterFinished:                            {Default: false, PreRelease: utilfeature.Alpha},
 	KubeletPodResources:                         {Default: false, PreRelease: utilfeature.Alpha},
+	WindowsGMSA:                                 {Default: false, PreRelease: utilfeature.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -167,11 +167,6 @@ func (ds *dockerService) CreateContainer(_ context.Context, r *runtimeapi.Create
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		for _, err := range ds.performPlatformSpecificContainerCreationCleanup(cleanupInfo) {
-			klog.Warningf("error when cleaning up after container %v's creation: %v", containerName, err)
-		}
-	}()
 
 	createResp, createErr := ds.client.CreateContainer(createConfig)
 	if createErr != nil {
@@ -179,8 +174,18 @@ func (ds *dockerService) CreateContainer(_ context.Context, r *runtimeapi.Create
 	}
 
 	if createResp != nil {
-		return &runtimeapi.CreateContainerResponse{ContainerId: createResp.ID}, nil
+		containerID := createResp.ID
+
+		if cleanupInfo != nil {
+			// save it for when the container starts or gets removed
+			ds.containerCleanupInfos[containerID] = cleanupInfo
+		}
+		return &runtimeapi.CreateContainerResponse{ContainerId: containerID}, nil
 	}
+
+	// the creation failed, let's clean up right away
+	ds.performPlatformSpecificContainerCleanupAndLogErrors(containerName, cleanupInfo)
+
 	return nil, createErr
 }
 
@@ -267,6 +272,8 @@ func (ds *dockerService) StartContainer(_ context.Context, r *runtimeapi.StartCo
 		return nil, fmt.Errorf("failed to start container %q: %v", r.ContainerId, err)
 	}
 
+	ds.performPlatformSpecificContainerForContainer(r.ContainerId)
+
 	return &runtimeapi.StartContainerResponse{}, nil
 }
 
@@ -281,6 +288,8 @@ func (ds *dockerService) StopContainer(_ context.Context, r *runtimeapi.StopCont
 
 // RemoveContainer removes the container.
 func (ds *dockerService) RemoveContainer(_ context.Context, r *runtimeapi.RemoveContainerRequest) (*runtimeapi.RemoveContainerResponse, error) {
+	ds.performPlatformSpecificContainerForContainer(r.ContainerId)
+
 	// Ideally, log lifecycle should be independent of container lifecycle.
 	// However, docker will remove container log after container is removed,
 	// we can't prevent that now, so we also clean up the symlink here.
@@ -437,4 +446,21 @@ func (ds *dockerService) UpdateContainerResources(_ context.Context, r *runtimea
 		return nil, fmt.Errorf("failed to update container %q: %v", r.ContainerId, err)
 	}
 	return &runtimeapi.UpdateContainerResourcesResponse{}, nil
+}
+
+func (ds *dockerService) performPlatformSpecificContainerForContainer(containerID string) {
+	if cleanupInfo, present := ds.containerCleanupInfos[containerID]; present {
+		ds.performPlatformSpecificContainerCleanupAndLogErrors(containerID, cleanupInfo)
+		delete(ds.containerCleanupInfos, containerID)
+	}
+}
+
+func (ds *dockerService) performPlatformSpecificContainerCleanupAndLogErrors(containerNameOrID string, cleanupInfo *containerCleanupInfo) {
+	if cleanupInfo == nil {
+		return
+	}
+
+	for _, err := range ds.performPlatformSpecificContainerCleanup(cleanupInfo) {
+		klog.Warningf("error when cleaning up after container %q: %v", containerNameOrID, err)
+	}
 }

--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -177,7 +177,10 @@ func (ds *dockerService) CreateContainer(_ context.Context, r *runtimeapi.Create
 		containerID := createResp.ID
 
 		if cleanupInfo != nil {
-			// save it for when the container starts or gets removed
+			// we don't perform the clean up just yet at that could destroy information
+			// needed for the container to start (e.g. Windows credentials stored in
+			// registry keys); instead, we'll clean up after the container successfully
+			// starts or gets removed
 			ds.containerCleanupInfos[containerID] = cleanupInfo
 		}
 		return &runtimeapi.CreateContainerResponse{ContainerId: containerID}, nil

--- a/pkg/kubelet/dockershim/docker_container_unsupported.go
+++ b/pkg/kubelet/dockershim/docker_container_unsupported.go
@@ -23,26 +23,35 @@ import (
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
-type containerCreationCleanupInfo struct{}
+type containerCleanupInfo struct{}
 
 // applyPlatformSpecificDockerConfig applies platform-specific configurations to a dockertypes.ContainerCreateConfig struct.
-// The containerCreationCleanupInfo struct it returns will be passed as is to performPlatformSpecificContainerCreationCleanup
-// after the container has been created.
-func (ds *dockerService) applyPlatformSpecificDockerConfig(*runtimeapi.CreateContainerRequest, *dockertypes.ContainerCreateConfig) (*containerCreationCleanupInfo, error) {
+// The containerCleanupInfo struct it returns will be passed as is to performPlatformSpecificContainerCleanup
+// after either:
+//   * the container creation has failed
+//   * the container has been successfully started
+//   * the container has been removed
+// whichever happens first.
+func (ds *dockerService) applyPlatformSpecificDockerConfig(*runtimeapi.CreateContainerRequest, *dockertypes.ContainerCreateConfig) (*containerCleanupInfo, error) {
 	return nil, nil
 }
 
-// performPlatformSpecificContainerCreationCleanup is responsible for doing any platform-specific cleanup
-// after a container creation. Any errors it returns are simply logged, but do not fail the container
-// creation.
-func (ds *dockerService) performPlatformSpecificContainerCreationCleanup(cleanupInfo *containerCreationCleanupInfo) (errors []error) {
+// performPlatformSpecificContainerCleanup is responsible for doing any platform-specific cleanup
+// after either:
+//   * the container creation has failed
+//   * the container has been successfully started
+//   * the container has been removed
+// whichever happens first.
+// Any errors it returns are simply logged, but do not prevent the container from being started or
+// removed.
+func (ds *dockerService) performPlatformSpecificContainerCleanup(cleanupInfo *containerCleanupInfo) (errors []error) {
 	return
 }
 
-// platformSpecificContainerCreationInitCleanup is called when dockershim
+// platformSpecificContainerInitCleanup is called when dockershim
 // is starting, and is meant to clean up any cruft left by previous runs
 // creating containers.
 // Errors are simply logged, but don't prevent dockershim from starting.
-func (ds *dockerService) platformSpecificContainerCreationInitCleanup() (errors []error) {
+func (ds *dockerService) platformSpecificContainerInitCleanup() (errors []error) {
 	return
 }

--- a/pkg/kubelet/dockershim/docker_container_windows_test.go
+++ b/pkg/kubelet/dockershim/docker_container_windows_test.go
@@ -82,7 +82,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 		defer setRandomReader(randomBytes)()
 
 		createConfig := &dockertypes.ContainerCreateConfig{}
-		cleanupInfo := &containerCreationCleanupInfo{}
+		cleanupInfo := &containerCleanupInfo{}
 		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, createConfig, cleanupInfo)
 
 		assert.Nil(t, err)
@@ -105,7 +105,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 		defer setRegistryCreateKeyFunc(t, &dummyRegistryKey{})()
 
 		createConfig := &dockertypes.ContainerCreateConfig{}
-		cleanupInfo := &containerCreationCleanupInfo{}
+		cleanupInfo := &containerCleanupInfo{}
 		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, createConfig, cleanupInfo)
 
 		assert.Nil(t, err)
@@ -127,7 +127,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 	t.Run("when there's an error generating the random value name", func(t *testing.T) {
 		defer setRandomReader([]byte{})()
 
-		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCreationCleanupInfo{})
+		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCleanupInfo{})
 
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "error when generating gMSA registry value name: unable to generate random string")
@@ -135,7 +135,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 	t.Run("if there's an error opening the registry key", func(t *testing.T) {
 		defer setRegistryCreateKeyFunc(t, &dummyRegistryKey{}, fmt.Errorf("dummy error"))()
 
-		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCreationCleanupInfo{})
+		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCleanupInfo{})
 
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "unable to open registry key")
@@ -145,7 +145,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 		key.setStringValueError = fmt.Errorf("dummy error")
 		defer setRegistryCreateKeyFunc(t, key)()
 
-		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCreationCleanupInfo{})
+		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCleanupInfo{})
 
 		if assert.NotNil(t, err) {
 			assert.Contains(t, err.Error(), "unable to write into registry value")
@@ -155,7 +155,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 	t.Run("if there is no GMSA annotation", func(t *testing.T) {
 		createConfig := &dockertypes.ContainerCreateConfig{}
 
-		err := applyGMSAConfig(&runtimeapi.ContainerConfig{}, createConfig, &containerCreationCleanupInfo{})
+		err := applyGMSAConfig(&runtimeapi.ContainerConfig{}, createConfig, &containerCleanupInfo{})
 
 		assert.Nil(t, err)
 		assert.Nil(t, createConfig.HostConfig)
@@ -164,7 +164,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 
 func TestRemoveGMSARegistryValue(t *testing.T) {
 	valueName := "k8s-cred-spec-1900254518529e2a3dedb85cdec03ce270559647459ab531f07af5eb1c5495fda709435ce82ab89c"
-	cleanupInfoWithValue := &containerCreationCleanupInfo{gMSARegistryValueName: valueName}
+	cleanupInfoWithValue := &containerCleanupInfo{gMSARegistryValueName: valueName}
 
 	t.Run("it does remove the registry value", func(t *testing.T) {
 		key := &dummyRegistryKey{}
@@ -204,7 +204,7 @@ func TestRemoveGMSARegistryValue(t *testing.T) {
 		key := &dummyRegistryKey{}
 		defer setRegistryCreateKeyFunc(t, key)()
 
-		err := removeGMSARegistryValue(&containerCreationCleanupInfo{})
+		err := removeGMSARegistryValue(&containerCleanupInfo{})
 
 		assert.Nil(t, err)
 		assert.Equal(t, 0, len(key.deleteValueArgs))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

A previous PR (https://github.com/kubernetes/kubernetes/pull/73726)
added GMSA support to the dockershim. Unfortunately, there was a
bug in there: the registry keys used to pass the cred specs down
to Docker were being cleaned up too early, right after the containers'
creation - before Docker would ever try to read them, when trying to
actually start the container.

This patch fixes this.

An e2e test is also provided in a separate PR (https://github.com/kubernetes/kubernetes/pull/74738)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
