### PR TITLE
Adding an e2e test on Windows GMSA support

### DIFF
--- a/test/e2e/windows/BUILD
+++ b/test/e2e/windows/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = [
         "density.go",
         "framework.go",
+        "gmsa.go",
         "hybrid_network.go",
         "memory_limits.go",
         "networking.go",

--- a/test/e2e/windows/README.md
+++ b/test/e2e/windows/README.md
@@ -4,7 +4,7 @@
 
 ```bash
 KUBECONFIG=path/to/kubeconfig
-curl https://raw.githubusercontent.com/e2e-win/e2e-win-prow-deployment/master/repo-list -o repo_list
+curl https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list -o repo_list
 export KUBE_TEST_REPO_LIST=$(pwd)/repo_list
 ```
 

--- a/test/e2e/windows/density.go
+++ b/test/e2e/windows/density.go
@@ -37,13 +37,7 @@ import (
 )
 
 var _ = SIGDescribe("[Feature:Windows] Density [Serial] [Slow]", func() {
-
 	f := framework.NewDefaultFramework("density-test-windows")
-
-	ginkgo.BeforeEach(func() {
-		// NOTE(vyta): these tests are Windows specific
-		framework.SkipUnlessNodeOSDistroIs("windows")
-	})
 
 	ginkgo.Context("create a batch of pods", func() {
 		// TODO(coufon): the values are generous, set more precise limits with benchmark data

--- a/test/e2e/windows/framework.go
+++ b/test/e2e/windows/framework.go
@@ -16,9 +16,20 @@ limitations under the License.
 
 package windows
 
-import "github.com/onsi/ginkgo"
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/onsi/ginkgo"
+)
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-windows] "+text, body)
+	return ginkgo.Describe("[sig-windows] "+text, func() {
+		ginkgo.BeforeEach(func() {
+			// all tests in this package are Windows specific
+			framework.SkipUnlessNodeOSDistroIs("windows")
+		})
+
+		body()
+	})
 }

--- a/test/e2e/windows/gmsa.go
+++ b/test/e2e/windows/gmsa.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package windows
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+var _ = SIGDescribe("[Feature:Windows] [Feature:WindowsGMSA] GMSA [Slow]", func() {
+	f := framework.NewDefaultFramework("gmsa-test-windows")
+
+	ginkgo.Describe("kubelet GMSA support", func() {
+		ginkgo.Context("when creating a pod with correct GMSA credential specs", func() {
+			ginkgo.It("passes the credential specs down to the Pod's containers", func() {
+				defer ginkgo.GinkgoRecover()
+
+				podName := "with-correct-gmsa-annotations"
+
+				container1Name := "container1"
+				podDomain := "acme.com"
+
+				container2Name := "container2"
+				container2Domain := "contoso.org"
+
+				containers := make([]corev1.Container, 2)
+				for i, name := range []string{container1Name, container2Name} {
+					containers[i] = corev1.Container{
+						Name:  name,
+						Image: imageutils.GetPauseImageName(),
+					}
+				}
+
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: podName,
+						Annotations: map[string]string{
+							"pod.alpha.windows.kubernetes.io/gmsa-credential-spec":                         generateDummyCredSpecs(podDomain),
+							container2Name + ".container.alpha.windows.kubernetes.io/gmsa-credential-spec": generateDummyCredSpecs(container2Domain),
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: containers,
+					},
+				}
+
+				ginkgo.By("creating a pod with correct GMSA annotations")
+				f.PodClient().Create(pod)
+
+				ginkgo.By("waiting for the pod and its containers to be running")
+				gomega.Eventually(func() bool {
+					pod, err := f.PodClient().Get(podName, metav1.GetOptions{})
+					if err != nil && pod.Status.Phase != corev1.PodRunning {
+						return false
+					}
+
+					for _, containerStatus := range pod.Status.ContainerStatuses {
+						if containerStatus.State.Running == nil {
+							return false
+						}
+					}
+
+					return true
+				}, 5*time.Minute, 1*time.Second).Should(gomega.BeTrue())
+
+				ginkgo.By("checking the domain reported by nltest in the containers")
+				namespaceOption := fmt.Sprintf("--namespace=%s", f.Namespace.Name)
+				for containerName, domain := range map[string]string{
+					container1Name: podDomain,
+					container2Name: container2Domain,
+				} {
+					var (
+						output string
+						err    error
+					)
+
+					containerOption := fmt.Sprintf("--container=%s", containerName)
+					// even for bogus creds, `nltest /PARENTDOMAIN` simply returns the AD domain, which is enough for our purpose here.
+					// note that the "eventually" part seems to be needed to account for the fact that powershell containers
+					// are a bit slow to become responsive, even when docker reports them as running.
+					gomega.Eventually(func() bool {
+						output, err = framework.RunKubectl("exec", namespaceOption, podName, containerOption, "--", "nltest", "/PARENTDOMAIN")
+						return err == nil
+					}, 1*time.Minute, 1*time.Second).Should(gomega.BeTrue())
+
+					if !strings.HasPrefix(output, domain) {
+						framework.Failf("Expected %q to start with %q", output, domain)
+					}
+
+					expectedSubstr := "The command completed successfully"
+					if !strings.Contains(output, expectedSubstr) {
+						framework.Failf("Expected %q to contain %q", output, expectedSubstr)
+					}
+				}
+
+				// If this was an e2e_node test, we could also check that the registry keys used to pass down the cred specs to Docker
+				// have been properly cleaned up - but as of right now, e2e_node tests don't support Windows. We should migrate this
+				// test to an e2e_node test when they start supporting Windows.
+			})
+		})
+	})
+})
+
+func generateDummyCredSpecs(domain string) string {
+	shortName := strings.ToUpper(strings.Split(domain, ".")[0])
+
+	return fmt.Sprintf(`{
+       "ActiveDirectoryConfig":{
+          "GroupManagedServiceAccounts":[
+             {
+                "Name":"WebApplication",
+                "Scope":"%s"
+             },
+             {
+                "Name":"WebApplication",
+                "Scope":"%s"
+             }
+          ]
+       },
+       "CmsPlugins":[
+          "ActiveDirectory"
+       ],
+       "DomainJoinConfig":{
+          "DnsName":"%s",
+          "DnsTreeName":"%s",
+          "Guid":"244818ae-87ca-4fcd-92ec-e79e5252348a",
+          "MachineAccountName":"WebApplication",
+          "NetBiosName":"%s",
+          "Sid":"S-1-5-21-2126729477-2524175714-3194792973"
+       }
+    }`, shortName, domain, domain, domain, shortName)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This patch is adding an e2e on the Windows GMSA support added in
https://github.com/kubernetes/kubernetes/pull/73726 and
https://github.com/kubernetes/kubernetes/pull/74737.

**Which issue(s) this PR fixes**:
@yujuhong requested an e2e test on this at https://github.com/kubernetes/kubernetes/pull/73726#pullrequestreview-206595783.

**Special notes for your reviewer**:
This e2e test has been verified to pass on a cluster with a Windows node with the
`WindowsGMSA=true` feature gate enabled (and the kubelet compiled from
https://github.com/kubernetes/kubernetes/pull/74737); however, I don't believe that
feature gate is enabled when running a "regular" build. Would it be possible to:
1) enable that feature gate when running Windows e2e tests in a build?
2) or else enable dynamic Kubelet config for these tests, so that each spec can
set the config it needs?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
