### PR TITLE
Fix smartLabelFor to properly handle annotations and labels containing .io

### DIFF
--- a/pkg/kubectl/describe/versioned/describe.go
+++ b/pkg/kubectl/describe/versioned/describe.go
@@ -301,9 +301,16 @@ func printUnstructuredContent(w PrefixWriter, level int, content map[string]inte
 	}
 }
 
-func smartLabelFor(field string) string {
-	commonAcronyms := []string{"API", "URL", "UID", "OSB", "GUID"}
+var commonAcronyms = []string{"API", "URL", "UID", "OSB", "GUID"}
 
+func smartLabelFor(field string) string {
+	// majority of labels and annotations have .io, for example:
+	// controller-tools.k8s.io, failure-domain.beta.kubernetes.io/zone,
+	// deployment.kubernetes.io/revision.
+	// None of these should be camel cased
+	if strings.Contains(field, ".io") {
+		return field
+	}
 	parts := camelcase.Split(field)
 	result := make([]string, 0, len(parts))
 	for _, part := range parts {

--- a/pkg/kubectl/describe/versioned/describe_test.go
+++ b/pkg/kubectl/describe/versioned/describe_test.go
@@ -2506,6 +2506,9 @@ Items:
 Kind:	Test
 Metadata:
   Creation Timestamp:	2017-04-01T00:00:00Z
+  Labels:
+    controller-tools.k8s.io:	1
+    deployment.kubernetes.io/revision:	1
   Name:	MyName
   Namespace:	MyNamespace
   Resource Version:	123
@@ -2542,8 +2545,12 @@ URL:	http://localhost
 			"dummy1":     "present",
 			"dummy2":     "present",
 			"metadata": map[string]interface{}{
-				"name":              "MyName",
-				"namespace":         "MyNamespace",
+				"name":      "MyName",
+				"namespace": "MyNamespace",
+				"labels": map[string]interface{}{
+					"deployment.kubernetes.io/revision": "1",
+					"controller-tools.k8s.io":           "1",
+				},
 				"creationTimestamp": "2017-04-01T00:00:00Z",
 				"resourceVersion":   123,
 				"uid":               "00000000-0000-0000-0000-000000000001",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The current implementation for generic describer will unnecessarily split "official" labels into unreadable data (before):
```
        Sigs . K 8 S . Io / Cluster - API - Machine - Role:  worker
        Sigs . K 8 S . Io / Cluster - API - Machine - Type:  worker
```
This fix ensure that everything containing `.io` will not be camel cased (after):
```
        sigs.k8s.io/cluster-api-machine-role:  worker
        sigs.k8s.io/cluster-api-machine-type:  worker
```

**Special notes for your reviewer**:
/assign @smarterclayton @juanvallejo 
it looks like you've touched this code recently too :wink: 

**Does this PR introduce a user-facing change?**:
```release-note
Improve printing labels and annotations for CRDs when using kubectl describe.
```
