### PR TITLE
cleanup-join-phases-flags

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -44,10 +44,12 @@ func getControlPlaneJoinPhaseFlags() []string {
 		options.CfgPath,
 		options.ControlPlane,
 		options.NodeName,
+		options.FileDiscovery,
 		options.TokenDiscovery,
 		options.TokenDiscoveryCAHash,
 		options.TokenDiscoverySkipCAHash,
-		options.KubeconfigPath,
+		options.TLSBootstrapToken,
+		options.TokenStr,
 	}
 }
 

--- a/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
@@ -41,9 +41,11 @@ func NewControlPlanePreparePhase() workflow.Phase {
 		Short: "Prepares the machine for serving a control plane.",
 		Phases: []workflow.Phase{
 			{
-				Name:           "all",
-				Short:          "Prepares the machine for serving a control plane.",
-				InheritFlags:   getControlPlanePreparePhaseFlags(),
+				Name:  "all",
+				Short: "Prepares the machine for serving a control plane.",
+				InheritFlags: append(getControlPlanePreparePhaseFlags(),
+					options.CertificateKey,
+				),
 				RunAllSiblings: true,
 			},
 			newControlPlanePrepareDownloadCertsSubphase(),
@@ -61,10 +63,12 @@ func getControlPlanePreparePhaseFlags() []string {
 		options.CfgPath,
 		options.ControlPlane,
 		options.NodeName,
+		options.FileDiscovery,
 		options.TokenDiscovery,
 		options.TokenDiscoveryCAHash,
 		options.TokenDiscoverySkipCAHash,
-		options.CertificateKey,
+		options.TLSBootstrapToken,
+		options.TokenStr,
 	}
 }
 
@@ -74,10 +78,9 @@ func newControlPlanePrepareDownloadCertsSubphase() workflow.Phase {
 		Short: fmt.Sprintf("Download certificates from %s", kubeadmconstants.KubeadmCertsSecret),
 		Long:  cmdutil.MacroCommandLongDescription,
 		Run:   runControlPlanePrepareDownloadCertsPhaseLocal,
-		InheritFlags: []string{
-			options.CfgPath,
+		InheritFlags: append(getControlPlanePreparePhaseFlags(),
 			options.CertificateKey,
-		},
+		),
 	}
 }
 

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -64,10 +64,11 @@ func NewKubeletStartPhase() workflow.Phase {
 			options.CfgPath,
 			options.NodeCRISocket,
 			options.NodeName,
-			options.TLSBootstrapToken,
+			options.FileDiscovery,
 			options.TokenDiscovery,
 			options.TokenDiscoveryCAHash,
 			options.TokenDiscoverySkipCAHash,
+			options.TLSBootstrapToken,
 			options.TokenStr,
 		},
 	}

--- a/cmd/kubeadm/app/cmd/phases/join/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/join/preflight.go
@@ -73,6 +73,7 @@ func NewPreflightPhase() workflow.Phase {
 			options.TokenDiscovery,
 			options.TokenDiscoveryCAHash,
 			options.TokenDiscoverySkipCAHash,
+			options.CertificateKey,
 		},
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR implement the first cleanup of flags for the newly added `kubeadm join phases` including:

1. All the phases are now consistently exposing flags for all the discovery methods
2. phase `preflight` gets the missing `--certificate-key`
3. phase `download-certs` get the missing `--control-plane` flags
4. phase `control-plane-prepare all` gets all the flags for the corresponding subphases

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
This PR makes things consistent/allow phases to properly work when invoked atomically
After this merge, it will be possible to try to reduce the number of flags

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cluster-lifecycle
/area kubeadm
/priority important-soon
@kubernetes/sig-cluster-lifecycle-pr-reviews
/assign @neolit123 
/cc @ereslibre 
/cc @rosti 
/cc @yagonobre 
