### PR TITLE
Increase Windows smoke-test timeout to 3 minutes.

### DIFF
--- a/cluster/gce/windows/smoke-test.sh
+++ b/cluster/gce/windows/smoke-test.sh
@@ -40,7 +40,7 @@
 # Override this to use a different kubectl binary.
 kubectl=kubectl
 linux_deployment_timeout=60
-windows_deployment_timeout=120
+windows_deployment_timeout=180
 output_file=/tmp/k8s-smoke-test.out
 
 function check_windows_nodes_are_ready {


### PR DESCRIPTION
I recently lowered the timeout value to 2 minutes but this turned out to
be too aggressive for now. 3 minutes is usually long enough for the test
containers to come up.

Note that this test is only used during development, it does not run
continuously anywhere.

/kind cleanup

```release-note
NONE
```
