### PR TITLE
Revert kubelet to default to ttl cache secret/configmap behavior

### DIFF
--- a/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted.yaml
@@ -101,7 +101,7 @@ cgroupsPerQOS: true
 clusterDNS:
 - 10.192.0.10
 clusterDomain: cluster.global
-configMapAndSecretChangeDetectionStrategy: Watch
+configMapAndSecretChangeDetectionStrategy: Cache
 containerLogMaxFiles: 5
 containerLogMaxSize: 10Mi
 contentType: application/vnd.kubernetes.protobuf

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted_non_linux.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted_non_linux.yaml
@@ -101,7 +101,7 @@ cgroupsPerQOS: true
 clusterDNS:
 - 10.192.0.10
 clusterDomain: cluster.global
-configMapAndSecretChangeDetectionStrategy: Watch
+configMapAndSecretChangeDetectionStrategy: Cache
 containerLogMaxFiles: 5
 containerLogMaxSize: 10Mi
 contentType: application/vnd.kubernetes.protobuf

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -215,7 +215,7 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 		obj.ContainerLogMaxFiles = utilpointer.Int32Ptr(5)
 	}
 	if obj.ConfigMapAndSecretChangeDetectionStrategy == "" {
-		obj.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.WatchChangeDetectionStrategy
+		obj.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.TTLCacheChangeDetectionStrategy
 	}
 	if obj.EnforceNodeAllocatable == nil {
 		obj.EnforceNodeAllocatable = DefaultNodeAllocatableEnforcement


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Reverts the kubelet to pre-1.12 behavior for fetching configmaps/secrets, due to http/2 stream saturation issues (https://github.com/golang/go/issues/27044, fixed in go1.12, but not available to k8s 1.12/1.13). Once we [update to golang 1.12+](https://github.com/kubernetes/kubernetes/pull/74632), and have scale tests in place to test this scenerio more thoroughly, we can re-enable the watching manager by default.

**Which issue(s) this PR fixes**:
xref #74412

**Does this PR introduce a user-facing change?**:
```release-note
kubelet: resolved hang/timeout issues when running large numbers of pods with unique configmap/secret references
```

/cc @wojtek-t 
@kubernetes/sig-scalability-pr-reviews 