### PR TITLE
Cleanup join data struct

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/join/checketcd.go
+++ b/cmd/kubeadm/app/cmd/phases/join/checketcd.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	etcdphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/etcd"
 )
 
@@ -61,7 +60,7 @@ func runCheckEtcdPhase(c workflow.RunData) error {
 	// Checks that the etcd cluster is healthy
 	// NB. this check cannot be implemented before because it requires the admin.conf and all the certificates
 	//     for connecting to etcd already in place
-	client, err := data.ClientSetFromFile(kubeadmconstants.GetAdminKubeConfigPath())
+	client, err := data.ClientSet()
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -109,9 +109,8 @@ func runEtcdPhase(c workflow.RunData) error {
 		return nil
 	}
 
-	kubeConfigFile := data.KubeConfigPath()
-
-	client, err := data.ClientSetFromFile(kubeConfigFile)
+	// gets access to the cluster using the identity defined in admin.conf
+	client, err := data.ClientSet()
 	if err != nil {
 		return errors.Wrap(err, "couldn't create Kubernetes client")
 	}
@@ -151,9 +150,8 @@ func runUploadConfigPhase(c workflow.RunData) error {
 		return nil
 	}
 
-	kubeConfigFile := data.KubeConfigPath()
-
-	client, err := data.ClientSetFromFile(kubeConfigFile)
+	// gets access to the cluster using the identity defined in admin.conf
+	client, err := data.ClientSet()
 	if err != nil {
 		return errors.Wrap(err, "couldn't create Kubernetes client")
 	}
@@ -179,9 +177,8 @@ func runMarkControlPlanePhase(c workflow.RunData) error {
 		return nil
 	}
 
-	kubeConfigFile := data.KubeConfigPath()
-
-	client, err := data.ClientSetFromFile(kubeConfigFile)
+	// gets access to the cluster using the identity defined in admin.conf
+	client, err := data.ClientSet()
 	if err != nil {
 		return errors.Wrap(err, "couldn't create Kubernetes client")
 	}

--- a/cmd/kubeadm/app/cmd/phases/join/data.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data.go
@@ -30,10 +30,9 @@ import (
 type JoinData interface {
 	CertificateKey() string
 	Cfg() *kubeadmapi.JoinConfiguration
-	KubeConfigPath() string
 	TLSBootstrapCfg() (*clientcmdapi.Config, error)
 	InitCfg() (*kubeadmapi.InitConfiguration, error)
-	ClientSetFromFile(path string) (*clientset.Clientset, error)
+	ClientSet() (*clientset.Clientset, error)
 	IgnorePreflightErrors() sets.String
 	OutputWriter() io.Writer
 }

--- a/cmd/kubeadm/app/cmd/phases/join/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data_test.go
@@ -31,11 +31,10 @@ type testJoinData struct{}
 // testJoinData must satisfy JoinData.
 var _ JoinData = &testJoinData{}
 
-func (j *testJoinData) CertificateKey() string                                      { return "" }
-func (j *testJoinData) Cfg() *kubeadmapi.JoinConfiguration                          { return nil }
-func (j *testJoinData) KubeConfigPath() string                                      { return "" }
-func (j *testJoinData) TLSBootstrapCfg() (*clientcmdapi.Config, error)              { return nil, nil }
-func (j *testJoinData) InitCfg() (*kubeadmapi.InitConfiguration, error)             { return nil, nil }
-func (j *testJoinData) ClientSetFromFile(path string) (*clientset.Clientset, error) { return nil, nil }
-func (j *testJoinData) IgnorePreflightErrors() sets.String                          { return nil }
-func (j *testJoinData) OutputWriter() io.Writer                                     { return nil }
+func (j *testJoinData) CertificateKey() string                          { return "" }
+func (j *testJoinData) Cfg() *kubeadmapi.JoinConfiguration              { return nil }
+func (j *testJoinData) TLSBootstrapCfg() (*clientcmdapi.Config, error)  { return nil, nil }
+func (j *testJoinData) InitCfg() (*kubeadmapi.InitConfiguration, error) { return nil, nil }
+func (j *testJoinData) ClientSet() (*clientset.Clientset, error)        { return nil, nil }
+func (j *testJoinData) IgnorePreflightErrors() sets.String              { return nil }
+func (j *testJoinData) OutputWriter() io.Writer                         { return nil }

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -73,28 +73,28 @@ func NewKubeletStartPhase() workflow.Phase {
 	}
 }
 
-func getKubeletStartJoinData(c workflow.RunData) (JoinData, *kubeadmapi.JoinConfiguration, *kubeadmapi.InitConfiguration, *clientcmdapi.Config, error) {
+func getKubeletStartJoinData(c workflow.RunData) (*kubeadmapi.JoinConfiguration, *kubeadmapi.InitConfiguration, *clientcmdapi.Config, error) {
 	data, ok := c.(JoinData)
 	if !ok {
-		return nil, nil, nil, nil, errors.New("kubelet-start phase invoked with an invalid data struct")
+		return nil, nil, nil, errors.New("kubelet-start phase invoked with an invalid data struct")
 	}
 	cfg := data.Cfg()
 	initCfg, err := data.InitCfg()
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 	tlsBootstrapCfg, err := data.TLSBootstrapCfg()
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
-	return data, cfg, initCfg, tlsBootstrapCfg, nil
+	return cfg, initCfg, tlsBootstrapCfg, nil
 }
 
 // runKubeletStartJoinPhase executes the kubelet TLS bootstrap process.
 // This process is executed by the kubelet and completes with the node joining the cluster
 // with a dedicates set of credentials as required by the node authorizer
 func runKubeletStartJoinPhase(c workflow.RunData) error {
-	data, cfg, initCfg, tlsBootstrapCfg, err := getKubeletStartJoinData(c)
+	cfg, initCfg, tlsBootstrapCfg, err := getKubeletStartJoinData(c)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func runKubeletStartJoinPhase(c workflow.RunData) error {
 		return err
 	}
 
-	bootstrapClient, err := data.ClientSetFromFile(bootstrapKubeConfigFile)
+	bootstrapClient, err := kubeconfigutil.ClientSetFromFile(bootstrapKubeConfigFile)
 	if err != nil {
 		return errors.Errorf("couldn't create client from kubeconfig file %q", bootstrapKubeConfigFile)
 	}
@@ -156,7 +156,7 @@ func runKubeletStartJoinPhase(c workflow.RunData) error {
 	}
 
 	// When we know the /etc/kubernetes/kubelet.conf file is available, get the client
-	client, err := data.ClientSetFromFile(kubeadmconstants.GetKubeletKubeConfigPath())
+	client, err := kubeconfigutil.ClientSetFromFile(kubeadmconstants.GetKubeletKubeConfigPath())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR implement two small cleanup for the newly added `JoinData` interface:

1. `clientSets  map[string]*clientset.Clientset` is refactored into `clientSet  *clientset.Clientset`
2. `KubeConfigPath` is dropped

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cluster-lifecycle
/area kubeadm
/priority important-soon
@kubernetes/sig-cluster-lifecycle-pr-reviews
/assign @neolit123 
/cc @ereslibre 
/cc @rosti 
/cc @yagonobre 
