### PR TITLE
Add custom runtime handler e2e test

### DIFF
--- a/test/e2e/common/BUILD
+++ b/test/e2e/common/BUILD
@@ -34,6 +34,7 @@ go_library(
         "projected_downwardapi.go",
         "projected_secret.go",
         "runtime.go",
+        "runtimeclass.go",
         "secrets.go",
         "secrets_volume.go",
         "security_context.go",
@@ -48,7 +49,9 @@ go_library(
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/client/conditions:go_default_library",
         "//pkg/kubelet:go_default_library",
+        "//pkg/kubelet/events:go_default_library",
         "//pkg/kubelet/images:go_default_library",
+        "//pkg/kubelet/runtimeclass/testing:go_default_library",
         "//pkg/kubelet/sysctl:go_default_library",
         "//pkg/security/apparmor:go_default_library",
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
@@ -80,6 +83,7 @@ go_library(
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/golang.org/x/net/websocket:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/test/e2e/node/BUILD
+++ b/test/e2e/node/BUILD
@@ -14,7 +14,6 @@ go_library(
         "pod_gc.go",
         "pods.go",
         "pre_stop.go",
-        "runtimeclass.go",
         "security_context.go",
         "ssh.go",
         "ttlafterfinished.go",
@@ -23,13 +22,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kubelet/apis/stats/v1alpha1:go_default_library",
-        "//pkg/kubelet/events:go_default_library",
-        "//pkg/kubelet/runtimeclass/testing:go_default_library",
         "//pkg/master/ports:go_default_library",
         "//pkg/util/slice:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
@@ -44,7 +40,6 @@ go_library(
         "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds a new e2e test for a custom runtime handler setup. This is a tricky thing to test, as it relies on a custom runtime handler to be configured outside of Kubernetes, which depends a lot on the underlying environment.

**Which issue(s) this PR fixes**:
For https://github.com/kubernetes/enhancements/issues/585

**Special notes for your reviewer**:
This change has a bunch of dependencies:
https://github.com/kubernetes/test-infra/pull/11572 and https://github.com/containerd/cri/pull/1069 to configure the underlying handler, and the bump of RuntimeClass to beta (since the node e2e's do not currently pipe feature gates through).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig node testing
/priority important-soon
/area test
/milestone v1.14