### PR TITLE
Use RESTMapper for checking scope of metrics

### DIFF
--- a/cmd/kube-controller-manager/app/autoscaling.go
+++ b/cmd/kube-controller-manager/app/autoscaling.go
@@ -63,6 +63,7 @@ func startHPAControllerWithRESTClient(ctx ControllerContext) (http.Handler, bool
 		resourceclient.NewForConfigOrDie(clientConfig),
 		custom_metrics.NewForConfig(clientConfig, ctx.RESTMapper, apiVersionsGetter),
 		external_metrics.NewForConfigOrDie(clientConfig),
+		ctx.RESTMapper,
 	)
 	return startHPAControllerWithMetricsClient(ctx, metricsClient)
 }

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -26,7 +26,7 @@ import (
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -617,6 +617,7 @@ func (tc *testCase) verifyResults(t *testing.T) {
 
 func (tc *testCase) setupController(t *testing.T) (*HorizontalController, informers.SharedInformerFactory) {
 	testClient, testMetricsClient, testCMClient, testEMClient, testScaleClient := tc.prepareTestClient(t)
+	mapper := testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)
 	if tc.testClient != nil {
 		testClient = tc.testClient
 	}
@@ -636,6 +637,7 @@ func (tc *testCase) setupController(t *testing.T) (*HorizontalController, inform
 		testMetricsClient.MetricsV1beta1(),
 		testCMClient,
 		testEMClient,
+		mapper,
 	)
 
 	eventClient := &fake.Clientset{}

--- a/pkg/controller/podautoscaler/metrics/rest_metrics_client_test.go
+++ b/pkg/controller/podautoscaler/metrics/rest_metrics_client_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	autoscalingapi "k8s.io/api/autoscaling/v2beta2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -226,7 +226,8 @@ func (tc *restClientTestCase) verifyResults(t *testing.T, metrics PodMetricsInfo
 func (tc *restClientTestCase) runTest(t *testing.T) {
 	var err error
 	testMetricsClient, testCMClient, testEMClient := tc.prepareTestClient(t)
-	metricsClient := NewRESTMetricsClient(testMetricsClient.MetricsV1beta1(), testCMClient, testEMClient)
+	mapper := testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)
+	metricsClient := NewRESTMetricsClient(testMetricsClient.MetricsV1beta1(), testCMClient, testEMClient, mapper)
 	isResource := len(tc.resourceName) > 0
 	isExternal := tc.metricSelector != nil
 	if isResource {

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -339,8 +339,8 @@ func (tc *replicaCalcTestCase) prepareTestClient(t *testing.T) (*fake.Clientset,
 
 func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 	testClient, testMetricsClient, testCMClient, testEMClient := tc.prepareTestClient(t)
-	metricsClient := metricsclient.NewRESTMetricsClient(testMetricsClient.MetricsV1beta1(), testCMClient, testEMClient)
-
+	mapper := testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)
+	metricsClient := metricsclient.NewRESTMetricsClient(testMetricsClient.MetricsV1beta1(), testCMClient, testEMClient, mapper)
 	informerFactory := informers.NewSharedInformerFactory(testClient, controller.NoResyncPeriodFunc())
 	informer := informerFactory.Core().V1().Pods()
 


### PR DESCRIPTION
 /kind bug


**What this PR does / why we need it**:

The HPA controller's metrics client currently assumes all objects referenced in the Object metrics type are namespaced (unless it's namespaces themselves). This is wrong -- we should be using a RESTMapper to figure out the scope.

Fixes #67777
 /release-note-none