### PR TITLE
Better detection of binaries for conformance image

### DIFF
--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -21,12 +21,13 @@ REGISTRY?=k8s.gcr.io
 ARCH?=amd64
 OUT_DIR?=_output
 
-OUTPUT_PATH=$(shell pwd)/../../../$(OUT_DIR)
-BINARY_PATH=$(shell test -d $(OUTPUT_PATH)/local && echo $(OUTPUT_PATH)/local || echo $(OUTPUT_PATH)/dockerized)
+LOCAL_OUTPUT_PATH=$(shell pwd)/../../../$(OUT_DIR)/local/bin/linux/$(ARCH)
+DOCKERIZED_OUTPUT_PATH=$(shell pwd)/../../../$(OUT_DIR)/dockerized/bin/linux/$(ARCH)
 
-GINKGO_BIN?=$(BINARY_PATH)/bin/linux/$(ARCH)/ginkgo
-KUBECTL_BIN?=$(BINARY_PATH)/bin/linux/$(ARCH)/kubectl
-E2E_TEST_BIN?=$(BINARY_PATH)/bin/linux/$(ARCH)/e2e.test
+GINKGO_BIN?=$(shell test -f $(LOCAL_OUTPUT_PATH)/ginkgo && echo $(LOCAL_OUTPUT_PATH)/ginkgo || echo $(DOCKERIZED_OUTPUT_PATH)/ginkgo)
+KUBECTL_BIN?=$(shell test -f $(LOCAL_OUTPUT_PATH)/kubectl && echo $(LOCAL_OUTPUT_PATH)/kubectl || echo $(DOCKERIZED_OUTPUT_PATH)/kubectl)
+E2E_TEST_BIN?=$(shell test -f $(LOCAL_OUTPUT_PATH)/e2e.test && echo $(LOCAL_OUTPUT_PATH)/e2e.test || echo $(DOCKERIZED_OUTPUT_PATH)/e2e.test)
+
 CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
 BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.12.1


### PR DESCRIPTION
Change-Id: Id33a0827e8cb1e3369544eea3335c80c89780786

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We need to be considerate to folks who may be trying to build this image not necessarily from a fresh checkout. currently without this change there are situations where `make quick-release` fails if `_output/local` exists but does not have the binaries. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
