### PR TITLE
Dump Windows version information during cluster bringup.

### DIFF
--- a/cluster/gce/windows/common.psm1
+++ b/cluster/gce/windows/common.psm1
@@ -65,14 +65,13 @@ function ShouldWrite-File {
 
 # Returns the GCE instance metadata value for $Key. If the key is not present
 # in the instance metadata returns $Default if set, otherwise returns $null.
-function Get-InstanceMetadataValue {
+function Get-InstanceMetadata {
   param (
     [parameter(Mandatory=$true)] [string]$Key,
     [parameter(Mandatory=$false)] [string]$Default
   )
 
-  $url = ("http://metadata.google.internal/computeMetadata/v1/instance/" +
-          "attributes/$Key")
+  $url = "http://metadata.google.internal/computeMetadata/v1/instance/$Key"
   try {
     $client = New-Object Net.WebClient
     $client.Headers.Add('Metadata-Flavor', 'Google')
@@ -87,6 +86,18 @@ function Get-InstanceMetadataValue {
       return $null
     }
   }
+}
+
+# Returns the GCE instance metadata value for $Key where key is an "attribute"
+# of the instance. If the key is not present in the instance metadata returns
+# $Default if set, otherwise returns $null.
+function Get-InstanceMetadataAttribute {
+  param (
+    [parameter(Mandatory=$true)] [string]$Key,
+    [parameter(Mandatory=$false)] [string]$Default
+  )
+
+  return Get-InstanceMetadata "attributes/$Key" $Default
 }
 
 function Validate-SHA1 {

--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -27,9 +27,10 @@ $ErrorActionPreference = 'Stop'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $ProgressPreference = 'SilentlyContinue'
 
-# Returns the GCE instance metadata value for $Key. If the key is not present
-# in the instance metadata returns $Default if set, otherwise returns $null.
-function Get-InstanceMetadataValue {
+# Returns the GCE instance metadata value for $Key where key is an "attribute"
+# of the instance. If the key is not present in the instance metadata returns
+# $Default if set, otherwise returns $null.
+function Get-InstanceMetadataAttribute {
   param (
     [parameter(Mandatory=$true)] [string]$Key,
     [parameter(Mandatory=$false)] [string]$Default
@@ -63,7 +64,7 @@ function FetchAndImport-ModuleFromMetadata {
     [parameter(Mandatory=$true)] [string]$Filename
   )
 
-  $module = Get-InstanceMetadataValue $MetadataKey
+  $module = Get-InstanceMetadataAttribute $MetadataKey
   if (Test-Path C:\$Filename) {
     if (-not $REDO_STEPS) {
       Log-Output "Skip: C:\$Filename already exists, not overwriting"
@@ -81,7 +82,7 @@ try {
   # Don't use FetchAndImport-ModuleFromMetadata for common.psm1 - the common
   # module includes variables and functions that any other function may depend
   # on.
-  $module = Get-InstanceMetadataValue 'common-psm1'
+  $module = Get-InstanceMetadataAttribute 'common-psm1'
   New-Item -ItemType file -Force C:\common.psm1 | Out-Null
   Set-Content C:\common.psm1 $module
   Import-Module -Force C:\common.psm1

--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -91,6 +91,7 @@ try {
   # then put these calls into a loop over a list of XYZ-psm1 keys.
   FetchAndImport-ModuleFromMetadata 'k8s-node-setup-psm1' 'k8s-node-setup.psm1'
 
+  Dump-DebugInfoToConsole
   Set-PrerequisiteOptions
   $kube_env = Fetch-KubeEnv
   Disable-WindowsDefender

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -135,7 +135,7 @@ function Add_GceMetadataServerRoute {
 function Fetch-KubeEnv {
   # Testing / debugging:
   # First:
-  #   ${kube_env} = Get-InstanceMetadataValue 'kube-env'
+  #   ${kube_env} = Get-InstanceMetadataAttribute 'kube-env'
   # or:
   #   ${kube_env} = [IO.File]::ReadAllText(".\kubeEnv.txt")
   # ${kube_env_table} = ConvertFrom-Yaml ${kube_env}
@@ -143,7 +143,7 @@ function Fetch-KubeEnv {
   # ${kube_env_table}.GetType()
 
   # The type of kube_env is a powershell String.
-  $kube_env = Get-InstanceMetadataValue 'kube-env'
+  $kube_env = Get-InstanceMetadataAttribute 'kube-env'
   $kube_env_table = ConvertFrom-Yaml ${kube_env}
   return ${kube_env_table}
 }
@@ -882,7 +882,7 @@ function Configure-Kubelet {
   # The Kubelet config is built by build-kubelet-config() in
   # cluster/gce/util.sh, and stored in the metadata server under the
   # 'kubelet-config' key.
-  $kubelet_config = Get-InstanceMetadataValue 'kubelet-config'
+  $kubelet_config = Get-InstanceMetadataAttribute 'kubelet-config'
   Set-Content ${env:KUBELET_CONFIG} $kubelet_config
   Log-Output "Kubelet config:`n$(Get-Content -Raw ${env:KUBELET_CONFIG})"
 }

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -128,6 +128,19 @@ function Add_GceMetadataServerRoute {
   }
 }
 
+# Writes debugging information, such as Windows version and patch info, to the
+# console.
+function Dump-DebugInfoToConsole {
+  Try {
+    $version = "$([System.Environment]::OSVersion.Version | Out-String)"
+    $hotfixes = "$(Get-Hotfix | Out-String)"
+    $image = "$(Get-InstanceMetadata 'image' | Out-String)"
+    Log-Output "Windows version:`n$version"
+    Log-Output "Installed hotfixes:`n$hotfixes"
+    Log-Output "GCE Windows image:`n$image"
+  } Catch { }
+}
+
 # Fetches the kube-env from the instance metadata.
 #
 # Returns: a PowerShell Hashtable object containing the key-value pairs from

--- a/cluster/gce/windows/testonly/install-ssh.psm1
+++ b/cluster/gce/windows/testonly/install-ssh.psm1
@@ -106,7 +106,7 @@ function Setup_WriteSshKeysScript {
 
   # Fetch helper module for manipulating Windows user profiles.
   if (ShouldWrite-File $USER_PROFILE_MODULE) {
-    $module = Get-InstanceMetadataValue 'user-profile-psm1'
+    $module = Get-InstanceMetadataAttribute 'user-profile-psm1'
     New-Item -ItemType file -Force $USER_PROFILE_MODULE | Out-Null
     Set-Content $USER_PROFILE_MODULE $module
   }


### PR DESCRIPTION
/kind cleanup

Dumps Windows version information as Windows nodes are joined to clusters running in GCE.

Example output in Windows VM's serial log:
```
Windows version:

Major  Minor  Build  Revision
-----  -----  -----  --------
10     0      17763  0

Installed hotfixes:

Source        Description      HotFixID      InstalledBy          InstalledOn
------        -----------      --------      -----------          -----------
KUBERNETES... Update           KB4483452     NT AUTHORITY\SYSTEM  2/26/2019 12:00:00 AM
KUBERNETES... Security Update  KB4470788     NT AUTHORITY\SYSTEM  2/26/2019 12:00:00 AM
KUBERNETES... Security Update  KB4487044     NT AUTHORITY\SYSTEM  2/26/2019 12:00:00 AM
```

```release-note
NONE
```