### PR TITLE
experiment: image arch used in test

### DIFF
--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -80,6 +80,7 @@ go_library(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -346,6 +347,7 @@ func deployWebhookAndService(f *framework.Framework, image string, context *cert
 		},
 	}
 	deployment, err := client.AppsV1().Deployments(namespace).Create(d)
+	klog.Errorf(">>>>> image being used: %v", deployment.Spec.Template.Spec.Containers[0].Image)
 	framework.ExpectNoError(err, "creating deployment %s in namespace %s", deploymentName, namespace)
 	By("Wait for the deployment to be ready")
 	err = framework.WaitForDeploymentRevisionAndImage(client, namespace, deploymentName, "1", image)


### PR DESCRIPTION
experiment: please don't review

noticed this when tested locally. double check if we are still using the legacy amd64 workaround with no arch suffix (or if there is some mutating webhook in test framework setting the arch)