### PR TITLE
move local PV to GA

### DIFF
--- a/pkg/api/persistentvolume/util.go
+++ b/pkg/api/persistentvolume/util.go
@@ -28,9 +28,6 @@ func DropDisabledFields(pvSpec *api.PersistentVolumeSpec, oldPVSpec *api.Persist
 	if !utilfeature.DefaultFeatureGate.Enabled(features.BlockVolume) && !volumeModeInUse(oldPVSpec) {
 		pvSpec.VolumeMode = nil
 	}
-	if !utilfeature.DefaultFeatureGate.Enabled(features.PersistentLocalVolumes) && !persistentLocalVolumesInUse(oldPVSpec) {
-		pvSpec.PersistentVolumeSource.Local = nil
-	}
 	if !utilfeature.DefaultFeatureGate.Enabled(features.CSIPersistentVolume) {
 		// if this is a new PV, or the old PV didn't already have the CSI field, clear it
 		if oldPVSpec == nil || oldPVSpec.PersistentVolumeSource.CSI == nil {
@@ -44,16 +41,6 @@ func volumeModeInUse(oldPVSpec *api.PersistentVolumeSpec) bool {
 		return false
 	}
 	if oldPVSpec.VolumeMode != nil {
-		return true
-	}
-	return false
-}
-
-func persistentLocalVolumesInUse(oldPVSpec *api.PersistentVolumeSpec) bool {
-	if oldPVSpec == nil {
-		return false
-	}
-	if oldPVSpec.PersistentVolumeSource.Local != nil {
 		return true
 	}
 	return false

--- a/pkg/api/persistentvolume/util_test.go
+++ b/pkg/api/persistentvolume/util_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package persistentvolume
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -151,101 +150,5 @@ func TestDropDisabledFields(t *testing.T) {
 				t.Error(diff.ObjectReflectDiff(tc.oldSpec, tc.expectOldSpec))
 			}
 		})
-	}
-}
-
-func TestDropDisabledFieldsPersistentLocalVolume(t *testing.T) {
-	pvWithoutLocalVolume := func() *api.PersistentVolume {
-		return &api.PersistentVolume{
-			Spec: api.PersistentVolumeSpec{
-				PersistentVolumeSource: api.PersistentVolumeSource{
-					Local: nil,
-				},
-			},
-		}
-	}
-	pvWithLocalVolume := func() *api.PersistentVolume {
-		fsType := "ext4"
-		return &api.PersistentVolume{
-			Spec: api.PersistentVolumeSpec{
-				PersistentVolumeSource: api.PersistentVolumeSource{
-					Local: &api.LocalVolumeSource{
-						Path:   "/a/b/c",
-						FSType: &fsType,
-					},
-				},
-			},
-		}
-	}
-
-	pvInfo := []struct {
-		description    string
-		hasLocalVolume bool
-		pv             func() *api.PersistentVolume
-	}{
-		{
-			description:    "pv without LocalVolume",
-			hasLocalVolume: false,
-			pv:             pvWithoutLocalVolume,
-		},
-		{
-			description:    "pv with LocalVolume",
-			hasLocalVolume: true,
-			pv:             pvWithLocalVolume,
-		},
-		{
-			description:    "is nil",
-			hasLocalVolume: false,
-			pv:             func() *api.PersistentVolume { return nil },
-		},
-	}
-
-	for _, enabled := range []bool{true, false} {
-		for _, oldpvInfo := range pvInfo {
-			for _, newpvInfo := range pvInfo {
-				oldpvHasLocalVolume, oldpv := oldpvInfo.hasLocalVolume, oldpvInfo.pv()
-				newpvHasLocalVolume, newpv := newpvInfo.hasLocalVolume, newpvInfo.pv()
-				if newpv == nil {
-					continue
-				}
-
-				t.Run(fmt.Sprintf("feature enabled=%v, old pvc %v, new pvc %v", enabled, oldpvInfo.description, newpvInfo.description), func(t *testing.T) {
-					defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PersistentLocalVolumes, enabled)()
-
-					var oldpvSpec *api.PersistentVolumeSpec
-					if oldpv != nil {
-						oldpvSpec = &oldpv.Spec
-					}
-					DropDisabledFields(&newpv.Spec, oldpvSpec)
-
-					// old pv should never be changed
-					if !reflect.DeepEqual(oldpv, oldpvInfo.pv()) {
-						t.Errorf("old pv changed: %v", diff.ObjectReflectDiff(oldpv, oldpvInfo.pv()))
-					}
-
-					switch {
-					case enabled || oldpvHasLocalVolume:
-						// new pv should not be changed if the feature is enabled, or if the old pv had LocalVolume source
-						if !reflect.DeepEqual(newpv, newpvInfo.pv()) {
-							t.Errorf("new pv changed: %v", diff.ObjectReflectDiff(newpv, newpvInfo.pv()))
-						}
-					case newpvHasLocalVolume:
-						// new pv should be changed
-						if reflect.DeepEqual(newpv, newpvInfo.pv()) {
-							t.Errorf("new pv was not changed")
-						}
-						// new pv should not have LocalVolume
-						if !reflect.DeepEqual(newpv, pvWithoutLocalVolume()) {
-							t.Errorf("new pv had LocalVolume source: %v", diff.ObjectReflectDiff(newpv, pvWithoutLocalVolume()))
-						}
-					default:
-						// new pv should not need to be changed
-						if !reflect.DeepEqual(newpv, newpvInfo.pv()) {
-							t.Errorf("new pv changed: %v", diff.ObjectReflectDiff(newpv, newpvInfo.pv()))
-						}
-					}
-				})
-			}
-		}
 	}
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -87,6 +87,8 @@ const (
 
 	// owner: @msau42
 	// alpha: v1.7
+	// beta: v1.10
+	// ga: v1.14
 	//
 	// A new volume type that supports local disks on a node.
 	PersistentLocalVolumes utilfeature.Feature = "PersistentLocalVolumes"
@@ -428,7 +430,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	TaintBasedEvictions:                         {Default: true, PreRelease: utilfeature.Beta},
 	RotateKubeletServerCertificate:              {Default: true, PreRelease: utilfeature.Beta},
 	RotateKubeletClientCertificate:              {Default: true, PreRelease: utilfeature.Beta},
-	PersistentLocalVolumes:                      {Default: true, PreRelease: utilfeature.Beta},
+	PersistentLocalVolumes:                      {Default: true, PreRelease: utilfeature.GA, LockToDefault: true}, // remove in 1.17
 	LocalStorageCapacityIsolation:               {Default: true, PreRelease: utilfeature.Beta},
 	HugePages:                                   {Default: true, PreRelease: utilfeature.GA, LockToDefault: true}, // remove in 1.16
 	Sysctls:                                     {Default: true, PreRelease: utilfeature.Beta},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The PersistentLocalVolumes feature is GA. The feature gate cannot be disabled and will be removed in Kubernetes 1.17
```
