### PR TITLE
Automated cherry pick of #74715: add Azure Container Registry anonymous repo support

### DIFF
--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -206,6 +206,13 @@ func (a *acrProvider) Provide() credentialprovider.DockerConfig {
 			cfg[url] = *cred
 		}
 	}
+
+	// add ACR anonymous repo support: use empty username and password for anonymous access
+	cfg["*.azurecr.*"] = credentialprovider.DockerConfigEntry{
+		Username: "",
+		Password: "",
+		Email:    dummyRegistryEmail,
+	}
 	return cfg
 }
 

--- a/pkg/credentialprovider/azure/azure_credentials_test.go
+++ b/pkg/credentialprovider/azure/azure_credentials_test.go
@@ -76,14 +76,14 @@ func Test(t *testing.T) {
 
 	creds := provider.Provide()
 
-	if len(creds) != len(result) {
-		t.Errorf("Unexpected list: %v, expected length %d", creds, len(result))
+	if len(creds) != len(result)+1 {
+		t.Errorf("Unexpected list: %v, expected length %d", creds, len(result)+1)
 	}
 	for _, cred := range creds {
-		if cred.Username != "foo" {
+		if cred.Username != "" && cred.Username != "foo" {
 			t.Errorf("expected 'foo' for username, saw: %v", cred.Username)
 		}
-		if cred.Password != "bar" {
+		if cred.Password != "" && cred.Password != "bar" {
 			t.Errorf("expected 'bar' for password, saw: %v", cred.Username)
 		}
 	}


### PR DESCRIPTION
Cherry pick of #74715 on release-1.13.

#74715: add Azure Container Registry anonymous repo support