### PR TITLE
fix bug iscsi volume attach failed of /sys/class/iscsi_host dir not e…

### DIFF
--- a/pkg/volume/util/device_util_linux.go
+++ b/pkg/volume/util/device_util_linux.go
@@ -21,6 +21,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -99,6 +100,9 @@ func (handler *deviceHandler) GetISCSIPortalHostMapForTarget(targetIqn string) (
 	sysPath := "/sys/class/iscsi_host"
 	hostDirs, err := io.ReadDir(sysPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return portalHostMap, nil
+		}
 		return nil, err
 	}
 	for _, hostDir := range hostDirs {


### PR DESCRIPTION

**What type of PR is this?**
/kind bug



**What this PR does / why we need it**:
the iscsi volume can not attached the minion,because the iscsi modules haven't even been loaded yet, the /sys/class/iscsi_host directory won't exist
**Which issue(s) this PR fixes**:
Fixes #74640

**Special notes for your reviewer**:
@bswartz
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
iscsi modules haven't even been loaded /sys/class/iscsi_host directory won't exist
```
