### PR TITLE
Promote graceful job deletion e2e test to conformance test

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -23,6 +23,7 @@ test/e2e/apps/deployment.go: "RecreateDeployment should delete old pods and crea
 test/e2e/apps/deployment.go: "deployment should delete old replica sets"
 test/e2e/apps/deployment.go: "deployment should support rollover"
 test/e2e/apps/deployment.go: "deployment should support proportional scaling"
+test/e2e/apps/job.go: "should delete a job"
 test/e2e/apps/rc.go: "should serve a basic image on each replica with a public image"
 test/e2e/apps/rc.go: "should adopt matching pods on creation"
 test/e2e/apps/rc.go: "should release no longer matching pods"

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -99,7 +99,12 @@ var _ = SIGDescribe("Job", func() {
 		Expect(err).NotTo(HaveOccurred(), "failed to ensure job past active deadline in namespace: %s", f.Namespace.Name)
 	})
 
-	It("should delete a job", func() {
+	/*
+		Release : v1.15
+		Testname: Jobs, active pods, graceful termination
+		Description: Create a job. Ensure the active pods reflect paralellism in the namespace and delete the job. Job MUST be deleted successfully.
+	*/
+	framework.ConformanceIt("should delete a job", func() {
 		By("Creating a job")
 		job := framework.NewTestJob("notTerminate", "foo", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
 		job, err := framework.CreateJob(f.ClientSet, f.Namespace.Name, job)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
 /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: TO promote an existing E2E test case to conformance i.e., "should delete a job"

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
release-note-none

/area conformance

cc @spiffxp @brahmaroutu @mgdevstack 