### PR TITLE
Update doc.go import for staging/src/k8s.io/metrics

### DIFF
--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/doc.go
@@ -18,4 +18,4 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/metrics/pkg/apis/custom_metrics
 // +k8s:openapi-gen=true
 
-package v1beta1
+package v1beta1 // import "k8s.io/metrics/pkg/apis/custom_metrics/v1beta1"

--- a/staging/src/k8s.io/metrics/pkg/apis/external_metrics/v1beta1/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/external_metrics/v1beta1/doc.go
@@ -18,4 +18,4 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/metrics/pkg/apis/external_metrics
 // +k8s:openapi-gen=true
 
-package v1beta1
+package v1beta1 // import " k8s.io/metrics/pkg/apis/external_metrics/v1beta1"

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/doc.go
@@ -17,4 +17,4 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +groupName=metrics.k8s.io
 
-package metrics
+package metrics // import "k8s.io/metrics/pkg/apis/metrics"

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/doc.go
@@ -18,4 +18,4 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/metrics/pkg/apis/metrics
 // +k8s:openapi-gen=true
 
-package v1alpha1
+package v1alpha1 // import "k8s.io/metrics/pkg/apis/metrics/v1alpha1"

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/doc.go
@@ -18,4 +18,4 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/metrics/pkg/apis/metrics
 // +k8s:openapi-gen=true
 
-package v1beta1
+package v1beta1 // import "k8s.io/metrics/pkg/apis/metrics/v1beta1"


### PR DESCRIPTION
What this PR does / why we need it:
update doc.go in:
staging/src/k8s.io/metrics

This is necessary so that if someone wants to import only this package, the import path is not referred to as github.com, but as the k8s.io vanity url.
Ref: https://golang.org/doc/go1.4#canonicalimports

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Only a partial fix for #68231

Special notes for your reviewer:

Release note:

NONE