### PR TITLE
src/k8s.io/apiserver: Increase cert expiration histogram resolution

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -39,6 +39,9 @@ var clientCertificateExpirationHistogram = prometheus.NewHistogram(
 		Help:      "Distribution of the remaining lifetime on the certificate used to authenticate a request.",
 		Buckets: []float64{
 			0,
+			(30 * time.Minute).Seconds(),
+			(1 * time.Hour).Seconds(),
+			(2 * time.Hour).Seconds(),
 			(6 * time.Hour).Seconds(),
 			(12 * time.Hour).Seconds(),
 			(24 * time.Hour).Seconds(),


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


/kind feature


**What this PR does / why we need it**:

The `certificate_expiration_seconds` histogram measures the remaining
time of client certificates used to authenticate to the API server. It
records the lifetime of received client request certificates in buckets
of 6h, 12h, ..., 1y.

In environments with automated certificate rotation it is not uncommen
to have issued certificates expire in less than the above mentioned
minimum bucket of 6h. In such environments the above histogram is
useless given that every request will be recorded in the first bucket.

This patch increases the histogram resolution by adding a 30m, 1h and 2h
bucket. Prometheus histogram buckets are cummulative, e.g. the 12h
bucket is counting _all_ records with an expiration date lower or equal
to 12h including _all_ requests of the 6h bucket. Thereby this patch
does not break existing monitoring setups.  This histogram is exposed
once per API server, thereby the 3 additional time series do not cause a
cardinality issue.

**Which issue(s) this PR fixes**:

Relates to https://github.com/openshift/cluster-monitoring-operator/pull/275

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Increase api server client certificate expiration histogram resolution to accommodate short-lived (< 6h) client certificates.
```
