### PR TITLE
Showcase conformance images options in the manifest

### DIFF
--- a/cluster/images/conformance/conformance-e2e.yaml
+++ b/cluster/images/conformance/conformance-e2e.yaml
@@ -59,7 +59,13 @@ spec:
     imagePullPolicy: IfNotPresent
     env:
     - name: E2E_FOCUS
-      value: "Pods should be submitted and removed"
+      value: "\\[Conformance\\]"
+    - name: E2E_SKIP
+      value: "Alpha|\\[(Disruptive|Feature:[^\\]]+|Flaky)\\]"
+    - name: E2E_PROVIDER
+      value: "local"
+    - name: E2E_PARALLEL
+      value: "y"
     volumeMounts:
     - name: output-volume
       mountPath: /tmp/results

--- a/cluster/images/conformance/conformance-e2e.yaml
+++ b/cluster/images/conformance/conformance-e2e.yaml
@@ -61,7 +61,7 @@ spec:
     - name: E2E_FOCUS
       value: "\\[Conformance\\]"
     - name: E2E_SKIP
-      value: "Alpha|\\[(Disruptive|Feature:[^\\]]+|Flaky)\\]"
+      value: ""
     - name: E2E_PROVIDER
       value: "local"
     - name: E2E_PARALLEL


### PR DESCRIPTION
The Dockerfile has a few more options, let's surface that in the
manifest. Also use the same defaults in the manifest as the Dockerfile
itself.

Change-Id: Ib7419cf7999430db15f39ac414c80ee362fcda76

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The Dockerfile has a few more options, let's surface that in the
manifest. Also use the same defaults in the manifest as the Dockerfile
itself.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
