### PR TITLE
go-1.12: fix 'go vet' failures

### DIFF
--- a/pkg/controller/testutil/test_utils.go
+++ b/pkg/controller/testutil/test_utils.go
@@ -374,7 +374,7 @@ func (f *FakeRecorder) PastEventf(obj runtime.Object, timestamp metav1.Time, eve
 
 // AnnotatedEventf emits a fake formatted event to the fake recorder
 func (f *FakeRecorder) AnnotatedEventf(obj runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
-	f.Eventf(obj, eventtype, reason, messageFmt, args)
+	f.Eventf(obj, eventtype, reason, messageFmt, args...)
 }
 
 func (f *FakeRecorder) generateEvent(obj runtime.Object, timestamp metav1.Time, eventtype, reason, message string) {

--- a/pkg/kubelet/container/sync_result_test.go
+++ b/pkg/kubelet/container/sync_result_test.go
@@ -45,7 +45,7 @@ func TestPodSyncResult(t *testing.T) {
 	result.AddSyncResult(okResults...)
 	result.AddSyncResult(errResults...)
 	if result.Error() == nil {
-		t.Errorf("PodSyncResult should be error: %q", result)
+		t.Errorf("PodSyncResult should be error: %v", result)
 	}
 
 	// If the PodSyncResult is failed, it should be error
@@ -53,7 +53,7 @@ func TestPodSyncResult(t *testing.T) {
 	result.AddSyncResult(okResults...)
 	result.Fail(errors.New("error"))
 	if result.Error() == nil {
-		t.Errorf("PodSyncResult should be error: %q", result)
+		t.Errorf("PodSyncResult should be error: %v", result)
 	}
 
 	// If the PodSyncResult is added an error PodSyncResult, it should be error
@@ -63,6 +63,6 @@ func TestPodSyncResult(t *testing.T) {
 	result.AddSyncResult(okResults...)
 	result.AddPodSyncResult(errResult)
 	if result.Error() == nil {
-		t.Errorf("PodSyncResult should be error: %q", result)
+		t.Errorf("PodSyncResult should be error: %v", result)
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -384,7 +384,7 @@ func TestGetPods(t *testing.T) {
 	assert.NoError(t, err)
 
 	if !verifyPods(expected, actual) {
-		t.Errorf("expected %q, got %q", expected, actual)
+		t.Errorf("expected %#v, got %#v", expected, actual)
 	}
 }
 

--- a/pkg/registry/core/service/allocator/utils_test.go
+++ b/pkg/registry/core/service/allocator/utils_test.go
@@ -46,7 +46,7 @@ func TestCountBits(t *testing.T) {
 	for _, test := range tests {
 		actual := countBits(test.n)
 		if test.expected != actual {
-			t.Errorf("%d should have %d bits but recorded as %d", test.n, test.expected, actual)
+			t.Errorf("%s should have %d bits but recorded as %d", test.n, test.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR fixes go vet failures after enabling go 1.12 in the verify-govet job.

the following files are touched as reported here:
https://github.com/kubernetes/kubernetes/pull/74632#issuecomment-468547779

```
# k8s.io/kubernetes/pkg/controller/testutil
pkg/controller/testutil/test_utils.go:377:2: missing ... in args forwarded to printf-like function
# k8s.io/kubernetes/pkg/kubelet/container
pkg/kubelet/container/sync_result_test.go:48:3: Errorf format %q has arg result of wrong type k8s.io/kubernetes/pkg/kubelet/container.PodSyncResult
pkg/kubelet/container/sync_result_test.go:56:3: Errorf format %q has arg result of wrong type k8s.io/kubernetes/pkg/kubelet/container.PodSyncResult
pkg/kubelet/container/sync_result_test.go:66:3: Errorf format %q has arg result of wrong type k8s.io/kubernetes/pkg/kubelet/container.PodSyncResult
# k8s.io/kubernetes/pkg/kubelet/kuberuntime
pkg/kubelet/kuberuntime/kuberuntime_manager_test.go:387:3: Errorf format %q has arg expected of wrong type []*k8s.io/kubernetes/pkg/kubelet/container.Pod
# k8s.io/kubernetes/pkg/registry/core/service/allocator
pkg/registry/core/service/allocator/utils_test.go:49:4: Errorf format %d has arg test.n of wrong type *math/big.Int
```

the kubeadm "fix" is a separate PR:
https://github.com/kubernetes/kubernetes/pull/74797

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/kind failing-test
/priority important-soon
cc @BenTheElder @cblecker @spiffxp 
/assign @liggitt 
