### PR TITLE
Remove unused size checks on service latency test

### DIFF
--- a/test/e2e/network/service_latency.go
+++ b/test/e2e/network/service_latency.go
@@ -70,7 +70,6 @@ var _ = SIGDescribe("Service endpoints latency", func() {
 			// true on HA clusters.
 			totalTrials    = 200
 			parallelTrials = 15
-			minSampleSize  = 100
 
 			// Acceptable failure ratio for getting service latencies.
 			acceptableFailureRatio = .05
@@ -89,13 +88,6 @@ var _ = SIGDescribe("Service endpoints latency", func() {
 		dSorted := durations(d)
 		sort.Sort(dSorted)
 		n := len(dSorted)
-		if n < minSampleSize {
-			failing.Insert(fmt.Sprintf("Did not get a good sample size: %v", dSorted))
-		}
-		if n < 2 {
-			failing.Insert("Less than two runs succeeded; aborting.")
-			framework.Failf(strings.Join(failing.List(), "\n"))
-		}
 		percentile := func(p int) time.Duration {
 			est := n * p / 100
 			if est >= n {


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

After https://github.com/kubernetes/kubernetes/commit/ac0a946d3e5e38173671c611f56bafd6084d075d
the e2e test allows up-to 10 failure samples (200 * 5%), that means
the sample size is always 190+. So current sample size checks for
100 and 2 are meaningless. This removes these checks.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
