### PR TITLE
lock csi and plugin watcher GA feature gates

### DIFF
--- a/pkg/api/persistentvolume/util.go
+++ b/pkg/api/persistentvolume/util.go
@@ -28,12 +28,6 @@ func DropDisabledFields(pvSpec *api.PersistentVolumeSpec, oldPVSpec *api.Persist
 	if !utilfeature.DefaultFeatureGate.Enabled(features.BlockVolume) && !volumeModeInUse(oldPVSpec) {
 		pvSpec.VolumeMode = nil
 	}
-	if !utilfeature.DefaultFeatureGate.Enabled(features.CSIPersistentVolume) {
-		// if this is a new PV, or the old PV didn't already have the CSI field, clear it
-		if oldPVSpec == nil || oldPVSpec.PersistentVolumeSource.CSI == nil {
-			pvSpec.PersistentVolumeSource.CSI = nil
-		}
-	}
 }
 
 func volumeModeInUse(oldPVSpec *api.PersistentVolumeSpec) bool {

--- a/pkg/api/persistentvolume/util_test.go
+++ b/pkg/api/persistentvolume/util_test.go
@@ -28,12 +28,6 @@ import (
 )
 
 func TestDropDisabledFields(t *testing.T) {
-	specWithCSI := func() *api.PersistentVolumeSpec {
-		return &api.PersistentVolumeSpec{PersistentVolumeSource: api.PersistentVolumeSource{CSI: &api.CSIPersistentVolumeSource{}}}
-	}
-	specWithoutCSI := func() *api.PersistentVolumeSpec {
-		return &api.PersistentVolumeSpec{PersistentVolumeSource: api.PersistentVolumeSource{CSI: nil}}
-	}
 	specWithMode := func(mode *api.PersistentVolumeMode) *api.PersistentVolumeSpec {
 		return &api.PersistentVolumeSpec{VolumeMode: mode}
 	}
@@ -45,53 +39,8 @@ func TestDropDisabledFields(t *testing.T) {
 		newSpec       *api.PersistentVolumeSpec
 		expectOldSpec *api.PersistentVolumeSpec
 		expectNewSpec *api.PersistentVolumeSpec
-		csiEnabled    bool
 		blockEnabled  bool
 	}{
-		"disabled csi clears new": {
-			csiEnabled:    false,
-			newSpec:       specWithCSI(),
-			expectNewSpec: specWithoutCSI(),
-			oldSpec:       nil,
-			expectOldSpec: nil,
-		},
-		"disabled csi clears update when old pv did not use csi": {
-			csiEnabled:    false,
-			newSpec:       specWithCSI(),
-			expectNewSpec: specWithoutCSI(),
-			oldSpec:       specWithoutCSI(),
-			expectOldSpec: specWithoutCSI(),
-		},
-		"disabled csi preserves update when old pv did use csi": {
-			csiEnabled:    false,
-			newSpec:       specWithCSI(),
-			expectNewSpec: specWithCSI(),
-			oldSpec:       specWithCSI(),
-			expectOldSpec: specWithCSI(),
-		},
-
-		"enabled csi preserves new": {
-			csiEnabled:    true,
-			newSpec:       specWithCSI(),
-			expectNewSpec: specWithCSI(),
-			oldSpec:       nil,
-			expectOldSpec: nil,
-		},
-		"enabled csi preserves update when old pv did not use csi": {
-			csiEnabled:    true,
-			newSpec:       specWithCSI(),
-			expectNewSpec: specWithCSI(),
-			oldSpec:       specWithoutCSI(),
-			expectOldSpec: specWithoutCSI(),
-		},
-		"enabled csi preserves update when old pv did use csi": {
-			csiEnabled:    true,
-			newSpec:       specWithCSI(),
-			expectNewSpec: specWithCSI(),
-			oldSpec:       specWithCSI(),
-			expectOldSpec: specWithCSI(),
-		},
-
 		"disabled block clears new": {
 			blockEnabled:  false,
 			newSpec:       specWithMode(&modeBlock),
@@ -139,7 +88,6 @@ func TestDropDisabledFields(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIPersistentVolume, tc.csiEnabled)()
 			defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.BlockVolume, tc.blockEnabled)()
 
 			DropDisabledFields(tc.newSpec, tc.oldSpec)

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -449,7 +449,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	ServiceNodeExclusion:                        {Default: false, PreRelease: utilfeature.Alpha},
 	MountContainers:                             {Default: false, PreRelease: utilfeature.Alpha},
 	VolumeScheduling:                            {Default: true, PreRelease: utilfeature.GA, LockToDefault: true}, // remove in 1.16
-	CSIPersistentVolume:                         {Default: true, PreRelease: utilfeature.GA},
+	CSIPersistentVolume:                         {Default: true, PreRelease: utilfeature.GA, LockToDefault: true}, // remove in 1.16
 	CSIDriverRegistry:                           {Default: true, PreRelease: utilfeature.Beta},
 	CSINodeInfo:                                 {Default: true, PreRelease: utilfeature.Beta},
 	CustomPodDNS:                                {Default: true, PreRelease: utilfeature.GA, LockToDefault: true}, // remove in 1.16
@@ -474,7 +474,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	BalanceAttachedNodeVolumes:                  {Default: false, PreRelease: utilfeature.Alpha},
 	PodReadinessGates:                           {Default: true, PreRelease: utilfeature.Beta},
 	VolumeSubpathEnvExpansion:                   {Default: false, PreRelease: utilfeature.Alpha},
-	KubeletPluginsWatcher:                       {Default: true, PreRelease: utilfeature.GA},
+	KubeletPluginsWatcher:                       {Default: true, PreRelease: utilfeature.GA, LockToDefault: true}, // remove in 1.16
 	ResourceQuotaScopeSelectors:                 {Default: true, PreRelease: utilfeature.Beta},
 	CSIBlockVolume:                              {Default: false, PreRelease: utilfeature.Alpha},
 	RuntimeClass:                                {Default: false, PreRelease: utilfeature.Alpha},

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -56,9 +56,6 @@ func TestNodeAuthorizer(t *testing.T) {
 		tokenNode2       = "node2-token"
 	)
 
-	// Enabled CSIPersistentVolume feature at startup so volumeattachments get watched
-	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIPersistentVolume, true)()
-
 	// Enable DynamicKubeletConfig feature so that Node.Spec.ConfigSource can be set
 	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DynamicKubeletConfig, true)()
 
@@ -576,12 +573,7 @@ func TestNodeAuthorizer(t *testing.T) {
 	expectAllowed(t, updatePVCCapacity(node2Client))
 	expectForbidden(t, updatePVCPhase(node2Client))
 
-	// Disabled CSIPersistentVolume feature
-	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIPersistentVolume, false)()
-	expectForbidden(t, getVolumeAttachment(node1ClientExternal))
-	expectForbidden(t, getVolumeAttachment(node2ClientExternal))
 	// Enabled CSIPersistentVolume feature
-	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIPersistentVolume, true)()
 	expectForbidden(t, getVolumeAttachment(node1ClientExternal))
 	expectAllowed(t, getVolumeAttachment(node2ClientExternal))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
GA features cannot be disabled

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The CSIPersistentVolume and KubeletPluginWatcher feature gates cannot be disabled, and will be removed in Kubernetes v1.16
```
