### PR TITLE
kubectl e2e: test client-side validation behavior on CustomResources

### DIFF
--- a/test/e2e/framework/crd_util.go
+++ b/test/e2e/framework/crd_util.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -184,4 +186,15 @@ func (c *TestCrd) GetAPIVersions() []string {
 
 func (c *TestCrd) GetV1DynamicClient() dynamic.ResourceInterface {
 	return c.DynamicClients["v1"]
+}
+
+// PatchSchema takes validation schema in YAML and patches it to given CRD
+func (c *TestCrd) PatchSchema(schema []byte) error {
+	s, err := utilyaml.ToJSON(schema)
+	if err != nil {
+		return fmt.Errorf("failed to create json patch: %v", err)
+	}
+	patch := []byte(fmt.Sprintf(`{"spec":{"validation":{"openAPIV3Schema":%s}}}`, string(s)))
+	c.Crd, err = c.ApiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Patch(c.GetMetaName(), types.MergePatchType, patch)
+	return err
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2371,6 +2371,11 @@ func RunKubectlOrDieInput(data string, args ...string) string {
 	return NewKubectlCommand(args...).WithStdinData(data).ExecOrDie()
 }
 
+// RunKubectlInput is a convenience wrapper over kubectlBuilder that takes input to stdin
+func RunKubectlInput(data string, args ...string) (string, error) {
+	return NewKubectlCommand(args...).WithStdinData(data).Exec()
+}
+
 // RunKubemciWithKubeconfig is a convenience wrapper over RunKubemciCmd
 func RunKubemciWithKubeconfig(args ...string) (string, error) {
 	if TestContext.KubeConfig != "" {


### PR DESCRIPTION
Part of testing plans in [publish CRD openapi KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/00xx-publish-crd-openapi.md#graduation-criteria)
ref: https://github.com/kubernetes/kubernetes/pull/71192

Having the test under sig-cli since: 
1. the test itself purely verifies no regression on kubectl behavior (doesn't depend on the new feature) 
2. sig-cli hosts [version-skew testing](https://github.com/kubernetes/test-infra/blob/6289d6514c037b1502911a1beac933acb3e1bd78/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml#L120) already


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @liggitt @sttts 