### PR TITLE
Report error when jq is missing

### DIFF
--- a/hack/godep-restore.sh
+++ b/hack/godep-restore.sh
@@ -23,6 +23,8 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::log::status "Restoring kubernetes godeps"
 
+kube::util::godep_restored_prepare
+
 if kube::util::godep_restored 2>&1; then
     kube::log::status "Dependencies appear to be current - skipping download"
     exit 0

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -347,13 +347,17 @@ kube::util::create-fake-git-tree() {
   popd >/dev/null || return 1
 }
 
+# Check requirements necessary to run godep_restored
+# We need a separate function for this because godep_restored() cannot report errors.
+kube::util::godep_restored_prepare() {
+  kube::util::require-jq
+}
+
 # Checks whether godep restore was run in the current GOPATH, i.e. that all referenced repos exist
 # and are checked out to the referenced rev.
 kube::util::godep_restored() {
   local -r godeps_json=${1:-Godeps/Godeps.json}
   local -r gopath=${2:-${GOPATH%:*}}
-
-  kube::util::require-jq
 
   local root
   local old_rev=""


### PR DESCRIPTION
Now `hack/run-in-gopath.sh hack/godep-restore.sh` loudly reports the error when jq is missing.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

It fixes a bug.

**Which issue(s) this PR fixes**:

Fixes #74838

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
