### PR TITLE
refactor: use controller.FilterActivePods in test/e2e/framework/util.go

### DIFF
--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -566,13 +566,7 @@ func WaitForPodsInactive(ps *testutils.PodStore, interval, timeout time.Duration
 	var activePods []*v1.Pod
 	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		pods := ps.List()
-		activePods = nil
-		for _, pod := range pods {
-			if controller.IsPodActive(pod) {
-				activePods = append(activePods, pod)
-			}
-		}
-
+		activePods = controller.FilterActivePods(pods)
 		if len(activePods) != 0 {
 			return false, nil
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

use existing filterActivePods to remove code duplication


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
