### PR TITLE
conformace/run_e2e.sh: pass shellcheck and autodetect ginkgo nodes

### DIFF
--- a/cluster/images/conformance/conformance-e2e.yaml
+++ b/cluster/images/conformance/conformance-e2e.yaml
@@ -63,9 +63,9 @@ spec:
     - name: E2E_SKIP
       value: ""
     - name: E2E_PROVIDER
-      value: "local"
+      value: "skeleton"
     - name: E2E_PARALLEL
-      value: "1"
+      value: "false"
     volumeMounts:
     - name: output-volume
       mountPath: /tmp/results

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -17,7 +17,6 @@
 ./cluster/gce/upgrade-aliases.sh
 ./cluster/gce/upgrade.sh
 ./cluster/gce/util.sh
-./cluster/images/conformance/run_e2e.sh
 ./cluster/log-dump/log-dump.sh
 ./cluster/pre-existing/util.sh
 ./cluster/restore-from-backup.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
- for ginkgo parallel mode pass -p to autodetect ginkgo nodes.
- disable parallel mode by default (false).
- use provider "skeleton" instead of "local".
- make run_e2e.sh pass shellcheck.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubernetes/issues/74853

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/kind bug
/priority important-longterm
/assign @dims @BenTheElder 

