### PR TITLE
kubelet/cm: code optimization for the static policy

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -158,24 +158,30 @@ func takeByTopology(topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, num
 	// Algorithm: topology-aware best-fit
 	// 1. Acquire whole sockets, if available and the container requires at
 	//    least a socket's-worth of CPUs.
-	for _, s := range acc.freeSockets() {
-		if acc.needs(acc.topo.CPUsPerSocket()) {
+	if acc.needs(acc.topo.CPUsPerSocket()) {
+		for _, s := range acc.freeSockets() {
 			klog.V(4).Infof("[cpumanager] takeByTopology: claiming socket [%d]", s)
 			acc.take(acc.details.CPUsInSocket(s))
 			if acc.isSatisfied() {
 				return acc.result, nil
+			}
+			if !acc.needs(acc.topo.CPUsPerSocket()) {
+				break
 			}
 		}
 	}
 
 	// 2. Acquire whole cores, if available and the container requires at least
 	//    a core's-worth of CPUs.
-	for _, c := range acc.freeCores() {
-		if acc.needs(acc.topo.CPUsPerCore()) {
+	if acc.needs(acc.topo.CPUsPerCore()) {
+		for _, c := range acc.freeCores() {
 			klog.V(4).Infof("[cpumanager] takeByTopology: claiming core [%d]", c)
 			acc.take(acc.details.CPUsInCore(c))
 			if acc.isSatisfied() {
 				return acc.result, nil
+			}
+			if !acc.needs(acc.topo.CPUsPerCore()) {
+				break
 			}
 		}
 	}

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -356,7 +356,7 @@ func TestTakeByTopology(t *testing.T) {
 			cpuset.NewCPUSet(2, 6),
 		},
 		{
-			"take three cpus from dual socket with HT - core from Socket 0",
+			"take one cpu from dual socket with HT - core from Socket 0",
 			topoDualSocketHT,
 			cpuset.NewCPUSet(1, 2, 3, 4, 5, 7, 8, 9, 10, 11),
 			1,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Minor optimization in the code that attempts to assign whole
sockets/cores in case the number of CPUs requested is higher
than CPUs-per-socket/core: check if the number of requested
CPUs is higher than CPUs-per-socket/core before retrieving
and iterating the free sockets/cores, and break the loops
when that is no longer the case.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
