### PR TITLE
kubeadm: add a flag to RunInitNodeChecks to indicate sec. control-plane

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/init/preflight.go
@@ -57,7 +57,7 @@ func runPreflight(c workflow.RunData) error {
 	}
 
 	fmt.Println("[preflight] Running pre-flight checks")
-	if err := preflight.RunInitNodeChecks(utilsexec.New(), data.Cfg(), data.IgnorePreflightErrors()); err != nil {
+	if err := preflight.RunInitNodeChecks(utilsexec.New(), data.Cfg(), data.IgnorePreflightErrors(), false); err != nil {
 		return err
 	}
 

--- a/cmd/kubeadm/app/cmd/phases/join/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/join/preflight.go
@@ -120,7 +120,7 @@ func runPreflight(c workflow.RunData) error {
 
 		// run kubeadm init preflight checks for checking all the prequisites
 		fmt.Println("[preflight] Running pre-flight checks before initializing the new control plane instance")
-		if err := preflight.RunInitNodeChecks(utilsexec.New(), initCfg, j.IgnorePreflightErrors()); err != nil {
+		if err := preflight.RunInitNodeChecks(utilsexec.New(), initCfg, j.IgnorePreflightErrors(), true); err != nil {
 			return err
 		}
 

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -232,7 +232,7 @@ func TestRunInitNodeChecks(t *testing.T) {
 	}
 	for _, rt := range tests {
 		// TODO: Make RunInitNodeChecks accept a ClusterConfiguration object instead of InitConfiguration
-		actual := RunInitNodeChecks(exec.New(), rt.cfg, sets.NewString())
+		actual := RunInitNodeChecks(exec.New(), rt.cfg, sets.NewString(), false)
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed RunInitNodeChecks:\n\texpected: %t\n\t  actual: %t\n\t error: %v",


### PR DESCRIPTION
**What this PR does / why we need it**:

Add an extra flag isSecondaryControlPlane to RunInitNodeChecks
which can be used to indicate that the node we are checking is
a secondary control-plane. In such a case we skip some tests
that are already covered by  RunJoinNodeChecks and
RunOptionalJoinNodeChecks.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/1204

**Special notes for your reviewer**:
decided to not make another function - it's more difficult to maintain.
ideally we want some sort of a profile mechanic for the checks - join vs join-cp vs init.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @fabriziopandini 
/kind cleanup
/priority important-soon
@kubernetes/sig-cluster-lifecycle-pr-reviews 

