### PR TITLE
Promote exceed quota e2e test for replicaSet to conformance test

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -30,6 +30,7 @@ test/e2e/apps/rc.go: "should surface a failure condition on a common issue like 
 test/e2e/apps/rc.go: "should adopt matching pods on creation"
 test/e2e/apps/rc.go: "should release no longer matching pods"
 test/e2e/apps/replica_set.go: "should serve a basic image on each replica with a public image"
+test/e2e/apps/replica_set.go: "should surface a failure condition on a common issue like exceeded quota"
 test/e2e/apps/replica_set.go: "should adopt matching pods on creation and release no longer matching pods"
 test/e2e/apps/statefulset.go: "should perform rolling updates and roll backs of template modifications"
 test/e2e/apps/statefulset.go: "should perform canary updates and phased rolling updates of template modifications"

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -100,7 +100,16 @@ var _ = SIGDescribe("ReplicaSet", func() {
 		testReplicaSetServeImageOrFail(f, "private", privateimage.GetE2EImage())
 	})
 
+<<<<<<< HEAD
 	ginkgo.It("should surface a failure condition on a common issue like exceeded quota", func() {
+=======
+	/*
+		Release : v1.15
+		Testname: Replica Set, check for issues like exceeding allocated quota
+		Description: Attempt to create a ReplicaSet with pods exceeding the namespace quota. The creation MUST fail
+	*/
+	framework.ConformanceIt("should surface a failure condition on a common issue like exceeded quota", func() {
+>>>>>>> Promote exceeding quota e2e test for replicaSet to conformance - Version updated to v1.15
 		testReplicaSetConditionCheck(f)
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
 /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: This PR requests to promote an existing E2E test for ReplicaSet to conformance. The E2E test for a common issue in ReplicaSet which involves verifying that the RS creation fails when the request for the number of pods exceeds the allocated pod count in the concerned namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**: The test is non-flaky, has no node dependency and goes on to verify the expected behaviour of the ReplicaSet. The E2E tests take approximately 8 seconds to execute

**Does this PR introduce a user-facing change?**: NONE

release-note-none

cc @brahmaroutu @mgdevstack 
/area conformance