### PR TITLE
Fix kubectl checkerr race

### DIFF
--- a/pkg/kubectl/cmd/apply/BUILD
+++ b/pkg/kubectl/cmd/apply/BUILD
@@ -75,6 +75,7 @@ go_test(
         "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//vendor/github.com/googleapis/gnostic/OpenAPIv2:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/kubectl/cmd/apply/apply_test.go
+++ b/pkg/kubectl/cmd/apply/apply_test.go
@@ -46,6 +46,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/klog"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
@@ -67,6 +68,12 @@ var (
 	}
 	codec = scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
 )
+
+func init() {
+	klog.InitFlags(nil)
+
+	cmdtesting.InitTestErrorHandler()
+}
 
 func TestApplyExtraArgsFail(t *testing.T) {
 	f := cmdtesting.NewTestFactory()
@@ -274,7 +281,6 @@ func walkMapPath(t *testing.T, start map[string]interface{}, path []string) map[
 }
 
 func TestRunApplyPrintsValidObjectList(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	configMapList := readConfigMapList(t, filenameCM)
 	pathCM := "/namespaces/test/configmaps"
 
@@ -469,7 +475,6 @@ func TestRunApplyViewLastApplied(t *testing.T) {
 }
 
 func TestApplyObjectWithoutAnnotation(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	nameRC, rcBytes := readReplicationController(t, filenameRC)
 	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
 
@@ -512,7 +517,6 @@ func TestApplyObjectWithoutAnnotation(t *testing.T) {
 }
 
 func TestApplyObject(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
 	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
 
@@ -560,7 +564,6 @@ func TestApplyObject(t *testing.T) {
 }
 
 func TestApplyObjectOutput(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
 	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
 
@@ -625,7 +628,6 @@ func TestApplyObjectOutput(t *testing.T) {
 }
 
 func TestApplyRetry(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
 	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
 
@@ -729,7 +731,6 @@ func TestApplyNonExistObject(t *testing.T) {
 }
 
 func TestApplyEmptyPatch(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	nameRC, _ := readAndAnnotateReplicationController(t, filenameRC)
 	pathRC := "/namespaces/test/replicationcontrollers"
 	pathNameRC := pathRC + "/" + nameRC
@@ -888,7 +889,6 @@ func readDeploymentFromFile(t *testing.T, file string) []byte {
 }
 
 func TestApplyNULLPreservation(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	deploymentName := "nginx-deployment"
 	deploymentPath := "/namespaces/test/deployments/" + deploymentName
 
@@ -964,7 +964,6 @@ func TestApplyNULLPreservation(t *testing.T) {
 
 // TestUnstructuredApply checks apply operations on an unstructured object
 func TestUnstructuredApply(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	name, curr := readAndAnnotateUnstructured(t, filenameWidgetClientside)
 	path := "/namespaces/test/widgets/" + name
 
@@ -1029,8 +1028,6 @@ func TestUnstructuredApply(t *testing.T) {
 
 // TestUnstructuredIdempotentApply checks repeated apply operation on an unstructured object
 func TestUnstructuredIdempotentApply(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-
 	serversideObject := readUnstructuredFromFile(t, filenameWidgetServerside)
 	serversideData, err := runtime.Encode(unstructured.JSONFallbackEncoder{Encoder: codec}, serversideObject)
 	if err != nil {
@@ -1090,7 +1087,6 @@ func TestUnstructuredIdempotentApply(t *testing.T) {
 }
 
 func TestRunApplySetLastApplied(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
 	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
 
@@ -1215,7 +1211,6 @@ func checkPatchString(t *testing.T, req *http.Request) {
 }
 
 func TestForceApply(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	scheme := runtime.NewScheme()
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
 	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC

--- a/pkg/kubectl/cmd/create/BUILD
+++ b/pkg/kubectl/cmd/create/BUILD
@@ -94,6 +94,7 @@ go_test(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/kubectl/cmd/create/create_test.go
+++ b/pkg/kubectl/cmd/create/create_test.go
@@ -24,13 +24,18 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
 	"k8s.io/client-go/rest/fake"
+	"k8s.io/klog"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
-func TestExtraArgsFail(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
+func init() {
+	klog.InitFlags(nil)
 
+	cmdtesting.InitTestErrorHandler()
+}
+
+func TestExtraArgsFail(t *testing.T) {
 	f := cmdtesting.NewTestFactory()
 	defer f.Cleanup()
 
@@ -42,7 +47,6 @@ func TestExtraArgsFail(t *testing.T) {
 }
 
 func TestCreateObject(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	_, _, rc := cmdtesting.TestData()
 	rc.Items[0].Name = "redis-master-controller"
 
@@ -78,7 +82,6 @@ func TestCreateObject(t *testing.T) {
 }
 
 func TestCreateMultipleObject(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	_, svc, rc := cmdtesting.TestData()
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
@@ -116,7 +119,6 @@ func TestCreateMultipleObject(t *testing.T) {
 }
 
 func TestCreateDirectory(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	_, _, rc := cmdtesting.TestData()
 	rc.Items[0].Name = "name"
 

--- a/pkg/kubectl/cmd/delete/BUILD
+++ b/pkg/kubectl/cmd/delete/BUILD
@@ -43,6 +43,7 @@ go_test(
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/kubectl/cmd/delete/delete_test.go
+++ b/pkg/kubectl/cmd/delete/delete_test.go
@@ -32,9 +32,16 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
 	"k8s.io/client-go/rest/fake"
+	"k8s.io/klog"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
+
+func init() {
+	klog.InitFlags(nil)
+
+	cmdtesting.InitTestErrorHandler()
+}
 
 func fakecmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -46,7 +53,6 @@ func fakecmd() *cobra.Command {
 }
 
 func TestDeleteObjectByTuple(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	_, _, rc := cmdtesting.TestData()
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
@@ -111,7 +117,6 @@ func hasExpectedPropagationPolicy(body io.ReadCloser, policy *metav1.DeletionPro
 
 // Tests that DeleteOptions.OrphanDependents is appropriately set while deleting objects.
 func TestOrphanDependentsInDeleteObject(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	_, _, rc := cmdtesting.TestData()
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
@@ -161,8 +166,6 @@ func TestOrphanDependentsInDeleteObject(t *testing.T) {
 }
 
 func TestDeleteNamedObject(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-	cmdtesting.InitTestErrorHandler(t)
 	_, _, rc := cmdtesting.TestData()
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
@@ -214,7 +217,6 @@ func TestDeleteNamedObject(t *testing.T) {
 }
 
 func TestDeleteObject(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	_, _, rc := cmdtesting.TestData()
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
@@ -249,7 +251,6 @@ func TestDeleteObject(t *testing.T) {
 }
 
 func TestDeleteObjectGraceZero(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	pods, _, _ := cmdtesting.TestData()
 
 	count := 0
@@ -298,7 +299,6 @@ func TestDeleteObjectGraceZero(t *testing.T) {
 }
 
 func TestDeleteObjectNotFound(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
 
@@ -335,7 +335,6 @@ func TestDeleteObjectNotFound(t *testing.T) {
 }
 
 func TestDeleteObjectIgnoreNotFound(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
 
@@ -366,7 +365,6 @@ func TestDeleteObjectIgnoreNotFound(t *testing.T) {
 }
 
 func TestDeleteAllNotFound(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	_, svc, _ := cmdtesting.TestData()
 	// Add an item to the list which will result in a 404 on delete
 	svc.Items = append(svc.Items, corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
@@ -415,7 +413,6 @@ func TestDeleteAllNotFound(t *testing.T) {
 }
 
 func TestDeleteAllIgnoreNotFound(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	_, svc, _ := cmdtesting.TestData()
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
@@ -457,7 +454,6 @@ func TestDeleteAllIgnoreNotFound(t *testing.T) {
 }
 
 func TestDeleteMultipleObject(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	_, svc, rc := cmdtesting.TestData()
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
@@ -494,7 +490,6 @@ func TestDeleteMultipleObject(t *testing.T) {
 }
 
 func TestDeleteMultipleObjectContinueOnMissing(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	_, svc, _ := cmdtesting.TestData()
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
@@ -542,7 +537,6 @@ func TestDeleteMultipleObjectContinueOnMissing(t *testing.T) {
 }
 
 func TestDeleteMultipleResourcesWithTheSameName(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	_, svc, rc := cmdtesting.TestData()
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
@@ -581,7 +575,6 @@ func TestDeleteMultipleResourcesWithTheSameName(t *testing.T) {
 }
 
 func TestDeleteDirectory(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	_, _, rc := cmdtesting.TestData()
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
@@ -615,7 +608,6 @@ func TestDeleteDirectory(t *testing.T) {
 }
 
 func TestDeleteMultipleSelector(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	pods, svc, _ := cmdtesting.TestData()
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
@@ -661,7 +653,6 @@ func TestDeleteMultipleSelector(t *testing.T) {
 }
 
 func TestResourceErrors(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	testCases := map[string]struct {
 		args  []string
 		errFn func(error) bool

--- a/pkg/kubectl/cmd/get/get_test.go
+++ b/pkg/kubectl/cmd/get/get_test.go
@@ -352,8 +352,6 @@ foo    0/0              0          <unknown>   <none>
 }
 
 func TestGetObjectIgnoreNotFound(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-
 	ns := &corev1.NamespaceList{
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "1",
@@ -733,8 +731,6 @@ serverunknown   Unhealthy             fizzbuzz error
 }
 
 func TestGetMixedGenericObjects(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-
 	// ensure that a runtime.Object without
 	// an ObjectMeta field is handled properly
 	structuredObj := &metav1.Status{

--- a/pkg/kubectl/cmd/testing/util.go
+++ b/pkg/kubectl/cmd/testing/util.go
@@ -19,14 +19,14 @@ package testing
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	restclient "k8s.io/client-go/rest"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
@@ -134,9 +134,9 @@ func GenResponseWithJsonEncodedBody(bodyStruct interface{}) (*http.Response, err
 	return &http.Response{StatusCode: 200, Header: DefaultHeader(), Body: BytesBody(jsonBytes)}, nil
 }
 
-func InitTestErrorHandler(t *testing.T) {
+func InitTestErrorHandler() {
 	cmdutil.BehaviorOnFatal(func(str string, code int) {
-		t.Errorf("Error running command (exit code %d): %s", code, str)
+		panic(fmt.Errorf("Error running command (exit code %d): %s", code, str))
 	})
 }
 

--- a/pkg/kubectl/cmd/top/BUILD
+++ b/pkg/kubectl/cmd/top/BUILD
@@ -54,6 +54,7 @@ go_test(
         "//staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake:go_default_library",
         "//vendor/github.com/googleapis/gnostic/OpenAPIv2:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/kubectl/cmd/top/top_node_test.go
+++ b/pkg/kubectl/cmd/top/top_node_test.go
@@ -21,16 +21,16 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
-
-	"net/url"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest/fake"
 	core "k8s.io/client-go/testing"
+	"k8s.io/klog"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	metricsv1alpha1api "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
@@ -43,8 +43,13 @@ const (
 	apiVersion = "v1"
 )
 
+func init() {
+	klog.InitFlags(nil)
+
+	cmdtesting.InitTestErrorHandler()
+}
+
 func TestTopNodeAllMetrics(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	metrics, nodes := testNodeV1alpha1MetricsData()
 	expectedMetricsPath := fmt.Sprintf("%s/%s/nodes", baseMetricsAddress, metricsAPIVersion)
 	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
@@ -100,7 +105,6 @@ func TestTopNodeAllMetricsCustomDefaults(t *testing.T) {
 	customBaseHeapsterServiceAddress := "/api/v1/namespaces/custom-namespace/services/https:custom-heapster-service:/proxy"
 	customBaseMetricsAddress := customBaseHeapsterServiceAddress + "/apis/metrics"
 
-	cmdtesting.InitTestErrorHandler(t)
 	metrics, nodes := testNodeV1alpha1MetricsData()
 	expectedMetricsPath := fmt.Sprintf("%s/%s/nodes", customBaseMetricsAddress, metricsAPIVersion)
 	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
@@ -157,7 +161,6 @@ func TestTopNodeAllMetricsCustomDefaults(t *testing.T) {
 }
 
 func TestTopNodeWithNameMetrics(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	metrics, nodes := testNodeV1alpha1MetricsData()
 	expectedMetrics := metrics.Items[0]
 	expectedNode := nodes.Items[0]
@@ -215,7 +218,6 @@ func TestTopNodeWithNameMetrics(t *testing.T) {
 }
 
 func TestTopNodeWithLabelSelectorMetrics(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	metrics, nodes := testNodeV1alpha1MetricsData()
 	expectedMetrics := metricsv1alpha1api.NodeMetricsList{
 		ListMeta: metrics.ListMeta,
@@ -284,7 +286,6 @@ func TestTopNodeWithLabelSelectorMetrics(t *testing.T) {
 }
 
 func TestTopNodeAllMetricsFromMetricsServer(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	expectedMetrics, nodes := testNodeV1beta1MetricsData()
 	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
 
@@ -345,7 +346,6 @@ func TestTopNodeAllMetricsFromMetricsServer(t *testing.T) {
 }
 
 func TestTopNodeWithNameMetricsFromMetricsServer(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	metrics, nodes := testNodeV1beta1MetricsData()
 	expectedMetrics := metrics.Items[0]
 	expectedNode := nodes.Items[0]
@@ -415,7 +415,6 @@ func TestTopNodeWithNameMetricsFromMetricsServer(t *testing.T) {
 }
 
 func TestTopNodeWithLabelSelectorMetricsFromMetricsServer(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
 	metrics, nodes := testNodeV1beta1MetricsData()
 	expectedMetrics := &metricsv1beta1api.NodeMetricsList{
 		ListMeta: metrics.ListMeta,

--- a/pkg/kubectl/cmd/top/top_pod_test.go
+++ b/pkg/kubectl/cmd/top/top_pod_test.go
@@ -88,6 +88,10 @@ const (
 }`
 )
 
+func init() {
+	cmdtesting.InitTestErrorHandler()
+}
+
 func TestTopPod(t *testing.T) {
 	testNS := "testns"
 	testCases := []struct {
@@ -142,7 +146,6 @@ func TestTopPod(t *testing.T) {
 			containers:   true,
 		},
 	}
-	cmdtesting.InitTestErrorHandler(t)
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Logf("Running test case: %s", testCase.name)
@@ -284,7 +287,6 @@ func TestTopPodWithMetricsServer(t *testing.T) {
 			containers:   true,
 		},
 	}
-	cmdtesting.InitTestErrorHandler(t)
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			metricsList := testV1beta1PodMetricsData()
@@ -493,7 +495,6 @@ func TestTopPodCustomDefaults(t *testing.T) {
 			containers:   true,
 		},
 	}
-	cmdtesting.InitTestErrorHandler(t)
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Logf("Running test case: %s", testCase.name)

--- a/pkg/kubectl/cmd/top/top_test.go
+++ b/pkg/kubectl/cmd/top/top_test.go
@@ -21,9 +21,8 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"time"
-
 	"testing"
+	"time"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -41,9 +40,11 @@ const (
 	metricsAPIVersion          = "v1alpha1"
 )
 
-func TestTopSubcommandsExist(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
+func init() {
+	cmdtesting.InitTestErrorHandler()
+}
 
+func TestTopSubcommandsExist(t *testing.T) {
 	f := cmdtesting.NewTestFactory()
 	defer f.Cleanup()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind flake

**What this PR does / why we need it**:
`t.Fatalf` and similar are not threadsafe so we cannot set it to a global `fatalErrHandler` which is called from goroutines. Whenever this code was reached the race detector went crazy and did not write out the important message.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @soltysh @kubernetes/sig-api-machinery-bugs 