### PR TITLE
Set RV on List calls for fake dynamic client

### DIFF
--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/evanphx/json-patch"
@@ -219,6 +220,12 @@ func (t *tracker) List(gvr schema.GroupVersionResource, gvk schema.GroupVersionK
 		return nil, err
 	}
 
+	// If there are no items in the store we return list resourceVersion "1" as "0" and "" are reserved values.
+	err = meta.NewAccessor().SetResourceVersion(list, "1")
+	if err != nil {
+		return nil, err
+	}
+
 	if !meta.IsListType(list) {
 		return nil, fmt.Errorf("%q is not a list type", listGVK.Kind)
 	}
@@ -229,6 +236,37 @@ func (t *tracker) List(gvr schema.GroupVersionResource, gvk schema.GroupVersionK
 	objs, ok := t.objects[gvr]
 	if !ok {
 		return list, nil
+	}
+
+	// We need to return resourceVersion for the List.
+	// It should be the highest resourceVersion in etcd for the key identifying the resource
+	// but given we know about only few objects picking the highest RV
+	// in the store for the particular resource is enough.
+	maxRv := uint64(1)
+	for _, obj := range objs {
+		rv, err := meta.NewAccessor().ResourceVersion(obj)
+		if err != nil {
+			return nil, err
+		}
+
+		if rv == "" {
+			// It's fine for unit tests
+			continue
+		}
+
+		// We are simulating the server so we are allowed to interpret RV
+		rvInt, err := strconv.ParseUint(rv, 10, 64)
+		if err != nil {
+			return nil, errors.NewInternalError(fmt.Errorf("failed to parse resourceVersion %q", rv))
+		}
+
+		if rvInt > maxRv {
+			maxRv = rvInt
+		}
+	}
+	err = meta.NewAccessor().SetResourceVersion(list, fmt.Sprintf("%d", maxRv))
+	if err != nil {
+		return nil, err
 	}
 
 	matchingObjs, err := filterByNamespaceAndName(objs, ns, "")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
List call shall always have List's RV set. With fake dynamic client it wasn't the case and `ListWatchUntil` couldn't use it because the watch was trying to start from RV "" which is forbidden.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @deads2k @kubernetes/sig-api-machinery-bugs 
