### PR TITLE
Promote CSI raw blocks to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -336,6 +336,7 @@ const (
 
 	// owner: @vladimirvivien
 	// alpha: v1.11
+	// beta: v1.14
 	//
 	// Enables CSI to use raw block storage volumes
 	CSIBlockVolume utilfeature.Feature = "CSIBlockVolume"
@@ -474,7 +475,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	VolumeSubpathEnvExpansion:                   {Default: false, PreRelease: utilfeature.Alpha},
 	KubeletPluginsWatcher:                       {Default: true, PreRelease: utilfeature.GA},
 	ResourceQuotaScopeSelectors:                 {Default: true, PreRelease: utilfeature.Beta},
-	CSIBlockVolume:                              {Default: false, PreRelease: utilfeature.Alpha},
+	CSIBlockVolume:                              {Default: true, PreRelease: utilfeature.Beta},
 	RuntimeClass:                                {Default: false, PreRelease: utilfeature.Alpha},
 	NodeLease:                                   {Default: true, PreRelease: utilfeature.Beta},
 	SCTPSupport:                                 {Default: false, PreRelease: utilfeature.Alpha},


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
Promote the CSIBlockVolume feature to beta.

**Does this PR introduce a user-facing change?**:
```release-note
The CSIBlockVolume feature gate is now beta, and defaults to enabled.
```
