### PR TITLE
If num-nodes is not set, then look up via API how many are scheduleable

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -102,6 +102,11 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// unschedulable, we need to wait until all of them are schedulable.
 	framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
 
+	// If NumNodes is not specified then auto-detect how many are scheduleable and not tainted
+	if framework.TestContext.CloudConfig.NumNodes == framework.DefaultNumNodes {
+		framework.TestContext.CloudConfig.NumNodes = len(framework.GetReadySchedulableNodesOrDie(c).Items)
+	}
+
 	// Ensure all pods are running and ready before starting tests (otherwise,
 	// cluster infrastructure pods that are being pulled or started can block
 	// test pods from running, and tests that ensure all pods are running and

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -35,7 +35,12 @@ import (
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 )
 
-const defaultHost = "http://127.0.0.1:8080"
+const (
+	defaultHost = "http://127.0.0.1:8080"
+
+	// DefaultNumNodes is the number of nodes. If not specified, then number of nodes is auto-detected
+	DefaultNumNodes = -1
+)
 
 // TestContextType contains test settings and global state. Due to
 // historic reasons, it is a mixture of items managed by the test
@@ -294,7 +299,7 @@ func RegisterClusterFlags() {
 	flag.StringVar(&cloudConfig.Cluster, "gke-cluster", "", "GKE name of cluster being used, if applicable")
 	flag.StringVar(&cloudConfig.NodeInstanceGroup, "node-instance-group", "", "Name of the managed instance group for nodes. Valid only for gce, gke or aws. If there is more than one group: comma separated list of groups.")
 	flag.StringVar(&cloudConfig.Network, "network", "e2e", "The cloud provider network for this e2e cluster.")
-	flag.IntVar(&cloudConfig.NumNodes, "num-nodes", -1, "Number of nodes in the cluster")
+	flag.IntVar(&cloudConfig.NumNodes, "num-nodes", DefaultNumNodes, fmt.Sprintf("Number of nodes in the cluster. If the default value of '%q' is used the number of schedulable nodes is auto-detected.", DefaultNumNodes))
 	flag.StringVar(&cloudConfig.ClusterIPRange, "cluster-ip-range", "10.64.0.0/14", "A CIDR notation IP range from which to assign IPs in the cluster.")
 	flag.StringVar(&cloudConfig.NodeTag, "node-tag", "", "Network tags used on node instances. Valid only for gce, gke")
 	flag.StringVar(&cloudConfig.MasterTag, "master-tag", "", "Network tags used on master instances. Valid only for gce, gke")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This checks if the `--num-nodes` flag is set (e.g. NumNodes < 0). If so, it creates a k8s client and looks for any node that is schedulable (e.g. Taint.Effect != "NoSchedule") and sets that count to the `NumNodes` variable in testContext.CloudConfig. 

Signed-off-by: Steve Sloka <slokas@vmware.com>

**Which issue(s) this PR fixes**:
Fixes #74853 

```release-note
NONE
```
