### PR TITLE
Automated cherry pick of #73457: Update docker support for k8s

### DIFF
--- a/cmd/kubeadm/app/util/system/docker_validator_test.go
+++ b/cmd/kubeadm/app/util/system/docker_validator_test.go
@@ -28,7 +28,7 @@ func TestValidateDockerInfo(t *testing.T) {
 		Reporter: DefaultReporter,
 	}
 	spec := &DockerSpec{
-		Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.06\..*`},
+		Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`},
 		GraphDriver: []string{"driver_1", "driver_2"},
 	}
 	for _, test := range []struct {

--- a/cmd/kubeadm/app/util/system/types_unix.go
+++ b/cmd/kubeadm/app/util/system/types_unix.go
@@ -62,7 +62,7 @@ var DefaultSysSpec = SysSpec{
 	Cgroups: []string{"cpu", "cpuacct", "cpuset", "devices", "freezer", "memory"},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
-			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.06\..*`},
+			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`},
 			GraphDriver: []string{"aufs", "overlay", "overlay2", "devicemapper", "zfs"},
 		},
 	},

--- a/cmd/kubeadm/app/util/system/types_windows.go
+++ b/cmd/kubeadm/app/util/system/types_windows.go
@@ -38,7 +38,7 @@ var DefaultSysSpec = SysSpec{
 	Cgroups: []string{},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
-			Version:     []string{`18\.06\..*`}, //Requires [18.06] or later
+			Version:     []string{`18\.0[6,9]\..*`},
 			GraphDriver: []string{"windowsfilter"},
 		},
 	},


### PR DESCRIPTION
Cherry pick of #73457 on release-1.13.

#73457: Update docker support for k8s

```release-note
Bump Docker supported version to 18.09
```

/cc @yguo0905 
/assign @luxas 

We need this cherry-pick to fix [this test in testgrid](https://k8s-testgrid.appspot.com/cos-cos1-k8sstable1#e2enode-cos1-k8sstable1-serial), which complains that:

```
I0304 00:12:16.311] DOCKER_VERSION: 18.09.1
I0304 00:12:16.311] F0304 00:12:12.034512 827 e2e_node_suite_test.go:117] system validation failed: unsupported docker version: 18.09.1
```

Thanks!
Filipe
