### PR TITLE
add TLS support for NLB / fix several NLB bugs

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -3398,7 +3398,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 	listeners := []*elb.Listener{}
 	v2Mappings := []nlbPortMapping{}
 
-	portList := getPortSets(annotations[ServiceAnnotationLoadBalancerSSLPorts])
+	sslPorts := getPortSets(annotations[ServiceAnnotationLoadBalancerSSLPorts])
 	for _, port := range apiService.Spec.Ports {
 		if port.Protocol != v1.ProtocolTCP {
 			return nil, fmt.Errorf("Only TCP LoadBalancer is supported for AWS ELB")
@@ -3409,16 +3409,32 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 		}
 
 		if isNLB(annotations) {
-			v2Mappings = append(v2Mappings, nlbPortMapping{
-				FrontendPort: int64(port.Port),
-				TrafficPort:  int64(port.NodePort),
+			portMapping := nlbPortMapping{
+				FrontendPort:     int64(port.Port),
+				FrontendProtocol: string(port.Protocol),
+				TrafficPort:      int64(port.NodePort),
+				TrafficProtocol:  string(port.Protocol),
+
 				// if externalTrafficPolicy == "Local", we'll override the
 				// health check later
 				HealthCheckPort:     int64(port.NodePort),
 				HealthCheckProtocol: elbv2.ProtocolEnumTcp,
-			})
+			}
+
+			certificateARN := annotations[ServiceAnnotationLoadBalancerCertificate]
+			if certificateARN != "" && (sslPorts == nil || sslPorts.numbers.Has(int64(port.Port)) || sslPorts.names.Has(port.Name)) {
+				portMapping.FrontendProtocol = elbv2.ProtocolEnumTls
+				portMapping.SSLCertificateARN = certificateARN
+				portMapping.SSLPolicy = annotations[ServiceAnnotationLoadBalancerSSLNegotiationPolicy]
+
+				if backendProtocol := annotations[ServiceAnnotationLoadBalancerBEProtocol]; backendProtocol == "ssl" {
+					portMapping.TrafficProtocol = elbv2.ProtocolEnumTls
+				}
+			}
+
+			v2Mappings = append(v2Mappings, portMapping)
 		}
-		listener, err := buildListener(port, annotations, portList)
+		listener, err := buildListener(port, annotations, sslPorts)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add [TLS support](https://aws.amazon.com/blogs/aws/new-tls-termination-for-network-load-balancers/) for NLB
Fix several NLB bugs(around targetGroup naming/tagging)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #73297
Fixes #69264
Fixes #75006

**Special notes for your reviewer**:
1. new targetGroups will get name k8s-{namespace:8}-{name:8}-{uuid:10}. 
2. TLS is an upgrade version of SSL protocol, in CLB, both SSL/TLS is identified as `SSL`, however, in ALB/NLB, both SSL/TLS is identified as `TLS`. To avoid confusing and ease migration from CLB to NLB, `service.beta.kubernetes.io/aws-load-balancer-backend-protocol:ssl` is re-used for denoting backend SSL in NLB as well.
3. Test done:
    * migration from TCP to TLS termination:
        1. create NLB service with TCP port(443), which forward to backend HTTPS port(443). 
        1. access the NLB, observed TLS termination at backend works fine(cert by backend).
        1. migrate to  NLB TLS termination by adding two annotation: `service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arnOfACMCert` and `service.beta.kubernetes.io/aws-load-balancer-backend-protocol: ssl`
        1. access the NLB, observed TLS termination at NLB works fine(cert by ACM), and NLB still talks to backend in TLS 😄 .
        1. migrate to TCP backend by remove annotation `service.beta.kubernetes.io/aws-load-balancer-backend-protocol: ssl`, and change service targetPort to an HTTP port.
        1. access the NLB, observed TLS termination at NLB works fine(cert by ACM), and NLB still talks to backend in TCP(HTTP) 😄 .
        1. migrate back to TLS backend by add annotation `service.beta.kubernetes.io/aws-load-balancer-backend-protocol: ssl`, and change service targetPort to an TLS port
        1. access the NLB, observed TLS termination at NLB works fine(cert by ACM), and NLB still talks to backend in TCP(HTTP) 😄 .

     * create NLB service with multiple TLS/TCP port.
        1. create NLB service with TCP port(80), which forward to backend HTTP port(80), and TLS port(443) which forward to backend HTTP port(80), by adding annotation `service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arnOfACMCert`, and `service.beta.kubernetes.io/aws-load-balancer-ssl-ports: 443`
         1. observed both port(80:TCP, 443:TLS) works as expected.
     * add TLS port to existing NLB service.
        1. create NLB service with TCP port(80), which forward to backend HTTP port(80).
        1. add an TLS port(443), which forward to backend HTTP port(80) by adding annotation `service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arnOfACMCert`, and `service.beta.kubernetes.io/aws-load-balancer-ssl-ports: 443`
        1. observed both port(80:TCP, 443:TLS) works as expected.
     * modify SSL policy
        1. create NLB service with TLS port.
        1. modify SSL policy by adding annotation `service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: ELBSecurityPolicy-2016-08`
        1. verify SSL policy updated.
      * targetGroup names/ tagging
        1. during the above testing, all new targetGroups are tagged properly, and named properly. targetGroups are recreated as need(while old targetGroup get deleted).
    

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add TLS termination support for NLB
```
