### PR TITLE
revert 72062: Perform GCE master log rotation check every 5 minutes

### DIFF
--- a/cluster/gce/gci/master.yaml
+++ b/cluster/gce/gci/master.yaml
@@ -83,10 +83,10 @@ write_files:
     owner: root
     content: |
       [Unit]
-      Description=kube-logrotate invocation
+      Description=Hourly kube-logrotate invocation
 
       [Timer]
-      OnCalendar=*-*-* *:00/5:00
+      OnCalendar=hourly
 
       [Install]
       WantedBy=kubernetes.target


### PR DESCRIPTION
#72062 might be causing the flaky test https://github.com/kubernetes/kubernetes/issues/74745. Let's revert it on release-1.14 and see if the issue is resolved.

@smourapina @liggitt @pbarker 