### PR TITLE
explicit the restartPolicy on the dockershim

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -137,6 +137,9 @@ func (ds *dockerService) CreateContainer(_ context.Context, r *runtimeapi.Create
 		},
 		HostConfig: &dockercontainer.HostConfig{
 			Binds: generateMountBindings(config.GetMounts()),
+			RestartPolicy: dockercontainer.RestartPolicy{
+				Name: "no",
+			},
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/priority important-soon

**What this PR does / why we need it**: This change explicits the restart policy, as on some docker version(e.g. 17.03.1-ce) the default for this field is "", which seems to be not
respected by dockerd

**Which issue(s) this PR fixes**: Fixes #73278

**Special notes for your reviewer**:

/assign @liggitt 

@jingxu97 FYI.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
