### PR TITLE
revert 72062: Perform GCE master log rotation check every 5 minutes

### DIFF
--- a/cluster/gce/gci/master.yaml
+++ b/cluster/gce/gci/master.yaml
@@ -83,10 +83,10 @@ write_files:
     owner: root
     content: |
       [Unit]
-      Description=kube-logrotate invocation
+      Description=Hourly kube-logrotate invocation
 
       [Timer]
-      OnCalendar=*-*-* *:00/5:00
+      OnCalendar=hourly
 
       [Install]
       WantedBy=kubernetes.target


### PR DESCRIPTION
#72062 might be causing the flaky test #74745. Let's revert it and see if the issue is resolved.

If this does fix the issue I'm still concerned we might have low level flaking since #72062 didn't change the log rotation policy, just how often is is applied, so reducing how often it is applied might just make flakes less common, but not eliminate them.

@smourapina @liggitt @pbarker 

/kind flake

```release-note
NONE
```