### PR TITLE
Fix Windows to read VM UUIDs from serial numbers

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere_util_linux.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util_linux.go
@@ -19,35 +19,15 @@ limitations under the License.
 package vsphere
 
 import (
-	"fmt"
 	"io/ioutil"
-	"strings"
 )
 
-const (
-	UUIDPath   = "/sys/class/dmi/id/product_serial"
-	UUIDPrefix = "VMware-"
-)
+const UUIDPath = "/sys/class/dmi/id/product_serial"
 
-func GetVMUUID() (string, error) {
+func getRawUUID() (string, error) {
 	id, err := ioutil.ReadFile(UUIDPath)
 	if err != nil {
-		return "", fmt.Errorf("error retrieving vm uuid: %s", err)
+		return "", err
 	}
-	uuidFromFile := string(id[:])
-	//strip leading and trailing white space and new line char
-	uuid := strings.TrimSpace(uuidFromFile)
-	// check the uuid starts with "VMware-"
-	if !strings.HasPrefix(uuid, UUIDPrefix) {
-		return "", fmt.Errorf("Failed to match Prefix, UUID read from the file is %v", uuidFromFile)
-	}
-	// Strip the prefix and white spaces and -
-	uuid = strings.Replace(uuid[len(UUIDPrefix):(len(uuid))], " ", "", -1)
-	uuid = strings.Replace(uuid, "-", "", -1)
-	if len(uuid) != 32 {
-		return "", fmt.Errorf("Length check failed, UUID read from the file is %v", uuidFromFile)
-	}
-	// need to add dashes, e.g. "564d395e-d807-e18a-cb25-b79f65eb2b9f"
-	uuid = fmt.Sprintf("%s-%s-%s-%s-%s", uuid[0:8], uuid[8:12], uuid[12:16], uuid[16:20], uuid[20:32])
-	return uuid, nil
+	return string(id), nil
 }

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util_unsupported.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util_unsupported.go
@@ -20,6 +20,6 @@ package vsphere
 
 import "fmt"
 
-func GetVMUUID() (string, error) {
+func getRawUUID() (string, error) {
 	return "", fmt.Errorf("Retrieving VM UUID on this build is not implemented.")
 }

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util_windows.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util_windows.go
@@ -24,14 +24,21 @@ import (
 	"strings"
 )
 
-func GetVMUUID() (string, error) {
-	result, err := exec.Command("wmic", "csproduct", "get", "UUID").Output()
+func getRawUUID() (string, error) {
+	result, err := exec.Command("wmic", "bios", "get", "serialnumber").Output()
 	if err != nil {
-		return "", fmt.Errorf("error retrieving vm uuid: %s", err)
+		return "", err
 	}
-	fields := strings.Fields(string(result))
-	if len(fields) != 2 {
+	lines := strings.FieldsFunc(string(result), func(r rune) bool {
+		switch r {
+		case '\n', '\r':
+			return true
+		default:
+			return false
+		}
+	})
+	if len(lines) != 2 {
 		return "", fmt.Errorf("received unexpected value retrieving vm uuid: %q", string(result))
 	}
-	return fields[1], nil
+	return lines[1], nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes the Windows implementation of retrieving the VM's UUID. Some versions of vSphere do not report the value correctly from `wmic csproduct get UUID`. This is the same problem with `/sys/class/dmi/id/product_uuid` that was addressed in #59519.

**Which issue(s) this PR fixes**:
Fixes #74888

**Does this PR introduce a user-facing change?**:
Assuming we get it into the same release as #71147 this doesn't need a new release note I think.

```release-note
NONE
```
