### PR TITLE
Fix NPD e2e test on clusters with Ubuntu nodes

### DIFF
--- a/test/e2e/node/node_problem_detector.go
+++ b/test/e2e/node/node_problem_detector.go
@@ -70,11 +70,14 @@ var _ = SIGDescribe("NodeProblemDetector", func() {
 			workingSetStats[host] = []float64{}
 
 			By(fmt.Sprintf("Check node %q has node-problem-detector process", host))
-			psCmd := "ps aux | grep node-problem-detector"
+			// Using brackets "[n]" is a trick to prevent grep command itself from
+			// showing up, because string text "[n]ode-problem-detector" does not
+			// match regular expression "[n]ode-problem-detector".
+			psCmd := "ps aux | grep [n]ode-problem-detector"
 			result, err := framework.SSH(psCmd, host, framework.TestContext.Provider)
 			framework.ExpectNoError(err)
 			Expect(result.Code).To(BeZero())
-			Expect(result.Stdout).To(ContainSubstring("/home/kubernetes/bin/node-problem-detector"))
+			Expect(result.Stdout).To(ContainSubstring("node-problem-detector"))
 
 			By(fmt.Sprintf("Check node-problem-detector is running fine on node %q", host))
 			journalctlCmd := "sudo journalctl -u node-problem-detector"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes NPD e2e test on clusters with Ubuntu nodes. This is part of https://github.com/kubernetes/node-problem-detector/issues/236.

Example of past failed run: 
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-cri-containerd-e2e-ubuntu-gce/11287

```
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/node_problem_detector.go:53
Expected
    <string>: root      4141  0.4  0.3 714124 23324 ?        Ssl  21:20   0:02 /node-problem-detector --logtostderr --system-log-monitors=/config/kernel-monitor.json,/config/kernel-monitor-filelog.json,/config/docker-monitor.json,/config/docker-monitor-filelog.json
    prow     30768  0.0  0.0  11284  3016 ?        Ss   21:29   0:00 bash -c ps aux | grep node-problem-detector
    prow     30770  0.0  0.0  12988   980 ?        S    21:29   0:00 grep node-problem-detector
    
to contain substring
    <string>: /home/kubernetes/bin/node-problem-detector
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/node_problem_detector.go:77
```

On GCE clusters with Ubuntu nodes, NPD is running as daemonset instead of systemd service. So the NPD binary path is `/node-problem-detector` instead of `/home/kubernetes/bin/node-problem-detector`. After this PR, we just search for `node-problem-detector` process, which would just work for both GCI and Ubuntu nodes.

Part of https://github.com/kubernetes/node-problem-detector/issues/236.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
