### PR TITLE
Add new CSI translation APIs required by CSI sidecars and unit tests

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -1355,7 +1355,7 @@ func (ctrl *PersistentVolumeController) getCSINameFromIntreeName(pluginName stri
 	if ctrl.csiNameFromIntreeNameHook != nil {
 		return ctrl.csiNameFromIntreeNameHook(pluginName)
 	}
-	return csitranslation.GetCSINameFromIntreeName(pluginName)
+	return csitranslation.GetCSINameFromInTreeName(pluginName)
 }
 
 // provisionClaimOperation provisions a volume. This method is running in

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -440,7 +440,7 @@ func (og *operationGenerator) GenerateDetachVolumeFunc(
 		// TODO(dyzz): This case can't distinguish between PV and In-line which is necessary because
 		// if it was PV it may have been migrated, but the same plugin with in-line may not have been.
 		// Suggestions welcome...
-		if csilib.IsMigratableByName(pluginName) && utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) {
+		if csilib.IsMigratableIntreePluginByName(pluginName) && utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) {
 			// The volume represented by this spec is CSI and thus should be migrated
 			attachableVolumePlugin, err = og.volumePluginMgr.FindAttachablePluginByName(csi.CSIPluginName)
 			if err != nil || attachableVolumePlugin == nil {

--- a/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
@@ -108,3 +108,8 @@ func (t *awsElasticBlockStoreCSITranslator) CanSupport(pv *v1.PersistentVolume) 
 func (t *awsElasticBlockStoreCSITranslator) GetInTreePluginName() string {
 	return AWSEBSInTreePluginName
 }
+
+// GetCSIPluginName returns the name of the CSI plugin
+func (t *awsElasticBlockStoreCSITranslator) GetCSIPluginName() string {
+	return AWSEBSDriverName
+}

--- a/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd.go
@@ -149,6 +149,11 @@ func (g *gcePersistentDiskCSITranslator) GetInTreePluginName() string {
 	return GCEPDInTreePluginName
 }
 
+// GetCSIPluginName returns the name of the CSI plugin
+func (g *gcePersistentDiskCSITranslator) GetCSIPluginName() string {
+	return GCEPDDriverName
+}
+
 func pdNameFromVolumeID(id string) (string, error) {
 	splitID := strings.Split(id, "/")
 	if len(splitID) != volIDTotalElements {

--- a/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
@@ -40,4 +40,7 @@ type InTreePlugin interface {
 
 	// GetInTreePluginName returns the in-tree plugin name this migrates
 	GetInTreePluginName() string
+
+	// GetCSIPluginName returns the name of the CSI plugin that supersedes the in-tree plugin
+	GetCSIPluginName() string
 }

--- a/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
@@ -96,3 +96,8 @@ func (t *osCinderCSITranslator) CanSupport(pv *v1.PersistentVolume) bool {
 func (t *osCinderCSITranslator) GetInTreePluginName() string {
 	return CinderInTreePluginName
 }
+
+// GetCSIPluginName returns the name of the CSI plugin
+func (t *osCinderCSITranslator) GetCSIPluginName() string {
+	return CinderDriverName
+}

--- a/staging/src/k8s.io/csi-translation-lib/translate.go
+++ b/staging/src/k8s.io/csi-translation-lib/translate.go
@@ -75,9 +75,9 @@ func TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, erro
 	return nil, fmt.Errorf("could not find in-tree plugin translation logic for %s", copiedPV.Spec.CSI.Driver)
 }
 
-// IsMigratableByName tests whether there is Migration logic for the in-tree plugin
-// whose name matches the given inTreePluginName
-func IsMigratableByName(inTreePluginName string) bool {
+// IsMigratableIntreePluginByName tests whether there is migration logic for the in-tree plugin
+// whose name matches the given name
+func IsMigratableIntreePluginByName(inTreePluginName string) bool {
 	for _, curPlugin := range inTreePlugins {
 		if curPlugin.GetInTreePluginName() == inTreePluginName {
 			return true
@@ -86,16 +86,17 @@ func IsMigratableByName(inTreePluginName string) bool {
 	return false
 }
 
-// SupersedesInTreePlugin tests whether there exists an in-tree plugin with logic
-// to migrate to the CSI plugin with given name
-func SupersedesInTreePlugin(csiPluginName string) bool {
+// IsMigratedCSIDriverByName tests whether there exists an in-tree plugin with logic
+// to migrate to the CSI driver with given name
+func IsMigratedCSIDriverByName(csiPluginName string) bool {
 	if _, ok := inTreePlugins[csiPluginName]; ok {
 		return true
 	}
 	return false
 }
 
-// GetCSINameFromInTreeName returns the name of a CSI driver that supersedes the in-tree plugin with the given name
+// GetCSINameFromInTreeName returns the name of a CSI driver that supersedes the
+// in-tree plugin with the given name
 func GetCSINameFromInTreeName(pluginName string) (string, error) {
 	for csiDriverName, curPlugin := range inTreePlugins {
 		if curPlugin.GetInTreePluginName() == pluginName {
@@ -105,7 +106,8 @@ func GetCSINameFromInTreeName(pluginName string) (string, error) {
 	return "", fmt.Errorf("Could not find CSI Driver name for plugin %v", pluginName)
 }
 
-// GetInTreeNameFromCSIName returns the name of the in-tree plugin superseded by a CSI driver with the given name
+// GetInTreeNameFromCSIName returns the name of the in-tree plugin superseded by
+// a CSI driver with the given name
 func GetInTreeNameFromCSIName(pluginName string) (string, error) {
 	if plugin, ok := inTreePlugins[pluginName]; ok {
 		return plugin.GetInTreePluginName(), nil

--- a/staging/src/k8s.io/csi-translation-lib/translate_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/translate_test.go
@@ -99,14 +99,14 @@ func TestPluginNameMappings(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error when mapping In-tree plugin name to CSI plugin name %s", err)
 		}
-		if !SupersedesInTreePlugin(csiPluginName) {
+		if !IsMigratedCSIDriverByName(csiPluginName) {
 			t.Errorf("%s expected to supersede an In-tree plugin", csiPluginName)
 		}
 		inTreePluginName, err := GetInTreeNameFromCSIName(csiPluginName)
 		if err != nil {
 			t.Errorf("Error when mapping CSI plugin name to In-tree plugin name %s", err)
 		}
-		if !IsMigratableByName(inTreePluginName) {
+		if !IsMigratableIntreePluginByName(inTreePluginName) {
 			t.Errorf("%s expected to be migratable to a CSI name", inTreePluginName)
 		}
 		if inTreePluginName != test.inTreePluginName || csiPluginName != test.csiPluginName {

--- a/staging/src/k8s.io/csi-translation-lib/translate_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/translate_test.go
@@ -76,4 +76,43 @@ func TestTranslationStability(t *testing.T) {
 	}
 }
 
+func TestPluginNameMappings(t *testing.T) {
+	testCases := []struct {
+		name             string
+		inTreePluginName string
+		csiPluginName    string
+	}{
+		{
+			name:             "GCE PD plugin name",
+			inTreePluginName: "kubernetes.io/gce-pd",
+			csiPluginName:    "pd.csi.storage.gke.io",
+		},
+		{
+			name:             "AWS EBS plugin name",
+			inTreePluginName: "kubernetes.io/aws-ebs",
+			csiPluginName:    "ebs.csi.aws.com",
+		},
+	}
+	for _, test := range testCases {
+		t.Logf("Testing %v", test.name)
+		csiPluginName, err := GetCSINameFromInTreeName(test.inTreePluginName)
+		if err != nil {
+			t.Errorf("Error when mapping In-tree plugin name to CSI plugin name %s", err)
+		}
+		if !SupersedesInTreePlugin(csiPluginName) {
+			t.Errorf("%s expected to supersede an In-tree plugin", csiPluginName)
+		}
+		inTreePluginName, err := GetInTreeNameFromCSIName(csiPluginName)
+		if err != nil {
+			t.Errorf("Error when mapping CSI plugin name to In-tree plugin name %s", err)
+		}
+		if !IsMigratableByName(inTreePluginName) {
+			t.Errorf("%s expected to be migratable to a CSI name", inTreePluginName)
+		}
+		if inTreePluginName != test.inTreePluginName || csiPluginName != test.csiPluginName {
+			t.Errorf("CSI plugin name and In-tree plugin name do not map to each other: [%s => %s], [%s => %s]", test.csiPluginName, inTreePluginName, test.inTreePluginName, csiPluginName)
+		}
+	}
+}
+
 // TODO: test for not modifying the original PV.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds an extra pair of APIs to the CSI translation library so that migration scenarios initiated outside of in-tree (i.e. from CSI side car containers) like provisioning can use the library.

**Which issue(s) this PR fixes**:
Related to https://github.com/kubernetes/enhancements/issues/625

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
