### PR TITLE
Don't disable Windows Defender.

### DIFF
--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -100,7 +100,6 @@ try {
   Dump-DebugInfoToConsole
   Set-PrerequisiteOptions
   $kube_env = Fetch-KubeEnv
-  Disable-WindowsDefender
 
   if (Test-IsTestCluster $kube_env) {
     Log-Output 'Test cluster detected, installing OpenSSH.'


### PR DESCRIPTION
/kind cleanup

This PR undoes https://github.com/kubernetes/kubernetes/pull/74444. In some test clusters we had seen 100% CPU utilization or Windows crashes that were seemingly attributable to Windows Defender, so that PR disabled it on our Windows nodes. Since then some Windows fixes have been released and now we want to try running with Defender turned on again.

```release-note
NONE
```