### PR TITLE
Fix #74900 - kubectl logs --selector supports --tail=-1

### DIFF
--- a/pkg/kubectl/cmd/logs/logs_test.go
+++ b/pkg/kubectl/cmd/logs/logs_test.go
@@ -328,7 +328,7 @@ func TestValidateLogOptions(t *testing.T) {
 				return o
 			},
 			args:     []string{"foo"},
-			expected: "must be greater than or equal to 0",
+			expected: "--tail must be greater than or equal to -1",
 		},
 		{
 			name: "container name combined with --all-containers",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix #74900 - kubectl logs --selector supports --tail=-1

**Which issue(s) this PR fixes**:
#74900

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
kubectl logs --selector will support --tail=-1.
```
