### PR TITLE
Typo fix in e2e test description message: defaut->default

### DIFF
--- a/test/e2e/scheduling/taints.go
+++ b/test/e2e/scheduling/taints.go
@@ -45,7 +45,7 @@ func getTestTaint() v1.Taint {
 	}
 }
 
-// Create a defaut pod for this test, with argument saying if the Pod should have
+// Create a default pod for this test, with argument saying if the Pod should have
 // toleration for Taits used in this test.
 func createPodForTaintsTest(hasToleration bool, tolerationSeconds int, podName, podLabel, ns string) *v1.Pod {
 	grace := int64(1)


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:
Typo fix:
Line 48: defaut->default

**Release note**:

```
NONE

```