### PR TITLE
client-go: detect /version path for k8s client-go metrics

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -523,14 +523,20 @@ func (r Request) finalURLTemplate() url.URL {
 
 	const CoreGroupPrefix = "api"
 	const NamedGroupPrefix = "apis"
+	const Version = "version"
 	isCoreGroup := segments[groupIndex] == CoreGroupPrefix
 	isNamedGroup := segments[groupIndex] == NamedGroupPrefix
+	isVersion := segments[groupIndex] == Version
 	if isCoreGroup {
 		// checking the case of core group with /api/v1/... format
 		index = groupIndex + 2
 	} else if isNamedGroup {
 		// checking the case of named group with /apis/apps/v1/... format
 		index = groupIndex + 3
+	} else if isVersion {
+		url.Path = "/version"
+		url.RawQuery = ""
+		return *url
 	} else {
 		// this should not happen that the only two possibilities are /api... and /apis..., just want to put an
 		// outlet here in case more API groups are added in future if ever possible:

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -485,6 +485,14 @@ func TestURLTemplate(t *testing.T) {
 			ExpectedFullURL:  "http://localhost/some/base/url/path/pre1/namespaces/namespaces/namespaces/namespaces/namespaces/namespaces/finalize",
 			ExpectedFinalURL: "http://localhost/%7Bprefix%7D",
 		},
+		{
+			// dynamic client with version path
+			// /apis/$NAMEDGROUPNAME/$RESOURCEVERSION/namespaces/$NAMESPACE/$RESOURCE/%NAME/$SUBRESOURCE
+			Request: NewRequestWithClient(uri, "", ClientContentConfig{GroupVersion: schema.GroupVersion{Group: "test"}}, nil).Verb("DELETE").
+				Prefix("/version"),
+			ExpectedFullURL:  "http://localhost/some/base/url/path/version",
+			ExpectedFinalURL: "http://localhost/version",
+		},
 	}
 	for i, testCase := range testCases {
 		r := testCase.Request


### PR DESCRIPTION
Signed-off-by: André Martins <aanm90@gmail.com>

K8s client-go metrics do not currently specify when a client reaches
/version API endpoint, causing metrics to simply present
`api_latency_time_seconds path="/{prefix}" method="GET"`. With this
change, `/version` API calls will be correctly represented in the
metrics as `api_latency_time_seconds path="/version" method="GET"`.

/kind bug

```release-note
detect /version path for client-go metrics
```
