### PR TITLE
Fix client-go fake client example flake

### DIFF
--- a/staging/src/k8s.io/client-go/examples/fake-client/BUILD
+++ b/staging/src/k8s.io/client-go/examples/fake-client/BUILD
@@ -7,6 +7,7 @@ go_test(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",

--- a/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
+++ b/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
@@ -30,8 +31,8 @@ import (
 
 // TestFakeClient demonstrates how to use a fake client with SharedInformerFactory in tests.
 func TestFakeClient(t *testing.T) {
-	// Use a timeout to keep the test from hanging.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Create the fake client.
 	client := fake.NewSimpleClientset()
@@ -45,7 +46,6 @@ func TestFakeClient(t *testing.T) {
 			pod := obj.(*v1.Pod)
 			t.Logf("pod added: %s/%s", pod.Namespace, pod.Name)
 			pods <- pod
-			cancel()
 		},
 	})
 
@@ -55,23 +55,19 @@ func TestFakeClient(t *testing.T) {
 	// This is not required in tests, but it serves as a proof-of-concept by
 	// ensuring that the informer goroutine have warmed up and called List before
 	// we send any events to it.
-	for !podInformer.HasSynced() {
-		time.Sleep(10 * time.Millisecond)
-	}
+	cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced)
 
 	// Inject an event into the fake client.
 	p := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "my-pod"}}
 	_, err := client.CoreV1().Pods("test-ns").Create(p)
 	if err != nil {
-		t.Errorf("error injecting pod add: %v", err)
+		t.Fatalf("error injecting pod add: %v", err)
 	}
 
-	// Wait and check result.
-	<-ctx.Done()
 	select {
 	case pod := <-pods:
 		t.Logf("Got pod from channel: %s/%s", pod.Namespace, pod.Name)
-	default:
+	case <-time.After(wait.ForeverTestTimeout):
 		t.Error("Informer did not get the added pod")
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
The test is flaky.  Seen e.g. in https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/batch/pull-ci-openshift-origin-master-unit/3803#githubcomopenshiftoriginvendork8sioclient-goexamplesfake-client-testfakeclient (according to @smarterclayton with 1/8 frequency) reproduced locally with pure kube:
```
go test -race ./vendor/k8s.io/client-go/examples/fake-client -run='TestFakeClient' -failfast -count=10000 -parallel=1000
--- FAIL: TestFakeClient (5.00s)
    main_test.go:75: Informer did not get the added pod
FAIL
FAIL	k8s.io/kubernetes/vendor/k8s.io/client-go/examples/fake-client	69.991s
```

**Special notes for your reviewer**:
I think the main issue was setting the timeout before spinning up the informers so locking and load would cause it to timeout.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @smarterclayton @kubernetes/sig-api-machinery-pr-reviews 