### PR TITLE
hack/lib/util.sh: fix empty array expansion with bash 3.

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -649,7 +649,9 @@ EOF
 # Determines if docker can be run, failures may simply require that the user be added to the docker group.
 function kube::util::ensure_docker_daemon_connectivity {
   IFS=" " read -ra DOCKER <<< "${DOCKER_OPTS}"
-  DOCKER=(docker "${DOCKER[@]}")
+  # Expand ${DOCKER[@]} only if it's not unset. This is to work around
+  # Bash 3 issue with unbound variable.
+  DOCKER=(docker ${DOCKER[@]:+"${DOCKER[@]}"})
   if ! "${DOCKER[@]}" info > /dev/null 2>&1 ; then
     cat <<'EOF' >&2
 Can't connect to 'docker' daemon.  please fix and retry.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix `hack/lib/util.sh` docker availability check on OS X.

**Special notes for your reviewer**:

Fix problem reported at https://github.com/kubernetes/kubernetes/pull/74257#discussion_r262554139

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
