### PR TITLE
Extra columns output for Kubectl get subcommand

### DIFF
--- a/pkg/kubectl/cmd/get/BUILD
+++ b/pkg/kubectl/cmd/get/BUILD
@@ -86,6 +86,7 @@ go_test(
         "//pkg/kubectl/cmd/util/openapi/testing:go_default_library",
         "//pkg/kubectl/scheme:go_default_library",
         "//pkg/kubectl/util/printers:go_default_library",
+        "//pkg/printers:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",

--- a/pkg/kubectl/cmd/get/customcolumn_test.go
+++ b/pkg/kubectl/cmd/get/customcolumn_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util/printers"
+	printerspkg "k8s.io/kubernetes/pkg/printers"
 )
 
 // UniversalDecoder call must specify parameter versions; otherwise it will decode to internal versions.
@@ -71,7 +72,7 @@ func TestMassageJSONPath(t *testing.T) {
 func TestNewColumnPrinterFromSpec(t *testing.T) {
 	tests := []struct {
 		spec            string
-		expectedColumns []Column
+		expectedColumns []printerspkg.Column
 		expectErr       bool
 		name            string
 		noHeaders       bool
@@ -99,7 +100,7 @@ func TestNewColumnPrinterFromSpec(t *testing.T) {
 		{
 			spec: "NAME:metadata.name,API_VERSION:apiVersion",
 			name: "ok",
-			expectedColumns: []Column{
+			expectedColumns: []printerspkg.Column{
 				{
 					Header:    "NAME",
 					FieldSpec: "{.metadata.name}",
@@ -166,7 +167,7 @@ const exampleTemplateTwo = `NAME               		API_VERSION
 func TestNewColumnPrinterFromTemplate(t *testing.T) {
 	tests := []struct {
 		spec            string
-		expectedColumns []Column
+		expectedColumns []printerspkg.Column
 		expectErr       bool
 		name            string
 	}{
@@ -193,7 +194,7 @@ func TestNewColumnPrinterFromTemplate(t *testing.T) {
 		{
 			spec: exampleTemplateOne,
 			name: "ok",
-			expectedColumns: []Column{
+			expectedColumns: []printerspkg.Column{
 				{
 					Header:    "NAME",
 					FieldSpec: "{.metadata.name}",
@@ -207,7 +208,7 @@ func TestNewColumnPrinterFromTemplate(t *testing.T) {
 		{
 			spec: exampleTemplateTwo,
 			name: "ok-2",
-			expectedColumns: []Column{
+			expectedColumns: []printerspkg.Column{
 				{
 					Header:    "NAME",
 					FieldSpec: "{.metadata.name}",
@@ -243,12 +244,12 @@ func TestNewColumnPrinterFromTemplate(t *testing.T) {
 
 func TestColumnPrint(t *testing.T) {
 	tests := []struct {
-		columns        []Column
+		columns        []printerspkg.Column
 		obj            runtime.Object
 		expectedOutput string
 	}{
 		{
-			columns: []Column{
+			columns: []printerspkg.Column{
 				{
 					Header:    "NAME",
 					FieldSpec: "{.metadata.name}",
@@ -260,7 +261,7 @@ foo
 `,
 		},
 		{
-			columns: []Column{
+			columns: []printerspkg.Column{
 				{
 					Header:    "NAME",
 					FieldSpec: "{.metadata.name}",
@@ -278,7 +279,7 @@ bar
 `,
 		},
 		{
-			columns: []Column{
+			columns: []printerspkg.Column{
 				{
 					Header:    "NAME",
 					FieldSpec: "{.metadata.name}",
@@ -294,7 +295,7 @@ foo    baz
 `,
 		},
 		{
-			columns: []Column{
+			columns: []printerspkg.Column{
 				{
 					Header:    "NAME",
 					FieldSpec: "{.metadata.name}",
@@ -334,7 +335,7 @@ foo    baz           <none>
 
 // this mimics how resource/get.go calls the customcolumn printer
 func TestIndividualPrintObjOnExistingTabWriter(t *testing.T) {
-	columns := []Column{
+	columns := []printerspkg.Column{
 		{
 			Header:    "NAME",
 			FieldSpec: "{.metadata.name}",

--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -79,6 +79,7 @@ type GetOptions struct {
 	Sort           bool
 	IgnoreNotFound bool
 	Export         bool
+	ExtraColumns   bool
 
 	genericclioptions.IOStreams
 }
@@ -206,6 +207,13 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 	}
 
 	sortBy, err := cmd.Flags().GetString("sort-by")
+
+	extraCols, err := cmd.Flags().GetStringSlice("extra-columns")
+	if err != nil {
+		return err
+	}
+	o.ExtraColumns = len(extraCols) > 0
+
 	if err != nil {
 		return err
 	}
@@ -428,8 +436,8 @@ func (o *GetOptions) transformRequests(req *rest.Request) {
 	tableParam := fmt.Sprintf("application/json;as=Table;v=%s;g=%s, application/json", version, group)
 	req.SetHeader("Accept", tableParam)
 
-	// if sorting, ensure we receive the full object in order to introspect its fields via jsonpath
-	if o.Sort {
+	// if sorting or printing extra columns, ensure we receive the full object in order to introspect its fields via jsonpath
+	if o.Sort || o.ExtraColumns {
 		req.Param("includeObject", "Object")
 	}
 }

--- a/pkg/kubectl/cmd/get/humanreadable_flags_test.go
+++ b/pkg/kubectl/cmd/get/humanreadable_flags_test.go
@@ -22,7 +22,11 @@ import (
 	"strings"
 	"testing"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -142,6 +146,247 @@ func TestHumanReadablePrinterSupportsExpectedOptions(t *testing.T) {
 
 			out := bytes.NewBuffer([]byte{})
 			err = p.PrintObj(testObject, out)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			match, err := regexp.Match(tc.expectedOutput, out.Bytes())
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !match {
+				t.Errorf("unexpected output: expecting %q, got %q", tc.expectedOutput, out.String())
+			}
+		})
+	}
+}
+
+func TestHumanReadablePrinterSupportsExtraColumnsPrinting(t *testing.T) {
+	columns := []metav1beta1.TableColumnDefinition{
+		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
+		{Name: "Ready", Type: "string", Description: "The aggregate readiness state of this pod for accepting traffic."},
+		{Name: "Status", Type: "string", Description: "The aggregate status of the containers in this pod."},
+		{Name: "Restarts", Type: "integer", Description: "The number of times the containers in this pod have been restarted."},
+		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
+		{Name: "IP", Type: "string", Priority: 1, Description: v1.PodStatus{}.SwaggerDoc()["podIP"]},
+		{Name: "Node", Type: "string", Priority: 1, Description: v1.PodSpec{}.SwaggerDoc()["nodeName"]},
+		{Name: "Nominated Node", Type: "string", Priority: 1, Description: v1.PodStatus{}.SwaggerDoc()["nominatedNodeName"]},
+		{Name: "Readiness Gates", Type: "string", Priority: 1, Description: v1.PodSpec{}.SwaggerDoc()["readinessGates"]},
+	}
+
+	pod1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "Pod",
+			"apiVersion": "v1",
+			"metadata": map[string]interface{}{
+				"name": "testpod123",
+				"labels": map[string]interface{}{
+					"app": "testapp123",
+				},
+			},
+			"spec": map[string]interface{}{
+				"nodeName": "testnode123",
+			},
+		},
+	}
+
+	pod2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "Pod",
+			"apiVersion": "v1",
+			"metadata": map[string]interface{}{
+				"name": "testpod123",
+				"labels": map[string]interface{}{
+					"app": "testapp123",
+				},
+			},
+			"spec": map[string]interface{}{
+				"nodeName": "atestnode456",
+			},
+		},
+	}
+
+	testCases := []struct {
+		name       string
+		input      *metav1beta1.Table
+		showKind   bool
+		showLabels bool
+
+		sortBy       string
+		columnLabels []string
+		extraColumns []string
+
+		noHeaders     bool
+		withNamespace bool
+
+		outputFormat string
+
+		expectedError  string
+		expectedOutput string
+		expectNoMatch  bool
+	}{
+		{
+			name:         "--extra-columns Name:.metadata.name prints name and default columns",
+			extraColumns: []string{"Name:.metadata.name"},
+			input: &metav1beta1.Table{
+				ColumnDefinitions: columns,
+				Rows: []metav1beta1.TableRow{
+					{
+						Cells:  []interface{}{"testpod", "1/1", "Running", int64(1), "24d", "<none>", "<none>", "<none>", "<none>"},
+						Object: runtime.RawExtension{Object: pod1},
+					},
+				},
+			},
+		},
+		{
+			name:         "--extra-columns Name:.metadata.name, Node:.spec.nodeName prints name, nodeName and default columns",
+			extraColumns: []string{"Name:.metadata.name", "Node:.spec.nodeName"},
+			input: &metav1beta1.Table{
+				ColumnDefinitions: columns,
+				Rows: []metav1beta1.TableRow{
+					{
+						Cells:  []interface{}{"testpod", "1/1", "Running", int64(1), "24d", "<none>", "<none>", "<none>", "<none>"},
+						Object: runtime.RawExtension{Object: pod1},
+					},
+				},
+			},
+			expectedOutput: "NAME\\ +READY\\ +STATUS\\ +RESTARTS\\ +AGE\\ +Name\\ +Node\ntestpod\\ +1/1\\ +Running\\ +1\\ +24d\\ +testpod123\\ +testnode123\n",
+		},
+		{
+			name:         "--extra-columns Node:.spec.nodeName prints node name and default columns",
+			extraColumns: []string{"Node:.spec.nodeName"},
+			input: &metav1beta1.Table{
+				ColumnDefinitions: columns,
+				Rows: []metav1beta1.TableRow{
+					{
+						Cells:  []interface{}{"testpod", "1/1", "Running", int64(1), "24d", "<none>", "<none>", "<none>", "<none>"},
+						Object: runtime.RawExtension{Object: pod1},
+					},
+				},
+			},
+			expectedOutput: "NAME\\ +READY\\ +STATUS\\ +RESTARTS\\ +AGE\\ +Node\ntestpod\\ +1/1\\ +Running\\ +1\\ +24d\\ +testnode123\n",
+		},
+		{
+			name:         "nonexistent spec path prints default columns and <none>",
+			extraColumns: []string{"NoneSpec:.spec.nonexistent"},
+			input: &metav1beta1.Table{
+				ColumnDefinitions: columns,
+				Rows: []metav1beta1.TableRow{
+					{
+						Cells:  []interface{}{"testpod", "1/1", "Running", int64(1), "24d", "<none>", "<none>", "<none>", "<none>"},
+						Object: runtime.RawExtension{Object: pod1},
+					},
+				},
+			},
+			expectedOutput: "NAME\\ +READY\\ +STATUS\\ +RESTARTS\\ +AGE\\ +NoneSpec\ntestpod\\ +1/1\\ +Running\\ +1\\ +24d\\ +<none>\n",
+		},
+		{
+			name:         "-o wide + --extra-columns Node:.spec.nodeName prints default wide columns and node name column",
+			extraColumns: []string{"Node:.spec.nodeName"},
+			outputFormat: "wide",
+			input: &metav1beta1.Table{
+				ColumnDefinitions: columns,
+				Rows: []metav1beta1.TableRow{
+					{
+						Cells:  []interface{}{"testpod", "1/1", "Running", int64(1), "24d", "10.209.18.164", "<none>", "<none>", "<none>"},
+						Object: runtime.RawExtension{Object: pod1},
+					},
+				},
+			},
+			expectedOutput: "NAME\\ +READY\\ +STATUS\\ +RESTARTS\\ +AGE\\ +IP\\ +NODE\\ +NOMINATED NODE\\ +READINESS GATES\\ +Node\ntestpod\\ +1/1\\ +Running\\ +1\\ +24d\\ +10.209.18.164\\ +<none>\\ +<none>\\ +<none>\\ +testnode123\n",
+		},
+		{
+			name:         "-L <label> + --extra-columns Node:.spec.nodeName prints default columns + label column + node name column",
+			extraColumns: []string{"Node:.spec.nodeName"},
+			columnLabels: []string{"app"},
+			input: &metav1beta1.Table{
+				ColumnDefinitions: columns,
+				Rows: []metav1beta1.TableRow{
+					{
+						Cells:  []interface{}{"testpod", "1/1", "Running", int64(1), "24d", "10.209.18.164", "<none>", "<none>", "<none>"},
+						Object: runtime.RawExtension{Object: pod1},
+					},
+				},
+			},
+			expectedOutput: "NAME\\ +READY\\ +STATUS\\ +RESTARTS\\ +AGE\\ +APP\\ +Node\ntestpod\\ +1/1\\ +Running\\ +1\\ +24d\\ +testapp123\\ +testnode123\n",
+		},
+		{
+			name:         "--no-headers + --extra-columns Node:.spec.nodeName prints default columns + node name column without headers",
+			extraColumns: []string{"Node:.spec.nodeName"},
+			noHeaders:    true,
+			input: &metav1beta1.Table{
+				ColumnDefinitions: columns,
+				Rows: []metav1beta1.TableRow{
+					{
+						Cells:  []interface{}{"testpod", "1/1", "Running", int64(1), "24d", "10.209.18.164", "<none>", "<none>", "<none>"},
+						Object: runtime.RawExtension{Object: pod1},
+					},
+				},
+			},
+			expectedOutput: "testpod\\ +1/1\\ +Running\\ +1\\ +24d\\ +testnode123\n",
+		},
+		{
+			name:         "--sorty-by .spec.nodeName + --extra-columns Node:.spec.nodeName prints default columns + node name column sorted by nodeName",
+			extraColumns: []string{"Node:.spec.nodeName"},
+			noHeaders:    true,
+			sortBy:       ".spec.nodeName",
+			input: &metav1beta1.Table{
+				ColumnDefinitions: columns,
+				Rows: []metav1beta1.TableRow{
+					{
+						Cells:  []interface{}{"testpod2", "1/1", "Running", int64(1), "12d", "10.209.18.165", "<none>", "<none>", "<none>"},
+						Object: runtime.RawExtension{Object: pod2},
+					},
+					{
+						Cells:  []interface{}{"testpod1", "1/1", "Running", int64(1), "24d", "10.209.18.164", "<none>", "<none>", "<none>"},
+						Object: runtime.RawExtension{Object: pod1},
+					},
+				},
+			},
+			expectedOutput: "testpod2\\ +1/1\\ +Running\\ +1\\ +12d\\ +atestnode456\ntestpod1\\ +1/1\\ +Running\\ +1\\ +24d\\ +testnode123\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			printFlags := HumanPrintFlags{
+				ShowKind:     &tc.showKind,
+				ShowLabels:   &tc.showLabels,
+				SortBy:       &tc.sortBy,
+				ColumnLabels: &tc.columnLabels,
+				ExtraColumns: &tc.extraColumns,
+
+				NoHeaders:     tc.noHeaders,
+				WithNamespace: tc.withNamespace,
+			}
+
+			if tc.showKind {
+				printFlags.Kind = schema.GroupKind{Kind: "pod"}
+			}
+
+			p, err := printFlags.ToPrinter(tc.outputFormat)
+			if tc.expectNoMatch {
+				if !genericclioptions.IsNoCompatiblePrinterError(err) {
+					t.Fatalf("expected no printer matches for output format %q", tc.outputFormat)
+				}
+				return
+			}
+			if genericclioptions.IsNoCompatiblePrinterError(err) {
+				t.Fatalf("expected to match template printer for output format %q", tc.outputFormat)
+			}
+
+			if len(tc.expectedError) > 0 {
+				if err == nil || !strings.Contains(err.Error(), tc.expectedError) {
+					t.Errorf("expecting error %q, got %v", tc.expectedError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			out := bytes.NewBuffer([]byte{})
+			err = p.PrintObj(tc.input, out)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/kubectl/cmd/get/humanreadable_flags_test.go
+++ b/pkg/kubectl/cmd/get/humanreadable_flags_test.go
@@ -44,6 +44,7 @@ func TestHumanReadablePrinterSupportsExpectedOptions(t *testing.T) {
 		// TODO(juanvallejo): test sorting once it's moved to the HumanReadablePrinter
 		sortBy       string
 		columnLabels []string
+		extraColumns []string
 
 		noHeaders     bool
 		withNamespace bool
@@ -108,6 +109,7 @@ func TestHumanReadablePrinterSupportsExpectedOptions(t *testing.T) {
 				ShowLabels:   &tc.showLabels,
 				SortBy:       &tc.sortBy,
 				ColumnLabels: &tc.columnLabels,
+				ExtraColumns: &tc.extraColumns,
 
 				NoHeaders:     tc.noHeaders,
 				WithNamespace: tc.withNamespace,

--- a/pkg/kubectl/cmd/get/sorter.go
+++ b/pkg/kubectl/cmd/get/sorter.go
@@ -126,7 +126,7 @@ func SortObjects(decoder runtime.Decoder, objs []runtime.Object, fieldInput stri
 	// Note that this requires empty fields to be considered later, when sorting.
 	var fieldFoundOnce bool
 	for _, obj := range objs {
-		values, err := findJSONPathResults(parser, obj)
+		values, err := jsonpath.FindJSONPathResults(parser, obj)
 		if err != nil {
 			return nil, err
 		}
@@ -284,12 +284,12 @@ func (r *RuntimeSort) Less(i, j int) bool {
 		panic(err)
 	}
 
-	iValues, err = findJSONPathResults(parser, iObj)
+	iValues, err = jsonpath.FindJSONPathResults(parser, iObj)
 	if err != nil {
 		klog.Fatalf("Failed to get i values for %#v using %s (%#v)", iObj, r.field, err)
 	}
 
-	jValues, err = findJSONPathResults(parser, jObj)
+	jValues, err = jsonpath.FindJSONPathResults(parser, jObj)
 	if err != nil {
 		klog.Fatalf("Failed to get j values for %#v using %s (%v)", jObj, r.field, err)
 	}
@@ -372,7 +372,7 @@ func NewTableSorter(table *metav1beta1.Table, field string) (*TableSorter, error
 
 	fieldFoundOnce := false
 	for i := range table.Rows {
-		parsedRow, err := findJSONPathResults(parser, table.Rows[i].Object.Object)
+		parsedRow, err := jsonpath.FindJSONPathResults(parser, table.Rows[i].Object.Object)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get values for %#v using %s (%#v)", parsedRow, field, err)
 		}
@@ -391,10 +391,4 @@ func NewTableSorter(table *metav1beta1.Table, field string) (*TableSorter, error
 		field:      field,
 		parsedRows: parsedRows,
 	}, nil
-}
-func findJSONPathResults(parser *jsonpath.JSONPath, from runtime.Object) ([][]reflect.Value, error) {
-	if unstructuredObj, ok := from.(*unstructured.Unstructured); ok {
-		return parser.FindResults(unstructuredObj.Object)
-	}
-	return parser.FindResults(reflect.ValueOf(from).Elem().Interface())
 }

--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -15,7 +15,6 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/printers",
     deps = [
-        "//staging/src/k8s.io/client-go/util/jsonpath:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
@@ -23,6 +22,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//staging/src/k8s.io/client-go/util/jsonpath:go_default_library",
         "//vendor/github.com/liggitt/tabwriter:go_default_library",
     ],
 )

--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -15,6 +15,7 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/printers",
     deps = [
+        "//staging/src/k8s.io/client-go/util/jsonpath:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",

--- a/pkg/printers/humanreadable.go
+++ b/pkg/printers/humanreadable.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/util/jsonpath"
 )
 
 type TableGenerator interface {
@@ -185,6 +186,18 @@ func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) er
 			// If this table has column definitions, remember them for future use.
 			h.lastColumns = table.ColumnDefinitions
 		}
+		if len(h.options.ExtraColumns) != 0 {
+			// Initialize JSON parsers
+			columns := h.options.ExtraColumns
+			parsers := make([]*jsonpath.JSONPath, len(columns))
+			for ix := range columns {
+				parsers[ix] = jsonpath.New(fmt.Sprintf("extracolumn%d", ix)).AllowMissingKeys(true)
+				if err := parsers[ix].Parse(columns[ix].FieldSpec); err != nil {
+					return err
+				}
+			}
+			return PrintTableWithExtraCols(table, parsers, output, h.options)
+		}
 
 		if err := DecorateTable(table, localOptions); err != nil {
 			return err
@@ -270,6 +283,86 @@ func PrintTable(table *metav1beta1.Table, output io.Writer, options PrintOptions
 			}
 			if cell != nil {
 				fmt.Fprint(output, cell)
+			}
+		}
+		fmt.Fprintln(output)
+	}
+	return nil
+}
+
+// PrintTableWithExtraCols prints a table to the provided output respecting the filtering rules for options
+// for wide columns and filtered rows and printing any extra columns using provided parsers. It filters out
+// rows that are Completed. You should call DecorateTable if you receive a table from a remote server before
+// calling PrintTableWithExtraCols.
+func PrintTableWithExtraCols(table *metav1beta1.Table, parsers []*jsonpath.JSONPath, output io.Writer, options PrintOptions) error {
+	if !options.NoHeaders {
+		// avoid printing headers if we have no rows to display
+		if len(table.Rows) == 0 {
+			return nil
+		}
+
+		first := true
+		for _, column := range table.ColumnDefinitions {
+			if !options.Wide && column.Priority != 0 {
+				continue
+			}
+			if first {
+				first = false
+			} else {
+				fmt.Fprint(output, "\t")
+			}
+			fmt.Fprint(output, strings.ToUpper(column.Name))
+		}
+
+		// Print extra columns headers
+		for ix := range options.ExtraColumns {
+			header := options.ExtraColumns[ix].Header
+			fmt.Fprint(output, "\t"+header)
+		}
+		fmt.Fprintln(output)
+	}
+	for i, row := range table.Rows {
+		first := true
+		for i, cell := range row.Cells {
+			if i >= len(table.ColumnDefinitions) {
+				// https://issue.k8s.io/66379
+				// don't panic in case of bad output from the server, with more cells than column definitions
+				break
+			}
+			column := table.ColumnDefinitions[i]
+			if !options.Wide && column.Priority != 0 {
+				continue
+			}
+			if first {
+				first = false
+			} else {
+				fmt.Fprint(output, "\t")
+			}
+			if cell != nil {
+				fmt.Fprint(output, cell)
+			}
+		}
+		// print extra columns table data
+		for ix := range parsers {
+			parser := parsers[ix]
+
+			var values [][]reflect.Value
+			var err error
+
+			// Parse the JSON values from the table
+			values, err = jsonpath.FindJSONPathResults(parser, table.Rows[i].Object.Object)
+
+			if err != nil {
+				return err
+			}
+
+			if len(values) == 0 || len(values[0]) == 0 {
+				fmt.Fprint(output, "\t"+"<none>")
+			}
+			for arrIx := range values {
+				for valIx := range values[arrIx] {
+					fmt.Fprint(output, "\t"+fmt.Sprintf("%v", values[arrIx][valIx].Interface()))
+				}
 			}
 		}
 		fmt.Fprintln(output)

--- a/pkg/printers/humanreadable.go
+++ b/pkg/printers/humanreadable.go
@@ -186,23 +186,20 @@ func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) er
 			// If this table has column definitions, remember them for future use.
 			h.lastColumns = table.ColumnDefinitions
 		}
-		if len(h.options.ExtraColumns) != 0 {
-			// Initialize JSON parsers
-			columns := h.options.ExtraColumns
-			parsers := make([]*jsonpath.JSONPath, len(columns))
-			for ix := range columns {
-				parsers[ix] = jsonpath.New(fmt.Sprintf("extracolumn%d", ix)).AllowMissingKeys(true)
-				if err := parsers[ix].Parse(columns[ix].FieldSpec); err != nil {
-					return err
-				}
+		columns := h.options.ExtraColumns
+		parsers := make([]*jsonpath.JSONPath, len(columns))
+		// Initialize JSON parsers
+		for ix := range columns {
+			parsers[ix] = jsonpath.New(fmt.Sprintf("extracolumn%d", ix)).AllowMissingKeys(true)
+			if err := parsers[ix].Parse(columns[ix].FieldSpec); err != nil {
+				return err
 			}
-			return PrintTableWithExtraCols(table, parsers, output, h.options)
 		}
 
 		if err := DecorateTable(table, localOptions); err != nil {
 			return err
 		}
-		return PrintTable(table, output, localOptions)
+		return PrintTable(table, parsers, output, localOptions)
 	}
 
 	// print with a registered handler
@@ -241,60 +238,10 @@ func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) er
 }
 
 // PrintTable prints a table to the provided output respecting the filtering rules for options
-// for wide columns and filtered rows. It filters out rows that are Completed. You should call
-// DecorateTable if you receive a table from a remote server before calling PrintTable.
-func PrintTable(table *metav1beta1.Table, output io.Writer, options PrintOptions) error {
-	if !options.NoHeaders {
-		// avoid printing headers if we have no rows to display
-		if len(table.Rows) == 0 {
-			return nil
-		}
-
-		first := true
-		for _, column := range table.ColumnDefinitions {
-			if !options.Wide && column.Priority != 0 {
-				continue
-			}
-			if first {
-				first = false
-			} else {
-				fmt.Fprint(output, "\t")
-			}
-			fmt.Fprint(output, strings.ToUpper(column.Name))
-		}
-		fmt.Fprintln(output)
-	}
-	for _, row := range table.Rows {
-		first := true
-		for i, cell := range row.Cells {
-			if i >= len(table.ColumnDefinitions) {
-				// https://issue.k8s.io/66379
-				// don't panic in case of bad output from the server, with more cells than column definitions
-				break
-			}
-			column := table.ColumnDefinitions[i]
-			if !options.Wide && column.Priority != 0 {
-				continue
-			}
-			if first {
-				first = false
-			} else {
-				fmt.Fprint(output, "\t")
-			}
-			if cell != nil {
-				fmt.Fprint(output, cell)
-			}
-		}
-		fmt.Fprintln(output)
-	}
-	return nil
-}
-
-// PrintTableWithExtraCols prints a table to the provided output respecting the filtering rules for options
 // for wide columns and filtered rows and printing any extra columns using provided parsers. It filters out
 // rows that are Completed. You should call DecorateTable if you receive a table from a remote server before
-// calling PrintTableWithExtraCols.
-func PrintTableWithExtraCols(table *metav1beta1.Table, parsers []*jsonpath.JSONPath, output io.Writer, options PrintOptions) error {
+// calling PrintTable.
+func PrintTable(table *metav1beta1.Table, parsers []*jsonpath.JSONPath, output io.Writer, options PrintOptions) error {
 	if !options.NoHeaders {
 		// avoid printing headers if we have no rows to display
 		if len(table.Rows) == 0 {

--- a/pkg/printers/interface.go
+++ b/pkg/printers/interface.go
@@ -37,6 +37,15 @@ func (fn ResourcePrinterFunc) PrintObj(obj runtime.Object, w io.Writer) error {
 	return fn(obj, w)
 }
 
+// Column represents a user specified column
+type Column struct {
+	// The header to print above the column, general style is ALL_CAPS
+	Header string
+	// The pointer to the field in the object to print in JSONPath form
+	// e.g. {.ObjectMeta.Name}, see pkg/util/jsonpath for more details.
+	FieldSpec string
+}
+
 type PrintOptions struct {
 	// supported Format types can be found in pkg/printers/printers.go
 	OutputFormatType     string
@@ -50,6 +59,7 @@ type PrintOptions struct {
 	AbsoluteTimestamps bool
 	Kind               schema.GroupKind
 	ColumnLabels       []string
+	ExtraColumns       []Column
 
 	SortBy string
 

--- a/pkg/printers/internalversion/BUILD
+++ b/pkg/printers/internalversion/BUILD
@@ -40,6 +40,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/printers:go_default_library",
+        "//staging/src/k8s.io/client-go/util/jsonpath:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	genericprinters "k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/client-go/util/jsonpath"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/apis/apps"
@@ -1094,12 +1095,13 @@ func TestPrintHunmanReadableIngressWithColumnLabels(t *testing.T) {
 		},
 	}
 	buff := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&ingress, printers.PrintOptions{ColumnLabels: []string{"app_name"}})
 	if err != nil {
 		t.Fatal(err)
 	}
 	verifyTable(t, table)
-	if err := printers.PrintTable(table, buff, printers.PrintOptions{NoHeaders: true}); err != nil {
+	if err := printers.PrintTable(table, parsers, buff, printers.PrintOptions{NoHeaders: true}); err != nil {
 		t.Fatal(err)
 	}
 	output := string(buff.Bytes())
@@ -1227,13 +1229,14 @@ func TestPrintHumanReadableService(t *testing.T) {
 
 	for _, svc := range tests {
 		for _, wide := range []bool{false, true} {
+			parsers := []*jsonpath.JSONPath{}
 			buff := bytes.NewBuffer([]byte{})
 			table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&svc, printers.PrintOptions{Wide: wide})
 			if err != nil {
 				t.Fatal(err)
 			}
 			verifyTable(t, table)
-			if err := printers.PrintTable(table, buff, printers.PrintOptions{NoHeaders: true}); err != nil {
+			if err := printers.PrintTable(table, parsers, buff, printers.PrintOptions{NoHeaders: true}); err != nil {
 				t.Fatal(err)
 			}
 			output := string(buff.Bytes())
@@ -2035,13 +2038,14 @@ func TestPrintDeployment(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.deployment, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.expect {
@@ -2051,7 +2055,7 @@ func TestPrintDeployment(t *testing.T) {
 		table, err = printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.deployment, printers.PrintOptions{Wide: true})
 		verifyTable(t, table)
 		// print deployment with '-o wide' option
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{Wide: true, NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{Wide: true, NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.wideExpect {
@@ -2090,13 +2094,14 @@ func TestPrintDaemonSet(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.ds, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if !strings.HasPrefix(buf.String(), test.startsWith) {
@@ -2179,13 +2184,14 @@ func TestPrintJob(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.job, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.expect {
@@ -2786,13 +2792,14 @@ func TestPrintHPA(t *testing.T) {
 	}
 
 	buff := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.hpa, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buff, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buff, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buff.String() != test.expected {
@@ -3016,13 +3023,14 @@ func TestPrintService(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.service, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		// We ignore time
@@ -3074,13 +3082,14 @@ func TestPrintPodDisruptionBudget(t *testing.T) {
 		}}
 
 	buf := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.pdb, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.expect {
@@ -3155,13 +3164,14 @@ func TestPrintControllerRevision(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.history, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.expect {
@@ -3216,13 +3226,14 @@ func TestPrintReplicaSet(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.replicaSet, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.expect {
@@ -3235,7 +3246,7 @@ func TestPrintReplicaSet(t *testing.T) {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true, Wide: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true, Wide: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.wideExpect {
@@ -3328,13 +3339,14 @@ func TestPrintPersistentVolumeClaim(t *testing.T) {
 		},
 	}
 	buf := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.pvc, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.expect {
@@ -3401,13 +3413,14 @@ func TestPrintCronJob(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.cronjob, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.expect {
@@ -3445,13 +3458,14 @@ func TestPrintStorageClass(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.sc, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.expect {
@@ -3495,12 +3509,13 @@ func TestPrintLease(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.sc, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.expect {
@@ -3539,13 +3554,14 @@ func TestPrintPriorityClass(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
+	parsers := []*jsonpath.JSONPath{}
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.pc, printers.PrintOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.expect {
@@ -3582,6 +3598,7 @@ func TestPrintRuntimeClass(t *testing.T) {
 		},
 	}
 
+	parsers := []*jsonpath.JSONPath{}
 	buf := bytes.NewBuffer([]byte{})
 	for _, test := range tests {
 		table, err := printers.NewTableGenerator().With(AddHandlers).GenerateTable(&test.rc, printers.PrintOptions{})
@@ -3589,7 +3606,7 @@ func TestPrintRuntimeClass(t *testing.T) {
 			t.Fatal(err)
 		}
 		verifyTable(t, table)
-		if err := printers.PrintTable(table, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
+		if err := printers.PrintTable(table, parsers, buf, printers.PrintOptions{NoHeaders: true}); err != nil {
 			t.Fatal(err)
 		}
 		if buf.String() != test.expect {

--- a/staging/src/k8s.io/client-go/util/jsonpath/BUILD
+++ b/staging/src/k8s.io/client-go/util/jsonpath/BUILD
@@ -26,9 +26,9 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/util/jsonpath",
     importpath = "k8s.io/client-go/util/jsonpath",
     deps = [
-        "//staging/src/k8s.io/client-go/third_party/forked/golang/template:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/client-go/third_party/forked/golang/template:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/client-go/util/jsonpath/BUILD
+++ b/staging/src/k8s.io/client-go/util/jsonpath/BUILD
@@ -25,7 +25,11 @@ go_library(
     ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/util/jsonpath",
     importpath = "k8s.io/client-go/util/jsonpath",
-    deps = ["//staging/src/k8s.io/client-go/third_party/forked/golang/template:go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/client-go/third_party/forked/golang/template:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+    ],
 )
 
 filegroup(

--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -23,6 +23,8 @@ import (
 	"reflect"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/third_party/forked/golang/template"
 )
 
@@ -522,4 +524,12 @@ func (j *JSONPath) evalToText(v reflect.Value) ([]byte, error) {
 	var buffer bytes.Buffer
 	fmt.Fprint(&buffer, iface)
 	return buffer.Bytes(), nil
+}
+
+// findJsonPath extracts a set of values from a runtime object using a parser
+func FindJSONPathResults(parser *JSONPath, from runtime.Object) ([][]reflect.Value, error) {
+	if unstructuredObj, ok := from.(*unstructured.Unstructured); ok {
+		return parser.FindResults(unstructuredObj.Object)
+	}
+	return parser.FindResults(reflect.ValueOf(from).Elem().Interface())
 }

--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -73,6 +73,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
+        "//staging/src/k8s.io/client-go/util/jsonpath:go_default_library",
         "//staging/src/k8s.io/client-go/util/keyutil:go_default_library",
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",

--- a/test/e2e/apimachinery/table_conversion.go
+++ b/test/e2e/apimachinery/table_conversion.go
@@ -26,13 +26,14 @@ import (
 	"github.com/onsi/gomega"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/client-go/util/workqueue"
 
 	utilversion "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/client-go/util/jsonpath"
 	"k8s.io/kubernetes/pkg/printers"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -165,7 +166,8 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 func printTable(table *metav1beta1.Table) string {
 	buf := &bytes.Buffer{}
 	tw := tabwriter.NewWriter(buf, 5, 8, 1, ' ', 0)
-	err := printers.PrintTable(table, tw, printers.PrintOptions{})
+	parsers := []*jsonpath.JSONPath{}
+	err := printers.PrintTable(table, parsers, tw, printers.PrintOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to print table: %+v", table)
 	tw.Flush()
 	return buf.String()


### PR DESCRIPTION
/kind feature
/sig cli

**What this PR does / why we need it**:

This PR adds a new flag `--extra-columns` to `kubectl get` that will provide functionality similar to the currently implemented `--custom-columns` output flag but with the added feature that it prints the columns specified alongside the normal human-readable output of the command. 

Currently `--custom-columns` only supports printing those columns which are selected by the user via a comma-delimited list of `COLUMN_NAME` mapped to a jsonpath value (eg: `COLUMN:.metadata.name`) that results in something like this:

```
$ kubectl get pod my-pod --custom-columns=COLUMN_NAME=.metadata.name
COLUMN_NAME
my-pod
```

With this new flag, a user can expect to have the option to add these columns to the default set of columns to attain output like the following:

```
$ kubectl get pod my-pod --extra-columns=CUSTOM_COLUMN=.metadata.name
NAME     READY     STATUS    RESTARTS   AGE   CUSTOM_COLUMN
my-pod   1/1       Running   0          28s   my-pod
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/71612

**Special notes for your reviewer**:
- Some minor refactoring was required to make `findJSONPathResults` callable from the `human-readable` printer, I moved this function into the `jsonpath` package to do this, but I'm open to other ways of implementing this if there are better places to put it.
- The same thing goes for the `Column` type that I found useful for this implementation. I moved this out of `customcolumn.go` and into `pkg/printers/interface.go`.
- I believe there are some scripts that need to be run in the hack directory to generate docs and a few other things, I still have not done that but I plan to add those changes soon
- I ran unit tests on the packages I changed, but I may still have broken some things, I will make sure to address any tests or packages that may have been affected by these changes
- Thanks for reviewing my first PR! I tried to follow the best practices and design patterns that were already present, but please do not hesitate to point out areas where I need to change things or where I might have missed some important parts of the contributor workflow. I'm still pretty new to both Golang and Kubernetes contributions.


```release-note
The kubectl get subcommand now supports appending additional columns to the normal get output through the --extra-columns flag
```