### PR TITLE
Track dry-run and apply in metrics

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -86,16 +86,16 @@ func ValidateDeleteOptions(options *metav1.DeleteOptions) field.ErrorList {
 		*options.PropagationPolicy != metav1.DeletePropagationOrphan {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("propagationPolicy"), options.PropagationPolicy, []string{string(metav1.DeletePropagationForeground), string(metav1.DeletePropagationBackground), string(metav1.DeletePropagationOrphan), "nil"}))
 	}
-	allErrs = append(allErrs, validateDryRun(field.NewPath("dryRun"), options.DryRun)...)
+	allErrs = append(allErrs, ValidateDryRun(field.NewPath("dryRun"), options.DryRun)...)
 	return allErrs
 }
 
 func ValidateCreateOptions(options *metav1.CreateOptions) field.ErrorList {
-	return validateDryRun(field.NewPath("dryRun"), options.DryRun)
+	return ValidateDryRun(field.NewPath("dryRun"), options.DryRun)
 }
 
 func ValidateUpdateOptions(options *metav1.UpdateOptions) field.ErrorList {
-	return validateDryRun(field.NewPath("dryRun"), options.DryRun)
+	return ValidateDryRun(field.NewPath("dryRun"), options.DryRun)
 }
 
 func ValidatePatchOptions(options *metav1.PatchOptions, patchType types.PatchType) field.ErrorList {
@@ -103,13 +103,14 @@ func ValidatePatchOptions(options *metav1.PatchOptions, patchType types.PatchTyp
 	if patchType != types.ApplyPatchType && options.Force != nil {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("force"), "may not be specified for non-apply patch"))
 	}
-	allErrs = append(allErrs, validateDryRun(field.NewPath("dryRun"), options.DryRun)...)
+	allErrs = append(allErrs, ValidateDryRun(field.NewPath("dryRun"), options.DryRun)...)
 	return allErrs
 }
 
 var allowedDryRunValues = sets.NewString(metav1.DryRunAll)
 
-func validateDryRun(fldPath *field.Path, dryRun []string) field.ErrorList {
+// ValidateDryRun validates that a dryRun query param only contains allowed values.
+func ValidateDryRun(fldPath *field.Path, dryRun []string) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if !allowedDryRunValues.HasAll(dryRun...) {
 		allErrs = append(allErrs, field.NotSupported(fldPath, dryRun, allowedDryRunValues.List()))

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
@@ -103,7 +103,7 @@ func TestValidDryRun(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v", test), func(t *testing.T) {
-			if errs := validateDryRun(field.NewPath("dryRun"), test); len(errs) != 0 {
+			if errs := ValidateDryRun(field.NewPath("dryRun"), test); len(errs) != 0 {
 				t.Errorf("%v should be a valid dry-run value: %v", test, errs)
 			}
 		})
@@ -118,7 +118,7 @@ func TestInvalidDryRun(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v", test), func(t *testing.T) {
-			if len(validateDryRun(field.NewPath("dryRun"), test)) == 0 {
+			if len(ValidateDryRun(field.NewPath("dryRun"), test)) == 0 {
 				t.Errorf("%v shouldn't be a valid dry-run value", test)
 			}
 		})

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/BUILD
@@ -23,6 +23,8 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/BUILD
@@ -18,6 +18,8 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/metrics",
     importpath = "k8s.io/apiserver/pkg/endpoints/metrics",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -330,7 +330,7 @@ func cleanVerb(verb string, request *http.Request) string {
 }
 
 func cleanDryRun(dryRun []string) string {
-	if err := validation.ValidateDryRun(nil, dryRun); err != nil {
+	if errs := validation.ValidateDryRun(nil, dryRun); len(errs) > 0 {
 		return "invalid"
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -31,6 +31,8 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	utilsets "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"github.com/emicklei/go-restful"
 	"github.com/prometheus/client_golang/prometheus"
@@ -323,7 +325,7 @@ func cleanVerb(verb string, request *http.Request) string {
 	if verb == "WATCHLIST" {
 		reportedVerb = "WATCH"
 	}
-	if verb == "PATCH" && request.Header.Get("Content-Type") == string(types.ApplyPatchType) {
+	if verb == "PATCH" && request.Header.Get("Content-Type") == string(types.ApplyPatchType) && utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
 		reportedVerb = "APPLY"
 	}
 	return reportedVerb

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -21,7 +21,6 @@ import (
 	"net"
 	"net/http"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -30,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/types"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	utilsets "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/emicklei/go-restful"
@@ -333,20 +333,9 @@ func cleanDryRun(dryRun []string) string {
 	if errs := validation.ValidateDryRun(nil, dryRun); len(errs) > 0 {
 		return "invalid"
 	}
-
 	// Since dryRun could be valid with any arbitrarily long length
 	// we have to dedup and sort the elements before joining them together
-	dryRunSet := map[string]bool{}
-	for _, element := range dryRun {
-		dryRunSet[element] = true
-	}
-	dryRunUnique := []string{}
-	for element := range dryRunSet {
-		dryRunUnique = append(dryRunUnique, element)
-	}
-	sort.Strings(dryRunUnique)
-
-	return strings.Join(dryRunUnique, ",")
+	return strings.Join(utilsets.NewString(dryRun...).List(), ",")
 }
 
 func cleanUserAgent(ua string) string {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/sig api-machinery
/wg apply
/priority important-soon

**What this PR does / why we need it**:
Example value of the metric from kube-up
```
...
apiserver_request_total{client="kubectl/v0.0.0 (linux/amd64) kubernetes/$Format",code="201",component="apiserver",contentType="application/json",dry_run="All",grou
p="apps",resource="deployments",scope="namespace",subresource="",verb="APPLY",version="v1"} 4
...
```

**Which issue(s) this PR fixes**:
Tracked in https://github.com/kubernetes/kubernetes/issues/73723

**Does this PR introduce a user-facing change?**:
```release-note
New "dry_run" metric label (indicating the value of the dryRun query parameter) into the metrics:
* apiserver_request_total
* apiserver_request_duration_seconds
New "APPLY" value for the "verb" metric label which indicates a PATCH with "Content-Type: apply-patch+yaml". This value is experimental and will only be present if the ServerSideApply alpha feature is enabled.
```
