### PR TITLE
Promote RuntimeClass to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -356,6 +356,7 @@ const (
 
 	// owner: @tallclair
 	// alpha: v1.12
+	// beta:  v1.14
 	//
 	// Enables RuntimeClass, for selecting between multiple runtimes to run a pod.
 	RuntimeClass utilfeature.Feature = "RuntimeClass"
@@ -498,7 +499,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	ResourceQuotaScopeSelectors:                 {Default: true, PreRelease: utilfeature.Beta},
 	CSIBlockVolume:                              {Default: true, PreRelease: utilfeature.Beta},
 	CSIInlineVolume:                             {Default: false, PreRelease: utilfeature.Alpha},
-	RuntimeClass:                                {Default: false, PreRelease: utilfeature.Alpha},
+	RuntimeClass:                                {Default: true, PreRelease: utilfeature.Beta},
 	NodeLease:                                   {Default: true, PreRelease: utilfeature.Beta},
 	SCTPSupport:                                 {Default: false, PreRelease: utilfeature.Alpha},
 	VolumeSnapshotDataSource:                    {Default: false, PreRelease: utilfeature.Alpha},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -1023,6 +1023,14 @@ items:
     - get
     - patch
     - update
+  - apiGroups:
+    - node.k8s.io
+    resources:
+    - runtimeclasses
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:

--- a/test/e2e/node/runtimeclass.go
+++ b/test/e2e/node/runtimeclass.go
@@ -34,7 +34,7 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = SIGDescribe("RuntimeClass [Feature:RuntimeClass]", func() {
+var _ = SIGDescribe("RuntimeClass", func() {
 	f := framework.NewDefaultFramework("runtimeclass")
 
 	It("should reject a Pod requesting a non-existent RuntimeClass", func() {

--- a/test/e2e/node/runtimeclass.go
+++ b/test/e2e/node/runtimeclass.go
@@ -43,12 +43,6 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		expectSandboxFailureEvent(f, pod, fmt.Sprintf("\"%s\" not found", rcName))
 	})
 
-	It("should run a Pod requesting a RuntimeClass with an empty handler", func() {
-		rcName := createRuntimeClass(f, "empty-handler", "")
-		pod := createRuntimeClassPod(f, rcName)
-		expectPodSuccess(f, pod)
-	})
-
 	It("should reject a Pod requesting a RuntimeClass with an unconfigured handler", func() {
 		handler := f.Namespace.Name + "-handler"
 		rcName := createRuntimeClass(f, "unconfigured-handler", handler)
@@ -57,7 +51,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 	})
 
 	It("should reject a Pod requesting a deleted RuntimeClass", func() {
-		rcName := createRuntimeClass(f, "delete-me", "")
+		rcName := createRuntimeClass(f, "delete-me", "runc")
 		rcClient := f.ClientSet.NodeV1beta1().RuntimeClasses()
 
 		By("Deleting RuntimeClass "+rcName, func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Promote RuntimeClass to beta.

**Which issue(s) this PR fixes**:
For https://github.com/kubernetes/enhancements/issues/585

**Special notes for your reviewer**:

Beta criteria defined here: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/runtime-class.md

Remaining criteria:

- Promote API to beta: https://github.com/kubernetes/kubernetes/pull/74433
- E2E coverage of a non-default handler: https://github.com/kubernetes/kubernetes/pull/74757
- Metrics (done!): https://github.com/kubernetes/kubernetes/pull/73549
- Upgrade story: https://github.com/kubernetes/enhancements/pull/723

The only missing item is the CRI validation tests, but as those are not tied to the Kubernetes code freeze, I'd like to petition for moving forward with the beta and following up with the validation tests post-freeze.

This PR is hard-blocked on https://github.com/kubernetes/kubernetes/pull/74433

**Does this PR introduce a user-facing change?**:
```release-note
Promote RuntimeClass to beta, and enable by default.
```

/sig node
/priority important-soon
/milestone v1.14

/assign @dchen1107 @derekwaynecarr 
/cc @thockin @vishh 