### PR TITLE
Update glbc.manifest [WIP]

### DIFF
--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -1,20 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v1.2.3
+  name: l7-lb-controller
   namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
     seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
   labels:
     k8s-app: gcp-lb-controller
-    version: v1.2.3
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.2.3
+  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.4.0
     livenessProbe:
       httpGet:
         path: /healthz
@@ -31,9 +30,6 @@ spec:
     - mountPath: /etc/gce.conf
       name: cloudconfig
       readOnly: true
-    - mountPath: /var/log/glbc.log
-      name: logfile
-      readOnly: false
     resources:
       # Request is set to accommodate this pod alongside the other
       # master components on a single core master.
@@ -41,17 +37,24 @@ spec:
       requests:
         cpu: 10m
         memory: 50Mi
-    command:
-    # TODO: split this out into args when we no longer need to pipe stdout to a file #6428
-    - sh
-    - -c
-    - 'exec /glbc --gce-ratelimit=ga.Operations.Get,qps,10,100 --gce-ratelimit=alpha.Operations.Get,qps,10,100 --gce-ratelimit=ga.BackendServices.Get,qps,1.8,1 --gce-ratelimit=ga.HealthChecks.Get,qps,1.8,1 --gce-ratelimit=alpha.HealthChecks.Get,qps,1.8,1 --gce-ratelimit=beta.NetworkEndpointGroups.Get,qps,1.8,1 --gce-ratelimit=beta.NetworkEndpointGroups.AttachNetworkEndpoints,qps,1.8,1 --gce-ratelimit=beta.NetworkEndpointGroups.DetachNetworkEndpoints,qps,1.8,1 --gce-ratelimit=beta.NetworkEndpointGroups.ListNetworkEndpoints,qps,1.8,1 --verbose --apiserver-host=http://localhost:8080 --default-backend-service=kube-system/default-http-backend --sync-period=600s --running-in-cluster=false --use-real-cloud=true --config-file-path=/etc/gce.conf --healthz-port=8086 1>>/var/log/glbc.log 2>&1'
+    args:
+    - --apiserver-host=http://localhost:8080
+    - --default-backend-service=kube-system/default-http-backend
+    - --sync-period=600s
+    - --running-in-cluster=false
+    - --config-file-path=/etc/gce.conf
+    - --healthz-port=8086
+    - --gce-ratelimit=ga.Operations.Get,qps,10,100
+    - --gce-ratelimit=alpha.Operations.Get,qps,10,100
+    - --gce-ratelimit=ga.BackendServices.Get,qps,1.8,1
+    - --gce-ratelimit=ga.HealthChecks.Get,qps,1.8,1
+    - --gce-ratelimit=alpha.HealthChecks.Get,qps,1.8,1
+    - --gce-ratelimit=beta.NetworkEndpointGroups.Get,qps,1.8,1
+    - --gce-ratelimit=beta.NetworkEndpointGroups.AttachNetworkEndpoints,qps,1.8,1
+    - --gce-ratelimit=beta.NetworkEndpointGroups.DetachNetworkEndpoints,qps,1.8,1
+    - --gce-ratelimit=beta.NetworkEndpointGroups.ListNetworkEndpoints,qps,1.8,1
   volumes:
   - hostPath:
       path: /etc/gce.conf
       type: FileOrCreate
     name: cloudconfig
-  - hostPath:
-      path: /var/log/glbc.log
-      type: FileOrCreate
-    name: logfile


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Update glbc.manifest to be more in line with current state of the world. Currently v1.4.0 is our most recent stable minor release.

Also, fix the manifest so that logs are sent to stderr rather than to file. In a typical k8s-on-gce deployment, one can now see logs with 'kubectl get logs...' rather than having to ssh onto the node. 

```release-note
None
```

/assign @freehan 
