### PR TITLE
kubeadm: amend flags for join phases

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/join/BUILD
+++ b/cmd/kubeadm/app/cmd/phases/join/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/cmd/options:go_default_library",
         "//cmd/kubeadm/app/cmd/phases/workflow:go_default_library",
-        "//cmd/kubeadm/app/cmd/util:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/phases/certs:go_default_library",
         "//cmd/kubeadm/app/phases/controlplane:go_default_library",

--- a/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
@@ -31,13 +31,20 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/copycerts"
 	kubeconfigphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubeconfig"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+	"k8s.io/kubernetes/pkg/util/normalizer"
 )
+
+var controlPlanePrepareExample = normalizer.Examples(`
+	# Prepares the machine for serving a control plane
+	kubeadm join phase control-plane-prepare all
+`)
 
 // NewControlPlanePreparePhase creates a kubeadm workflow phase that implements the preparation of the node to serve a control plane
 func NewControlPlanePreparePhase() workflow.Phase {
 	return workflow.Phase{
-		Name:  "control-plane-prepare",
-		Short: "Prepares the machine for serving a control plane.",
+		Name:    "control-plane-prepare",
+		Short:   "Prepares the machine for serving a control plane.",
+		Example: controlPlanePrepareExample,
 		Phases: []workflow.Phase{
 			{
 				Name:           "all [api-server-endpoint]",
@@ -48,33 +55,75 @@ func NewControlPlanePreparePhase() workflow.Phase {
 			newControlPlanePrepareDownloadCertsSubphase(),
 			newControlPlanePrepareCertsSubphase(),
 			newControlPlanePrepareKubeconfigSubphase(),
-			newControlPlanePrepareManifestsSubphases(),
+			newControlPlanePrepareControlPlaneSubphase(),
 		},
 	}
 }
 
 func getControlPlanePreparePhaseFlags(name string) []string {
-	flags := []string{
-		options.APIServerAdvertiseAddress,
-		options.APIServerBindPort,
-		options.CfgPath,
-		options.ControlPlane,
-		options.NodeName,
-	}
-	if name != "manifests" {
-		flags = append(flags,
+	var flags []string
+	switch name {
+	case "all":
+		flags = []string{
+			options.APIServerAdvertiseAddress,
+			options.APIServerBindPort,
+			options.CfgPath,
+			options.ControlPlane,
+			options.NodeName,
 			options.FileDiscovery,
 			options.TokenDiscovery,
 			options.TokenDiscoveryCAHash,
 			options.TokenDiscoverySkipCAHash,
 			options.TLSBootstrapToken,
 			options.TokenStr,
-		)
-	}
-	if name == "all" || name == "download-certs" {
-		flags = append(flags,
 			options.CertificateKey,
-		)
+		}
+	case "download-certs":
+		flags = []string{
+			options.CfgPath,
+			options.ControlPlane,
+			options.FileDiscovery,
+			options.TokenDiscovery,
+			options.TokenDiscoveryCAHash,
+			options.TokenDiscoverySkipCAHash,
+			options.TLSBootstrapToken,
+			options.TokenStr,
+			options.CertificateKey,
+		}
+	case "certs":
+		flags = []string{
+			options.APIServerAdvertiseAddress,
+			options.CfgPath,
+			options.ControlPlane,
+			options.NodeName,
+			options.FileDiscovery,
+			options.TokenDiscovery,
+			options.TokenDiscoveryCAHash,
+			options.TokenDiscoverySkipCAHash,
+			options.TLSBootstrapToken,
+			options.TokenStr,
+		}
+	case "kubeconfig":
+		flags = []string{
+			options.CfgPath,
+			options.ControlPlane,
+			options.FileDiscovery,
+			options.TokenDiscovery,
+			options.TokenDiscoveryCAHash,
+			options.TokenDiscoverySkipCAHash,
+			options.TLSBootstrapToken,
+			options.TokenStr,
+			options.CertificateKey,
+		}
+	case "control-plane":
+		flags = []string{
+			options.APIServerAdvertiseAddress,
+			options.APIServerBindPort,
+			options.CfgPath,
+			options.ControlPlane,
+		}
+	default:
+		flags = []string{}
 	}
 	return flags
 }
@@ -106,16 +155,16 @@ func newControlPlanePrepareKubeconfigSubphase() workflow.Phase {
 	}
 }
 
-func newControlPlanePrepareManifestsSubphases() workflow.Phase {
+func newControlPlanePrepareControlPlaneSubphase() workflow.Phase {
 	return workflow.Phase{
 		Name:         "control-plane",
 		Short:        "Generates the manifests for the new control plane components",
-		Run:          runControlPlanePrepareManifestsSubphase, //NB. eventually in future we would like to break down this in sub phases for each component
-		InheritFlags: getControlPlanePreparePhaseFlags("manifests"),
+		Run:          runControlPlanePrepareControlPlaneSubphase, //NB. eventually in future we would like to break down this in sub phases for each component
+		InheritFlags: getControlPlanePreparePhaseFlags("control-plane"),
 	}
 }
 
-func runControlPlanePrepareManifestsSubphase(c workflow.RunData) error {
+func runControlPlanePrepareControlPlaneSubphase(c workflow.RunData) error {
 	data, ok := c.(JoinData)
 	if !ok {
 		return errors.New("control-plane-prepare phase invoked with an invalid data struct")


### PR DESCRIPTION
**What this PR does / why we need it**:

Certain join phases have flags that are redundant:
- getControlPlanePreparePhaseFlags():
  - amend flags (use switch / case)
  - add example for the parent command
  - rename internal function and sub-phase "manifests"
    to "control-plane"
- getControlPlaneJoinPhaseFlags():
  - amend flags
  - remove MacroCommandLongDescription

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/1204
gdoc for the flags:
https://docs.google.com/document/d/1tqgjB_KJMeYAXHYqOuBKKpCLSzxVgSl-MUfXf7d8C8U/edit#

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/kind cleanup
/priority important-soon
/assign @fabriziopandini @rosti 
@kubernetes/sig-cluster-lifecycle-pr-reviews 
