### PR TITLE
Promote E2E test to verify job does not exceed activeDeadlineSeconds limit to conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -23,6 +23,7 @@ test/e2e/apps/deployment.go: "RecreateDeployment should delete old pods and crea
 test/e2e/apps/deployment.go: "deployment should delete old replica sets"
 test/e2e/apps/deployment.go: "deployment should support rollover"
 test/e2e/apps/deployment.go: "deployment should support proportional scaling"
+test/e2e/apps/job.go: "should exceed active deadline"
 test/e2e/apps/rc.go: "should serve a basic image on each replica with a public image"
 test/e2e/apps/rc.go: "should adopt matching pods on creation"
 test/e2e/apps/rc.go: "should release no longer matching pods"

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -88,7 +88,12 @@ var _ = SIGDescribe("Job", func() {
 		Expect(err).NotTo(HaveOccurred(), "failed to ensure job completion in namespace: %s", f.Namespace.Name)
 	})
 
-	It("should exceed active deadline", func() {
+	/*
+		Release : v1.15
+		Testname: Jobs, activeDeadlineSeconds behaviour
+		Description: Create a job with a set activeDeadlineSeconds limit. Verify that the Job reaches activeDeadlineSeconds, all of its Pods are terminated and the Job status is set to type: Failed with reason: DeadlineExceeded.
+	*/
+	framework.ConformanceIt("should exceed active deadline", func() {
 		By("Creating a job")
 		var activeDeadlineSeconds int64 = 1
 		job := framework.NewTestJob("notTerminate", "exceed-active-deadline", v1.RestartPolicyNever, parallelism, completions, &activeDeadlineSeconds, backoffLimit)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: This PR requests to promote the existing e2e test to verify JOB behaviour with respect to "activeDeadlineSeconds" option to conformance. The job should be terminated once "activeDeadlineSeconds" limit is reached. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**: Aas per definition, "The activeDeadlineSeconds applies to the duration of the job, no matter how many Pods are created. Once a Job reaches activeDeadlineSeconds, all of its Pods are terminated and the Job status will become type: Failed with reason: DeadlineExceeded.". The defined behaviour is verified in the concerned E2E test. This PR request to promote the test to conformance. The E2E test takes approximately 8 seconds to execute and is non-flaky and non-disruptive.

**Does this PR introduce a user-facing change?**: NONE

/release-note-none

cc @brahmaroutu @mgdevstack 

/area conformance