### PR TITLE
avoid watching deep directories for plugin socket discovery

### DIFF
--- a/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
@@ -210,6 +210,10 @@ func (w *Watcher) traversePluginDir(dir string) error {
 			if err := w.fsWatcher.Add(path); err != nil {
 				return fmt.Errorf("failed to watch %s, err: %v", path, err)
 			}
+
+			if path != dir {
+				return filepath.SkipDir
+			}
 		case mode&os.ModeSocket != 0:
 			w.wg.Add(1)
 			go func() {


### PR DESCRIPTION
Signed-off-by: Chia-liang Kao <clkao@clkao.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This change limits the plugin directory traversal depth that CSI plugin registration socket is looked for. the deprecated plugin path traversal causes excessive watcher.add calls, as flex volume might mount the filesystem under the directory.  for example, rook rbd volumes are under `/var/lib/kubelet/plugins/rook.io/rook/mounts`

Note that https://github.com/kubernetes/kubernetes/pull/72221 added `/varlib/kubelet/plugins/kubernetes.io` as blacklist for traversal, which prevented the problem with using gce-pd pvc.

Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #74669 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed kubelet failed starts due to excessive mounted pvc traversal, which exhausted inotify watcher or crash on pvcs that are full.
```

/sig storage
/sig node