### PR TITLE
clean the deprecated metrics which introduced recently

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1356,7 +1356,6 @@ func (proxier *Proxier) syncProxyRules() {
 	for _, lastChangeTriggerTime := range endpointUpdateResult.LastChangeTriggerTimes {
 		latency := metrics.SinceInSeconds(lastChangeTriggerTime)
 		metrics.NetworkProgrammingLatency.Observe(latency)
-		metrics.DeprecatedNetworkProgrammingLatency.Observe(latency)
 		klog.V(4).Infof("Network programming took %f seconds", latency)
 	}
 

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1203,7 +1203,6 @@ func (proxier *Proxier) syncProxyRules() {
 	for _, lastChangeTriggerTime := range endpointUpdateResult.LastChangeTriggerTimes {
 		latency := metrics.SinceInSeconds(lastChangeTriggerTime)
 		metrics.NetworkProgrammingLatency.Observe(latency)
-		metrics.DeprecatedNetworkProgrammingLatency.Observe(latency)
 		klog.V(4).Infof("Network programming took %f seconds", latency)
 	}
 

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -63,18 +63,6 @@ var (
 			Buckets: prometheus.ExponentialBuckets(0.001, 2, 20),
 		},
 	)
-
-	// DeprecatedNetworkProgrammingLatency is deprecated, please use NetworkProgrammingLatency.
-	DeprecatedNetworkProgrammingLatency = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Subsystem: kubeProxySubsystem,
-			Name:      "network_programming_latency_seconds",
-			Help:      "(Deprecated) In Cluster Network Programming Latency in seconds",
-			// TODO(mm4tt): Reevaluate buckets before 1.14 release.
-			// The last bucket will be [0.001s*2^20 ~= 17min, +inf)
-			Buckets: prometheus.ExponentialBuckets(0.001, 2, 20),
-		},
-	)
 )
 
 var registerMetricsOnce sync.Once
@@ -85,7 +73,6 @@ func RegisterMetrics() {
 		prometheus.MustRegister(SyncProxyRulesLatency)
 		prometheus.MustRegister(DeprecatedSyncProxyRulesLatency)
 		prometheus.MustRegister(NetworkProgrammingLatency)
-		prometheus.MustRegister(DeprecatedNetworkProgrammingLatency)
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
/sig instrumentation

**What this PR does / why we need it**:

Thanks for @liggitt 's finding, the metrics `network_programming_latency_seconds` is newly introduced in 1.14. It can safely be replaced by `network_programming_duration_seconds` .

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
