### PR TITLE
kubeadm: Don't hardcode temp path in a test

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -18,11 +18,9 @@ package upgrade
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
-	"time"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
@@ -77,17 +75,25 @@ func TestGetK8sVersionFromUserInput(t *testing.T) {
 			name: "Version is optional",
 		},
 	}
-	for tnum, tt := range tcases {
+	for _, tt := range tcases {
 		t.Run(tt.name, func(t *testing.T) {
 			flags := &applyPlanFlags{}
 			if len(tt.clusterConfig) > 0 {
-				tmpfile := fmt.Sprintf("/tmp/kubeadm-upgrade-common-test-%d-%d.yaml", tnum, time.Now().Unix())
-				if err := ioutil.WriteFile(tmpfile, []byte(tt.clusterConfig), 0666); err != nil {
+				file, err := ioutil.TempFile("", "kubeadm-upgrade-common-test-*.yaml")
+				if err != nil {
 					t.Fatalf("Failed to create test config file: %+v", err)
 				}
-				defer os.Remove(tmpfile)
 
-				flags.cfgPath = tmpfile
+				tmpFileName := file.Name()
+				defer os.Remove(tmpFileName)
+
+				_, err = file.WriteString(tt.clusterConfig)
+				file.Close()
+				if err != nil {
+					t.Fatalf("Failed to write test config file contents: %+v", err)
+				}
+
+				flags.cfgPath = tmpFileName
 			}
 
 			userVersion, err := getK8sVersionFromUserInput(flags, tt.args, tt.isVersionMandatory)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Hard-coding a temp path of /tmp/... is not portable and can potentially cause other issues (such as flakyness) too.
Use TempFile instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

**Special notes for your reviewer**:

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/priority important-longterm
/assign @neolit123
/assign @fabriziopandini

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
