### PR TITLE
Add examples how to run make test-cmd specific tests

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -282,8 +282,12 @@ endif
 define TEST_CMD_HELP_INFO
 # Build and run cmdline tests.
 #
+# Args:
+#   WHAT: List of tests to run, check test/cmd/legacy-script.sh for names.
+#     For example, WHAT=deployment will run run_deployment_tests function.
 # Example:
 #   make test-cmd
+#   make test-cmd WHAT="deployment impersonation"
 endef
 .PHONY: test-cmd
 ifeq ($(PRINT_HELP),y)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is adding sample usage for `make test-cmd` which now allows running only a subset of tests. This is a followup to https://github.com/kubernetes/kubernetes/pull/72939

**Special notes for your reviewer**:
/assign @liggitt 
/cc @runyontr

/sig cli
/priority important-longterm

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
