### PR TITLE
feat: update pvc accessmodes and resources when statefulset creates/u…

### DIFF
--- a/pkg/controller/statefulset/BUILD
+++ b/pkg/controller/statefulset/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/controller/history:go_default_library",
+        "//pkg/volume/util:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -307,6 +307,30 @@ func AccessModesContainedInAll(indexedModes []v1.PersistentVolumeAccessMode, req
 	return true
 }
 
+// AccessModesEqualSet returns true when two array of modes exactly represent the same set of access modes
+func AccessModesEqualSet(modes []v1.PersistentVolumeAccessMode, otherModes []v1.PersistentVolumeAccessMode) bool {
+	var uniqModes []v1.PersistentVolumeAccessMode
+	var uniqOtherModes []v1.PersistentVolumeAccessMode
+
+	for _, mode := range modes {
+		if AccessModesContains(uniqModes, mode) {
+			continue
+		}
+		uniqModes = append(uniqModes, mode)
+	}
+
+	for _, mode := range otherModes {
+		if AccessModesContains(uniqOtherModes, mode) {
+			continue
+		}
+		uniqOtherModes = append(uniqOtherModes, mode)
+	}
+
+	return len(uniqModes) == len(uniqOtherModes) &&
+		AccessModesContainedInAll(uniqModes, uniqOtherModes) &&
+		AccessModesContainedInAll(uniqOtherModes, uniqModes)
+}
+
 // GetWindowsPath get a windows path
 func GetWindowsPath(path string) string {
 	windowsPath := strings.Replace(path, "/", "\\", -1)


### PR DESCRIPTION
**What type of PR is this?**

kind/feature

**What this PR does / why we need it**:

Update PVC accessmodes and storage when statefulset updates volumeClaimTemplates

Related to #57587

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update PVC accessmodes and storage when statefulset updates volumeClaimTemplates
```
