### PR TITLE
Disable Windows Defender in Windows nodes on GCE again.

### DIFF
--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -100,6 +100,7 @@ try {
   Dump-DebugInfoToConsole
   Set-PrerequisiteOptions
   $kube_env = Fetch-KubeEnv
+  Disable-WindowsDefender
 
   if (Test-IsTestCluster $kube_env) {
     Log-Output 'Test cluster detected, installing OpenSSH.'


### PR DESCRIPTION
/kind bug

This reverts commit fbf4fe4714d749ced197ce51b3b806304dda091a. Windows
Defender seems to be causing our Windows nodes to crash and reboot
during e2e tests, e.g.
https://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-windows-gce/228/artifacts/e2e-228-36623-windows-node-group-q4.

```release-note
NONE
```