### PR TITLE
fix hack/update-bazel.sh for mac os environments

### DIFF
--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -31,7 +31,7 @@ go install k8s.io/kubernetes/vendor/k8s.io/repo-infra/kazel
 
 # Find all of the staging repos.
 while IFS='' read -r repo; do staging_repos+=("${repo}"); done <\
-  <(cd "${KUBE_ROOT}/staging/src" && find k8s.io/ -mindepth 1 -maxdepth 1 -type d | LANG=C sort)
+  <(cd "${KUBE_ROOT}/staging/src" && find k8s.io -mindepth 1 -maxdepth 1 -type d | LANG=C sort)
 
 # Save the staging repos into a Starlark list that can be used by Bazel rules.
 (


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix `hack/update-bazel.sh` for mac environments. `find` prepends an extra `/` and replacing `k8s.io/` with `k8s.io` fixes it. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @ixdy 