### PR TITLE
Ignore changes to managed field in noderestriction

### DIFF
--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -309,6 +309,12 @@ func (c *nodePlugin) admitPVCStatus(nodeName string, a admission.Attributes) err
 		oldPVC.Status.Conditions = nil
 		newPVC.Status.Conditions = nil
 
+		// TODO(apelisse): We don't have a good mechanism to
+		// verify that only the things that should have changed
+		// have changed. Ignore it for now.
+		oldPVC.ObjectMeta.ManagedFields = nil
+		newPVC.ObjectMeta.ManagedFields = nil
+
 		// ensure no metadata changed. nodes should not be able to relabel, add finalizers/owners, etc
 		if !apiequality.Semantic.DeepEqual(oldPVC, newPVC) {
 			return admission.NewForbidden(a, fmt.Errorf("node %q is not allowed to update fields other than status.capacity and status.conditions: %v", nodeName, diff.ObjectReflectDiff(oldPVC, newPVC)))


### PR DESCRIPTION
The validation is failing because the managedfields are changed when the
object is updated. We don't have a good way to verify that the changes
are only the ones that are supposed to happen, so we'll just ignore them
for now.

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #74049

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @msau42 @liggitt 
