### PR TITLE
fix handling of nil times in managedFields sorting

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -160,8 +161,12 @@ func sortEncodedManagedFields(encodedManagedFields []metav1.ManagedFieldsEntry) 
 			return p.Operation < q.Operation
 		}
 
-		if p.Time == nil || q.Time == nil {
-			return false
+		ntime := &metav1.Time{Time: time.Time{}}
+		if p.Time == nil {
+			p.Time = ntime
+		}
+		if q.Time == nil {
+			q.Time = ntime
 		}
 		if !p.Time.Equal(q.Time) {
 			return p.Time.Before(q.Time)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields_test.go
@@ -229,6 +229,30 @@ func TestSortEncodedManagedFields(t *testing.T) {
 			},
 		},
 		{
+			name: "manager without time first",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "a", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+				{Manager: "a", Operation: metav1.ManagedFieldsOperationApply, Time: parseTimeOrPanic("2001-01-01T01:00:00Z")},
+			},
+			expected: []metav1.ManagedFieldsEntry{
+				{Manager: "a", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+				{Manager: "a", Operation: metav1.ManagedFieldsOperationApply, Time: parseTimeOrPanic("2001-01-01T01:00:00Z")},
+			},
+		},
+		{
+			name: "manager without time first name last",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "a", Operation: metav1.ManagedFieldsOperationApply, Time: parseTimeOrPanic("2001-01-01T01:00:00Z")},
+				{Manager: "b", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+				{Manager: "a", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+			},
+			expected: []metav1.ManagedFieldsEntry{
+				{Manager: "a", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+				{Manager: "b", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+				{Manager: "a", Operation: metav1.ManagedFieldsOperationApply, Time: parseTimeOrPanic("2001-01-01T01:00:00Z")},
+			},
+		},
+		{
 			name: "apply first",
 			managedFields: []metav1.ManagedFieldsEntry{
 				{Manager: "a", Operation: metav1.ManagedFieldsOperationUpdate, Time: parseTimeOrPanic("2001-01-01T01:00:00Z")},
@@ -274,18 +298,24 @@ func TestSortEncodedManagedFields(t *testing.T) {
 			managedFields: []metav1.ManagedFieldsEntry{
 				{Manager: "c", Operation: metav1.ManagedFieldsOperationUpdate, Time: parseTimeOrPanic("2001-01-01T01:00:00Z")},
 				{Manager: "a", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+				{Manager: "g", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
 				{Manager: "f", Operation: metav1.ManagedFieldsOperationUpdate, Time: parseTimeOrPanic("2002-01-01T01:00:00Z")},
+				{Manager: "i", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
 				{Manager: "d", Operation: metav1.ManagedFieldsOperationUpdate, Time: parseTimeOrPanic("2002-01-01T01:00:00Z")},
-				{Manager: "e", Operation: metav1.ManagedFieldsOperationUpdate, Time: parseTimeOrPanic("2002-01-01T01:00:00Z")},
+				{Manager: "h", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+				{Manager: "e", Operation: metav1.ManagedFieldsOperationUpdate, Time: parseTimeOrPanic("2003-01-01T01:00:00Z")},
 				{Manager: "b", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
 			},
 			expected: []metav1.ManagedFieldsEntry{
 				{Manager: "a", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
 				{Manager: "b", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+				{Manager: "g", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+				{Manager: "h", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+				{Manager: "i", Operation: metav1.ManagedFieldsOperationApply, Time: nil},
 				{Manager: "c", Operation: metav1.ManagedFieldsOperationUpdate, Time: parseTimeOrPanic("2001-01-01T01:00:00Z")},
 				{Manager: "d", Operation: metav1.ManagedFieldsOperationUpdate, Time: parseTimeOrPanic("2002-01-01T01:00:00Z")},
-				{Manager: "e", Operation: metav1.ManagedFieldsOperationUpdate, Time: parseTimeOrPanic("2002-01-01T01:00:00Z")},
 				{Manager: "f", Operation: metav1.ManagedFieldsOperationUpdate, Time: parseTimeOrPanic("2002-01-01T01:00:00Z")},
+				{Manager: "e", Operation: metav1.ManagedFieldsOperationUpdate, Time: parseTimeOrPanic("2003-01-01T01:00:00Z")},
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
follow-up to fix issues addressed in https://github.com/kubernetes/kubernetes/pull/74721#discussion_r262752109

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig api-machinery
/cc @apelisse @jennybuckley @tedyu 
/wg apply