### PR TITLE
testing: use arch-specific image instead of legacy amd64 workaround

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -253,12 +253,12 @@ func GetConfig(image int) Config {
 
 // GetE2EImage returns the fully qualified URI to an image (including version)
 func GetE2EImage(image int) string {
-	return fmt.Sprintf("%s/%s:%s", imageConfigs[image].registry, imageConfigs[image].name, imageConfigs[image].version)
+	return fmt.Sprintf("%s/%s-amd64:%s", imageConfigs[image].registry, imageConfigs[image].name, imageConfigs[image].version)
 }
 
 // GetE2EImage returns the fully qualified URI to an image (including version)
 func (i *Config) GetE2EImage() string {
-	return fmt.Sprintf("%s/%s:%s", i.registry, i.name, i.version)
+	return fmt.Sprintf("%s/%s-amd64:%s", i.registry, i.name, i.version)
 }
 
 // GetPauseImageName returns the pause image name with proper version


### PR DESCRIPTION
fixes: https://github.com/kubernetes/kubernetes/issues/75076

ref: "Actual tests need to be modified to use these images based on the architecture later." https://github.com/kubernetes/kubernetes/pull/44910

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig testing