### PR TITLE
Promote container runtime e2e having non default TerminationMessagePath set

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -147,6 +147,7 @@ test/e2e/common/projected_secret.go: "should be consumable from pods in volume w
 test/e2e/common/projected_secret.go: "should be consumable in multiple volumes in a pod"
 test/e2e/common/projected_secret.go: "optional updates should be reflected in volume"
 test/e2e/common/runtime.go: "should run with the expected status"
+test/e2e/common/runtime.go: "should report termination message  if TerminationMessagePath is set as non-root user and at a non-default path"
 test/e2e/common/secrets.go: "should be consumable from pods in env vars"
 test/e2e/common/secrets.go: "should be consumable via the environment"
 test/e2e/common/secrets_volume.go: "should be consumable from pods in volume"

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -174,8 +174,13 @@ while true; do sleep 1; done
 				matchTerminationMessage(container, v1.PodSucceeded, Equal("DONE"))
 			})
 
-			It("should report termination message [LinuxOnly] if TerminationMessagePath is set as non-root user and at a non-default path [NodeConformance]", func() {
-				// Cannot mount files in Windows Containers.
+			/*
+				Release: v1.15
+				Name: Container Runtime, TerminationMessagePath, non-root user and non-default path
+				Description: Create a pod with a container to run it as a non-root user with a custom TerminationMessagePath set. Pod redirects the output to the provided path successfully. When the container is terminated, the termination message MUST match the expected output logged in the provided custom path.
+				[LinuxOnly]: Tagged LinuxOnly due to use of 'uid' and unable to mount files in Windows Containers.
+			*/
+			framework.ConformanceIt("should report termination message [LinuxOnly] if TerminationMessagePath is set as non-root user and at a non-default path [NodeConformance]", func() {
 				container := v1.Container{
 					Image:                  framework.BusyBoxImage,
 					Command:                []string{"/bin/sh", "-c"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Promotes container runtime e2e which validates terminationMessage behavior when custom terminationMessagePath is set and the container is allowed to run as non-root user.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
- No flakes found
- Verifies important behavior of retrieving termination message from a custom path.
- Execution completion time:  [SLOW TEST:8.136 seconds]

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/area conformance
/sig testing
@kubernetes/sig-node-pr-reviews 
@kubernetes/sig-architecture-pr-reviews 
@kubernetes/cncf-conformance-wg