### PR TITLE
events: add NewBroadcasterWithNoSpamFilter broadcaster

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/event_test.go
@@ -416,7 +416,7 @@ func TestWriteEventError(t *testing.T) {
 	}
 
 	clock := clock.IntervalClock{Time: time.Now(), Duration: time.Second}
-	eventCorrelator := NewEventCorrelator(&clock)
+	eventCorrelator := NewEventCorrelator(&clock, NewEventSourceObjectSpamFilter(&clock))
 	randGen := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	for caseName, ent := range table {

--- a/staging/src/k8s.io/client-go/tools/record/events_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/events_cache_test.go
@@ -234,7 +234,7 @@ func TestEventCorrelator(t *testing.T) {
 	for testScenario, testInput := range scenario {
 		eventInterval := time.Duration(testInput.intervalSeconds) * time.Second
 		clock := clock.IntervalClock{Time: time.Now(), Duration: eventInterval}
-		correlator := NewEventCorrelator(&clock)
+		correlator := NewEventCorrelator(&clock, NewEventSourceObjectSpamFilter(&clock))
 		for i := range testInput.previousEvents {
 			event := testInput.previousEvents[i]
 			now := metav1.NewTime(clock.Now())


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Existing `NewBroadcaster` implementation hide a "spam filter" in the event correlation. The spam filter can cause that some events are removed if the event source is the same (involved object + component name, etc.). 
In some cases this is not desired and it might lead to situation where important events are missing because of this rate limiting.

`NewBroadcasterWithNoSpamFilter` is added to addition to `NewBroadcaster` (so it won't break the client-go API and the existing applications). This allows users to opt-out from using the spam filter in events.

A use-case here is to have an operator that use event recorder with involved object set the to operator namespace or the workload resource where the operator binary runs.
Inside the operator there are 10 control loops all sharing this event broadcaster and all firing events.
The result is that only few events pass the spam filter and a lot of events is just dropped.

```release-note
NONE
```