### PR TITLE
Fix initContainer failed to get its own field value as environment variable values

### DIFF
--- a/pkg/api/v1/resource/helpers.go
+++ b/pkg/api/v1/resource/helpers.go
@@ -177,6 +177,11 @@ func findContainerInPod(pod *v1.Pod, containerName string) (*v1.Container, error
 			return &container, nil
 		}
 	}
+	for _, container := range pod.Spec.InitContainers {
+		if container.Name == containerName {
+			return &container, nil
+		}
+	}
 	return nil, fmt.Errorf("container %s not found", containerName)
 }
 

--- a/pkg/api/v1/resource/helpers_test.go
+++ b/pkg/api/v1/resource/helpers_test.go
@@ -137,6 +137,72 @@ func TestExtractResourceValue(t *testing.T) {
 			pod:           getPod("foo", "", "", "10Mi", "100Mi"),
 			expectedValue: "104857600",
 		},
+		{
+			fs: &v1.ResourceFieldSelector{
+				Resource: "limits.cpu",
+			},
+			cName:         "init-foo",
+			pod:           getPod("foo", "", "9", "", ""),
+			expectedValue: "9",
+		},
+		{
+			fs: &v1.ResourceFieldSelector{
+				Resource: "requests.cpu",
+			},
+			cName:         "init-foo",
+			pod:           getPod("foo", "", "", "", ""),
+			expectedValue: "0",
+		},
+		{
+			fs: &v1.ResourceFieldSelector{
+				Resource: "requests.cpu",
+			},
+			cName:         "init-foo",
+			pod:           getPod("foo", "8", "", "", ""),
+			expectedValue: "8",
+		},
+		{
+			fs: &v1.ResourceFieldSelector{
+				Resource: "requests.cpu",
+			},
+			cName:         "init-foo",
+			pod:           getPod("foo", "100m", "", "", ""),
+			expectedValue: "1",
+		},
+		{
+			fs: &v1.ResourceFieldSelector{
+				Resource: "requests.cpu",
+				Divisor:  resource.MustParse("100m"),
+			},
+			cName:         "init-foo",
+			pod:           getPod("foo", "1200m", "", "", ""),
+			expectedValue: "12",
+		},
+		{
+			fs: &v1.ResourceFieldSelector{
+				Resource: "requests.memory",
+			},
+			cName:         "init-foo",
+			pod:           getPod("foo", "", "", "100Mi", ""),
+			expectedValue: "104857600",
+		},
+		{
+			fs: &v1.ResourceFieldSelector{
+				Resource: "requests.memory",
+				Divisor:  resource.MustParse("1Mi"),
+			},
+			cName:         "init-foo",
+			pod:           getPod("foo", "", "", "100Mi", "1Gi"),
+			expectedValue: "100",
+		},
+		{
+			fs: &v1.ResourceFieldSelector{
+				Resource: "limits.memory",
+			},
+			cName:         "init-foo",
+			pod:           getPod("foo", "", "", "10Mi", "100Mi"),
+			expectedValue: "104857600",
+		},
 	}
 	as := assert.New(t)
 	for idx, tc := range cases {
@@ -172,6 +238,12 @@ func getPod(cname, cpuRequest, cpuLimit, memoryRequest, memoryLimit string) *v1.
 			Containers: []v1.Container{
 				{
 					Name:      cname,
+					Resources: resources,
+				},
+			},
+			InitContainers: []v1.Container{
+				{
+					Name:      "init-" + cname,
 					Resources: resources,
 				},
 			},


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix initContainer failed to get its own field value as environment variable values

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/75103

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow init container to get its own field value as environment variable values(downwardAPI spport)
```
