### PR TITLE
Send events before adding watchers in traversePluginDir

### DIFF
--- a/pkg/kubelet/util/pluginwatcher/BUILD
+++ b/pkg/kubelet/util/pluginwatcher/BUILD
@@ -29,6 +29,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/kubelet/apis/pluginregistration/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
@@ -124,24 +124,17 @@ func (w *Watcher) Start() error {
 			select {
 			case event := <-fsWatcher.Events:
 				//TODO: Handle errors by taking corrective measures
-
-				w.wg.Add(1)
-				func() {
-					defer w.wg.Done()
-
-					if event.Op&fsnotify.Create == fsnotify.Create {
-						err := w.handleCreateEvent(event)
-						if err != nil {
-							klog.Errorf("error %v when handling create event: %s", err, event)
-						}
-					} else if event.Op&fsnotify.Remove == fsnotify.Remove {
-						err := w.handleDeleteEvent(event)
-						if err != nil {
-							klog.Errorf("error %v when handling delete event: %s", err, event)
-						}
+				if event.Op&fsnotify.Create == fsnotify.Create {
+					err := w.handleCreateEvent(event)
+					if err != nil {
+						klog.Errorf("error %v when handling create event: %s", err, event)
 					}
-					return
-				}()
+				} else if event.Op&fsnotify.Remove == fsnotify.Remove {
+					err := w.handleDeleteEvent(event)
+					if err != nil {
+						klog.Errorf("error %v when handling delete event: %s", err, event)
+					}
+				}
 				continue
 			case err := <-fsWatcher.Errors:
 				if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR changes the function `devicemanager.traversePluginDir` in order to send events before adding watchers to directories.

**Which issue(s) this PR fixes**:

Fixes #75097

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
/sig storage
/sig node
/assign @liggitt 