### PR TITLE
add config file for nodetaint admission

### DIFF
--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -70,7 +70,7 @@ var AllOrderedPlugins = []string{
 	limitranger.PluginName,                  // LimitRanger
 	serviceaccount.PluginName,               // ServiceAccount
 	noderestriction.PluginName,              // NodeRestriction
-	nodetaint.PluginName,                    // TaintNodesByCondition
+	nodetaint.PluginName,                    // TaintNodesAtCreation
 	alwayspullimages.PluginName,             // AlwaysPullImages
 	imagepolicy.PluginName,                  // ImagePolicyWebhook
 	podsecuritypolicy.PluginName,            // PodSecurityPolicy
@@ -144,7 +144,7 @@ func DefaultOffAdmissionPlugins() sets.String {
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.TaintNodesByCondition) {
-		defaultOnPlugins.Insert(nodetaint.PluginName) //TaintNodesByCondition
+		defaultOnPlugins.Insert(nodetaint.PluginName) //TaintNodesAtCreation
 	}
 
 	return sets.NewString(AllOrderedPlugins...).Difference(defaultOnPlugins)

--- a/plugin/pkg/admission/nodetaint/BUILD
+++ b/plugin/pkg/admission/nodetaint/BUILD
@@ -2,12 +2,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["admission.go"],
+    srcs = [
+        "admission.go",
+        "config.go",
+    ],
     importpath = "k8s.io/kubernetes/plugin/pkg/admission/nodetaint",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/core:go_default_library",
         "//pkg/features:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],

--- a/plugin/pkg/admission/nodetaint/config.go
+++ b/plugin/pkg/admission/nodetaint/config.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodetaint
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+// AdmissionConfig holds config data for admission controllers
+type AdmissionConfig struct {
+	Taints []api.Taint
+}
+
+// loadConfiguration loads the provided configuration.
+func loadConfiguration(reader io.Reader) (*AdmissionConfig, error) {
+	// if no config is provided, return a default configuration
+	var admissionConfig AdmissionConfig
+	if reader == nil {
+		return &admissionConfig, nil
+	}
+	// we have a config so parse it.
+	d := yaml.NewYAMLOrJSONDecoder(reader, 4096)
+	if err := d.Decode(&admissionConfig); err != nil {
+		return nil, err
+	}
+	return &admissionConfig, nil
+}

--- a/test/e2e_node/services/apiserver.go
+++ b/test/e2e_node/services/apiserver.go
@@ -55,7 +55,7 @@ func (a *APIServer) Start() error {
 	}
 	o.ServiceClusterIPRange = *ipnet
 	o.AllowPrivileged = true
-	o.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
+	o.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesAtCreation"}
 	errCh := make(chan error)
 	go func() {
 		defer close(errCh)

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -83,7 +83,7 @@ func TestNodeAuthorizer(t *testing.T) {
 		"--enable-admission-plugins", "NodeRestriction",
 		// The "default" SA is not installed, causing the ServiceAccount plugin to retry for ~1s per
 		// API request.
-		"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition",
+		"--disable-admission-plugins", "ServiceAccount,TaintNodesAtCreation",
 	}, framework.SharedEtcd())
 	defer server.TearDownFn()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
>
> /kind enhancement

**What this PR does / why we need it**:
Add taints specified in config file to new nodes during admission

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #75108

**Special notes for your reviewer**:
Not-ready taint will always be added to node whether config file is specified. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
User could add taints specified in config file to new nodes during admission.
User's custom controller is responsible for removing the taints when it judges node schedulable .
```
