### PR TITLE
Adding conditional constraint before semver substitution

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -71,11 +71,12 @@ kube::version::get_version_vars() {
       # TODO: We continue calling this "git version" because so many
       # downstream consumers are expecting it there.
       DASHES_IN_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/[^-]//g")
+      PLUSES_IN_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/[^+]//g")
       if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
         # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
         KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
-      elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
-        # We have distance to base tag (v1.1.0-1-gCommitHash)
+      elif [[ "${DASHES_IN_VERSION}" == "--" ]] && [[ -z "${PLUSES_IN_VERSION}" ]]; then
+        # We have distance to base tag (v1.1.0-1-gCommitHash) and no existing downstream metadata ('+')
         KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
       fi
       if [[ "${KUBE_GIT_TREE_STATE}" == "dirty" ]]; then


### PR DESCRIPTION
Signed-off-by: Ruben Orduz <rdodev@vmware.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug


**What this PR does / why we need it**:
This PR adds a check to the build scripts so that if there's already downstream metadata (i.e. 'vM.m.p+stuffhere') in the tag presently being built it doesn't replace the replace '-' with a '+' and thus respecting semver and regex.
**Which issue(s) this PR fixes**:

Fixes #
https://github.com/kubernetes/kubernetes/issues/75297

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Fixed: It is now possible to build downstream tagged versions with SemVer metadata ('vM.m.p+metadata')
```
