### PR TITLE
Handle watch.Errors in Until*

### DIFF
--- a/pkg/kubectl/cmd/delete/delete.go
+++ b/pkg/kubectl/cmd/delete/delete.go
@@ -297,9 +297,11 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		DynamicClient:  o.DynamicClient,
 		Timeout:        effectiveTimeout,
 
-		Printer:     printers.NewDiscardingPrinter(),
-		ConditionFn: cmdwait.IsDeleted,
-		IOStreams:   o.IOStreams,
+		Printer: printers.NewDiscardingPrinter(),
+		ConditionFn: cmdwait.Wait{
+			ErrOut: o.Out,
+		}.IsDeleted,
+		IOStreams: o.IOStreams,
 	}
 	err = waitOptions.RunWait()
 	if errors.IsForbidden(err) || errors.IsMethodNotSupported(err) {

--- a/pkg/kubectl/cmd/wait/wait_test.go
+++ b/pkg/kubectl/cmd/wait/wait_test.go
@@ -18,6 +18,7 @@ package wait
 
 import (
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -425,9 +426,11 @@ func TestWaitForDeletion(t *testing.T) {
 				DynamicClient:  fakeClient,
 				Timeout:        test.timeout,
 
-				Printer:     printers.NewDiscardingPrinter(),
-				ConditionFn: IsDeleted,
-				IOStreams:   genericclioptions.NewTestIOStreamsDiscard(),
+				Printer: printers.NewDiscardingPrinter(),
+				ConditionFn: Wait{
+					ErrOut: os.Stdout,
+				}.IsDeleted,
+				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
 			}
 			err := o.RunWait()
 			switch {

--- a/staging/src/k8s.io/client-go/tools/watch/BUILD
+++ b/staging/src/k8s.io/client-go/tools/watch/BUILD
@@ -34,6 +34,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
Every single user of `client-go/tools/watch.Until*` functions needs to check for this case and it is likely that some forget to do so. This will make sure it's converted into the returned golang error which needs to be checked anyways.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`client-go/tools/watch.Until*` functions now handle watcher errors and wrap them into a golang error that is returned
```

@smarterclayton you asked for it here: https://github.com/kubernetes/kubernetes/pull/50102/commits/fc1d926e04be717f75823597556da4da41cfd7ef#r206550022

@kubernetes/sig-api-machinery-pr-reviews 