### PR TITLE
Fixed log message in client-go

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -356,7 +356,7 @@ func LoadFromFile(filename string) (*clientcmdapi.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	klog.V(6).Infoln("Config loaded from file", filename)
+	klog.V(6).Infoln("Config loaded from file: ", filename)
 
 	// set LocationOfOrigin on every Cluster, User, and Context
 	for key, obj := range config.AuthInfos {


### PR DESCRIPTION
An example of incorrect log message:

{
  "component":"virtctl",
  "level":"info",
  "msg":"Config loaded from fileocp/auth/kubeconfig",
  "pos":"loader.go:359",
  "timestamp":"2019-03-07T18:50:20.923470Z"
}

```release-note
NONE
```

Note how the resulting message has no characters between the text and
file name.