### PR TITLE
e2e: external snapshotter

### DIFF
--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -253,7 +253,7 @@ func (d *driverDefinition) GetSnapshotClass(config *testsuites.PerTestConfig) *u
 		framework.Skipf("Driver %q does not support snapshotting - skipping", d.DriverInfo.Name)
 	}
 
-	snapshotter := config.GetUniqueDriverName()
+	snapshotter := d.DriverInfo.Name
 	parameters := map[string]string{}
 	ns := config.Framework.Namespace.Name
 	suffix := snapshotter + "-vsc"

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -192,6 +192,8 @@ func (d *driverDefinition) SkipUnsupportedTest(pattern testpatterns.TestPattern)
 	supported := false
 	// TODO (?): add support for more volume types
 	switch pattern.VolType {
+	case "":
+		supported = true
 	case testpatterns.DynamicPV:
 		if d.StorageClass.FromName || d.StorageClass.FromFile != "" {
 			supported = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The recently introduced support for testing an external storage driver (PR #72836) had code for testing snapshotting, but that code turned out to be faulty:
- drivers which supported snapshotting skipped a test that should have run
- snapshotting failed because the  snapshotter name was wrong

With this PR, the kubernetes-csi CI script runs the snapshotting test successfully.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig storage
/assign @msau42 
/priority important-soon
