### PR TITLE
Automated cherry pick of #74625: GetMountRefs fixed to handle corrupted mounts by treating it

### DIFF
--- a/pkg/util/mount/mount_helper.go
+++ b/pkg/util/mount/mount_helper.go
@@ -120,5 +120,5 @@ func IsCorruptedMnt(err error) bool {
 		underlyingError = pe.Err
 	}
 
-	return underlyingError == syscall.ENOTCONN || underlyingError == syscall.ESTALE || underlyingError == syscall.EIO
+	return underlyingError == syscall.ENOTCONN || underlyingError == syscall.ESTALE || underlyingError == syscall.EIO || underlyingError == syscall.EACCES
 }

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -1003,10 +1003,14 @@ func (mounter *Mounter) SafeMakeDir(subdir string, base string, perm os.FileMode
 }
 
 func (mounter *Mounter) GetMountRefs(pathname string) ([]string, error) {
-	if _, err := os.Stat(pathname); os.IsNotExist(err) {
+	pathExists, pathErr := PathExists(pathname)
+	if !pathExists {
 		return []string{}, nil
-	} else if err != nil {
-		return nil, err
+	} else if IsCorruptedMnt(pathErr) {
+		glog.Warningf("GetMountRefs found corrupted mount at %s, treating as unmounted path", pathname)
+		return []string{}, nil
+	} else if pathErr != nil {
+		return nil, fmt.Errorf("error checking path %s: %v", pathname, pathErr)
 	}
 	realpath, err := filepath.EvalSymlinks(pathname)
 	if err != nil {

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -496,10 +496,14 @@ func getAllParentLinks(path string) ([]string, error) {
 
 // GetMountRefs : empty implementation here since there is no place to query all mount points on Windows
 func (mounter *Mounter) GetMountRefs(pathname string) ([]string, error) {
-	if _, err := os.Stat(normalizeWindowsPath(pathname)); os.IsNotExist(err) {
+	pathExists, pathErr := PathExists(normalizeWindowsPath(pathname))
+	// TODO(#75012): Need a Windows specific IsCorruptedMnt function that checks against whatever errno's
+	// Windows emits when we try to Stat a corrupted mount
+	// https://golang.org/pkg/syscall/?GOOS=windows&GOARCH=amd64#Errno
+	if !pathExists {
 		return []string{}, nil
-	} else if err != nil {
-		return nil, err
+	} else if pathErr != nil {
+		return nil, fmt.Errorf("error checking path %s: %v", normalizeWindowsPath(pathname), pathErr)
 	}
 	return []string{pathname}, nil
 }

--- a/pkg/util/mount/nsenter_mount.go
+++ b/pkg/util/mount/nsenter_mount.go
@@ -337,12 +337,11 @@ func (mounter *NsenterMounter) SafeMakeDir(subdir string, base string, perm os.F
 }
 
 func (mounter *NsenterMounter) GetMountRefs(pathname string) ([]string, error) {
-	exists, err := mounter.ExistsPath(pathname)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
+	pathExists, pathErr := PathExists(pathname)
+	if !pathExists || IsCorruptedMnt(pathErr) {
 		return []string{}, nil
+	} else if pathErr != nil {
+		return nil, fmt.Errorf("Error checking path %s: %v", pathname, pathErr)
 	}
 	hostpath, err := mounter.ne.EvalSymlinks(pathname, true /* mustExist */)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #74625 on release-1.12.

#74625: GetMountRefs fixed to handle corrupted mounts by treating it

```release-note
Allow cleanup of corrupted mounts from xfs, nfs, other remote network plugins by treating them as unmounted
```