### PR TITLE
Update cadvisor to v0.33.1.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2002,188 +2002,188 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/accelerators",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/containerd",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/crio",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/mesos",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/zfs",
-			"Comment": "v0.33.0",
-			"Rev": "511ec9ef821b334c3825cebb728208578c2300e8"
+			"Comment": "v0.33.1",
+			"Rev": "7e9ea00b05397d43b6539d22ea6ea51bf70fea83"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go",

--- a/vendor/github.com/google/cadvisor/container/raw/handler.go
+++ b/vendor/github.com/google/cadvisor/container/raw/handler.go
@@ -188,16 +188,15 @@ func fsToFsStats(fs *fs.Fs) info.FsStats {
 
 func (self *rawContainerHandler) getFsStats(stats *info.ContainerStats) error {
 	var filesystems []fs.Fs
-
-	if self.includedMetrics.Has(container.DiskUsageMetrics) || self.includedMetrics.Has(container.DiskIOMetrics) {
-		var err error
-		// Get Filesystem information only for the root cgroup.
-		if isRootCgroup(self.name) {
-			filesystems, err = self.fsInfo.GetGlobalFsInfo()
-			if err != nil {
-				return err
-			}
-		} else if len(self.externalMounts) > 0 {
+	var err error
+	// Get Filesystem information only for the root cgroup.
+	if isRootCgroup(self.name) {
+		filesystems, err = self.fsInfo.GetGlobalFsInfo()
+		if err != nil {
+			return err
+		}
+	} else if self.includedMetrics.Has(container.DiskUsageMetrics) || self.includedMetrics.Has(container.DiskIOMetrics) {
+		if len(self.externalMounts) > 0 {
 			var mountSet map[string]struct{}
 			mountSet = make(map[string]struct{})
 			for _, mount := range self.externalMounts {
@@ -210,14 +209,14 @@ func (self *rawContainerHandler) getFsStats(stats *info.ContainerStats) error {
 		}
 	}
 
-	if self.includedMetrics.Has(container.DiskUsageMetrics) {
+	if isRootCgroup(self.name) || self.includedMetrics.Has(container.DiskUsageMetrics) {
 		for i := range filesystems {
 			fs := filesystems[i]
 			stats.Filesystem = append(stats.Filesystem, fsToFsStats(&fs))
 		}
 	}
 
-	if self.includedMetrics.Has(container.DiskIOMetrics) {
+	if isRootCgroup(self.name) || self.includedMetrics.Has(container.DiskIOMetrics) {
 		common.AssignDeviceNamesToDiskStats(&fsNamer{fs: filesystems, factory: self.machineInfoFactory}, &stats.DiskIo)
 
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug

**What this PR does / why we need it**:

Update cadvisor to v0.33.1 to fix the issue that cadvisor doesn't collect rootfs disk stats for CRI container runtimes.
https://k8s-testgrid.appspot.com/sig-node-containerd#node-e2e

**Special notes for your reviewer**:
no

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
