### PR TITLE
Ensure namespaces exist on start

### DIFF
--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pborman/uuid"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
@@ -151,6 +152,13 @@ func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 		healthStatus := 0
 		kubeClient.Discovery().RESTClient().Get().AbsPath("/healthz").Do().StatusCode(&healthStatus)
 		if healthStatus != http.StatusOK {
+			return false, nil
+		}
+
+		if _, err := kubeClient.CoreV1().Namespaces().Get("default", metav1.GetOptions{}); err != nil {
+			return false, nil
+		}
+		if _, err := kubeClient.CoreV1().Namespaces().Get("kube-system", metav1.GetOptions{}); err != nil {
 			return false, nil
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind flake

**What this PR does / why we need it**:

Ensures the apiserver is started up before returning control to integration tests.

Fixes https://storage.googleapis.com/k8s-gubernator/triage/index.html?pr=1&text=namespaces%20%22default%22%20not%20found&job=integration

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @caesarxuchao 