### PR TITLE
kubelet: updated logic of verifying a static critical pod

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -1164,6 +1164,11 @@ func TestCriticalPodsAreNotEvicted(t *testing.T) {
 	activePodsFunc := func() []*v1.Pod {
 		return pods
 	}
+	mirrorPodFunc := func(staticPod *v1.Pod) (*v1.Pod, bool) {
+		mirrorPod := staticPod.DeepCopy()
+		mirrorPod.Annotations[kubelettypes.ConfigSourceAnnotationKey] = kubelettypes.ApiserverSource
+		return mirrorPod, true
+	}
 
 	fakeClock := clock.NewFakeClock(time.Now())
 	podKiller := &mockPodKiller{}
@@ -1198,6 +1203,7 @@ func TestCriticalPodsAreNotEvicted(t *testing.T) {
 	manager := &managerImpl{
 		clock:                        fakeClock,
 		killPodFunc:                  podKiller.killPodNow,
+		mirrorPodFunc:                mirrorPodFunc,
 		imageGC:                      diskGC,
 		containerGC:                  diskGC,
 		config:                       config,

--- a/pkg/kubelet/eviction/types.go
+++ b/pkg/kubelet/eviction/types.go
@@ -94,6 +94,10 @@ type ContainerGC interface {
 // gracePeriodOverride - the grace period override to use instead of what is on the pod spec
 type KillPodFunc func(pod *v1.Pod, status v1.PodStatus, gracePeriodOverride *int64) error
 
+// MirrorPodFunc returns the mirror pod for the given static pod and
+// whether it was known to the pod manager.
+type MirrorPodFunc func(*v1.Pod) (*v1.Pod, bool)
+
 // ActivePodsFunc returns pods bound to the kubelet that are active (i.e. non-terminal state)
 type ActivePodsFunc func() []*v1.Pod
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -820,7 +820,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.podKillingCh = make(chan *kubecontainer.PodPair, podKillingChannelCapacity)
 
 	// setup eviction manager
-	evictionManager, evictionAdmitHandler := eviction.NewManager(klet.resourceAnalyzer, evictionConfig, killPodNow(klet.podWorkers, kubeDeps.Recorder), klet.imageManager, klet.containerGC, kubeDeps.Recorder, nodeRef, klet.clock)
+	evictionManager, evictionAdmitHandler := eviction.NewManager(klet.resourceAnalyzer, evictionConfig, killPodNow(klet.podWorkers, kubeDeps.Recorder), klet.podManager.GetMirrorPodByPod, klet.imageManager, klet.containerGC, kubeDeps.Recorder, nodeRef, klet.clock)
 
 	klet.evictionManager = evictionManager
 	klet.admitHandlers.AddPodAdmitHandler(evictionAdmitHandler)

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -89,19 +89,7 @@ func (kl *Kubelet) listPodsFromDisk() ([]types.UID, error) {
 
 // GetActivePods returns non-terminal pods
 func (kl *Kubelet) GetActivePods() []*v1.Pod {
-	allPods, mirrorPods := kl.podManager.GetPodsAndMirrorPods()
-	mirrorPodSet := make(map[string]*v1.Pod)
-	for _, p := range mirrorPods {
-		mirrorPodSet[kubecontainer.GetPodFullName(p)] = p
-	}
-	for i := range allPods {
-		podFullName := kubecontainer.GetPodFullName(allPods[i])
-		// replace static pod with mirror pod as some info (e.g. spec.Priority)
-		// is needed to make further decisions (e.g. eviction)
-		if mirrorPod, ok := mirrorPodSet[podFullName]; ok {
-			allPods[i] = mirrorPod
-		}
-	}
+	allPods := kl.podManager.GetPods()
 	activePods := kl.filterOutTerminatedPods(allPods)
 	return activePods
 }

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -305,7 +305,7 @@ func newTestKubeletWithImageList(
 		Namespace: "",
 	}
 	// setup eviction manager
-	evictionManager, evictionAdmitHandler := eviction.NewManager(kubelet.resourceAnalyzer, eviction.Config{}, killPodNow(kubelet.podWorkers, fakeRecorder), kubelet.imageManager, kubelet.containerGC, fakeRecorder, nodeRef, kubelet.clock)
+	evictionManager, evictionAdmitHandler := eviction.NewManager(kubelet.resourceAnalyzer, eviction.Config{}, killPodNow(kubelet.podWorkers, fakeRecorder), kubelet.podManager.GetMirrorPodByPod, kubelet.imageManager, kubelet.containerGC, fakeRecorder, nodeRef, kubelet.clock)
 
 	kubelet.evictionManager = evictionManager
 	kubelet.admitHandlers.AddPodAdmitHandler(evictionAdmitHandler)

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -120,7 +120,8 @@ func TestRunOnce(t *testing.T) {
 	fakeKillPodFunc := func(pod *v1.Pod, podStatus v1.PodStatus, gracePeriodOverride *int64) error {
 		return nil
 	}
-	evictionManager, evictionAdmitHandler := eviction.NewManager(kb.resourceAnalyzer, eviction.Config{}, fakeKillPodFunc, nil, nil, kb.recorder, nodeRef, kb.clock)
+	fakeMirrodPodFunc := func(*v1.Pod) (*v1.Pod, bool) { return nil, false }
+	evictionManager, evictionAdmitHandler := eviction.NewManager(kb.resourceAnalyzer, eviction.Config{}, fakeKillPodFunc, fakeMirrodPodFunc, nil, nil, kb.recorder, nodeRef, kb.clock)
 
 	kb.evictionManager = evictionManager
 	kb.admitHandlers.AddPodAdmitHandler(evictionAdmitHandler)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This is a supplemental fix of #74222.

> The case in that #74222 completely replaces static pods with the mirror pods. But static pods contains important annotations such as kubernetes.io/config.source. For static pods is file, for mirror is api. As a result, eviction manager supposes that pod is not static.

This PR revers part of #74222 (e2e test is still valid and is kept), and updated the logic of verifying a static critical pod:

- check if a pod is static by its static pod info
- meanwhile, check if a pod is critical by its corresponding mirror pod info

**Which issue(s) this PR fixes**:

Supplemental fix for #73572

**Special notes for your reviewer**:

Here is a detailed explanation on why previous PR passed the e2e test:

- As @namreg [pointed out](https://github.com/kubernetes/kubernetes/issues/73572#issuecomment-470426246), the critical static pod failed on IsStaticPod() check (because of mirror pod is tagged as "kubernetes.io/config.source: api")
- And it's reasonable that it's being marked as "to be deleted":
    ```
    I0307 18:09:26.138497   31769 eviction_manager.go:564] eviction manager: pod static-web-127.0.0.1_kube-system(513a7ec5-4136-11e9-b8f7-0cc47a8f8932) is evicted successfully
    ```
- However, as @ravisantoshgudimetla [observed](https://github.com/kubernetes/kubernetes/pull/74222#issuecomment-468271473), there is some weird log showing:
    ```
    I0307 18:09:27.138643   31769 kubelet_pods.go:918] Pod "static-web-127.0.0.1_kube-system(513a7ec5-4136-11e9-b8f7-0cc47a8f8932)" is terminated, but some containers are still running
    ```
- It's because the pod we passed onto pkg/kubelet/pod_workers.go#killPodNow() is a mirror pod, and it's deleted (or probably a dummy delete) by container runtime **without any error**. To take an analogy, it's sort of like a "controllee" (mirror pod) gets deleted, but "controller" (static pod) is still alive, so it causes data inconsistency, and the above error msg popped up.
- And in user's perspective, the static pod is "not" evicted, then it "looks" like previous PR works.

**Does this PR introduce a user-facing change?**:

```release-note
kubelet: updated logic of verifying a static critical pod.
```

/sig node
/sig scheduling

/cc @ravisantoshgudimetla @derekwaynecarr 
