### PR TITLE
Fix apply conversion bug

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -72,7 +72,7 @@ func NewCRDFieldManager(objectConverter runtime.ObjectConvertor, objectDefaulter
 		groupVersion:    gv,
 		hubVersion:      hub,
 		updater: merge.Updater{
-			Converter: internal.NewVersionConverter(internal.DeducedTypeConverter{}, objectConverter, hub),
+			Converter: internal.NewCRDVersionConverter(internal.DeducedTypeConverter{}, objectConverter, hub),
 		},
 	}
 }

--- a/test/integration/apiserver/apply/BUILD
+++ b/test/integration/apiserver/apply/BUILD
@@ -15,6 +15,7 @@ go_test(
         "//pkg/master:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/priority important-soon
/sig api-machinery
/wg apply
/cc apelisse

**What this PR does / why we need it**:
When we implemented the version converter we assumed that we could always convert from any version to the hub version (as defined in the request scope), but it turns out that this is not true for resources which span multiple groups.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
