### PR TITLE
Don't test metadata server connectivity from GCE Windows pods.

### DIFF
--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -51,7 +51,11 @@ var _ = SIGDescribe("DNS", func() {
 		// Added due to #8512. This is critical for GCE and GKE deployments.
 		if framework.ProviderIs("gce", "gke") {
 			namesToResolve = append(namesToResolve, "google.com")
-			namesToResolve = append(namesToResolve, "metadata")
+			// Windows containers do not have a route to the GCE
+			// metadata server by default.
+			if !framework.NodeOSDistroIs("windows") {
+				namesToResolve = append(namesToResolve, "metadata")
+			}
 		}
 		wheezyProbeCmd, wheezyFileNames := createProbeCommand(namesToResolve, nil, "", "wheezy", f.Namespace.Name, framework.TestContext.ClusterDNSDomain)
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, nil, "", "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain)
@@ -74,7 +78,11 @@ var _ = SIGDescribe("DNS", func() {
 		// Added due to #8512. This is critical for GCE and GKE deployments.
 		if framework.ProviderIs("gce", "gke") {
 			namesToResolve = append(namesToResolve, "google.com")
-			namesToResolve = append(namesToResolve, "metadata")
+			// Windows containers do not have a route to the GCE
+			// metadata server by default.
+			if !framework.NodeOSDistroIs("windows") {
+				namesToResolve = append(namesToResolve, "metadata")
+			}
 		}
 		hostFQDN := fmt.Sprintf("%s.%s.%s.svc.cluster.local", dnsTestPodHostName, dnsTestServiceName, f.Namespace.Name)
 		hostEntries := []string{hostFQDN, dnsTestPodHostName}


### PR DESCRIPTION
Windows containers do not include a route to the GCE metadata server by
default. This check is causing the "DNS should provide DNS for the
cluster" test to fail consistently for clusters with Windows nodes
(https://testgrid.k8s.io/sig-windows#gce-windows-master&width=20).

Tested that this works by running "DNS should provide DNS for the
cluster" against an e2e cluster with Windows nodes brought up on GCE.

/kind failing-test

```release-note
NONE
```