### PR TITLE
Promote garbage collection E2E test for Cronjob deletion to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -7,6 +7,7 @@ test/e2e/apimachinery/garbage_collector.go: "should orphan RS created by deploym
 test/e2e/apimachinery/garbage_collector.go: "should keep the rc around until all its pods are deleted if the deleteOptions says so"
 test/e2e/apimachinery/garbage_collector.go: "should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted"
 test/e2e/apimachinery/garbage_collector.go: "should not be blocked by dependency circle"
+test/e2e/apimachinery/garbage_collector.go: "should delete jobs and pods created by cronjob"
 test/e2e/apimachinery/namespace.go: "should ensure that all pods are removed when a namespace is deleted"
 test/e2e/apimachinery/namespace.go: "should ensure that all services are removed when a namespace is deleted"
 test/e2e/apimachinery/watch.go: "should observe add, update, and delete watch notifications on configmaps"

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -1073,7 +1073,12 @@ var _ = SIGDescribe("Garbage collector", func() {
 		}
 	})
 
-	It("should delete jobs and pods created by cronjob", func() {
+	/*
+		Release : v1.14
+		Testname: Garbage Collector, job and pod lifecycle management on cronjob deletion
+		Description: Create a Cronjob, wait for the Cronjob to create new jobs. Once the jobs are created, delete the CronJob. Verify that all the jobs and pods associated with the Cronjob is deleted and not left behind.
+	*/
+	framework.ConformanceIt("should delete jobs and pods created by cronjob", func() {
 		framework.SkipIfMissingResource(f.DynamicClient, CronJobGroupVersionResource, f.Namespace.Name)
 
 		By("Create the cronjob")


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Promotes garbage collection e2e tests for Cronjob to conformance. All the pods and jobs associated with the cronjob should be deleted once the delete call is executed successfully for CronJob.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
1. The test is not flaky and is non-disruptive in nature
2. Verifies the implementational behaviour of the garbage collector with respect to CronJob on deletion. All the pods and jobs associated with the Cronjob needs to be deleted on delete api call for the cronjob.
3. Execution time status: [SLOW TEST:38.187 seconds]

**Does this PR introduce a user-facing change?**:

NONE

/release-note-none
/area conformance

cc @brahmaroutu @mgdevstack 