### PR TITLE
Handle nil interface inputs to diff.ObjectReflectDiff

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -446,7 +446,6 @@ staging/src/k8s.io/apimachinery/pkg/test
 staging/src/k8s.io/apimachinery/pkg/types
 staging/src/k8s.io/apimachinery/pkg/util/cache
 staging/src/k8s.io/apimachinery/pkg/util/clock
-staging/src/k8s.io/apimachinery/pkg/util/diff
 staging/src/k8s.io/apimachinery/pkg/util/errors
 staging/src/k8s.io/apimachinery/pkg/util/framer
 staging/src/k8s.io/apimachinery/pkg/util/httpstream

--- a/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go
@@ -78,7 +78,20 @@ func ObjectGoPrintDiff(a, b interface{}) string {
 	)
 }
 
+// ObjectReflectDiff returns a multi-line formatted diff between two objects
+// of equal type. If an object with private fields is passed you will
+// only see string comparison for those fields. Otherwise this presents the
+// most human friendly diff of two structs of equal type in this package.
 func ObjectReflectDiff(a, b interface{}) string {
+	if a == nil && b == nil {
+		return "<no diffs>"
+	}
+	if a == nil {
+		return fmt.Sprintf("a is nil and b is not-nil")
+	}
+	if b == nil {
+		return fmt.Sprintf("a is not-nil and b is nil")
+	}
 	vA, vB := reflect.ValueOf(a), reflect.ValueOf(b)
 	if vA.Type() != vB.Type() {
 		return fmt.Sprintf("type A %T and type B %T do not match", a, b)

--- a/staging/src/k8s.io/apimachinery/pkg/util/diff/diff_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/diff/diff_test.go
@@ -27,6 +27,20 @@ func TestObjectReflectDiff(t *testing.T) {
 		a, b interface{}
 		out  string
 	}{
+		"both nil": {
+			a: interface{}(nil),
+			b: interface{}(nil),
+		},
+		"a nil": {
+			a:   interface{}(nil),
+			b:   "test",
+			out: "a is nil and b is not-nil",
+		},
+		"b nil": {
+			a:   "test",
+			b:   interface{}(nil),
+			out: "a is not-nil and b is nil",
+		},
 		"map": {
 			a: map[string]int{},
 			b: map[string]int{},


### PR DESCRIPTION
Causes a panic today. Add godoc bragging about how ridiculously awesome
ObjectReflectDiff is.

/assign @liggitt
/kind bug

```release-note
NONE
```