### PR TITLE
Handle unstructured status in RetryWatcher

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -184,12 +184,16 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 				continue
 
 			case watch.Error:
-				status, ok := event.Object.(*metav1.Status)
+				// This round trip allows us to handle unstructured status
+				errObject := apierrors.FromObject(event.Object)
+				statusErr, ok := errObject.(*apierrors.StatusError)
 				if !ok {
 					klog.Error(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
 					// Retry unknown errors
 					return false, 0
 				}
+
+				status := statusErr.ErrStatus
 
 				statusDelay := time.Duration(0)
 				if status.Details != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When RetryWatcher receives watch.Error is should handle even its unstructured form.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @liggitt 
@kubernetes/sig-api-machinery-pr-reviews 