### PR TITLE
Update Cluster Autoscaler version to 1.3.8

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.7",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.8",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION

```release-note
Update Cluster Autoscaler version to 1.3.8. Release notes: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.3.8
```
