### PR TITLE
make describers of different versions work properly when autoscaling/v2beta2 is not supported

### DIFF
--- a/pkg/kubectl/describe/versioned/BUILD
+++ b/pkg/kubectl/describe/versioned/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/kubectl/util/slice:go_default_library",
         "//pkg/kubectl/util/storage:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/api/autoscaling/v2beta2:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1beta1:go_default_library",
@@ -73,6 +74,7 @@ go_test(
     deps = [
         "//pkg/kubectl/describe:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/api/autoscaling/v2beta2:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/networking/v1:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When we use kubectl v1.13 and api-server v1.11, the HorizontalPodAutoscaler describer will not work properly because autoscaling/v2beta2 has not been introduced in v1.11. So to guarantee the matches of different versions of api-server and kubectl, we have to describe autoscaling/v2beta object firstly, if it fails, we will fall back to describe autoscaling/v1 object.

**Which issue(s) this PR fixes**:
[https://github.com/kubernetes/kubectl/issues/568](https://github.com/kubernetes/kubectl/issues/568)

