### PR TITLE
Update Cluster Autoscaler version to 1.12.3

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.12.2",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.12.3",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION

```release-note
Update Cluster Autoscaler version to 1.12.3. Release notes: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.12.3
```
