### PR TITLE
ignore uncommitted generated openapi files in verify-godeps

### DIFF
--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -101,7 +101,7 @@ pushd "${KUBE_ROOT}" > /dev/null 2>&1
     ret=1
   fi
 
-  if ! _out="$(diff -Naupr -x "BUILD" -x "AUTHORS*" -x "CONTRIBUTORS*" vendor "${_kubetmp}/vendor")"; then
+  if ! _out="$(diff -Naupr -x "BUILD" -x "zz_generated.openapi.go" -x "AUTHORS*" -x "CONTRIBUTORS*" vendor "${_kubetmp}/vendor")"; then
     echo "Your vendored results are different:" >&2
     echo "${_out}" >&2
     echo "Godeps Verify failed." >&2


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
ignore uncommitted generated openapi changes in verify-godeps

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/75125

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @sttts 