### PR TITLE
kubeadm: add integration tests for certs transfer

### DIFF
--- a/cmd/kubeadm/app/phases/copycerts/BUILD
+++ b/cmd/kubeadm/app/phases/copycerts/BUILD
@@ -46,8 +46,14 @@ go_test(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
+        "//cmd/kubeadm/app/phases/certs:go_default_library",
         "//cmd/kubeadm/app/util/crypto:go_default_library",
         "//cmd/kubeadm/test:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//staging/src/k8s.io/client-go/util/cert:go_default_library",
+        "//staging/src/k8s.io/client-go/util/keyutil:go_default_library",
         "//vendor/github.com/lithammer/dedent:go_default_library",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
* Upload certificates: generate certificates and check that the kubeadm-certs
  secret is populated with the expected contents.

* Download certificates: given we have a kubeadm-certs secret, ensure that
  keys and certificates are copied on the expected target, and that depending
  on the secret nature they have the expected permissions.

**Which issue(s) this PR fixes**:
Refs https://github.com/kubernetes/kubeadm/issues/1373

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
