### PR TITLE
set backup value to ensure connections against kubelets eventually close

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -147,6 +147,8 @@ func ListenAndServeKubeletServer(
 	s := &http.Server{
 		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
 		Handler:        &handler,
+		ReadTimeout:    4 * 60 * time.Minute,
+		WriteTimeout:   4 * 60 * time.Minute,
 		MaxHeaderBytes: 1 << 20,
 	}
 	if tlsOptions != nil {


### PR DESCRIPTION
This makes sure that bodies must eventually be read from the kubelet.

@liggitt I remember this idea as originating with you long ago.

/kind cleanup
/priority important-longterm
@kubernetes/sig-node-pr-reviews 

```release-note
NONE
```