### PR TITLE
add label area/test in k8s.io/kubernetes/test/*

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -64,4 +64,5 @@ approvers:
   - vishh
   - MaciekPytel # for test/e2e/common/autoscaling_utils.go
 labels:
+- area/test
 - sig/testing


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Automatically adds the label `area/test` to all PRs that touch `k8s.io/kubernetes/test/*`. In the testing-commons subproject meeting we discussed using `area/testing` but given `area/test` already exists and is used in a bunch of places figured we stick with `area/test`. 

This should help us triage testing PRs going forward. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
