### PR TITLE
make kubectl scale work without a GET if a precodition isn't requested

### DIFF
--- a/pkg/kubectl/cmd/scale/scale.go
+++ b/pkg/kubectl/cmd/scale/scale.go
@@ -209,7 +209,12 @@ func (o *ScaleOptions) RunScale() error {
 		return fmt.Errorf("cannot use --resource-version with multiple resources")
 	}
 
-	precondition := &kubectl.ScalePrecondition{Size: o.CurrentReplicas, ResourceVersion: o.ResourceVersion}
+	// only set a precondition if the user has requested one.  A nil precondition means we can do a blind update, so
+	// we avoid a Scale GET that may or may not succeed
+	var precondition *kubectl.ScalePrecondition
+	if o.CurrentReplicas != -1 || len(o.ResourceVersion) > 0 {
+		precondition = &kubectl.ScalePrecondition{Size: o.CurrentReplicas, ResourceVersion: o.ResourceVersion}
+	}
 	retry := kubectl.NewRetryParams(1*time.Second, 5*time.Minute)
 
 	var waitForReplicas *kubectl.RetryParams

--- a/pkg/kubectl/scale.go
+++ b/pkg/kubectl/scale.go
@@ -21,11 +21,11 @@ import (
 	"strconv"
 	"time"
 
-	autoscalingapi "k8s.io/api/autoscaling/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-
 	scaleclient "k8s.io/client-go/scale"
 )
 
@@ -95,7 +95,7 @@ func ScaleCondition(r Scaler, precondition *ScalePrecondition, namespace, name s
 }
 
 // validateGeneric ensures that the preconditions match. Returns nil if they are valid, otherwise an error
-func (precondition *ScalePrecondition) validate(scale *autoscalingapi.Scale) error {
+func (precondition *ScalePrecondition) validate(scale *autoscalingv1.Scale) error {
 	if precondition.Size != -1 && int(scale.Spec.Replicas) != precondition.Size {
 		return PreconditionError{"replicas", strconv.Itoa(precondition.Size), strconv.Itoa(int(scale.Spec.Replicas))}
 	}
@@ -114,11 +114,15 @@ var _ Scaler = &genericScaler{}
 
 // ScaleSimple updates a scale of a given resource. It returns the resourceVersion of the scale if the update was successful.
 func (s *genericScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint, gr schema.GroupResource) (updatedResourceVersion string, err error) {
-	scale, err := s.scaleNamespacer.Scales(namespace).Get(gr, name)
-	if err != nil {
-		return "", err
+	scale := &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
 	}
 	if preconditions != nil {
+		var err error
+		scale, err = s.scaleNamespacer.Scales(namespace).Get(gr, name)
+		if err != nil {
+			return "", err
+		}
 		if err := preconditions.validate(scale); err != nil {
 			return "", err
 		}
@@ -135,9 +139,6 @@ func (s *genericScaler) ScaleSimple(namespace, name string, preconditions *Scale
 // Scale updates a scale of a given resource to a new size, with optional precondition check (if preconditions is not nil),
 // optional retries (if retry is not nil), and then optionally waits for the status to reach desired count.
 func (s *genericScaler) Scale(namespace, resourceName string, newSize uint, preconditions *ScalePrecondition, retry, waitForReplicas *RetryParams, gr schema.GroupResource) error {
-	if preconditions == nil {
-		preconditions = &ScalePrecondition{-1, ""}
-	}
 	if retry == nil {
 		// make it try only once, immediately
 		retry = &RetryParams{Interval: time.Millisecond, Timeout: time.Millisecond}


### PR DESCRIPTION
`kubectl scale` without preconditions does not need to do a GET.  Since GETs may actually fail if there is no current scale, you can create resources which should be scalable and are not. (see https://github.com/kubernetes/kubernetes/pull/55168#discussion_r167539755 for the discussion about defaults in CRDs).

/kind bug
/priority important-soon

```release-note
NONE
```