### PR TITLE
kubeadm: print key inside the upload-certs phase of init

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -379,6 +379,11 @@ func (d *initData) SetCertificateKey(key string) {
 	d.certificateKey = key
 }
 
+// SkipCertificateKeyPrint returns the skipCertificateKeyPrint flag.
+func (d *initData) SkipCertificateKeyPrint() bool {
+	return d.skipCertificateKeyPrint
+}
+
 // Cfg returns initConfiguration.
 func (d *initData) Cfg() *kubeadmapi.InitConfiguration {
 	return d.cfg

--- a/cmd/kubeadm/app/cmd/phases/init/data.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data.go
@@ -30,6 +30,7 @@ type InitData interface {
 	UploadCerts() bool
 	CertificateKey() string
 	SetCertificateKey(key string)
+	SkipCertificateKeyPrint() bool
 	Cfg() *kubeadmapi.InitConfiguration
 	DryRun() bool
 	SkipTokenPrint() bool

--- a/cmd/kubeadm/app/cmd/phases/init/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data_test.go
@@ -33,6 +33,7 @@ var _ InitData = &testInitData{}
 func (t *testInitData) UploadCerts() bool                    { return false }
 func (t *testInitData) CertificateKey() string               { return "" }
 func (t *testInitData) SetCertificateKey(key string)         {}
+func (t *testInitData) SkipCertificateKeyPrint() bool        { return false }
 func (t *testInitData) Cfg() *kubeadmapi.InitConfiguration   { return nil }
 func (t *testInitData) DryRun() bool                         { return false }
 func (t *testInitData) SkipTokenPrint() bool                 { return false }

--- a/cmd/kubeadm/app/cmd/phases/init/uploadcerts.go
+++ b/cmd/kubeadm/app/cmd/phases/init/uploadcerts.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/klog"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
@@ -40,6 +39,7 @@ func NewUploadCertsPhase() workflow.Phase {
 			options.CfgPath,
 			options.UploadCerts,
 			options.CertificateKey,
+			options.SkipCertificateKeyPrint,
 		},
 	}
 }
@@ -51,7 +51,7 @@ func runUploadCerts(c workflow.RunData) error {
 	}
 
 	if !data.UploadCerts() {
-		klog.V(1).Infoln("[upload-certs] Skipping certs upload")
+		fmt.Printf("[upload-certs] Skipping phase. Please see --%s\n", options.UploadCerts)
 		return nil
 	}
 	client, err := data.Client()
@@ -69,6 +69,9 @@ func runUploadCerts(c workflow.RunData) error {
 
 	if err := copycerts.UploadCerts(client, data.Cfg(), data.CertificateKey()); err != nil {
 		return errors.Wrap(err, "error uploading certs")
+	}
+	if !data.SkipCertificateKeyPrint() {
+		fmt.Printf("[upload-certs] Using certificate key:\n%s\n", data.CertificateKey())
 	}
 	return nil
 }

--- a/cmd/kubeadm/app/phases/copycerts/copycerts.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts.go
@@ -85,7 +85,7 @@ func CreateCertificateKey() (string, error) {
 
 //UploadCerts save certs needs to join a new control-plane on kubeadm-certs sercret.
 func UploadCerts(client clientset.Interface, cfg *kubeadmapi.InitConfiguration, key string) error {
-	fmt.Printf("[upload-certs] storing the certificates in ConfigMap %q in the %q Namespace\n", kubeadmconstants.KubeadmCertsSecret, metav1.NamespaceSystem)
+	fmt.Printf("[upload-certs] Storing the certificates in ConfigMap %q in the %q Namespace\n", kubeadmconstants.KubeadmCertsSecret, metav1.NamespaceSystem)
 	decodedKey, err := hex.DecodeString(key)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

**TL;DR** the key is now printed in both standalone and phase runner workflow,
unless the user uses `--skip-certificate-key-print`.

The standalone execution of upload-certs phase does not print
the key that that user should use for the newly uploaded encrypted
secret. Print this key in the upload-certs phase in both
standalone mode or if executed in the standard init workflow.

Make it possible to omit the printing if the user passes
--skip-certificate-key-print in the standard init workflow.

Also:
- Uppercase string in Printf call in copycerts.go
- Don't use V(1) for the "Skipping phase" message in uploadcerts.go
instead always print a message that the user case use
--experimental-upload-certs. This solves a problem if the user tried
the standalone phase without V(1) but didn't pass --experimental-upload-certs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#1443

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/kind bug
/priority critical-urgent
/assign @fabriziopandini 
/cc @ereslibre 
@kubernetes/sig-cluster-lifecycle-pr-reviews 
