### PR TITLE
Add bracket to the sig-window tag and other fixes

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -347,7 +347,7 @@ func (g *gcePDCSIDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 	if pattern.FsType == "xfs" {
 		framework.SkipUnlessNodeOSDistroIs("ubuntu", "custom")
 	}
-	if pattern.FeatureTag == "sig-windows" {
+	if pattern.FeatureTag == "[sig-windows]" {
 		framework.Skipf("Skipping tests for windows since CSI does not support it yet")
 	}
 }
@@ -464,7 +464,7 @@ func (g *gcePDExternalCSIDriver) SkipUnsupportedTest(pattern testpatterns.TestPa
 	if pattern.FsType == "xfs" {
 		framework.SkipUnlessNodeOSDistroIs("ubuntu", "custom")
 	}
-	if pattern.FeatureTag == "sig-windows" {
+	if pattern.FeatureTag == "[sig-windows]" {
 		framework.Skipf("Skipping tests for windows since CSI does not support it yet")
 	}
 }

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1106,21 +1106,18 @@ var _ testsuites.DynamicPVTestDriver = &gcePdDriver{}
 
 // InitGcePdDriver returns gcePdDriver that implements TestDriver interface
 func InitGcePdDriver() testsuites.TestDriver {
-	var supportedTypes sets.String
-	var capFsGroup bool
-	if framework.NodeOSDistroIs("windows") {
-		supportedTypes = sets.NewString("ntfs")
-		capFsGroup = false
-	} else {
-		supportedTypes = sets.NewString(
-			"", // Default fsType
-			"ext2",
-			"ext3",
-			"ext4",
-			"xfs",
-		)
-		capFsGroup = true
-	}
+	// In current test structure, it first initialize the driver and then set up
+	// the new framework, so we cannot get the correct OS here. So here set to
+	// support all fs types including both linux and windows. We have code to check Node OS later
+	// during test.
+	supportedTypes := sets.NewString(
+		"", // Default fsType
+		"ext2",
+		"ext3",
+		"ext4",
+		"xfs",
+		"ntfs",
+	)
 	return &gcePdDriver{
 		driverInfo: testsuites.DriverInfo{
 			Name:                 "gcepd",
@@ -1129,7 +1126,7 @@ func InitGcePdDriver() testsuites.TestDriver {
 			SupportedMountOption: sets.NewString("debug", "nouid32"),
 			Capabilities: map[testsuites.Capability]bool{
 				testsuites.CapPersistence: true,
-				testsuites.CapFsGroup:     capFsGroup,
+				testsuites.CapFsGroup:     true,
 				testsuites.CapBlock:       true,
 				testsuites.CapExec:        true,
 			},
@@ -1143,7 +1140,7 @@ func (g *gcePdDriver) GetDriverInfo() *testsuites.DriverInfo {
 
 func (g *gcePdDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 	framework.SkipUnlessProviderIs("gce", "gke")
-	if pattern.FeatureTag == "sig-windows" {
+	if pattern.FeatureTag == "[sig-windows]" {
 		framework.SkipUnlessNodeOSDistroIs("windows")
 	}
 }

--- a/test/e2e/storage/testpatterns/testpattern.go
+++ b/test/e2e/storage/testpatterns/testpattern.go
@@ -152,21 +152,21 @@ var (
 		Name:       "Inline-volume (ntfs)",
 		VolType:    InlineVolume,
 		FsType:     "ntfs",
-		FeatureTag: "sig-windows",
+		FeatureTag: "[sig-windows]",
 	}
 	// NtfsPreprovisionedPV is TestPattern for "Pre-provisioned PV (ntfs)"
 	NtfsPreprovisionedPV = TestPattern{
 		Name:       "Pre-provisioned PV (ntfs)",
 		VolType:    PreprovisionedPV,
 		FsType:     "ntfs",
-		FeatureTag: "sig-windows",
+		FeatureTag: "[sig-windows]",
 	}
 	// NtfsDynamicPV is TestPattern for "Dynamic PV (xfs)"
 	NtfsDynamicPV = TestPattern{
 		Name:       "Dynamic PV (ntfs)",
 		VolType:    DynamicPV,
 		FsType:     "ntfs",
-		FeatureTag: "sig-windows",
+		FeatureTag: "[sig-windows]",
 	}
 
 	// Definitions for Filesystem volume mode

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -125,7 +125,7 @@ func (t *volumeIOTestSuite) defineTests(driver TestDriver, pattern testpatterns.
 		fileSizes := createFileSizes(dInfo.MaxFileSize)
 		testFile := fmt.Sprintf("%s_io_test_%s", dInfo.Name, f.Namespace.Name)
 		var fsGroup *int64
-		if dInfo.Capabilities[CapFsGroup] {
+		if !framework.NodeOSDistroIs("windows") && dInfo.Capabilities[CapFsGroup] {
 			fsGroupVal := int64(1234)
 			fsGroup = &fsGroupVal
 		}

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -152,7 +152,7 @@ func (t *volumesTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		}
 		config := convertTestConfig(l.config)
 		var fsGroup *int64
-		if dInfo.Capabilities[CapFsGroup] {
+		if framework.NodeOSDistroIs("windows") && dInfo.Capabilities[CapFsGroup] {
 			fsGroupVal := int64(1234)
 			fsGroup = &fsGroupVal
 		}
@@ -185,7 +185,12 @@ func testScriptInPod(
 	)
 	suffix := generateSuffixForPodName(volumeType)
 	fileName := fmt.Sprintf("test-%s", suffix)
-	content := fmt.Sprintf("ls %s", volPath)
+	var content string
+	if framework.NodeOSDistroIs("windows") {
+		content = fmt.Sprintf("ls -n %s", volPath)
+	} else {
+		content = fmt.Sprintf("ls %s", volPath)
+	}
 	command := framework.GenerateWriteandExecuteScriptFileCmd(content, fileName, volPath)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Need to add bracket in the tag for sig-windows
It PR also contains a few small fixes for window tests including
1. Add all supported file systems including both windows and linux during InitGcePDDriver
2. change the command to list only file names to avoid new lines if file name is too long
