### PR TITLE
Change the maxDurationBeforeRetry value

### DIFF
--- a/pkg/util/goroutinemap/exponentialbackoff/exponential_backoff.go
+++ b/pkg/util/goroutinemap/exponentialbackoff/exponential_backoff.go
@@ -34,7 +34,7 @@ const (
 	// durationBeforeRetry will grow to due to exponential backoff.
 	// Value is slightly offset from 2 minutes to make timeouts due to this
 	// constant recognizable.
-	maxDurationBeforeRetry time.Duration = 2*time.Minute + 2*time.Second
+	maxDurationBeforeRetry time.Duration = 30 * time.Second
 )
 
 // ExponentialBackoff contains the last occurrence of an error and the duration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
exponentialBackOff would lead to driver implementing attacher not mounting volume in time

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #75230 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
