### PR TITLE
Automated cherry pick of #70325 upstream release 1.11

### DIFF
--- a/pkg/proxy/ipvs/README.md
+++ b/pkg/proxy/ipvs/README.md
@@ -200,7 +200,7 @@ DNAT       tcp  --  0.0.0.0/0            0.0.0.0/0            /* default/nginx-s
 Currently, local-up scripts, GCE scripts and kubeadm support switching IPVS proxy mode via exporting environment variables or specifying flags.  
 
 ### Prerequisite
-Ensure IPVS required kernel modules
+Ensure IPVS required kernel modules (**Notes**: use `nf_conntrack` instead of `nf_conntrack_ipv4` for Linux kernel 4.19 and later)
 ```shell
 ip_vs
 ip_vs_rr

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -157,6 +157,7 @@ var ipvsModules = []string{
 	"ip_vs_wrr",
 	"ip_vs_sh",
 	"nf_conntrack_ipv4",
+	"nf_conntrack",
 }
 
 // In IPVS proxy mode, the following flags need to be set
@@ -522,8 +523,21 @@ func CanUseIPVSProxier(handle KernelHandler, ipsetver IPSetVersioner) (bool, err
 	wantModules.Insert(ipvsModules...)
 	loadModules.Insert(mods...)
 	modules := wantModules.Difference(loadModules).UnsortedList()
-	if len(modules) != 0 {
-		return false, fmt.Errorf("IPVS proxier will not be used because the following required kernel modules are not loaded: %v", modules)
+	var missingMods []string
+	ConntrackiMissingCounter := 0
+	for _, mod := range modules {
+		if strings.Contains(mod, "nf_conntrack") {
+			ConntrackiMissingCounter++
+		} else {
+			missingMods = append(missingMods, mod)
+		}
+	}
+	if ConntrackiMissingCounter == 2 {
+		missingMods = append(missingMods, "nf_conntrack_ipv4(or nf_conntrack for Linux kernel 4.19 and later)")
+	}
+
+	if len(missingMods) != 0 {
+		return false, fmt.Errorf("IPVS proxier will not be used because the following required kernel modules are not loaded: %v", missingMods)
 	}
 
 	// Check ipset version


### PR DESCRIPTION
#70325: add module 'nf_conntrack' in ipvs prerequisite check
(Support for Linux kernel 4.19 and later)
Addresses #72146

/sig network
/area ipvs
/kind bug

/assign @m1093782566 

```release-note
[IPVS] Support for kernels 4.19+
```