### PR TITLE
Automated cherry pick of #70325 upstream release 1.12

### DIFF
--- a/pkg/proxy/ipvs/README.md
+++ b/pkg/proxy/ipvs/README.md
@@ -259,7 +259,7 @@ ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0            match-set KUBE-EXT
 Currently, local-up scripts, GCE scripts and kubeadm support switching IPVS proxy mode via exporting environment variables or specifying flags.
 
 ### Prerequisite
-Ensure IPVS required kernel modules
+Ensure IPVS required kernel modules (**Notes**: use `nf_conntrack` instead of `nf_conntrack_ipv4` for Linux kernel 4.19 and later)
 ```shell
 ip_vs
 ip_vs_rr


### PR DESCRIPTION
#70325: add module 'nf_conntrack' in ipvs prerequisite check
(Support for Linux kernel 4.19 and later)
Addresses #72146

/sig network
/area ipvs
/kind bug

/assign @m1093782566 

```release-note
[IPVS] Support for kernels 4.19+
```