### PR TITLE
Avoid allocating when performing VisitRulesFor on service accounts

### DIFF
--- a/pkg/registry/rbac/validation/rule.go
+++ b/pkg/registry/rbac/validation/rule.go
@@ -286,7 +286,8 @@ func appliesToUser(user user.Info, subject rbacv1.Subject, namespace string) boo
 		if len(saNamespace) == 0 {
 			return false
 		}
-		return serviceaccount.MakeUsername(saNamespace, subject.Name) == user.GetName()
+		// use a more efficient comparison for RBAC checking
+		return serviceaccount.MatchesUsername(saNamespace, subject.Name, user.GetName())
 	default:
 		return false
 	}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/util.go
@@ -36,6 +36,27 @@ func MakeUsername(namespace, name string) string {
 	return ServiceAccountUsernamePrefix + namespace + ServiceAccountUsernameSeparator + name
 }
 
+// MatchesUsername checks whether the provided username matches the namespace and name without
+// allocating. Use this when checking a service account namespace and name against a known string.
+func MatchesUsername(namespace, name string, username string) bool {
+	if !strings.HasPrefix(username, ServiceAccountUsernamePrefix) {
+		return false
+	}
+	username = username[len(ServiceAccountUsernamePrefix):]
+
+	if !strings.HasPrefix(username, namespace) {
+		return false
+	}
+	username = username[len(namespace):]
+
+	if !strings.HasPrefix(username, ServiceAccountUsernameSeparator) {
+		return false
+	}
+	username = username[len(ServiceAccountUsernameSeparator):]
+
+	return username == name
+}
+
 var invalidUsernameErr = fmt.Errorf("Username must be in the form %s", MakeUsername("namespace", "name"))
 
 // SplitUsername returns the namespace and ServiceAccount name embedded in the given username,


### PR DESCRIPTION
Service account authorization checks are done frequently and were
observed to perform 7% of allocations on a system running e2e tests.
The allocation comes from when we walk the authorization rules to
find matching service accounts.

Optimize the check for service account names to avoid allocating.

Allocations over about 5m of a 1.12 server running e2es.

![image](https://www.dropbox.com/s/l27vnhlkz6beupr/Screenshot%202019-03-11%2011.53.45.png?raw=1)

```
4892626	5.21%	5.21%	4892626	5.21%	github.com/openshift/origin/vendor/k8s.io/apiserver/pkg/authentication/serviceaccount.MakeUsername	(inline)
0	0.00%	5.21%	4869687	5.19%	net/http.HandlerFunc.ServeHTTP	
0	0.00%	5.21%	4892626	5.21%	github.com/openshift/origin/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac.(*RBACAuthorizer).Authorize	
0	0.00%	5.21%	4892626	5.21%	github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/registry/rbac/validation.appliesToUser	
0	0.00%	5.21%	4892626	5.21%	github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/registry/rbac/validation.appliesTo	
0	0.00%	5.21%	4892626	5.21%	github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/registry/rbac/validation.(*DefaultRuleResolver).VisitRulesFor	
0	0.00%	5.21%	4869687	5.19%	github.com/openshift/origin/vendor/k8s.io/apiserver/pkg/server/filters.WithMaxInFlightLimit.func1	
0	0.00%	5.21%	4869687	5.19%	github.com/openshift/origin/vendor/k8s.io/apiserver/pkg/server/filters.WithCORS.func1	
0	0.00%	5.21%	4861494	5.18%	github.com/openshift/origin/vendor/k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1	
0	0.00%	5.21%	4869687	5.19%	github.com/openshift/origin/vendor/k8s.io/apiserver/pkg/endpoints/filters.WithImpersonation.func1	
0	0.00%	5.21%	4869687	5.19%	github.com/openshift/origin/vendor/k8s.io/apiserver/pkg/endpoints/filters.WithAuthorization.func1	
0	0.00%	5.21%	4869687	5.19%	github.com/openshift/origin/vendor/k8s.io/apiserver/pkg/endpoints/filters.WithAuthentication.func1	
0	0.00%	5.21%	4869687	5.19%	github.com/openshift/origin/vendor/k8s.io/apiserver/pkg/endpoints/filters.WithAudit.func1	
0	0.00%	5.21%	4892626	5.21%	github.com/openshift/origin/vendor/k8s.io/apiserver/pkg/authorization/union.unionAuthzHandler.Authorize	
0	0.00%	5.21%	4892626	5.21%	github.com/openshift/origin/vendor/k8s.io/apiserver/pkg/authorization/union.(*unionAuthzHandler).Authorize	
0	0.00%	5.21%	4892626	5.21%	github.com/openshift/origin/pkg/authorization/authorizer/browsersafe.(*browserSafeAuthorizer).Authorize	
```

/kind bug

```release-note
NONE
```