### PR TITLE
Use UUIDv4 not UUIDv1

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -471,6 +471,10 @@
 			"Rev": "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 		},
 		{
+			"ImportPath": "github.com/google/uuid",
+			"Rev": "8c31c18f31ede9fc8eae72290a7e7a8064e9b3e3"
+		},
+		{
 			"ImportPath": "github.com/googleapis/gnostic/OpenAPIv2",
 			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
 		},

--- a/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
@@ -63,6 +63,10 @@
 			"Rev": "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 		},
 		{
+			"ImportPath": "github.com/google/uuid",
+			"Rev": "8c31c18f31ede9fc8eae72290a7e7a8064e9b3e3"
+		},
+		{
 			"ImportPath": "github.com/googleapis/gnostic/OpenAPIv2",
 			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
 		},
@@ -97,10 +101,6 @@
 		{
 			"ImportPath": "github.com/mxk/go-flowrate/flowrate",
 			"Rev": "cca7078d478f8520f85629ad7c68962d31ed7682"
-		},
-		{
-			"ImportPath": "github.com/pborman/uuid",
-			"Rev": "ca53cad383cad2479bbba7f7a1a05797ec1386e4"
 		},
 		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",

--- a/staging/src/k8s.io/apimachinery/pkg/util/uuid/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/uuid/BUILD
@@ -12,7 +12,7 @@ go_library(
     importpath = "k8s.io/apimachinery/pkg/util/uuid",
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/github.com/pborman/uuid:go_default_library",
+        "//vendor/github.com/google/uuid:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/uuid/uuid.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/uuid/uuid.go
@@ -17,27 +17,11 @@ limitations under the License.
 package uuid
 
 import (
-	"sync"
-
-	"github.com/pborman/uuid"
+	"github.com/google/uuid"
 
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var uuidLock sync.Mutex
-var lastUUID uuid.UUID
-
 func NewUUID() types.UID {
-	uuidLock.Lock()
-	defer uuidLock.Unlock()
-	result := uuid.NewUUID()
-	// The UUID package is naive and can generate identical UUIDs if the
-	// time interval is quick enough.
-	// The UUID uses 100 ns increments so it's short enough to actively
-	// wait for a new value.
-	for uuid.Equal(lastUUID, result) == true {
-		result = uuid.NewUUID()
-	}
-	lastUUID = result
-	return types.UID(result.String())
+	return types.UID(uuid.New().String())
 }

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -451,6 +451,10 @@
 			"Rev": "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 		},
 		{
+			"ImportPath": "github.com/google/uuid",
+			"Rev": "8c31c18f31ede9fc8eae72290a7e7a8064e9b3e3"
+		},
+		{
 			"ImportPath": "github.com/googleapis/gnostic/OpenAPIv2",
 			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
 		},

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -143,6 +143,10 @@
 			"Rev": "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 		},
 		{
+			"ImportPath": "github.com/google/uuid",
+			"Rev": "8c31c18f31ede9fc8eae72290a7e7a8064e9b3e3"
+		},
+		{
 			"ImportPath": "github.com/googleapis/gnostic/OpenAPIv2",
 			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
 		},

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -135,6 +135,10 @@
 			"Rev": "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 		},
 		{
+			"ImportPath": "github.com/google/uuid",
+			"Rev": "8c31c18f31ede9fc8eae72290a7e7a8064e9b3e3"
+		},
+		{
 			"ImportPath": "github.com/googleapis/gnostic/OpenAPIv2",
 			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

UUIDv1 has several disadvantages:
 - it encodes the MAC address of the host, which is a potential privacy issue
 - it uses the clock of the host, which reveals time information
 - the clock is very coarse, hence the complex code handling duplicates

UUIDv4 is simply a 122 bit random number encoded into the UUID format, which
has no problems with duplicates or locking.

Use the google/uuid library, as newer versions of pborman/uuid just wrap the
Google upstream.

Note that technically a random UUID might fail, but Go ensures that this
should not take place, as it will block if entropy is not available.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
