### PR TITLE
Fix server side apply int/float bug

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/typeconverter.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/typeconverter.go
@@ -105,7 +105,12 @@ func (c *typeConverter) YAMLToTyped(from []byte) (typed.TypedValue, error) {
 		return nil, fmt.Errorf("error decoding YAML: %v", err)
 	}
 
-	return c.ObjectToTyped(unstructured)
+	gvk := unstructured.GetObjectKind().GroupVersionKind()
+	t := c.parser.Type(gvk)
+	if t == nil {
+		return nil, fmt.Errorf("no corresponding type for %v", gvk)
+	}
+	return t.FromYAML(typed.YAMLObject(string(from)))
 }
 
 func (c *typeConverter) TypedToObject(value typed.TypedValue) (runtime.Object, error) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/typeconverter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/typeconverter_test.go
@@ -68,7 +68,6 @@ metadata:
   labels:
     app: nginx
 spec:
-  replicas: 3
   selector:
     matchLabels:
       app: nginx
@@ -91,7 +90,6 @@ metadata:
   labels:
     app: nginx
 spec:
-  replicas: 3
   selector:
     matchLabels:
       app: nginx

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -119,6 +119,19 @@ func TestApplyAlsoCreates(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to retrieve object: %v", err)
 		}
+
+		// Test that we can re apply with a different field manager and don't get conflicts
+		_, err = client.CoreV1().RESTClient().Patch(types.ApplyPatchType).
+			Namespace("default").
+			Resource(tc.resource).
+			Name(tc.name).
+			Param("fieldManager", "apply_test_2").
+			Body([]byte(tc.body)).
+			Do().
+			Get()
+		if err != nil {
+			t.Fatalf("Failed to re-apply object using Apply patch: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

Fixes a bug with serverside apply where appliers were unable to share ownership of scalar integer fields. The problem was that the patch bytes were being unmarshaled into unstructured which converts all numerics to floats, then this was compared to the live object which would be a go struct, so integers would still be integers, and the comparison would always show those fields as modified.

```release-note
NONE
```
