### PR TITLE
[kube-proxy/ipvs] Do not delete existing VS and RS when starting

### DIFF
--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -204,21 +204,5 @@ func (m *GracefulTerminationManager) MoveRSOutofGracefulDeleteList(uniqueRS stri
 
 // Run start a goroutine to try to delete rs in the graceful delete rsList with an interval 1 minute
 func (m *GracefulTerminationManager) Run() {
-	// before start, add leftover in delete rs to graceful delete rsList
-	vss, err := m.ipvs.GetVirtualServers()
-	if err != nil {
-		klog.Errorf("IPVS graceful delete manager failed to get IPVS virtualserver")
-	}
-	for _, vs := range vss {
-		rss, err := m.ipvs.GetRealServers(vs)
-		if err != nil {
-			klog.Errorf("IPVS graceful delete manager failed to get %v realserver", vs)
-			continue
-		}
-		for _, rs := range rss {
-			m.GracefulDeleteRS(vs, rs)
-		}
-	}
-
 	go wait.Until(m.tryDeleteRs, rsCheckDeleteInterval, wait.NeverStop)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Avoid graceful deletion of RS when starting the GracefulTerminationManager. By doing this, we were removing RS that had no Active/Inactive connections and setting the weight of the others to 0. This means no connection could be established until syncProxyRules ran for the first time.

I tested several cases to make sure this did not break anything:
- turn off kube-proxy
- delete a service
- delete an endpoint on another service
- restart kube-proxy

=> Everything was successfully resynced as soon as syncProxyRules ran

However, I don't have the initial context for this behavior at start-up so I may be missing something. @Lion-Wei / @m1093782566 you may have some insights?

**Which issue(s) this PR fixes**:
Fixes #73154

**Does this PR introduce a user-facing change?**:
```release-note
[IPVS] Allow for transparent kube-proxy restarts
```

/assign @m1093782566 
/sig network
/area ipvs