### PR TITLE
remove  DevicePlugin test for feature gate that can no longer be set

### DIFF
--- a/test/e2e_node/device_plugin.go
+++ b/test/e2e_node/device_plugin.go
@@ -45,17 +45,12 @@ const (
 )
 
 // Serial because the test restarts Kubelet
-var _ = framework.KubeDescribe("Device Plugin [Feature:DevicePlugin][NodeFeature:DevicePlugin][Serial]", func() {
-	f := framework.NewDefaultFramework("device-plugin-errors")
-	testDevicePlugin(f, false, pluginapi.DevicePluginPath)
-})
-
 var _ = framework.KubeDescribe("Device Plugin [Feature:DevicePluginProbe][NodeFeature:DevicePluginProbe][Serial]", func() {
 	f := framework.NewDefaultFramework("device-plugin-errors")
-	testDevicePlugin(f, true, "/var/lib/kubelet/plugins_registry")
+	testDevicePlugin(f, "/var/lib/kubelet/plugins_registry")
 })
 
-func testDevicePlugin(f *framework.Framework, enablePluginWatcher bool, pluginSockDir string) {
+func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 	pluginSockDir = filepath.Join(pluginSockDir) + "/"
 	Context("DevicePlugin", func() {
 		By("Enabling support for Kubelet Plugins Watcher")
@@ -63,7 +58,6 @@ func testDevicePlugin(f *framework.Framework, enablePluginWatcher bool, pluginSo
 			if initialConfig.FeatureGates == nil {
 				initialConfig.FeatureGates = map[string]bool{}
 			}
-			initialConfig.FeatureGates[string(features.KubeletPluginsWatcher)] = enablePluginWatcher
 			initialConfig.FeatureGates[string(features.KubeletPodResources)] = true
 		})
 		It("Verifies the Kubelet device plugin functionality.", func() {


### PR DESCRIPTION
**What type of PR is this?**
 /kind failing-test

**What this PR does / why we need it**:
This breaks the entire serial test suite.  It was introduced in https://github.com/kubernetes/kubernetes/pull/74830

**Which issue(s) this PR fixes**:
Serial node-e2e tests are failing because they are setting a feature gate which cannot be reset:
https://k8s-testgrid.appspot.com/sig-node-kubelet#node-kubelet-serial

kubelet[23350]: F0312 15:34:51.155095   23350 server.go:234] cannot set feature gate KubeletPluginsWatcher to false, feature is locked to true

This prevents the kubelet from passing its configz check, and aborts the test.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
NONE
```
