### PR TITLE
Use apps/v1 APIs in integration tests

### DIFF
--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -448,7 +448,7 @@ func TestApplyRemoveContainerPort(t *testing.T) {
 	defer closeFn()
 
 	obj := []byte(`{
-		"apiVersion": "extensions/v1beta1",
+		"apiVersion": "apps/v1",
 		"kind": "Deployment",
 		"metadata": {
 			"name": "deployment",
@@ -482,7 +482,7 @@ func TestApplyRemoveContainerPort(t *testing.T) {
 	}`)
 
 	_, err := client.CoreV1().RESTClient().Patch(types.ApplyPatchType).
-		AbsPath("/apis/extensions/v1beta1").
+		AbsPath("/apis/apps/v1").
 		Namespace("default").
 		Resource("deployments").
 		Name("deployment").


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
uses non-deprecated apps/v1 API in integration test. extracted from https://github.com/kubernetes/kubernetes/pull/70672 for early merge

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/kubernetes/issues/43214

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @apelisse  @jennybuckley 