### PR TITLE
Rebase core master image from debian to distroless

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -35,7 +35,7 @@ DOCKERIZED_BINARIES = {
         "target": "//cmd/cloud-controller-manager:cloud-controller-manager",
     },
     "kube-apiserver": {
-        "base": "@debian-base-{ARCH}//image",
+        "base": "@distroless-static//image",
         "target": "//cmd/kube-apiserver:kube-apiserver",
     },
     "kube-controller-manager": {
@@ -43,7 +43,7 @@ DOCKERIZED_BINARIES = {
         "target": "//cmd/kube-controller-manager:kube-controller-manager",
     },
     "kube-scheduler": {
-        "base": "@debian-base-{ARCH}//image",
+        "base": "@distroless-static//image",
         "target": "//cmd/kube-scheduler:kube-scheduler",
     },
     "kube-proxy": {

--- a/build/common.sh
+++ b/build/common.sh
@@ -95,9 +95,9 @@ kube::build::get_docker_wrapped_binaries() {
   ### in build/BUILD. And kube::golang::server_image_targets
   local targets=(
     cloud-controller-manager,"k8s.gcr.io/debian-base-${arch}:${debian_base_version}"
-    kube-apiserver,"k8s.gcr.io/debian-base-${arch}:${debian_base_version}"
+    kube-apiserver,"gcr.io/distroless/static:latest"
     kube-controller-manager,"k8s.gcr.io/debian-base-${arch}:${debian_base_version}"
-    kube-scheduler,"k8s.gcr.io/debian-base-${arch}:${debian_base_version}"
+    kube-scheduler,"gcr.io/distroless/static:latest"
     kube-proxy,"k8s.gcr.io/debian-iptables-${arch}:${debian_iptables_version}"
   )
 

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -47,7 +47,7 @@ _ETCD_TARBALL_ARCH_SHA256 = {
 def release_dependencies():
     cni_tarballs()
     cri_tarballs()
-    debian_image_dependencies()
+    image_dependencies()
     etcd_tarballs()
 
 def cni_tarballs():
@@ -102,8 +102,14 @@ def _digest(d, arch):
         return d["manifest"]
     return d[arch]
 
-def debian_image_dependencies():
+def image_dependencies():
     for arch in SERVER_PLATFORMS["linux"]:
+        container_pull(
+            name = "distroless-static",
+            registry = "gcr.io",
+            repository = "distroless/static",
+        )
+
         container_pull(
             name = "debian-base-" + arch,
             architecture = arch,


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR is part of the effort on rebasing kubernetes images to distroless/static. See [this KEP](https://github.com/kubernetes/enhancements/pull/900) for details.  

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
