### PR TITLE
enable s390x to test containers

### DIFF
--- a/test/images/dnsutils/BASEIMAGE
+++ b/test/images/dnsutils/BASEIMAGE
@@ -2,3 +2,4 @@ amd64=alpine:3.6
 arm=arm32v6/alpine:3.6
 arm64=arm64v8/alpine:3.6
 ppc64le=ppc64le/alpine:3.6
+s390x=s390x/alpine:3.6

--- a/test/images/echoserver/BASEIMAGE
+++ b/test/images/echoserver/BASEIMAGE
@@ -2,3 +2,4 @@ amd64=nginx:1.15-alpine
 arm=arm32v6/nginx:1.15-alpine
 arm64=arm64v8/nginx:1.15-alpine
 ppc64le=ppc64le/nginx:1.15-alpine
+s390x=s390x/nginx:1.15-alpine

--- a/test/images/hostexec/BASEIMAGE
+++ b/test/images/hostexec/BASEIMAGE
@@ -2,3 +2,4 @@ amd64=alpine:3.6
 arm=arm32v6/alpine:3.6
 arm64=arm64v8/alpine:3.6
 ppc64le=ppc64le/alpine:3.6
+s390x=s390x/alpine:3.6

--- a/test/images/jessie-dnsutils/BASEIMAGE
+++ b/test/images/jessie-dnsutils/BASEIMAGE
@@ -2,3 +2,4 @@ amd64=debian:jessie
 arm=arm32v7/debian:jessie
 arm64=arm64v8/debian:jessie
 ppc64le=ppc64le/debian:jessie
+s390x=s390x/debian:jessie

--- a/test/images/jessie-dnsutils/fixup-apt-list.sh
+++ b/test/images/jessie-dnsutils/fixup-apt-list.sh
@@ -21,7 +21,7 @@ DEB_ARCH=$(dpkg --print-architecture)
 # /etc/apt/sources.list which is "deb http://deb.debian.org/debian jessie-updates main"
 
 case ${DEB_ARCH} in
-    arm64|ppc64el)
+    s390x|arm64|ppc64el)
         sed -i '/debian-security/d' /etc/apt/sources.list
         ;;
 esac

--- a/test/images/net/BASEIMAGE
+++ b/test/images/net/BASEIMAGE
@@ -2,3 +2,4 @@ amd64=alpine:3.6
 arm=arm32v6/alpine:3.6
 arm64=arm64v8/alpine:3.6
 ppc64le=ppc64le/alpine:3.6
+s390x=s390x/alpine:3.6

--- a/test/images/redis/BASEIMAGE
+++ b/test/images/redis/BASEIMAGE
@@ -2,3 +2,4 @@ amd64=alpine:3.6
 arm=arm32v6/alpine:3.6
 arm64=arm64v8/alpine:3.6
 ppc64le=ppc64le/alpine:3.6
+s390x=s390x/alpine:3.6

--- a/test/images/resource-consumer/BASEIMAGE
+++ b/test/images/resource-consumer/BASEIMAGE
@@ -2,3 +2,4 @@ amd64=k8s.gcr.io/debian-base-amd64:0.4.1
 arm=k8s.gcr.io/debian-base-arm:0.4.1
 arm64=k8s.gcr.io/debian-base-arm64:0.4.1
 ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4.1
+s390x=k8s.gcr.io/debian-base-s390x:0.4.1


### PR DESCRIPTION

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Conformance testing on s390x https://github.com/kubernetes/kubernetes/issues/67721

**Which issue(s) this PR fixes**:

Fixes #
conformance failures on s390x

**Special notes for your reviewer**:
I'm assuming since other s390 containers are being built, that changing these value will automatically build them for s390?

cc: @dims 
