### PR TITLE
kubectl: removes pkg/version dependency

### DIFF
--- a/cmd/kubectl/BUILD
+++ b/cmd/kubectl/BUILD
@@ -3,7 +3,7 @@ load(
     "go_binary",
     "go_library",
 )
-load("//pkg/version:def.bzl", "version_x_defs")
+load("//pkg/kubectl/version:def.bzl", "version_x_defs")
 
 go_binary(
     name = "kubectl",

--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -142,6 +142,7 @@ kube::version::ldflag() {
   # If you update these, also update the list pkg/version/def.bzl.
   echo "-X '${KUBE_GO_PACKAGE}/pkg/version.${key}=${val}'"
   echo "-X '${KUBE_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.${key}=${val}'"
+  echo "-X '${KUBE_GO_PACKAGE}/pkg/kubectl/version.${key}=${val}'"
 }
 
 # Prints the value that needs to be passed to the -ldflags parameter of go build

--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -117,6 +117,7 @@ filegroup(
         "//pkg/kubectl/scheme:all-srcs",
         "//pkg/kubectl/util:all-srcs",
         "//pkg/kubectl/validation:all-srcs",
+        "//pkg/kubectl/version:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -18,7 +18,7 @@ go_library(
         "//pkg/kubectl/scheme:go_default_library",
         "//pkg/kubectl/util/templates:go_default_library",
         "//pkg/kubectl/validation:go_default_library",
-        "//pkg/version:go_default_library",
+        "//pkg/kubectl/version:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",

--- a/pkg/kubectl/cmd/util/kubectl_match_version.go
+++ b/pkg/kubectl/cmd/util/kubectl_match_version.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/kubernetes/pkg/version"
+	"k8s.io/kubernetes/pkg/kubectl/version"
 )
 
 const (

--- a/pkg/kubectl/cmd/version/BUILD
+++ b/pkg/kubectl/cmd/version/BUILD
@@ -9,7 +9,7 @@ go_library(
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/util/i18n:go_default_library",
         "//pkg/kubectl/util/templates:go_default_library",
-        "//pkg/version:go_default_library",
+        "//pkg/kubectl/version:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/client-go/discovery:go_default_library",

--- a/pkg/kubectl/cmd/version/version.go
+++ b/pkg/kubectl/cmd/version/version.go
@@ -31,7 +31,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
-	"k8s.io/kubernetes/pkg/version"
+	"k8s.io/kubernetes/pkg/kubectl/version"
 )
 
 // Version is a struct for version information

--- a/pkg/kubectl/version/BUILD
+++ b/pkg/kubectl/version/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "base.go",
+        "version.go",
+    ],
+    importpath = "k8s.io/kubernetes/pkg/kubectl/version",
+    visibility = ["//visibility:public"],
+    deps = ["//staging/src/k8s.io/apimachinery/pkg/version:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/kubectl/version/base.go
+++ b/pkg/kubectl/version/base.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via go ldflags. It provides an approximation of the Kubernetes
+// version for ad-hoc builds (e.g. `go build`) that cannot get the version
+// information from git.
+//
+// If you are looking at these fields in the git tree, they look
+// strange. They are modified on the fly by the build process. The
+// in-tree values are dummy values used for "git archive", which also
+// works for GitHub tar downloads.
+//
+// When releasing a new Kubernetes version, this file is updated by
+// build/mark_new_version.sh to reflect the new version, and then a
+// git annotated tag (using format vX.Y where X == Major version and Y
+// == Minor version) is created to point to the commit that updates
+// pkg/version/base.go
+var (
+	// TODO: Deprecate gitMajor and gitMinor, use only gitVersion
+	// instead. First step in deprecation, keep the fields but make
+	// them irrelevant. (Next we'll take it out, which may muck with
+	// scripts consuming the kubectl version output - but most of
+	// these should be looking at gitVersion already anyways.)
+	gitMajor string // major version, always numeric
+	gitMinor string // minor version, numeric possibly followed by "+"
+
+	// semantic version, derived by build scripts (see
+	// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md
+	// for a detailed discussion of this field)
+	//
+	// TODO: This field is still called "gitVersion" for legacy
+	// reasons. For prerelease versions, the build metadata on the
+	// semantic version is a git hash, but the version itself is no
+	// longer the direct output of "git describe", but a slight
+	// translation to be semver compliant.
+
+	// NOTE: The $Format strings are replaced during 'git archive' thanks to the
+	// companion .gitattributes file containing 'export-subst' in this same
+	// directory.  See also https://git-scm.com/docs/gitattributes
+	gitVersion   = "v0.0.0-master+$Format:%h$"
+	gitCommit    = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState = ""            // state of git tree, either "clean" or "dirty"
+
+	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+)

--- a/pkg/kubectl/version/def.bzl
+++ b/pkg/kubectl/version/def.bzl
@@ -1,0 +1,40 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Implements hack/lib/version.sh's kube::version::ldflags() for Bazel.
+# Modifies the version variables (stamp_vars:buildDate, gitCommit, ...)
+# Example go build command with ldflags:
+#   go install ... -ldflags -X 'k8s.io/kubernetes/pkg/kubectl/cmd/version.gitMinor=12+' ...
+def version_x_defs():
+    stamp_pkgs = [
+        "k8s.io/kubernetes/pkg/kubectl/version",
+    ]
+
+    # This should match the list of vars in kube::version::ldflags
+    # It should also match the list of vars set in hack/print-workspace-status.sh.
+    stamp_vars = [
+        "buildDate",
+        "gitCommit",
+        "gitMajor",
+        "gitMinor",
+        "gitTreeState",
+        "gitVersion",
+    ]
+
+    # Generate the cross-product.
+    x_defs = {}
+    for pkg in stamp_pkgs:
+        for var in stamp_vars:
+            x_defs["%s.%s" % (pkg, var)] = "{%s}" % var
+    return x_defs

--- a/pkg/kubectl/version/version.go
+++ b/pkg/kubectl/version/version.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+)
+
+// Get returns the overall codebase version. It's for detecting
+// what code a binary was built from.
+func Get() apimachineryversion.Info {
+	// These variables typically come from -ldflags settings and in
+	// their absence fallback to the settings in ./base.go
+	return apimachineryversion.Info{
+		Major:        gitMajor,
+		Minor:        gitMinor,
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
* Removes kubectl dependency on pkg/version in Kubernetes core.
* Copies the same version variables in base.go into kubectl.
* Updates kubectl_match_version.go to use kubectl version variables.
* Updates make to emit ldflags updating version variables in kubectl.
* Updates bazel to build emitting ldflags updating version variables in kubectl.

Helps fix:
https://github.com/kubernetes/kubectl/issues/80

```release-note
NONE
```

/kind cleanup
/sig cli
/area kubectl
/assign