### PR TITLE
Daemon Set Conformance test fails in CI process using ci-kubernetes-c…

### DIFF
--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -381,9 +381,8 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	  rollback of updates to a DaemonSet.
 	*/
 	framework.ConformanceIt("should rollback without unnecessary restarts", func() {
-		if framework.TestContext.CloudConfig.NumNodes < 2 {
-			framework.Logf("Conformance test suite needs a cluster with at least 2 nodes.")
-		}
+		schedulableNodes := framework.GetReadySchedulableNodesOrDie(c)
+		Expect(len(schedulableNodes.Items)).To(BeNumerically(">", 1), "Conformance test suite needs a cluster with at least 2 nodes.")
 		framework.Logf("Create a RollingUpdate DaemonSet")
 		label := map[string]string{daemonsetNameLabel: dsName}
 		ds := newDaemonSet(dsName, image, label)
@@ -421,7 +420,8 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 				framework.Failf("unexpected pod found, image = %s", image)
 			}
 		}
-		if framework.TestContext.CloudConfig.NumNodes < 2 {
+		schedulableNodes = framework.GetReadySchedulableNodesOrDie(c)
+		if len(schedulableNodes.Items) < 2 {
 			Expect(len(existingPods)).To(Equal(0))
 		} else {
 			Expect(len(existingPods)).NotTo(Equal(0))


### PR DESCRIPTION
…onformance-image as the num nodes is calculates incorrectly by the test context.

This will fixe the issue with bug #75348 where the num nodes is calculated incorrectly.
/sig testing
/area conformance
/kind test
/release-note-none
/sig apps

ping @neolit123 @dims 

EDIT(spiffxp)
Fixes #75348 