### PR TITLE
Fix debug printouts for zsh completion

### DIFF
--- a/pkg/kubectl/cmd/completion/completion.go
+++ b/pkg/kubectl/cmd/completion/completion.go
@@ -294,6 +294,7 @@ __kubectl_convert_bash_to_zsh() {
 	-e "s/${LWORD}compopt${RWORD}/__kubectl_compopt/g" \
 	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
 	-e "s/\\\$(type${RWORD}/\$(__kubectl_type/g" \
+	-e "s/FUNCNAME/funcstack/" \
 	<<'BASH_COMPLETION_EOF'
 `
 	out.Write([]byte(zshInitialization))


### PR DESCRIPTION
Cobra provides some out-of-the-box debugging for bash completion.
To use it, one must set the variable BASH_COMP_DEBUG_FILE to
some file where the debug output will be written.  Many of the
debug printouts indicate the current method name; they do so
by using bash's FUNCNAME variable. This variable is
different in zsh and is called funcstack.

This commit adds the proper sed modification to convert from
bash to zsh.

It is worth noting that although zsh arrays usually start at
index 1, this is not always the case when emulating other shells.
During completion, we run the command
  emulate -L sh
which affects the indexing of zsh arrays to make it start at 0.

Consequently, when replacing FUNCNAME by funcstack, we should not
change the index.

Signed-off-by: Marc Khouzam <marc.khouzam@ville.montreal.qc.ca>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This is a small fix to allow better logs when debugging zsh completion for kubectl.

**Special notes for your reviewer**:
Here is an example of a session debugging kubectl completion is zsh before and after the fix.
```
> export BASH_COMP_DEBUG_FILE=/tmp/hello
> rm /tmp/hello
>
> git checkout master
> build/run.sh make kubectl KUBE_BUILD_PLATFORMS=darwin/amd64
[...]
> source <(_output/dockerized/bin/darwin/amd64/kubectl completion zsh)
>
> _output/dockerized/bin/darwin/amd64/kubectl compl<TAB>
> _output/dockerized/bin/darwin/amd64/kubectl completion zs<TAB>
>
> cat /tmp/hello

: c is 0 words[c] is _output/dockerized/bin/darwin/amd64/kubectl
: c is 0 words[c] is _output/dockerized/bin/darwin/amd64/kubectl
: looking for _kubectl_root_command

: c is 0 words[c] is _output/dockerized/bin/darwin/amd64/kubectl
: c is 0 words[c] is _output/dockerized/bin/darwin/amd64/kubectl
: looking for _kubectl_root_command
: c is 1 words[c] is completion
: c is 1 words[c] is completion
: looking for _kubectl_completion

# Notice there is nothing before the :

> rm /tmp/hello
> git checkout fix/zshCompletionDebug
> build/run.sh make kubectl KUBE_BUILD_PLATFORMS=darwin/amd64
[...]
> source <(_output/dockerized/bin/darwin/amd64/kubectl completion zsh)
>
> _output/dockerized/bin/darwin/amd64/kubectl compl<TAB>
> _output/dockerized/bin/darwin/amd64/kubectl completion zs<TAB>
>
> cat /tmp/hello

__kubectl_handle_word: c is 0 words[c] is _output/dockerized/bin/darwin/amd64/kubectl
__kubectl_handle_command: c is 0 words[c] is _output/dockerized/bin/darwin/amd64/kubectl
__kubectl_handle_command: looking for _kubectl_root_command
__kubectl_handle_reply
__kubectl_handle_word: c is 0 words[c] is _output/dockerized/bin/darwin/amd64/kubectl
__kubectl_handle_command: c is 0 words[c] is _output/dockerized/bin/darwin/amd64/kubectl
__kubectl_handle_command: looking for _kubectl_root_command
__kubectl_handle_word: c is 1 words[c] is completion
__kubectl_handle_command: c is 1 words[c] is completion
__kubectl_handle_command: looking for _kubectl_completion
__kubectl_handle_reply

# Notice the method names are now printed before the :
```

I noticed this bug in helm when working on new completions.  It was fixed in helm here:
https://github.com/helm/helm/pull/5425

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
