### PR TITLE
CSI fix for ephemeral support in detacher/deviceMounter operations

### DIFF
--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -1161,7 +1161,7 @@ func TestAttacherMountDeviceWithInline(t *testing.T) {
 			volName:         "test-vol1",
 			devicePath:      "path1",
 			deviceMountPath: "path2",
-			shouldFail:      true,
+			shouldFail:      false,
 			spec:            volume.NewSpecFromVolume(makeTestVol(pvName, testDriver)),
 		},
 		{

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -411,7 +411,7 @@ func (c *csiMountMgr) applyFSGroup(fsType string, fsGroup *int64) error {
 // isDirMounted returns the !notMounted result from IsLikelyNotMountPoint check
 func isDirMounted(plug *csiPlugin, dir string) (bool, error) {
 	mounter := plug.host.GetMounter(plug.GetPluginName())
-	notMnt, err := mounter.IsLikelyNotMountPoint(dir)
+	notMnt, err := mounter.IsNotMountPoint(dir)
 	if err != nil && !os.IsNotExist(err) {
 		klog.Error(log("isDirMounted IsLikelyNotMountPoint test failed for dir [%v]", dir))
 		return false, err

--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -209,28 +209,30 @@ func TestPluginGetVolumeNameWithInline(t *testing.T) {
 	plug, tmpDir := newTestPlugin(t, nil)
 	defer os.RemoveAll(tmpDir)
 	testCases := []struct {
-		name       string
-		driverName string
-		volName    string
-		shouldFail bool
-		spec       *volume.Spec
+		name         string
+		driverName   string
+		volName      string
+		expectedName string
+		shouldFail   bool
+		spec         *volume.Spec
 	}{
 		{
 			name:       "missing spec",
 			shouldFail: true,
 		},
 		{
-			name:       "alphanum names for pv",
-			driverName: "testdr",
-			volName:    "testvol",
-			spec:       volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, "testdr", "testvol"), false),
+			name:         "alphanum names for pv",
+			driverName:   "testdr",
+			volName:      "testvol",
+			spec:         volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, "testdr", "testvol"), false),
+			expectedName: fmt.Sprintf("%s%s%s", "testdr", volNameSep, "testvol"),
 		},
 		{
-			name:       "alphanum names for vol source",
-			driverName: "testdr",
-			volName:    "testvol",
-			spec:       volume.NewSpecFromVolume(makeTestVol("test-pv", "testdr")),
-			shouldFail: true,
+			name:         "alphanum names for vol source",
+			driverName:   "testdr",
+			volName:      "testvol",
+			spec:         volume.NewSpecFromVolume(makeTestVol("test-pv", "testdr")),
+			expectedName: fmt.Sprintf("%s%s%s", "testdr", volNameSep, "test-pv"),
 		},
 	}
 
@@ -245,7 +247,7 @@ func TestPluginGetVolumeNameWithInline(t *testing.T) {
 			t.Log(err)
 			continue
 		}
-		if name != fmt.Sprintf("%s%s%s", tc.driverName, volNameSep, tc.volName) {
+		if name != tc.expectedName {
 			t.Errorf("unexpected volume name %s", name)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This is needed to fix issues with the CSI ephemeral alpha support.  The volume controller gets stuck in volume detachment reconciliation upon startup.

**Which issue(s) this PR fixes**:
Fixes #75353 

```release-note
NONE
```

/sig storage