### PR TITLE
Don't flush iptables chains when using iptables proxy but IPVS is available

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -557,7 +557,7 @@ func (s *ProxyServer) Run() error {
 	if s.CleanupAndExit {
 		encounteredError := userspace.CleanupLeftovers(s.IptInterface)
 		encounteredError = iptables.CleanupLeftovers(s.IptInterface) || encounteredError
-		encounteredError = ipvs.CleanupLeftovers(s.IpvsInterface, s.IptInterface, s.IpsetInterface, s.CleanupIPVS) || encounteredError
+		encounteredError = ipvs.CleanupLeftovers(s.IpvsInterface, s.IptInterface, s.IpsetInterface) || encounteredError
 		if encounteredError {
 			return errors.New("encountered an error while tearing down rules.")
 		}

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -590,26 +590,27 @@ func cleanupIptablesLeftovers(ipt utiliptables.Interface) (encounteredError bool
 }
 
 // CleanupLeftovers clean up all ipvs and iptables rules created by ipvs Proxier.
-func CleanupLeftovers(ipvs utilipvs.Interface, ipt utiliptables.Interface, ipset utilipset.Interface, cleanupIPVS bool) (encounteredError bool) {
-	if cleanupIPVS {
-		// Return immediately when ipvs interface is nil - Probably initialization failed in somewhere.
-		if ipvs == nil {
-			return true
-		}
-		encounteredError = false
-		err := ipvs.Flush()
-		if err != nil {
-			klog.Errorf("Error flushing IPVS rules: %v", err)
-			encounteredError = true
-		}
+func CleanupLeftovers(ipvs utilipvs.Interface, ipt utiliptables.Interface, ipset utilipset.Interface) (encounteredError bool) {
+	// Return immediately when ipvs interface is nil - Probably initialization failed in somewhere.
+	if ipvs == nil {
+		return true
 	}
+
+	encounteredError = false
+	err := ipvs.Flush()
+	if err != nil {
+		klog.Errorf("Error flushing IPVS rules: %v", err)
+		encounteredError = true
+	}
+
 	// Delete dummy interface created by ipvs Proxier.
 	nl := NewNetLinkHandle(false)
-	err := nl.DeleteDummyDevice(DefaultDummyDevice)
+	err = nl.DeleteDummyDevice(DefaultDummyDevice)
 	if err != nil {
 		klog.Errorf("Error deleting dummy device %s created by IPVS proxier: %v", DefaultDummyDevice, err)
 		encounteredError = true
 	}
+
 	// Clear iptables created by ipvs Proxier.
 	encounteredError = cleanupIptablesLeftovers(ipt) || encounteredError
 	// Destroy ip sets created by ipvs Proxier.  We should call it after cleaning up

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -266,7 +266,7 @@ func TestCleanupLeftovers(t *testing.T) {
 	fp.syncProxyRules()
 
 	// test cleanup left over
-	if CleanupLeftovers(ipvs, ipt, ipset, true) {
+	if CleanupLeftovers(ipvs, ipt, ipset) {
 		t.Errorf("Cleanup leftovers failed")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
There's a behavior in the kubelet where if the proxier is set to iptables but the proxy _can_ use IPVS (i.e. the ipvs kernel module is loaded), it tries to flush iptable chains used for IPVS which conflict with chains used for iptables. This impacts traffic through the proxy every time kube-proxy restarts, even though there is no cleanup required. Trying to clean up IPVS rules is nice to have here, but I don't think it's worth flushing iptable chains (especially when the proxier is set to use iptables). This PR changes the proxy to only clean up IPVS rules if `--cleanup-ipvs=true`. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/75360

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Don't flush iptable chains when using iptables proxy but IPVS is available
```
