### PR TITLE
{WIP} Capture total mount/unmount operation time

### DIFF
--- a/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
@@ -24,6 +24,7 @@ package cache
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -183,6 +184,8 @@ type volumeToAttach struct {
 	// the name of the pod and the value is a pod object containing more
 	// information about the pod.
 	scheduledPods map[types.UniquePodName]pod
+
+	attachRequestTime time.Time
 }
 
 // The pod represents a pod that references the underlying volume and is
@@ -248,6 +251,7 @@ func (dsw *desiredStateOfWorld) AddPod(
 			volumeName:               volumeName,
 			spec:                     volumeSpec,
 			scheduledPods:            make(map[types.UniquePodName]pod),
+			attachRequestTime:        time.Now(),
 		}
 		dsw.nodesManaged[nodeName].volumesToAttach[volumeName] = volumeObj
 	}
@@ -383,6 +387,7 @@ func (dsw *desiredStateOfWorld) GetVolumesToAttach() []VolumeToAttach {
 						VolumeSpec:               volumeObj.spec,
 						NodeName:                 nodeName,
 						ScheduledPods:            getPodsFromMap(volumeObj.scheduledPods),
+						AttachRequestTime:        volumeObj.attachRequestTime,
 					}})
 		}
 	}

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -267,6 +267,7 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods() {
 		dswp.desiredStateOfWorld.DeletePodFromVolume(
 			volumeToMount.PodName, volumeToMount.VolumeName)
 		dswp.deleteProcessedPod(volumeToMount.PodName)
+		dswp.actualStateOfWorld.RecordVolumeUnmount(volumeToMount.PodName, volumeToMount.VolumeName)
 	}
 }
 

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -349,7 +349,13 @@ type VolumeToMount struct {
 	// ReportedInUse indicates that the volume was successfully added to the
 	// VolumesInUse field in the node's status.
 	ReportedInUse bool
+
+	// time at which volume was requested to be mounted
+	MountRequestTime time.Time
 }
+
+var _ util.OperationRequestTime = &VolumeToMount{}
+var _ util.OperationRequestTime = &MountedVolume{}
 
 // GenerateMsgDetailed returns detailed msgs for volumes to mount
 func (volume *VolumeToMount) GenerateMsgDetailed(prefixMsg, suffixMsg string) (detailedMsg string) {
@@ -369,6 +375,10 @@ func (volume *VolumeToMount) GenerateMsg(prefixMsg, suffixMsg string) (simpleMsg
 		volumeSpecName = volume.VolumeSpec.Name()
 	}
 	return generateVolumeMsg(prefixMsg, suffixMsg, volumeSpecName, detailedStr)
+}
+
+func (volume VolumeToMount) GetOperationRequestTime() time.Time {
+	return volume.MountRequestTime
 }
 
 // GenerateErrorDetailed returns detailed errors for volumes to mount
@@ -556,6 +566,9 @@ type MountedVolume struct {
 	// DeviceMountPath contains the path on the node where the device should
 	// be mounted after it is attached.
 	DeviceMountPath string
+
+	// contains time at which volume was requested to be unmounted
+	UnmountRequestTime time.Time
 }
 
 // GenerateMsgDetailed returns detailed msgs for mounted volumes
@@ -579,6 +592,11 @@ func (volume *MountedVolume) GenerateErrorDetailed(prefixMsg string, err error) 
 func (volume *MountedVolume) GenerateError(prefixMsg string, err error) (simpleErr, detailedErr error) {
 	simpleMsg, detailedMsg := volume.GenerateMsg(prefixMsg, errSuffix(err))
 	return fmt.Errorf(simpleMsg), fmt.Errorf(detailedMsg)
+}
+
+// GetOperationRequestTime returns time at which unmount was requested.
+func (volume MountedVolume) GetOperationRequestTime() time.Time {
+	return volume.UnmountRequestTime
 }
 
 type operationExecutor struct {

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -274,6 +274,9 @@ type VolumeToAttach struct {
 	// the name of the pod and the value is a pod object containing more
 	// information about the pod.
 	ScheduledPods []*v1.Pod
+
+	// AttachRequestTime stores time at which attach was issued.
+	AttachRequestTime time.Time
 }
 
 // GenerateMsgDetailed returns detailed msgs for volumes to attach
@@ -284,6 +287,11 @@ func (volume *VolumeToAttach) GenerateMsgDetailed(prefixMsg, suffixMsg string) (
 		volumeSpecName = volume.VolumeSpec.Name()
 	}
 	return generateVolumeMsgDetailed(prefixMsg, suffixMsg, volumeSpecName, detailedStr)
+}
+
+// GetOperationRequestTime returns time at which attach operation was performed.
+func (volume VolumeToAttach) GetOperationRequestTime() time.Time {
+	return volume.AttachRequestTime
 }
 
 // GenerateMsg returns simple and detailed msgs for volumes to attach

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -706,10 +706,12 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 		}
 	}
 
+	qualifiedPluginName := util.GetFullQualifiedPluginNameForVolume(volumePluginName, volumeToMount.VolumeSpec)
+
 	return volumetypes.GeneratedOperations{
 		OperationFunc:     mountVolumeFunc,
 		EventRecorderFunc: eventRecorderFunc,
-		CompleteFunc:      util.OperationCompleteHook(util.GetFullQualifiedPluginNameForVolume(volumePluginName, volumeToMount.VolumeSpec), "volume_mount"),
+		CompleteFunc:      util.CaptureTotalOpTime(volumeToMount, qualifiedPluginName, "volume_mount"),
 	}
 }
 
@@ -832,10 +834,11 @@ func (og *operationGenerator) GenerateUnmountVolumeFunc(
 
 		return nil, nil
 	}
+	qualifiedPluginName := util.GetFullQualifiedPluginNameForVolume(volumePlugin.GetPluginName(), volumeToUnmount.VolumeSpec)
 
 	return volumetypes.GeneratedOperations{
 		OperationFunc:     unmountVolumeFunc,
-		CompleteFunc:      util.OperationCompleteHook(util.GetFullQualifiedPluginNameForVolume(volumePlugin.GetPluginName(), volumeToUnmount.VolumeSpec), "volume_unmount"),
+		CompleteFunc:      util.CaptureTotalOpTime(volumeToUnmount, qualifiedPluginName, "volume_unmount"),
 		EventRecorderFunc: nil, // nil because we do not want to generate event on error
 	}, nil
 }

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -387,10 +387,12 @@ func (og *operationGenerator) GenerateAttachVolumeFunc(
 		return nil, nil
 	}
 
+	qualifiedPluginName := util.GetFullQualifiedPluginNameForVolume(attachableVolumePlugin.GetPluginName(), volumeToAttach.VolumeSpec)
+
 	return volumetypes.GeneratedOperations{
 		OperationFunc:     attachVolumeFunc,
 		EventRecorderFunc: eventRecorderFunc,
-		CompleteFunc:      util.OperationCompleteHook(util.GetFullQualifiedPluginNameForVolume(attachableVolumePlugin.GetPluginName(), volumeToAttach.VolumeSpec), "volume_attach"),
+		CompleteFunc:      util.CaptureTotalOpTime(volumeToAttach, qualifiedPluginName, "volume_attach"),
 	}, nil
 }
 


### PR DESCRIPTION
Another attempt to capture total mount and unmount operation time.

These metrics are different from current mount/unmount metrics because these(new) metrics capture total time taken from time a pod enters kubelet's volumemanager to time volume is actually mounted. So it includes time spent in things like - waiting for secret/configmap or volume to be attached etc. 

Similarly for unmount it captures time taken for verifying if volume should be unmounted and everything else. 

Hopefully, these metrics will be more representative of actual mount and unmount timings.

/sig storage

cc @msau42 
