### PR TITLE
Remove reference to USE_RELEASE_NODE_BINARIES.

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -323,7 +323,7 @@ function find-tar() {
 #   KUBE_MANIFESTS_TAR
 function find-release-tars() {
   SERVER_BINARY_TAR=$(find-tar kubernetes-server-linux-amd64.tar.gz)
-  if [[ "${NUM_WINDOWS_NODES}" -gt "0" && "${USE_RELEASE_NODE_BINARIES:-false}" == "false" ]]; then
+  if [[ "${NUM_WINDOWS_NODES}" -gt "0" ]]; then
     NODE_BINARY_TAR=$(find-tar kubernetes-node-windows-amd64.tar.gz)
   fi
 


### PR DESCRIPTION
This variable was used for development purposes and was accidentally
introduced in
https://github.com/kubernetes/kubernetes/commit/f0f78299348afcf770d4e8d89dcea82f80811b28.

This is its only use in the tree:
https://github.com/kubernetes/kubernetes/search?q=USE_RELEASE_NODE_BINARIES&unscoped_q=USE_RELEASE_NODE_BINARIES

/kind cleanup

```release-note
NONE
```