### PR TITLE
Add DeletePropagationBackground DeleteOptions to deployment controller

### DIFF
--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -449,7 +449,8 @@ func (dc *DeploymentController) cleanupDeployment(oldRSs []*apps.ReplicaSet, dep
 			continue
 		}
 		klog.V(4).Infof("Trying to cleanup replica set %q for deployment %q", rs.Name, deployment.Name)
-		if err := dc.client.AppsV1().ReplicaSets(rs.Namespace).Delete(rs.Name, nil); err != nil && !errors.IsNotFound(err) {
+		background := metav1.DeletePropagationBackground
+		if err := dc.client.AppsV1().ReplicaSets(rs.Namespace).Delete(rs.Name, &metav1.DeleteOptions{PropagationPolicy: &background}); err != nil && !errors.IsNotFound(err) {
 			// Return error instead of aggregating and continuing DELETEs on the theory
 			// that we may be overloading the api server.
 			return err


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Several resources default to orphaning dependents for backwards compatibility:
deployments in extensions/v1beta1, apps/v1beta1, apps/v1beta2
Calls made via client-go to delete these resource via these versions which do not specify a deletion propagation policy default to orphaning dependents. 
This PR added propagation for deployment. 

**Which issue(s) this PR fixes**:
Fixes #71807
cc @liggitt 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```