### PR TITLE
Update Cluster Autscaler version to 1.14.0-beta.2

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.14.0-beta.1",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.14.0-beta.2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
This PR updates CA version in gce manifests to 1.14.0-beta.2
We need a second beta as we discovered a bug related to internal scheduler-simulator initialization which resulted in CA misbehaviour if anti-affinity was used on Pods.

```release-note
NONE
```