### PR TITLE
Per the JSON response object from the ScaleIO gateway API, the attrib…

### DIFF
--- a/pkg/volume/scaleio/sio_client.go
+++ b/pkg/volume/scaleio/sio_client.go
@@ -305,7 +305,7 @@ func (c *sioClient) IID() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		sdc, err := c.sysClient.FindSdc("SdcGUID", guid)
+		sdc, err := c.sysClient.FindSdc("sdcGuid", guid)
 		if err != nil {
 			klog.Error(log("failed to retrieve sdc info %s", err))
 			return "", err


### PR DESCRIPTION
…ute name for the SDC GUID is sdcGuid, rather than SdcGUID

cat out.json | jq ".[0] | .sdcGuid"
"B7FE7B35-6905-4BB7-9956-4B5E7228C43B"

cat out.json | jq ".[0] | .SdcGUID"
null

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind bug

**What this PR does / why we need it**:
Fixes an issue with the ScaleIO storage driver addressing an attribute with the correct name.

**Which issue(s) this PR fixes**:
Fixes #75409

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fixed issue with SDC GUID attribute being referenced as SdcGUID instead of sdcGuid
```
