### PR TITLE
fix kubeadm init output

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -63,11 +63,25 @@ var (
 		Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
 		  https://kubernetes.io/docs/concepts/cluster-administration/addons/
 
-		You can now join any number of machines by running the following on each node
-		as root:
-
-		  {{.joinCommand}}
-
+		{{if .ControlPlaneEndpoint -}}
+		{{if .UploadCerts -}}
+		You can now join any number of the control-plane node running the following command on each as root:
+					  
+		  {{.joinControlPlaneCommand}}
+					
+		Please note that the certificate-key gives access to cluster sensitive data, keep it secret!
+		As a safeguard, uploaded-certs will be deleted in two hours; If necessary, you can use 
+		"kubeadm init phase upload-certs --experimental-upload-certs" to reload certs afterward.
+		  
+		{{else -}}
+		You can now join any number of control-plane nodes by copying certificate authorities 
+		and service account keys on each node and then running the following as root:
+				  
+		  {{.joinControlPlaneCommand}}	  
+		  
+		{{end}}{{end}}Then you can join any number of worker nodes by running the following on each as root:
+						  
+		{{.joinWorkerCommand}}
 		`)))
 )
 
@@ -490,14 +504,22 @@ func (d *initData) Tokens() []string {
 }
 
 func printJoinCommand(out io.Writer, adminKubeConfigPath, token string, i *initData) error {
-	joinCommand, err := cmdutil.GetJoinCommand(adminKubeConfigPath, token, i.certificateKey, i.skipTokenPrint, i.uploadCerts, i.skipCertificateKeyPrint)
+	joinControlPlaneCommand, err := cmdutil.GetJoinControlPlaneCommand(adminKubeConfigPath, token, i.certificateKey, i.skipTokenPrint, i.skipCertificateKeyPrint)
 	if err != nil {
 		return err
 	}
 
-	ctx := map[string]string{
-		"KubeConfigPath": adminKubeConfigPath,
-		"joinCommand":    joinCommand,
+	joinWorkerCommand, err := cmdutil.GetJoinWorkerCommand(adminKubeConfigPath, token, i.skipTokenPrint)
+	if err != nil {
+		return err
+	}
+
+	ctx := map[string]interface{}{
+		"KubeConfigPath":          adminKubeConfigPath,
+		"ControlPlaneEndpoint":    i.Cfg().ControlPlaneEndpoint,
+		"UploadCerts":             i.uploadCerts,
+		"joinControlPlaneCommand": joinControlPlaneCommand,
+		"joinWorkerCommand":       joinWorkerCommand,
 	}
 
 	return initDoneTempl.Execute(out, ctx)

--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -228,11 +228,8 @@ func RunCreateToken(out io.Writer, client clientset.Interface, cfgPath string, c
 	// if --print-join-command was specified, print the full `kubeadm join` command
 	// otherwise, just print the token
 	if printJoinCommand {
-		key := ""
 		skipTokenPrint := false
-		uploadCerts := false
-		skipCertificateKeyPrint := false
-		joinCommand, err := cmdutil.GetJoinCommand(kubeConfigFile, internalcfg.BootstrapTokens[0].Token.String(), key, skipTokenPrint, uploadCerts, skipCertificateKeyPrint)
+		joinCommand, err := cmdutil.GetJoinWorkerCommand(kubeConfigFile, internalcfg.BootstrapTokens[0].Token.String(), skipTokenPrint)
 		if err != nil {
 			return errors.Wrap(err, "failed to get join command")
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a duplicated message in the kubeadm init output (`You can now join any number of machines by running the following on each node as root` repeated twice) and wrong indentation.

Additionally, now the join control-plane message is printed only when the preconditions for joining a control plane are satisfied:

kubeadm init output for cluster WITHOUT `controlPlaneEndpoint` --> join control-plane conditions not satisfied:
```bash
....
Then you can join any number of worker nodes by running the following on each as root:

kubeadm join 172.17.0.2:6443 --token abcdef.0123456789abcdef \
    --discovery-token-ca-cert-hash sha256:4d170b1dfb24229319e0439a052b3cb56d02b152fc5903a4e4753e4fa76f8aca
````

kubeadm init output for cluster WITH `controlPlaneEndpoint`, but created WITHOUT `--upload-certs`
```bash
....
You can now join any number of control-plane node by copying certificate authorities
and service account keys on each node and then running the following as root:

  kubeadm join 172.17.0.2:6443 --token abcdef.0123456789abcdef \
    --discovery-token-ca-cert-hash sha256:c2b92b4d0864ed76706f51962ab709f404d58874f8a5b7e7e8aa88fcfe8fc518 \
    --experimental-control-plane

Then you can join any number of worker nodes by running the following on each as root:

kubeadm join 172.17.0.2:6443 --token abcdef.0123456789abcdef \
    --discovery-token-ca-cert-hash sha256:c2b92b4d0864ed76706f51962ab709f404d58874f8a5b7e7e8aa88fcfe8fc518
````

kubeadm init output for cluster WITH `controlPlaneEndpoint` and WITH `--upload-certs`
```bash
....
You can now join any number of the control-plane node running the following command on each as a root:

  kubeadm join 172.17.0.4:6443 --token abcdef.0123456789abcdef \
    --discovery-token-ca-cert-hash sha256:65034066a1b500506b6e673a70da433e171ebda9201f1f3e2767c68417bb44f6 \
    --experimental-control-plane --certificate-key 0123456789012345678901234567890123456789012345678901234567890123

Please note that the certificate-key gives access to cluster sensitive data, keep it secret!
As a safeguard, uploaded-certs will be deleted in two hours; If necessary, you can use
"kubeadm init phase upload-certs" to reload certs afterward.

Then you can join any number of worker nodes by running the following on each as root:

kubeadm join 172.17.0.4:6443 --token abcdef.0123456789abcdef \
    --discovery-token-ca-cert-hash sha256:65034066a1b500506b6e673a70da433e171ebda9201f1f3e2767c68417bb44f6
````

**Does this PR introduce a user-facing change?**:
```release-note 
kubeadm: the kubeadm init output now provides join control-plane example only when the preconditions for joining a control plane are satisfied
```

/sig cluster-lifecycle
/priority critical-urgent
/milestone v1.14
/assign @neolit123 
/assign @timothysc 
/cc @yagonobre 