### PR TITLE
kubeadm: Support >= 5.0 Linux Kernel

### DIFF
--- a/cmd/kubeadm/app/util/system/types_unix.go
+++ b/cmd/kubeadm/app/util/system/types_unix.go
@@ -30,7 +30,7 @@ const dockerEndpoint = "unix:///var/run/docker.sock"
 var DefaultSysSpec = SysSpec{
 	OS: "Linux",
 	KernelSpec: KernelSpec{
-		Versions: []string{`3\.[1-9][0-9].*`, `4\..*`}, // Requires 3.10+ or 4+
+		Versions: []string{`3\.[1-9][0-9].*`, `4\..*`, `5\..*`}, // Requires 3.10+, 4+ or 5+
 		// TODO(random-liu): Add more config
 		// TODO(random-liu): Add description for each kernel configuration:
 		Required: []KernelConfig{


### PR DESCRIPTION
Cherry pick of #74355 on release-1.13.

#74355 : kubeadm: Support >= 5.0 Linux kernel 