### PR TITLE
Automated cherry pick of #75375: stop vsphere cloud provider from spamming logs with `failed

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -585,7 +585,7 @@ func getLocalIP() ([]v1.NodeAddress, error) {
 							)
 							klog.V(4).Infof("Detected local IP address as %q", ipnet.IP.String())
 						} else {
-							klog.Warningf("Failed to patch IP as MAC address %q does not belong to a VMware platform", vmMACAddr)
+							klog.V(4).Infof("Failed to patch IP for interface %q as MAC address %q does not belong to a VMware platform", i.Name, vmMACAddr)
 						}
 					}
 				}


### PR DESCRIPTION
Cherry pick of #75375 on release-1.14.

#75375: stop vsphere cloud provider from spamming logs with `failed