### PR TITLE
change bandwidth units from Kb to b

### DIFF
--- a/pkg/kubelet/dockershim/network/cni/cni.go
+++ b/pkg/kubelet/dockershim/network/cni/cni.go
@@ -398,11 +398,14 @@ func (plugin *cniNetworkPlugin) buildCNIRuntimeConf(podName string, podNs string
 	if ingress != nil || egress != nil {
 		bandwidthParam := cniBandwidthEntry{}
 		if ingress != nil {
-			bandwidthParam.IngressRate = int(ingress.Value() / 1000)
+			// see: https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md and
+			// https://github.com/containernetworking/plugins/blob/master/plugins/meta/bandwidth/README.md
+			// Rates are in bits per second, burst values are in bits.
+			bandwidthParam.IngressRate = int(ingress.Value())
 			bandwidthParam.IngressBurst = math.MaxInt32 // no limit
 		}
 		if egress != nil {
-			bandwidthParam.EgressRate = int(egress.Value() / 1000)
+			bandwidthParam.EgressRate = int(egress.Value())
 			bandwidthParam.EgressBurst = math.MaxInt32 // no limit
 		}
 		rt.CapabilityArgs["bandwidth"] = bandwidthParam

--- a/pkg/kubelet/dockershim/network/cni/cni_test.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_test.go
@@ -291,7 +291,7 @@ func TestCNIPlugin(t *testing.T) {
 		t.Errorf("mismatch in expected port mappings. expected %v got %v", expectedMappings, inputConfig.RuntimeConfig.PortMappings)
 	}
 	expectedBandwidth := map[string]interface{}{
-		"ingressRate": 1000.0, "egressRate": 1000.0,
+		"ingressRate": 1000000.0, "egressRate": 1000000.0,
 		"ingressBurst": 2147483647.0, "egressBurst": 2147483647.0,
 	}
 	if !reflect.DeepEqual(inputConfig.RuntimeConfig.Bandwidth, expectedBandwidth) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
CNI bandwidth plugin is designed to use bits-per-second and bits as the units of bandwidth rates and brust, and bandwidth plugin doc has changed its bandwidth related units from Kb to b in [https://github.com/containernetworking/plugins/commit/220499db6b3ff270db1d91c042f36d7fd6f07a15](https://github.com/containernetworking/plugins/commit/220499db6b3ff270db1d91c042f36d7fd6f07a15), and CNI CONVENTIONS has also use b as its unit in [https://github.com/containernetworking/cni/commit/d2be2fa823345daaf628b55832214162fbd95094](https://github.com/containernetworking/cni/commit/d2be2fa823345daaf628b55832214162fbd95094). So we have to change bandwidth unit from Kb to b in kubelet/cni.

```release-note
none
```