### PR TITLE
Update branding guidelines

### DIFF
--- a/logo/usage_guidelines.md
+++ b/logo/usage_guidelines.md
@@ -4,21 +4,19 @@ These guidelines provide you with guidance for using the Kubernetes logo. You
 can use the logo on your website or in print without pre-approval, provided you
 follow these basic guidelines.
 
-You may display, modify, or use the Kubernetes logo only in connection with
-compliant implementations of Kubernetes and related uses in the following ways.
-A compliant implementation is an implementation of the unmodified Cloud Native
-Compute Foundation (CNCF)
-version of Kubernetes found at https://github.com/kubernetes/kubernetes and
-compatible branches thereof, together with published specifications, APIs and
-operational patterns.  Acceptable related uses include display, modification,
-or use of the Kubernetes logo in connection with your compliant implementation,
-your integration with a compliant implementation, your support for a compliant
-implementation, your Kubernetes-compatible product, or in collateral,
-presentations, and marketing materials relating to compliant implementations of
-Kubernetes.
+All artwork is made available under the Linux Foundation trademark usage
+[guidelines](https://www.linuxfoundation.org/trademark-usage/). This text from
+those guidelines, and the correct and incorrect usage examples, are particularly
+helpful:
+>Certain marks of The Linux Foundation have been created to enable you to
+>communicate compatibility or interoperability of software or products. In
+>addition to the requirement that any use of a mark to make an assertion of
+>compatibility must, of course, be accurate, the use of these marks must
+>avoid confusion regarding The Linux Foundation’s association with the
+>product. The use of the mark cannot imply that The Linux Foundation or
+>its projects are sponsoring or endorsing the product.
 
-All other uses of this logo are covered by the Linux Foundation trademark
-guidelines found [here](https://linuxfoundation.org/trademark-usage).
+Additionally, permission is granted to modify the Kubernetes mark for non-commercial uses such as t-shirts and stickers.
 
 ## Links to logo images
 Logo:

--- a/logo/usage_guidelines.md
+++ b/logo/usage_guidelines.md
@@ -1,9 +1,6 @@
 # Kubernetes Branding Guidelines
 
-These guidelines provide you with guidance for using the Kubernetes logo. You
-can use the logo on your website or in print without pre-approval, provided you
-follow these basic guidelines.
-
+These guidelines provide you with guidance for using the Kubernetes logo.
 All artwork is made available under the Linux Foundation trademark usage
 [guidelines](https://www.linuxfoundation.org/trademark-usage/). This text from
 those guidelines, and the correct and incorrect usage examples, are particularly


### PR DESCRIPTION
Signed-off-by: Dan Kohn <dan@dankohn.com>

This change has been recommended by Linux Foundation legal counsel. It brings Kubernetes logo usage guidelines into alignment with other logos and trademarks managed by the Linux Foundation.

The CNCF governing board has requested the change while also voting to add an additional permission not normally granted: "Additionally, permission is granted to modify the Kubernetes mark for non-commercial uses such as t-shirts and stickers." Importantly, this change removes permission for Certified Kubernetes offerings to *modify* the Kubernetes logo. [None](https://landscape.cncf.io/category=certified-kubernetes-distribution,certified-kubernetes-hosted,certified-kubernetes-installer&format=card-mode&grouping=no) of the 97 certified products currently do so, but we don't want them to start.

The Kubernetes Steering Committee should sign off on this.

Cc Kubernetes Steering Committee: @spiffxp @dims @timothysc @derekwaynecarr @michelleN @pwittrock @joebeda @brendandburns @smarterclayton @bgrant0607 @sarahnovotny @philips
Cc Original author: @thockin 

/committee steering
/kind documentation
