### PR TITLE
Replace all time.Now().Sub with time.Since

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -278,7 +278,7 @@ func shouldBackupAPIServerCertAndKey(certAndKeyDir string) (bool, error) {
 		return false, errors.New("no certificate data found")
 	}
 
-	if time.Now().Sub(certs[0].NotBefore) > expiry {
+	if time.Since(certs[0].NotBefore) > expiry {
 		return true, nil
 	}
 

--- a/pkg/cloudprovider/providers/gce/gce_tpu.go
+++ b/pkg/cloudprovider/providers/gce/gce_tpu.go
@@ -158,7 +158,7 @@ func (g *Cloud) waitForTPUOp(ctx context.Context, op *tpuapi.Operation) (*tpuapi
 
 		start := time.Now()
 		g.operationPollRateLimiter.Accept()
-		duration := time.Now().Sub(start)
+		duration := time.Since(start)
 		if duration > 5*time.Second {
 			klog.V(2).Infof("Getting operation %q throttled for %v", op.Name, duration)
 		}

--- a/pkg/controller/route/route_controller.go
+++ b/pkg/controller/route/route_controller.go
@@ -192,7 +192,7 @@ func (rc *RouteController) reconcile(nodes []*v1.Node, routes []*cloudprovider.R
 						klog.V(4).Infof(msg)
 						return err
 					}
-					klog.Infof("Created route for node %s %s with hint %s after %v", nodeName, route.DestinationCIDR, nameHint, time.Now().Sub(startTime))
+					klog.Infof("Created route for node %s %s with hint %s after %v", nodeName, route.DestinationCIDR, nameHint, time.Since(startTime))
 					return nil
 				})
 				if err != nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -854,7 +854,7 @@ func (m *kubeGenericRuntimeManager) cleanupErrorTimeouts() {
 	m.errorMapLock.Lock()
 	defer m.errorMapLock.Unlock()
 	for name, timeout := range m.errorPrinted {
-		if time.Now().Sub(timeout) >= identicalErrorDelay {
+		if time.Since(timeout) >= identicalErrorDelay {
 			delete(m.errorPrinted, name)
 			delete(m.lastError, name)
 		}
@@ -913,7 +913,7 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(uid kubetypes.UID, name, namesp
 	defer m.errorMapLock.Unlock()
 	if err != nil {
 		lastMsg, ok := m.lastError[podFullName]
-		if !ok || err.Error() != lastMsg || time.Now().Sub(m.errorPrinted[podFullName]) >= identicalErrorDelay {
+		if !ok || err.Error() != lastMsg || time.Since(m.errorPrinted[podFullName]) >= identicalErrorDelay {
 			klog.Errorf("getPodContainerStatuses for pod %q failed: %v", podFullName, err)
 			m.errorPrinted[podFullName] = time.Now()
 			m.lastError[podFullName] = err.Error()

--- a/pkg/kubelet/remote/remote_runtime.go
+++ b/pkg/kubelet/remote/remote_runtime.go
@@ -296,7 +296,7 @@ func (r *RemoteRuntimeService) cleanupErrorTimeouts() {
 	r.errorMapLock.Lock()
 	defer r.errorMapLock.Unlock()
 	for ID, timeout := range r.errorPrinted {
-		if time.Now().Sub(timeout) >= identicalErrorDelay {
+		if time.Since(timeout) >= identicalErrorDelay {
 			delete(r.lastError, ID)
 			delete(r.errorPrinted, ID)
 		}
@@ -317,7 +317,7 @@ func (r *RemoteRuntimeService) ContainerStatus(containerID string) (*runtimeapi.
 	if err != nil {
 		// Don't spam the log with endless messages about the same failure.
 		lastMsg, ok := r.lastError[containerID]
-		if !ok || err.Error() != lastMsg || time.Now().Sub(r.errorPrinted[containerID]) >= identicalErrorDelay {
+		if !ok || err.Error() != lastMsg || time.Since(r.errorPrinted[containerID]) >= identicalErrorDelay {
 			klog.Errorf("ContainerStatus %q from runtime service failed: %v", containerID, err)
 			r.errorPrinted[containerID] = time.Now()
 			r.lastError[containerID] = err.Error()
@@ -505,7 +505,7 @@ func (r *RemoteRuntimeService) ContainerStats(containerID string) (*runtimeapi.C
 	defer r.errorMapLock.Unlock()
 	if err != nil {
 		lastMsg, ok := r.lastError[containerID]
-		if !ok || err.Error() != lastMsg || time.Now().Sub(r.errorPrinted[containerID]) >= identicalErrorDelay {
+		if !ok || err.Error() != lastMsg || time.Since(r.errorPrinted[containerID]) >= identicalErrorDelay {
 			klog.Errorf("ContainerStatus %q from runtime service failed: %v", containerID, err)
 			r.errorPrinted[containerID] = time.Now()
 			r.lastError[containerID] = err.Error()

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -845,7 +845,7 @@ func printJob(obj *batch.Job, options printers.PrintOptions) ([]metav1beta1.Tabl
 	switch {
 	case obj.Status.StartTime == nil:
 	case obj.Status.CompletionTime == nil:
-		jobDuration = duration.HumanDuration(time.Now().Sub(obj.Status.StartTime.Time))
+		jobDuration = duration.HumanDuration(time.Since(obj.Status.StartTime.Time))
 	default:
 		jobDuration = duration.HumanDuration(obj.Status.CompletionTime.Sub(obj.Status.StartTime.Time))
 	}

--- a/plugin/pkg/auth/authorizer/node/node_authorizer_test.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer_test.go
@@ -828,7 +828,7 @@ func BenchmarkAuthorization(b *testing.B) {
 								},
 							},
 						})
-						diff := time.Now().Sub(start)
+						diff := time.Since(start)
 						atomic.AddInt64(&writes, 1)
 						switch {
 						case diff < time.Millisecond:

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/table/table.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/table/table.go
@@ -67,5 +67,5 @@ func ConvertToHumanReadableDateType(timestamp metav1.Time) string {
 	if timestamp.IsZero() {
 		return "<unknown>"
 	}
-	return duration.HumanDuration(time.Now().Sub(timestamp.Time))
+	return duration.HumanDuration(time.Since(timestamp.Time))
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/clock/clock_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/clock/clock_test.go
@@ -44,8 +44,8 @@ func TestFakeClock(t *testing.T) {
 
 	tt := tc.Now()
 	tc.SetTime(tt.Add(time.Hour))
-	if tc.Now().Sub(tt) != time.Hour {
-		t.Errorf("input: %s now=%s gap=%s expected=%s", tt, tc.Now(), tc.Now().Sub(tt), time.Hour)
+	if tc.Since(tt) != time.Hour {
+		t.Errorf("input: %s now=%s gap=%s expected=%s", tt, tc.Now(), tc.Since(tt), time.Hour)
 	}
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -531,7 +531,7 @@ func TestWaitForWithEarlyClosingWaitFunc(t *testing.T) {
 	}, func() (bool, error) {
 		return false, nil
 	}, stopCh)
-	duration := time.Now().Sub(start)
+	duration := time.Since(start)
 
 	// The WaitFor should return immediately, so the duration is close to 0s.
 	if duration >= ForeverTestTimeout/2 {
@@ -555,7 +555,7 @@ func TestWaitForWithClosedChannel(t *testing.T) {
 	}, func() (bool, error) {
 		return false, nil
 	}, stopCh)
-	duration := time.Now().Sub(start)
+	duration := time.Since(start)
 	// The WaitFor should return immediately, so the duration is close to 0s.
 	if duration >= ForeverTestTimeout/2 {
 		t.Errorf("expected short timeout duration")

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -363,7 +363,7 @@ loop:
 		}
 	}
 
-	watchDuration := r.clock.Now().Sub(start)
+	watchDuration := r.clock.Since(start)
 	if watchDuration < 1*time.Second && eventCount == 0 {
 		return fmt.Errorf("very short watch: %s: Unexpected watch close - watch lasted less than a second and no items received", r.name)
 	}

--- a/staging/src/k8s.io/client-go/util/flowcontrol/backoff.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/backoff.go
@@ -99,7 +99,7 @@ func (p *Backoff) IsInBackOffSince(id string, eventTime time.Time) bool {
 	if hasExpired(eventTime, entry.lastUpdate, p.maxDuration) {
 		return false
 	}
-	return p.Clock.Now().Sub(eventTime) < entry.backoff
+	return p.Clock.Since(eventTime) < entry.backoff
 }
 
 // Returns True if time since lastupdate is less than the current backoff window.

--- a/staging/src/k8s.io/client-go/util/flowcontrol/backoff_test.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/backoff_test.go
@@ -114,14 +114,14 @@ func TestBackoffGC(t *testing.T) {
 	b.GC()
 	_, found := b.perItemBackoff[id]
 	if !found {
-		t.Errorf("expected GC to skip entry, elapsed time=%s maxDuration=%s", tc.Now().Sub(lastUpdate), maxDuration)
+		t.Errorf("expected GC to skip entry, elapsed time=%s maxDuration=%s", tc.Since(lastUpdate), maxDuration)
 	}
 
 	tc.Step(maxDuration + step)
 	b.GC()
 	r, found := b.perItemBackoff[id]
 	if found {
-		t.Errorf("expected GC of entry after %s got entry %v", tc.Now().Sub(lastUpdate), r)
+		t.Errorf("expected GC of entry after %s got entry %v", tc.Since(lastUpdate), r)
 	}
 }
 

--- a/test/integration/kubelet/watch_manager_test.go
+++ b/test/integration/kubelet/watch_manager_test.go
@@ -96,7 +96,7 @@ func TestWatchBasedManager(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed on %s: %v", name, err)
 				}
-				if d := time.Now().Sub(start); d > time.Second {
+				if d := time.Since(start); d > time.Second {
 					t.Logf("%s took %v", name, d)
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Just some small tweaks:) l found that `time.Now().Sub` are used in some places while others not. I think they should be consistent.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
