### PR TITLE
Mark audit e2e tests as flaky

### DIFF
--- a/test/e2e/auth/audit.go
+++ b/test/e2e/auth/audit.go
@@ -55,7 +55,8 @@ var (
 )
 
 // TODO: Get rid of [DisabledForLargeClusters] when feature request #53455 is ready.
-var _ = SIGDescribe("Advanced Audit [DisabledForLargeClusters]", func() {
+// Marked as flaky until a reliable method for collecting server-side audit logs is available. See http://issue.k8s.io/74745#issuecomment-474052439
+var _ = SIGDescribe("Advanced Audit [DisabledForLargeClusters][Flaky]", func() {
 	f := framework.NewDefaultFramework("audit")
 	var namespace string
 	BeforeEach(func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind flake

**What this PR does / why we need it**:
marks the e2e advanced audit tests as flaky. the methodology they are using to obtain audit events is inherently flaky in the face of server-side log rotation.

xref https://github.com/kubernetes/kubernetes/issues/74745#issuecomment-474052439

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @tallclair @pbarker 