### PR TITLE
Restore username and password kubectl flags

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -439,7 +439,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 
 	addProfilingFlags(flags)
 
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true)
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
 	kubeConfigFlags.AddFlags(flags)
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
 	matchVersionKubeConfigFlags.AddFlags(cmds.PersistentFlags())


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Restores username and password flags to kubectl, lost in https://github.com/kubernetes/kubernetes/commit/3ca222b2d951b95deb825c7f62f6c1a446acf908#diff-d1745d70bc28d1ce59e3f8df9512084fR271

**Which issue(s) this PR fixes**:
Fixes #75450

**Does this PR introduce a user-facing change?**:
```release-note
Restores --username and --password flags to kubectl
```

/sig cli
/sig auth
/cc @juanvallejo 