### PR TITLE
Skip smart label in kubectl describe if field has special chars

### DIFF
--- a/pkg/kubectl/describe/versioned/describe.go
+++ b/pkg/kubectl/describe/versioned/describe.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+	"unicode"
 
 	"github.com/fatih/camelcase"
 
@@ -302,8 +303,15 @@ func printUnstructuredContent(w PrefixWriter, level int, content map[string]inte
 }
 
 func smartLabelFor(field string) string {
-	commonAcronyms := []string{"API", "URL", "UID", "OSB", "GUID"}
+	// skip creating smart label if field name contains
+	// special characters other than '-'
+	if strings.IndexFunc(field, func(r rune) bool {
+		return !unicode.IsLetter(r) && r != '-'
+	}) != -1 {
+		return field
+	}
 
+	commonAcronyms := []string{"API", "URL", "UID", "OSB", "GUID"}
 	parts := camelcase.Split(field)
 	result := make([]string, 0, len(parts))
 	for _, part := range parts {

--- a/pkg/kubectl/describe/versioned/describe_test.go
+++ b/pkg/kubectl/describe/versioned/describe_test.go
@@ -2499,7 +2499,11 @@ func TestDescribeUnstructuredContent(t *testing.T) {
 	}{
 		{
 			expected: `API Version:	v1
-Dummy 2:	present
+Dummy - Dummy:	present
+dummy-dummy@dummy:	present
+dummy/dummy:	present
+dummy2:	present
+Dummy Dummy:	present
 Items:
   Item Bool:	true
   Item Int:	42
@@ -2537,10 +2541,14 @@ URL:	http://localhost
 	w := NewPrefixWriter(out)
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Test",
-			"dummy1":     "present",
-			"dummy2":     "present",
+			"apiVersion":        "v1",
+			"kind":              "Test",
+			"dummyDummy":        "present",
+			"dummy/dummy":       "present",
+			"dummy-dummy@dummy": "present",
+			"dummy-dummy":       "present",
+			"dummy1":            "present",
+			"dummy2":            "present",
 			"metadata": map[string]interface{}{
 				"name":              "MyName",
 				"namespace":         "MyNamespace",


### PR DESCRIPTION
Attempts to create smart label for fields containing special character ends
up looking very odd. This change skips creating smart labels for fields
containing special characters other than '-'.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Attempts to create smart label for fields containing special character ends
up looking very odd. This change skips creating smart labels for fields
containing special characters other than '-'.

```
<             Name:                                                          cluster-1-subnet-private
<             Kubernetes . Io / Cluster / Cluster - 1:                       owned
<             Sigs . K 8 S . Io / Cluster - API - Provider - Aws / Managed:  true
<             Sigs . K 8 S . Io / Cluster - API - Provider - Aws / Role:     common
<           Availability Zone:                                               us-east-1a
<           Cidr Block:                                                      10.0.1.0/24

>             Name:                                          cluster-1-subnet-private
>             kubernetes.io/cluster/cluster-1:               owned
>             sigs.k8s.io/cluster-api-provider-aws/managed:  true
>             sigs.k8s.io/cluster-api-provider-aws/role:     common
>           Availability Zone:                               us-east-1a
>           Cidr Block:                                      10.0.1.0/24
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/260

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
In the 'kubectl describe' output, the fields with names containing special characters are displayed as-is without any pretty formatting. 
```
