### PR TITLE
 Fix fake clientsets in metrics.k8s.io.

### DIFF
--- a/staging/src/k8s.io/metrics/BUILD
+++ b/staging/src/k8s.io/metrics/BUILD
@@ -13,6 +13,7 @@ filegroup(
         "//staging/src/k8s.io/metrics/pkg/apis/external_metrics:all-srcs",
         "//staging/src/k8s.io/metrics/pkg/apis/metrics:all-srcs",
         "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned:all-srcs",
+        "//staging/src/k8s.io/metrics/pkg/client/clientset_test:all-srcs",
         "//staging/src/k8s.io/metrics/pkg/client/custom_metrics:all-srcs",
         "//staging/src/k8s.io/metrics/pkg/client/external_metrics:all-srcs",
     ],

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/doc.go
@@ -18,5 +18,6 @@ limitations under the License.
 // +k8s:protobuf-gen=package
 // +k8s:conversion-gen=k8s.io/metrics/pkg/apis/metrics
 // +k8s:openapi-gen=true
+// +groupName=metrics.k8s.io
 
 package v1alpha1

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/doc.go
@@ -18,5 +18,6 @@ limitations under the License.
 // +k8s:protobuf-gen=package
 // +k8s:conversion-gen=k8s.io/metrics/pkg/apis/metrics
 // +k8s:openapi-gen=true
+// +groupName=metrics.k8s.io
 
 package v1beta1

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_nodemetrics.go
@@ -32,9 +32,9 @@ type FakeNodeMetricses struct {
 	Fake *FakeMetricsV1alpha1
 }
 
-var nodemetricsesResource = schema.GroupVersionResource{Group: "metrics", Version: "v1alpha1", Resource: "nodes"}
+var nodemetricsesResource = schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1alpha1", Resource: "nodes"}
 
-var nodemetricsesKind = schema.GroupVersionKind{Group: "metrics", Version: "v1alpha1", Kind: "NodeMetrics"}
+var nodemetricsesKind = schema.GroupVersionKind{Group: "metrics.k8s.io", Version: "v1alpha1", Kind: "NodeMetrics"}
 
 // Get takes name of the nodeMetrics, and returns the corresponding nodeMetrics object, and an error if there is any.
 func (c *FakeNodeMetricses) Get(name string, options v1.GetOptions) (result *v1alpha1.NodeMetrics, err error) {

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_podmetrics.go
@@ -33,9 +33,9 @@ type FakePodMetricses struct {
 	ns   string
 }
 
-var podmetricsesResource = schema.GroupVersionResource{Group: "metrics", Version: "v1alpha1", Resource: "pods"}
+var podmetricsesResource = schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1alpha1", Resource: "pods"}
 
-var podmetricsesKind = schema.GroupVersionKind{Group: "metrics", Version: "v1alpha1", Kind: "PodMetrics"}
+var podmetricsesKind = schema.GroupVersionKind{Group: "metrics.k8s.io", Version: "v1alpha1", Kind: "PodMetrics"}
 
 // Get takes name of the podMetrics, and returns the corresponding podMetrics object, and an error if there is any.
 func (c *FakePodMetricses) Get(name string, options v1.GetOptions) (result *v1alpha1.PodMetrics, err error) {

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
@@ -31,7 +31,7 @@ type MetricsV1alpha1Interface interface {
 	PodMetricsesGetter
 }
 
-// MetricsV1alpha1Client is used to interact with features provided by the metrics group.
+// MetricsV1alpha1Client is used to interact with features provided by the metrics.k8s.io group.
 type MetricsV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_nodemetrics.go
@@ -32,9 +32,9 @@ type FakeNodeMetricses struct {
 	Fake *FakeMetricsV1beta1
 }
 
-var nodemetricsesResource = schema.GroupVersionResource{Group: "metrics", Version: "v1beta1", Resource: "nodes"}
+var nodemetricsesResource = schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "nodes"}
 
-var nodemetricsesKind = schema.GroupVersionKind{Group: "metrics", Version: "v1beta1", Kind: "NodeMetrics"}
+var nodemetricsesKind = schema.GroupVersionKind{Group: "metrics.k8s.io", Version: "v1beta1", Kind: "NodeMetrics"}
 
 // Get takes name of the nodeMetrics, and returns the corresponding nodeMetrics object, and an error if there is any.
 func (c *FakeNodeMetricses) Get(name string, options v1.GetOptions) (result *v1beta1.NodeMetrics, err error) {

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_podmetrics.go
@@ -33,9 +33,9 @@ type FakePodMetricses struct {
 	ns   string
 }
 
-var podmetricsesResource = schema.GroupVersionResource{Group: "metrics", Version: "v1beta1", Resource: "pods"}
+var podmetricsesResource = schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"}
 
-var podmetricsesKind = schema.GroupVersionKind{Group: "metrics", Version: "v1beta1", Kind: "PodMetrics"}
+var podmetricsesKind = schema.GroupVersionKind{Group: "metrics.k8s.io", Version: "v1beta1", Kind: "PodMetrics"}
 
 // Get takes name of the podMetrics, and returns the corresponding podMetrics object, and an error if there is any.
 func (c *FakePodMetricses) Get(name string, options v1.GetOptions) (result *v1beta1.PodMetrics, err error) {

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
@@ -31,7 +31,7 @@ type MetricsV1beta1Interface interface {
 	PodMetricsesGetter
 }
 
-// MetricsV1beta1Client is used to interact with features provided by the metrics group.
+// MetricsV1beta1Client is used to interact with features provided by the metrics.k8s.io group.
 type MetricsV1beta1Client struct {
 	restClient rest.Interface
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_test/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_test/BUILD
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["clientset_test.go"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_test/clientset_test.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_test/clientset_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientset_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/metrics/pkg/client/clientset/versioned/fake"
+)
+
+// TestFakeList is a basic sanity check that makes sure the fake Clientset is working properly.
+func TestFakeList(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	if _, err := client.MetricsV1alpha1().PodMetricses("").List(metav1.ListOptions{}); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if _, err := client.MetricsV1alpha1().NodeMetricses().List(metav1.ListOptions{}); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if _, err := client.MetricsV1beta1().PodMetricses("").List(metav1.ListOptions{}); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if _, err := client.MetricsV1beta1().NodeMetricses().List(metav1.ListOptions{}); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/sig instrumentation

**What this PR does / why we need it**:
The generated fake clientsets were using the API group "metrics" instead
of "metrics.k8s.io". The `+groupName` annotation needed to be copied to
these packages to fix it.

As a result, tests using this fake clientset work as expected.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
