### PR TITLE
Restore machine readability to the print-join-command output

### DIFF
--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -225,7 +225,7 @@ func RunCreateToken(out io.Writer, client clientset.Interface, cfgPath string, c
 		return err
 	}
 
-	// if --print-join-command was specified, print the full `kubeadm join` command
+	// if --print-join-command was specified, print a machine-readable full `kubeadm join` command
 	// otherwise, just print the token
 	if printJoinCommand {
 		skipTokenPrint := false
@@ -233,6 +233,8 @@ func RunCreateToken(out io.Writer, client clientset.Interface, cfgPath string, c
 		if err != nil {
 			return errors.Wrap(err, "failed to get join command")
 		}
+		joinCommand = strings.ReplaceAll(joinCommand, "\\\n", "")
+		joinCommand = strings.ReplaceAll(joinCommand, "\t", "")
 		fmt.Fprintln(out, joinCommand)
 	} else {
 		fmt.Fprintln(out, internalcfg.BootstrapTokens[0].Token.String())


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The output of `kubeadm token create --print-join-command` should be
usable by batch scripts.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubeadm/issues/1454

```release-note
kubeadm: fix the machine readability of "kubeadm token create --print-join-command"
```