### PR TITLE
fix StatefulSetStatus currentReplicas calculating

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -511,7 +511,9 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 				set.Name,
 				replicas[target].Name)
 			err := ssc.podControl.DeleteStatefulPod(set, replicas[target])
-			status.CurrentReplicas--
+			if getPodRevision(replicas[target]) == currentRevision.Name {
+				status.CurrentReplicas--
+			}
 			return &status, err
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In some cases, currentReplicas in StatefulSetStatus may be updated to an incorrect number.

Way to reproduce:
1. create a new statefulset with replicas=3 and partition=1, assume revision is `a`.
2. update statefulset template, assume revision is `b`. After controller has updated pod 2 and 3,  status comes to:
```
replicas=3
currentReplicas=1
updatedReplicas=2
currentRevision=a
updateRevision=b
```
3. update statefulset template again, assume revision is `c`. Then controller will delete pod 2 immediately and update status incorrectly:
```
replicas=3
currentReplicas=0
updatedReplicas=0
currentRevision=a
updateRevision=c
```
At this moment, currentReplicas should be 1 because of pod 0 running, but controller actually decrease currentReplicas to 0 after deleting pod 2, whose revision is not currentRevision `a`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
