### PR TITLE
scheduler: add metrics to record number of pending pods in different queues

### DIFF
--- a/pkg/controller/.import-restrictions
+++ b/pkg/controller/.import-restrictions
@@ -258,7 +258,8 @@
         "k8s.io/kubernetes/pkg/fieldpath",
         "k8s.io/kubernetes/pkg/scheduler/volumebinder",
         "k8s.io/kubernetes/pkg/util/resizefs",
-        "k8s.io/kubernetes/pkg/apis/apps"
+        "k8s.io/kubernetes/pkg/apis/apps",
+        "k8s.io/kubernetes/pkg/scheduler/metrics"
       ]
     },
     {

--- a/pkg/scheduler/internal/queue/BUILD
+++ b/pkg/scheduler/internal/queue/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/algorithm/priorities/util:go_default_library",
+        "//pkg/scheduler/metrics:go_default_library",
         "//pkg/scheduler/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
@@ -31,11 +32,13 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/api/v1/pod:go_default_library",
+        "//pkg/scheduler/metrics:go_default_library",
         "//pkg/scheduler/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -647,7 +647,7 @@ func TestUnschedulablePodsMap(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			upm := newUnschedulablePodsMap()
+			upm := newUnschedulablePodsMap(nil)
 			for _, p := range test.podsToAdd {
 				upm.addOrUpdate(newPodInfoNoTimestamp(p))
 			}

--- a/pkg/scheduler/metrics/BUILD
+++ b/pkg/scheduler/metrics/BUILD
@@ -1,13 +1,13 @@
 package(default_visibility = ["//visibility:public"])
 
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_library",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["metrics.go"],
+    srcs = [
+        "metric_recorder.go",
+        "metrics.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/metrics",
     deps = [
         "//pkg/controller/volume/persistentvolume:go_default_library",
@@ -26,4 +26,10 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["metric_recorder_test.go"],
+    embed = [":go_default_library"],
 )

--- a/pkg/scheduler/metrics/metric_recorder.go
+++ b/pkg/scheduler/metrics/metric_recorder.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MetricRecorder represents a metric recorder which takes action when the
+// metric Inc(), Dec() and Clear()
+type MetricRecorder interface {
+	Inc()
+	Dec()
+	Clear()
+}
+
+var _ MetricRecorder = &PendingPodsRecorder{}
+
+// PendingPodsRecorder is an implementation of MetricRecorder
+type PendingPodsRecorder struct {
+	recorder prometheus.Gauge
+}
+
+// NewActivePodsRecorder returns ActivePods in a Prometheus metric fashion
+func NewActivePodsRecorder() *PendingPodsRecorder {
+	return &PendingPodsRecorder{
+		recorder: ActivePods,
+	}
+}
+
+// NewUnschedulablePodsRecorder returns UnschedulablePods in a Prometheus metric fashion
+func NewUnschedulablePodsRecorder() *PendingPodsRecorder {
+	return &PendingPodsRecorder{
+		recorder: UnschedulablePods,
+	}
+}
+
+// NewBackoffPodsRecorder returns BackoffPods in a Prometheus metric fashion
+func NewBackoffPodsRecorder() *PendingPodsRecorder {
+	return &PendingPodsRecorder{
+		recorder: BackoffPods,
+	}
+}
+
+// Inc increases a metric counter by 1, in an atomic way
+func (r *PendingPodsRecorder) Inc() {
+	r.recorder.Inc()
+}
+
+// Dec decreases a metric counter by 1, in an atomic way
+func (r *PendingPodsRecorder) Dec() {
+	r.recorder.Dec()
+}
+
+// Clear set a metric counter to 0, in an atomic way
+func (r *PendingPodsRecorder) Clear() {
+	r.recorder.Set(float64(0))
+}

--- a/pkg/scheduler/metrics/metric_recorder_test.go
+++ b/pkg/scheduler/metrics/metric_recorder_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+var _ MetricRecorder = &fakePodsRecorder{}
+
+type fakePodsRecorder struct {
+	counter int64
+}
+
+func (r *fakePodsRecorder) Inc() {
+	atomic.AddInt64(&r.counter, 1)
+}
+
+func (r *fakePodsRecorder) Dec() {
+	atomic.AddInt64(&r.counter, -1)
+}
+
+func (r *fakePodsRecorder) Clear() {
+	atomic.StoreInt64(&r.counter, 0)
+}
+
+func TestInc(t *testing.T) {
+	fakeRecorder := fakePodsRecorder{}
+	var wg sync.WaitGroup
+	loops := 100
+	wg.Add(loops)
+	for i := 0; i < loops; i++ {
+		go func() {
+			fakeRecorder.Inc()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	if fakeRecorder.counter != int64(loops) {
+		t.Errorf("Expected %v, got %v", loops, fakeRecorder.counter)
+	}
+}
+
+func TestDec(t *testing.T) {
+	fakeRecorder := fakePodsRecorder{counter: 100}
+	var wg sync.WaitGroup
+	loops := 100
+	wg.Add(loops)
+	for i := 0; i < loops; i++ {
+		go func() {
+			fakeRecorder.Dec()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	if fakeRecorder.counter != int64(0) {
+		t.Errorf("Expected %v, got %v", loops, fakeRecorder.counter)
+	}
+}
+
+func TestClear(t *testing.T) {
+	fakeRecorder := fakePodsRecorder{}
+	var wg sync.WaitGroup
+	incLoops, decLoops := 100, 80
+	wg.Add(incLoops + decLoops)
+	for i := 0; i < incLoops; i++ {
+		go func() {
+			fakeRecorder.Inc()
+			wg.Done()
+		}()
+	}
+	for i := 0; i < decLoops; i++ {
+		go func() {
+			fakeRecorder.Dec()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	if fakeRecorder.counter != int64(incLoops-decLoops) {
+		t.Errorf("Expected %v, got %v", incLoops-decLoops, fakeRecorder.counter)
+	}
+	// verify Clear() works
+	fakeRecorder.Clear()
+	if fakeRecorder.counter != int64(0) {
+		t.Errorf("Expected %v, got %v", 0, fakeRecorder.counter)
+	}
+}

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -192,6 +192,16 @@ var (
 			Help:      "Total preemption attempts in the cluster till now",
 		})
 
+	pendingPods = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      "pending_pods_total",
+			Help:      "Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableQ.",
+		}, []string{"queue"})
+	ActivePods        = pendingPods.With(prometheus.Labels{"queue": "active"})
+	BackoffPods       = pendingPods.With(prometheus.Labels{"queue": "backoff"})
+	UnschedulablePods = pendingPods.With(prometheus.Labels{"queue": "unschedulable"})
+
 	metricsList = []prometheus.Collector{
 		scheduleAttempts,
 		SchedulingLatency,
@@ -210,6 +220,7 @@ var (
 		DeprecatedSchedulingAlgorithmPremptionEvaluationDuration,
 		PreemptionVictims,
 		PreemptionAttempts,
+		pendingPods,
 	}
 )
 

--- a/pkg/scheduler/util/BUILD
+++ b/pkg/scheduler/util/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//pkg/apis/scheduling:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/scheduler/api:go_default_library",
+        "//pkg/scheduler/metrics:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig scheduling
/assign @bsalamat 

**What this PR does / why we need it**:

Expose metrics of pending pods so as to know overall health of the whole cluster.

BTW: metrics of scheduled pods has been represented by `scheduler_schedule_attempts_total{result="scheduled"}`.

**Which issue(s) this PR fixes**:

Fixes #75267.

**Special notes for your reviewer**:

1. commit 4e849b2 was refactored for reusability. @denkensk PTAL to ensure it doesn't break your previous PR.
1. in addition to unit test 0b0d3ac, this PR is also verified in a single node cluster:
    - **case a)** taint the node, then run a 100-replica deployment. this is aimed to ensure metrics works well with `flushUnschedulableQLeftover` which runs every 30 seconds. In this case, `unschedulable` is always 0 as the cluster doesn't become more "schedulable".
        ```console
        scheduler_pending_pods_num{queue="active"} 57
        scheduler_pending_pods_num{queue="backoff"} 0
        scheduler_pending_pods_num{queue="unschedulable"} 42
        scheduler_pending_pods_num{queue="active"} 41
        scheduler_pending_pods_num{queue="backoff"} 0
        scheduler_pending_pods_num{queue="unschedulable"} 59
        scheduler_pending_pods_num{queue="active"} 16
        scheduler_pending_pods_num{queue="backoff"} 0
        scheduler_pending_pods_num{queue="unschedulable"} 83
        scheduler_pending_pods_num{queue="active"} 0
        scheduler_pending_pods_num{queue="backoff"} 0
        scheduler_pending_pods_num{queue="unschedulable"} 100
        ```
    - **case b)** taint the node, run a 100-replica deployment, then simulate a high-churn cluster by repeat tainting the node with different key/values. this is aimed to ensure metrics works well with backoff related code.
        ```console
        scheduler_pending_pods_num{queue="active"} 0
        scheduler_pending_pods_num{queue="backoff"} 0
        scheduler_pending_pods_num{queue="unschedulable"} 100
        scheduler_pending_pods_num{queue="active"} 87
        scheduler_pending_pods_num{queue="backoff"} 0
        scheduler_pending_pods_num{queue="unschedulable"} 12
        scheduler_pending_pods_num{queue="active"} 63
        scheduler_pending_pods_num{queue="backoff"} 33
        scheduler_pending_pods_num{queue="unschedulable"} 3
        scheduler_pending_pods_num{queue="active"} 33
        scheduler_pending_pods_num{queue="backoff"} 33
        scheduler_pending_pods_num{queue="unschedulable"} 33
        scheduler_pending_pods_num{queue="active"} 9
        scheduler_pending_pods_num{queue="backoff"} 68
        scheduler_pending_pods_num{queue="unschedulable"} 22
        scheduler_pending_pods_num{queue="active"} 0
        scheduler_pending_pods_num{queue="backoff"} 98
        scheduler_pending_pods_num{queue="unschedulable"} 2
        scheduler_pending_pods_num{queue="active"} 1
        scheduler_pending_pods_num{queue="backoff"} 87
        scheduler_pending_pods_num{queue="unschedulable"} 11
        ```
    - in both cases, total number of pending pods doesn't exceed 100 (some pods can be in scheduling cycle, or goroutines, so total number can be less than 100)

**Does this PR introduce a user-facing change?**:

```release-note
scheduler: add metrics to record number of pending pods in different queues
```
