### PR TITLE
An extra sandbox container created after job pod succeed

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -845,7 +845,7 @@ func TestComputePodActions(t *testing.T) {
 			},
 			actions: podActions{
 				SandboxID:         baseStatus.SandboxStatuses[0].Id,
-				Attempt:           uint32(2),
+				Attempt:           uint32(1),
 				CreateSandbox:     false,
 				KillPod:           true,
 				ContainersToStart: []int{},


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug


**What this PR does / why we need it**:

When a job pod finish quickly.
Such as the container's args is "date; echo Hello from the Kubernetes cluster"
the container and sandbox will exited quickly,
then sometimes if the RECONCILE event slower than the PLEG ContainerDied event kubelet will start a new sandbox.
It because the kubelet worker use the old pod status from the podmanager 
So it will create two sandbox when a job finish.
The first sandbox will teardown when in the PLEG ContainerDied Even syncpod.
The second sandbox will teardown by housekeeping.
But the second sandbox dont have network namespace.So the cni can not release some network 
resource.
So we should try to not create two sandbox in one job,

Check if the pod's container all succeeded,the kubelet will not create a new sandbox.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #75441 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
When check sandbox changed,filter the succeeded pod.
```
