### PR TITLE
Skip GlusterDynamicProvisioner test in GKE

### DIFF
--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -818,6 +818,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 	framework.KubeDescribe("GlusterDynamicProvisioner", func() {
 		It("should create and delete persistent volumes [fast]", func() {
+			framework.SkipIfProviderIs("gke")
 			By("creating a Gluster DP server Pod")
 			pod := startGlusterDpServerPod(c, ns)
 			serverUrl := "http://" + pod.Status.PodIP + ":8081"


### PR DESCRIPTION
The GlusterDynamicProvisioner test will not work on GKE because master
node is in a different project and cannot talk to the pod running on
node which is used for gluster provisioner. So add the code to skip the
test on GKE