### PR TITLE
Automated cherry pick of #75529: bump required minimum go version to 1.12.1 (strings pkg compatibility)

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -382,7 +382,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.11.1
+  minimum_go_version=go1.12.1
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     kube::log::usage_from_stdin <<EOF
 Detected go version: ${go_version[*]}.


### PR DESCRIPTION
Cherry pick of #75529 on release-1.14.

#75529: bump required minimum go version to 1.12.1 (due to strings package compatibility).

```release-note
None
```