### PR TITLE
Automated cherry pick of #72143: Fix aad support in kubectl for sovereign cloud

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure_test.go
@@ -53,6 +53,13 @@ func TestAzureTokenSource(t *testing.T) {
 
 	wantCfg := token2Cfg(token)
 	persistedCfg := persiter.Cache()
+
+	wantCfgLen := len(wantCfg)
+	persistedCfgLen := len(persistedCfg)
+	if wantCfgLen != persistedCfgLen {
+		t.Errorf("wantCfgLen and persistedCfgLen do not match, wantCfgLen=%v, persistedCfgLen=%v", wantCfgLen, persistedCfgLen)
+	}
+
 	for k, v := range persistedCfg {
 		if strings.Compare(v, wantCfg[k]) != 0 {
 			t.Errorf("Token() persisted cfg %s: got %v, want %v", k, v, wantCfg[k])
@@ -103,6 +110,7 @@ type fakeTokenSource struct {
 func (ts *fakeTokenSource) Token() (*azureToken, error) {
 	return &azureToken{
 		token:       newFackeAzureToken(ts.accessToken, ts.expiresOn),
+		environment: "testenv",
 		clientID:    "fake",
 		tenantID:    "fake",
 		apiserverID: "fake",
@@ -113,6 +121,7 @@ func token2Cfg(token *azureToken) map[string]string {
 	cfg := make(map[string]string)
 	cfg[cfgAccessToken] = token.token.AccessToken
 	cfg[cfgRefreshToken] = token.token.RefreshToken
+	cfg[cfgEnvironment] = token.environment
 	cfg[cfgClientID] = token.clientID
 	cfg[cfgTenantID] = token.tenantID
 	cfg[cfgApiserverID] = token.apiserverID


### PR DESCRIPTION
Cherry pick of #72143 on release-1.13.

#72143: Fix aad support in kubectl for sovereign cloud