### PR TITLE
Automated cherry pick of #72143: Fix aad support in kubectl for sovereign cloud

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure.go
@@ -144,6 +144,7 @@ func (r *azureRoundTripper) WrappedRoundTripper() http.RoundTripper { return r.r
 
 type azureToken struct {
 	token       adal.Token
+	environment string
 	clientID    string
 	tenantID    string
 	apiserverID string
@@ -218,6 +219,10 @@ func (ts *azureTokenSource) retrieveTokenFromCfg() (*azureToken, error) {
 	if refreshToken == "" {
 		return nil, fmt.Errorf("no refresh token in cfg: %s", cfgRefreshToken)
 	}
+	environment := ts.cfg[cfgEnvironment]
+	if environment == "" {
+		return nil, fmt.Errorf("no environment in cfg: %s", cfgEnvironment)
+	}
 	clientID := ts.cfg[cfgClientID]
 	if clientID == "" {
 		return nil, fmt.Errorf("no client ID in cfg: %s", cfgClientID)
@@ -249,6 +254,7 @@ func (ts *azureTokenSource) retrieveTokenFromCfg() (*azureToken, error) {
 			Resource:     fmt.Sprintf("spn:%s", apiserverID),
 			Type:         tokenType,
 		},
+		environment: environment,
 		clientID:    clientID,
 		tenantID:    tenantID,
 		apiserverID: apiserverID,
@@ -259,6 +265,7 @@ func (ts *azureTokenSource) storeTokenInCfg(token *azureToken) error {
 	newCfg := make(map[string]string)
 	newCfg[cfgAccessToken] = token.token.AccessToken
 	newCfg[cfgRefreshToken] = token.token.RefreshToken
+	newCfg[cfgEnvironment] = token.environment
 	newCfg[cfgClientID] = token.clientID
 	newCfg[cfgTenantID] = token.tenantID
 	newCfg[cfgApiserverID] = token.apiserverID
@@ -274,7 +281,12 @@ func (ts *azureTokenSource) storeTokenInCfg(token *azureToken) error {
 }
 
 func (ts *azureTokenSource) refreshToken(token *azureToken) (*azureToken, error) {
-	oauthConfig, err := adal.NewOAuthConfig(azure.PublicCloud.ActiveDirectoryEndpoint, token.tenantID)
+	env, err := azure.EnvironmentFromName(token.environment)
+	if err != nil {
+		return nil, err
+	}
+
+	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, token.tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("building the OAuth configuration for token refresh: %v", err)
 	}
@@ -298,6 +310,7 @@ func (ts *azureTokenSource) refreshToken(token *azureToken) (*azureToken, error)
 
 	return &azureToken{
 		token:       spt.Token(),
+		environment: token.environment,
 		clientID:    token.clientID,
 		tenantID:    token.tenantID,
 		apiserverID: token.apiserverID,
@@ -352,6 +365,7 @@ func (ts *azureTokenSourceDeviceCode) Token() (*azureToken, error) {
 
 	return &azureToken{
 		token:       *token,
+		environment: ts.environment.Name,
 		clientID:    ts.clientID,
 		tenantID:    ts.tenantID,
 		apiserverID: ts.apiserverID,

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure_test.go
@@ -52,6 +52,13 @@ func TestAzureTokenSource(t *testing.T) {
 
 	wantCfg := token2Cfg(token)
 	persistedCfg := persiter.Cache()
+
+	wantCfgLen := len(wantCfg)
+	persistedCfgLen := len(persistedCfg)
+	if wantCfgLen != persistedCfgLen {
+		t.Errorf("wantCfgLen and persistedCfgLen do not match, wantCfgLen=%v, persistedCfgLen=%v", wantCfgLen, persistedCfgLen)
+	}
+
 	for k, v := range persistedCfg {
 		if strings.Compare(v, wantCfg[k]) != 0 {
 			t.Errorf("Token() persisted cfg %s: got %v, want %v", k, v, wantCfg[k])
@@ -102,6 +109,7 @@ type fakeTokenSource struct {
 func (ts *fakeTokenSource) Token() (*azureToken, error) {
 	return &azureToken{
 		token:       newFackeAzureToken(ts.accessToken, ts.expiresOn),
+		environment: "testenv",
 		clientID:    "fake",
 		tenantID:    "fake",
 		apiserverID: "fake",
@@ -112,6 +120,7 @@ func token2Cfg(token *azureToken) map[string]string {
 	cfg := make(map[string]string)
 	cfg[cfgAccessToken] = token.token.AccessToken
 	cfg[cfgRefreshToken] = token.token.RefreshToken
+	cfg[cfgEnvironment] = token.environment
 	cfg[cfgClientID] = token.clientID
 	cfg[cfgTenantID] = token.tenantID
 	cfg[cfgApiserverID] = token.apiserverID


### PR DESCRIPTION
Cherry pick of #72143 on release-1.11.

#72143: Fix aad support in kubectl for sovereign cloud