### PR TITLE
Implement make test-e2e-kubeadm

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -279,6 +279,36 @@ test-e2e-node: ginkgo generated_files
 	hack/make-rules/test-e2e-node.sh
 endif
 
+define TEST_E2E_KUBEADM_HELP_INFO
+# Build and run kubeadm end-to-end tests.
+#
+# Args:
+#  FOCUS: Regexp that matches the tests to be run.  Defaults to "".
+#  SKIP: Regexp that matches the tests that needs to be skipped.  Defaults
+#    to "".
+#  RUN_UNTIL_FAILURE: If true, pass --untilItFails to ginkgo so tests are run
+#    repeatedly until they fail. Defaults to false.
+#  ARTIFACTS: Local directory to save test artifacts into. Defaults to "/tmp/_artifacts".
+#  PARALLELISM: The number of gingko nodes to run.  If empty ginkgo default 
+#    parallelism (cores - 1) is used
+#  BUILD: Build kubeadm end-to-end tests. Defaults to true.
+#
+# Example:
+#   make test-e2e-kubeadm 
+#   make test-e2e-kubeadm FOCUS=kubeadm-config 
+#   make test-e2e-kubeadm SKIP=kubeadm-config
+#
+# Build and run tests.
+endef
+.PHONY: test-e2e-kubeadm
+ifeq ($(PRINT_HELP),y)
+test-e2e-kubeadm:
+	@echo "$$TEST_E2E_KUBEADM_HELP_INFO"
+else
+test-e2e-kubeadm: 
+	hack/make-rules/test-e2e-kubeadm.sh
+endif
+
 define TEST_CMD_HELP_INFO
 # Build and run cmdline tests.
 #

--- a/hack/make-rules/test-e2e-kubeadm.sh
+++ b/hack/make-rules/test-e2e-kubeadm.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+focus=${FOCUS:-""}
+skip=${SKIP:-""}
+parallelism=${PARALLELISM:-""}
+artifacts=${ARTIFACTS:-"/tmp/_artifacts/$(date +%y%m%dT%H%M%S)"}
+run_until_failure=${RUN_UNTIL_FAILURE:-"false"}
+build=${BUILD:-"true"}
+
+# Parse the flags to pass to ginkgo
+ginkgoflags=""
+if [[ ${parallelism} != "" ]]; then
+  ginkgoflags="${ginkgoflags} -nodes=${parallelism} "
+else
+  ginkgoflags="${ginkgoflags} -p "
+fi
+
+if [[ ${focus} != "" ]]; then
+  ginkgoflags="${ginkgoflags} -focus=\"${focus}\" "
+fi
+
+if [[ ${skip} != "" ]]; then
+  ginkgoflags="${ginkgoflags} -skip=\"${skip}\" "
+fi
+
+if [[ ${run_until_failure} != "false" ]]; then
+  ginkgoflags="${ginkgoflags} -untilItFails=${run_until_failure} "
+fi
+
+# Setup the directory to copy test artifacts (logs, junit.xml, etc) from remote host to local host
+if [[ ! -d "${artifacts}" ]]; then
+  echo "Creating artifacts directory at ${artifacts}"
+  mkdir -p "${artifacts}"
+fi
+echo "Test artifacts will be written to ${artifacts}"
+
+# Test 
+kube::golang::verify_go_version
+
+go run test/e2e_kubeadm/runner/local/run_local.go \
+  --ginkgo-flags="${ginkgoflags}" \
+  --test-flags="--provider=skeleton --report-dir=${artifacts}" \
+  --build="${build}" 2>&1 | tee -i "${artifacts}/build-log.txt"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As of today e2e tests for kubeadm can be invoked only with `go run test/e2e_kubeadm/runner/local/run_local.go`, which isn't really developer friendly.

This PR implement a new make target,`make test-e2e-kubeadm`, similarly to `make test-e2e-node`, that makes e2e tests for kubeadm easier to discover and to use

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cluster-lifecycle
/area kubeadm
/priority backlog

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/assign @timothysc  @neolit123