### PR TITLE
filter empty replicas to improve scheduler selector_spreading performance

### DIFF
--- a/pkg/scheduler/algorithm/priorities/metadata.go
+++ b/pkg/scheduler/algorithm/priorities/metadata.go
@@ -91,22 +91,28 @@ func getSelectors(pod *v1.Pod, sl algorithm.ServiceLister, cl algorithm.Controll
 
 	if rcs, err := cl.GetPodControllers(pod); err == nil {
 		for _, rc := range rcs {
-			selectors = append(selectors, labels.SelectorFromSet(rc.Spec.Selector))
+			if *rc.Spec.Replicas > 0 {
+				selectors = append(selectors, labels.SelectorFromSet(rc.Spec.Selector))
+			}
 		}
 	}
 
 	if rss, err := rsl.GetPodReplicaSets(pod); err == nil {
 		for _, rs := range rss {
-			if selector, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector); err == nil {
-				selectors = append(selectors, selector)
+			if *rs.Spec.Replicas > 0 {
+				if selector, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector); err == nil {
+					selectors = append(selectors, selector)
+				}
 			}
 		}
 	}
 
 	if sss, err := ssl.GetPodStatefulSets(pod); err == nil {
 		for _, ss := range sss {
-			if selector, err := metav1.LabelSelectorAsSelector(ss.Spec.Selector); err == nil {
-				selectors = append(selectors, selector)
+			if *ss.Spec.Replicas > 0 {
+				if selector, err := metav1.LabelSelectorAsSelector(ss.Spec.Selector); err == nil {
+					selectors = append(selectors, selector)
+				}
 			}
 		}
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

filter empty rc, rs, sts to improve scheduler selector_spreading performace,
in our test case, for deployment with revisionHistoryLimit = 10, there will be a lot of replicaset with replicas == 0, and the scheduler SelectorSpreadPriority will loop over all these empty replicasets to get the selector candidate sets.

 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

```release-note
filter empty rc,rs,sts to improve scheduler SelectorSpreadPriority performance
```
