### PR TITLE
Set ipvs scheduler from annotation in the service manifest

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -785,18 +785,17 @@ const EntryInvalidErr = "error adding entry %s to ipset %s"
 
 const ipvsSchedulerKey = "kube-proxy.kubernetes.io/ipvs-scheduler"
 
-var validScheduler *regexp.Regexp = regexp.MustCompile("^(rr|wrr|lc|wlc|lblc|lblcr|dh|sh|sed|nq)$")
+var validScheduler = regexp.MustCompile("^(rr|wrr|lc|wlc|lblc|lblcr|dh|sh|sed|nq)$")
 
 func (proxier *Proxier) getScheduler(sp proxy.ServicePort) string {
 	if v, ok := sp.GetAnnotations()[ipvsSchedulerKey]; ok {
 		// Check that the scheduler is valid
 		if validScheduler.MatchString(v) {
 			return v
-		} else {
-			// Delete the entry to avoid unnecessary re-checks and log flooding
-			delete(sp.GetAnnotations(), ipvsSchedulerKey)
-			klog.Warningf("Invalid ipvs-scheduler ignored [%s]", v)
 		}
+		// Delete the entry to avoid unnecessary re-checks and log flooding
+		delete(sp.GetAnnotations(), ipvsSchedulerKey)
+		klog.Warningf("Invalid ipvs-scheduler ignored [%s]", v)
 	}
 	return proxier.ipvsScheduler
 }

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -783,10 +783,20 @@ func (proxier *Proxier) OnEndpointsSynced() {
 // EntryInvalidErr indicates if an ipset entry is invalid or not
 const EntryInvalidErr = "error adding entry %s to ipset %s"
 
+const ipvsSchedulerKey = "kube-proxy.kubernetes.io/ipvs-scheduler"
+
+var validScheduler *regexp.Regexp = regexp.MustCompile("^(rr|wrr|lc|wlc|lblc|lblcr|dh|sh|sed|nq)$")
+
 func (proxier *Proxier) getScheduler(sp proxy.ServicePort) string {
-	if v, ok := sp.GetAnnotations()["kube-proxy.kubernetes.io/ipvs-scheduler"]; ok {
-		// Check that the scheduler is valid?
-		return v
+	if v, ok := sp.GetAnnotations()[ipvsSchedulerKey]; ok {
+		// Check that the scheduler is valid
+		if validScheduler.MatchString(v) {
+			return v
+		} else {
+			// Delete the entry to avoid unnecessary re-checks and log flooding
+			delete(sp.GetAnnotations(), ipvsSchedulerKey)
+			klog.Warningf("Invalid ipvs-scheduler ignored [%s]", v)
+		}
 	}
 	return proxier.ipvsScheduler
 }

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -785,12 +785,12 @@ const EntryInvalidErr = "error adding entry %s to ipset %s"
 
 const ipvsSchedulerKey = "kube-proxy.kubernetes.io/ipvs-scheduler"
 
-var validScheduler = regexp.MustCompile("^(rr|wrr|lc|wlc|lblc|lblcr|dh|sh|sed|nq)$")
+var validSchedulers = sets.NewString("rr", "wrr", "lc", "wlc", "lblc", "lblcr", "dh", "sh", "sed", "nq")
 
 func (proxier *Proxier) getScheduler(sp proxy.ServicePort) string {
 	if v, ok := sp.GetAnnotations()[ipvsSchedulerKey]; ok {
 		// Check that the scheduler is valid
-		if validScheduler.MatchString(v) {
+		if validSchedulers.Has(v) {
 			return v
 		}
 		// Delete the entry to avoid unnecessary re-checks and log flooding

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -51,6 +51,7 @@ type BaseServiceInfo struct {
 	loadBalancerSourceRanges []string
 	healthCheckNodePort      int
 	onlyNodeLocalEndpoints   bool
+	annotations              map[string]string
 }
 
 var _ ServicePort = &BaseServiceInfo{}
@@ -105,6 +106,11 @@ func (info *BaseServiceInfo) ExternalIPStrings() []string {
 	return info.externalIPs
 }
 
+// GetAnnotationsis part of ServicePort interface.
+func (info *BaseServiceInfo) GetAnnotations() map[string]string {
+	return info.Annotations
+}
+
 // LoadBalancerIPStrings is part of ServicePort interface.
 func (info *BaseServiceInfo) LoadBalancerIPStrings() []string {
 	var ips []string
@@ -139,6 +145,7 @@ func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, servic
 		sessionAffinityType:    service.Spec.SessionAffinity,
 		stickyMaxAgeSeconds:    stickyMaxAgeSeconds,
 		onlyNodeLocalEndpoints: onlyNodeLocalEndpoints,
+		annotations:            make(map[string]string),
 	}
 
 	if sct.isIPv6Mode == nil {
@@ -170,6 +177,11 @@ func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, servic
 		}
 	}
 
+	for k, v := range service.ObjectMeta.Annotations {
+		if strings.HasPrefix(k, "kube-proxy.kubernetes.io/") {
+			info.Annotations[k] = v
+		}
+	}
 	return info
 }
 

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -108,7 +108,7 @@ func (info *BaseServiceInfo) ExternalIPStrings() []string {
 
 // GetAnnotationsis part of ServicePort interface.
 func (info *BaseServiceInfo) GetAnnotations() map[string]string {
-	return info.Annotations
+	return info.annotations
 }
 
 // LoadBalancerIPStrings is part of ServicePort interface.
@@ -179,7 +179,7 @@ func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, servic
 
 	for k, v := range service.ObjectMeta.Annotations {
 		if strings.HasPrefix(k, "kube-proxy.kubernetes.io/") {
-			info.Annotations[k] = v
+			info.annotations[k] = v
 		}
 	}
 	return info

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -156,7 +156,7 @@ func TestServiceToServiceMap(t *testing.T) {
 			}),
 			expected: map[ServicePortName]*BaseServiceInfo{
 				makeServicePortName("ns2", "cluster-ip", "p1"): makeTestServiceInfo("172.16.55.4", 1234, "UDP", 0, func(info *BaseServiceInfo) {
-					info.Annotations["kube-proxy.kubernetes.io/ipvs-scheduler"] = "lc"
+					info.annotations["kube-proxy.kubernetes.io/ipvs-scheduler"] = "lc"
 				}),
 			},
 		},
@@ -392,7 +392,7 @@ func TestServiceToServiceMap(t *testing.T) {
 				svcInfo.protocol != expectedInfo.protocol ||
 				svcInfo.healthCheckNodePort != expectedInfo.healthCheckNodePort ||
 				!sets.NewString(svcInfo.externalIPs...).Equal(sets.NewString(expectedInfo.externalIPs...)) ||
-				!sets.NewString(svcInfo.loadBalancerSourceRanges...).Equal(sets.NewString(expectedInfo.loadBalancerSourceRanges...)) {
+				!sets.NewString(svcInfo.loadBalancerSourceRanges...).Equal(sets.NewString(expectedInfo.loadBalancerSourceRanges...)) ||
 				len(svcInfo.annotations) > 0 && !reflect.DeepEqual(svcInfo.annotations, expectedInfo.annotations) {
 				t.Errorf("[%s] expected new[%v]to be %v, got %v", tc.desc, svcKey, expectedInfo, *svcInfo)
 			}

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -33,9 +33,9 @@ const testHostname = "test-hostname"
 
 func makeTestServiceInfo(clusterIP string, port int, protocol string, healthcheckNodePort int, svcInfoFuncs ...func(*BaseServiceInfo)) *BaseServiceInfo {
 	info := &BaseServiceInfo{
-		clusterIP: net.ParseIP(clusterIP),
-		port:      port,
-		protocol:  v1.Protocol(protocol),
+		clusterIP:   net.ParseIP(clusterIP),
+		port:        port,
+		protocol:    v1.Protocol(protocol),
 		annotations: make(map[string]string),
 	}
 	if healthcheckNodePort != 0 {

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package proxy
 
 import (
-	"github.com/davecgh/go-spew/spew"
 	"net"
 	"reflect"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -75,6 +75,8 @@ type ServicePort interface {
 	NodePort() int
 	// GetOnlyNodeLocalEndpoints returns if a service has only node local endpoints
 	OnlyNodeLocalEndpoints() bool
+	// GetAnnotations returns annotations in the service. Only "kube-proxy.kubernetes.io/" annotations are returned.
+	GetAnnotations() map[string]string
 }
 
 // Endpoint in an interface which abstracts information about an endpoint.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds the possibility to set the scheduler in proxy-mode=ipvs with an annotation in the service manifest.

Some applications wants to control the scheduler.

**Which issue(s) this PR fixes**:

Fixes #75502 


**Special notes for your reviewer**:

The PR is 2 parts;

* Store all annotations with prefix; "kube-proxy.kubernetes.io/". This is on "proxy" level, i.e. all proxies are affected by this change.
* In the ipvs proxier the feature above is used to set the scheduler

The first is tested with an added unit-test the last is tested only on cluster. With manifest;

```
apiVersion: v1
kind: Service
metadata:
  name: mconnect
  annotations:
    kube-proxy.kubernetes.io/ipvs-scheduler: lc
...
```

The scheduler can be investigated with;
```
# ipvsadm -L -n
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
TCP  192.168.0.4:31837 lc
  -> 11.0.1.2:5001                Masq    1      0          0         
  -> 11.0.2.2:5001                Masq    1      0          0         
  -> 11.0.3.3:5001                Masq    1      0          0         
  -> 11.0.4.2:5001                Masq    1      0          0         
...
TCP  12.0.0.1:443 rr
  -> 192.168.1.1:6443             Masq    1      0          0         
TCP  12.0.0.2:53 rr
  -> 11.0.3.2:53                  Masq    1      0          0
...
```
The `mconnect` service (port 5001) has "lc" (least connections) as scheduler while the kubernetes and coredns services has the default "rr" (round robin).

Unit-tests pass in all proxiers but e2e tests have not been executed. Also a test that the specified scheduler really is a valid ipvs scheduler should be added. But I would like to get a "go ahead" on this before I spend too much time on it.

**Does this PR introduce a user-facing change?**:

```release-note
In proxy-mode=ipvs the scheduler can be controlled with an annotation in the service manifest. Example; "kube-proxy.kubernetes.io/ipvs-scheduler: lc"
```
