### PR TITLE
Bump debian-* base images for security fixes

### DIFF
--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -18,7 +18,7 @@ REGISTRY ?= staging-k8s.gcr.io
 IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
-TAG ?= 0.4.1
+TAG ?= 0.4.2
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -19,12 +19,12 @@
 
 REGISTRY?=staging-k8s.gcr.io
 IMAGE?=$(REGISTRY)/debian-hyperkube-base
-TAG=0.12.1
+TAG=0.12.2
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 CACHEBUST?=1
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.4.1
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.4.2
 CNI_VERSION=v0.7.5
 
 TEMP_DIR:=$(shell mktemp -d)

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,12 +16,12 @@
 
 REGISTRY?="staging-k8s.gcr.io"
 IMAGE=$(REGISTRY)/debian-iptables
-TAG?=v11.0.1
+TAG?=v11.0.2
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 TEMP_DIR:=$(shell mktemp -d)
 
-BASEIMAGE?=k8s.gcr.io/debian-base-$(ARCH):0.4.1
+BASEIMAGE?=k8s.gcr.io/debian-base-$(ARCH):0.4.2
 
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
Bump debian-* base images to pick up fix for critical vuln [CVE-2017-16997](https://security-tracker.debian.org/tracker/CVE-2017-16997) among [many other high or lower severity vulns](https://pantheon.corp.google.com/gcr/images/google-containers/GLOBAL/debian-base-amd64@sha256:8ccb65cd2dd7e0c24193d0742a20e4a673dbd11af5a33f16fcd471a31486866c/details?tab=vulnz&project=google-containers&gcrVulnzListsize=30).

**Does this PR introduce a user-facing change?:**
```
NONE
```

/assign @tallclair 