### PR TITLE
Convert interface type check %#v into %T for clarity and brevity

### DIFF
--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -156,7 +156,7 @@ func (cc *CertificateController) processNextWorkItem() bool {
 func (cc *CertificateController) enqueueCertificateRequest(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", obj, err))
 		return
 	}
 	cc.queue.Add(key)

--- a/pkg/controller/certificates/rootcacertpublisher/BUILD
+++ b/pkg/controller/certificates/rootcacertpublisher/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/util/metrics:go_default_library",
-        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"time"
 
-	"k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -211,11 +210,11 @@ func convertToCM(obj interface{}) (*v1.ConfigMap, error) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			return nil, fmt.Errorf("Couldn't get object from tombstone %#v", obj)
+			return nil, fmt.Errorf("Couldn't get object from tombstone %T", obj)
 		}
 		cm, ok = tombstone.Obj.(*v1.ConfigMap)
 		if !ok {
-			return nil, fmt.Errorf("Tombstone contained object that is not a ConfigMap %#v", obj)
+			return nil, fmt.Errorf("Tombstone contained object that is not a ConfigMap %T", tombstone.Obj)
 		}
 	}
 	return cm, nil

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -199,7 +199,7 @@ func (c *ClusterRoleAggregationController) enqueue() {
 		}
 		key, err := controller.KeyFunc(clusterRole)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", clusterRole, err))
+			utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", clusterRole, err))
 			return
 		}
 		c.queue.Add(key)

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -133,7 +133,7 @@ var ExpKeyFunc = func(obj interface{}) (string, error) {
 	if e, ok := obj.(*ControlleeExpectations); ok {
 		return e.key, nil
 	}
-	return "", fmt.Errorf("could not find key for obj %#v", obj)
+	return "", fmt.Errorf("could not find key for obj %T", obj)
 }
 
 // ControllerExpectationsInterface is an interface that allows users to set and wait on expectations.
@@ -298,7 +298,7 @@ var UIDSetKeyFunc = func(obj interface{}) (string, error) {
 	if u, ok := obj.(*UIDSet); ok {
 		return u.key, nil
 	}
-	return "", fmt.Errorf("could not find key for obj %#v", obj)
+	return "", fmt.Errorf("could not find key for obj %T", obj)
 }
 
 // UIDSet holds a key and a set of UIDs. Used by the

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -246,12 +246,12 @@ func (dsc *DaemonSetsController) deleteDaemonset(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %T", obj))
 			return
 		}
 		ds, ok = tombstone.Obj.(*apps.DaemonSet)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a DaemonSet %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a DaemonSet %T", obj))
 			return
 		}
 	}
@@ -308,7 +308,7 @@ func (dsc *DaemonSetsController) processNextWorkItem() bool {
 func (dsc *DaemonSetsController) enqueue(ds *apps.DaemonSet) {
 	key, err := controller.KeyFunc(ds)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", ds, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", ds, err))
 		return
 	}
 
@@ -319,7 +319,7 @@ func (dsc *DaemonSetsController) enqueue(ds *apps.DaemonSet) {
 func (dsc *DaemonSetsController) enqueueRateLimited(ds *apps.DaemonSet) {
 	key, err := controller.KeyFunc(ds)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", ds, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", ds, err))
 		return
 	}
 
@@ -329,7 +329,7 @@ func (dsc *DaemonSetsController) enqueueRateLimited(ds *apps.DaemonSet) {
 func (dsc *DaemonSetsController) enqueueDaemonSetAfter(obj interface{}, after time.Duration) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", obj, err))
 		return
 	}
 
@@ -460,12 +460,12 @@ func (dsc *DaemonSetsController) deleteHistory(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %T", obj))
 			return
 		}
 		history, ok = tombstone.Obj.(*apps.ControllerRevision)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a ControllerRevision %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a ControllerRevision %T", obj))
 			return
 		}
 	}
@@ -649,12 +649,12 @@ func (dsc *DaemonSetsController) deletePod(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %T", obj))
 			return
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %T", obj))
 			return
 		}
 	}
@@ -985,7 +985,7 @@ func (dsc *DaemonSetsController) syncNodes(ds *apps.DaemonSet, podsToDelete, nod
 	// We need to set expectations before creating/deleting pods to avoid race conditions.
 	dsKey, err := controller.KeyFunc(ds)
 	if err != nil {
-		return fmt.Errorf("couldn't get key for object %#v: %v", ds, err)
+		return fmt.Errorf("couldn't get key for object %T: %v", ds, err)
 	}
 
 	createDiff := len(nodesNeedingDaemonPods)
@@ -1237,7 +1237,7 @@ func (dsc *DaemonSetsController) syncDaemonSet(key string) error {
 	// then we do not want to call manage on foo until the daemon pods have been created.
 	dsKey, err := controller.KeyFunc(ds)
 	if err != nil {
-		return fmt.Errorf("couldn't get key for object %#v: %v", ds, err)
+		return fmt.Errorf("couldn't get key for object %T: %v", ds, err)
 	}
 
 	// If the DaemonSet is being deleted (either by foreground deletion or

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -181,12 +181,12 @@ func (dc *DeploymentController) deleteDeployment(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %T", obj))
 			return
 		}
 		d, ok = tombstone.Obj.(*apps.Deployment)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Deployment %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Deployment %T", obj))
 			return
 		}
 	}
@@ -310,12 +310,12 @@ func (dc *DeploymentController) deleteReplicaSet(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %T", obj))
 			return
 		}
 		rs, ok = tombstone.Obj.(*apps.ReplicaSet)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a ReplicaSet %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a ReplicaSet %T", obj))
 			return
 		}
 	}
@@ -344,12 +344,12 @@ func (dc *DeploymentController) deletePod(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %T", obj))
 			return
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a pod %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a pod %T", obj))
 			return
 		}
 	}
@@ -377,7 +377,7 @@ func (dc *DeploymentController) deletePod(obj interface{}) {
 func (dc *DeploymentController) enqueue(deployment *apps.Deployment) {
 	key, err := controller.KeyFunc(deployment)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", deployment, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", deployment, err))
 		return
 	}
 
@@ -387,7 +387,7 @@ func (dc *DeploymentController) enqueue(deployment *apps.Deployment) {
 func (dc *DeploymentController) enqueueRateLimited(deployment *apps.Deployment) {
 	key, err := controller.KeyFunc(deployment)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", deployment, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", deployment, err))
 		return
 	}
 
@@ -398,7 +398,7 @@ func (dc *DeploymentController) enqueueRateLimited(deployment *apps.Deployment) 
 func (dc *DeploymentController) enqueueAfter(deployment *apps.Deployment, after time.Duration) {
 	key, err := controller.KeyFunc(deployment)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", deployment, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", deployment, err))
 		return
 	}
 

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -333,12 +333,12 @@ func (e *EndpointController) deletePod(obj interface{}) {
 	// If we reached here it means the pod was deleted but its final state is unrecorded.
 	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %T", obj))
 		return
 	}
 	pod, ok := tombstone.Obj.(*v1.Pod)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Pod: %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Pod: %T", obj))
 		return
 	}
 	klog.V(4).Infof("Enqueuing services of deleted pod %s/%s having final state unrecorded", pod.Namespace, pod.Name)
@@ -349,7 +349,7 @@ func (e *EndpointController) deletePod(obj interface{}) {
 func (e *EndpointController) enqueueService(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", obj, err))
 		return
 	}
 
@@ -588,7 +588,7 @@ func (e *EndpointController) checkLeftoverEndpoints() {
 		}
 		key, err := controller.KeyFunc(ep)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("Unable to get key for endpoint %#v", ep))
+			utilruntime.HandleError(fmt.Errorf("Unable to get key for endpoint %T", ep))
 			continue
 		}
 		e.queue.Add(key)

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -292,7 +292,7 @@ func (gc *GarbageCollector) attemptToDeleteWorker() bool {
 	defer gc.attemptToDelete.Done(item)
 	n, ok := item.(*node)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("expect *node, got %#v", item))
+		utilruntime.HandleError(fmt.Errorf("expect *node, got %T", item))
 		return true
 	}
 	err := gc.attemptToDeleteItem(n)
@@ -591,7 +591,7 @@ func (gc *GarbageCollector) attemptToOrphanWorker() bool {
 	defer gc.attemptToOrphan.Done(item)
 	owner, ok := item.(*node)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("expect *node, got %#v", item))
+		utilruntime.HandleError(fmt.Errorf("expect *node, got %T", item))
 		return true
 	}
 	// we don't need to lock each element, because they never get updated

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	batch "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -292,12 +292,12 @@ func (jm *JobController) deletePod(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %T", obj))
 			return
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %+v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %T", obj))
 			return
 		}
 	}
@@ -354,7 +354,7 @@ func (jm *JobController) updateJob(old, cur interface{}) {
 func (jm *JobController) enqueueController(obj interface{}, immediate bool) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", obj, err))
 		return
 	}
 
@@ -688,7 +688,7 @@ func (jm *JobController) manageJob(activePods []*v1.Pod, succeeded int32, job *b
 	parallelism := *job.Spec.Parallelism
 	jobKey, err := controller.KeyFunc(job)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for job %#v: %v", job, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for job %T: %v", job, err))
 		return 0, nil
 	}
 

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -104,7 +104,7 @@ func NewNamespaceController(
 func (nm *NamespaceController) enqueueNamespace(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", obj, err))
 		return
 	}
 

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -175,7 +175,7 @@ func (a *HorizontalController) updateHPA(old, cur interface{}) {
 func (a *HorizontalController) enqueueHPA(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %T: %v", obj, err))
 		return
 	}
 
@@ -188,7 +188,7 @@ func (a *HorizontalController) enqueueHPA(obj interface{}) {
 func (a *HorizontalController) deleteHPA(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %T: %v", obj, err))
 		return
 	}
 

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -379,12 +379,12 @@ func (rsc *ReplicaSetController) deletePod(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %T", obj))
 			return
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %T", obj))
 			return
 		}
 	}
@@ -411,7 +411,7 @@ func (rsc *ReplicaSetController) deletePod(obj interface{}) {
 func (rsc *ReplicaSetController) enqueueReplicaSet(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %T: %v", obj, err))
 		return
 	}
 	rsc.queue.Add(key)
@@ -421,7 +421,7 @@ func (rsc *ReplicaSetController) enqueueReplicaSet(obj interface{}) {
 func (rsc *ReplicaSetController) enqueueReplicaSetAfter(obj interface{}, after time.Duration) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %T: %v", obj, err))
 		return
 	}
 	rsc.queue.AddAfter(key, after)
@@ -460,7 +460,7 @@ func (rsc *ReplicaSetController) manageReplicas(filteredPods []*v1.Pod, rs *apps
 	diff := len(filteredPods) - int(*(rs.Spec.Replicas))
 	rsKey, err := controller.KeyFunc(rs)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for %v %#v: %v", rsc.Kind, rs, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for %v %T: %v", rsc.Kind, rs, err))
 		return nil
 	}
 	if diff < 0 {

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -151,12 +151,12 @@ func (h conversionEventHandler) OnDelete(obj interface{}) {
 		// Convert the Obj inside DeletedFinalStateUnknown.
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: couldn't get object from tombstone %+v", obj))
+			utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: couldn't get object from tombstone %T", obj))
 			return
 		}
 		rc, ok = tombstone.Obj.(*v1.ReplicationController)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: tombstone contained object that is not a RC %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: tombstone contained object that is not a RC %T", obj))
 			return
 		}
 		rs, err := convertRCtoRS(rc, nil)

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -184,7 +184,7 @@ func (rq *ResourceQuotaController) enqueueAll() {
 	for i := range rqs {
 		key, err := controller.KeyFunc(rqs[i])
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", rqs[i], err))
+			utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", rqs[i], err))
 			continue
 		}
 		rq.queue.Add(key)

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -132,12 +132,12 @@ func (c *ServiceAccountsController) serviceAccountDeleted(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %T", obj))
 			return
 		}
 		sa, ok = tombstone.Obj.(*v1.ServiceAccount)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a ServiceAccount %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a ServiceAccount %T", obj))
 			return
 		}
 	}

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -656,7 +656,7 @@ func (e *TokensController) getSecret(ns string, name string, uid types.UID, fetc
 	if exists {
 		secret, ok := obj.(*v1.Secret)
 		if !ok {
-			return nil, fmt.Errorf("expected *v1.Secret, got %#v", secret)
+			return nil, fmt.Errorf("expected *v1.Secret, got %T", secret)
 		}
 		// Ensure UID matches if given
 		if len(uid) == 0 || uid == secret.UID {

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -247,12 +247,12 @@ func (ssc *StatefulSetController) deletePod(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %T", obj))
 			return
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %+v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %T", obj))
 			return
 		}
 	}
@@ -375,7 +375,7 @@ func (ssc *StatefulSetController) resolveControllerRef(namespace string, control
 func (ssc *StatefulSetController) enqueueStatefulSet(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", obj, err))
 		return
 	}
 	ssc.queue.Add(key)

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -138,7 +138,7 @@ func (tc *Controller) enqueue(job *batch.Job) {
 	klog.V(4).Infof("Add job %s/%s to cleanup", job.Namespace, job.Name)
 	key, err := controller.KeyFunc(job)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", job, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %T: %v", job, err))
 		return
 	}
 
@@ -148,7 +148,7 @@ func (tc *Controller) enqueue(job *batch.Job) {
 func (tc *Controller) enqueueAfter(job *batch.Job, after time.Duration) {
 	key, err := controller.KeyFunc(job)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", job, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %T: %v", job, err))
 		return
 	}
 

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -579,7 +579,7 @@ func (adc *attachDetachController) nodeDelete(obj interface{}) {
 func (adc *attachDetachController) enqueuePVC(obj interface{}) {
 	key, err := kcache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		runtime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
+		runtime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", obj, err))
 		return
 	}
 	adc.pvcQueue.Add(key)

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -169,12 +169,12 @@ func (expc *expandController) deletePVC(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(kcache.DeletedFinalStateUnknown)
 		if !ok {
-			runtime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			runtime.HandleError(fmt.Errorf("couldn't get object from tombstone %T", obj))
 			return
 		}
 		pvc, ok = tombstone.Obj.(*v1.PersistentVolumeClaim)
 		if !ok {
-			runtime.HandleError(fmt.Errorf("tombstone contained object that is not a pvc %#v", obj))
+			runtime.HandleError(fmt.Errorf("tombstone contained object that is not a pvc %T", obj))
 			return
 		}
 	}

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -384,7 +384,7 @@ func (ctrl *PersistentVolumeController) syncUnboundClaim(claim *v1.PersistentVol
 		} else {
 			volume, ok := obj.(*v1.PersistentVolume)
 			if !ok {
-				return fmt.Errorf("Cannot convert object from volume cache to volume %q!?: %+v", claim.Spec.VolumeName, obj)
+				return fmt.Errorf("Cannot convert object from volume cache to volume %q!?: %T", claim.Spec.VolumeName, obj)
 			}
 			klog.V(4).Infof("synchronizing unbound PersistentVolumeClaim[%s]: volume %q requested and found: %s", claimToClaimKey(claim), claim.Spec.VolumeName, getVolumeStatusForLogging(volume))
 			if volume.Spec.ClaimRef == nil {
@@ -466,7 +466,7 @@ func (ctrl *PersistentVolumeController) syncBoundClaim(claim *v1.PersistentVolum
 	} else {
 		volume, ok := obj.(*v1.PersistentVolume)
 		if !ok {
-			return fmt.Errorf("Cannot convert object from volume cache to volume %q!?: %#v", claim.Spec.VolumeName, obj)
+			return fmt.Errorf("Cannot convert object from volume cache to volume %q!?: %T", claim.Spec.VolumeName, obj)
 		}
 
 		klog.V(4).Infof("synchronizing bound PersistentVolumeClaim[%s]: volume %q found: %s", claimToClaimKey(claim), claim.Spec.VolumeName, getVolumeStatusForLogging(volume))
@@ -573,7 +573,7 @@ func (ctrl *PersistentVolumeController) syncVolume(volume *v1.PersistentVolume) 
 			var ok bool
 			claim, ok = obj.(*v1.PersistentVolumeClaim)
 			if !ok {
-				return fmt.Errorf("Cannot convert object from volume cache to volume %q!?: %#v", claim.Spec.VolumeName, obj)
+				return fmt.Errorf("Cannot convert object from volume cache to volume %q!?: %T", claim.Spec.VolumeName, obj)
 			}
 			klog.V(4).Infof("synchronizing PersistentVolume[%s]: claim %s found: %s", volume.Name, claimrefToClaimKey(volume.Spec.ClaimRef), getClaimStatusForLogging(claim))
 		}
@@ -1248,7 +1248,7 @@ func (ctrl *PersistentVolumeController) isVolumeReleased(volume *v1.PersistentVo
 		var ok bool
 		claim, ok = obj.(*v1.PersistentVolumeClaim)
 		if !ok {
-			return false, fmt.Errorf("Cannot convert object from claim cache to claim!?: %#v", obj)
+			return false, fmt.Errorf("Cannot convert object from claim cache to claim!?: %T", obj)
 		}
 	}
 	if claim != nil && claim.UID == volume.Spec.ClaimRef.UID {

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -473,7 +473,7 @@ func getVolumeStatusForLogging(volume *v1.PersistentVolume) string {
 func storeObjectUpdate(store cache.Store, obj interface{}, className string) (bool, error) {
 	objName, err := controller.KeyFunc(obj)
 	if err != nil {
-		return false, fmt.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return false, fmt.Errorf("Couldn't get key for object %T: %v", obj, err)
 	}
 	oldObj, found, err := store.Get(obj)
 	if err != nil {

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -241,12 +241,12 @@ func (c *Controller) isBeingUsed(pvc *v1.PersistentVolumeClaim) (bool, error) {
 func (c *Controller) pvcAddedUpdated(obj interface{}) {
 	pvc, ok := obj.(*v1.PersistentVolumeClaim)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("PVC informer returned non-PVC object: %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("PVC informer returned non-PVC object: %T", obj))
 		return
 	}
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(pvc)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for Persistent Volume Claim %#v: %v", pvc, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for Persistent Volume Claim %T: %v", pvc, err))
 		return
 	}
 	klog.V(4).Infof("Got event on PVC %s", key)
@@ -262,12 +262,12 @@ func (c *Controller) podAddedDeletedUpdated(obj interface{}, deleted bool) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %T", obj))
 			return
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Pod %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Pod %T", obj))
 			return
 		}
 	}

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -198,7 +198,7 @@ func (c *Controller) isBeingUsed(pv *v1.PersistentVolume) bool {
 func (c *Controller) pvAddedUpdated(obj interface{}) {
 	pv, ok := obj.(*v1.PersistentVolume)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("PV informer returned non-PV object: %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("PV informer returned non-PV object: %T", obj))
 		return
 	}
 	klog.V(4).Infof("Got event on PV %s", pv.Name)

--- a/pkg/kubectl/polymorphichelpers/helpers.go
+++ b/pkg/kubectl/polymorphichelpers/helpers.go
@@ -75,7 +75,7 @@ func GetFirstPod(client coreclient.PodsGetter, namespace string, selector string
 	}
 	pod, ok := event.Object.(*corev1.Pod)
 	if !ok {
-		return nil, 0, fmt.Errorf("%#v is not a pod event", event)
+		return nil, 0, fmt.Errorf("%T is not a pod event", event.Object)
 	}
 	return pod, 1, nil
 }

--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -120,7 +120,7 @@ func tryDecodeSinglePod(data []byte, defaultFn defaultFunc) (parsed bool, pod *v
 	newPod, ok := obj.(*api.Pod)
 	// Check whether the object could be converted to single pod.
 	if !ok {
-		return false, pod, fmt.Errorf("invalid pod: %#v", obj)
+		return false, pod, fmt.Errorf("invalid pod: %T", obj)
 	}
 
 	// Apply default values and validate the pod.
@@ -147,7 +147,7 @@ func tryDecodePodList(data []byte, defaultFn defaultFunc) (parsed bool, pods v1.
 	newPods, ok := obj.(*api.PodList)
 	// Check whether the object could be converted to list of pods.
 	if !ok {
-		err = fmt.Errorf("invalid pods list: %#v", obj)
+		err = fmt.Errorf("invalid pods list: %T", obj)
 		return false, pods, err
 	}
 

--- a/pkg/registry/apps/deployment/storage/storage.go
+++ b/pkg/registry/apps/deployment/storage/storage.go
@@ -212,7 +212,7 @@ func (r *RollbackREST) setDeploymentRollback(ctx context.Context, deploymentID s
 	err = r.store.Storage.GuaranteedUpdate(ctx, dKey, &apps.Deployment{}, false, nil, storage.SimpleUpdate(func(obj runtime.Object) (runtime.Object, error) {
 		d, ok := obj.(*apps.Deployment)
 		if !ok {
-			return nil, fmt.Errorf("unexpected object: %#v", obj)
+			return nil, fmt.Errorf("unexpected object: %T", obj)
 		}
 		if d.Annotations == nil {
 			d.Annotations = make(map[string]string)

--- a/pkg/registry/core/node/rest/proxy.go
+++ b/pkg/registry/core/node/rest/proxy.go
@@ -64,7 +64,7 @@ func (r *ProxyREST) NewConnectOptions() (runtime.Object, bool, string) {
 func (r *ProxyREST) Connect(ctx context.Context, id string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	proxyOpts, ok := opts.(*api.NodeProxyOptions)
 	if !ok {
-		return nil, fmt.Errorf("Invalid options object: %#v", opts)
+		return nil, fmt.Errorf("Invalid options object: %T", opts)
 	}
 	location, transport, err := node.ResourceLocation(r.Store, r.Connection, r.ProxyTransport, ctx, id)
 	if err != nil {

--- a/pkg/registry/core/pod/rest/log.go
+++ b/pkg/registry/core/pod/rest/log.go
@@ -65,7 +65,7 @@ func (r *LogREST) ProducesObject(verb string) interface{} {
 func (r *LogREST) Get(ctx context.Context, name string, opts runtime.Object) (runtime.Object, error) {
 	logOpts, ok := opts.(*api.PodLogOptions)
 	if !ok {
-		return nil, fmt.Errorf("invalid options object: %#v", opts)
+		return nil, fmt.Errorf("invalid options object: %T", opts)
 	}
 	if errs := validation.ValidatePodLogOptions(logOpts); len(errs) > 0 {
 		return nil, errors.NewInvalid(api.Kind("PodLogOptions"), name, errs)

--- a/pkg/registry/core/pod/rest/subresources.go
+++ b/pkg/registry/core/pod/rest/subresources.go
@@ -65,7 +65,7 @@ func (r *ProxyREST) NewConnectOptions() (runtime.Object, bool, string) {
 func (r *ProxyREST) Connect(ctx context.Context, id string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	proxyOpts, ok := opts.(*api.PodProxyOptions)
 	if !ok {
-		return nil, fmt.Errorf("Invalid options object: %#v", opts)
+		return nil, fmt.Errorf("Invalid options object: %T", opts)
 	}
 	location, transport, err := pod.ResourceLocation(r.Store, r.ProxyTransport, ctx, id)
 	if err != nil {
@@ -97,7 +97,7 @@ func (r *AttachREST) New() runtime.Object {
 func (r *AttachREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	attachOpts, ok := opts.(*api.PodAttachOptions)
 	if !ok {
-		return nil, fmt.Errorf("Invalid options object: %#v", opts)
+		return nil, fmt.Errorf("Invalid options object: %T", opts)
 	}
 	location, transport, err := pod.AttachLocation(r.Store, r.KubeletConn, ctx, name, attachOpts)
 	if err != nil {
@@ -134,7 +134,7 @@ func (r *ExecREST) New() runtime.Object {
 func (r *ExecREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	execOpts, ok := opts.(*api.PodExecOptions)
 	if !ok {
-		return nil, fmt.Errorf("invalid options object: %#v", opts)
+		return nil, fmt.Errorf("invalid options object: %T", opts)
 	}
 	location, transport, err := pod.ExecLocation(r.Store, r.KubeletConn, ctx, name, execOpts)
 	if err != nil {
@@ -182,7 +182,7 @@ func (r *PortForwardREST) ConnectMethods() []string {
 func (r *PortForwardREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	portForwardOpts, ok := opts.(*api.PodPortForwardOptions)
 	if !ok {
-		return nil, fmt.Errorf("invalid options object: %#v", opts)
+		return nil, fmt.Errorf("invalid options object: %T", opts)
 	}
 	location, transport, err := pod.PortForwardLocation(r.Store, r.KubeletConn, ctx, name, portForwardOpts)
 	if err != nil {

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -171,7 +171,7 @@ func (r *BindingREST) setPodHostAndAnnotations(ctx context.Context, podID, oldMa
 	err = r.store.Storage.GuaranteedUpdate(ctx, podKey, &api.Pod{}, false, nil, storage.SimpleUpdate(func(obj runtime.Object) (runtime.Object, error) {
 		pod, ok := obj.(*api.Pod)
 		if !ok {
-			return nil, fmt.Errorf("unexpected object: %#v", obj)
+			return nil, fmt.Errorf("unexpected object: %T", obj)
 		}
 		if pod.DeletionTimestamp != nil {
 			return nil, fmt.Errorf("pod %s is being deleted, cannot be assigned to a host", pod.Name)

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -229,7 +229,7 @@ func getPod(getter ResourceGetter, ctx context.Context, name string) (*api.Pod, 
 	}
 	pod := obj.(*api.Pod)
 	if pod == nil {
-		return nil, fmt.Errorf("Unexpected object type: %#v", pod)
+		return nil, fmt.Errorf("Unexpected object type: %T", pod)
 	}
 	return pod, nil
 }

--- a/pkg/registry/core/service/proxy.go
+++ b/pkg/registry/core/service/proxy.go
@@ -60,7 +60,7 @@ func (r *ProxyREST) NewConnectOptions() (runtime.Object, bool, string) {
 func (r *ProxyREST) Connect(ctx context.Context, id string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	proxyOpts, ok := opts.(*api.ServiceProxyOptions)
 	if !ok {
-		return nil, fmt.Errorf("Invalid options object: %#v", opts)
+		return nil, fmt.Errorf("Invalid options object: %T", opts)
 	}
 	location, transport, err := r.Redirector.ResourceLocation(ctx, id)
 	if err != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -289,7 +289,7 @@ func (c *CRDFinalizer) processNextWorkItem() bool {
 func (c *CRDFinalizer) enqueue(obj *apiextensions.CustomResourceDefinition) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", obj, err))
 		return
 	}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -326,7 +326,7 @@ func (c *NamingConditionController) processNextWorkItem() bool {
 func (c *NamingConditionController) enqueue(obj *apiextensions.CustomResourceDefinition) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %T: %v", obj, err))
 		return
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -592,7 +592,7 @@ type GetWithOptionsRESTStorage struct {
 
 func (r *GetWithOptionsRESTStorage) Get(ctx context.Context, name string, options runtime.Object) (runtime.Object, error) {
 	if _, ok := options.(*genericapitesting.SimpleGetOptions); !ok {
-		return nil, fmt.Errorf("Unexpected options object: %#v", options)
+		return nil, fmt.Errorf("Unexpected options object: %T", options)
 	}
 	r.optionsReceived = options
 	return r.SimpleRESTStorage.Get(ctx, name, &metav1.GetOptions{})
@@ -619,7 +619,7 @@ func (r *GetWithOptionsRootRESTStorage) NamespaceScoped() bool {
 
 func (r *GetWithOptionsRootRESTStorage) Get(ctx context.Context, name string, options runtime.Object) (runtime.Object, error) {
 	if _, ok := options.(*genericapitesting.SimpleGetOptions); !ok {
-		return nil, fmt.Errorf("Unexpected options object: %#v", options)
+		return nil, fmt.Errorf("Unexpected options object: %T", options)
 	}
 	r.optionsReceived = options
 	return r.SimpleTypedStorage.Get(ctx, name, &metav1.GetOptions{})

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -175,14 +175,14 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	cn, ok := w.(http.CloseNotifier)
 	if !ok {
-		err := fmt.Errorf("unable to start watch - can't get http.CloseNotifier: %#v", w)
+		err := fmt.Errorf("unable to start watch - can't get http.CloseNotifier: %T", w)
 		utilruntime.HandleError(err)
 		s.Scope.err(errors.NewInternalError(err), w, req)
 		return
 	}
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		err := fmt.Errorf("unable to start watch - can't get http.Flusher: %#v", w)
+		err := fmt.Errorf("unable to start watch - can't get http.Flusher: %T", w)
 		utilruntime.HandleError(err)
 		s.Scope.err(errors.NewInternalError(err), w, req)
 		return

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -370,7 +370,7 @@ func (w *watchCache) Replace(objs []interface{}, resourceVersion string) error {
 	for _, obj := range objs {
 		object, ok := obj.(runtime.Object)
 		if !ok {
-			return fmt.Errorf("didn't get runtime.Object for replace: %#v", obj)
+			return fmt.Errorf("didn't get runtime.Object for replace: %T", obj)
 		}
 		key, err := w.keyFunc(object)
 		if err != nil {

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -231,7 +231,7 @@ func (f *DeltaFIFO) Delete(obj interface{}) error {
 func (f *DeltaFIFO) AddIfNotPresent(obj interface{}) error {
 	deltas, ok := obj.(Deltas)
 	if !ok {
-		return fmt.Errorf("object must be of type deltas, but got: %#v", obj)
+		return fmt.Errorf("object must be of type deltas, but got: %T", obj)
 	}
 	id, err := f.KeyOf(deltas.Newest().Object)
 	if err != nil {

--- a/staging/src/k8s.io/sample-controller/controller.go
+++ b/staging/src/k8s.io/sample-controller/controller.go
@@ -211,7 +211,7 @@ func (c *Controller) processNextWorkItem() bool {
 			// Forget here else we'd go into a loop of attempting to
 			// process a work item that is invalid.
 			c.workqueue.Forget(obj)
-			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %T", obj))
 			return nil
 		}
 		// Run the syncHandler, passing it the namespace/name string of the


### PR DESCRIPTION
While reviewing the codebase for the use of `%#v` in `fmt.Errorf()`
which recently caused a performance regression there were many places
where we were inconsistent about using %T with type checks. This corrects
most of the controllers and core code to be consistent where the only
info that matters when debugging the problem is what the input type is

/kind cleanup

```release-note
NONE
```