### PR TITLE
Remove use of `%#v` in frequently accessed code

### DIFF
--- a/pkg/kubelet/container/ref.go
+++ b/pkg/kubelet/container/ref.go
@@ -54,9 +54,8 @@ func fieldPath(pod *v1.Pod, container *v1.Container) (string, error) {
 		if here.Name == container.Name {
 			if here.Name == "" {
 				return fmt.Sprintf("spec.containers[%d]", i), nil
-			} else {
-				return fmt.Sprintf("spec.containers{%s}", here.Name), nil
 			}
+			return fmt.Sprintf("spec.containers{%s}", here.Name), nil
 		}
 	}
 	for i := range pod.Spec.InitContainers {
@@ -64,10 +63,9 @@ func fieldPath(pod *v1.Pod, container *v1.Container) (string, error) {
 		if here.Name == container.Name {
 			if here.Name == "" {
 				return fmt.Sprintf("spec.initContainers[%d]", i), nil
-			} else {
-				return fmt.Sprintf("spec.initContainers{%s}", here.Name), nil
 			}
+			return fmt.Sprintf("spec.initContainers{%s}", here.Name), nil
 		}
 	}
-	return "", fmt.Errorf("container %#v not found in pod %#v", container, pod)
+	return "", fmt.Errorf("container %q not found in pod %s/%s", container.Name, pod.Namespace, pod.Name)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go
@@ -51,7 +51,7 @@ func UnsafeObjectConvertor(scheme *Scheme) ObjectConvertor {
 func SetField(src interface{}, v reflect.Value, fieldName string) error {
 	field := v.FieldByName(fieldName)
 	if !field.IsValid() {
-		return fmt.Errorf("couldn't find %v field in %#v", fieldName, v.Interface())
+		return fmt.Errorf("couldn't find %v field in %T", fieldName, v.Interface())
 	}
 	srcValue := reflect.ValueOf(src)
 	if srcValue.Type().AssignableTo(field.Type()) {
@@ -70,7 +70,7 @@ func SetField(src interface{}, v reflect.Value, fieldName string) error {
 func Field(v reflect.Value, fieldName string, dest interface{}) error {
 	field := v.FieldByName(fieldName)
 	if !field.IsValid() {
-		return fmt.Errorf("couldn't find %v field in %#v", fieldName, v.Interface())
+		return fmt.Errorf("couldn't find %v field in %T", fieldName, v.Interface())
 	}
 	destValue, err := conversion.EnforcePtr(dest)
 	if err != nil {
@@ -93,7 +93,7 @@ func Field(v reflect.Value, fieldName string, dest interface{}) error {
 func FieldPtr(v reflect.Value, fieldName string, dest interface{}) error {
 	field := v.FieldByName(fieldName)
 	if !field.IsValid() {
-		return fmt.Errorf("couldn't find %v field in %#v", fieldName, v.Interface())
+		return fmt.Errorf("couldn't find %v field in %T", fieldName, v.Interface())
 	}
 	v, err := conversion.EnforcePtr(dest)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -592,7 +592,7 @@ func (r *Request) WatchWithSpecificDecoders(wrapperDecoderFn func(io.ReadCloser)
 		if result := r.transformResponse(resp, req); result.err != nil {
 			return nil, result.err
 		}
-		return nil, fmt.Errorf("for request '%+v', got status: %v", url, resp.StatusCode)
+		return nil, fmt.Errorf("for request %s, got status: %v", url, resp.StatusCode)
 	}
 	wrapperDecoder := wrapperDecoderFn(resp.Body)
 	return watch.NewStreamWatcher(restclientwatch.NewDecoder(wrapperDecoder, embeddedDecoder)), nil
@@ -845,13 +845,13 @@ func (r *Request) transformResponse(resp *http.Response, req *http.Request) Resu
 			// 3. Apiserver closes connection.
 			// 4. client-go should catch this and return an error.
 			klog.V(2).Infof("Stream error %#v when reading response body, may be caused by closed connection.", err)
-			streamErr := fmt.Errorf("Stream error %#v when reading response body, may be caused by closed connection. Please retry.", err)
+			streamErr := fmt.Errorf("Stream error when reading response body, may be caused by closed connection. Please retry. Original error: %v", err)
 			return Result{
 				err: streamErr,
 			}
 		default:
-			klog.Errorf("Unexpected error when reading response body: %#v", err)
-			unexpectedErr := fmt.Errorf("Unexpected error %#v when reading response body. Please retry.", err)
+			klog.Errorf("Unexpected error when reading response body: %v", err)
+			unexpectedErr := fmt.Errorf("Unexpected error when reading response body. Please retry. Original error: %v", err)
 			return Result{
 				err: unexpectedErr,
 			}

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -555,7 +555,7 @@ func (p *processorListener) run() {
 				case deleteNotification:
 					p.handler.OnDelete(notification.oldObj)
 				default:
-					utilruntime.HandleError(fmt.Errorf("unrecognized notification: %#v", next))
+					utilruntime.HandleError(fmt.Errorf("unrecognized notification: %T", next))
 				}
 			}
 			// the only way to get here is if the p.nextCh is empty and closed


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/75570 identified that %#v can be expensive, and more specific formatters can be easier to debug in some cases. Adjust some relatively core errors to use %T or %s instead.

/kind bug
```release-note
NONE
```