### PR TITLE
Add azure_route support routeTableResourceGroup

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -96,6 +96,8 @@ type Config struct {
 	SecurityGroupName string `json:"securityGroupName" yaml:"securityGroupName"`
 	// (Optional in 1.6) The name of the route table attached to the subnet that the cluster is deployed in
 	RouteTableName string `json:"routeTableName" yaml:"routeTableName"`
+	// The name of the resource group that the RouteTable is deployed in
+	RouteTableResourceGroup string `json:"routeTableResourceGroup" yaml:"routeTableResourceGroup"`
 	// (Optional) The name of the availability set that should be used as the load balancer backend
 	// If this is set, the Azure cloudprovider will only add nodes from that availability set to the load
 	// balancer backend pool. If this is not set, and multiple agent pools (availability sets) are used, then
@@ -229,6 +231,10 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 	config, err := parseConfig(configReader)
 	if err != nil {
 		return nil, err
+	}
+
+	if config.RouteTableResourceGroup == "" {
+		config.RouteTableResourceGroup = config.ResourceGroup
 	}
 
 	if config.VMType == "" {

--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -429,7 +429,7 @@ func (az *Cloud) CreateOrUpdateRouteTable(routeTable network.RouteTable) error {
 		ctx, cancel := getContextWithCancel()
 		defer cancel()
 
-		resp, err := az.RouteTablesClient.CreateOrUpdate(ctx, az.ResourceGroup, az.RouteTableName, routeTable)
+		resp, err := az.RouteTablesClient.CreateOrUpdate(ctx, az.RouteTableResourceGroup, az.RouteTableName, routeTable)
 		return az.processHTTPResponse(nil, "", resp, err)
 	}
 
@@ -442,7 +442,7 @@ func (az *Cloud) createOrUpdateRouteTableWithRetry(routeTable network.RouteTable
 		ctx, cancel := getContextWithCancel()
 		defer cancel()
 
-		resp, err := az.RouteTablesClient.CreateOrUpdate(ctx, az.ResourceGroup, az.RouteTableName, routeTable)
+		resp, err := az.RouteTablesClient.CreateOrUpdate(ctx, az.RouteTableResourceGroup, az.RouteTableName, routeTable)
 		return az.processHTTPRetryResponse(nil, "", resp, err)
 	})
 }
@@ -453,7 +453,7 @@ func (az *Cloud) CreateOrUpdateRoute(route network.Route) error {
 		ctx, cancel := getContextWithCancel()
 		defer cancel()
 
-		resp, err := az.RoutesClient.CreateOrUpdate(ctx, az.ResourceGroup, az.RouteTableName, *route.Name, route)
+		resp, err := az.RoutesClient.CreateOrUpdate(ctx, az.RouteTableResourceGroup, az.RouteTableName, *route.Name, route)
 		klog.V(10).Infof("RoutesClient.CreateOrUpdate(%s): end", *route.Name)
 		return az.processHTTPResponse(nil, "", resp, err)
 	}
@@ -467,7 +467,7 @@ func (az *Cloud) createOrUpdateRouteWithRetry(route network.Route) error {
 		ctx, cancel := getContextWithCancel()
 		defer cancel()
 
-		resp, err := az.RoutesClient.CreateOrUpdate(ctx, az.ResourceGroup, az.RouteTableName, *route.Name, route)
+		resp, err := az.RoutesClient.CreateOrUpdate(ctx, az.RouteTableResourceGroup, az.RouteTableName, *route.Name, route)
 		klog.V(10).Infof("RoutesClient.CreateOrUpdate(%s): end", *route.Name)
 		return az.processHTTPRetryResponse(nil, "", resp, err)
 	})
@@ -479,7 +479,7 @@ func (az *Cloud) DeleteRouteWithName(routeName string) error {
 		ctx, cancel := getContextWithCancel()
 		defer cancel()
 
-		resp, err := az.RoutesClient.Delete(ctx, az.ResourceGroup, az.RouteTableName, routeName)
+		resp, err := az.RoutesClient.Delete(ctx, az.RouteTableResourceGroup, az.RouteTableName, routeName)
 		klog.V(10).Infof("RoutesClient.Delete(%s,%s): end", az.RouteTableName, routeName)
 		return az.processHTTPResponse(nil, "", resp, err)
 	}
@@ -493,7 +493,7 @@ func (az *Cloud) deleteRouteWithRetry(routeName string) error {
 		ctx, cancel := getContextWithCancel()
 		defer cancel()
 
-		resp, err := az.RoutesClient.Delete(ctx, az.ResourceGroup, az.RouteTableName, routeName)
+		resp, err := az.RoutesClient.Delete(ctx, az.RouteTableResourceGroup, az.RouteTableName, routeName)
 		klog.V(10).Infof("RoutesClient.Delete(%s,%s): end", az.RouteTableName, routeName)
 		return az.processHTTPRetryResponse(nil, "", resp, err)
 	})

--- a/pkg/cloudprovider/providers/azure/azure_routes_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_routes_test.go
@@ -35,9 +35,9 @@ func TestDeleteRoute(t *testing.T) {
 	cloud := &Cloud{
 		RoutesClient: fakeRoutes,
 		Config: Config{
-			ResourceGroup:  "foo",
-			RouteTableName: "bar",
-			Location:       "location",
+			RouteTableResourceGroup: "foo",
+			RouteTableName:          "bar",
+			Location:                "location",
 		},
 		unmanagedNodes:     sets.NewString(),
 		nodeInformerSynced: func() bool { return true },
@@ -100,9 +100,9 @@ func TestCreateRoute(t *testing.T) {
 		RoutesClient:      fakeRoutes,
 		vmSet:             fakeVM,
 		Config: Config{
-			ResourceGroup:  "foo",
-			RouteTableName: "bar",
-			Location:       "location",
+			RouteTableResourceGroup: "foo",
+			RouteTableName:          "bar",
+			Location:                "location",
 		},
 		unmanagedNodes:     sets.NewString(),
 		nodeInformerSynced: func() bool { return true },
@@ -115,7 +115,7 @@ func TestCreateRoute(t *testing.T) {
 		Location: &cloud.Location,
 	}
 	fakeTable.FakeStore = map[string]map[string]network.RouteTable{}
-	fakeTable.FakeStore[cloud.ResourceGroup] = map[string]network.RouteTable{
+	fakeTable.FakeStore[cloud.RouteTableResourceGroup] = map[string]network.RouteTable{
 		cloud.RouteTableName: expectedTable,
 	}
 	route := cloudprovider.Route{TargetNode: "node", DestinationCIDR: "1.2.3.4/24"}
@@ -179,9 +179,9 @@ func TestCreateRouteTableIfNotExists_Exists(t *testing.T) {
 	cloud := &Cloud{
 		RouteTablesClient: fake,
 		Config: Config{
-			ResourceGroup:  "foo",
-			RouteTableName: "bar",
-			Location:       "location",
+			RouteTableResourceGroup: "foo",
+			RouteTableName:          "bar",
+			Location:                "location",
 		},
 	}
 	cache, _ := cloud.newRouteTableCache()
@@ -192,7 +192,7 @@ func TestCreateRouteTableIfNotExists_Exists(t *testing.T) {
 		Location: &cloud.Location,
 	}
 	fake.FakeStore = map[string]map[string]network.RouteTable{}
-	fake.FakeStore[cloud.ResourceGroup] = map[string]network.RouteTable{
+	fake.FakeStore[cloud.RouteTableResourceGroup] = map[string]network.RouteTable{
 		cloud.RouteTableName: expectedTable,
 	}
 	err := cloud.createRouteTableIfNotExists("clusterName", &cloudprovider.Route{TargetNode: "node", DestinationCIDR: "1.2.3.4/16"})
@@ -210,9 +210,9 @@ func TestCreateRouteTableIfNotExists_NotExists(t *testing.T) {
 	cloud := &Cloud{
 		RouteTablesClient: fake,
 		Config: Config{
-			ResourceGroup:  "foo",
-			RouteTableName: "bar",
-			Location:       "location",
+			RouteTableResourceGroup: "foo",
+			RouteTableName:          "bar",
+			Location:                "location",
 		},
 	}
 	cache, _ := cloud.newRouteTableCache()
@@ -229,7 +229,7 @@ func TestCreateRouteTableIfNotExists_NotExists(t *testing.T) {
 		t.FailNow()
 	}
 
-	table := fake.FakeStore[cloud.ResourceGroup][cloud.RouteTableName]
+	table := fake.FakeStore[cloud.RouteTableResourceGroup][cloud.RouteTableName]
 	if *table.Location != *expectedTable.Location {
 		t.Errorf("mismatch: %s vs %s", *table.Location, *expectedTable.Location)
 	}
@@ -246,9 +246,9 @@ func TestCreateRouteTable(t *testing.T) {
 	cloud := &Cloud{
 		RouteTablesClient: fake,
 		Config: Config{
-			ResourceGroup:  "foo",
-			RouteTableName: "bar",
-			Location:       "location",
+			RouteTableResourceGroup: "foo",
+			RouteTableName:          "bar",
+			Location:                "location",
 		},
 	}
 	cache, _ := cloud.newRouteTableCache()

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -64,6 +64,7 @@ func TestParseConfig(t *testing.T) {
 		"primaryScaleSetName": "primaryScaleSetName",
 		"resourceGroup": "resourceGroup",
 		"routeTableName": "routeTableName",
+		"routeTableResourceGroup": "routeTableResourceGroup",
 		"securityGroupName": "securityGroupName",
 		"subnetName": "subnetName",
 		"subscriptionId": "subscriptionId",
@@ -101,6 +102,7 @@ func TestParseConfig(t *testing.T) {
 		PrimaryScaleSetName:               "primaryScaleSetName",
 		ResourceGroup:                     "resourcegroup",
 		RouteTableName:                    "routeTableName",
+		RouteTableResourceGroup:           "routeTableResourceGroup",
 		SecurityGroupName:                 "securityGroupName",
 		SubnetName:                        "subnetName",
 		UseInstanceMetadata:               true,
@@ -941,6 +943,7 @@ func getTestCloud() (az *Cloud) {
 			},
 			ResourceGroup:                "rg",
 			VnetResourceGroup:            "rg",
+			RouteTableResourceGroup:      "rg",
 			Location:                     "westus",
 			VnetName:                     "vnet",
 			SubnetName:                   "subnet",
@@ -1524,6 +1527,7 @@ func TestNewCloudFromJSON(t *testing.T) {
 		"aadClientCertPath": "--aad-client-cert-path--",
 		"aadClientCertPassword": "--aad-client-cert-password--",
 		"resourceGroup": "--resource-group--",
+		"routeTableResourceGroup": "--route-table-resource-group--",
 		"location": "--location--",
 		"subnetName": "--subnet-name--",
 		"securityGroupName": "--security-group-name--",
@@ -1557,7 +1561,8 @@ aadClientSecret: --aad-client-secret--
 	validateEmptyConfig(t, config)
 }
 
-// Test Configuration deserialization (yaml)
+// Test Configuration deserialization (yaml) without
+// specific resource group for the route table
 func TestNewCloudFromYAML(t *testing.T) {
 	config := `
 tenantId: --tenant-id--
@@ -1567,6 +1572,7 @@ aadClientSecret: --aad-client-secret--
 aadClientCertPath: --aad-client-cert-path--
 aadClientCertPassword: --aad-client-cert-password--
 resourceGroup: --resource-group--
+routeTableResourceGroup: --route-table-resource-group--
 location: --location--
 subnetName: --subnet-name--
 securityGroupName: --security-group-name--
@@ -1608,6 +1614,9 @@ func validateConfig(t *testing.T, config string) {
 	}
 	if azureCloud.ResourceGroup != "--resource-group--" {
 		t.Errorf("got incorrect value for ResourceGroup")
+	}
+	if azureCloud.RouteTableResourceGroup != "--route-table-resource-group--" {
+		t.Errorf("got incorrect value for RouteTableResourceGroup")
 	}
 	if azureCloud.Location != "--location--" {
 		t.Errorf("got incorrect value for Location")

--- a/pkg/cloudprovider/providers/azure/azure_wrap.go
+++ b/pkg/cloudprovider/providers/azure/azure_wrap.go
@@ -275,7 +275,7 @@ func (az *Cloud) newRouteTableCache() (*timedCache, error) {
 	getter := func(key string) (interface{}, error) {
 		ctx, cancel := getContextWithCancel()
 		defer cancel()
-		rt, err := az.RouteTablesClient.Get(ctx, az.ResourceGroup, key, "")
+		rt, err := az.RouteTablesClient.Get(ctx, az.RouteTableResourceGroup, key, "")
 		exists, message, realErr := checkResourceExistsFromError(err)
 		if realErr != nil {
 			return nil, realErr


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds a new parameter in the Azure Cloud Provider config file.
The new parameter is RouteTableResourceGroup. It has the same behavior as the VNetResourceGroup has for Vnet. Because sometimes, you want to use an Azure RouteTable which is not is in the same Resource Group as your main Resource Group

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Azure Cloud Provider: Add new parameter `RouteTableResourceGroup`

```release-note
Support specify the Resource Group of Route Table when update Pod network route (Azure)
```

This pr just origin from https://github.com/kubernetes/kubernetes/pull/71321 . Thanks titilambert