### PR TITLE
Updated client-go expiration cache to take in expiration policies

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/expiration_cache_fakes.go
+++ b/staging/src/k8s.io/client-go/tools/cache/expiration_cache_fakes.go
@@ -38,7 +38,7 @@ type FakeExpirationPolicy struct {
 	RetrieveKeyFunc KeyFunc
 }
 
-func (p *FakeExpirationPolicy) IsExpired(obj *timestampedEntry) bool {
+func (p *FakeExpirationPolicy) IsExpired(obj *TimestampedEntry) bool {
 	key, _ := p.RetrieveKeyFunc(obj)
 	return !p.NeverExpire.Has(key)
 }

--- a/staging/src/k8s.io/client-go/tools/cache/expiration_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/expiration_cache_test.go
@@ -34,7 +34,7 @@ func TestTTLExpirationBasic(t *testing.T) {
 		&FakeExpirationPolicy{
 			NeverExpire: sets.NewString(),
 			RetrieveKeyFunc: func(obj interface{}) (string, error) {
-				return obj.(*timestampedEntry).obj.(testStoreObject).id, nil
+				return obj.(*TimestampedEntry).Obj.(testStoreObject).id, nil
 			},
 		},
 		clock.RealClock{},
@@ -67,7 +67,7 @@ func TestReAddExpiredItem(t *testing.T) {
 	exp := &FakeExpirationPolicy{
 		NeverExpire: sets.NewString(),
 		RetrieveKeyFunc: func(obj interface{}) (string, error) {
-			return obj.(*timestampedEntry).obj.(testStoreObject).id, nil
+			return obj.(*TimestampedEntry).Obj.(testStoreObject).id, nil
 		},
 	}
 	ttlStore := NewFakeExpirationStore(
@@ -130,7 +130,7 @@ func TestTTLList(t *testing.T) {
 		&FakeExpirationPolicy{
 			NeverExpire: sets.NewString(testObjs[1].id),
 			RetrieveKeyFunc: func(obj interface{}) (string, error) {
-				return obj.(*timestampedEntry).obj.(testStoreObject).id, nil
+				return obj.(*TimestampedEntry).Obj.(testStoreObject).id, nil
 			},
 		},
 		clock.RealClock{},
@@ -168,15 +168,15 @@ func TestTTLPolicy(t *testing.T) {
 	expiredTime := fakeTime.Add(-(ttl + 1))
 
 	policy := TTLPolicy{ttl, clock.NewFakeClock(fakeTime)}
-	fakeTimestampedEntry := &timestampedEntry{obj: struct{}{}, timestamp: exactlyOnTTL}
+	fakeTimestampedEntry := &TimestampedEntry{Obj: struct{}{}, Timestamp: exactlyOnTTL}
 	if policy.IsExpired(fakeTimestampedEntry) {
 		t.Errorf("TTL cache should not expire entries exactly on ttl")
 	}
-	fakeTimestampedEntry.timestamp = fakeTime
+	fakeTimestampedEntry.Timestamp = fakeTime
 	if policy.IsExpired(fakeTimestampedEntry) {
 		t.Errorf("TTL Cache should not expire entries before ttl")
 	}
-	fakeTimestampedEntry.timestamp = expiredTime
+	fakeTimestampedEntry.Timestamp = expiredTime
 	if !policy.IsExpired(fakeTimestampedEntry) {
 		t.Errorf("TTL Cache should expire entries older than ttl")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
A new expiration store function was added to allow for different expiration policies and therefore custom IsExpired handling. TimestampedEntry needed to become public in order for custom isExpired methods. 

```
// NewExpirationStore creates and returns a ExpirationCache for a given policy
func NewExpirationStore(keyFunc KeyFunc, expirationPolicy ExpirationPolicy) Store {
	return &ExpirationCache{
		cacheStorage:     NewThreadSafeStore(Indexers{}, Indices{}),
		keyFunc:          keyFunc,
		clock:            clock.RealClock{},
		expirationPolicy: expirationPolicy,
	}
}
```

**Special notes for your reviewer**:
This is needed for PR #75587 to use expiredAt from the Amazon ECS API per registry for credentials provider.
This also helps fix https://github.com/kubernetes/kubernetes/issues/37962.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @yastij @andrewsykim @mcrute @nckturner @cheftako 
/assign @liggitt @justinsb @ncdc