### PR TITLE
fix rbd info when return warning information

### DIFF
--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -708,7 +708,7 @@ func (util *RBDUtil) rbdInfo(b *rbdMounter) (int, error) {
 	//
 	klog.V(4).Infof("rbd: info %s using mon %s, pool %s id %s key %s", b.Image, mon, b.Pool, id, secret)
 	output, err = b.exec.Run("rbd",
-		"info", b.Image, "--pool", b.Pool, "-m", mon, "--id", id, "--key="+secret, "--format=json")
+		"info", b.Image, "--pool", b.Pool, "-m", mon, "--id", id, "--key="+secret, "-k=/dev/null", "--format=json")
 
 	if err, ok := err.(*exec.Error); ok {
 		if err.Err == exec.ErrNotFound {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it:**
fix https://github.com/kubernetes/kubernetes/issues/75581
This pr clean rbd info command output of warning information. If not fix this, provider will parse the output error.
**Special notes for your reviewer:**
/sig storage
**Does this PR introduce a user-facing change?:**
```release-note
Ceph RBD volume plugin now does not use any keyring (/etc/ceph/ceph.client.lvs01cinder.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin) for authentication. Ceph user credentials must be provided in PersistentVolume objects and referred Secrets.
```



