### PR TITLE
Automated cherry pick of #74290: Use wget instead of curl for e2e network policy tests

### DIFF
--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -17,7 +17,7 @@ limitations under the License.
 package network
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"


### PR DESCRIPTION
Cherry pick of #74290 on release-1.13.

#74290: Use wget instead of curl for e2e network policy tests