### PR TITLE
kubeadm: check etcd member health before trying to sync

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -27,9 +27,9 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/pkg/errors"
-	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"

--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -150,7 +150,7 @@ func (c *Client) Sync() error {
 		return err
 	}
 	c.Endpoints = cli.Endpoints()
-	klog.V(1).Infof("etcd endpoints read from etcd: %s", strings.Join(cli.Endpoints(), ","))
+	klog.V(1).Infof("etcd endpoints read from etcd: %s", strings.Join(c.Endpoints, ","))
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes kubeadm join master flow for the edge case where the kubeadm configmap memberlist is stale and not all of those members are still valid etcd endpoints. Checks the members in the memberlist for their etcd health, and uses a healthy node's memberlist to build a known good etcd client dynamically.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/1432

**Special notes for your reviewer**:
This fix may become obsolete when etcd merges and releases the client fix for https://github.com/etcd-io/etcd/issues/9949 (https://github.com/etcd-io/etcd/pull/10489). This healthcheck logic may still have some value as it doesn't depend on the etcd client loadbalancer, or it can serve as a starting point for the node reset work discussion in the above issue. All that said, this fixes a blocker in using kubeadm HA _today_.

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: fix kubeadm failure due to using stale etcd members in initial etcd client
```
