### PR TITLE
test/e2e/framework: add OWNERS file

### DIFF
--- a/test/e2e/framework/OWNERS
+++ b/test/e2e/framework/OWNERS
@@ -1,0 +1,20 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-testing-approvers
+- timothysc
+- andrewsykim
+- fabriziopandini
+- pohly
+- oomichi
+- neolit123
+reviewers:
+- sig-testing-reviewers
+- timothysc
+- andrewsykim
+- fabriziopandini
+- pohly
+- oomichi
+- neolit123
+labels:
+- area/e2e-test-framework


### PR DESCRIPTION
there is ongoing planning to refactor the e2e framework.
https://github.com/kubernetes/kubernetes/issues/75601

handle the new e2e-test-framework label from the OWNERS file:
https://github.com/kubernetes/test-infra/pull/11897

included a list of approvers and reviewers.
let me know if this list needs changes or if should be omitted completely for now.

/assign @timothysc @spiffxp 
/kind cleanup
/priority important-soon
/release-note-none
/sig testing

cc @andrewsykim @fabriziopandini @pohly @oomichi
