### PR TITLE
Fix lint issues

### DIFF
--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -118,31 +118,31 @@ func NewServiceAccount() *serviceAccount {
 	}
 }
 
-func (a *serviceAccount) SetExternalKubeClientSet(cl kubernetes.Interface) {
-	a.client = cl
+func (s *serviceAccount) SetExternalKubeClientSet(cl kubernetes.Interface) {
+	s.client = cl
 }
 
-func (a *serviceAccount) SetExternalKubeInformerFactory(f informers.SharedInformerFactory) {
+func (s *serviceAccount) SetExternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	serviceAccountInformer := f.Core().V1().ServiceAccounts()
-	a.serviceAccountLister = serviceAccountInformer.Lister()
+	s.serviceAccountLister = serviceAccountInformer.Lister()
 
 	secretInformer := f.Core().V1().Secrets()
-	a.secretLister = secretInformer.Lister()
+	s.secretLister = secretInformer.Lister()
 
-	a.SetReadyFunc(func() bool {
+	s.SetReadyFunc(func() bool {
 		return serviceAccountInformer.Informer().HasSynced() && secretInformer.Informer().HasSynced()
 	})
 }
 
 // ValidateInitialization ensures an authorizer is set.
-func (a *serviceAccount) ValidateInitialization() error {
-	if a.client == nil {
+func (s *serviceAccount) ValidateInitialization() error {
+	if s.client == nil {
 		return fmt.Errorf("missing client")
 	}
-	if a.secretLister == nil {
+	if s.secretLister == nil {
 		return fmt.Errorf("missing secretLister")
 	}
-	if a.serviceAccountLister == nil {
+	if s.serviceAccountLister == nil {
 		return fmt.Errorf("missing serviceAccountLister")
 	}
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

/kind flake

**What this PR does / why we need it**:
Fix the following lint issue:
```
Line 151: warning: receiver name s should be consistent with previous receiver name a for serviceAccount (golint)
Line 192: warning: receiver name s should be consistent with previous receiver name a for serviceAccount (golint)
Line 273: warning: receiver name s should be consistent with previous receiver name a for serviceAccount (golint)
[...]
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
