### PR TITLE
Correct test name for existing E2E related to active deadline in jobs

### DIFF
--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -123,7 +123,7 @@ var _ = SIGDescribe("Job", func() {
 		framework.ExpectNoError(err, "failed to ensure job completion in namespace: %s", f.Namespace.Name)
 	})
 
-	ginkgo.It("should exceed active deadline", func() {
+	ginkgo.It("should fail when exceeds active deadline", func() {
 		ginkgo.By("Creating a job")
 		var activeDeadlineSeconds int64 = 1
 		job := jobutil.NewTestJob("notTerminate", "exceed-active-deadline", v1.RestartPolicyNever, parallelism, completions, &activeDeadlineSeconds, backoffLimit)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: This PR request to correct an existing E2E test name with respect to Jobs in Kubernetes

**Which issue(s) this PR fixes**: #75508 

**Special notes for your reviewer**:
1. This PR updates a test name for an existing E2E test.
2. The description reflects that the jobs should exceed active deadline whereas it shouldn't.
3. Active deadline limit applies to the duration of the job. Once the deadline is reached, the job is terminated by terminating all the pods and updating the job status to failed with reason "Deadline Exceeded".
4. The existing E2E verifies Point-3 above but the test name conveys a different meaning which is being requested for correction

**Does this PR introduce a user-facing change?**: NONE

release-note-none

@mgdevstack @brahmaroutu 