### PR TITLE
Use fixed width value in reasonStrings before sorting

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -94,7 +94,7 @@ func (f *FitError) Error() string {
 		for k, v := range reasons {
 			reasonStrings = append(reasonStrings, fmt.Sprintf("%5v %v", v, k))
 		}
-		sort.Strings(reasonStrings)
+		sort.Sort(sort.Reverse(sort.StringSlice(reasonStrings)))
 		return reasonStrings
 	}
 	reasonMsg := fmt.Sprintf(NoNodeAvailableMsg+": %v.", f.NumAllNodes, strings.Join(sortReasonsHistogram(), ", "))

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -92,7 +92,7 @@ func (f *FitError) Error() string {
 	sortReasonsHistogram := func() []string {
 		reasonStrings := []string{}
 		for k, v := range reasons {
-			reasonStrings = append(reasonStrings, fmt.Sprintf("%v %v", v, k))
+			reasonStrings = append(reasonStrings, fmt.Sprintf("%5v %v", v, k))
 		}
 		sort.Strings(reasonStrings)
 		return reasonStrings


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In FitError#Error, the value of count is used as first field for sorting.
Since there is no width specifier for the value, tuple with smaller value may appear after tuple with larger value.
See example in first comment.

This PR adds width specifier to achieve intended effect.

```release-note
NONE
```
