### PR TITLE
Sort out 'golint' errors in Cloud Controller Manager

### DIFF
--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults.go
@@ -29,7 +29,9 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-func SetDefaults_CloudControllerManagerConfiguration(obj *CloudControllerManagerConfiguration) {
+// SetDefaultsCloudControllerManagerConfiguration will apply default values (such as setting node status update
+// frequency to five minutes) where no such explicit values have been supplied.
+func SetDefaultsCloudControllerManagerConfiguration(obj *CloudControllerManagerConfiguration) {
 	zero := metav1.Duration{}
 	if obj.NodeStatusUpdateFrequency == zero {
 		obj.NodeStatusUpdateFrequency = metav1.Duration{Duration: 5 * time.Minute}

--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults_test.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestCloudControllerManagerDefaultsRoundTrip(t *testing.T) {
 	ks1 := &CloudControllerManagerConfiguration{}
-	SetDefaults_CloudControllerManagerConfiguration(ks1)
+	SetDefaultsCloudControllerManagerConfiguration(ks1)
 	cm, err := convertObjToConfigMap("CloudControllerManagerConfiguration", ks1)
 	if err != nil {
 		t.Errorf("unexpected ConvertObjToConfigMap error %v", err)

--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/types.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/types.go
@@ -23,6 +23,7 @@ import (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// CloudControllerManagerConfiguration holds configuration for the Cloud Controller Manager.
 type CloudControllerManagerConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -1,4 +1,3 @@
-cmd/cloud-controller-manager/app/apis/config/v1alpha1
 cmd/kube-apiserver/app
 cmd/kube-controller-manager/app
 cmd/kube-proxy/app


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix some `golint` failures in the `cmd/cloud-controller-manager/app/apis/config/v1alpha1` package.

**Which issue(s) this PR fixes**:
ref: #68026
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
There was a generated file `cmd/cloud-controller-manager/app/apis/config/v1alpha1/zz_generated.defaults.go` which referred to one of the functions that I renamed per golint's feedback, but I did not edit this generated file.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
