### PR TITLE
Add @xichengliudui to test/OWNERS

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -31,6 +31,7 @@ reviewers:
   - vishh
   - MaciekPytel # for test/e2e/common/autoscaling_utils.go
   - oomichi
+  - xichengliudui
 approvers:
   - bowei # for test/e2e/{dns*,network}.go
   - cblecker


### PR DESCRIPTION
**What this PR does / why we need it**:

@xichengliudui  continues reviewing PRs which are related to e2e tests,
then this adds him to a reviewer to get him involved more.