### PR TITLE
fix 'make generated_files' build on MacOS

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -718,7 +718,7 @@ kube::golang::build_binaries() {
       platforms=("${host_platform}")
     fi
 
-    local binaries
+    local -a binaries
     while IFS="" read -r binary; do binaries+=("$binary"); done < <(kube::golang::binaries_from_targets "${targets[@]}")
 
     local parallel=false


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What type of PR is this?**

Recent change to hack/lib/golang.sh broke the build on MacOS this way:

```
$ make clean && make generated_files
+++ [0325 13:38:22] Verifying Prerequisites....
+++ [0325 13:38:23] Removing _output directory
k8s.io/kubernetes/vendor/github.com/spf13/pflag
k8s.io/kubernetes/hack/make-rules/helpers/go2make
+++ [0325 13:38:40] Building go targets for darwin/amd64:
    ./vendor/k8s.io/code-generator/cmd/deepcopy-gen
can't load package: package k8s.io/kubernetes: no Go files in k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes
!!! [0325 13:38:40] Call tree:
!!! [0325 13:38:40]  1: k8s.io/kubernetes/hack/lib/golang.sh:629 kube::golang::build_some_binaries(...)
!!! [0325 13:38:40]  2: k8s.io/kubernetes/hack/lib/golang.sh:764 kube::golang::build_binaries_for_platform(...)
!!! [0325 13:38:40]  3: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
make[1]: *** [_output/bin/deepcopy-gen] Error 1
make: *** [generated_files] Error 2
```

It was caused by 'binaries' array not being declared with 'local -a'.
It looks like MacOS' old bash version makes an array to contain first
empty element if declared this way.
    
The fix has been tested on MacOS High Sierra and Linux openSUSE 42.3 (x86_64)

**Which issue(s) this PR fixes**:

#75679 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```