### PR TITLE
Clean up some PodSecurityPolicy code

### DIFF
--- a/pkg/security/podsecuritypolicy/BUILD
+++ b/pkg/security/podsecuritypolicy/BUILD
@@ -49,8 +49,6 @@ go_test(
         "//staging/src/k8s.io/api/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
-        "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],

--- a/pkg/security/podsecuritypolicy/provider.go
+++ b/pkg/security/podsecuritypolicy/provider.go
@@ -59,10 +59,10 @@ func NewSimpleProvider(psp *policy.PodSecurityPolicy, namespace string, strategy
 	}, nil
 }
 
-// DefaultPodSecurityContext sets the default values of the required but not filled fields.
-// It modifies the SecurityContext and annotations of the provided pod. Validation should be
-// used after the context is defaulted to ensure it complies with the required restrictions.
-func (s *simpleProvider) DefaultPodSecurityContext(pod *api.Pod) error {
+// MutatePod sets the default values of the required but not filled fields.
+// Validation should be used after the context is defaulted to ensure it
+// complies with the required restrictions.
+func (s *simpleProvider) MutatePod(pod *api.Pod) error {
 	sc := securitycontext.NewPodSecurityContextMutator(pod.Spec.SecurityContext)
 
 	if sc.SupplementalGroups() == nil {
@@ -104,13 +104,25 @@ func (s *simpleProvider) DefaultPodSecurityContext(pod *api.Pod) error {
 
 	pod.Spec.SecurityContext = sc.PodSecurityContext()
 
+	for i := range pod.Spec.InitContainers {
+		if err := s.mutateContainer(pod, &pod.Spec.InitContainers[i]); err != nil {
+			return err
+		}
+	}
+
+	for i := range pod.Spec.Containers {
+		if err := s.mutateContainer(pod, &pod.Spec.Containers[i]); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
-// DefaultContainerSecurityContext sets the default values of the required but not filled fields.
+// mutateContainer sets the default values of the required but not filled fields.
 // It modifies the SecurityContext of the container and annotations of the pod. Validation should
 // be used after the context is defaulted to ensure it complies with the required restrictions.
-func (s *simpleProvider) DefaultContainerSecurityContext(pod *api.Pod, container *api.Container) error {
+func (s *simpleProvider) mutateContainer(pod *api.Pod, container *api.Container) error {
 	sc := securitycontext.NewEffectiveContainerSecurityContextMutator(
 		securitycontext.NewPodSecurityContextAccessor(pod.Spec.SecurityContext),
 		securitycontext.NewContainerSecurityContextMutator(container.SecurityContext),
@@ -282,11 +294,22 @@ func (s *simpleProvider) ValidatePod(pod *api.Pod) field.ErrorList {
 			}
 		}
 	}
+
+	fldPath := field.NewPath("spec", "initContainers")
+	for i := range pod.Spec.InitContainers {
+		allErrs = append(allErrs, s.validateContainer(pod, &pod.Spec.InitContainers[i], fldPath.Index(i))...)
+	}
+
+	fldPath = field.NewPath("spec", "containers")
+	for i := range pod.Spec.Containers {
+		allErrs = append(allErrs, s.validateContainer(pod, &pod.Spec.Containers[i], fldPath.Index(i))...)
+	}
+
 	return allErrs
 }
 
 // Ensure a container's SecurityContext is in compliance with the given constraints
-func (s *simpleProvider) ValidateContainer(pod *api.Pod, container *api.Container, containerPath *field.Path) field.ErrorList {
+func (s *simpleProvider) validateContainer(pod *api.Pod, container *api.Container, containerPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	podSC := securitycontext.NewPodSecurityContextAccessor(pod.Spec.SecurityContext)

--- a/pkg/security/podsecuritypolicy/types.go
+++ b/pkg/security/podsecuritypolicy/types.go
@@ -32,16 +32,12 @@ import (
 // Provider provides the implementation to generate a new security
 // context based on constraints or validate an existing security context against constraints.
 type Provider interface {
-	// DefaultPodSecurityContext sets the default values of the required but not filled fields.
-	// It modifies the SecurityContext and annotations of the provided pod.
-	DefaultPodSecurityContext(pod *api.Pod) error
-	// DefaultContainerSecurityContext sets the default values of the required but not filled fields.
-	// It modifies the SecurityContext of the container and annotations of the pod.
-	DefaultContainerSecurityContext(pod *api.Pod, container *api.Container) error
-	// Ensure a pod is in compliance with the given constraints.
+	// MutatePod sets the default values of the required but not filled fields of the pod and all
+	// containers in the pod.
+	MutatePod(pod *api.Pod) error
+	// ValidatePod ensures a pod and all its containers are in compliance with the given constraints.
+	// ValidatePod MUST NOT mutate the pod.
 	ValidatePod(pod *api.Pod) field.ErrorList
-	// Ensure a container's SecurityContext is in compliance with the given constraints.
-	ValidateContainer(pod *api.Pod, container *api.Container, containerPath *field.Path) field.ErrorList
 	// Get the name of the PSP that this provider was initialized with.
 	GetPSPName() string
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

1. Change the PSP provider interface to apply to the whole pod. The security context specific bits were out of date, as the scope of PSP has grown beyond what's in the security context (e.g. volumes & mount options, soon: RunitmeClass)
2. Modernize the unit test. This made debugging some errors caused by the first refactor easier.

**Special notes for your reviewer**:

There's a lot more in the PSP code that could be cleaned up, but I had to exercise some restraint to avoid going too deep.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig auth
/assign @liggitt 
/priority important-soon