### PR TITLE
Unset CPU CFS quota when CPU sets are in use

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -102,6 +102,10 @@ func (p *mockPolicy) RemoveContainer(s state.State, containerID string) error {
 	return p.err
 }
 
+func (p *mockPolicy) EnforceCPUQuota(pod *v1.Pod, container *v1.Container) bool {
+	return true
+}
+
 type mockRuntimeService struct {
 	err error
 }
@@ -363,7 +367,7 @@ func TestReconcileState(t *testing.T) {
 		expectFailedContainerName    string
 	}{
 		{
-			description: "cpu manager reconclie - no error",
+			description: "cpu manager reconcile - no error",
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -431,7 +435,7 @@ func TestReconcileState(t *testing.T) {
 			expectFailedContainerName:    "",
 		},
 		{
-			description: "cpu manager reconclie - pod status not found",
+			description: "cpu manager reconcile - pod status not found",
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -456,7 +460,7 @@ func TestReconcileState(t *testing.T) {
 			expectFailedContainerName:    "fakeName",
 		},
 		{
-			description: "cpu manager reconclie - container id not found",
+			description: "cpu manager reconcile - container id not found",
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -488,7 +492,7 @@ func TestReconcileState(t *testing.T) {
 			expectFailedContainerName:    "fakeName",
 		},
 		{
-			description: "cpu manager reconclie - cpuset is empty",
+			description: "cpu manager reconcile - cpuset is empty",
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -522,7 +526,7 @@ func TestReconcileState(t *testing.T) {
 			expectFailedContainerName:    "fakeName",
 		},
 		{
-			description: "cpu manager reconclie - container update error",
+			description: "cpu manager reconcile - container update error",
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kubelet/cm/cpumanager/policy.go
+++ b/pkg/kubelet/cm/cpumanager/policy.go
@@ -29,4 +29,6 @@ type Policy interface {
 	AddContainer(s state.State, pod *v1.Pod, container *v1.Container, containerID string) error
 	// RemoveContainer call is idempotent
 	RemoveContainer(s state.State, containerID string) error
+	// EnforceCPUQuota determines whether the pod should have CFS CPU quota enforced
+	EnforceCPUQuota(pod *v1.Pod, container *v1.Container) bool
 }

--- a/pkg/kubelet/cm/cpumanager/policy_none.go
+++ b/pkg/kubelet/cm/cpumanager/policy_none.go
@@ -49,3 +49,7 @@ func (p *nonePolicy) AddContainer(s state.State, pod *v1.Pod, container *v1.Cont
 func (p *nonePolicy) RemoveContainer(s state.State, containerID string) error {
 	return nil
 }
+
+func (p *nonePolicy) EnforceCPUQuota(pod *v1.Pod, container *v1.Container) bool {
+	return true
+}

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -203,6 +203,12 @@ func (p *staticPolicy) RemoveContainer(s state.State, containerID string) error 
 	return nil
 }
 
+func (p *staticPolicy) EnforceCPUQuota(pod *v1.Pod, container *v1.Container) bool {
+	// When a dedicated CPU set is assigned, unset CFS CPU quota to avoid performance
+	// degradation due to the way this quota is implemented in the Linux kernel.
+	return guaranteedCPUs(pod, container) == 0
+}
+
 func (p *staticPolicy) allocateCPUs(s state.State, numCPUs int) (cpuset.CPUSet, error) {
 	klog.Infof("[cpumanager] allocateCpus: (numCPUs: %d)", numCPUs)
 	result, err := takeByTopology(p.topology, p.assignableCPUs(s), numCPUs)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Having CFS CPU quota enabled can cause performance degradation due to the (buggy) way current Linux kernels enforce this quota.

For containers that have CPU cores dedicated to them through CPU sets, any CFS CPU quota can be safely unset to prevent this issue.

This PR also aligns the implementation with the [CPU Management documentation](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/) ("CFS quota is not used to bound the CPU usage of these containers as their usage is bound by the scheduling domain itself.").

**Which issue(s) this PR fixes**:
Fixes #70585

**Does this PR introduce a user-facing change?**:
```release-note
Unset CPU CFS quota when CPU sets are in use
```
