### PR TITLE
[WIP] Add componentconfig defaulting/roundtrip testing libraries

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/error.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/error.go
@@ -120,3 +120,43 @@ func IsMissingVersion(err error) bool {
 	_, ok := err.(*missingVersionErr)
 	return ok
 }
+
+// strictDecoderError is a base error type that is returned by a strict Decoder such
+// as UniversalStrictDecoder.
+type strictDecoderError struct {
+	message      string
+	gvk          schema.GroupVersionKind
+	originalData []byte
+}
+
+// NewStrictDecoderError creates a new strictDecoderError object
+func NewStrictDecoderError(message string, gvk schema.GroupVersionKind, originalData []byte) error {
+	return &strictDecoderError{
+		message:      message,
+		gvk:          gvk,
+		originalData: originalData,
+	}
+}
+
+func (e *strictDecoderError) Error() string {
+	return fmt.Sprintf("strict decoder error for %#v: %s", e.gvk, e.message)
+}
+
+// GVK returns the GVK that was extracted when Decoding using a strict Decoder.
+func (e *strictDecoderError) GVK() schema.GroupVersionKind {
+	return e.gvk
+}
+
+// OriginalData returns the original byte slice input that was passed to a strict Decoder.
+func (e *strictDecoderError) OriginalData() []byte {
+	return e.originalData
+}
+
+// IsStrictDecoderError returns true if the error is a result of a strict Decoder.
+func IsStrictDecoderError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*strictDecoderError)
+	return ok
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -45,6 +45,20 @@ func NewSerializer(meta MetaFactory, creater runtime.ObjectCreater, typer runtim
 	}
 }
 
+// NewStrictSerializer is the same as NewSerializer except that it creates a strict JSON serializer
+// that can also return errors of type strictDecoderError.
+// Note that this serializer is not as performant as the non-strict variant, and should not be used in fast paths.
+func NewStrictSerializer(meta MetaFactory, creater runtime.ObjectCreater, typer runtime.ObjectTyper, pretty bool) *Serializer {
+	return &Serializer{
+		meta:    meta,
+		creater: creater,
+		typer:   typer,
+		yaml:    false,
+		pretty:  pretty,
+		strict:  true,
+	}
+}
+
 // NewYAMLSerializer creates a YAML serializer that handles encoding versioned objects into the proper YAML form. If typer
 // is not nil, the object has the group, version, and kind fields set. This serializer supports only the subset of YAML that
 // matches JSON, and will error if constructs are used that do not serialize to JSON.
@@ -57,12 +71,26 @@ func NewYAMLSerializer(meta MetaFactory, creater runtime.ObjectCreater, typer ru
 	}
 }
 
+// NewStrictYAMLSerializer is the same as NewYAMLSerializer except that it creates a strict YAML serializer
+// that can also return errors of type strictDecoderError.
+// Note that this serializer is not as performant as the non-strict variant, and should not be used in fast paths.
+func NewStrictYAMLSerializer(meta MetaFactory, creater runtime.ObjectCreater, typer runtime.ObjectTyper) *Serializer {
+	return &Serializer{
+		meta:    meta,
+		creater: creater,
+		typer:   typer,
+		yaml:    true,
+		strict:  true,
+	}
+}
+
 type Serializer struct {
 	meta    MetaFactory
 	creater runtime.ObjectCreater
 	typer   runtime.ObjectTyper
 	yaml    bool
 	pretty  bool
+	strict  bool
 }
 
 // Serializer implements Serializer
@@ -119,11 +147,28 @@ func CaseSensitiveJsonIterator() jsoniter.API {
 	return config
 }
 
-// Private copy of jsoniter to try to shield against possible mutations
+// StrictCaseSensitiveJsonIterator returns a jsoniterator API that's configured to be
+// case-sensitive, but also disallows unknown fields when unmarshalling. It is compatible with
+// the encoding/json standard library.
+func StrictCaseSensitiveJsonIterator() jsoniter.API {
+	config := jsoniter.Config{
+		EscapeHTML:             true,
+		SortMapKeys:            true,
+		ValidateJsonRawMessage: true,
+		CaseSensitive:          true,
+		DisallowUnknownFields:  true,
+	}.Froze()
+	// Force jsoniter to decode number to interface{} via int64/float64, if possible.
+	config.RegisterExtension(&customNumberExtension{})
+	return config
+}
+
+// Private copies of jsoniter to try to shield against possible mutations
 // from outside. Still does not protect from package level jsoniter.Register*() functions - someone calling them
 // in some other library will mess with every usage of the jsoniter library in the whole program.
 // See https://github.com/json-iterator/go/issues/265
 var caseSensitiveJsonIterator = CaseSensitiveJsonIterator()
+var strictCaseSensitiveJsonIterator = StrictCaseSensitiveJsonIterator()
 
 // gvkWithDefaults returns group kind and version defaulting from provided default
 func gvkWithDefaults(actual, defaultGVK schema.GroupVersionKind) schema.GroupVersionKind {
@@ -216,6 +261,32 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 	if err := caseSensitiveJsonIterator.Unmarshal(data, obj); err != nil {
 		return nil, actual, err
 	}
+
+	// If the deserializer is non-strict, return successfully here.
+	if !s.strict {
+		return obj, actual, nil
+	}
+
+	// In strict mode pass the data trough the YAMLToJSONStrict converter.
+	// This is done to catch duplicate fields regardless of encoding (JSON or YAML). For JSON data,
+	// the output would equal the input, unless there is a parsing error such as duplicate fields.
+	// As we know this was successful in the non-strict case, the only error that may be returned here
+	// is because of the newly-added strictness. hence we know we can return the typed strictDecoderError
+	// the actual error is that the object contains duplicate fields.
+	altered, err := yaml.YAMLToJSONStrict(originalData)
+	if err != nil {
+		return nil, actual, runtime.NewStrictDecoderError(err.Error(), *actual, originalData)
+	}
+	// As performance is not an issue for now for the strict deserializer (one has regardless to do
+	// the unmarshal twice), we take the sanitized, altered data that is guaranteed to have no duplicated
+	// fields, and unmarshal this into a copy of the already-populated obj. Any error that occurs here is
+	// due to that a matching field doesn't exist in the object. hence we can return a typed strictDecoderError,
+	// the actual error is that the object contains unknown field.
+	strictObj := obj.DeepCopyObject()
+	if err := strictCaseSensitiveJsonIterator.Unmarshal(altered, strictObj); err != nil {
+		return nil, actual, runtime.NewStrictDecoderError(err.Error(), *actual, originalData)
+	}
+	// Always return the same object as the non-strict serializer to avoid any deviations.
 	return obj, actual, nil
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
@@ -59,8 +59,22 @@ type DecodableSpec struct {
 func (d *testDecodable) GetObjectKind() schema.ObjectKind                { return d }
 func (d *testDecodable) SetGroupVersionKind(gvk schema.GroupVersionKind) { d.gvk = gvk }
 func (d *testDecodable) GroupVersionKind() schema.GroupVersionKind       { return d.gvk }
-func (d *testDecodable) DeepCopyObject() runtime.Object {
-	panic("testDecodable does not support DeepCopy")
+func (in *testDecodable) DeepCopyObject() runtime.Object {
+	if in == nil {
+		return nil
+	}
+	out := new(testDecodable)
+	in.DeepCopyInto(out)
+	return out
+}
+func (in *testDecodable) DeepCopyInto(out *testDecodable) {
+	*out = *in
+	out.Other = in.Other
+	out.Value = in.Value
+	out.Spec = in.Spec
+	out.Interface = in.Interface
+	out.gvk = in.gvk
+	return
 }
 
 func TestDecode(t *testing.T) {
@@ -69,6 +83,7 @@ func TestDecode(t *testing.T) {
 		typer   runtime.ObjectTyper
 		yaml    bool
 		pretty  bool
+		strict  bool
 
 		data       []byte
 		defaultGVK *schema.GroupVersionKind
@@ -274,14 +289,146 @@ func TestDecode(t *testing.T) {
 				Spec: DecodableSpec{A: 1, H: 3},
 			},
 		},
+		// Unknown fields should return an error from the strict JSON deserializer.
+		{
+			data:        []byte(`{"unknown": 1}`),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "found unknown field")
+			},
+			strict: true,
+		},
+		// Unknown fields should return an error from the strict YAML deserializer.
+		{
+			data:        []byte("unknown: 1\n"),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "found unknown field")
+			},
+			yaml:   true,
+			strict: true,
+		},
+		// Duplicate fields should return an error from the strict JSON deserializer.
+		{
+			data:        []byte(`{"value":1,"value":1}`),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "already set in map")
+			},
+			strict: true,
+		},
+		// Duplicate fields should return an error from the strict YAML deserializer.
+		{
+			data: []byte("value: 1\n" +
+				"value: 1\n"),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "already set in map")
+			},
+			yaml:   true,
+			strict: true,
+		},
+		// Strict JSON decode should fail for untagged fields.
+		{
+			data:        []byte(`{"kind":"Test","apiVersion":"other/blah","value":1,"Other":"test"}`),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "found unknown field")
+			},
+			strict: true,
+		},
+		// Strict YAML decode should fail for untagged fields.
+		{
+			data: []byte("kind: Test\n" +
+				"apiVersion: other/blah\n" +
+				"value: 1\n" +
+				"Other: test\n"),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "found unknown field")
+			},
+			yaml:   true,
+			strict: true,
+		},
+		// Strict JSON decode into unregistered objects directly.
+		{
+			data:        []byte(`{"kind":"Test","apiVersion":"other/blah","value":1,"Other":"test"}`),
+			into:        &testDecodable{},
+			typer:       &mockTyper{err: runtime.NewNotRegisteredErrForKind("mock", schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"})},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			expectedObject: &testDecodable{
+				Other: "test",
+				Value: 1,
+			},
+			strict: true,
+		},
+		// Strict YAML decode into unregistered objects directly.
+		{
+			data: []byte("kind: Test\n" +
+				"apiVersion: other/blah\n" +
+				"value: 1\n" +
+				"Other: test\n"),
+			into:        &testDecodable{},
+			typer:       &mockTyper{err: runtime.NewNotRegisteredErrForKind("mock", schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"})},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			expectedObject: &testDecodable{
+				Other: "test",
+				Value: 1,
+			},
+			yaml:   true,
+			strict: true,
+		},
+		// Valid strict JSON decode without GVK.
+		{
+			data:        []byte(`{"value":1234}`),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			expectedObject: &testDecodable{
+				Value: 1234,
+			},
+			strict: true,
+		},
+		// Valid strict YAML decode without GVK.
+		{
+			data:        []byte("value: 1234\n"),
+			into:        &testDecodable{},
+			typer:       &mockTyper{gvk: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"}},
+			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
+			expectedObject: &testDecodable{
+				Value: 1234,
+			},
+			yaml:   true,
+			strict: true,
+		},
 	}
 
 	for i, test := range testCases {
 		var s runtime.Serializer
 		if test.yaml {
-			s = json.NewYAMLSerializer(json.DefaultMetaFactory, test.creater, test.typer)
+			if !test.strict {
+				s = json.NewYAMLSerializer(json.DefaultMetaFactory, test.creater, test.typer)
+			} else {
+				s = json.NewStrictYAMLSerializer(json.DefaultMetaFactory, test.creater, test.typer)
+			}
 		} else {
-			s = json.NewSerializer(json.DefaultMetaFactory, test.creater, test.typer, test.pretty)
+			if !test.strict {
+				s = json.NewSerializer(json.DefaultMetaFactory, test.creater, test.typer, test.pretty)
+			} else {
+				s = json.NewStrictSerializer(json.DefaultMetaFactory, test.creater, test.typer, test.pretty)
+			}
 		}
 		obj, gvk, err := s.Decode([]byte(test.data), test.defaultGVK, test.into)
 

--- a/staging/src/k8s.io/component-base/config/BUILD
+++ b/staging/src/k8s.io/component-base/config/BUILD
@@ -24,6 +24,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//staging/src/k8s.io/component-base/config/serializer:all-srcs",
         "//staging/src/k8s.io/component-base/config/v1alpha1:all-srcs",
         "//staging/src/k8s.io/component-base/config/validation:all-srcs",
     ],

--- a/staging/src/k8s.io/component-base/config/BUILD
+++ b/staging/src/k8s.io/component-base/config/BUILD
@@ -25,6 +25,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//staging/src/k8s.io/component-base/config/serializer:all-srcs",
+        "//staging/src/k8s.io/component-base/config/testing:all-srcs",
         "//staging/src/k8s.io/component-base/config/v1alpha1:all-srcs",
         "//staging/src/k8s.io/component-base/config/validation:all-srcs",
     ],

--- a/staging/src/k8s.io/component-base/config/serializer/BUILD
+++ b/staging/src/k8s.io/component-base/config/serializer/BUILD
@@ -1,0 +1,45 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "encode.go",
+        "error.go",
+    ],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/component-base/config/serializer",
+    importpath = "k8s.io/component-base/config/serializer",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["encode_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/conversion:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/testing:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/component-base/config/serializer/encode.go
+++ b/staging/src/k8s.io/component-base/config/serializer/encode.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serializer
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+)
+
+// EncodingFormat is a high-level, typed constant configuring how an object should be encoded.
+type EncodingFormat string
+
+const (
+	// ContentTypeYAML encodes a config file in the YAML format.
+	ContentTypeYAML EncodingFormat = "application/yaml"
+	// ContentTypeJSON encodes a config file in compact JSON format.
+	ContentTypeJSON EncodingFormat = "application/json"
+)
+
+// NewConfigSerializer creates a new implementation of the ConfigSerializer interface.
+func NewConfigSerializer(scheme *runtime.Scheme, codecs *serializer.CodecFactory) ConfigSerializer {
+	knownEncoders := map[EncodingFormat]runtime.Encoder{}
+	for _, serializerInfo := range codecs.SupportedMediaTypes() {
+		switch serializerInfo.MediaType {
+		case "application/json":
+			knownEncoders[ContentTypeJSON] = serializerInfo.Serializer
+		case "application/yaml":
+			knownEncoders[ContentTypeYAML] = serializerInfo.Serializer
+		}
+	}
+
+	// Create the strict deserializer, and creates a decoder later.
+	strictYAMLSerializer := json.NewStrictYAMLSerializer(json.DefaultMetaFactory, scheme, scheme)
+	universalDecoder := codecs.CodecForVersions(nil, strictYAMLSerializer, nil, runtime.InternalGroupVersioner)
+
+	return &configSerializer{scheme, codecs, knownEncoders, universalDecoder}
+}
+
+// ConfigSerializer provides encoding/decoding for a configuration file.
+type ConfigSerializer interface {
+	DecodeInto([]byte, runtime.Object) error
+	Encode(EncodingFormat, schema.GroupVersion, runtime.Object) ([]byte, error)
+}
+
+// configSerializer implements the ConfigSerializer interface.
+var _ ConfigSerializer = &configSerializer{}
+
+type configSerializer struct {
+	scheme        *runtime.Scheme
+	codecs        *serializer.CodecFactory
+	knownEncoders map[EncodingFormat]runtime.Encoder
+	decoder       runtime.Decoder
+}
+
+// DecodeInto decodes bytes into a pointer of the desired type.
+func (cs *configSerializer) DecodeInto(data []byte, into runtime.Object) error {
+	out, gvk, err := cs.decoder.Decode(data, nil, into)
+	// return a structured error if the group was registered with the scheme but the version was unrecognized.
+	if gvk != nil && err != nil {
+		if cs.scheme.IsGroupRegistered(gvk.Group) && !cs.scheme.IsVersionRegistered(gvk.GroupVersion()) {
+			return NewUnrecognizedVersionError(*gvk, data)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if out != into {
+		return fmt.Errorf("unable to decode %s into %T", gvk, reflect.TypeOf(into))
+	}
+	return nil
+}
+
+// Encode encodes the object into a byte slice for the specific format and version.
+func (cs *configSerializer) Encode(format EncodingFormat, gv schema.GroupVersion, obj runtime.Object) ([]byte, error) {
+	knownEncoder, ok := cs.knownEncoders[format]
+	if !ok {
+		return []byte{}, fmt.Errorf("encoding format not supported: %s", format)
+	}
+	// versionSpecificEncoder writes out the specific format bytes for exactly this group version.
+	versionSpecificEncoder := cs.codecs.EncoderForVersion(knownEncoder, gv)
+	// Encode the object to the specific format for the given version.
+	return runtime.Encode(versionSpecificEncoder, obj)
+}

--- a/staging/src/k8s.io/component-base/config/serializer/encode_test.go
+++ b/staging/src/k8s.io/component-base/config/serializer/encode_test.go
@@ -29,9 +29,9 @@ import (
 )
 
 var (
-	scheme        = runtime.NewScheme()
-	codecs        = serializer.NewCodecFactory(scheme)
-	cfgserializer = NewConfigSerializer(scheme, &codecs)
+	scheme           = runtime.NewScheme()
+	codecs           = serializer.NewCodecFactory(scheme)
+	strictSerializer = NewStrictYAMLJSONSerializer(scheme, &codecs)
 
 	intsb = runtime.NewSchemeBuilder(addInternalTypes)
 	extsb = runtime.NewSchemeBuilder(registerConversions, addExternalTypes)
@@ -160,7 +160,7 @@ func TestEncode(t *testing.T) {
 
 	for _, rt := range tests {
 		t.Run(rt.name, func(t2 *testing.T) {
-			actual, actualErr := cfgserializer.Encode(rt.format, rt.gv, rt.obj)
+			actual, actualErr := strictSerializer.Encode(rt.format, rt.gv, rt.obj)
 			if (actualErr != nil) != rt.expectedErr {
 				t2.Errorf("expected error %t but actual %t", rt.expectedErr, actualErr != nil)
 			}
@@ -192,7 +192,7 @@ func TestDecode(t *testing.T) {
 
 	for _, rt := range tests {
 		t.Run(rt.name, func(t2 *testing.T) {
-			actual := cfgserializer.DecodeInto(rt.data, rt.obj)
+			actual := strictSerializer.DecodeInto(rt.data, rt.obj)
 			if (actual != nil) != rt.expectedErr {
 				t2.Errorf("expected error %t but actual %t, error:%v", rt.expectedErr, actual != nil, actual)
 			}
@@ -219,11 +219,11 @@ func TestRoundtrip(t *testing.T) {
 
 	for _, rt := range tests {
 		t.Run(rt.name, func(t2 *testing.T) {
-			err := cfgserializer.DecodeInto(rt.data, rt.obj)
+			err := strictSerializer.DecodeInto(rt.data, rt.obj)
 			if err != nil {
 				t2.Errorf("unexpected decode error: %v", err)
 			}
-			actual, err := cfgserializer.Encode(rt.format, rt.gv, rt.obj)
+			actual, err := strictSerializer.Encode(rt.format, rt.gv, rt.obj)
 			if err != nil {
 				t2.Errorf("unexpected encode error: %v", err)
 			}

--- a/staging/src/k8s.io/component-base/config/serializer/encode_test.go
+++ b/staging/src/k8s.io/component-base/config/serializer/encode_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serializer
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	runtimetest "k8s.io/apimachinery/pkg/runtime/testing"
+)
+
+var (
+	scheme        = runtime.NewScheme()
+	codecs        = serializer.NewCodecFactory(scheme)
+	cfgserializer = NewConfigSerializer(scheme, &codecs)
+
+	intsb = runtime.NewSchemeBuilder(addInternalTypes)
+	extsb = runtime.NewSchemeBuilder(registerConversions, addExternalTypes)
+
+	groupname = "foogroup"
+	intgv     = schema.GroupVersion{Group: groupname, Version: runtime.APIVersionInternal}
+	extgv     = schema.GroupVersion{Group: groupname, Version: "v1alpha1"}
+)
+
+func registerConversions(s *runtime.Scheme) error {
+	if err := s.AddGeneratedConversionFunc((*runtimetest.ExternalSimple)(nil), (*runtimetest.InternalSimple)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return autoConvertExternalSimpleToInternalSimple(a.(*runtimetest.ExternalSimple), b.(*runtimetest.InternalSimple), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddGeneratedConversionFunc((*runtimetest.InternalSimple)(nil), (*runtimetest.ExternalSimple)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return autoConvertInternalSimpleToExternalSimple(a.(*runtimetest.InternalSimple), b.(*runtimetest.ExternalSimple), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddGeneratedConversionFunc((*runtimetest.ExternalComplex)(nil), (*runtimetest.InternalComplex)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return autoConvertExternalComplexToInternalComplex(a.(*runtimetest.ExternalComplex), b.(*runtimetest.InternalComplex), scope)
+	}); err != nil {
+		return err
+	}
+	return s.AddGeneratedConversionFunc((*runtimetest.InternalComplex)(nil), (*runtimetest.ExternalComplex)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return autoConvertInternalComplexToExternalComplex(a.(*runtimetest.InternalComplex), b.(*runtimetest.ExternalComplex), scope)
+	})
+}
+
+func autoConvertExternalSimpleToInternalSimple(in *runtimetest.ExternalSimple, out *runtimetest.InternalSimple, s conversion.Scope) error {
+	out.TestString = in.TestString
+	return nil
+}
+
+func autoConvertInternalSimpleToExternalSimple(in *runtimetest.InternalSimple, out *runtimetest.ExternalSimple, s conversion.Scope) error {
+	out.TestString = in.TestString
+	return nil
+}
+
+func autoConvertExternalComplexToInternalComplex(in *runtimetest.ExternalComplex, out *runtimetest.InternalComplex, s conversion.Scope) error {
+	out.String = in.String
+	out.Integer = in.Integer
+	out.Integer64 = in.Integer64
+	out.Int64 = in.Int64
+	out.Bool = in.Bool
+	return nil
+}
+
+func autoConvertInternalComplexToExternalComplex(in *runtimetest.InternalComplex, out *runtimetest.ExternalComplex, s conversion.Scope) error {
+	out.String = in.String
+	out.Integer = in.Integer
+	out.Integer64 = in.Integer64
+	out.Int64 = in.Int64
+	out.Bool = in.Bool
+	return nil
+}
+
+func addInternalTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypeWithName(intgv.WithKind("Simple"), &runtimetest.InternalSimple{})
+	scheme.AddKnownTypeWithName(intgv.WithKind("Complex"), &runtimetest.InternalComplex{})
+	return nil
+}
+
+func addExternalTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypeWithName(extgv.WithKind("Simple"), &runtimetest.ExternalSimple{})
+	scheme.AddKnownTypeWithName(extgv.WithKind("Complex"), &runtimetest.ExternalComplex{})
+	return nil
+}
+
+func init() {
+	intsb.AddToScheme(scheme)
+	extsb.AddToScheme(scheme)
+}
+
+var (
+	oneSimple = []byte(`apiVersion: foogroup/v1alpha1
+kind: Simple
+testString: foo
+`)
+	simpleUnknownField = []byte(`apiVersion: foogroup/v1alpha1
+kind: Simple
+testString: foo
+unknownField: bar
+`)
+	simpleDuplicateField = []byte(`apiVersion: foogroup/v1alpha1
+kind: Simple
+testString: foo
+testString: bar
+`)
+	unrecognizedVersion = []byte(`apiVersion: foogroup/v1alpha0
+kind: Simple
+testString: foo
+`)
+	oneComplex = []byte(`Int64: 0
+apiVersion: foogroup/v1alpha1
+bool: false
+int: 0
+kind: Complex
+string: bar
+`)
+	simpleJSON = []byte(`{"apiVersion":"foogroup/v1alpha1","kind":"Simple","testString":"foo"}
+`)
+	complexJSON = []byte(`{"apiVersion":"foogroup/v1alpha1","kind":"Complex","string":"bar","int":0,"Int64":0,"bool":false}
+`)
+)
+
+func TestEncode(t *testing.T) {
+	simpleObj := &runtimetest.InternalSimple{TestString: "foo"}
+	complexObj := &runtimetest.InternalComplex{String: "bar"}
+	tests := []struct {
+		name        string
+		format      EncodingFormat
+		gv          schema.GroupVersion
+		obj         runtime.Object
+		expected    []byte
+		expectedErr bool
+	}{
+		{"simple yaml", ContentTypeYAML, extgv, simpleObj, oneSimple, false},
+		{"complex yaml", ContentTypeYAML, extgv, complexObj, oneComplex, false},
+		{"simple json", ContentTypeJSON, extgv, simpleObj, simpleJSON, false},
+		{"complex json", ContentTypeJSON, extgv, complexObj, complexJSON, false},
+		{"no-conversion simple", ContentTypeJSON, extgv, &runtimetest.ExternalSimple{TestString: "foo"}, simpleJSON, false},
+		{"support internal", ContentTypeJSON, intgv, simpleObj, []byte(`{"testString":"foo"}` + "\n"), false},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t2 *testing.T) {
+			actual, actualErr := cfgserializer.Encode(rt.format, rt.gv, rt.obj)
+			if (actualErr != nil) != rt.expectedErr {
+				t2.Errorf("expected error %t but actual %t", rt.expectedErr, actualErr != nil)
+			}
+			if !bytes.Equal(actual, rt.expected) {
+				t2.Errorf("expected %q but actual %q", string(rt.expected), string(actual))
+			}
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	simpleMeta := runtime.TypeMeta{APIVersion: "foogroup/v1alpha1", Kind: "Simple"}
+	complexMeta := runtime.TypeMeta{APIVersion: "foogroup/v1alpha1", Kind: "Complex"}
+	tests := []struct {
+		name        string
+		data        []byte
+		obj         runtime.Object
+		expected    runtime.Object
+		expectedErr bool
+	}{
+		{"simple internal", oneSimple, &runtimetest.InternalSimple{}, &runtimetest.InternalSimple{TestString: "foo"}, false},
+		{"complex internal", oneComplex, &runtimetest.InternalComplex{}, &runtimetest.InternalComplex{String: "bar"}, false},
+		{"simple external", oneSimple, &runtimetest.ExternalSimple{}, &runtimetest.ExternalSimple{TypeMeta: simpleMeta, TestString: "foo"}, false},
+		{"complex external", oneComplex, &runtimetest.ExternalComplex{}, &runtimetest.ExternalComplex{TypeMeta: complexMeta, String: "bar"}, false},
+		{"unknown fields", simpleUnknownField, &runtimetest.InternalSimple{}, nil, true},
+		{"duplicate fields", simpleDuplicateField, &runtimetest.InternalSimple{}, nil, true},
+		{"unrecognized API version", unrecognizedVersion, &runtimetest.InternalSimple{}, nil, true},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t2 *testing.T) {
+			actual := cfgserializer.DecodeInto(rt.data, rt.obj)
+			if (actual != nil) != rt.expectedErr {
+				t2.Errorf("expected error %t but actual %t, error:%v", rt.expectedErr, actual != nil, actual)
+			}
+			if rt.expected != nil && !reflect.DeepEqual(rt.obj, rt.expected) {
+				t2.Errorf("expected %#v but actual %#v", rt.expected, rt.obj)
+			}
+		})
+	}
+}
+
+func TestRoundtrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   []byte
+		format EncodingFormat
+		gv     schema.GroupVersion
+		obj    runtime.Object
+	}{
+		{"simple yaml", oneSimple, ContentTypeYAML, extgv, &runtimetest.InternalSimple{}},
+		{"complex yaml", oneComplex, ContentTypeYAML, extgv, &runtimetest.InternalComplex{}},
+		{"simple json", simpleJSON, ContentTypeJSON, extgv, &runtimetest.InternalSimple{}},
+		{"complex json", complexJSON, ContentTypeJSON, extgv, &runtimetest.InternalComplex{}},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t2 *testing.T) {
+			err := cfgserializer.DecodeInto(rt.data, rt.obj)
+			if err != nil {
+				t2.Errorf("unexpected decode error: %v", err)
+			}
+			actual, err := cfgserializer.Encode(rt.format, rt.gv, rt.obj)
+			if err != nil {
+				t2.Errorf("unexpected encode error: %v", err)
+			}
+			if !bytes.Equal(actual, rt.data) {
+				t2.Errorf("expected %q but actual %q", string(rt.data), string(actual))
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/component-base/config/serializer/error.go
+++ b/staging/src/k8s.io/component-base/config/serializer/error.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serializer
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Error implements the error interface.
+var _ error = &unrecognizedVersionError{}
+
+// unrecognizedVersionError is a base error type that is returned when decoding bytes that
+// use a too old API version.
+type unrecognizedVersionError struct {
+	gvk          schema.GroupVersionKind
+	originalData []byte
+}
+
+// NewUnrecognizedVersionError creates a new unrecognizedVersionError object.
+func NewUnrecognizedVersionError(gvk schema.GroupVersionKind, originalData []byte) error {
+	return &unrecognizedVersionError{
+		gvk:          gvk,
+		originalData: originalData,
+	}
+}
+
+// Error return a string error message.
+func (e *unrecognizedVersionError) Error() string {
+	return fmt.Sprintf("unrecognized version %s in known group %s for kind %v", e.gvk.Version, e.gvk.Group, e.gvk)
+}
+
+// GVK returns the GroupVersionKind for this error.
+func (e *unrecognizedVersionError) GVK() schema.GroupVersionKind {
+	return e.gvk
+}
+
+// OriginalData returns the original byte slice input.
+func (e *unrecognizedVersionError) OriginalData() []byte {
+	return e.originalData
+}
+
+// IsUnrecognizedVersionError returns true if the error indicates that the provided object
+// contain unknown 'Version' field.
+func IsUnrecognizedVersionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*unrecognizedVersionError)
+	return ok
+}

--- a/staging/src/k8s.io/component-base/config/testing/BUILD
+++ b/staging/src/k8s.io/component-base/config/testing/BUILD
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "defaulting.go",
+        "roundtrip.go",
+    ],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/component-base/config/testing",
+    importpath = "k8s.io/component-base/config/testing",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/component-base/config/serializer:go_default_library",
+        "//vendor/github.com/pmezard/go-difflib/difflib:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/component-base/config/testing/defaulting.go
+++ b/staging/src/k8s.io/component-base/config/testing/defaulting.go
@@ -26,6 +26,8 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
+// GetDefaultingTestCases generates test cases for every yaml file in testdata/<kind>/before/.
+// The corresponding named file in the testdata/<kind>/after/ directory is indicated for comparison.
 func GetDefaultingTestCases(scheme *runtime.Scheme) []TestCase {
 	cases := []TestCase{}
 	for gvk := range scheme.AllKnownTypes() {

--- a/staging/src/k8s.io/component-base/config/testing/defaulting.go
+++ b/staging/src/k8s.io/component-base/config/testing/defaulting.go
@@ -29,11 +29,9 @@ import (
 func GetDefaultingTestCases(scheme *runtime.Scheme) []TestCase {
 	cases := []TestCase{}
 	for gvk := range scheme.AllKnownTypes() {
-		fmt.Println(gvk)
 		beforeDir := fmt.Sprintf("testdata/%s/before", gvk.Kind)
 		afterDir := fmt.Sprintf("testdata/%s/after", gvk.Kind)
 		utilruntime.Must(filepath.Walk(beforeDir, func(path string, info os.FileInfo, err error) error {
-			fmt.Println(info.Name(), path)
 			if err != nil {
 				return err
 			}
@@ -47,7 +45,7 @@ func GetDefaultingTestCases(scheme *runtime.Scheme) []TestCase {
 				return nil
 			}
 			cases = append(cases, TestCase{
-				name:  fmt.Sprintf("default_%s", info.Name()),
+				name:  fmt.Sprintf("default_%s_%s", gvk.Kind, info.Name()),
 				in:    filepath.Join(beforeDir, info.Name()),
 				inGVK: gvk,
 				out:   filepath.Join(afterDir, info.Name()),

--- a/staging/src/k8s.io/component-base/config/testing/defaulting.go
+++ b/staging/src/k8s.io/component-base/config/testing/defaulting.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package testing
 
 import (

--- a/staging/src/k8s.io/component-base/config/testing/defaulting.go
+++ b/staging/src/k8s.io/component-base/config/testing/defaulting.go
@@ -1,0 +1,44 @@
+package testing
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+func GetDefaultingTestCases(scheme *runtime.Scheme) []TestCase {
+	cases := []TestCase{}
+	for gvk := range scheme.AllKnownTypes() {
+		fmt.Println(gvk)
+		beforeDir := fmt.Sprintf("testdata/%s/before", gvk.Kind)
+		afterDir := fmt.Sprintf("testdata/%s/after", gvk.Kind)
+		utilruntime.Must(filepath.Walk(beforeDir, func(path string, info os.FileInfo, err error) error {
+			fmt.Println(info.Name(), path)
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if info.Name() == "before" {
+					return nil
+				}
+				return filepath.SkipDir
+			}
+			if !strings.HasSuffix(info.Name(), ".yaml") {
+				return nil
+			}
+			cases = append(cases, TestCase{
+				name:  fmt.Sprintf("default_%s", info.Name()),
+				in:    filepath.Join(beforeDir, info.Name()),
+				inGVK: gvk,
+				out:   filepath.Join(afterDir, info.Name()),
+				outGV: gvk.GroupVersion(),
+			})
+			return nil
+		}))
+	}
+	return cases
+}

--- a/staging/src/k8s.io/component-base/config/testing/roundtrip.go
+++ b/staging/src/k8s.io/component-base/config/testing/roundtrip.go
@@ -1,0 +1,119 @@
+package testing
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/pmezard/go-difflib/difflib"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
+	configserializer "k8s.io/component/pkg/serializer"
+)
+
+type TestCase struct {
+	name, in, out string
+	inGVK         schema.GroupVersionKind
+	outGV         schema.GroupVersion
+}
+
+func GetRoundtripTestCases(scheme *runtime.Scheme, disallowMarshalGroupVersions sets.String) []TestCase {
+	cases := []TestCase{}
+	versionsForKind := map[schema.GroupKind][]string{}
+	for gvk := range scheme.AllKnownTypes() {
+		versionsForKind[gvk.GroupKind()] = append(versionsForKind[gvk.GroupKind()], gvk.Version)
+	}
+
+	for gk, versions := range versionsForKind {
+		for _, vin := range versions {
+			if vin == runtime.APIVersionInternal {
+				continue // Don't try to deserialize the internal version
+			}
+			for _, vout := range versions {
+				inGVK := schema.GroupVersionKind{Group: gk.Group, Version: vin, Kind: gk.Kind}
+				marshalGV := schema.GroupVersion{Group: gk.Group, Version: vout}
+				if disallowMarshalGroupVersions.Has(marshalGV.String()) {
+					continue // Don't marshal a gv that is blacklisted
+				}
+				cases = append(cases, TestCase{
+					name:  fmt.Sprintf("%sTo%s", vin, vout),
+					in:    fmt.Sprintf("testdata/%s/%s.yaml", gk.Kind, vin),
+					inGVK: inGVK,
+					out:   fmt.Sprintf("testdata/%s/%s.yaml", gk.Kind, vout),
+					outGV: marshalGV,
+				})
+			}
+		}
+	}
+	return cases
+}
+
+func RunTestsOnYAMLData(t *testing.T, tests []TestCase, scheme *runtime.Scheme, codecs *serializer.CodecFactory) {
+	for _, rt := range tests {
+		t.Run(rt.name, func(t2 *testing.T) {
+
+			obj, err := decodeTestData(rt.in, rt.inGVK, scheme, codecs)
+			if err != nil {
+				t2.Fatal(err)
+			}
+
+			actual, err := configserializer.Encode(configserializer.YAML, rt.outGV, obj, scheme, codecs)
+			if err != nil {
+				t2.Fatal(err)
+			}
+
+			expected, err := ioutil.ReadFile(rt.out)
+			if err != nil {
+				t2.Fatalf("couldn't read test data")
+			}
+
+			if !bytes.Equal(expected, actual) {
+				t2.Errorf("the expected and actual output differs.\n\tin: %s\n\tout: %s\n\tgroupversion: %s\n\tdiff: \n%s\n",
+					rt.in, rt.out, rt.outGV.String(), DiffBytes(expected, actual))
+			}
+		})
+	}
+}
+
+func decodeTestData(path string, gvk schema.GroupVersionKind, scheme *runtime.Scheme, codecs *serializer.CodecFactory) (runtime.Object, error) {
+	obj, err := scheme.New(gvk)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := configserializer.DecodeInto(content, obj, codecs, &buf); err != nil {
+		return nil, err
+	}
+	if buf.Len() > 0 {
+		// If the buffer contains anything
+		return nil, errors.Errorf("the input test YAML file invalid with strict validation errors: %s", buf.Bytes())
+	}
+	return obj, nil
+}
+
+func DiffBytes(expected, actual []byte) string {
+	var diffBytes bytes.Buffer
+	difflib.WriteUnifiedDiff(&diffBytes, difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(expected)),
+		B:        difflib.SplitLines(string(actual)),
+		FromFile: "expected",
+		ToFile:   "actual",
+		Context:  3,
+	})
+	return diffBytes.String()
+}
+
+/*
+TODO: Add a scheme tester that enforces a couple of things...
+*/

--- a/staging/src/k8s.io/component-base/config/testing/roundtrip.go
+++ b/staging/src/k8s.io/component-base/config/testing/roundtrip.go
@@ -74,7 +74,7 @@ func RunTestsOnYAMLData(t *testing.T, tests []TestCase, scheme *runtime.Scheme, 
 	for _, rt := range tests {
 		t.Run(rt.name, func(t2 *testing.T) {
 
-			obj, err := decodeTestData(rt.in, rt.inGVK, scheme, codecs)
+			obj, err := decodeTestData(rt.in, rt.inGVK, scheme, sz)
 			if err != nil {
 				t2.Fatal(err)
 			}
@@ -97,9 +97,7 @@ func RunTestsOnYAMLData(t *testing.T, tests []TestCase, scheme *runtime.Scheme, 
 	}
 }
 
-func decodeTestData(path string, gvk schema.GroupVersionKind, scheme *runtime.Scheme, codecs *serializer.CodecFactory) (runtime.Object, error) {
-	sz := configserializer.NewStrictYAMLJSONSerializer(scheme, codecs)
-
+func decodeTestData(path string, gvk schema.GroupVersionKind, scheme *runtime.Scheme, sz configserializer.StrictYAMLJSONSerializer) (runtime.Object, error) {
 	obj, err := scheme.New(gvk)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/component-base/config/testing/roundtrip.go
+++ b/staging/src/k8s.io/component-base/config/testing/roundtrip.go
@@ -43,12 +43,12 @@ type TestCase struct {
 // Destination-GroupVersions contained in `disallowMarshalGroupVersions` are excluded from the generated TestCases.
 func GetRoundtripTestCases(scheme *runtime.Scheme, disallowMarshalGroupVersions sets.String) []TestCase {
 	cases := []TestCase{}
-	versionsForKind := map[schema.GroupKind][]string{}
+	gkToVersions := map[schema.GroupKind][]string{}
 	for gvk := range scheme.AllKnownTypes() {
-		versionsForKind[gvk.GroupKind()] = append(versionsForKind[gvk.GroupKind()], gvk.Version)
+		gkToVersions[gvk.GroupKind()] = append(gkToVersions[gvk.GroupKind()], gvk.Version)
 	}
 
-	for gk, versions := range versionsForKind {
+	for gk, versions := range gkToVersions {
 		for _, vin := range versions {
 			if vin == runtime.APIVersionInternal {
 				continue // Don't try to deserialize the internal version

--- a/staging/src/k8s.io/component-base/config/testing/roundtrip.go
+++ b/staging/src/k8s.io/component-base/config/testing/roundtrip.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package testing
 
 import (

--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -5,6 +5,7 @@ module k8s.io/component-base
 go 1.12
 
 require (
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/pflag v1.0.1
 	k8s.io/apimachinery v0.0.0
 	k8s.io/klog v0.0.0-20190306015804-8e90cee79f82


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This patch adds testing libraries for component creators to validate the behavior of their ComponentConfig's value behavior.

Tracking Issue: https://github.com/kubernetes/kubernetes/issues/75426

**Special notes for your reviewer**:
This is currently based on a patch for our serializer abstraction: https://github.com/kubernetes/kubernetes/pull/74111

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```