### PR TITLE
Avoid allocations when building SelfLinks and fast path escape

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
@@ -34,6 +34,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",
+        "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/k8s.io/utils/trace:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/namer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/namer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -86,6 +87,21 @@ func (n ContextBasedNaming) Name(req *http.Request) (namespace, name string, err
 	return ns, requestInfo.Name, nil
 }
 
+// fastURLPathEncode encodes the provided path as a URL path
+func fastURLPathEncode(path string) string {
+	for _, r := range []byte(path) {
+		switch {
+		case r >= '-' && r <= '9', r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z':
+			// characters within this range do not require escaping
+		default:
+			var u url.URL
+			u.Path = path
+			return u.EscapedPath()
+		}
+	}
+	return path
+}
+
 func (n ContextBasedNaming) GenerateLink(requestInfo *request.RequestInfo, obj runtime.Object) (uri string, err error) {
 	namespace, name, err := n.ObjectName(obj)
 	if err == errEmptyName && len(requestInfo.Name) > 0 {
@@ -101,19 +117,23 @@ func (n ContextBasedNaming) GenerateLink(requestInfo *request.RequestInfo, obj r
 		return n.SelfLinkPathPrefix + url.QueryEscape(name) + n.SelfLinkPathSuffix, nil
 	}
 
-	return n.SelfLinkPathPrefix +
-			url.QueryEscape(namespace) +
-			"/" + url.QueryEscape(requestInfo.Resource) + "/" +
-			url.QueryEscape(name) +
-			n.SelfLinkPathSuffix,
-		nil
+	builder := strings.Builder{}
+	builder.Grow(len(n.SelfLinkPathPrefix) + len(namespace) + len(requestInfo.Resource) + len(name) + len(n.SelfLinkPathSuffix) + 8)
+	builder.WriteString(n.SelfLinkPathPrefix)
+	builder.WriteString(namespace)
+	builder.WriteByte('/')
+	builder.WriteString(requestInfo.Resource)
+	builder.WriteByte('/')
+	builder.WriteString(name)
+	builder.WriteString(n.SelfLinkPathSuffix)
+	return fastURLPathEncode(builder.String()), nil
 }
 
 func (n ContextBasedNaming) GenerateListLink(req *http.Request) (uri string, err error) {
 	if len(req.URL.RawPath) > 0 {
 		return req.URL.RawPath, nil
 	}
-	return req.URL.EscapedPath(), nil
+	return fastURLPathEncode(req.URL.Path), nil
 }
 
 func (n ContextBasedNaming) ObjectName(obj runtime.Object) (namespace, name string, err error) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -757,6 +757,30 @@ func TestWatchHTTPTimeout(t *testing.T) {
 func BenchmarkWatchHTTP(b *testing.B) {
 	items := benchmarkItems(b)
 
+	// use ASCII names to capture the cost of handling ASCII only self-links
+	for i := range items {
+		item := &items[i]
+		item.Namespace = fmt.Sprintf("namespace-%d", i)
+		item.Name = fmt.Sprintf("reasonable-name-%d", i)
+	}
+
+	runWatchHTTPBenchmark(b, items)
+}
+
+func BenchmarkWatchHTTP_UTF8(b *testing.B) {
+	items := benchmarkItems(b)
+
+	// use UTF names to capture the cost of handling UTF-8 escaping in self-links
+	for i := range items {
+		item := &items[i]
+		item.Namespace = fmt.Sprintf("躀痢疈蜧í柢-%d", i)
+		item.Name = fmt.Sprintf("翏Ŏ熡韐-%d", i)
+	}
+
+	runWatchHTTPBenchmark(b, items)
+}
+
+func runWatchHTTPBenchmark(b *testing.B, items []example.Pod) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := handle(map[string]rest.Storage{"simples": simpleStorage})
 	server := httptest.NewServer(handler)


### PR DESCRIPTION
A self link should only require one allocation, and we should skip
url.PathEscape() except when the path actually needs it.

Add a fuzz test to build random strings and verify them against
the optimized implementation. Add a new BenchmarkWatchHTTP_UTF8 that
covers when we have unicode names in the self link.

```
> before
BenchmarkWatchHTTP-12    	   30000	     38346 ns/op	    1893 B/op	      29 allocs/op

> after
BenchmarkWatchHTTP-12         	   50000	     35988 ns/op	    1571 B/op	      26 allocs/op
BenchmarkWatchHTTP_UTF8-12    	   50000	     41467 ns/op	    1928 B/op	      28 allocs/op
```

Saves 3 allocations in the fast path and 1 in the slow path (the
slow path has to build the buffer and then call url.EscapedPath
which always allocates).

/kind bug

```release-note
NONE
```