### PR TITLE
Reduce frequency of locking in IsListType

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
@@ -57,6 +57,11 @@ func IsListType(obj runtime.Object) bool {
 		ok = err == nil
 
 		// cache only the first 1024 types
+		isListCache.lock.RLock()
+		defer isListCache.lock.RUnlock()
+		if len(isListCache.byType) >= 1024 {
+			return ok
+		}
 		isListCache.lock.Lock()
 		if len(isListCache.byType) < 1024 {
 			isListCache.byType[t] = ok

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
@@ -58,10 +58,11 @@ func IsListType(obj runtime.Object) bool {
 
 		// cache only the first 1024 types
 		isListCache.lock.RLock()
-		defer isListCache.lock.RUnlock()
 		if len(isListCache.byType) >= 1024 {
+			isListCache.lock.RUnlock()
 			return ok
 		}
+		isListCache.lock.RUnlock()
 		isListCache.lock.Lock()
 		if len(isListCache.byType) < 1024 {
 			isListCache.byType[t] = ok


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The function IsListType in help.go always takes lock before checking occupancy of the map.

Since there is no eviction, the length would only grow.
We can acquire the read lock first, and check the length.
If the length reaches 1024, there is no need to acquire the write lock.

```release-note
NONE
```
