### PR TITLE
DO NOT MERGE - Test a set of perf patches to go-restful

### DIFF
--- a/vendor/github.com/emicklei/go-restful/curly.go
+++ b/vendor/github.com/emicklei/go-restful/curly.go
@@ -45,7 +45,7 @@ func (c CurlyRouter) SelectRoute(
 
 // selectRoutes return a collection of Route from a WebService that matches the path tokens from the request.
 func (c CurlyRouter) selectRoutes(ws *WebService, requestTokens []string) sortableCurlyRoutes {
-	candidates := sortableCurlyRoutes{}
+	candidates := make(sortableCurlyRoutes, 0, 8)
 	for _, each := range ws.routes {
 		matches, paramCount, staticCount := c.matchesRouteByPathTokens(each.pathParts, requestTokens)
 		if matches {

--- a/vendor/github.com/emicklei/go-restful/curly_route.go
+++ b/vendor/github.com/emicklei/go-restful/curly_route.go
@@ -18,6 +18,7 @@ func (s *sortableCurlyRoutes) add(route curlyRoute) {
 }
 
 func (s sortableCurlyRoutes) routes() (routes []Route) {
+	routes = make([]Route, 0, len(s))
 	for _, each := range s {
 		routes = append(routes, each.route) // TODO change return type
 	}

--- a/vendor/github.com/emicklei/go-restful/curly_route.go
+++ b/vendor/github.com/emicklei/go-restful/curly_route.go
@@ -31,22 +31,22 @@ func (s sortableCurlyRoutes) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 func (s sortableCurlyRoutes) Less(i, j int) bool {
-	ci := s[i]
-	cj := s[j]
+	a := s[i]
+	b := s[j]
 
 	// primary key
-	if ci.staticCount < cj.staticCount {
+	if a.staticCount < b.staticCount {
 		return true
 	}
-	if ci.staticCount > cj.staticCount {
+	if a.staticCount > b.staticCount {
 		return false
 	}
 	// secundary key
-	if ci.paramCount < cj.paramCount {
+	if a.paramCount < b.paramCount {
 		return true
 	}
-	if ci.paramCount > cj.paramCount {
+	if a.paramCount > b.paramCount {
 		return false
 	}
-	return ci.route.Path < cj.route.Path
+	return a.route.Path < b.route.Path
 }

--- a/vendor/github.com/emicklei/go-restful/route.go
+++ b/vendor/github.com/emicklei/go-restful/route.go
@@ -161,8 +161,11 @@ func (r Route) matchesContentType(mimeTypes string) bool {
 
 // Extract the parameters from the request url path
 func (r Route) extractParameters(urlPath string) map[string]string {
+	if len(r.pathParts) == 0 {
+		return nil
+	}
 	urlParts := tokenizePath(urlPath)
-	pathParameters := map[string]string{}
+	var pathParameters map[string]string
 	for i, key := range r.pathParts {
 		var value string
 		if i >= len(urlParts) {
@@ -171,6 +174,9 @@ func (r Route) extractParameters(urlPath string) map[string]string {
 			value = urlParts[i]
 		}
 		if strings.HasPrefix(key, "{") { // path-parameter
+			if pathParameters == nil {
+				pathParameters = make(map[string]string, len(r.pathParts))
+			}
 			if colon := strings.Index(key, ":"); colon != -1 {
 				// extract by regex
 				regPart := key[colon+1 : len(key)-1]
@@ -178,9 +184,9 @@ func (r Route) extractParameters(urlPath string) map[string]string {
 				if regPart == "*" {
 					pathParameters[keyPart] = untokenizePath(i, urlParts)
 					break
-				} else {
-					pathParameters[keyPart] = value
 				}
+				pathParameters[keyPart] = value
+
 			} else {
 				// without enclosing {}
 				pathParameters[key[1:len(key)-1]] = value
@@ -206,7 +212,7 @@ func untokenizePath(offset int, parts []string) string {
 // Tokenize an URL path using the slash separator ; the result does not have empty tokens
 func tokenizePath(path string) []string {
 	if "/" == path {
-		return []string{}
+		return nil
 	}
 	return strings.Split(strings.Trim(path, "/"), "/")
 }


### PR DESCRIPTION
go-restful performs some unnecessary allocations in the hot path. Combined this
reduces our allocations for a simple GET (excluding etcd loads) from ~60 -> ~40
which is non-trivial.

Needs testing to make sure it actually works.

```release-note
NONE
```