### PR TITLE
Remove the cache of datastore folderId

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -61,7 +61,6 @@ const (
 )
 
 var cleanUpRoutineInitialized = false
-var datastoreFolderIDMap = make(map[string]map[string]string)
 
 var cleanUpRoutineInitLock sync.Mutex
 var cleanUpDummyVMLock sync.RWMutex


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This vSphere e2e test fails intermittently with the Volume not attachable to the pod. The failure looks like this.
```
STEP: Found 4 events.
Mar 20 06:30:05.827: INFO: At 2019-03-20 06:25:05 -0700 PDT - event for pvc-dvkbs: {persistentvolume-controller } ProvisioningSucceeded: Successfully provisioned volume pvc-827c594a-4b13-11e9-bc4a-005056b38f56 using kubernetes.io/vsphere-volume
Mar 20 06:30:05.827: INFO: At 2019-03-20 06:25:06 -0700 PDT - event for pvc-tester-fz95r: {default-scheduler } Scheduled: Successfully assigned volume-vsan-policy-4073/pvc-tester-fz95r to node2
Mar 20 06:30:05.827: INFO: At 2019-03-20 06:25:07 -0700 PDT - event for pvc-tester-fz95r: {attachdetach-controller } FailedAttachVolume: AttachVolume.Attach failed for volume "pvc-827c594a-4b13-11e9-bc4a-005056b38f56" : File []/vmfs/volumes/vsan:52e7f41444c10dd8-07397ea798e59bfc/b6ea915c-a52b-047b-3c56-020001d1d089/kubernetes-dynamic-pvc-827c594a-4b13-11e9-bc4a-005056b38f56.vmdk was not found
Mar 20 06:30:05.827: INFO: At 2019-03-20 06:27:09 -0700 PDT - event for pvc-tester-fz95r: {kubelet node2} FailedMount: Unable to mount volumes for pod "pvc-tester-fz95r_volume-vsan-policy-4073(939f50ef-4b13-11e9-bc4a-005056b38f56)": timeout expired waiting for volumes to attach or mount for pod "volume-vsan-policy-4073"/"pvc-tester-fz95r". list of unmounted volumes=[volume1]. list of unattached volumes=[volume1 default-token-mhw9b]
[Fail] [sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] [It] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass
```
This happens since the canonical volume path, `[vsanDatastore] b6ea915c-a52b-047b-3c56-020001d1d089/kubernetes-dynamic-pvc-827c594a-4b13-11e9-bc4a-005056b38f56.vmdk` in the above case, has a wrong folderId of b6ea915c-a52b-047b-3c56-020001d1d089 for the folder named 'kubevols'. The folderId for 'kubevols' folder name is cached in `vsphere.go` in `datastoreFolderIDMap` when the first volume is created in the datastore. If this folder is deleted from the Datastore for any reason, then the cached value becomes invalid. Looks like the e2e tests when run in some sequence, end up deleting the 'kubevols' folder leaving a stale cache entry in VCP. This stale folderId is used for subsequent Volumes created and therefore leads to invalid volume paths. This problem can be reproduced when a user manually deletes the 'kubevols' folder and then creates a Volume using a storage policy. This volume will end up with a wrong folderId in its path.

One fix could be to invalidate the cache when the folder is deleted. However this is expensive since this involves listening to folder delete events from vCenter.

Another way to fix this issue would be to validate whether the cached folder ID is valid before using it. However, this is as expensive as re-computing the folderId for the given folder name each time. So the easiest way to fix this issue is to drop the cache completely. The impact would be one more round trip to vCenter (to find the folderId for given folder name) at Volume provision time. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This fixes the intermittent failure of a vSphere e2e test named "verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass"

**Special notes for your reviewer**:
This fix was tested manually as well as by running the e2e tests. Found that the previous failures do not occur anymore.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```