### PR TITLE
Automated cherry pick of #75283 upstream release 1.14

### DIFF
--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -204,21 +204,5 @@ func (m *GracefulTerminationManager) MoveRSOutofGracefulDeleteList(uniqueRS stri
 
 // Run start a goroutine to try to delete rs in the graceful delete rsList with an interval 1 minute
 func (m *GracefulTerminationManager) Run() {
-	// before start, add leftover in delete rs to graceful delete rsList
-	vss, err := m.ipvs.GetVirtualServers()
-	if err != nil {
-		klog.Errorf("IPVS graceful delete manager failed to get IPVS virtualserver")
-	}
-	for _, vs := range vss {
-		rss, err := m.ipvs.GetRealServers(vs)
-		if err != nil {
-			klog.Errorf("IPVS graceful delete manager failed to get %v realserver", vs)
-			continue
-		}
-		for _, rs := range rss {
-			m.GracefulDeleteRS(vs, rs)
-		}
-	}
-
 	go wait.Until(m.tryDeleteRs, rsCheckDeleteInterval, wait.NeverStop)
 }


### PR DESCRIPTION
#75283 Do not delete existing VS and RS when starting

/sig network
/area ipvs
/kind bug

/assign @m1093782566 

```release-note
[IPVS] Allow for transparent kube-proxy restarts
```