### PR TITLE
Automated cherry pick of #71561: Fix updating 'currentMetrics' field for HPA with

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -377,7 +377,7 @@ func (a *HorizontalController) computeStatusForResourceMetric(currentReplicas in
 			return 0, time.Time{}, "", fmt.Errorf("failed to get %s utilization: %v", metricSpec.Resource.Name, err)
 		}
 		metricNameProposal := fmt.Sprintf("%s resource", metricSpec.Resource.Name)
-		status = &autoscalingv2.MetricStatus{
+		*status = autoscalingv2.MetricStatus{
 			Type: autoscalingv2.ResourceMetricSourceType,
 			Resource: &autoscalingv2.ResourceMetricStatus{
 				Name: metricSpec.Resource.Name,


### PR DESCRIPTION
Cherry pick of #71561 on release-1.13.

#71561: Fix updating 'currentMetrics' field for HPA with

```release-note
Fix updating `currentMetrics` field for HPA if targetAverageValue on resource metric is used
```