### PR TITLE
Automated cherry pick of #75480: Update Cluster Autscaler version to 1.14.0

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.14.0-beta.2",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.14.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Cherry pick of #75480 on release-1.14.

#75480: Update Cluster Autscaler version to 1.14.0

This is just a version update. I did not notice that release-1.14 was no longer fast-forwarded from master.
Apart from different version number there are no changes between `v1.14.0-beta.2` and `v1.14.0`.