### PR TITLE
cleanup: split APIInstaller code 

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/BUILD
@@ -12,7 +12,6 @@ go_library(
     importpath = "k8s.io/apiextensions-apiserver/pkg/controller/openapi",
     visibility = ["//visibility:public"],
     deps = [
-        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -67,6 +67,7 @@ type action struct {
 	handler           restful.RouteFunction
 	readObject        interface{}
 	producedObject    interface{}
+	consumedMIMETypes []string
 	producedMIMETypes []string
 }
 
@@ -425,24 +426,24 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
 		// Add actions at the resource path: /api/apiVersion/resource
-		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, isLister)
-		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, isCreater)
-		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, isCollectionDeleter)
+		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil, nil, nil, nil}, isLister)
+		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil, nil, nil, nil}, isCreater)
+		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil, nil, nil, nil}, isCollectionDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, allowWatchList)
+		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil, nil, nil, nil}, allowWatchList)
 
 		// Add actions at the item path: /api/apiVersion/resource/{name}
-		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isGetter)
+		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil, nil, nil, nil}, isGetter)
 		if getSubpath {
-			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil, nil}, isGetter)
+			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil, nil, nil}, isGetter)
 		}
-		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isUpdater)
-		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isPatcher)
-		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isGracefulDeleter)
+		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil, nil, nil, nil}, isUpdater)
+		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil, nil, nil, nil}, isPatcher)
+		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil, nil, nil, nil}, isGracefulDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil, nil, nil}, isWatcher)
-		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isConnecter)
-		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil, nil}, isConnecter && connectSubpath)
+		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil, nil, nil, nil}, isWatcher)
+		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil, nil, nil, nil}, isConnecter)
+		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil, nil, nil}, isConnecter && connectSubpath)
 	default:
 		namespaceParamName := "namespaces"
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
@@ -472,31 +473,31 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			SelfLinkPathSuffix: itemPathSuffix,
 		}
 
-		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, isLister)
-		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, isCreater)
-		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, isCollectionDeleter)
+		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil, nil, nil, nil}, isLister)
+		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil, nil, nil, nil}, isCreater)
+		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil, nil, nil, nil}, isCollectionDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, allowWatchList)
+		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil, nil, nil, nil}, allowWatchList)
 
-		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isGetter)
+		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil, nil, nil, nil}, isGetter)
 		if getSubpath {
-			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil, nil}, isGetter)
+			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil, nil, nil}, isGetter)
 		}
-		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isUpdater)
-		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isPatcher)
-		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isGracefulDeleter)
+		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil, nil, nil, nil}, isUpdater)
+		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil, nil, nil, nil}, isPatcher)
+		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil, nil, nil, nil}, isGracefulDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil, nil, nil}, isWatcher)
-		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isConnecter)
-		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil, nil}, isConnecter && connectSubpath)
+		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil, nil, nil, nil}, isWatcher)
+		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil, nil, nil, nil}, isConnecter)
+		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil, nil, nil}, isConnecter && connectSubpath)
 
 		// list or post across namespace.
 		// For ex: LIST all pods in all namespaces by sending a LIST request at /api/apiVersion/pods.
 		// TODO: more strongly type whether a resource allows these actions on "all namespaces" (bulk delete)
 		if !isSubresource {
-			actions = appendIf(actions, action{"LIST", resource, params, namer, true, nil, nil, nil, nil}, isLister)
+			actions = appendIf(actions, action{"LIST", resource, params, namer, true, nil, nil, nil, nil, nil}, isLister)
 			// DEPRECATED in 1.11
-			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true, nil, nil, nil, nil}, allowWatchList)
+			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true, nil, nil, nil, nil, nil}, allowWatchList)
 		}
 	}
 
@@ -669,6 +670,24 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		}
 
 		actions[i].producedObject = producedObject
+	}
+
+	// assign consumedMIMETypes for each action
+	for i, action := range actions {
+		switch action.Verb {
+		case "PATCH": // Partially update a resource
+			supportedTypes := []string{
+				string(types.JSONPatchType),
+				string(types.MergePatchType),
+				string(types.StrategicMergePatchType),
+			}
+			if utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
+				supportedTypes = append(supportedTypes, string(types.ApplyPatchType))
+			}
+			actions[i].consumedMIMETypes = supportedTypes
+		case "CONNECT":
+			actions[i].consumedMIMETypes = []string{"*/*"}
+		}
 	}
 
 	// assign producedMIMETypes for each action
@@ -891,18 +910,10 @@ func registerActionsToWebService(action action, ws *restful.WebService, isNamesp
 		if isSubresource {
 			doc = "partially update " + subresource + " of the specified " + kind
 		}
-		supportedTypes := []string{
-			string(types.JSONPatchType),
-			string(types.MergePatchType),
-			string(types.StrategicMergePatchType),
-		}
-		if utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
-			supportedTypes = append(supportedTypes, string(types.ApplyPatchType))
-		}
 		route := ws.PATCH(action.Path).To(action.handler).
 			Doc(doc).
 			Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-			Consumes(supportedTypes...).
+			Consumes(action.consumedMIMETypes...).
 			Operation("patch"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 			Produces(action.producedMIMETypes...).
 			Returns(http.StatusOK, "OK", action.producedObject).
@@ -1011,7 +1022,7 @@ func registerActionsToWebService(action action, ws *restful.WebService, isNamesp
 				Doc(doc).
 				Operation("connect" + strings.Title(strings.ToLower(method)) + namespaced + kind + strings.Title(subresource) + operationSuffix).
 				Produces(action.producedMIMETypes...).
-				Consumes("*/*").
+				Consumes(action.consumedMIMETypes...).
 				Writes(connectProducedObject)
 			addParams(route, action.Params)
 			routes = append(routes, route)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -63,6 +63,8 @@ type action struct {
 	Params        []*restful.Parameter // List of parameters associated with the action.
 	Namer         handlers.ScopeNamer
 	AllNamespaces bool // true iff the action is namespaced but works on aggregate result for all namespaces
+
+	handler restful.RouteFunction
 }
 
 // An interface to see if one storage supports override its default verb for monitoring
@@ -420,24 +422,24 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
 		// Add actions at the resource path: /api/apiVersion/resource
-		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false}, isLister)
-		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false}, isCreater)
-		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false}, isCollectionDeleter)
+		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil}, isLister)
+		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil}, isCreater)
+		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil}, isCollectionDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false}, allowWatchList)
+		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil}, allowWatchList)
 
 		// Add actions at the item path: /api/apiVersion/resource/{name}
-		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false}, isGetter)
+		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil}, isGetter)
 		if getSubpath {
-			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false}, isGetter)
+			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil}, isGetter)
 		}
-		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false}, isUpdater)
-		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false}, isPatcher)
-		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false}, isGracefulDeleter)
+		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil}, isUpdater)
+		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil}, isPatcher)
+		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil}, isGracefulDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false}, isWatcher)
-		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false}, isConnecter)
-		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false}, isConnecter && connectSubpath)
+		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil}, isWatcher)
+		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil}, isConnecter)
+		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil}, isConnecter && connectSubpath)
 	default:
 		namespaceParamName := "namespaces"
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
@@ -467,31 +469,31 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			SelfLinkPathSuffix: itemPathSuffix,
 		}
 
-		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false}, isLister)
-		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false}, isCreater)
-		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false}, isCollectionDeleter)
+		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil}, isLister)
+		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil}, isCreater)
+		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil}, isCollectionDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false}, allowWatchList)
+		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil}, allowWatchList)
 
-		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false}, isGetter)
+		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil}, isGetter)
 		if getSubpath {
-			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false}, isGetter)
+			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil}, isGetter)
 		}
-		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false}, isUpdater)
-		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false}, isPatcher)
-		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false}, isGracefulDeleter)
+		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil}, isUpdater)
+		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil}, isPatcher)
+		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil}, isGracefulDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false}, isWatcher)
-		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false}, isConnecter)
-		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false}, isConnecter && connectSubpath)
+		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil}, isWatcher)
+		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil}, isConnecter)
+		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil}, isConnecter && connectSubpath)
 
 		// list or post across namespace.
 		// For ex: LIST all pods in all namespaces by sending a LIST request at /api/apiVersion/pods.
 		// TODO: more strongly type whether a resource allows these actions on "all namespaces" (bulk delete)
 		if !isSubresource {
-			actions = appendIf(actions, action{"LIST", resource, params, namer, true}, isLister)
+			actions = appendIf(actions, action{"LIST", resource, params, namer, true, nil}, isLister)
 			// DEPRECATED in 1.11
-			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true}, allowWatchList)
+			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true, nil}, allowWatchList)
 		}
 	}
 
@@ -563,6 +565,72 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		reqScope.FieldManager = fm
 	}
 
+	// construct handler for each action
+	for i, action := range actions {
+		var handler restful.RouteFunction
+		reqScope.Namer = action.Namer
+		verbOverrider, needOverride := storage.(StorageMetricsOverride)
+		requestScope := "cluster"
+		if apiResource.Namespaced {
+			requestScope = "namespace"
+		}
+		if strings.HasSuffix(action.Path, "/{path:*}") {
+			requestScope = "resource"
+		}
+		if action.AllNamespaces {
+			requestScope = "cluster"
+		}
+
+		switch action.Verb {
+		case "GET": // Get a resource.
+			if isGetterWithOptions {
+				handler = restfulGetResourceWithOptions(getterWithOptions, reqScope, isSubresource)
+			} else {
+				handler = restfulGetResource(getter, exporter, reqScope)
+			}
+
+			if needOverride {
+				// need change the reported verb
+				handler = metrics.InstrumentRouteFunc(verbOverrider.OverrideMetricsVerb(action.Verb), group, version, resource, subresource, requestScope, metrics.APIServerComponent, handler)
+			} else {
+				handler = metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, handler)
+			}
+
+			if a.enableAPIResponseCompression {
+				handler = genericfilters.RestfulWithCompression(handler)
+			}
+		case "LIST": // List all resources of a kind.
+			handler = metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulListResource(lister, watcher, reqScope, false, a.minRequestTimeout))
+			if a.enableAPIResponseCompression {
+				handler = genericfilters.RestfulWithCompression(handler)
+			}
+		case "PUT": // Update a resource.
+			handler = metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulUpdateResource(updater, reqScope, admit))
+		case "PATCH": // Partially update a resource
+			handler = metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulPatchResource(patcher, reqScope, admit, supportedTypes))
+		case "POST": // Create a resource.
+			var handler restful.RouteFunction
+			if isNamedCreater {
+				handler = restfulCreateNamedResource(namedCreater, reqScope, admit)
+			} else {
+				handler = restfulCreateResource(creater, reqScope, admit)
+			}
+			handler = metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, handler)
+		case "DELETE": // Delete a resource.
+			handler = metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulDeleteResource(gracefulDeleter, isGracefulDeleter, reqScope, admit))
+		case "DELETECOLLECTION":
+			handler = metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulDeleteCollection(collectionDeleter, isCollectionDeleter, reqScope, admit))
+		case "WATCH": // Watch a resource.
+			handler = metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulListResource(lister, watcher, reqScope, true, a.minRequestTimeout))
+		case "WATCHLIST": // Watch all resources of a kind.
+			handler = metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulListResource(lister, watcher, reqScope, true, a.minRequestTimeout))
+		case "CONNECT":
+			handler = metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulConnectResource(connecter, reqScope, admit, path, isSubresource))
+		}
+
+		actions[i].handler = handler
+	}
+
 	if err := registerActionsToWebService(actions, ws); err != nil {
 		return nil, err
 	}
@@ -595,21 +663,16 @@ func registerActionsToWebService(actions []action, ws *restful.WebService) error
 		if producedObject == nil {
 			producedObject = defaultVersionedObject
 		}
-		reqScope.Namer = action.Namer
 
-		requestScope := "cluster"
 		var namespaced string
 		var operationSuffix string
 		if apiResource.Namespaced {
-			requestScope = "namespace"
 			namespaced = "Namespaced"
 		}
 		if strings.HasSuffix(action.Path, "/{path:*}") {
-			requestScope = "resource"
 			operationSuffix = operationSuffix + "WithPath"
 		}
 		if action.AllNamespaces {
-			requestScope = "cluster"
 			operationSuffix = operationSuffix + "ForAllNamespaces"
 			namespaced = ""
 		}
@@ -638,32 +701,13 @@ func registerActionsToWebService(actions []action, ws *restful.WebService) error
 			kind = fqParentKind.Kind
 		}
 
-		verbOverrider, needOverride := storage.(StorageMetricsOverride)
-
 		switch action.Verb {
 		case "GET": // Get a resource.
-			var handler restful.RouteFunction
-			if isGetterWithOptions {
-				handler = restfulGetResourceWithOptions(getterWithOptions, reqScope, isSubresource)
-			} else {
-				handler = restfulGetResource(getter, exporter, reqScope)
-			}
-
-			if needOverride {
-				// need change the reported verb
-				handler = metrics.InstrumentRouteFunc(verbOverrider.OverrideMetricsVerb(action.Verb), group, version, resource, subresource, requestScope, metrics.APIServerComponent, handler)
-			} else {
-				handler = metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, handler)
-			}
-
-			if a.enableAPIResponseCompression {
-				handler = genericfilters.RestfulWithCompression(handler)
-			}
 			doc := "read the specified " + kind
 			if isSubresource {
 				doc = "read " + subresource + " of the specified " + kind
 			}
-			route := ws.GET(action.Path).To(handler).
+			route := ws.GET(action.Path).To(action.handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("read"+namespaced+kind+strings.Title(subresource)+operationSuffix).
@@ -687,11 +731,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService) error
 			if isSubresource {
 				doc = "list " + subresource + " of objects of kind " + kind
 			}
-			handler := metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulListResource(lister, watcher, reqScope, false, a.minRequestTimeout))
-			if a.enableAPIResponseCompression {
-				handler = genericfilters.RestfulWithCompression(handler)
-			}
-			route := ws.GET(action.Path).To(handler).
+			route := ws.GET(action.Path).To(action.handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("list"+namespaced+kind+strings.Title(subresource)+operationSuffix).
@@ -722,8 +762,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService) error
 			if isSubresource {
 				doc = "replace " + subresource + " of the specified " + kind
 			}
-			handler := metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulUpdateResource(updater, reqScope, admit))
-			route := ws.PUT(action.Path).To(handler).
+			route := ws.PUT(action.Path).To(action.handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("replace"+namespaced+kind+strings.Title(subresource)+operationSuffix).
@@ -752,8 +791,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService) error
 			if utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
 				supportedTypes = append(supportedTypes, string(types.ApplyPatchType))
 			}
-			handler := metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulPatchResource(patcher, reqScope, admit, supportedTypes))
-			route := ws.PATCH(action.Path).To(handler).
+			route := ws.PATCH(action.Path).To(action.handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Consumes(supportedTypes...).
@@ -768,19 +806,12 @@ func registerActionsToWebService(actions []action, ws *restful.WebService) error
 			addParams(route, action.Params)
 			routes = append(routes, route)
 		case "POST": // Create a resource.
-			var handler restful.RouteFunction
-			if isNamedCreater {
-				handler = restfulCreateNamedResource(namedCreater, reqScope, admit)
-			} else {
-				handler = restfulCreateResource(creater, reqScope, admit)
-			}
-			handler = metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, handler)
 			article := GetArticleForNoun(kind, " ")
 			doc := "create" + article + kind
 			if isSubresource {
 				doc = "create " + subresource + " of" + article + kind
 			}
-			route := ws.POST(action.Path).To(handler).
+			route := ws.POST(action.Path).To(action.handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("create"+namespaced+kind+strings.Title(subresource)+operationSuffix).
@@ -803,8 +834,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService) error
 			if isSubresource {
 				doc = "delete " + subresource + " of" + article + kind
 			}
-			handler := metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulDeleteResource(gracefulDeleter, isGracefulDeleter, reqScope, admit))
-			route := ws.DELETE(action.Path).To(handler).
+			route := ws.DELETE(action.Path).To(action.handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("delete"+namespaced+kind+strings.Title(subresource)+operationSuffix).
@@ -826,8 +856,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService) error
 			if isSubresource {
 				doc = "delete collection of " + subresource + " of a " + kind
 			}
-			handler := metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulDeleteCollection(collectionDeleter, isCollectionDeleter, reqScope, admit))
-			route := ws.DELETE(action.Path).To(handler).
+			route := ws.DELETE(action.Path).To(action.handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("deletecollection"+namespaced+kind+strings.Title(subresource)+operationSuffix).
@@ -846,8 +875,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService) error
 				doc = "watch changes to " + subresource + " of an object of kind " + kind
 			}
 			doc += ". deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter."
-			handler := metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulListResource(lister, watcher, reqScope, true, a.minRequestTimeout))
-			route := ws.GET(action.Path).To(handler).
+			route := ws.GET(action.Path).To(action.handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("watch"+namespaced+kind+strings.Title(subresource)+operationSuffix).
@@ -866,8 +894,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService) error
 				doc = "watch individual changes to a list of " + subresource + " of " + kind
 			}
 			doc += ". deprecated: use the 'watch' parameter with a list operation instead."
-			handler := metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulListResource(lister, watcher, reqScope, true, a.minRequestTimeout))
-			route := ws.GET(action.Path).To(handler).
+			route := ws.GET(action.Path).To(action.handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("watch"+namespaced+kind+strings.Title(subresource)+"List"+operationSuffix).
@@ -889,9 +916,8 @@ func registerActionsToWebService(actions []action, ws *restful.WebService) error
 				if isSubresource {
 					doc = "connect " + method + " requests to " + subresource + " of " + kind
 				}
-				handler := metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, restfulConnectResource(connecter, reqScope, admit, path, isSubresource))
 				route := ws.Method(method).Path(action.Path).
-					To(handler).
+					To(action.handler).
 					Doc(doc).
 					Operation("connect" + strings.Title(strings.ToLower(method)) + namespaced + kind + strings.Title(subresource) + operationSuffix).
 					Produces("*/*").

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -64,8 +64,9 @@ type action struct {
 	Namer         handlers.ScopeNamer
 	AllNamespaces bool // true iff the action is namespaced but works on aggregate result for all namespaces
 
-	handler        restful.RouteFunction
-	producedObject interface{}
+	handler           restful.RouteFunction
+	producedObject    interface{}
+	producedMIMETypes []string
 }
 
 // An interface to see if one storage supports override its default verb for monitoring
@@ -423,24 +424,24 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
 		// Add actions at the resource path: /api/apiVersion/resource
-		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil}, isLister)
-		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil}, isCreater)
-		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil}, isCollectionDeleter)
+		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil, nil}, isLister)
+		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil, nil}, isCreater)
+		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil, nil}, isCollectionDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil}, allowWatchList)
+		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil, nil}, allowWatchList)
 
 		// Add actions at the item path: /api/apiVersion/resource/{name}
-		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil}, isGetter)
+		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil, nil}, isGetter)
 		if getSubpath {
-			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil}, isGetter)
+			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil}, isGetter)
 		}
-		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil}, isUpdater)
-		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil}, isPatcher)
-		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil}, isGracefulDeleter)
+		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil, nil}, isUpdater)
+		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil, nil}, isPatcher)
+		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil, nil}, isGracefulDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil}, isWatcher)
-		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil}, isConnecter)
-		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil}, isConnecter && connectSubpath)
+		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil, nil}, isWatcher)
+		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil, nil}, isConnecter)
+		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil}, isConnecter && connectSubpath)
 	default:
 		namespaceParamName := "namespaces"
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
@@ -470,31 +471,31 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			SelfLinkPathSuffix: itemPathSuffix,
 		}
 
-		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil}, isLister)
-		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil}, isCreater)
-		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil}, isCollectionDeleter)
+		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil, nil}, isLister)
+		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil, nil}, isCreater)
+		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil, nil}, isCollectionDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil}, allowWatchList)
+		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil, nil}, allowWatchList)
 
-		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil}, isGetter)
+		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil, nil}, isGetter)
 		if getSubpath {
-			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil}, isGetter)
+			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil}, isGetter)
 		}
-		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil}, isUpdater)
-		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil}, isPatcher)
-		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil}, isGracefulDeleter)
+		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil, nil}, isUpdater)
+		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil, nil}, isPatcher)
+		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil, nil}, isGracefulDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil}, isWatcher)
-		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil}, isConnecter)
-		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil}, isConnecter && connectSubpath)
+		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil, nil}, isWatcher)
+		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil, nil}, isConnecter)
+		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil}, isConnecter && connectSubpath)
 
 		// list or post across namespace.
 		// For ex: LIST all pods in all namespaces by sending a LIST request at /api/apiVersion/pods.
 		// TODO: more strongly type whether a resource allows these actions on "all namespaces" (bulk delete)
 		if !isSubresource {
-			actions = appendIf(actions, action{"LIST", resource, params, namer, true, nil, nil}, isLister)
+			actions = appendIf(actions, action{"LIST", resource, params, namer, true, nil, nil, nil}, isLister)
 			// DEPRECATED in 1.11
-			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true, nil, nil}, allowWatchList)
+			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true, nil, nil, nil}, allowWatchList)
 		}
 	}
 
@@ -649,6 +650,22 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		actions[i].producedObject = producedObject
 	}
 
+	// assign producedMIMETypes for each action
+	for i, action := range actions {
+		var producedMIMETypes []string
+		producedMIMETypes = append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)
+		switch action.Verb {
+		case "LIST":
+			producedMIMETypes = append(storageMeta.ProducesMIMETypes(action.Verb), allMediaTypes...)
+		case "WATCH", "WATCHLIST":
+			producedMIMETypes = allMediaTypes
+		case "CONNECT":
+			producedMIMETypes = []string{"*/*"}
+		}
+
+		actions[i].producedMIMETypes = producedMIMETypes
+	}
+
 	// If there is a subresource, kind should be the parent's kind.
 	if isSubresource {
 		parentStorage, ok := a.group.Storage[resource]
@@ -726,7 +743,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("read"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
+				Produces(action.producedMIMETypes...).
 				Returns(http.StatusOK, "OK", action.producedObject).
 				Writes(action.producedObject)
 			if isGetterWithOptions {
@@ -750,7 +767,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("list"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), allMediaTypes...)...).
+				Produces(action.producedMIMETypes...).
 				Returns(http.StatusOK, "OK", action.producedObject).
 				Writes(action.producedObject)
 			if err := AddObjectParams(ws, route, versionedListOptions); err != nil {
@@ -781,7 +798,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("replace"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
+				Produces(action.producedMIMETypes...).
 				Returns(http.StatusOK, "OK", action.producedObject).
 				// TODO: in some cases, the API may return a v1.Status instead of the versioned object
 				// but currently go-restful can't handle multiple different objects being returned.
@@ -811,7 +828,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Consumes(supportedTypes...).
 				Operation("patch"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
+				Produces(action.producedMIMETypes...).
 				Returns(http.StatusOK, "OK", action.producedObject).
 				Reads(metav1.Patch{}).
 				Writes(action.producedObject)
@@ -830,7 +847,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("create"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
+				Produces(action.producedMIMETypes...).
 				Returns(http.StatusOK, "OK", action.producedObject).
 				// TODO: in some cases, the API may return a v1.Status instead of the versioned object
 				// but currently go-restful can't handle multiple different objects being returned.
@@ -853,7 +870,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("delete"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
+				Produces(action.producedMIMETypes...).
 				Writes(action.producedObject).
 				Returns(http.StatusOK, "OK", action.producedObject).
 				Returns(http.StatusAccepted, "Accepted", action.producedObject)
@@ -875,7 +892,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("deletecollection"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
+				Produces(action.producedMIMETypes...).
 				Writes(action.producedObject).
 				Returns(http.StatusOK, "OK", action.producedObject)
 			if err := AddObjectParams(ws, route, versionedListOptions); err != nil {
@@ -894,7 +911,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("watch"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(allMediaTypes...).
+				Produces(action.producedMIMETypes...).
 				Returns(http.StatusOK, "OK", action.producedObject).
 				Writes(action.producedObject)
 			if err := AddObjectParams(ws, route, versionedListOptions); err != nil {
@@ -913,7 +930,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("watch"+namespaced+kind+strings.Title(subresource)+"List"+operationSuffix).
-				Produces(allMediaTypes...).
+				Produces(action.producedMIMETypes...).
 				Returns(http.StatusOK, "OK", action.producedObject).
 				Writes(action.producedObject)
 			if err := AddObjectParams(ws, route, versionedListOptions); err != nil {
@@ -935,7 +952,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 					To(action.handler).
 					Doc(doc).
 					Operation("connect" + strings.Title(strings.ToLower(method)) + namespaced + kind + strings.Title(subresource) + operationSuffix).
-					Produces("*/*").
+					Produces(action.producedMIMETypes...).
 					Consumes("*/*").
 					Writes(connectProducedObject)
 				if versionedConnectOptions != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -859,21 +859,6 @@ func registerActionsToWebService(action action, ws *restful.WebService, isNamesp
 		}
 		method = "GET"
 		operation = "read"
-		route = ws.Method(method).Path(action.Path).To(action.handler).
-			Doc(doc).
-			Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-			Operation(operation+namespaced+kind+strings.Title(subresource)+operationSuffix).
-			Produces(action.producedMIMETypes...).
-			Returns(http.StatusOK, "OK", action.producedObject).
-			Writes(action.producedObject)
-		if action.readObject != nil {
-			route.Reads(action.readObject)
-		}
-		if action.consumedMIMETypes != nil {
-			route.Consumes(action.consumedMIMETypes...)
-		}
-		addParams(route, action.Params)
-		routes = append(routes, route)
 	case "LIST": // List all resources of a kind.
 		doc = "list objects of kind " + kind
 		if isSubresource {
@@ -883,33 +868,16 @@ func registerActionsToWebService(action action, ws *restful.WebService, isNamesp
 		operation = "list"
 		switch {
 		case isLister && isWatcher:
-			doc := "list or watch objects of kind " + kind
+			doc = "list or watch objects of kind " + kind
 			if isSubresource {
 				doc = "list or watch " + subresource + " of objects of kind " + kind
 			}
-			route.Doc(doc)
 		case isWatcher:
-			doc := "watch objects of kind " + kind
+			doc = "watch objects of kind " + kind
 			if isSubresource {
 				doc = "watch " + subresource + "of objects of kind " + kind
 			}
-			route.Doc(doc)
 		}
-		route = ws.Method(method).Path(action.Path).To(action.handler).
-			Doc(doc).
-			Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-			Operation(operation+namespaced+kind+strings.Title(subresource)+operationSuffix).
-			Produces(action.producedMIMETypes...).
-			Returns(http.StatusOK, "OK", action.producedObject).
-			Writes(action.producedObject)
-		if action.readObject != nil {
-			route.Reads(action.readObject)
-		}
-		if action.consumedMIMETypes != nil {
-			route.Consumes(action.consumedMIMETypes...)
-		}
-		addParams(route, action.Params)
-		routes = append(routes, route)
 	case "PUT": // Update a resource.
 		doc = "replace the specified " + kind
 		if isSubresource {
@@ -917,24 +885,6 @@ func registerActionsToWebService(action action, ws *restful.WebService, isNamesp
 		}
 		method = "PUT"
 		operation = "replace"
-		// // TODO: in some cases, the API may return a v1.Status instead of the versioned object
-		// // but currently go-restful can't handle multiple different objects being returned.
-		// Returns(http.StatusCreated, "Created", action.producedObject)
-		route = ws.Method(method).Path(action.Path).To(action.handler).
-			Doc(doc).
-			Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-			Operation(operation+namespaced+kind+strings.Title(subresource)+operationSuffix).
-			Produces(action.producedMIMETypes...).
-			Returns(http.StatusOK, "OK", action.producedObject).
-			Writes(action.producedObject)
-		if action.readObject != nil {
-			route.Reads(action.readObject)
-		}
-		if action.consumedMIMETypes != nil {
-			route.Consumes(action.consumedMIMETypes...)
-		}
-		addParams(route, action.Params)
-		routes = append(routes, route)
 	case "PATCH": // Partially update a resource
 		doc = "partially update the specified " + kind
 		if isSubresource {
@@ -942,21 +892,6 @@ func registerActionsToWebService(action action, ws *restful.WebService, isNamesp
 		}
 		method = "PATCH"
 		operation = "patch"
-		route = ws.Method(method).Path(action.Path).To(action.handler).
-			Doc(doc).
-			Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-			Operation(operation+namespaced+kind+strings.Title(subresource)+operationSuffix).
-			Produces(action.producedMIMETypes...).
-			Returns(http.StatusOK, "OK", action.producedObject).
-			Writes(action.producedObject)
-		if action.readObject != nil {
-			route.Reads(action.readObject)
-		}
-		if action.consumedMIMETypes != nil {
-			route.Consumes(action.consumedMIMETypes...)
-		}
-		addParams(route, action.Params)
-		routes = append(routes, route)
 	case "POST": // Create a resource.
 		article := GetArticleForNoun(kind, " ")
 		doc = "create" + article + kind
@@ -965,25 +900,6 @@ func registerActionsToWebService(action action, ws *restful.WebService, isNamesp
 		}
 		method = "POST"
 		operation = "create"
-		// // TODO: in some cases, the API may return a v1.Status instead of the versioned object
-		// // but currently go-restful can't handle multiple different objects being returned.
-		// Returns(http.StatusCreated, "Created", action.producedObject).
-		// Returns(http.StatusAccepted, "Accepted", action.producedObject).
-		route = ws.Method(method).Path(action.Path).To(action.handler).
-			Doc(doc).
-			Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-			Operation(operation+namespaced+kind+strings.Title(subresource)+operationSuffix).
-			Produces(action.producedMIMETypes...).
-			Returns(http.StatusOK, "OK", action.producedObject).
-			Writes(action.producedObject)
-		if action.readObject != nil {
-			route.Reads(action.readObject)
-		}
-		if action.consumedMIMETypes != nil {
-			route.Consumes(action.consumedMIMETypes...)
-		}
-		addParams(route, action.Params)
-		routes = append(routes, route)
 	case "DELETE": // Delete a resource.
 		article := GetArticleForNoun(kind, " ")
 		doc = "delete" + article + kind
@@ -992,26 +908,6 @@ func registerActionsToWebService(action action, ws *restful.WebService, isNamesp
 		}
 		method = "DELETE"
 		operation = "delete"
-		// Returns(http.StatusAccepted, "Accepted", action.producedObject)
-		route = ws.Method(method).Path(action.Path).To(action.handler).
-			Doc(doc).
-			Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-			Operation(operation+namespaced+kind+strings.Title(subresource)+operationSuffix).
-			Produces(action.producedMIMETypes...).
-			Returns(http.StatusOK, "OK", action.producedObject).
-			Writes(action.producedObject)
-		if action.readObject != nil {
-			route.Reads(action.readObject)
-		}
-		if action.consumedMIMETypes != nil {
-			route.Consumes(action.consumedMIMETypes...)
-		}
-		if isGracefulDeleter {
-			route.Reads(action.readObject)
-			route.ParameterNamed("body").Required(false)
-		}
-		addParams(route, action.Params)
-		routes = append(routes, route)
 	case "DELETECOLLECTION":
 		doc = "delete collection of " + kind
 		if isSubresource {
@@ -1019,21 +915,6 @@ func registerActionsToWebService(action action, ws *restful.WebService, isNamesp
 		}
 		method = "DELETE"
 		operation = "deletecollection"
-		route = ws.Method(method).Path(action.Path).To(action.handler).
-			Doc(doc).
-			Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-			Operation(operation+namespaced+kind+strings.Title(subresource)+operationSuffix).
-			Produces(action.producedMIMETypes...).
-			Returns(http.StatusOK, "OK", action.producedObject).
-			Writes(action.producedObject)
-		if action.readObject != nil {
-			route.Reads(action.readObject)
-		}
-		if action.consumedMIMETypes != nil {
-			route.Consumes(action.consumedMIMETypes...)
-		}
-		addParams(route, action.Params)
-		routes = append(routes, route)
 	// deprecated in 1.11
 	case "WATCH": // Watch a resource.
 		doc = "watch changes to an object of kind " + kind
@@ -1043,21 +924,6 @@ func registerActionsToWebService(action action, ws *restful.WebService, isNamesp
 		doc += ". deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter."
 		method = "GET"
 		operation = "watch"
-		route = ws.Method(method).Path(action.Path).To(action.handler).
-			Doc(doc).
-			Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-			Operation(operation+namespaced+kind+strings.Title(subresource)+operationSuffix).
-			Produces(action.producedMIMETypes...).
-			Returns(http.StatusOK, "OK", action.producedObject).
-			Writes(action.producedObject)
-		if action.readObject != nil {
-			route.Reads(action.readObject)
-		}
-		if action.consumedMIMETypes != nil {
-			route.Consumes(action.consumedMIMETypes...)
-		}
-		addParams(route, action.Params)
-		routes = append(routes, route)
 	// deprecated in 1.11
 	case "WATCHLIST": // Watch all resources of a kind.
 		doc = "watch individual changes to a list of " + kind
@@ -1067,24 +933,48 @@ func registerActionsToWebService(action action, ws *restful.WebService, isNamesp
 		doc += ". deprecated: use the 'watch' parameter with a list operation instead."
 		method = "GET"
 		operation = "watch"
-		route = ws.Method(method).Path(action.Path).To(action.handler).
-			Doc(doc).
-			Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
-			Operation(operation+namespaced+kind+strings.Title(subresource)+operationSuffix).
-			Produces(action.producedMIMETypes...).
-			Returns(http.StatusOK, "OK", action.producedObject).
-			Writes(action.producedObject)
-		if action.readObject != nil {
-			route.Reads(action.readObject)
-		}
-		if action.consumedMIMETypes != nil {
-			route.Consumes(action.consumedMIMETypes...)
-		}
-		addParams(route, action.Params)
-		routes = append(routes, route)
 	default:
 		return nil, fmt.Errorf("unrecognized action verb: %s", action.Verb)
 	}
+
+	route = ws.Method(method).Path(action.Path).To(action.handler).
+		Doc(doc).
+		Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
+		Operation(operation+namespaced+kind+strings.Title(subresource)+operationSuffix).
+		Produces(action.producedMIMETypes...).
+		Returns(http.StatusOK, "OK", action.producedObject).
+		Writes(action.producedObject)
+	if action.readObject != nil {
+		if action.Verb == "DELETE" {
+			if isGracefulDeleter {
+				route.Reads(action.readObject)
+				route.ParameterNamed("body").Required(false)
+			}
+		} else {
+			route.Reads(action.readObject)
+		}
+	}
+	if action.consumedMIMETypes != nil {
+		route.Consumes(action.consumedMIMETypes...)
+	}
+	addParams(route, action.Params)
+
+	// additional return codes for specific verbs
+	switch action.Verb {
+	case "PUT":
+		// TODO: in some cases, the API may return a v1.Status instead of the versioned object
+		// but currently go-restful can't handle multiple different objects being returned.
+		route.Returns(http.StatusCreated, "Created", action.producedObject)
+	case "POST":
+		// TODO: in some cases, the API may return a v1.Status instead of the versioned object
+		// but currently go-restful can't handle multiple different objects being returned.
+		route.Returns(http.StatusCreated, "Created", action.producedObject).
+			Returns(http.StatusAccepted, "Accepted", action.producedObject)
+	case "DELETE":
+		route.Returns(http.StatusAccepted, "Accepted", action.producedObject)
+	}
+
+	routes = append(routes, route)
 	return routes, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -64,7 +64,8 @@ type action struct {
 	Namer         handlers.ScopeNamer
 	AllNamespaces bool // true iff the action is namespaced but works on aggregate result for all namespaces
 
-	handler restful.RouteFunction
+	handler        restful.RouteFunction
+	producedObject interface{}
 }
 
 // An interface to see if one storage supports override its default verb for monitoring
@@ -422,24 +423,24 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
 		// Add actions at the resource path: /api/apiVersion/resource
-		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil}, isLister)
-		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil}, isCreater)
-		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil}, isCollectionDeleter)
+		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil}, isLister)
+		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil}, isCreater)
+		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil}, isCollectionDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil}, allowWatchList)
+		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil}, allowWatchList)
 
 		// Add actions at the item path: /api/apiVersion/resource/{name}
-		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil}, isGetter)
+		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil}, isGetter)
 		if getSubpath {
-			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil}, isGetter)
+			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil}, isGetter)
 		}
-		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil}, isUpdater)
-		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil}, isPatcher)
-		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil}, isGracefulDeleter)
+		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil}, isUpdater)
+		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil}, isPatcher)
+		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil}, isGracefulDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil}, isWatcher)
-		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil}, isConnecter)
-		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil}, isConnecter && connectSubpath)
+		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil}, isWatcher)
+		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil}, isConnecter)
+		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil}, isConnecter && connectSubpath)
 	default:
 		namespaceParamName := "namespaces"
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
@@ -469,31 +470,31 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			SelfLinkPathSuffix: itemPathSuffix,
 		}
 
-		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil}, isLister)
-		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil}, isCreater)
-		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil}, isCollectionDeleter)
+		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil}, isLister)
+		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil}, isCreater)
+		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil}, isCollectionDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil}, allowWatchList)
+		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil}, allowWatchList)
 
-		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil}, isGetter)
+		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil}, isGetter)
 		if getSubpath {
-			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil}, isGetter)
+			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil}, isGetter)
 		}
-		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil}, isUpdater)
-		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil}, isPatcher)
-		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil}, isGracefulDeleter)
+		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil}, isUpdater)
+		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil}, isPatcher)
+		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil}, isGracefulDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil}, isWatcher)
-		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil}, isConnecter)
-		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil}, isConnecter && connectSubpath)
+		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil}, isWatcher)
+		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil}, isConnecter)
+		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil}, isConnecter && connectSubpath)
 
 		// list or post across namespace.
 		// For ex: LIST all pods in all namespaces by sending a LIST request at /api/apiVersion/pods.
 		// TODO: more strongly type whether a resource allows these actions on "all namespaces" (bulk delete)
 		if !isSubresource {
-			actions = appendIf(actions, action{"LIST", resource, params, namer, true, nil}, isLister)
+			actions = appendIf(actions, action{"LIST", resource, params, namer, true, nil, nil}, isLister)
 			// DEPRECATED in 1.11
-			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true, nil}, allowWatchList)
+			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true, nil, nil}, allowWatchList)
 		}
 	}
 
@@ -630,6 +631,24 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		actions[i].handler = handler
 	}
 
+	// assign producedObject for each action
+	for i, action := range actions {
+		producedObject := storageMeta.ProducesObject(action.Verb)
+		if producedObject == nil {
+			producedObject = defaultVersionedObject
+		}
+		switch action.Verb {
+		case "LIST":
+			producedObject = versionedList
+		case "DELETE", "DELECTCOLLECTION":
+			producedObject = versionedStatus
+		case "WATCH", "WATCHLIST":
+			producedObject = versionedWatchEvent
+		}
+
+		actions[i].producedObject = producedObject
+	}
+
 	// If there is a subresource, kind should be the parent's kind.
 	if isSubresource {
 		parentStorage, ok := a.group.Storage[resource]
@@ -644,7 +663,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		kind = fqParentKind.Kind
 	}
 
-	kubeVerbs, err := registerActionsToWebService(actions, ws, apiResource.Namespaced, isSubresource, kind, subresource)
+	kubeVerbs, err := registerActionsToWebService(actions, ws, apiResource.Namespaced, isSubresource, kind, subresource, storageMeta)
 	if err != nil {
 		return nil, err
 	}
@@ -671,14 +690,9 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 	return &apiResource, nil
 }
 
-func registerActionsToWebService(actions []action, ws *restful.WebService, isNamespaced, isSubresource bool, kind, subresource string) (map[string]struct{}, error) {
+func registerActionsToWebService(actions []action, ws *restful.WebService, isNamespaced, isSubresource bool, kind, subresource string, storageMeta rest.StorageMetadata) (map[string]struct{}, error) {
 	kubeVerbs := map[string]struct{}{}
 	for _, action := range actions {
-		producedObject := storageMeta.ProducesObject(action.Verb)
-		if producedObject == nil {
-			producedObject = defaultVersionedObject
-		}
-
 		var namespaced string
 		var operationSuffix string
 		if isNamespaced {
@@ -713,8 +727,8 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("read"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
-				Returns(http.StatusOK, "OK", producedObject).
-				Writes(producedObject)
+				Returns(http.StatusOK, "OK", action.producedObject).
+				Writes(action.producedObject)
 			if isGetterWithOptions {
 				if err := AddObjectParams(ws, route, versionedGetOptions); err != nil {
 					return nil, err
@@ -737,8 +751,8 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("list"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), allMediaTypes...)...).
-				Returns(http.StatusOK, "OK", versionedList).
-				Writes(versionedList)
+				Returns(http.StatusOK, "OK", action.producedObject).
+				Writes(action.producedObject)
 			if err := AddObjectParams(ws, route, versionedListOptions); err != nil {
 				return nil, err
 			}
@@ -768,12 +782,12 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("replace"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
-				Returns(http.StatusOK, "OK", producedObject).
+				Returns(http.StatusOK, "OK", action.producedObject).
 				// TODO: in some cases, the API may return a v1.Status instead of the versioned object
 				// but currently go-restful can't handle multiple different objects being returned.
-				Returns(http.StatusCreated, "Created", producedObject).
+				Returns(http.StatusCreated, "Created", action.producedObject).
 				Reads(defaultVersionedObject).
-				Writes(producedObject)
+				Writes(action.producedObject)
 			if err := AddObjectParams(ws, route, versionedUpdateOptions); err != nil {
 				return nil, err
 			}
@@ -798,9 +812,9 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Consumes(supportedTypes...).
 				Operation("patch"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
-				Returns(http.StatusOK, "OK", producedObject).
+				Returns(http.StatusOK, "OK", action.producedObject).
 				Reads(metav1.Patch{}).
-				Writes(producedObject)
+				Writes(action.producedObject)
 			if err := AddObjectParams(ws, route, versionedPatchOptions); err != nil {
 				return nil, err
 			}
@@ -817,13 +831,13 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("create"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
-				Returns(http.StatusOK, "OK", producedObject).
+				Returns(http.StatusOK, "OK", action.producedObject).
 				// TODO: in some cases, the API may return a v1.Status instead of the versioned object
 				// but currently go-restful can't handle multiple different objects being returned.
-				Returns(http.StatusCreated, "Created", producedObject).
-				Returns(http.StatusAccepted, "Accepted", producedObject).
+				Returns(http.StatusCreated, "Created", action.producedObject).
+				Returns(http.StatusAccepted, "Accepted", action.producedObject).
 				Reads(defaultVersionedObject).
-				Writes(producedObject)
+				Writes(action.producedObject)
 			if err := AddObjectParams(ws, route, versionedCreateOptions); err != nil {
 				return nil, err
 			}
@@ -840,9 +854,9 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("delete"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
-				Writes(versionedStatus).
-				Returns(http.StatusOK, "OK", versionedStatus).
-				Returns(http.StatusAccepted, "Accepted", versionedStatus)
+				Writes(action.producedObject).
+				Returns(http.StatusOK, "OK", action.producedObject).
+				Returns(http.StatusAccepted, "Accepted", action.producedObject)
 			if isGracefulDeleter {
 				route.Reads(versionedDeleterObject)
 				route.ParameterNamed("body").Required(false)
@@ -862,8 +876,8 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("deletecollection"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
-				Writes(versionedStatus).
-				Returns(http.StatusOK, "OK", versionedStatus)
+				Writes(action.producedObject).
+				Returns(http.StatusOK, "OK", action.producedObject)
 			if err := AddObjectParams(ws, route, versionedListOptions); err != nil {
 				return nil, err
 			}
@@ -881,8 +895,8 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("watch"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(allMediaTypes...).
-				Returns(http.StatusOK, "OK", versionedWatchEvent).
-				Writes(versionedWatchEvent)
+				Returns(http.StatusOK, "OK", action.producedObject).
+				Writes(action.producedObject)
 			if err := AddObjectParams(ws, route, versionedListOptions); err != nil {
 				return nil, err
 			}
@@ -900,8 +914,8 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("watch"+namespaced+kind+strings.Title(subresource)+"List"+operationSuffix).
 				Produces(allMediaTypes...).
-				Returns(http.StatusOK, "OK", versionedWatchEvent).
-				Writes(versionedWatchEvent)
+				Returns(http.StatusOK, "OK", action.producedObject).
+				Writes(action.producedObject)
 			if err := AddObjectParams(ws, route, versionedListOptions); err != nil {
 				return nil, err
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -266,7 +266,6 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 	watcher, isWatcher := storage.(rest.Watcher)
 	connecter, isConnecter := storage.(rest.Connecter)
 	storageMeta, isMetadata := storage.(rest.StorageMetadata)
-	storageVersionProvider, isStorageVersionProvider := storage.(rest.StorageVersionProvider)
 	if !isMetadata {
 		storageMeta = defaultStorageMetadata{}
 	}
@@ -703,10 +702,15 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		// Note: update GetAuthorizerAttributes() when adding a custom handler.
 	}
 
+	return a.constructAPIResource(storage, kubeVerbs, namespaceScoped, path, resourceKind)
+}
+
+func (a *APIInstaller) constructAPIResource(storage rest.Storage, kubeVerbs map[string]struct{}, namespaceScoped bool, path, resourceKind string) (*metav1.APIResource, error) {
 	var apiResource metav1.APIResource
 	apiResource.Name = path
 	apiResource.Namespaced = namespaceScoped
 	apiResource.Kind = resourceKind
+	storageVersionProvider, isStorageVersionProvider := storage.(rest.StorageVersionProvider)
 	if utilfeature.DefaultFeatureGate.Enabled(features.StorageVersionHash) &&
 		isStorageVersionProvider &&
 		storageVersionProvider.StorageVersion() != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -65,6 +65,7 @@ type action struct {
 	AllNamespaces bool // true iff the action is namespaced but works on aggregate result for all namespaces
 
 	handler           restful.RouteFunction
+	readObject        interface{}
 	producedObject    interface{}
 	producedMIMETypes []string
 }
@@ -424,24 +425,24 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
 		// Add actions at the resource path: /api/apiVersion/resource
-		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil, nil}, isLister)
-		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil, nil}, isCreater)
-		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil, nil}, isCollectionDeleter)
+		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, isLister)
+		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, isCreater)
+		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, isCollectionDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil, nil}, allowWatchList)
+		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, allowWatchList)
 
 		// Add actions at the item path: /api/apiVersion/resource/{name}
-		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil, nil}, isGetter)
+		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isGetter)
 		if getSubpath {
-			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil}, isGetter)
+			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil, nil}, isGetter)
 		}
-		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil, nil}, isUpdater)
-		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil, nil}, isPatcher)
-		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil, nil}, isGracefulDeleter)
+		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isUpdater)
+		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isPatcher)
+		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isGracefulDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil, nil}, isWatcher)
-		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil, nil}, isConnecter)
-		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil}, isConnecter && connectSubpath)
+		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil, nil, nil}, isWatcher)
+		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isConnecter)
+		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil, nil}, isConnecter && connectSubpath)
 	default:
 		namespaceParamName := "namespaces"
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
@@ -471,31 +472,31 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			SelfLinkPathSuffix: itemPathSuffix,
 		}
 
-		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil, nil}, isLister)
-		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil, nil}, isCreater)
-		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil, nil}, isCollectionDeleter)
+		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, isLister)
+		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, isCreater)
+		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, isCollectionDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil, nil}, allowWatchList)
+		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false, nil, nil, nil, nil}, allowWatchList)
 
-		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil, nil}, isGetter)
+		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isGetter)
 		if getSubpath {
-			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil}, isGetter)
+			actions = appendIf(actions, action{"GET", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil, nil}, isGetter)
 		}
-		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil, nil}, isUpdater)
-		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil, nil}, isPatcher)
-		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil, nil}, isGracefulDeleter)
+		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isUpdater)
+		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isPatcher)
+		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isGracefulDeleter)
 		// DEPRECATED in 1.11
-		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil, nil}, isWatcher)
-		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil, nil}, isConnecter)
-		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil}, isConnecter && connectSubpath)
+		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false, nil, nil, nil, nil}, isWatcher)
+		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false, nil, nil, nil, nil}, isConnecter)
+		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false, nil, nil, nil, nil}, isConnecter && connectSubpath)
 
 		// list or post across namespace.
 		// For ex: LIST all pods in all namespaces by sending a LIST request at /api/apiVersion/pods.
 		// TODO: more strongly type whether a resource allows these actions on "all namespaces" (bulk delete)
 		if !isSubresource {
-			actions = appendIf(actions, action{"LIST", resource, params, namer, true, nil, nil, nil}, isLister)
+			actions = appendIf(actions, action{"LIST", resource, params, namer, true, nil, nil, nil, nil}, isLister)
 			// DEPRECATED in 1.11
-			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true, nil, nil, nil}, allowWatchList)
+			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true, nil, nil, nil, nil}, allowWatchList)
 		}
 	}
 
@@ -630,6 +631,18 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		}
 
 		actions[i].handler = handler
+	}
+
+	// assign readObject for each action
+	for i, action := range actions {
+		switch action.Verb {
+		case "PUT", "POST":
+			actions[i].readObject = defaultVersionedObject
+		case "DELETE":
+			actions[i].readObject = versionedDeleterObject
+		case "PATCH":
+			actions[i].readObject = metav1.Patch{}
+		}
 	}
 
 	// assign producedObject for each action
@@ -851,7 +864,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				// TODO: in some cases, the API may return a v1.Status instead of the versioned object
 				// but currently go-restful can't handle multiple different objects being returned.
 				Returns(http.StatusCreated, "Created", action.producedObject).
-				Reads(defaultVersionedObject).
+				Reads(action.readObject).
 				Writes(action.producedObject)
 			addParams(route, action.Params)
 			routes = append(routes, route)
@@ -875,7 +888,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Operation("patch"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(action.producedMIMETypes...).
 				Returns(http.StatusOK, "OK", action.producedObject).
-				Reads(metav1.Patch{}).
+				Reads(action.readObject).
 				Writes(action.producedObject)
 			addParams(route, action.Params)
 			routes = append(routes, route)
@@ -895,7 +908,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				// but currently go-restful can't handle multiple different objects being returned.
 				Returns(http.StatusCreated, "Created", action.producedObject).
 				Returns(http.StatusAccepted, "Accepted", action.producedObject).
-				Reads(defaultVersionedObject).
+				Reads(action.readObject).
 				Writes(action.producedObject)
 			addParams(route, action.Params)
 			routes = append(routes, route)
@@ -914,7 +927,7 @@ func registerActionsToWebService(actions []action, ws *restful.WebService, isNam
 				Returns(http.StatusOK, "OK", action.producedObject).
 				Returns(http.StatusAccepted, "Accepted", action.producedObject)
 			if isGracefulDeleter {
-				route.Reads(versionedDeleterObject)
+				route.Reads(action.readObject)
 				route.ParameterNamed("body").Required(false)
 			}
 			addParams(route, action.Params)


### PR DESCRIPTION
/kind cleanup

Split [`func (a *APIInstaller) registerResourceHandlers`](https://github.com/kubernetes/kubernetes/blob/7dfcacd1cfcbdfe74b28f2473fb107e9a47ec905/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go#L183-L922) into smaller pieces so the code can be shared with apiextensions-apiserver. 

Prerequisite for unifying openapi path generation between [CRD](https://github.com/kubernetes/kubernetes/blob/7dfcacd1cfcbdfe74b28f2473fb107e9a47ec905/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder.go#L72-L75) and native resources. ref https://github.com/kubernetes/kubernetes/issues/74976

**TODO:**
- [x] switch CRD to use the same code as native resources
- [ ] ~_use the existing CRD [templating](https://github.com/kubernetes/kubernetes/blob/7dfcacd1cfcbdfe74b28f2473fb107e9a47ec905/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder.go#L228) to test the switch?_~
- [ ] better documentation and names

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
