### PR TITLE
log preshutdowndown registration error if we encounter one

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -258,10 +258,13 @@ func (s *GenericAPIServer) PrepareRun() preparedGenericAPIServer {
 
 	// Register audit backend preShutdownHook.
 	if s.AuditBackend != nil {
-		s.AddPreShutdownHook("audit-backend", func() error {
+		err := s.AddPreShutdownHook("audit-backend", func() error {
 			s.AuditBackend.Shutdown()
 			return nil
 		})
+		if err != nil {
+			klog.Errorf("Failed to add pre-shutdown hook for audit-backend %s", err)
+		}
 	}
 
 	return preparedGenericAPIServer{s}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently we are silently ignoring an error encountered during audit-backend preshutdown hook registration. Let's log it out if this happens instead. 

```release-note
NONE
```
