### PR TITLE
clean up func podTimestamp in queue

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -247,19 +247,6 @@ type PriorityQueue struct {
 // Making sure that PriorityQueue implements SchedulingQueue.
 var _ = SchedulingQueue(&PriorityQueue{})
 
-// podTimeStamp returns pod's last schedule time or its creation time if the
-// scheduler has never tried scheduling it.
-func podTimestamp(pod *v1.Pod) *metav1.Time {
-	_, condition := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
-	if condition == nil {
-		return &pod.CreationTimestamp
-	}
-	if condition.LastProbeTime.IsZero() {
-		return &condition.LastTransitionTime
-	}
-	return &condition.LastProbeTime
-}
-
 // podInfo is minimum cell in the scheduling queue.
 type podInfo struct {
 	pod *v1.Pod


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig scheduling

**What this PR does / why we need it**:
After PR #73700 is merged, we use the podInfo.timestamp as the time pod added to the scheduling queue. And The func `podTimestamp` isn't used anymore, so remove it to make code clean.

```release-note
NONE
```
