### PR TITLE
Add [LinuxOnly] tag to few e2e verifying dns resolution

### DIFF
--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -69,7 +69,8 @@ var _ = SIGDescribe("DNS", func() {
 		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
-	ginkgo.It("should resolve DNS of partial qualified names for the cluster ", func() {
+	// [LinuxOnly]: As Windows currently does not support resolving PQDNs.
+	ginkgo.It("should resolve DNS of partial qualified names for the cluster [LinuxOnly]", func() {
 		// All the names we need to be able to resolve.
 		// TODO: Spin up a separate test service and test that dns works for that service.
 		namesToResolve := []string{
@@ -171,7 +172,8 @@ var _ = SIGDescribe("DNS", func() {
 		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
-	ginkgo.It("should resolve DNS of partial qualified names for services ", func() {
+	// [LinuxOnly]: As Windows currently does not support resolving PQDNs.
+	ginkgo.It("should resolve DNS of partial qualified names for services [LinuxOnly]", func() {
 		// Create a test headless service.
 		ginkgo.By("Creating a test headless service")
 		testServiceSelector := map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Adds [LinuxOnly] tag to following e2e.

- `should resolve DNS of partial qualified names for the cluster [LinuxOnly]`
    as per https://github.com/kubernetes/kubernetes/pull/74977#issuecomment-471567855
- `should resolve DNS of partial qualified names for services [LinuxOnly]`
    as per https://github.com/kubernetes/kubernetes/pull/74977#issuecomment-471567855 && https://github.com/kubernetes/kubernetes/pull/74980#discussion_r269315179
-  ~~`should provide DNS for pods for Hostname and Subdomain [LinuxOnly]`~~
    as per https://github.com/kubernetes/kubernetes/pull/74977#issuecomment-471567855 && https://github.com/kubernetes/kubernetes/pull/75591#issuecomment-476854539
-  ~~`should support configurable pod resolv.conf [LinuxOnly]`~~
    as per https://github.com/kubernetes/kubernetes/pull/74985#discussion_r267970243 && https://github.com/kubernetes/kubernetes/pull/74985#discussion_r267981453

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
/area conformance
/sig testing
@kubernetes/sig-network-pr-reviews
/assign @johnbelamaric 