### PR TITLE
Fix a test build failed error

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
@@ -80,7 +80,7 @@ var (
 func GetItemsPtr(list runtime.Object) (interface{}, error) {
 	obj, err := getItemsPtr(list)
 	if err != nil {
-		return nil, fmt.Errorf("%T is not a list: %v", err)
+		return nil, fmt.Errorf("%T is not a list: %v", list, err)
 	}
 	return obj, nil
 }


### PR DESCRIPTION
 /kind bug


**What this PR does / why we need it**:
Execute 
`make test WHAT=./vendor/k8s.io/apimachinery/pkg/api/meta`
It failed with
`vendor/k8s.io/apimachinery/pkg/api/meta/help.go:83:15: Errorf format %v reads arg #2, but call has 1 arg`

This patch fix it


```release-note
NONE
```
