### PR TITLE
Automated cherry pick of #75659: Bump go-openapi/jsonpointer and go-openapi/jsonreference

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1602,12 +1602,12 @@
 		},
 		{
 			"ImportPath": "github.com/go-openapi/jsonpointer",
-			"Comment": "v0.18.0",
+			"Comment": "v0.19.0",
 			"Rev": "ef5f0afec364d3b9396b7b77b43dbe26bf1f8004"
 		},
 		{
 			"ImportPath": "github.com/go-openapi/jsonreference",
-			"Comment": "v0.18.0",
+			"Comment": "v0.19.0",
 			"Rev": "8483a886a90412cd6858df4ea3483dce9c8e35a3"
 		},
 		{


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/issues/75653

Cherry pick of #75659 on release-1.13.

#75659: Bump go-openapi/jsonpointer and go-openapi/jsonreference