### PR TITLE
kube-aggregator: bump openapi aggregation log level for delegation targets

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
@@ -99,7 +99,13 @@ func (c *AggregationController) processNextWorkItem() bool {
 		return false
 	}
 
-	klog.Infof("OpenAPI AggregationController: Processing item %s", key)
+	if aggregator.IsLocalAPIService(key.(string)) {
+		// for local delegation targets that are aggregated once per second, log at
+		// higher level to avoid flooding the log
+		klog.V(5).Infof("OpenAPI AggregationController: Processing item %s", key)
+	} else {
+		klog.Infof("OpenAPI AggregationController: Processing item %s", key)
+	}
 
 	action, err := c.syncHandler(key.(string))
 	if err == nil {


### PR DESCRIPTION
fixes #75777

in 1.14 we increased the frequency of [resyncing local openapi specs](https://github.com/kubernetes/kubernetes/pull/71192/commits/3079798d030a13d292bf3f87727ac6ed6ddfccf6) to once per second. However the controller logs every item unbiasedly without verbose level set. As a result many local openapi aggregation logs are generated during normal operation. 

This PR bumps the verbose level if the item is a local spec.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Increased verbose level for local openapi aggregation logs to avoid flooding the log during normal operation
```

we'll need to cherry-pick the fix for 1.14.1