### PR TITLE
add annotation from namespace controller to indicate why deletion failed

### DIFF
--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/klog"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -134,6 +134,9 @@ func (d *namespacedResourcesDeleter) Delete(nsName string) error {
 
 	// there may still be content for us to remove
 	estimate, err := d.deleteAllContent(namespace.Name, *namespace.DeletionTimestamp)
+	// we don't care about errors on reporting the status message update
+	// we unconditionally set this value to ensure that we clear it when deletion is complete
+	_, _ = d.retryOnConflictError(namespace, d.updateSetDeletionFailureFunc(err))
 	if err != nil {
 		return err
 	}
@@ -293,6 +296,20 @@ func (d *namespacedResourcesDeleter) updateNamespaceStatusFunc(namespace *v1.Nam
 	newNamespace.Status = namespace.Status
 	newNamespace.Status.Phase = v1.NamespaceTerminating
 	return d.nsClient.UpdateStatus(&newNamespace)
+}
+
+// updateSetDeletionFailureFunc will set an annotation indicating that the namespace controller has failed to delete all content
+func (d *namespacedResourcesDeleter) updateSetDeletionFailureFunc(err error) func(namespace *v1.Namespace) (*v1.Namespace, error) {
+	errorAnnotationName := "namespace-controller.kube-controller-manager.kubernetes.io/deletion-error"
+	return func(namespace *v1.Namespace) (*v1.Namespace, error) {
+		newNamespace := namespace.DeepCopy()
+		if err == nil || len(err.Error()) == 0 {
+			delete(newNamespace.Annotations, errorAnnotationName)
+		} else {
+			newNamespace.Annotations[errorAnnotationName] = err.Error()
+		}
+		return d.nsClient.Update(newNamespace)
+	}
 }
 
 // finalized returns true if the namespace.Spec.Finalizers is an empty list


### PR DESCRIPTION
Today, when a namespace cannot be finalized you have to dig into the kube-controller-manager logs.  This exposes the error as an annotation on the namespace.  You cannot send an event to a namespace that is finalizing.

@kubernetes/sig-api-machinery-bugs 
/kind bug
/priority important-soon

```release-note
NONE
```