### PR TITLE
Fix golint failures of e2e/framework/v*.go

### DIFF
--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -160,7 +160,7 @@ func (t *volumesTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		// local), plugin skips setting fsGroup if volume is already mounted
 		// and we don't have reliable way to detect volumes are unmounted or
 		// not before starting the second pod.
-		framework.InjectHtml(f.ClientSet, config, fsGroup, tests[0].Volume, tests[0].ExpectedContent)
+		framework.InjectHTML(f.ClientSet, config, fsGroup, tests[0].Volume, tests[0].ExpectedContent)
 		framework.TestVolumeClient(f.ClientSet, config, fsGroup, pattern.FsType, tests)
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This fixes golint failures of the following file:
- test/e2e/framework/volume_util.go

This changes following file also, because of changing function name in above file.
- test/e2e/storage/testsuites/volumes.go

Ref: #68026

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```
