### PR TITLE
return empty devicepath for csi attach

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -29,7 +29,7 @@ import (
 
 	"k8s.io/klog"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,8 +108,8 @@ func (c *csiAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string
 
 	klog.V(4).Info(log("attacher.Attach finished OK with VolumeAttachment object [%s]", attachID))
 
-	// TODO(71164): In 1.15, return empty devicePath
-	return attachID, nil
+	// Don't return attachID as a devicePath. We can reconstruct the attachID using getAttachmentName()
+	return "", nil
 }
 
 func (c *csiAttacher) WaitForAttach(spec *volume.Spec, _ string, pod *v1.Pod, timeout time.Duration) (string, error) {

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -198,7 +198,7 @@ func TestAttacherAttach(t *testing.T) {
 
 		csiAttacher := attacher.(*csiAttacher)
 
-		go func(spec *volume.Spec, id, nodename string, fail bool) {
+		go func(spec *volume.Spec, nodename string, fail bool) {
 			attachID, err := csiAttacher.Attach(spec, types.NodeName(nodename))
 			if !fail && err != nil {
 				t.Errorf("expecting no failure, but got err: %v", err)
@@ -206,10 +206,10 @@ func TestAttacherAttach(t *testing.T) {
 			if fail && err == nil {
 				t.Errorf("expecting failure, but got no err")
 			}
-			if attachID != id && !fail {
-				t.Errorf("expecting attachID %v, got %v", id, attachID)
+			if attachID != "" {
+				t.Errorf("expecting empty attachID, got %v", attachID)
 			}
-		}(tc.spec, tc.attachID, tc.nodeName, tc.shouldFail)
+		}(tc.spec, tc.nodeName, tc.shouldFail)
 
 		var status storage.VolumeAttachmentStatus
 		if tc.injectAttacherError {
@@ -277,15 +277,15 @@ func TestAttacherAttachWithInline(t *testing.T) {
 		}
 		csiAttacher := attacher.(*csiAttacher)
 
-		go func(spec *volume.Spec, id, nodename string, fail bool) {
+		go func(spec *volume.Spec, nodename string, fail bool) {
 			attachID, err := csiAttacher.Attach(spec, types.NodeName(nodename))
 			if fail != (err != nil) {
 				t.Errorf("expecting no failure, but got err: %v", err)
 			}
-			if attachID != id && !fail {
-				t.Errorf("expecting attachID %v, got %v", id, attachID)
+			if attachID != "" {
+				t.Errorf("expecting empty attachID, got %v", attachID)
 			}
-		}(tc.spec, tc.attachID, tc.nodeName, tc.shouldFail)
+		}(tc.spec, tc.nodeName, tc.shouldFail)
 
 		var status storage.VolumeAttachmentStatus
 		if tc.injectAttacherError {
@@ -362,10 +362,7 @@ func TestAttacherWithCSIDriver(t *testing.T) {
 				if err != nil {
 					t.Errorf("Attach() failed: %s", err)
 				}
-				if expectAttach && attachID == "" {
-					t.Errorf("Expected attachID, got nothing")
-				}
-				if !expectAttach && attachID != "" {
+				if attachID != "" {
 					t.Errorf("Expected empty attachID, got %q", attachID)
 				}
 			}(spec, test.expectVolumeAttachment)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In 1.13, csi node plugin stopped using the devicePath passed between AD controller and kubelet.  Now it is safe to remove returning the devicePath from AD controller.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #71164

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ACTION REQUIRED: The Node.Status.Volumes.Attached.DevicePath field is now unset for CSI volumes. Update any external controllers that depend on this field.
```
