### PR TITLE
Make(--watch-cache-sizes) of kube-apiserver to set cache for CRD

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
@@ -67,6 +67,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
@@ -116,6 +116,7 @@ func NewCRDRESTOptionsGetter(etcdOptions genericoptions.EtcdOptions) genericregi
 		StoragePrefix:           etcdOptions.StorageConfig.Prefix,
 		EnableWatchCache:        etcdOptions.EnableWatchCache,
 		DefaultWatchCacheSize:   etcdOptions.DefaultWatchCacheSize,
+		WatchCacheSizes:         etcdOptions.WatchCacheSizes,
 		EnableGarbageCollection: etcdOptions.EnableGarbageCollection,
 		DeleteCollectionWorkers: etcdOptions.DeleteCollectionWorkers,
 		CountMetricPollPeriod:   etcdOptions.StorageConfig.CountMetricPollPeriod,


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
We was trying to set up watch cache size for some specific customer resource. However we found parameter --watch-cache-sizes is not honored for customer resource during storage initialization. 

**Which issue(s) this PR fixes**:
Fixes #75677

**Special notes for your reviewer**:
/assign @jpbetz 

**Does this PR introduce a user-facing change?**:
```release-note
Fix watch cache size settings for custom resource using the flag `--watch-cache-sizes` on kube-apiserver.
```