### PR TITLE
Fixes #75706 - Show warning message when namespace is specified for deleting a cluster-scoped resource

### DIFF
--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -1326,6 +1326,12 @@ run_namespace_tests() {
   output_message=$(! kubectl get ns/my-namespace 2>&1 "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" ' not found'
 
+  kubectl create namespace my-namespace
+  kube::test::get_object_assert 'namespaces/my-namespace' "{{$id_field}}" 'my-namespace'
+  output_message=$(! kubectl delete namespace -n my-namespace --all 2>&1 "${kube_flags[@]}")
+  kube::test::if_has_string "${output_message}" 'warning: deleting cluster-scoped resources'
+  kube::test::if_has_string "${output_message}" 'namespace "my-namespace" deleted'
+
   ######################
   # Pods in Namespaces #
   ######################

--- a/test/cmd/rbac.sh
+++ b/test/cmd/rbac.sh
@@ -32,6 +32,12 @@ run_clusterroles_tests() {
   # test `kubectl create clusterrole`
   kubectl create "${kube_flags[@]}" clusterrole pod-admin --verb=* --resource=pods
   kube::test::get_object_assert clusterrole/pod-admin "{{range.rules}}{{range.verbs}}{{.}}:{{end}}{{end}}" '\*:'
+  output_message=$(kubectl delete clusterrole pod-admin -n test 2>&1 "${kube_flags[@]}")
+  kube::test::if_has_string "${output_message}" 'warning: deleting cluster-scoped resources'
+  kube::test::if_has_string "${output_message}" 'clusterrole.rbac.authorization.k8s.io "pod-admin" deleted'
+
+  kubectl create "${kube_flags[@]}" clusterrole pod-admin --verb=* --resource=pods
+  kube::test::get_object_assert clusterrole/pod-admin "{{range.rules}}{{range.verbs}}{{.}}:{{end}}{{end}}" '\*:'
   kube::test::get_object_assert clusterrole/pod-admin "{{range.rules}}{{range.resources}}{{.}}:{{end}}{{end}}" 'pods:'
   kube::test::get_object_assert clusterrole/pod-admin "{{range.rules}}{{range.apiGroups}}{{.}}:{{end}}{{end}}" ':'
   kubectl create "${kube_flags[@]}" clusterrole resource-reader --verb=get,list --resource=pods,deployments.apps

--- a/test/cmd/storage.sh
+++ b/test/cmd/storage.sh
@@ -41,6 +41,13 @@ run_persistent_volumes_tests() {
   # Post-condition: no PVs
   kube::test::get_object_assert pv "{{range.items}}{{$id_field}}:{{end}}" ''
 
+  kubectl create -f test/fixtures/doc-yaml/user-guide/persistent-volumes/volumes/local-01.yaml "${kube_flags[@]}"
+  kube::test::get_object_assert pv "{{range.items}}{{$id_field}}:{{end}}" 'pv0001:'
+  output_message=$(kubectl delete pv -n test --all 2>&1 "${kube_flags[@]}")
+  kube::test::if_has_string "${output_message}" 'warning: deleting cluster-scoped resources'
+  kube::test::if_has_string "${output_message}" 'persistentvolume "pv0001" deleted'
+  kube::test::get_object_assert pv "{{range.items}}{{$id_field}}:{{end}}" ''
+
   set +o nounset
   set +o errexit
 }


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature


**What this PR does / why we need it**:

Show warning message when namespace is specified for deleting a cluster-scoped resource


**Which issue(s) this PR fixes**:

Fixes # 75706

**Special notes for your reviewer**:
/assign @liggitt 
/assign @yue9944882

**Does this PR introduce a user-facing change?**:

   no

```release-note
NONE
```
