### PR TITLE
Support mixed protocol LBs

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3834,7 +3834,7 @@ func ValidateService(service *core.Service) field.ErrorList {
 				includeProtocols.Insert(string(service.Spec.Ports[i].Protocol))
 			}
 		}
-		if includeProtocols.Len() > 1 {
+		if !utilfeature.DefaultFeatureGate.Enabled(features.ServiceLoadBalancerMixedProtocol) && includeProtocols.Len() > 1 {
 			allErrs = append(allErrs, field.Invalid(portsPath, service.Spec.Ports, "cannot create an external load balancer with mix protocols"))
 		}
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -423,6 +423,12 @@ const (
 	// Enables Finalizer Protection for Service LoadBalancers.
 	ServiceLoadBalancerFinalizer featuregate.Feature = "ServiceLoadBalancerFinalizer"
 
+	// owner: @kiall
+	// alpha: v1.15
+	//
+	// Enables mixed protocol LoadBalancers (e.g. UDP and TCP combined)
+	ServiceLoadBalancerMixedProtocol featuregate.Feature = "ServiceLoadBalancerMixedProtocol"
+
 	// owner: @RobertKrawitz
 	// alpha: v1.15
 	//
@@ -518,6 +524,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	KubeletPodResources:                         {Default: true, PreRelease: featuregate.Beta},
 	WindowsGMSA:                                 {Default: false, PreRelease: featuregate.Alpha},
 	ServiceLoadBalancerFinalizer:                {Default: false, PreRelease: featuregate.Alpha},
+	ServiceLoadBalancerMixedProtocol:            {Default: false, PreRelease: featuregate.Alpha},
 	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Alpha},
 	NonPreemptingPriority:                          {Default: false, PreRelease: featuregate.Alpha},
 	VolumePVCDataSource:                            {Default: false, PreRelease: featuregate.Alpha},

--- a/staging/src/k8s.io/cloud-provider/service/helpers/BUILD
+++ b/staging/src/k8s.io/cloud-provider/service/helpers/BUILD
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/cloud-provider/service/helpers/helper.go
+++ b/staging/src/k8s.io/cloud-provider/service/helpers/helper.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -114,4 +115,13 @@ func HasLBFinalizer(service *v1.Service) bool {
 		}
 	}
 	return false
+}
+
+// HasMixedProtocols checks if a service has more than one protocol in use
+func HasMixedProtocols(service *v1.Service) bool {
+	includeProtocols := sets.NewString()
+	for i := range service.Spec.Ports {
+		includeProtocols.Insert(string(service.Spec.Ports[i].Protocol))
+	}
+	return includeProtocols.Len() > 1
 }

--- a/staging/src/k8s.io/cloud-provider/service/helpers/helper_test.go
+++ b/staging/src/k8s.io/cloud-provider/service/helpers/helper_test.go
@@ -269,3 +269,68 @@ func TestHasLBFinalizer(t *testing.T) {
 		})
 	}
 }
+
+func TestHasMixedProtocols(t *testing.T) {
+	checkHasMixedProtocols := func(hasMixedProtocols bool, service *v1.Service) {
+		res := HasMixedProtocols(service)
+		if res != hasMixedProtocols {
+			t.Errorf("Expected has mixed protocols = %v, got %v",
+				hasMixedProtocols, res)
+		}
+	}
+
+	checkHasMixedProtocols(false, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolTCP,
+				},
+			},
+		},
+	})
+	checkHasMixedProtocols(false, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolUDP,
+				},
+			},
+		},
+	})
+	checkHasMixedProtocols(false, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolTCP,
+				},
+				{
+					Protocol: v1.ProtocolTCP,
+				},
+			},
+		},
+	})
+	checkHasMixedProtocols(false, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolUDP,
+				},
+				{
+					Protocol: v1.ProtocolUDP,
+				},
+			},
+		},
+	})
+	checkHasMixedProtocols(true, &v1.Service{
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolTCP,
+				},
+				{
+					Protocol: v1.ProtocolUDP,
+				},
+			},
+		},
+	})
+}

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	cloudprovider "k8s.io/cloud-provider"
+	servicehelpers "k8s.io/cloud-provider/service/helpers"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -115,6 +116,10 @@ func (g *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, svc 
 	}
 
 	klog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v): ensure %v loadbalancer", clusterName, svc.Namespace, svc.Name, loadBalancerName, g.region, desiredScheme)
+
+	if servicehelpers.HasMixedProtocols(svc) {
+		return nil, fmt.Errorf("Cannot create a GCE load balancer with mixed protocols")
+	}
 
 	existingFwdRule, err := g.GetRegionForwardingRule(loadBalancerName, g.region)
 	if err != nil && !isNotFound(err) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds support for configuring a service of type LoadBalancer with more than 1 protocol. For example, this allows configuring a LoadBalancer with both TCP and UDP port 53 (for a DNS server), or TCP and UDP 443 for HTTPS + QUIC (HTTP 3.0).

**Which issue(s) this PR fixes**:

Fixes #23880

**Special notes for your reviewer**:

Mixed protocol LBs are supported by Azure and MetalLB. Other providers MAY support this, however, I'm unable to verify the implementations and have opted to reject mixed protocol LBs on these CPIs where necessary (this turned out to only need rejection in the GCP provider)

An example service to enable and use this feature:

    apiVersion: v1
    kind: Service
    metadata:
      name: mixed-protocol
    spec:
      type: LoadBalancer
      ports:
        - name: dns-udp
          port: 53
          protocol: UDP
        - name: dns-tcp
          port: 53
          protocol: TCP
      selector:
        app: my-dns-server

If the feature gate is enabled, while a CPI without support is enabled, the following event will be recorded:

	 Type     Reason                      Age                   From                Message
	 ----     ------                      ----                  ----                -------
	 Warning  CreatingLoadBalancerFailed  112s (x71 over 32m)   service-controller  Error creating load balancer (will retry): failed to ensure load balancer for service default/mixed-protocol: Cannot create an GCP load balancer with mixed protocols

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added support for mixed protocol services of type=LoadBalancer, enabled through the use of a new `ServiceLoadBalancerMixedProtocol` feature gate.
```
