### PR TITLE
kubeadm: fix join control-plane with external-etcd

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/init/preflight.go
@@ -57,7 +57,7 @@ func runPreflight(c workflow.RunData) error {
 	}
 
 	fmt.Println("[preflight] Running pre-flight checks")
-	if err := preflight.RunInitNodeChecks(utilsexec.New(), data.Cfg(), data.IgnorePreflightErrors(), false); err != nil {
+	if err := preflight.RunInitNodeChecks(utilsexec.New(), data.Cfg(), data.IgnorePreflightErrors(), false, false); err != nil {
 		return err
 	}
 

--- a/cmd/kubeadm/app/cmd/phases/join/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/join/preflight.go
@@ -120,7 +120,8 @@ func runPreflight(c workflow.RunData) error {
 
 		// run kubeadm init preflight checks for checking all the prerequisites
 		fmt.Println("[preflight] Running pre-flight checks before initializing the new control plane instance")
-		if err := preflight.RunInitNodeChecks(utilsexec.New(), initCfg, j.IgnorePreflightErrors(), true); err != nil {
+
+		if err := preflight.RunInitNodeChecks(utilsexec.New(), initCfg, j.IgnorePreflightErrors(), true, hasCertificateKey); err != nil {
 			return err
 		}
 

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -186,9 +186,11 @@ func (pfct preflightCheckTest) Check() (warning, errorList []error) {
 
 func TestRunInitNodeChecks(t *testing.T) {
 	var tests = []struct {
-		name     string
-		cfg      *kubeadmapi.InitConfiguration
-		expected bool
+		name                    string
+		cfg                     *kubeadmapi.InitConfiguration
+		expected                bool
+		isSecondaryControlPlane bool
+		downloadCerts           bool
 	}{
 		{name: "Test valid advertised address",
 			cfg: &kubeadmapi.InitConfiguration{
@@ -197,7 +199,7 @@ func TestRunInitNodeChecks(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "Test CA file exists if specfied",
+			name: "Test CA file exists if specified",
 			cfg: &kubeadmapi.InitConfiguration{
 				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
 					Etcd: kubeadmapi.Etcd{External: &kubeadmapi.ExternalEtcd{CAFile: "/foo"}},
@@ -206,7 +208,18 @@ func TestRunInitNodeChecks(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "Test Cert file exists if specfied",
+			name: "Skip test CA file exists if specified/download certs",
+			cfg: &kubeadmapi.InitConfiguration{
+				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
+					Etcd: kubeadmapi.Etcd{External: &kubeadmapi.ExternalEtcd{CAFile: "/foo"}},
+				},
+			},
+			expected:                true,
+			isSecondaryControlPlane: true,
+			downloadCerts:           true,
+		},
+		{
+			name: "Test Cert file exists if specified",
 			cfg: &kubeadmapi.InitConfiguration{
 				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
 					Etcd: kubeadmapi.Etcd{External: &kubeadmapi.ExternalEtcd{CertFile: "/foo"}},
@@ -215,7 +228,7 @@ func TestRunInitNodeChecks(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "Test Key file exists if specfied",
+			name: "Test Key file exists if specified",
 			cfg: &kubeadmapi.InitConfiguration{
 				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
 					Etcd: kubeadmapi.Etcd{External: &kubeadmapi.ExternalEtcd{CertFile: "/foo"}},
@@ -232,7 +245,7 @@ func TestRunInitNodeChecks(t *testing.T) {
 	}
 	for _, rt := range tests {
 		// TODO: Make RunInitNodeChecks accept a ClusterConfiguration object instead of InitConfiguration
-		actual := RunInitNodeChecks(exec.New(), rt.cfg, sets.NewString(), false)
+		actual := RunInitNodeChecks(exec.New(), rt.cfg, sets.NewString(), rt.isSecondaryControlPlane, rt.downloadCerts)
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed RunInitNodeChecks:\n\texpected: %t\n\t  actual: %t\n\t error: %v",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes preflight checks for `kubeadm join control-plane` in case of external-etcd/secured

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes/kubeadm/issues/1472

**Special notes for your reviewer**:
This Fix is a candidate for cherry picking in v1.14

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: preflight checks on external etcd certificates are now skipped when joining a control-plane node with automatic copy of cluster certificates (--certificate-key)
```

/sig cluster-lifecycle
/priority critical-urgent
/assign @neolit123 @rosti 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 


