### PR TITLE
Add ListPager.EachListItem util

### DIFF
--- a/staging/src/k8s.io/client-go/tools/pager/BUILD
+++ b/staging/src/k8s.io/client-go/tools/pager/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/client-go/tools/pager/pager_test.go
+++ b/staging/src/k8s.io/client-go/tools/pager/pager_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -115,7 +116,6 @@ func (p *testPager) ExpiresOnSecondPageThenFullList(ctx context.Context, options
 	}
 	return p.PagedList(ctx, options)
 }
-
 func TestListPager_List(t *testing.T) {
 	type fields struct {
 		PageSize          int64
@@ -189,7 +189,11 @@ func TestListPager_List(t *testing.T) {
 				PageFn:            tt.fields.PageFn,
 				FullListIfExpired: tt.fields.FullListIfExpired,
 			}
-			got, err := p.List(tt.args.ctx, tt.args.options)
+			ctx := tt.args.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			got, err := p.List(ctx, tt.args.options)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ListPager.List() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -200,6 +204,240 @@ func TestListPager_List(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ListPager.List() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListPager_EachListItem(t *testing.T) {
+	type fields struct {
+		PageSize int64
+		PageFn   ListPageFunc
+	}
+	tests := []struct {
+		name                 string
+		fields               fields
+		want                 runtime.Object
+		wantErr              bool
+		wantPanic            bool
+		isExpired            bool
+		processorErrorOnItem int
+		processorPanicOnItem int
+		cancelContextOnItem  int
+	}{
+		{
+			name:   "empty page",
+			fields: fields{PageSize: 10, PageFn: (&testPager{t: t, expectPage: 10, remaining: 0, rv: "rv:20"}).PagedList},
+			want:   list(0, "rv:20"),
+		},
+		{
+			name:   "one page",
+			fields: fields{PageSize: 10, PageFn: (&testPager{t: t, expectPage: 10, remaining: 9, rv: "rv:20"}).PagedList},
+			want:   list(9, "rv:20"),
+		},
+		{
+			name:   "one full page",
+			fields: fields{PageSize: 10, PageFn: (&testPager{t: t, expectPage: 10, remaining: 10, rv: "rv:20"}).PagedList},
+			want:   list(10, "rv:20"),
+		},
+		{
+			name:   "two pages",
+			fields: fields{PageSize: 10, PageFn: (&testPager{t: t, expectPage: 10, remaining: 11, rv: "rv:20"}).PagedList},
+			want:   list(11, "rv:20"),
+		},
+		{
+			name:   "three pages",
+			fields: fields{PageSize: 10, PageFn: (&testPager{t: t, expectPage: 10, remaining: 21, rv: "rv:20"}).PagedList},
+			want:   list(21, "rv:20"),
+		},
+		{
+			name:      "expires on second page",
+			fields:    fields{PageSize: 10, PageFn: (&testPager{t: t, expectPage: 10, remaining: 21, rv: "rv:20"}).ExpiresOnSecondPage},
+			want:      list(10, "rv:20"), // all items on the first page should have been visited
+			wantErr:   true,
+			isExpired: true,
+		},
+		{
+			name:                 "error processing item",
+			fields:               fields{PageSize: 10, PageFn: (&testPager{t: t, expectPage: 10, remaining: 51, rv: "rv:20"}).PagedList},
+			want:                 list(3, "rv:20"), // all the items <= the one the processor returned an error on should have been visited
+			wantPanic:            true,
+			processorPanicOnItem: 3,
+		},
+		{
+			name:                "cancel context while processing",
+			fields:              fields{PageSize: 10, PageFn: (&testPager{t: t, expectPage: 10, remaining: 51, rv: "rv:20"}).PagedList},
+			want:                list(3, "rv:20"), // all the items <= the one the processor returned an error on should have been visited
+			wantErr:             true,
+			cancelContextOnItem: 3,
+		},
+		{
+			name:      "panic processing item",
+			fields:    fields{PageSize: 10, PageFn: (&testPager{t: t, expectPage: 10, remaining: 51, rv: "rv:20"}).PagedList},
+			want:      list(3, "rv:20"), // all the items <= the one the processor returned an error on should have been visited
+			wantPanic: true,
+		},
+	}
+
+	processorErr := fmt.Errorf("processor error")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			p := &ListPager{
+				PageSize: tt.fields.PageSize,
+				PageFn:   tt.fields.PageFn,
+			}
+			var items []runtime.Object
+
+			fn := func(obj runtime.Object) error {
+				items = append(items, obj)
+				if tt.processorErrorOnItem > 0 && len(items) == tt.processorErrorOnItem {
+					return processorErr
+				}
+				if tt.processorPanicOnItem > 0 && len(items) == tt.processorPanicOnItem {
+					panic(processorErr)
+				}
+				if tt.cancelContextOnItem > 0 && len(items) == tt.cancelContextOnItem {
+					cancel()
+				}
+				return nil
+			}
+			var err error
+			var panic interface{}
+			func() {
+				defer func() {
+					panic = recover()
+				}()
+				err = p.EachListItem(ctx, metav1.ListOptions{}, fn)
+			}()
+			if (panic != nil) && !tt.wantPanic {
+				t.Fatalf(".EachListItem() panic = %v, wantPanic %v", panic, tt.wantPanic)
+			} else {
+				return
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ListPager.EachListItem() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.isExpired != errors.IsResourceExpired(err) {
+				t.Errorf("ListPager.EachListItem() error = %v, isExpired %v", err, tt.isExpired)
+				return
+			}
+			if tt.processorErrorOnItem > 0 && err != processorErr {
+				t.Errorf("ListPager.EachListItem() error = %v, processorErrorOnItem %d", err, tt.processorErrorOnItem)
+				return
+			}
+			l := tt.want.(*metainternalversion.List)
+			if !reflect.DeepEqual(items, l.Items) {
+				t.Errorf("ListPager.EachListItem() = %v, want %v", items, l.Items)
+			}
+		})
+	}
+}
+
+func TestListPager_eachListPageBuffered(t *testing.T) {
+	tests := []struct {
+		name           string
+		totalPages     int
+		pagesProcessed int
+		wantPageLists  int
+		pageBufferSize int32
+		pageSize       int
+	}{
+		{
+			name:           "no buffer, one total page",
+			totalPages:     1,
+			pagesProcessed: 1,
+			wantPageLists:  1,
+			pageBufferSize: 0,
+		}, {
+			name:           "no buffer, 1/5 pages processed",
+			totalPages:     5,
+			pagesProcessed: 1,
+			wantPageLists:  2, // 1 received for processing, 1 listed
+			pageBufferSize: 0,
+		},
+		{
+			name:           "no buffer, 2/5 pages processed",
+			totalPages:     5,
+			pagesProcessed: 2,
+			wantPageLists:  3,
+			pageBufferSize: 0,
+		},
+		{
+			name:           "no buffer, 5/5 pages processed",
+			totalPages:     5,
+			pagesProcessed: 5,
+			wantPageLists:  5,
+			pageBufferSize: 0,
+		},
+		{
+			name:           "size 1 buffer, 1/5 pages processed",
+			totalPages:     5,
+			pagesProcessed: 1,
+			wantPageLists:  3,
+			pageBufferSize: 1,
+		},
+		{
+			name:           "size 1 buffer, 5/5 pages processed",
+			totalPages:     5,
+			pagesProcessed: 5,
+			wantPageLists:  5,
+			pageBufferSize: 1,
+		},
+		{
+			name:           "size 10 buffer, 1/5 page processed",
+			totalPages:     5,
+			pagesProcessed: 1,
+			wantPageLists:  5,
+			pageBufferSize: 10, // buffer is larger than list
+		},
+	}
+	processorErr := fmt.Errorf("processor error")
+	pageSize := 10
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pgr := &testPager{t: t, expectPage: int64(pageSize), remaining: tt.totalPages * pageSize, rv: "rv:20"}
+			pageLists := 0
+			wantedPageListsDone := make(chan struct{})
+			listFn := func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				pageLists++
+				if pageLists == tt.wantPageLists {
+					close(wantedPageListsDone)
+				}
+				return pgr.PagedList(ctx, options)
+			}
+			p := &ListPager{
+				PageSize:       int64(pageSize),
+				PageBufferSize: tt.pageBufferSize,
+				PageFn:         listFn,
+			}
+
+			pagesProcessed := 0
+			fn := func(obj runtime.Object) error {
+				pagesProcessed++
+				if tt.pagesProcessed == pagesProcessed && tt.wantPageLists > 0 {
+					// wait for buffering to catch up
+					select {
+					case <-time.After(time.Second):
+						return fmt.Errorf("Timed out waiting for %d page lists", tt.wantPageLists)
+					case <-wantedPageListsDone:
+					}
+					return processorErr
+				}
+				return nil
+			}
+			err := p.eachListChunkBuffered(context.Background(), metav1.ListOptions{}, fn)
+			if tt.pagesProcessed > 0 && err == processorErr {
+				// expected
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantPageLists > 0 && pageLists != tt.wantPageLists {
+				t.Errorf("expected %d page lists, got %d", tt.wantPageLists, pageLists)
+			}
+			if pagesProcessed != tt.pagesProcessed {
+				t.Errorf("expected %d pages processed, got %d", tt.pagesProcessed, pagesProcessed)
 			}
 		})
 	}


### PR DESCRIPTION
Introduce a `ListPager.EachListItem` convenience utility for incrementally processing chunked List results. This makes it easy for a client to only request list chunks from the apiserver that it can actually keep up with processing. `EachListItem` buffers up to `PageBufferSize` (default: 10) pages in the background to minimize foreground wait time.

Example usage:

```go
podPager = pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {                                                                                                                 
  return client.CoreV1().Pods().List(opts)                                                                                                                                                   
}))
podPager.EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {                                                                                                       
  if pod, ok := obj.(*v1.Pod); ok {
    doSomethingWithThePod(pod)
  } else { ...}
  ...
}
```

There are some warts with this approach that I'd like to find a way of smoothing over, namely: (1) having to creating the pager (2) having to cast each item to the correct type. But that should be possible to add via code generators in the future.

The name and function signature were picked to be consistent with the existing `meta.EachListItem` function.

```release-note
Add ListPager.EachListItem utility function to client-go to enable incremental processing of chunked list responses
```

/kind feature
/priority important-longterm
/sig api-machinery