### PR TITLE
apimachinery & apiserver: use stacktrace in the stdlib

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime_test.go
@@ -17,7 +17,12 @@ limitations under the License.
 package runtime
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -68,4 +73,67 @@ func TestCustomHandleError(t *testing.T) {
 	if result != err {
 		t.Errorf("did not receive custom handler")
 	}
+}
+
+func TestHandleCrashLog(t *testing.T) {
+	log, err := captureStderr(func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("expected a panic to recover from")
+			}
+		}()
+		defer HandleCrash()
+		panic("test panic")
+	})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	// Example log:
+	//
+	// ...] Observed a panic: test panic
+	// goroutine 6 [running]:
+	// command-line-arguments.logPanic(0x..., 0x...)
+	// 	.../src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:69 +0x...
+	lines := strings.Split(log, "\n")
+	if len(lines) < 4 {
+		t.Fatalf("panic log should have 1 line of message, 1 line per goroutine and 2 lines per function call")
+	}
+	if match, _ := regexp.MatchString("Observed a panic: test panic", lines[0]); !match {
+		t.Errorf("mismatch panic message: %s", lines[0])
+	}
+	// The following regexp's verify that Kubernetes panic log matches Golang stdlib
+	// stacktrace pattern. We need to update these regexp's if stdlib changes its pattern.
+	if match, _ := regexp.MatchString(`goroutine [0-9]+ \[.+\]:`, lines[1]); !match {
+		t.Errorf("mismatch goroutine: %s", lines[1])
+	}
+	if match, _ := regexp.MatchString(`logPanic(.*)`, lines[2]); !match {
+		t.Errorf("mismatch symbolized function name: %s", lines[2])
+	}
+	if match, _ := regexp.MatchString(`runtime\.go:[0-9]+ \+0x`, lines[3]); !match {
+		t.Errorf("mismatch file/line/offset information: %s", lines[3])
+	}
+}
+
+// captureStderr redirects stderr to result string, and then restore stderr from backup
+func captureStderr(f func()) (string, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+	bak := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = bak }()
+
+	resultCh := make(chan string)
+	// copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		resultCh <- buf.String()
+	}()
+
+	f()
+	w.Close()
+
+	return <-resultCh, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"net/url"
 	goruntime "runtime"
-	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -197,10 +196,12 @@ func finishRequest(timeout time.Duration, fn resultFunc) (result runtime.Object,
 		defer func() {
 			panicReason := recover()
 			if panicReason != nil {
+				// Same as stdlib http server code. Manually allocate stack
+				// trace buffer size to prevent excessively large logs
 				const size = 64 << 10
 				buf := make([]byte, size)
 				buf = buf[:goruntime.Stack(buf, false)]
-				panicReason = strings.TrimSuffix(fmt.Sprintf("%v\n%s", panicReason, string(buf)), "\n")
+				panicReason = fmt.Sprintf("%v\n%s", panicReason, buf)
 				// Propagate to parent goroutine
 				panicCh <- panicReason
 			}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
@@ -99,6 +99,8 @@ func (t *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			err := recover()
 			if err != nil {
+				// Same as stdlib http server code. Manually allocate stack
+				// trace buffer size to prevent excessively large logs
 				const size = 64 << 10
 				buf := make([]byte, size)
 				buf = buf[:runtime.Stack(buf, false)]


### PR DESCRIPTION
use `runtime.Stack()` in the stdlib to log stack trace instead of using customized code, so that third party lib can parse the panic (like [panicparse](https://github.com/maruel/panicparse))

e.g. if we have a panic [here](https://github.com/roycaihw/kubernetes/commit/b7874c8fbf8fb4520487aab17e8d4b589308bdd9), with the change, the tool is able to parse all [three goroutines](https://gist.github.com/roycaihw/56eb78c23aff3c8dbdd66bbc5d2aaec3)

without the change, only the first goroutine (`finishRequest`) gets parsed. The second goroutine (`timeoutHandler`) is missed because we drop a trailing newline in the one goroutine before. The third goroutine (`HandleCrash`) is missed because `getCaller()` is non-standard which only contains filename + line number.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Use stdlib to log stack trace when a panic occurs
```

/cc @logicalhan @sttts 