### PR TITLE
Disable GCE agent address management on Windows nodes.

### DIFF
--- a/cluster/gce/windows/node-helper.sh
+++ b/cluster/gce/windows/node-helper.sh
@@ -36,6 +36,10 @@ function get-windows-node-instance-metadata-from-file {
 function get-windows-node-instance-metadata {
   local metadata=""
   metadata+="k8s-version=${KUBE_VERSION:-v1.13.2},"
+  # Prevent the GCE Windows agent from managing IP addresses, since kube-proxy
+  # and these cluster setup scripts should take care of everything. See
+  # https://github.com/kubernetes/kubernetes/issues/75561.
+  metadata+="disable-address-manager=true,"
   metadata+="serial-port-enable=1,"
   # This enables logging the serial port output.
   # https://cloud.google.com/compute/docs/instances/viewing-serial-port-output


### PR DESCRIPTION
/kind bug

This PR prevents the GCE Windows agent (https://github.com/GoogleCloudPlatform/compute-image-windows) from performing network address management which interferes with Kubernetes service networking.

Tested:
```
PROJECT=${CLOUDSDK_CORE_PROJECT} KUBE_GCE_ENABLE_IP_ALIASES=true NUM_WINDOWS_NODES=2 NUM_NODES=2 KUBERNETES_NODE_PLATFORM=windows go run ./hack/e2e.go -- --up
cluster/gce/windows/smoke-test.sh

cat > iis.yaml <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: iis
  labels:
    app: iis
spec:
  containers:
  - image: mcr.microsoft.com/windows/servercore/iis
    imagePullPolicy: IfNotPresent
    name: iis-server
    ports:
    - containerPort: 80
      protocol: TCP
  nodeSelector:
    beta.kubernetes.io/os: windows
  tolerations:
  - effect: NoSchedule
    key: node.kubernetes.io/os
    operator: Equal
    value: windows1809
EOF

kubectl create -f iis.yaml
kubectl expose pod iis --type=LoadBalancer --name=iis
kubectl get services
curl http://<service external IP address>
```

Fixes #75561
```release-note
GCE Windows nodes will rely solely on kubernetes and kube-proxy (and not the GCE agent) for network address management.
```