### PR TITLE
Bebase etcd image to k8s.gcr.io/debian-base

### DIFF
--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -57,19 +57,19 @@ GOARM=7
 TEMP_DIR:=$(shell mktemp -d)
 
 ifeq ($(ARCH),amd64)
-	BASEIMAGE?=busybox
+    BASEIMAGE?=k8s.gcr.io/debian-base:v1.0.0
 endif
 ifeq ($(ARCH),arm)
-	BASEIMAGE?=arm32v7/busybox
+    BASEIMAGE?=k8s.gcr.io/debian-base-arm:v1.0.0
 endif
 ifeq ($(ARCH),arm64)
-	BASEIMAGE?=arm64v8/busybox
+    BASEIMAGE?=k8s.gcr.io/debian-base-arm64:v1.0.0
 endif
 ifeq ($(ARCH),ppc64le)
-	BASEIMAGE?=ppc64le/busybox
+    BASEIMAGE?=k8s.gcr.io/debian-base-ppc64le:v1.0.0
 endif
 ifeq ($(ARCH),s390x)
-	BASEIMAGE?=s390x/busybox
+    BASEIMAGE?=k8s.gcr.io/debian-base-s390x:v1.0.0
 endif
 
 build:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
See [sig-release KEP](https://github.com/kubernetes/enhancements/pull/900) for details. Basically, busybox has many vulnerability concerns that makes the maintenance cost really high. Rebasing to a k8s custom debian-base image can 1.)keep a smaller image size 2.) reduce the number of etcd image versions generated everytime after a vulnerability patch is deployed.    

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # [KEP Rebase k8s images to distroless](https://github.com/kubernetes/enhancements/pull/900/files) 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
