### PR TITLE
kubeadm: list images in YAML and JSON formats

### DIFF
--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 const (
-	defaultNumberOfImages = 8
+	defaultNumberOfImages = 7
 )
 
 // dummyKubernetesVersion is just used for unit testing, in order to not make
@@ -53,7 +53,7 @@ func TestNewCmdConfigImagesList(t *testing.T) {
 	mockK8sVersion := dummyKubernetesVersion
 	images := NewCmdConfigImagesList(&output, &mockK8sVersion)
 	images.Run(nil, nil)
-	actual := strings.Split(output.String(), "\n")
+	actual := strings.Split(strings.TrimSpace(output.String()), "\n")
 	if len(actual) != defaultNumberOfImages {
 		t.Fatalf("Expected %v but found %v images", defaultNumberOfImages, len(actual))
 	}
@@ -118,7 +118,7 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 			if i.Run(&output) != nil {
 				t.Fatalf("Error from running the images command: %v", err)
 			}
-			actual := strings.Split(output.String(), "\n")
+			actual := strings.Split(strings.TrimSpace(output.String()), "\n")
 			if len(actual) != tc.expectedImageCount {
 				t.Fatalf("did not get the same number of images: actual: %v expected: %v. Actual value: %v", len(actual), tc.expectedImageCount, actual)
 			}
@@ -208,7 +208,7 @@ func TestConfigImagesListRunWithoutPath(t *testing.T) {
 				t.Fatalf("did not expect an error running the Images command: %v", err)
 			}
 
-			actual := strings.Split(output.String(), "\n")
+			actual := strings.Split(strings.TrimSpace(output.String()), "\n")
 			if len(actual) != tc.expectedImages {
 				t.Fatalf("expected %v images but got %v", tc.expectedImages, actual)
 			}

--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -64,6 +64,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Implemented --output option for 'kubeadm config images list' to
show list of images in a parseable form.

Example output:
```
root@kind-control-plane:/# kubeadm config images list --output yaml

Images:
- k8s.gcr.io/kube-apiserver:v1.14.0
- k8s.gcr.io/kube-controller-manager:v1.14.0
- k8s.gcr.io/kube-scheduler:v1.14.0
- k8s.gcr.io/kube-proxy:v1.14.0
- k8s.gcr.io/pause:3.1
- k8s.gcr.io/etcd:3.3.10
- k8s.gcr.io/coredns:1.3.1

root@kind-control-plane:/# kubeadm config images list --output json
{
  "Images": [
    "k8s.gcr.io/kube-apiserver:v1.14.0",
    "k8s.gcr.io/kube-controller-manager:v1.14.0",
    "k8s.gcr.io/kube-scheduler:v1.14.0",
    "k8s.gcr.io/kube-proxy:v1.14.0",
    "k8s.gcr.io/pause:3.1",
    "k8s.gcr.io/etcd:3.3.10",
    "k8s.gcr.io/coredns:1.3.1"
  ]
}
```

**Does this PR introduce a user-facing change?**:

```release-note
kubeadm: support optional YAML/JSON output when listing images
```