### PR TITLE
Update debian base image OWNERS

### DIFF
--- a/build/debian-base/OWNERS
+++ b/build/debian-base/OWNERS
@@ -8,5 +8,3 @@ approvers:
   - BenTheElder
   - mkumatag
   - tallclair
-labels:
-- sig/release

--- a/build/debian-iptables/OWNERS
+++ b/build/debian-iptables/OWNERS
@@ -2,11 +2,17 @@
 
 reviewers:
   - BenTheElder
+  - bowei
+  - freehan
+  - jingax10
   - mkumatag
+  - mrhohn
   - tallclair
 approvers:
   - BenTheElder
+  - bowei
+  - freehan
+  - jingax10
   - mkumatag
+  - mrhohn
   - tallclair
-labels:
-- sig/release


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Add myself to debian base image owners.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig release
/assign @ixdy 