### PR TITLE
[WIP] Replace MASQUERADE with SNAT

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -754,7 +754,7 @@ func (proxier *Proxier) syncProxyRules() {
 		"-A", string(kubePostroutingChain),
 		"-m", "comment", "--comment", `"kubernetes service traffic requiring SNAT"`,
 		"-m", "mark", "--mark", proxier.masqueradeMark,
-		"-j", "MASQUERADE",
+		"-j", "SNAT", "--to-source", proxier.nodeIP.String(),
 	}...)
 
 	// Install the kubernetes-specific masquerade mark rule. We use a whole chain for


### PR DESCRIPTION
In a kubernetes cluster has has nodes with BGP configured, using
MASQUERADE for the proxy rules causes nodes to not be able to reach
services via the iptables proxy rules.

Instead of using `.246` as the source address, like the routing table
specifies, I see packets with a source of `192.168.0.3`, which is a point
to point link.

-A KUBE-SERVICES ! -s 192.168.28.0/22 -d 192.168.24.136/32 -p tcp -m comment --comment "kube-system/calico-etcd: cluster IP" -m tcp --dport 6666 -j KUBE-MARK-MASQ
-A KUBE-SERVICES -d 192.168.24.136/32 -p tcp -m comment --comment "kube-system/calico-etcd: cluster IP" -m tcp --dport 6666 -j KUBE-SVC-NTYB37XIWATNM25Y

    ubuntu@oscomp-bgcloudv3-1:~$ ip r
    default  proto zebra  src 10.255.161.246
            nexthop via 192.168.0.2  dev eno1 weight 1
            nexthop via 192.168.0.44  dev eno2 weight 1

    <- SNIP ->

    10.255.161.240  proto zebra  src 10.255.161.246
            nexthop via 192.168.0.2  dev eno1 weight 1
            nexthop via 192.168.0.44  dev eno2 weight 1

    <- SNIP ->

    192.168.0.2/31 dev eno1  proto kernel  scope link  src 192.168.0.3

    <- SNIP ->

    192.168.0.44/31 dev eno2  proto kernel  scope link  src 192.168.0.45

When switching to using SNAT and setting --to-source to
`10.255.161.246` - packets flow correctly to the etcd service IP and to
the daemonset on `.240` correctly.