### PR TITLE
Remove unnecessary test case and reference to cadvisor/container/crio package

### DIFF
--- a/pkg/kubelet/cadvisor/BUILD
+++ b/pkg/kubelet/cadvisor/BUILD
@@ -51,9 +51,7 @@ go_test(
         "@io_bazel_rules_go//go/platform:linux": [
             "//staging/src/k8s.io/api/core/v1:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-            "//vendor/github.com/google/cadvisor/container/crio:go_default_library",
             "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
-            "//vendor/github.com/stretchr/testify/assert:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/kubelet/cadvisor/util_test.go
+++ b/pkg/kubelet/cadvisor/util_test.go
@@ -22,9 +22,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/cadvisor/container/crio"
 	info "github.com/google/cadvisor/info/v1"
-	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -50,8 +48,4 @@ func TestCapacityFromMachineInfoWithHugePagesEnable(t *testing.T) {
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("when set hugepages true, got resource list %v, want %v", actual, expected)
 	}
-}
-
-func TestCrioSocket(t *testing.T) {
-	assert.EqualValues(t, CrioSocket, crio.CrioSocket, "CrioSocket in this package must equal the one in github.com/google/cadvisor/container/crio/client.go")
 }


### PR DESCRIPTION
Change-Id: I70563c8d6d02952f1ef6843833c738cdc11241b9

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This helps eliminate the dependency on crio and will help reduce the size of our vendored dependencies

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
