### PR TITLE
Automated cherry pick of #75900: kubeadm: fix "upgrade plan" not working without k8s version

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -154,7 +154,7 @@ func enforceRequirements(flags *applyPlanFlags, dryRun bool, newK8sVersion strin
 	}
 
 	// Use a real version getter interface that queries the API server, the kubeadm client and the Kubernetes CI system for latest versions
-	return client, upgrade.NewOfflineVersionGetter(upgrade.NewKubeVersionGetter(client, os.Stdout), cfg.KubernetesVersion), cfg, nil
+	return client, upgrade.NewOfflineVersionGetter(upgrade.NewKubeVersionGetter(client, os.Stdout), newK8sVersion), cfg, nil
 }
 
 // printConfiguration prints the external version of the API to yaml


### PR DESCRIPTION
Cherry pick of #75900 on release-1.14.

#75900: kubeadm: fix "upgrade plan" not working without k8s version