### PR TITLE
bazel: update repo-infra dependency to fix bazel 0.24+ (requires 0.23+)

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -10,13 +10,13 @@ http_archive(
 
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
-versions.check(minimum_bazel_version = "0.18.0")
+versions.check(minimum_bazel_version = "0.23.0")
 
 http_archive(
     name = "io_k8s_repo_infra",
-    sha256 = "2cc74219eafebb0af1e0cf80b9c2b78aac9aa570de762bfb82b83e9164be9da2",
-    strip_prefix = "repo-infra-b461270ab6ccfb94ff2d78df96d26f669376d660",
-    urls = mirror("https://github.com/kubernetes/repo-infra/archive/b461270ab6ccfb94ff2d78df96d26f669376d660.tar.gz"),
+    sha256 = "4a8384320fba401cbf21fef177aa113ed8fe35952ace98e00b796cac87ae7868",
+    strip_prefix = "repo-infra-df02ded38f9506e5bbcbf21702034b4fef815f2f",
+    urls = mirror("https://github.com/kubernetes/repo-infra/archive/df02ded38f9506e5bbcbf21702034b4fef815f2f.tar.gz"),
 )
 
 http_archive(


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: 
Due to some deprecations and incompatibilities, it's currently not possible to build kubernetes using bazel 0.24+. I've fixed the issues in https://github.com/kubernetes/repo-infra/pull/111, but we need to update the repo-infra dependency here to use it.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/repo-infra/issues/108

**Special notes for your reviewer**:
This change requires bazel 0.23+, since I also fixed some other issues which would otherwise soon break us in bazel 0.25+. Prow is going to fail until kubekins-e2e is updated to at least bazel 0.23.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig testing release
/priority important-soon
/assign @fejta 