### PR TITLE
Fix EFK addon: Current fluentd Image Not Found

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -77,7 +77,7 @@ spec:
       serviceAccountName: fluentd-es
       containers:
       - name: fluentd-es
-        image: k8s.gcr.io/fluentd-elasticsearch:v2.5.0
+        image: gcr.io/fluentd-elasticsearch/fluentd:v2.5.0
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The current fluentd image defined in fluentd-es-ds.yaml does not exist. Added the fluentd v2.5.0 image from the same GCR used in es-statefulset.yaml.

**Which issue(s) this PR fixes**:
None as far as I could tell from my searches.

**Special notes for your reviewer**:
I'm not really sure which SIG this should be targeted at.
/needs-sig

**Does this PR introduce a user-facing change?**:
I'm not 100% sure as using the EFK addon currently shouldn't work for anyone who is attempting to use it. For the sake of completeness, I'll add the following release note, but feel free to change it if needed.

```release-note
action required: You will need to pull the new fluentd image.
```
