### PR TITLE
Fixed default value for ConfigMapAndSecretChangeDetectionStrategy (kubelet)

### DIFF
--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -663,7 +663,7 @@ type KubeletConfiguration struct {
 	ContainerLogMaxFiles *int32 `json:"containerLogMaxFiles,omitempty"`
 	// ConfigMapAndSecretChangeDetectionStrategy is a mode in which
 	// config map and secret managers are running.
-	// Default: "Watching"
+	// Default: "Watch"
 	// +optional
 	ConfigMapAndSecretChangeDetectionStrategy ResourceChangeDetectionStrategy `json:"configMapAndSecretChangeDetectionStrategy,omitempty"`
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:

Corrects the default value for ConfigMapAndSecretChangeDetectionStrategy in the API documentation.  ConfigMapAndSecretChangeDetectionStrategy defaults to WatchChangeDetectionStrategy in the kubelet code (`kubelet/apis/config/v1beta1/defaults.go` line 218) which is the constant "Watch" and not "Watching" as stated in the API docs. 

**Which issue(s) this PR fixes**:

None. No issue created.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
