### PR TITLE
Remove unwanted `else` block from statefulset controller.

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -374,9 +374,9 @@ func TestStatefulPodControlUpdatePodConflictSuccess(t *testing.T) {
 		if !conflict {
 			conflict = true
 			return true, update.GetObject(), apierrors.NewConflict(action.GetResource().GroupResource(), pod.Name, errors.New("conflict"))
-		} else {
-			return true, update.GetObject(), nil
 		}
+		return true, update.GetObject(), nil
+
 	})
 	pod.Name = "goo-0"
 	if err := control.UpdateStatefulPod(set, pod); err != nil {

--- a/pkg/controller/statefulset/stateful_set_status_updater_test.go
+++ b/pkg/controller/statefulset/stateful_set_status_updater_test.go
@@ -96,9 +96,9 @@ func TestStatefulSetStatusUpdaterUpdateReplicasConflict(t *testing.T) {
 		if !conflict {
 			conflict = true
 			return true, update.GetObject(), apierrors.NewConflict(action.GetResource().GroupResource(), set.Name, errors.New("Object already exists"))
-		} else {
-			return true, update.GetObject(), nil
 		}
+		return true, update.GetObject(), nil
+
 	})
 	if err := updater.UpdateStatefulSetStatus(set, &status); err != nil {
 		t.Errorf("UpdateStatefulSetStatus returned an error: %s", err)

--- a/pkg/controller/statefulset/stateful_set_test.go
+++ b/pkg/controller/statefulset/stateful_set_test.go
@@ -648,11 +648,11 @@ func scaleUpStatefulSetController(set *apps.StatefulSet, ssc *StatefulSetControl
 		if err := assertMonotonicInvariants(set, spc); err != nil {
 			return err
 		}
-		if obj, _, err := spc.setsIndexer.Get(set); err != nil {
+		obj, _, err := spc.setsIndexer.Get(set)
+		if err != nil {
 			return err
-		} else {
-			set = obj.(*apps.StatefulSet)
 		}
+		set = obj.(*apps.StatefulSet)
 
 	}
 	return assertMonotonicInvariants(set, spc)
@@ -701,11 +701,12 @@ func scaleDownStatefulSetController(set *apps.StatefulSet, ssc *StatefulSetContr
 		spc.DeleteStatefulPod(set, pod)
 		ssc.deletePod(pod)
 		fakeWorker(ssc)
-		if obj, _, err := spc.setsIndexer.Get(set); err != nil {
+		obj, _, err := spc.setsIndexer.Get(set)
+		if err != nil {
 			return err
-		} else {
-			set = obj.(*apps.StatefulSet)
 		}
+		set = obj.(*apps.StatefulSet)
+
 	}
 	return assertMonotonicInvariants(set, spc)
 }


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
