### PR TITLE
Fix golint failures of e2e/framework/ssh.go, e2e/framework/size.go

### DIFF
--- a/test/e2e/framework/size.go
+++ b/test/e2e/framework/size.go
@@ -26,6 +26,7 @@ const (
 	resizeNodeNotReadyTimeout = 2 * time.Minute
 )
 
+// ResizeGroup resizes an instance group
 func ResizeGroup(group string, size int32) error {
 	if TestContext.ReportDir != "" {
 		CoreDump(TestContext.ReportDir)
@@ -34,14 +35,17 @@ func ResizeGroup(group string, size int32) error {
 	return TestContext.CloudConfig.Provider.ResizeGroup(group, size)
 }
 
+// GetGroupNodes returns a node name for the specified node group
 func GetGroupNodes(group string) ([]string, error) {
 	return TestContext.CloudConfig.Provider.GetGroupNodes(group)
 }
 
+// GroupSize returns the size of an instance group
 func GroupSize(group string) (int, error) {
 	return TestContext.CloudConfig.Provider.GroupSize(group)
 }
 
+// WaitForGroupSize waits for node instance group reached the desired size
 func WaitForGroupSize(group string, size int32) error {
 	timeout := 30 * time.Minute
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(20 * time.Second) {

--- a/test/e2e/framework/ssh.go
+++ b/test/e2e/framework/ssh.go
@@ -111,6 +111,7 @@ func NodeSSHHosts(c clientset.Interface) ([]string, error) {
 	return sshHosts, nil
 }
 
+// SSHResult holds the execution result of SSH command
 type SSHResult struct {
 	User   string
 	Host   string
@@ -230,6 +231,7 @@ func RunSSHCommandViaBastion(cmd, user, bastion, host string, signer ssh.Signer)
 	return bout.String(), berr.String(), code, err
 }
 
+// LogSSHResult records SSHResult log
 func LogSSHResult(result SSHResult) {
 	remote := fmt.Sprintf("%s@%s", result.User, result.Host)
 	Logf("ssh %s: command:   %s", remote, result.Cmd)
@@ -238,6 +240,7 @@ func LogSSHResult(result SSHResult) {
 	Logf("ssh %s: exit code: %d", remote, result.Code)
 }
 
+// IssueSSHCommandWithResult tries to execute a SSH command and returns the execution result
 func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*SSHResult, error) {
 	Logf("Getting external IP address for %s", node.Name)
 	host := ""
@@ -274,6 +277,7 @@ func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*SSHResult,
 	return &result, nil
 }
 
+// IssueSSHCommand tries to execute a SSH command
 func IssueSSHCommand(cmd, provider string, node *v1.Node) error {
 	_, err := IssueSSHCommandWithResult(cmd, provider, node)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Fix golint failures of e2e/framework/ssh.go, e2e/framework/size.go

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
