### PR TITLE
Fix golint failures of e2e/framework/pods.go, provider.go, upgrade_util.go

### DIFF
--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -38,6 +38,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
+// DefaultPodDeletionTimeout is the default timeout for deleting pod
 const DefaultPodDeletionTimeout = 3 * time.Minute
 
 // ImageWhiteList is the images used in the current test suite. It should be initialized in test suite and

--- a/test/e2e/framework/provider.go
+++ b/test/e2e/framework/provider.go
@@ -129,7 +129,7 @@ func (n NullProvider) GetGroupNodes(group string) ([]string, error) {
 	return nil, fmt.Errorf("provider does not support InstanceGroups")
 }
 
-// DeleteNode is a base implementation which returns group size.
+// GroupSize returns the size of an instance group
 func (n NullProvider) GroupSize(group string) (int, error) {
 	return -1, fmt.Errorf("provider does not support InstanceGroups")
 }

--- a/test/e2e/framework/upgrade_util.go
+++ b/test/e2e/framework/upgrade_util.go
@@ -57,6 +57,7 @@ func traceRouteToMaster() {
 	}
 }
 
+// CheckMasterVersion validates the master version
 func CheckMasterVersion(c clientset.Interface, want string) error {
 	Logf("Checking master version")
 	var err error
@@ -84,6 +85,7 @@ func CheckMasterVersion(c clientset.Interface, want string) error {
 	return nil
 }
 
+// CheckNodesVersions validates the nodes versions
 func CheckNodesVersions(cs clientset.Interface, want string) error {
 	l := GetReadySchedulableNodesOrDie(cs)
 	for _, n := range l.Items {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Fix golint failures of e2e/framework/pods.go, provider.go, upgrade_util.go

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
