### PR TITLE
1.13: Fix AWS driver fails to provision specified fsType

### DIFF
--- a/pkg/volume/awsebs/aws_util.go
+++ b/pkg/volume/awsebs/aws_util.go
@@ -120,8 +120,10 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner, node *
 	}
 
 	fstype := ""
-	if v, ok := c.options.Parameters[volume.VolumeParameterFSType]; ok {
-		fstype = v
+	for k, v := range c.options.Parameters {
+		if strings.ToLower(k) == volume.VolumeParameterFSType {
+			fstype = v
+		}
 	}
 
 	return name, volumeOptions.CapacityGB, labels, fstype, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig storage
/sig aws

**What this PR does / why we need it**:
This is **manual** cherry pick of commit https://github.com/kubernetes/kubernetes/pull/70823/commits/732eb69597f6b397b9be0253a1ff44759190483b from #70823 which is too big to backport (it expects storage e2e test framework from 1.14).

**Which issue(s) this PR fixes**:
Fixes #75941

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed parsing of fsType in AWS StorageClass parameters
```
