### PR TITLE
improving tokencleaner performance by limiting informers to kube-system namespace

### DIFF
--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -18,7 +18,6 @@ package app
 
 import (
 	"fmt"
-
 	"net/http"
 
 	"k8s.io/kubernetes/pkg/controller/bootstrap"
@@ -39,10 +38,11 @@ func startBootstrapSignerController(ctx ControllerContext) (http.Handler, bool, 
 }
 
 func startTokenCleanerController(ctx ControllerContext) (http.Handler, bool, error) {
+	tokenCleanerOpts := bootstrap.DefaultTokenCleanerOptions()
+	tokenCleanerOpts.SecretResync = ctx.ResyncPeriod()
 	tcc, err := bootstrap.NewTokenCleaner(
 		ctx.ClientBuilder.ClientOrDie("token-cleaner"),
-		ctx.InformerFactory.Core().V1().Secrets(),
-		bootstrap.DefaultTokenCleanerOptions(),
+		tokenCleanerOpts,
 	)
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating TokenCleaner controller: %v", err)

--- a/pkg/controller/bootstrap/BUILD
+++ b/pkg/controller/bootstrap/BUILD
@@ -53,6 +53,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",

--- a/pkg/controller/bootstrap/tokencleaner_test.go
+++ b/pkg/controller/bootstrap/tokencleaner_test.go
@@ -39,7 +39,7 @@ func newTokenCleaner() (*TokenCleaner, *fake.Clientset, coreinformers.SecretInfo
 	cl := fake.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(cl, options.SecretResync)
 	secrets := informerFactory.Core().V1().Secrets()
-	tcc, err := NewTokenCleaner(cl, secrets, options)
+	tcc, err := NewTokenCleaner(cl, options)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
No need to list all secrets in all namespaces, since only secrets in `kube-system` are counted. And that will would greatly slow down apiserver as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #75945

**Special notes for your reviewer**:
/cc @kubernetes/sig-apps-pr-reviews 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
tokencleaner performance improved by limiting informers to kube-system namespace
```
