### PR TITLE
bootstrapsigner: performance improving by limiting informer to certain namespaces

### DIFF
--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -25,11 +25,12 @@ import (
 )
 
 func startBootstrapSignerController(ctx ControllerContext) (http.Handler, bool, error) {
+	bootstrapSignerOpts := bootstrap.DefaultSignerOptions()
+	bootstrapSignerOpts.SecretResync = ctx.ResyncPeriod()
+	bootstrapSignerOpts.ConfigMapResync = ctx.ResyncPeriod()
 	bsc, err := bootstrap.NewSigner(
 		ctx.ClientBuilder.ClientOrDie("bootstrap-signer"),
-		ctx.InformerFactory.Core().V1().Secrets(),
-		ctx.InformerFactory.Core().V1().ConfigMaps(),
-		bootstrap.DefaultSignerOptions(),
+		bootstrapSignerOpts,
 	)
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating BootstrapSigner controller: %v", err)

--- a/pkg/controller/bootstrap/BUILD
+++ b/pkg/controller/bootstrap/BUILD
@@ -53,6 +53,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",

--- a/pkg/controller/bootstrap/bootstrapsigner_test.go
+++ b/pkg/controller/bootstrap/bootstrapsigner_test.go
@@ -45,7 +45,7 @@ func newSigner() (*Signer, *fake.Clientset, coreinformers.SecretInformer, corein
 	informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
 	secrets := informers.Core().V1().Secrets()
 	configMaps := informers.Core().V1().ConfigMaps()
-	bsc, err := NewSigner(cl, secrets, configMaps, options)
+	bsc, err := NewSigner(cl, options)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Bootstrapsigner controller only care about `kube-system` and `kube-public` namespaces. There is no need to set informers on all namespaces. That will cause unnecessary requests and payloads for apiserver.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref #75945, #75946

**Special notes for your reviewer**:
/cc @kubernetes/sig-apps-pr-reviews

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
bootstrapsigner: performance improving by limiting informer to certain namespaces
```
