### PR TITLE
kubeadm : fix-kubeadm-upgrade-12-13-14

### DIFF
--- a/cmd/kubeadm/app/phases/certs/renewal/renewal.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/renewal.go
@@ -18,6 +18,7 @@ package renewal
 
 import (
 	"crypto/x509"
+	"net"
 
 	"github.com/pkg/errors"
 	certutil "k8s.io/client-go/util/cert"
@@ -59,4 +60,44 @@ func certToConfig(cert *x509.Certificate) *certutil.Config {
 		},
 		Usages: cert.ExtKeyUsage,
 	}
+}
+
+// RenewAndMutateExistingEtcdServerCert loads a certificate file, uses the renew interface to renew it,
+// and saves the resulting certificate and key over the old one.
+// This method differs from usual RenewExistingCert because it checks if the etcd server certificate
+// includes the advertiseAddress in the SANS list; if not, the certificate is mutated in order to include it.
+// N.B. this code is necessary only in v1.14; starting from v1.15 all the etcd manifests should have 2 endpoints
+func RenewAndMutateExistingEtcdServerCert(certsDir, baseName string, advertiseAddress net.IP, impl Interface) error {
+	certificatePath, _ := pkiutil.PathsForCertAndKey(certsDir, baseName)
+	certs, err := certutil.CertsFromFile(certificatePath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to load existing certificate %s", baseName)
+	}
+
+	if len(certs) != 1 {
+		return errors.Errorf("wanted exactly one certificate from %s, got %d", baseName, len(certs))
+	}
+
+	cfg := certToConfig(certs[0])
+
+	hasAdvertiseAddress := false
+	for _, val := range cfg.AltNames.IPs {
+		if val.Equal(advertiseAddress) {
+			hasAdvertiseAddress = true
+			break
+		}
+	}
+	if !hasAdvertiseAddress {
+		cfg.AltNames.IPs = append(cfg.AltNames.IPs, advertiseAddress)
+	}
+
+	newCert, newKey, err := impl.Renew(cfg)
+	if err != nil {
+		return errors.Wrapf(err, "failed to renew certificate %s", baseName)
+	}
+
+	if err := pkiutil.WriteCertAndKey(certsDir, baseName, newCert, newKey); err != nil {
+		return errors.Wrapf(err, "failed to write new certificate %s", baseName)
+	}
+	return nil
 }

--- a/cmd/kubeadm/app/util/etcd/BUILD
+++ b/cmd/kubeadm/app/util/etcd/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util/config:go_default_library",
+        "//cmd/kubeadm/app/util/staticpod:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/github.com/coreos/etcd/clientv3:go_default_library",
         "//vendor/github.com/coreos/etcd/pkg/transport:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As reported by users, `kubedm upgrade` fails when upgrading cluster created with kubeadm v1.12,  then upgraded to v1.13, and finally in the process to upgrade to v1.14.

This happened because the upgrade v1.12 to v1.13, didn't change the etcd manifest because the etcd version didn't change

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/1471

**Special notes for your reviewer**:
This fix should apply to v1.14 branch only and aims to get rid of etcd manifests with listening address localhost only when upgrading from v1.13 to v1.14 

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: fixes error when upgrading from v1.13 to v1.14 clusters created with kubeadm v1.12. Please note that it is required to upgrade etcd during the final v1.13 to v1.14 upgrade.
```

/sig cluster-lifecycle
/priority critical-urgent
/milestone v1.14
/assign @neolit123 @rosti @mauilion @timothysc 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews