### PR TITLE
staging/publishing: split rules for godeps and go.mod bot

### DIFF
--- a/staging/publishing/rules-godeps.yaml
+++ b/staging/publishing/rules-godeps.yaml
@@ -1,0 +1,893 @@
+recursive-delete-patterns:
+- BUILD
+- "*/BUILD"
+- BUILD.bazel
+- "*/BUILD.bazel"
+- Gopkg.toml
+rules:
+- destination: code-generator
+  branches:
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.11
+    go: 1.10.2
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.12
+    go: 1.10.8
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.13
+    go: 1.11.2
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.14
+    go: 1.12
+- destination: apimachinery
+  library: true
+  branches:
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.11
+    go: 1.10.2
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.12
+    go: 1.10.8
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.13
+    go: 1.11.2
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.14
+    go: 1.12
+- destination: api
+  library: true
+  branches:
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/api
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/api
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/api
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/api
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+- destination: client-go
+  library: true
+  branches:
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/client-go
+    name: release-8.0
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/client-go
+    name: release-9.0
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/client-go
+    name: release-10.0
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/client-go
+    name: release-11.0
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: api
+        branch: release-1.14
+  smoke-test: |
+    godep restore
+    go build ./...
+    go test $(go list ./... | grep -v /vendor/)
+- destination: component-base
+  library: true
+  branches:
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/component-base
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+- destination: apiserver
+  library: true
+  branches:
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+    - repository: client-go
+      branch: release-8.0
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: api
+        branch: release-1.14
+      - repository: client-go
+        branch: release-11.0
+      - repository: component-base
+        branch: release-1.14
+- destination: kube-aggregator
+  branches:
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+    - repository: client-go
+      branch: release-8.0
+    - repository: apiserver
+      branch: release-1.11
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+    - repository: apiserver
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+    - repository: apiserver
+      branch: release-1.13
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: api
+        branch: release-1.14
+      - repository: client-go
+        branch: release-11.0
+      - repository: apiserver
+        branch: release-1.14
+      - repository: component-base
+        branch: release-1.14
+- destination: sample-apiserver
+  branches:
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+    - repository: client-go
+      branch: release-8.0
+    - repository: apiserver
+      branch: release-1.11
+    - repository: code-generator
+      branch: release-1.11
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+    - repository: apiserver
+      branch: release-1.12
+    - repository: code-generator
+      branch: release-1.12
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+    - repository: apiserver
+      branch: release-1.13
+    - repository: code-generator
+      branch: release-1.13
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: api
+        branch: release-1.14
+      - repository: client-go
+        branch: release-11.0
+      - repository: apiserver
+        branch: release-1.14
+      - repository: code-generator
+        branch: release-1.14
+      - repository: component-base
+        branch: release-1.14
+    required-packages:
+      - k8s.io/code-generator
+  smoke-test: |
+    # vendor/ should have all dependencies as a non-library
+    go build .
+    # re-create vendor/ and try again
+    godep restore
+    rm -rf vendor/ Godeps/
+    godep save ./...
+    go build .
+- destination: sample-controller
+  branches:
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+    - repository: client-go
+      branch: release-8.0
+    - repository: code-generator
+      branch: release-1.11
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+    - repository: code-generator
+      branch: release-1.12
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+    - repository: code-generator
+      branch: release-1.13
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: api
+        branch: release-1.14
+      - repository: client-go
+        branch: release-11.0
+      - repository: code-generator
+        branch: release-1.14
+      - repository: component-base
+        branch: release-1.14
+    required-packages:
+      - k8s.io/code-generator
+  smoke-test: |
+    # vendor/ should have all dependencies as a non-library
+    go build .
+
+    # re-create vendor/ and try again
+    godep restore
+    rm -rf vendor/ Godeps/
+    godep save ./...
+    go build .
+- destination: apiextensions-apiserver
+  branches:
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+    - repository: client-go
+      branch: release-8.0
+    - repository: apiserver
+      branch: release-1.11
+    - repository: code-generator
+      branch: release-1.11
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+    - repository: apiserver
+      branch: release-1.12
+    - repository: code-generator
+      branch: release-1.12
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+    - repository: apiserver
+      branch: release-1.13
+    - repository: code-generator
+      branch: release-1.13
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: api
+        branch: release-1.14
+      - repository: client-go
+        branch: release-11.0
+      - repository: apiserver
+        branch: release-1.14
+      - repository: code-generator
+        branch: release-1.14
+      - repository: component-base
+        branch: release-1.14
+    required-packages:
+      - k8s.io/code-generator
+- destination: metrics
+  library: true
+  branches:
+  - source:
+      branch: release-1.11
+      dir: staging/src/k8s.io/metrics
+    name: release-1.11
+    go: 1.10.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.11
+    - repository: api
+      branch: release-1.11
+    - repository: client-go
+      branch: release-8.0
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/metrics
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/metrics
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/metrics
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: api
+        branch: release-1.14
+      - repository: client-go
+        branch: release-11.0
+- destination: csi-api
+  library: true
+  branches:
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/csi-api
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+    - repository: apiextensions-apiserver
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/csi-api
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+    - repository: apiextensions-apiserver
+      branch: release-1.13
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/csi-api
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: api
+        branch: release-1.14
+      - repository: client-go
+        branch: release-11.0
+      - repository: apiextensions-apiserver
+        branch: release-1.14
+- destination: cli-runtime
+  library: true
+  branches:
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: api
+      branch: release-1.12
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: api
+      branch: release-1.13
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: api
+        branch: release-1.14
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: client-go
+        branch: release-11.0
+- destination: sample-cli-plugin
+  library: false
+  branches:
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: api
+      branch: release-1.12
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: cli-runtime
+      branch: release-1.12
+    - repository: client-go
+      branch: release-9.0
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: api
+      branch: release-1.13
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: cli-runtime
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: api
+        branch: release-1.14
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: cli-runtime
+        branch: release-1.14
+      - repository: client-go
+        branch: release-11.0
+      - repository: component-base
+        branch: release-1.14
+- destination: kube-proxy
+  library: true
+  branches:
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: component-base
+        branch: release-1.14
+- destination: kubelet
+  library: true
+  branches:
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: api
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: api
+        branch: release-1.14
+      - repository: component-base
+        branch: release-1.14
+- destination: kube-scheduler
+  library: true
+  branches:
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: apiserver
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: apiserver
+      branch: release-1.13
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: apiserver
+        branch: release-1.14
+      - repository: component-base
+        branch: release-1.14
+- destination: kube-controller-manager
+  library: true
+  branches:
+  - source:
+      branch: release-1.12
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.12
+    go: 1.10.8
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.12
+    - repository: apiserver
+      branch: release-1.12
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: apiserver
+      branch: release-1.13
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: apiserver
+        branch: release-1.14
+      - repository: component-base
+        branch: release-1.14
+- destination: cluster-bootstrap
+  library: true
+  branches:
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: api
+      branch: release-1.13
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: api
+        branch: release-1.14
+- destination: cloud-provider
+  library: true
+  branches:
+  - source:
+      branch: release-1.13
+      dir: staging/src/k8s.io/cloud-provider
+    name: release-1.13
+    go: 1.11.2
+    dependencies:
+    - repository: api
+      branch: release-1.13
+    - repository: apimachinery
+      branch: release-1.13
+    - repository: client-go
+      branch: release-10.0
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/cloud-provider
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: api
+        branch: release-1.14
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: apiserver
+        branch: release-1.14
+      - repository: client-go
+        branch: release-11.0
+- destination: node-api
+  library: true
+  branches:
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/node-api
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: api
+        branch: release-1.14
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: client-go
+        branch: release-11.0
+- destination: csi-translation-lib
+  library: true
+  branches:
+  - source:
+      branch: release-1.14
+      dir: staging/src/k8s.io/csi-translation-lib
+    name: release-1.14
+    go: 1.12
+    dependencies:
+      - repository: api
+        branch: release-1.14
+      - repository: apimachinery
+        branch: release-1.14
+      - repository: cloud-provider
+        branch: release-1.14

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -11,26 +11,6 @@ rules:
       branch: master
       dir: staging/src/k8s.io/code-generator
     name: master
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/code-generator
-    name: release-1.11
-    go: 1.10.2
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/code-generator
-    name: release-1.12
-    go: 1.10.8
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/code-generator
-    name: release-1.13
-    go: 1.11.2
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/code-generator
-    name: release-1.14
-    go: 1.12
 - destination: apimachinery
   library: true
   branches:
@@ -38,26 +18,6 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apimachinery
     name: master
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/apimachinery
-    name: release-1.11
-    go: 1.10.2
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/apimachinery
-    name: release-1.12
-    go: 1.10.8
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/apimachinery
-    name: release-1.13
-    go: 1.11.2
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/apimachinery
-    name: release-1.14
-    go: 1.12
 - destination: api
   library: true
   branches:
@@ -68,38 +28,6 @@ rules:
     dependencies:
     - repository: apimachinery
       branch: master
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/api
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/api
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/api
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/api
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
 - destination: client-go
   library: true
   branches:
@@ -112,46 +40,6 @@ rules:
       branch: master
     - repository: api
       branch: master
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/client-go
-    name: release-8.0
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/client-go
-    name: release-9.0
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/client-go
-    name: release-10.0
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/client-go
-    name: release-11.0
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: api
-        branch: release-1.14
   smoke-test: |
     godep restore
     go build ./...
@@ -166,14 +54,6 @@ rules:
     dependencies:
     - repository: apimachinery
       branch: master
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/component-base
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
 - destination: apiserver
   library: true
   branches:
@@ -190,56 +70,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/apiserver
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-    - repository: client-go
-      branch: release-8.0
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/apiserver
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/apiserver
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/apiserver
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: api
-        branch: release-1.14
-      - repository: client-go
-        branch: release-11.0
-      - repository: component-base
-        branch: release-1.14
 - destination: kube-aggregator
   branches:
   - source:
@@ -257,64 +87,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-    - repository: client-go
-      branch: release-8.0
-    - repository: apiserver
-      branch: release-1.11
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-    - repository: apiserver
-      branch: release-1.12
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-    - repository: apiserver
-      branch: release-1.13
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: api
-        branch: release-1.14
-      - repository: client-go
-        branch: release-11.0
-      - repository: apiserver
-        branch: release-1.14
-      - repository: component-base
-        branch: release-1.14
 - destination: sample-apiserver
   branches:
   - source:
@@ -336,80 +108,6 @@ rules:
       branch: master
     required-packages:
     - k8s.io/code-generator
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-    - repository: client-go
-      branch: release-8.0
-    - repository: apiserver
-      branch: release-1.11
-    - repository: code-generator
-      branch: release-1.11
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-    - repository: apiserver
-      branch: release-1.12
-    - repository: code-generator
-      branch: release-1.12
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-    - repository: apiserver
-      branch: release-1.13
-    - repository: code-generator
-      branch: release-1.13
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: api
-        branch: release-1.14
-      - repository: client-go
-        branch: release-11.0
-      - repository: apiserver
-        branch: release-1.14
-      - repository: code-generator
-        branch: release-1.14
-      - repository: component-base
-        branch: release-1.14
-    required-packages:
-      - k8s.io/code-generator
   smoke-test: |
     # vendor/ should have all dependencies as a non-library
     go build .
@@ -437,72 +135,6 @@ rules:
       branch: master
     required-packages:
     - k8s.io/code-generator
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-    - repository: client-go
-      branch: release-8.0
-    - repository: code-generator
-      branch: release-1.11
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-    - repository: code-generator
-      branch: release-1.12
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-    - repository: code-generator
-      branch: release-1.13
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: api
-        branch: release-1.14
-      - repository: client-go
-        branch: release-11.0
-      - repository: code-generator
-        branch: release-1.14
-      - repository: component-base
-        branch: release-1.14
-    required-packages:
-      - k8s.io/code-generator
   smoke-test: |
     # vendor/ should have all dependencies as a non-library
     go build .
@@ -533,80 +165,6 @@ rules:
       branch: master
     required-packages:
     - k8s.io/code-generator
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-    - repository: client-go
-      branch: release-8.0
-    - repository: apiserver
-      branch: release-1.11
-    - repository: code-generator
-      branch: release-1.11
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-    - repository: apiserver
-      branch: release-1.12
-    - repository: code-generator
-      branch: release-1.12
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-    - repository: apiserver
-      branch: release-1.13
-    - repository: code-generator
-      branch: release-1.13
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: api
-        branch: release-1.14
-      - repository: client-go
-        branch: release-11.0
-      - repository: apiserver
-        branch: release-1.14
-      - repository: code-generator
-        branch: release-1.14
-      - repository: component-base
-        branch: release-1.14
-    required-packages:
-      - k8s.io/code-generator
 - destination: metrics
   library: true
   branches:
@@ -621,54 +179,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/metrics
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-    - repository: client-go
-      branch: release-8.0
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/metrics
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/metrics
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/metrics
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: api
-        branch: release-1.14
-      - repository: client-go
-        branch: release-11.0
 - destination: csi-api
   library: true
   branches:
@@ -685,48 +195,6 @@ rules:
       branch: master
     - repository: apiextensions-apiserver
       branch: master
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/csi-api
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-    - repository: apiextensions-apiserver
-      branch: release-1.12
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/csi-api
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-    - repository: apiextensions-apiserver
-      branch: release-1.13
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/csi-api
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: api
-        branch: release-1.14
-      - repository: client-go
-        branch: release-11.0
-      - repository: apiextensions-apiserver
-        branch: release-1.14
 - destination: cli-runtime
   library: true
   branches:
@@ -741,42 +209,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/cli-runtime
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: api
-      branch: release-1.12
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/cli-runtime
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: api
-      branch: release-1.13
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/cli-runtime
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: api
-        branch: release-1.14
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: client-go
-        branch: release-11.0
 - destination: sample-cli-plugin
   library: false
   branches:
@@ -795,50 +227,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: api
-      branch: release-1.12
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: cli-runtime
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: api
-      branch: release-1.13
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: cli-runtime
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: api
-        branch: release-1.14
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: cli-runtime
-        branch: release-1.14
-      - repository: client-go
-        branch: release-11.0
-      - repository: component-base
-        branch: release-1.14
 - destination: kube-proxy
   library: true
   branches:
@@ -851,32 +239,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/kube-proxy
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/kube-proxy
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/kube-proxy
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: component-base
-        branch: release-1.14
 - destination: kubelet
   library: true
   branches:
@@ -891,38 +253,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/kubelet
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/kubelet
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/kubelet
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: api
-        branch: release-1.14
-      - repository: component-base
-        branch: release-1.14
 - destination: kube-scheduler
   library: true
   branches:
@@ -937,38 +267,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: apiserver
-      branch: release-1.12
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: apiserver
-      branch: release-1.13
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: apiserver
-        branch: release-1.14
-      - repository: component-base
-        branch: release-1.14
 - destination: kube-controller-manager
   library: true
   branches:
@@ -983,38 +281,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: apiserver
-      branch: release-1.12
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: apiserver
-      branch: release-1.13
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: apiserver
-        branch: release-1.14
-      - repository: component-base
-        branch: release-1.14
 - destination: cluster-bootstrap
   library: true
   branches:
@@ -1027,26 +293,6 @@ rules:
       branch: master
     - repository: api
       branch: master
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/cluster-bootstrap
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/cluster-bootstrap
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: api
-        branch: release-1.14
 - destination: cloud-provider
   library: true
   branches:
@@ -1063,32 +309,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/cloud-provider
-    name: release-1.13
-    go: 1.11.2
-    dependencies:
-    - repository: api
-      branch: release-1.13
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/cloud-provider
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: api
-        branch: release-1.14
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: apiserver
-        branch: release-1.14
-      - repository: client-go
-        branch: release-11.0
 - destination: node-api
   library: true
   branches:
@@ -1103,18 +323,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/node-api
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: api
-        branch: release-1.14
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: client-go
-        branch: release-11.0
 - destination: csi-translation-lib
   library: true
   branches:
@@ -1129,22 +337,10 @@ rules:
       branch: master
     - repository: cloud-provider
       branch: master
-  - source:
-      branch: release-1.14
-      dir: staging/src/k8s.io/csi-translation-lib
-    name: release-1.14
-    go: 1.12
-    dependencies:
-      - repository: api
-        branch: release-1.14
-      - repository: apimachinery
-        branch: release-1.14
-      - repository: cloud-provider
-        branch: release-1.14
 - destination: cri-api
   library: true
   branches:
-    - source:
-        branch: master
-        dir: staging/src/k8s.io/cri-api
-      name: master
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/cri-api
+    name: master


### PR DESCRIPTION
We will run two bots in the forseeable future: one for Godeps bases releases and one for go.mod (starting with master branch).