### PR TITLE
Add new flag to expose max backoff parameter

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -143,6 +143,7 @@ API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,N
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,NodeLifecycleControllerConfiguration,UnhealthyZoneThreshold
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeBinderControllerConfiguration,PVClaimBinderSyncPeriod
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeBinderControllerConfiguration,VolumeConfiguration
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeBinderControllerConfiguration,VolumeOperationMaxBackoff
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeRecyclerConfiguration,IncrementTimeoutHostPath
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeRecyclerConfiguration,IncrementTimeoutNFS
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeRecyclerConfiguration,MaximumRetry
@@ -168,6 +169,7 @@ API rule violation: names_match,k8s.io/kube-proxy/config/v1alpha1,KubeProxyConfi
 API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,IPTablesDropBit
 API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,IPTablesMasqueradeBit
 API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,ResolverConfig
+API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,VolumeOperationMaxBackOff
 API rule violation: names_match,k8s.io/kubernetes/cmd/cloud-controller-manager/app/apis/config/v1alpha1,CloudControllerManagerConfiguration,Generic
 API rule violation: names_match,k8s.io/kubernetes/cmd/cloud-controller-manager/app/apis/config/v1alpha1,CloudControllerManagerConfiguration,KubeCloudShared
 API rule violation: names_match,k8s.io/kubernetes/cmd/cloud-controller-manager/app/apis/config/v1alpha1,CloudControllerManagerConfiguration,NodeStatusUpdateFrequency

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"net"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -278,7 +278,8 @@ func TestAddFlags(t *testing.T) {
 		},
 		PersistentVolumeBinderController: &PersistentVolumeBinderControllerOptions{
 			&persistentvolumeconfig.PersistentVolumeBinderControllerConfiguration{
-				PVClaimBinderSyncPeriod: metav1.Duration{Duration: 30 * time.Second},
+				PVClaimBinderSyncPeriod:   metav1.Duration{Duration: 30 * time.Second},
+				VolumeOperationMaxBackoff: metav1.Duration{Duration: 2*time.Minute + 2*time.Second},
 				VolumeConfiguration: persistentvolumeconfig.VolumeConfiguration{
 					EnableDynamicProvisioning:  false,
 					EnableHostPathProvisioning: true,

--- a/cmd/kube-controller-manager/app/options/persistentvolumebindercontroller.go
+++ b/cmd/kube-controller-manager/app/options/persistentvolumebindercontroller.go
@@ -43,6 +43,7 @@ func (o *PersistentVolumeBinderControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.VolumeConfiguration.EnableHostPathProvisioning, "enable-hostpath-provisioner", o.VolumeConfiguration.EnableHostPathProvisioning, "Enable HostPath PV provisioning when running without a cloud provider. This allows testing and development of provisioning features.  HostPath provisioning is not supported in any way, won't work in a multi-node cluster, and should not be used for anything other than testing or development.")
 	fs.BoolVar(&o.VolumeConfiguration.EnableDynamicProvisioning, "enable-dynamic-provisioning", o.VolumeConfiguration.EnableDynamicProvisioning, "Enable dynamic provisioning for environments that support it.")
 	fs.StringVar(&o.VolumeConfiguration.FlexVolumePluginDir, "flex-volume-plugin-dir", o.VolumeConfiguration.FlexVolumePluginDir, "Full path of the directory in which the flex volume plugin should search for additional third party volume plugins.")
+	fs.DurationVar(&o.VolumeOperationMaxBackoff.Duration, "volume-operation-max-backoff-time", o.VolumeOperationMaxBackoff.Duration, "The maximum backoff time of pv operation, defaults to 2minutes+2second.")
 }
 
 // ApplyTo fills up PersistentVolumeBinderController config with options.
@@ -53,6 +54,7 @@ func (o *PersistentVolumeBinderControllerOptions) ApplyTo(cfg *persistentvolumec
 
 	cfg.PVClaimBinderSyncPeriod = o.PVClaimBinderSyncPeriod
 	cfg.VolumeConfiguration = o.VolumeConfiguration
+	cfg.VolumeOperationMaxBackoff = o.VolumeOperationMaxBackoff
 
 	return nil
 }

--- a/cmd/kubeadm/app/componentconfigs/validation_test.go
+++ b/cmd/kubeadm/app/componentconfigs/validation_test.go
@@ -315,6 +315,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 						RegistryPullQPS:             5,
 						HairpinMode:                 "promiscuous-bridge",
 						NodeLeaseDurationSeconds:    40,
+						VolumeOperationMaxBackOff:   metav1.Duration{Duration: 30 * time.Second},
 					},
 				},
 			},

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -563,6 +563,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 	fs.Var(cliflag.NewMapStringString(&c.EvictionMinimumReclaim), "eviction-minimum-reclaim", "A set of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.")
 	fs.Int32Var(&c.PodsPerCore, "pods-per-core", c.PodsPerCore, "Number of Pods per core that can run on this Kubelet. The total number of Pods on this Kubelet cannot exceed max-pods, so max-pods will be used if this calculation results in a larger number of Pods allowed on the Kubelet. A value of 0 disables this limit.")
 	fs.BoolVar(&c.ProtectKernelDefaults, "protect-kernel-defaults", c.ProtectKernelDefaults, "Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.")
+	fs.DurationVar(&c.VolumeOperationMaxBackOff.Duration, "volume-operation-max-backoff-time", c.VolumeOperationMaxBackOff.Duration, "The maximum backoff time of volume operation.")
 
 	// Node Allocatable Flags
 	fs.Var(cliflag.NewMapStringString(&c.SystemReserved), "system-reserved", "A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=500Mi,ephemeral-storage=1Gi) pairs that describe resources reserved for non-kubernetes components. Currently only cpu and memory are supported. See http://kubernetes.io/docs/user-guide/compute-resources for more detail. [default=none]")

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1058,7 +1058,8 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 		kubeServer.NodeLabels,
 		kubeServer.SeccompProfileRoot,
 		kubeServer.BootstrapCheckpointPath,
-		kubeServer.NodeStatusMaxImages)
+		kubeServer.NodeStatusMaxImages,
+		kubeServer.VolumeOperationMaxBackOff)
 	if err != nil {
 		return fmt.Errorf("failed to create kubelet: %v", err)
 	}
@@ -1134,7 +1135,8 @@ func createAndInitKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeLabels map[string]string,
 	seccompProfileRoot string,
 	bootstrapCheckpointPath string,
-	nodeStatusMaxImages int32) (k kubelet.Bootstrap, err error) {
+	nodeStatusMaxImages int32,
+	volumeOperationMaxBackoff metav1.Duration) (k kubelet.Bootstrap, err error) {
 	// TODO: block until all sources have delivered at least one update to the channel, or break the sync loop
 	// up into "per source" synchronizations
 
@@ -1168,7 +1170,8 @@ func createAndInitKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		nodeLabels,
 		seccompProfileRoot,
 		bootstrapCheckpointPath,
-		nodeStatusMaxImages)
+		nodeStatusMaxImages,
+		volumeOperationMaxBackoff)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -41,7 +41,7 @@ import (
 	kcache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/cloud-provider"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache"
@@ -112,7 +112,8 @@ func NewAttachDetachController(
 	prober volume.DynamicPluginProber,
 	disableReconciliationSync bool,
 	reconcilerSyncDuration time.Duration,
-	timerConfig TimerConfig) (AttachDetachController, error) {
+	timerConfig TimerConfig,
+	volumeOperationMaxBackoff time.Duration) (AttachDetachController, error) {
 	// TODO: The default resyncPeriod for shared informers is 12 hours, this is
 	// unacceptable for the attach/detach controller. For example, if a pod is
 	// skipped because the node it is scheduled to didn't set its annotation in
@@ -171,7 +172,8 @@ func NewAttachDetachController(
 			&adc.volumePluginMgr,
 			recorder,
 			false, // flag for experimental binary check for volume mount
-			blkutil))
+			blkutil),
+			volumeOperationMaxBackoff)
 	adc.nodeStatusUpdater = statusupdater.NewNodeStatusUpdater(
 		kubeClient, nodeInformer.Lister(), adc.actualStateOfWorld)
 

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -51,7 +51,8 @@ func Test_NewAttachDetachController_Positive(t *testing.T) {
 		nil, /* prober */
 		false,
 		5*time.Second,
-		DefaultTimerConfig)
+		DefaultTimerConfig,
+		30*time.Second)
 
 	// Assert
 	if err != nil {
@@ -227,7 +228,9 @@ func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2
 		prober,
 		false,
 		1*time.Second,
-		DefaultTimerConfig)
+		DefaultTimerConfig,
+		// volumeOperationMaxBackoff is the max backOff time of volume operations
+		30*time.Second)
 
 	if err != nil {
 		t.Fatalf("Run failed with error. Expected: <no error> Actual: <%v>", err)

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
@@ -40,6 +40,8 @@ const (
 	syncLoopPeriod            time.Duration = 100 * time.Minute
 	maxWaitForUnmountDuration time.Duration = 50 * time.Millisecond
 	resyncPeriod              time.Duration = 5 * time.Minute
+	// volumeOperationMaxBackoff is the max backOff time of volume operations
+	volumeOperationMaxBackoff time.Duration = 30 * time.Second
 )
 
 // Calls Run()
@@ -57,7 +59,8 @@ func Test_Run_Positive_DoNothing(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nsu := statusupdater.NewNodeStatusUpdater(
 		fakeKubeClient, informerFactory.Core().V1().Nodes().Lister(), asw)
@@ -93,7 +96,8 @@ func Test_Run_Positive_OneDesiredVolumeAttach(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, fakeRecorder)
@@ -145,7 +149,8 @@ func Test_Run_Positive_OneDesiredVolumeAttachThenDetachWithUnmountedVolume(t *te
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, fakeRecorder)
@@ -218,7 +223,8 @@ func Test_Run_Positive_OneDesiredVolumeAttachThenDetachWithMountedVolume(t *test
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, fakeRecorder)
@@ -291,7 +297,8 @@ func Test_Run_Negative_OneDesiredVolumeAttachThenDetachWithUnmountedVolumeUpdate
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	nsu := statusupdater.NewFakeNodeStatusUpdater(true /* returnError */)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, fakeRecorder)
@@ -367,7 +374,8 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteMany(t *testing.
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, fakeRecorder)
@@ -460,7 +468,8 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteOnce(t *testing.
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, fakeRecorder)
@@ -551,7 +560,8 @@ func Test_Run_OneVolumeAttachAndDetachUncertainNodesWithReadWriteOnce(t *testing
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, fakeRecorder)
@@ -618,7 +628,8 @@ func Test_Run_OneVolumeAttachAndDetachTimeoutNodesWithReadWriteOnce(t *testing.T
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, fakeRecorder)
@@ -724,7 +735,8 @@ func Test_ReportMultiAttachError(t *testing.T) {
 			volumePluginMgr,
 			fakeRecorder,
 			false, /* checkNodeCapabilitiesBeforeMount */
-			fakeHandler))
+			fakeHandler),
+			volumeOperationMaxBackoff)
 		nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 		rc := NewReconciler(
 			reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, fakeRecorder)

--- a/pkg/controller/volume/persistentvolume/config/types.go
+++ b/pkg/controller/volume/persistentvolume/config/types.go
@@ -28,6 +28,8 @@ type PersistentVolumeBinderControllerConfiguration struct {
 	PVClaimBinderSyncPeriod metav1.Duration
 	// volumeConfiguration holds configuration for volume related features.
 	VolumeConfiguration VolumeConfiguration
+	// VolumeOperationMaxBackoff is the max backOff time of volume operations
+	VolumeOperationMaxBackoff metav1.Duration
 }
 
 // VolumeConfiguration contains *all* enumerated flags meant to configure all volume

--- a/pkg/controller/volume/persistentvolume/config/v1alpha1/defaults.go
+++ b/pkg/controller/volume/persistentvolume/config/v1alpha1/defaults.go
@@ -38,7 +38,9 @@ func RecommendedDefaultPersistentVolumeBinderControllerConfiguration(obj *kubect
 	if obj.PVClaimBinderSyncPeriod == zero {
 		obj.PVClaimBinderSyncPeriod = metav1.Duration{Duration: 15 * time.Second}
 	}
-
+	if obj.VolumeOperationMaxBackoff == zero {
+		obj.VolumeOperationMaxBackoff = metav1.Duration{Duration: 2*time.Minute + 2*time.Second}
+	}
 	// Use the default VolumeConfiguration options.
 	RecommendedDefaultVolumeConfiguration(&obj.VolumeConfiguration)
 }

--- a/pkg/controller/volume/persistentvolume/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/volume/persistentvolume/config/v1alpha1/zz_generated.conversion.go
@@ -115,6 +115,7 @@ func autoConvert_v1alpha1_PersistentVolumeBinderControllerConfiguration_To_confi
 	if err := Convert_v1alpha1_VolumeConfiguration_To_config_VolumeConfiguration(&in.VolumeConfiguration, &out.VolumeConfiguration, s); err != nil {
 		return err
 	}
+	out.VolumeOperationMaxBackoff = in.VolumeOperationMaxBackoff
 	return nil
 }
 
@@ -123,6 +124,7 @@ func autoConvert_config_PersistentVolumeBinderControllerConfiguration_To_v1alpha
 	if err := Convert_config_VolumeConfiguration_To_v1alpha1_VolumeConfiguration(&in.VolumeConfiguration, &out.VolumeConfiguration, s); err != nil {
 		return err
 	}
+	out.VolumeOperationMaxBackoff = in.VolumeOperationMaxBackoff
 	return nil
 }
 

--- a/pkg/controller/volume/persistentvolume/config/zz_generated.deepcopy.go
+++ b/pkg/controller/volume/persistentvolume/config/zz_generated.deepcopy.go
@@ -25,6 +25,7 @@ func (in *PersistentVolumeBinderControllerConfiguration) DeepCopyInto(out *Persi
 	*out = *in
 	out.PVClaimBinderSyncPeriod = in.PVClaimBinderSyncPeriod
 	out.VolumeConfiguration = in.VolumeConfiguration
+	out.VolumeOperationMaxBackoff = in.VolumeOperationMaxBackoff
 	return
 }
 

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -96,6 +96,7 @@ type testCall func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeRe
 
 const testNamespace = "default"
 const mockPluginName = "kubernetes.io/mock-volume"
+const defaultVolumeOperationMaxBackOff = 30 * time.Second
 
 var novolumes []*v1.PersistentVolume
 var noclaims []*v1.PersistentVolumeClaim
@@ -224,6 +225,7 @@ func newTestController(kubeClient clientset.Interface, informerFactory informers
 		NodeInformer:              informerFactory.Core().V1().Nodes(),
 		EventRecorder:             record.NewFakeRecorder(1000),
 		EnableDynamicProvisioning: enableDynamicProvisioning,
+		VolumeOperationMaxBackoff: defaultVolumeOperationMaxBackOff,
 	}
 	ctrl, err := NewController(params)
 	if err != nil {

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -66,6 +66,7 @@ type ControllerParameters struct {
 	NodeInformer              coreinformers.NodeInformer
 	EventRecorder             record.EventRecorder
 	EnableDynamicProvisioning bool
+	VolumeOperationMaxBackoff time.Duration
 }
 
 // NewController creates a new PersistentVolume controller
@@ -83,7 +84,7 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 		claims:                        cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc),
 		kubeClient:                    p.KubeClient,
 		eventRecorder:                 eventRecorder,
-		runningOperations:             goroutinemap.NewGoRoutineMap(true /* exponentialBackOffOnError */),
+		runningOperations:             goroutinemap.NewGoRoutineMap(true /* exponentialBackOffOnError */, p.VolumeOperationMaxBackoff),
 		cloud:                         p.Cloud,
 		enableDynamicProvisioning:     p.EnableDynamicProvisioning,
 		clusterName:                   p.ClusterName,

--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -94,6 +94,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.ContainerLogMaxFiles = 5
 			obj.ContainerLogMaxSize = "10Mi"
 			obj.ConfigMapAndSecretChangeDetectionStrategy = "Watch"
+			obj.VolumeOperationMaxBackOff = metav1.Duration{Duration: 2*time.Minute + 2*time.Second}
 		},
 	}
 }

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -218,5 +218,6 @@ var (
 		"TypeMeta.APIVersion",
 		"TypeMeta.Kind",
 		"VolumeStatsAggPeriod.Duration",
+		"VolumeOperationMaxBackOff.Duration",
 	)
 )

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -288,6 +288,8 @@ type KubeletConfiguration struct {
 	ContainerLogMaxFiles int32
 	// ConfigMapAndSecretChangeDetectionStrategy is a mode in which config map and secret managers are running.
 	ConfigMapAndSecretChangeDetectionStrategy ResourceChangeDetectionStrategy
+	// VolumeOperationMaxBackOff sets max backoff to volume options, e.g. attach, verify.
+	VolumeOperationMaxBackOff metav1.Duration
 
 	/* the following fields are meant for Node Allocatable */
 

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -217,6 +217,9 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 	if obj.ConfigMapAndSecretChangeDetectionStrategy == "" {
 		obj.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.WatchChangeDetectionStrategy
 	}
+	if obj.VolumeOperationMaxBackOff == zeroDuration {
+		obj.VolumeOperationMaxBackOff = metav1.Duration{Duration: 2*time.Minute + 2*time.Second}
+	}
 	if obj.EnforceNodeAllocatable == nil {
 		obj.EnforceNodeAllocatable = DefaultNodeAllocatableEnforcement
 	}

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -323,6 +323,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 		return err
 	}
 	out.ConfigMapAndSecretChangeDetectionStrategy = config.ResourceChangeDetectionStrategy(in.ConfigMapAndSecretChangeDetectionStrategy)
+	out.VolumeOperationMaxBackOff = in.VolumeOperationMaxBackOff
 	out.SystemReserved = *(*map[string]string)(unsafe.Pointer(&in.SystemReserved))
 	out.KubeReserved = *(*map[string]string)(unsafe.Pointer(&in.KubeReserved))
 	out.SystemReservedCgroup = in.SystemReservedCgroup
@@ -453,6 +454,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 		return err
 	}
 	out.ConfigMapAndSecretChangeDetectionStrategy = v1beta1.ResourceChangeDetectionStrategy(in.ConfigMapAndSecretChangeDetectionStrategy)
+	out.VolumeOperationMaxBackOff = in.VolumeOperationMaxBackOff
 	out.SystemReserved = *(*map[string]string)(unsafe.Pointer(&in.SystemReserved))
 	out.KubeReserved = *(*map[string]string)(unsafe.Pointer(&in.KubeReserved))
 	out.SystemReservedCgroup = in.SystemReservedCgroup

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -111,6 +111,9 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration) error 
 	if kc.ServerTLSBootstrap && !localFeatureGate.Enabled(features.RotateKubeletServerCertificate) {
 		allErrors = append(allErrors, fmt.Errorf("invalid configuration: ServerTLSBootstrap %v requires feature gate RotateKubeletServerCertificate", kc.ServerTLSBootstrap))
 	}
+	if kc.VolumeOperationMaxBackOff.Duration < time.Second {
+		allErrors = append(allErrors, fmt.Errorf("invalid configuration: VolumeOperationMaxBackOff %v (--volume-operation-max-backoff-time) must be 1s or greater", kc.VolumeOperationMaxBackOff))
+	}
 	for _, val := range kc.EnforceNodeAllocatable {
 		switch val {
 		case kubetypes.NodeAllocatableEnforcementKey:

--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -53,6 +53,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		HairpinMode:                 kubeletconfig.PromiscuousBridge,
 		NodeLeaseDurationSeconds:    1,
 		CPUCFSQuotaPeriod:           metav1.Duration{Duration: 100 * time.Millisecond},
+		VolumeOperationMaxBackOff:   metav1.Duration{Duration: 30 * time.Second},
 	}
 	if allErrors := ValidateKubeletConfiguration(successCase); allErrors != nil {
 		t.Errorf("expect no errors, got %v", allErrors)
@@ -83,8 +84,9 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		HairpinMode:                 "foo",
 		NodeLeaseDurationSeconds:    -1,
 		CPUCFSQuotaPeriod:           metav1.Duration{Duration: 0},
+		VolumeOperationMaxBackOff:   metav1.Duration{Duration: 0},
 	}
-	const numErrs = 25
+	const numErrs = 26
 	if allErrors := ValidateKubeletConfiguration(errorCase); len(allErrors.(utilerrors.Aggregate).Errors()) != numErrs {
 		t.Errorf("expect %d errors, got %v", numErrs, len(allErrors.(utilerrors.Aggregate).Errors()))
 	}

--- a/pkg/kubelet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/config/zz_generated.deepcopy.go
@@ -161,6 +161,7 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 			(*out)[key] = val
 		}
 	}
+	out.VolumeOperationMaxBackOff = in.VolumeOperationMaxBackOff
 	if in.SystemReserved != nil {
 		in, out := &in.SystemReserved, &out.SystemReserved
 		*out = make(map[string]string, len(*in))

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -49,7 +49,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/certificate"
 	"k8s.io/client-go/util/flowcontrol"
-	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/cloud-provider"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	"k8s.io/klog"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -356,7 +356,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeLabels map[string]string,
 	seccompProfileRoot string,
 	bootstrapCheckpointPath string,
-	nodeStatusMaxImages int32) (*Kubelet, error) {
+	nodeStatusMaxImages int32,
+	volumeOperationMaxBackoff metav1.Duration) (*Kubelet, error) {
 	if rootDirectory == "" {
 		return nil, fmt.Errorf("invalid root directory %q", rootDirectory)
 	}
@@ -815,7 +816,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		klet.getPodsDir(),
 		kubeDeps.Recorder,
 		experimentalCheckNodeCapabilitiesBeforeMount,
-		keepTerminatedPodVolumes)
+		keepTerminatedPodVolumes,
+		volumeOperationMaxBackoff.Duration)
 
 	klet.reasonCache = NewReasonCache()
 	klet.workQueue = queue.NewBasicWorkQueue(klet.clock)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -325,7 +325,8 @@ func newTestKubeletWithImageList(
 		kubelet.getPodsDir(),
 		kubelet.recorder,
 		false, /* experimentalCheckNodeCapabilitiesBeforeMount*/
-		false /* keepTerminatedPodVolumes */)
+		false, /* keepTerminatedPodVolumes */
+		30*time.Second /* maxBackoffTime */)
 
 	kubelet.pluginManager = pluginmanager.NewPluginManager(
 		kubelet.getPluginsRegistrationDir(), /* sockDir */

--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_executor.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_executor.go
@@ -52,12 +52,15 @@ type OperationExecutor interface {
 	UnregisterPlugin(socketPath string, pluginHandlers map[string]cache.PluginHandler, actualStateOfWorld ActualStateOfWorldUpdater) error
 }
 
+const defaultMaxBackoffDuration = 2*time.Minute + 2*time.Second
+
 // NewOperationExecutor returns a new instance of OperationExecutor.
 func NewOperationExecutor(
 	operationGenerator OperationGenerator) OperationExecutor {
 
 	return &operationExecutor{
-		pendingOperations:  goroutinemap.NewGoRoutineMap(true /* exponentialBackOffOnError */),
+		pendingOperations: goroutinemap.NewGoRoutineMap(true, /* exponentialBackOffOnError */
+			defaultMaxBackoffDuration),
 		operationGenerator: operationGenerator,
 	}
 }

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -106,7 +106,8 @@ func TestRunOnce(t *testing.T) {
 		kb.getPodsDir(),
 		kb.recorder,
 		false, /* experimentalCheckNodeCapabilitiesBeforeMount */
-		false /* keepTerminatedPodVolumes */)
+		false, /* keepTerminatedPodVolumes */
+		30*time.Second /* maxBackoffTime */)
 
 	// TODO: Factor out "StatsProvider" from Kubelet so we don't have a cyclic dependency
 	volumeStatsAggPeriod := time.Second * 10

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -52,6 +52,8 @@ const (
 	waitForAttachTimeout time.Duration     = 1 * time.Second
 	nodeName             k8stypes.NodeName = k8stypes.NodeName("mynodename")
 	kubeletPodsDir       string            = "fake-dir"
+	// volumeOperationMaxBackoff is the max backOff time of volume operations
+	volumeOperationMaxBackoff time.Duration = 30 * time.Second
 )
 
 func hasAddedPods() bool { return true }
@@ -71,8 +73,8 @@ func Test_Run_Positive_DoNothing(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler,
-	))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	reconciler := NewReconciler(
 		kubeClient,
 		false, /* controllerAttachDetachEnabled */
@@ -115,7 +117,8 @@ func Test_Run_Positive_VolumeAttachAndMount(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	reconciler := NewReconciler(
 		kubeClient,
 		false, /* controllerAttachDetachEnabled */
@@ -192,7 +195,8 @@ func Test_Run_Positive_VolumeMountControllerAttachEnabled(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	reconciler := NewReconciler(
 		kubeClient,
 		true, /* controllerAttachDetachEnabled */
@@ -270,7 +274,8 @@ func Test_Run_Positive_VolumeAttachMountUnmountDetach(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	reconciler := NewReconciler(
 		kubeClient,
 		false, /* controllerAttachDetachEnabled */
@@ -359,7 +364,8 @@ func Test_Run_Positive_VolumeUnmountControllerAttachEnabled(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	reconciler := NewReconciler(
 		kubeClient,
 		true, /* controllerAttachDetachEnabled */
@@ -449,7 +455,8 @@ func Test_Run_Positive_VolumeAttachAndMap(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	reconciler := NewReconciler(
 		kubeClient,
 		false, /* controllerAttachDetachEnabled */
@@ -533,7 +540,8 @@ func Test_Run_Positive_BlockVolumeMapControllerAttachEnabled(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	reconciler := NewReconciler(
 		kubeClient,
 		true, /* controllerAttachDetachEnabled */
@@ -618,7 +626,8 @@ func Test_Run_Positive_BlockVolumeAttachMapUnmapDetach(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	reconciler := NewReconciler(
 		kubeClient,
 		false, /* controllerAttachDetachEnabled */
@@ -713,7 +722,8 @@ func Test_Run_Positive_VolumeUnmapControllerAttachEnabled(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	reconciler := NewReconciler(
 		kubeClient,
 		true, /* controllerAttachDetachEnabled */
@@ -817,7 +827,8 @@ func Test_GenerateMapVolumeFunc_Plugin_Not_Found(t *testing.T) {
 				volumePluginMgr,
 				nil,   /* fakeRecorder */
 				false, /* checkNodeCapabilitiesBeforeMount */
-				nil))
+				nil),
+				volumeOperationMaxBackoff)
 
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -871,7 +882,8 @@ func Test_GenerateUnmapVolumeFunc_Plugin_Not_Found(t *testing.T) {
 				volumePluginMgr,
 				nil,   /* fakeRecorder */
 				false, /* checkNodeCapabilitiesBeforeMount */
-				nil))
+				nil),
+				volumeOperationMaxBackoff)
 			volumeMode := v1.PersistentVolumeBlock
 			tmpSpec := &volume.Spec{PersistentVolume: &v1.PersistentVolume{Spec: v1.PersistentVolumeSpec{VolumeMode: &volumeMode}}}
 			volumeToUnmount := operationexecutor.MountedVolume{
@@ -917,7 +929,8 @@ func Test_GenerateUnmapDeviceFunc_Plugin_Not_Found(t *testing.T) {
 				volumePluginMgr,
 				nil,   /* fakeRecorder */
 				false, /* checkNodeCapabilitiesBeforeMount */
-				nil))
+				nil),
+				volumeOperationMaxBackoff)
 			var mounter mount.Interface
 			volumeMode := v1.PersistentVolumeBlock
 			tmpSpec := &volume.Spec{PersistentVolume: &v1.PersistentVolume{Spec: v1.PersistentVolumeSpec{VolumeMode: &volumeMode}}}
@@ -991,7 +1004,8 @@ func Test_Run_Positive_VolumeFSResizeControllerAttachEnabled(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 
 	reconciler := NewReconciler(
 		kubeClient,
@@ -1169,7 +1183,8 @@ func Test_Run_Positive_VolumeMountControllerAttachEnabledRace(t *testing.T) {
 		volumePluginMgr,
 		fakeRecorder,
 		false, /* checkNodeCapabilitiesBeforeMount */
-		fakeHandler))
+		fakeHandler),
+		volumeOperationMaxBackoff)
 	reconciler := NewReconciler(
 		kubeClient,
 		true, /* controllerAttachDetachEnabled */

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -154,7 +154,8 @@ func NewVolumeManager(
 	kubeletPodsDir string,
 	recorder record.EventRecorder,
 	checkNodeCapabilitiesBeforeMount bool,
-	keepTerminatedPodVolumes bool) VolumeManager {
+	keepTerminatedPodVolumes bool,
+	volumeOperationMaxBackoff time.Duration) VolumeManager {
 
 	vm := &volumeManager{
 		kubeClient:          kubeClient,
@@ -166,7 +167,8 @@ func NewVolumeManager(
 			volumePluginMgr,
 			recorder,
 			checkNodeCapabilitiesBeforeMount,
-			volumepathhandler.NewBlockVolumePathHandler())),
+			volumepathhandler.NewBlockVolumePathHandler()),
+			volumeOperationMaxBackoff),
 	}
 
 	vm.desiredStateOfWorldPopulator = populator.NewDesiredStateOfWorldPopulator(

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -235,7 +235,8 @@ func newTestVolumeManager(tmpDir string, podManager kubepod.Manager, kubeClient 
 		"",
 		fakeRecorder,
 		false, /* experimentalCheckNodeCapabilitiesBeforeMount */
-		false /* keepTerminatedPodVolumes */)
+		false, /* keepTerminatedPodVolumes */
+		30*time.Second)
 
 	return vm
 }

--- a/pkg/util/goroutinemap/exponentialbackoff/exponential_backoff.go
+++ b/pkg/util/goroutinemap/exponentialbackoff/exponential_backoff.go
@@ -29,20 +29,22 @@ const (
 	// the same target (if exponentialBackOffOnError is enabled). Each
 	// successive error results in a wait 2x times the previous.
 	initialDurationBeforeRetry time.Duration = 500 * time.Millisecond
-
-	// maxDurationBeforeRetry is the maximum amount of time that
-	// durationBeforeRetry will grow to due to exponential backoff.
-	// Value is slightly offset from 2 minutes to make timeouts due to this
-	// constant recognizable.
-	maxDurationBeforeRetry time.Duration = 2*time.Minute + 2*time.Second
 )
 
 // ExponentialBackoff contains the last occurrence of an error and the duration
 // that retries are not permitted.
 type ExponentialBackoff struct {
-	lastError           error
-	lastErrorTime       time.Time
-	durationBeforeRetry time.Duration
+	lastError              error
+	lastErrorTime          time.Time
+	durationBeforeRetry    time.Duration
+	maxDurationBeforeRetry time.Duration
+}
+
+// NewExponentialBackoff initializes a ExponentialBackoff using max duration(before retry)
+func NewExponentialBackoff(maxDurationBeforeRetry time.Duration) *ExponentialBackoff {
+	return &ExponentialBackoff{
+		maxDurationBeforeRetry: maxDurationBeforeRetry,
+	}
 }
 
 // SafeToRetry returns an error if the durationBeforeRetry period for the given
@@ -60,8 +62,8 @@ func (expBackoff *ExponentialBackoff) Update(err *error) {
 		expBackoff.durationBeforeRetry = initialDurationBeforeRetry
 	} else {
 		expBackoff.durationBeforeRetry = 2 * expBackoff.durationBeforeRetry
-		if expBackoff.durationBeforeRetry > maxDurationBeforeRetry {
-			expBackoff.durationBeforeRetry = maxDurationBeforeRetry
+		if expBackoff.durationBeforeRetry > expBackoff.maxDurationBeforeRetry {
+			expBackoff.durationBeforeRetry = expBackoff.maxDurationBeforeRetry
 		}
 	}
 

--- a/pkg/util/goroutinemap/goroutinemap_test.go
+++ b/pkg/util/goroutinemap/goroutinemap_test.go
@@ -39,11 +39,14 @@ const (
 	// wait for an operation to complete (each successive failure results in
 	// exponential backoff).
 	initialOperationWaitTimeLong time.Duration = 500 * time.Millisecond
+
+	// volumeOperationMaxBackoff is the max backOff time of volume operations
+	volumeOperationMaxBackoff time.Duration = 30 * time.Second
 )
 
 func Test_NewGoRoutineMap_Positive_SingleOp(t *testing.T) {
 	// Arrange
-	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-name"
 	operation := func() error { return nil }
 
@@ -58,7 +61,7 @@ func Test_NewGoRoutineMap_Positive_SingleOp(t *testing.T) {
 
 func Test_NewGoRoutineMap_Positive_TwoOps(t *testing.T) {
 	// Arrange
-	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operation1Name := "operation1-name"
 	operation2Name := "operation2-name"
 	operation := func() error { return nil }
@@ -79,7 +82,7 @@ func Test_NewGoRoutineMap_Positive_TwoOps(t *testing.T) {
 
 func Test_NewGoRoutineMap_Positive_SingleOpWithExpBackoff(t *testing.T) {
 	// Arrange
-	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-name"
 	operation := func() error { return nil }
 
@@ -94,7 +97,7 @@ func Test_NewGoRoutineMap_Positive_SingleOpWithExpBackoff(t *testing.T) {
 
 func Test_NewGoRoutineMap_Positive_SecondOpAfterFirstCompletes(t *testing.T) {
 	// Arrange
-	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
 	operation1 := generateCallbackFunc(operation1DoneCh)
@@ -126,7 +129,7 @@ func Test_NewGoRoutineMap_Positive_SecondOpAfterFirstCompletes(t *testing.T) {
 
 func Test_NewGoRoutineMap_Positive_SecondOpAfterFirstCompletesWithExpBackoff(t *testing.T) {
 	// Arrange
-	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
 	operation1 := generateCallbackFunc(operation1DoneCh)
@@ -158,7 +161,7 @@ func Test_NewGoRoutineMap_Positive_SecondOpAfterFirstCompletesWithExpBackoff(t *
 
 func Test_NewGoRoutineMap_Positive_SecondOpAfterFirstPanics(t *testing.T) {
 	// Arrange
-	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-name"
 	operation1 := generatePanicFunc()
 	err1 := grm.Run(operationName, operation1)
@@ -188,7 +191,7 @@ func Test_NewGoRoutineMap_Positive_SecondOpAfterFirstPanics(t *testing.T) {
 
 func Test_NewGoRoutineMap_Positive_SecondOpAfterFirstPanicsWithExpBackoff(t *testing.T) {
 	// Arrange
-	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-name"
 	operation1 := generatePanicFunc()
 	err1 := grm.Run(operationName, operation1)
@@ -218,7 +221,7 @@ func Test_NewGoRoutineMap_Positive_SecondOpAfterFirstPanicsWithExpBackoff(t *tes
 
 func Test_NewGoRoutineMap_Negative_SecondOpBeforeFirstCompletes(t *testing.T) {
 	// Arrange
-	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
 	operation1 := generateWaitFunc(operation1DoneCh)
@@ -242,7 +245,7 @@ func Test_NewGoRoutineMap_Negative_SecondOpBeforeFirstCompletes(t *testing.T) {
 
 func Test_NewGoRoutineMap_Negative_SecondOpBeforeFirstCompletesWithExpBackoff(t *testing.T) {
 	// Arrange
-	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
 	operation1 := generateWaitFunc(operation1DoneCh)
@@ -266,7 +269,7 @@ func Test_NewGoRoutineMap_Negative_SecondOpBeforeFirstCompletesWithExpBackoff(t 
 
 func Test_NewGoRoutineMap_Positive_ThirdOpAfterFirstCompletes(t *testing.T) {
 	// Arrange
-	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
 	operation1 := generateWaitFunc(operation1DoneCh)
@@ -310,7 +313,7 @@ func Test_NewGoRoutineMap_Positive_ThirdOpAfterFirstCompletes(t *testing.T) {
 
 func Test_NewGoRoutineMap_Positive_ThirdOpAfterFirstCompletesWithExpBackoff(t *testing.T) {
 	// Arrange
-	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
 	operation1 := generateWaitFunc(operation1DoneCh)
@@ -355,7 +358,7 @@ func Test_NewGoRoutineMap_Positive_ThirdOpAfterFirstCompletesWithExpBackoff(t *t
 func Test_NewGoRoutineMap_Positive_WaitEmpty(t *testing.T) {
 	// Test than Wait() on empty GoRoutineMap always succeeds without blocking
 	// Arrange
-	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 
 	// Act
 	waitDoneCh := make(chan interface{}, 1)
@@ -374,7 +377,7 @@ func Test_NewGoRoutineMap_Positive_WaitEmpty(t *testing.T) {
 func Test_NewGoRoutineMap_Positive_WaitEmptyWithExpBackoff(t *testing.T) {
 	// Test than Wait() on empty GoRoutineMap always succeeds without blocking
 	// Arrange
-	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 
 	// Act
 	waitDoneCh := make(chan interface{}, 1)
@@ -393,7 +396,7 @@ func Test_NewGoRoutineMap_Positive_WaitEmptyWithExpBackoff(t *testing.T) {
 func Test_NewGoRoutineMap_Positive_Wait(t *testing.T) {
 	// Test that Wait() really blocks until the last operation succeeds
 	// Arrange
-	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
 	operation1 := generateWaitFunc(operation1DoneCh)
@@ -422,7 +425,7 @@ func Test_NewGoRoutineMap_Positive_Wait(t *testing.T) {
 func Test_NewGoRoutineMap_Positive_WaitWithExpBackoff(t *testing.T) {
 	// Test that Wait() really blocks until the last operation succeeds
 	// Arrange
-	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
 	operation1 := generateWaitFunc(operation1DoneCh)
@@ -449,7 +452,7 @@ func Test_NewGoRoutineMap_Positive_WaitWithExpBackoff(t *testing.T) {
 }
 
 func Test_NewGoRoutineMap_WaitForCompletionWithExpBackoff(t *testing.T) {
-	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */)
+	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */, volumeOperationMaxBackoff)
 	operationName := "operation-err"
 
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -150,11 +150,12 @@ type OperationExecutor interface {
 
 // NewOperationExecutor returns a new instance of OperationExecutor.
 func NewOperationExecutor(
-	operationGenerator OperationGenerator) OperationExecutor {
-
+	operationGenerator OperationGenerator,
+	volumeOperationMaxBackoff time.Duration) OperationExecutor {
 	return &operationExecutor{
 		pendingOperations: nestedpendingoperations.NewNestedPendingOperations(
-			true /* exponentialBackOffOnError */),
+			true, /* exponentialBackOffOnError */
+			volumeOperationMaxBackoff),
 		operationGenerator: operationGenerator,
 	}
 }

--- a/pkg/volume/util/operationexecutor/operation_executor_test.go
+++ b/pkg/volume/util/operationexecutor/operation_executor_test.go
@@ -31,18 +31,19 @@ import (
 )
 
 const (
-	numVolumesToMount                    = 2
-	numAttachableVolumesToUnmount        = 2
-	numNonAttachableVolumesToUnmount     = 2
-	numDevicesToUnmount                  = 2
-	numVolumesToAttach                   = 2
-	numVolumesToDetach                   = 2
-	numVolumesToVerifyAttached           = 2
-	numVolumesToVerifyControllerAttached = 2
-	numVolumesToMap                      = 2
-	numAttachableVolumesToUnmap          = 2
-	numNonAttachableVolumesToUnmap       = 2
-	numDevicesToUnmap                    = 2
+	numVolumesToMount                                  = 2
+	numAttachableVolumesToUnmount                      = 2
+	numNonAttachableVolumesToUnmount                   = 2
+	numDevicesToUnmount                                = 2
+	numVolumesToAttach                                 = 2
+	numVolumesToDetach                                 = 2
+	numVolumesToVerifyAttached                         = 2
+	numVolumesToVerifyControllerAttached               = 2
+	numVolumesToMap                                    = 2
+	numAttachableVolumesToUnmap                        = 2
+	numNonAttachableVolumesToUnmap                     = 2
+	numDevicesToUnmap                                  = 2
+	volumeOperationMaxBackoff            time.Duration = 30 * time.Second
 )
 
 var _ OperationGenerator = &fakeOperationGenerator{}
@@ -634,7 +635,7 @@ loop:
 
 func setup() (chan interface{}, chan interface{}, OperationExecutor) {
 	ch, quit := make(chan interface{}), make(chan interface{})
-	return ch, quit, NewOperationExecutor(newFakeOperationGenerator(ch, quit))
+	return ch, quit, NewOperationExecutor(newFakeOperationGenerator(ch, quit), volumeOperationMaxBackoff)
 }
 
 // This function starts by writing to ch and blocks on the quit channel

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -383,6 +383,8 @@ type PersistentVolumeBinderControllerConfiguration struct {
 	PVClaimBinderSyncPeriod metav1.Duration
 	// volumeConfiguration holds configuration for volume related features.
 	VolumeConfiguration VolumeConfiguration
+	// VolumeOperationMaxBackoff is the max backOff time of volume operations
+	VolumeOperationMaxBackoff metav1.Duration
 }
 
 // PodGCControllerConfiguration contains elements describing PodGCController.

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/zz_generated.deepcopy.go
@@ -384,6 +384,7 @@ func (in *PersistentVolumeBinderControllerConfiguration) DeepCopyInto(out *Persi
 	*out = *in
 	out.PVClaimBinderSyncPeriod = in.PVClaimBinderSyncPeriod
 	in.VolumeConfiguration.DeepCopyInto(&out.VolumeConfiguration)
+	out.VolumeOperationMaxBackoff = in.VolumeOperationMaxBackoff
 	return
 }
 

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -666,6 +666,12 @@ type KubeletConfiguration struct {
 	// Default: "Watch"
 	// +optional
 	ConfigMapAndSecretChangeDetectionStrategy ResourceChangeDetectionStrategy `json:"configMapAndSecretChangeDetectionStrategy,omitempty"`
+	// VolumeOperationMaxBackOff sets max backoff to volume options, e.g. attach, verify.
+	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// lowering it may increase the stress of nodes.
+	// Defaults: 2m2s
+	// +optional
+	VolumeOperationMaxBackOff metav1.Duration `json:"volumeOperationMaxBackoff,omitempty"`
 
 	/* the following fields are meant for Node Allocatable */
 

--- a/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
@@ -261,6 +261,7 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = new(int32)
 		**out = **in
 	}
+	out.VolumeOperationMaxBackOff = in.VolumeOperationMaxBackOff
 	if in.SystemReserved != nil {
 		in, out := &in.SystemReserved, &out.SystemReserved
 		*out = make(map[string]string, len(*in))

--- a/test/integration/scheduler/volume_binding_test.go
+++ b/test/integration/scheduler/volume_binding_test.go
@@ -76,12 +76,13 @@ var (
 )
 
 const (
-	node1                 = "node-1"
-	node2                 = "node-2"
-	podLimit              = 100
-	volsPerPod            = 5
-	nodeAffinityLabelKey  = "kubernetes.io/hostname"
-	provisionerPluginName = "kubernetes.io/mock-provisioner"
+	node1                            = "node-1"
+	node2                            = "node-2"
+	podLimit                         = 100
+	volsPerPod                       = 5
+	nodeAffinityLabelKey             = "kubernetes.io/hostname"
+	provisionerPluginName            = "kubernetes.io/mock-provisioner"
+	defaultVolumeOperationMaxBackOff = 30 * time.Second
 )
 
 type testPV struct {
@@ -959,6 +960,7 @@ func initPVController(context *testContext, provisionDelaySeconds int) (*persist
 		PodInformer:               informerFactory.Core().V1().Pods(),
 		NodeInformer:              informerFactory.Core().V1().Nodes(),
 		EnableDynamicProvisioning: true,
+		VolumeOperationMaxBackoff: defaultVolumeOperationMaxBackOff,
 	}
 
 	ctrl, err := persistentvolume.NewController(params)

--- a/test/integration/volume/attach_detach_test.go
+++ b/test/integration/volume/attach_detach_test.go
@@ -437,7 +437,8 @@ func createAdClients(ns *v1.Namespace, t *testing.T, server *httptest.Server, sy
 		nil, /* prober */
 		false,
 		5*time.Second,
-		timers)
+		timers,
+		30*time.Second)
 
 	if err != nil {
 		t.Fatalf("Error creating AttachDetach : %v", err)
@@ -457,6 +458,7 @@ func createAdClients(ns *v1.Namespace, t *testing.T, server *httptest.Server, sy
 		PodInformer:               informers.Core().V1().Pods(),
 		NodeInformer:              informers.Core().V1().Nodes(),
 		EnableDynamicProvisioning: false,
+		VolumeOperationMaxBackoff: 30 * time.Second,
 	}
 	pvCtrl, err := persistentvolume.NewController(params)
 	if err != nil {

--- a/test/integration/volume/persistent_volumes_test.go
+++ b/test/integration/volume/persistent_volumes_test.go
@@ -57,6 +57,7 @@ import (
 //
 const defaultObjectCount = 100
 const defaultSyncPeriod = 1 * time.Second
+const defaultVolumeOperationMaxBackOff = 30 * time.Second
 
 const provisionerPluginName = "kubernetes.io/mock-provisioner"
 
@@ -1137,6 +1138,7 @@ func createClients(ns *v1.Namespace, t *testing.T, s *httptest.Server, syncPerio
 			PodInformer:               informers.Core().V1().Pods(),
 			NodeInformer:              informers.Core().V1().Nodes(),
 			EnableDynamicProvisioning: true,
+			VolumeOperationMaxBackoff: defaultVolumeOperationMaxBackOff,
 		})
 	if err != nil {
 		t.Fatalf("Failed to construct PersistentVolumes: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/kind feature

**What this PR does / why we need it**:

Currently,  the max backoff is a const value, which maybe unreasonable for volume operations. Different CSI drivers of cloud providers would have different performance.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #75230

**Special notes for your reviewer**:
cc @jingxu97 @gnufied 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kubelet and kube-controller-manager expose `volume-operation-max-backoff-time` to make max backoff time of volume operations configurable.
```
