### PR TITLE
Fix translation from kube-dns to CoreDNS Config to skip invalid values

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/BUILD
+++ b/cmd/kubeadm/app/phases/addons/dns/BUILD
@@ -48,6 +48,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/github.com/mholt/caddy/caddyfile:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -19,6 +19,7 @@ package dns
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/mholt/caddy/caddyfile"
@@ -32,6 +33,7 @@ import (
 	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
@@ -177,7 +179,7 @@ func coreDNSAddon(cfg *kubeadmapi.ClusterConfiguration, client clientset.Interfa
 		return err
 	}
 
-	upstreamNameserver, err := translateUpstreamNameServerOfKubeDNSToUpstreamProxyCoreDNS(kubeDNSUpstreamNameservers, kubeDNSConfigMap)
+	upstreamNameserver, err := translateUpstreamNameServerOfKubeDNSToUpstreamForwardCoreDNS(kubeDNSUpstreamNameservers, kubeDNSConfigMap)
 	if err != nil {
 		return err
 	}
@@ -309,7 +311,15 @@ func translateStubDomainOfKubeDNSToForwardCoreDNS(dataField string, kubeDNSConfi
 		}
 
 		var proxyStanza []interface{}
-		for domain, proxyIP := range stubDomainData {
+		for domain, proxyHosts := range stubDomainData {
+			proxyIP, err := omitHostnameInTranslation(proxyHosts)
+			if err != nil {
+				return "", errors.Wrap(err, "invalid format to parse for proxy")
+			}
+			if len(proxyIP) == 0 {
+				break
+			}
+
 			pStanza := map[string]interface{}{}
 			pStanza["keys"] = []string{domain + ":53"}
 			pStanza["body"] = [][]string{
@@ -335,22 +345,27 @@ func translateStubDomainOfKubeDNSToForwardCoreDNS(dataField string, kubeDNSConfi
 	return "", nil
 }
 
-// translateUpstreamNameServerOfKubeDNSToUpstreamProxyCoreDNS translates UpstreamNameServer Data in kube-dns ConfigMap
+// translateUpstreamNameServerOfKubeDNSToUpstreamForwardCoreDNS translates UpstreamNameServer Data in kube-dns ConfigMap
 // in the form of Proxy for the CoreDNS Corefile.
-func translateUpstreamNameServerOfKubeDNSToUpstreamProxyCoreDNS(dataField string, kubeDNSConfigMap *v1.ConfigMap) (string, error) {
+func translateUpstreamNameServerOfKubeDNSToUpstreamForwardCoreDNS(dataField string, kubeDNSConfigMap *v1.ConfigMap) (string, error) {
 	if kubeDNSConfigMap == nil {
 		return "", nil
 	}
 
 	if upstreamValues, ok := kubeDNSConfigMap.Data[dataField]; ok {
-		var upstreamProxyIP []string
+		var upstreamProxyValues []string
 
-		err := json.Unmarshal([]byte(upstreamValues), &upstreamProxyIP)
+		err := json.Unmarshal([]byte(upstreamValues), &upstreamProxyValues)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to parse JSON from 'kube-dns ConfigMap")
 		}
 
-		coreDNSProxyStanzaList := strings.Join(upstreamProxyIP, " ")
+		upstreamProxyValues, err = omitHostnameInTranslation(upstreamProxyValues)
+		if err != nil {
+			return "", errors.Wrap(err, "invalid format to parse for proxy")
+		}
+
+		coreDNSProxyStanzaList := strings.Join(upstreamProxyValues, " ")
 		return coreDNSProxyStanzaList, nil
 	}
 	return "/etc/resolv.conf", nil
@@ -400,11 +415,37 @@ func translateFederationsofKubeDNSToCoreDNS(dataField, coreDNSDomain string, kub
 // prepCorefileFormat indents the output of the Corefile caddytext and replaces tabs with spaces
 // to neatly format the configmap, making it readable.
 func prepCorefileFormat(s string, indentation int) string {
-	r := []string{}
+	var r []string
+	if s == "" {
+		return ""
+	}
 	for _, line := range strings.Split(s, "\n") {
 		indented := strings.Repeat(" ", indentation) + line
 		r = append(r, indented)
 	}
 	corefile := strings.Join(r, "\n")
 	return "\n" + strings.Replace(corefile, "\t", "   ", -1)
+}
+
+// omitHostnameInTranslation checks if the data extracted from the kube-dns ConfigMap contains a valid
+// IP address. Hostname to nameservers is not supported on CoreDNS and will
+// skip that particular instance, if there is any hostname present.
+func omitHostnameInTranslation(forwardIPs []string) ([]string, error) {
+	index := 0
+	for _, value := range forwardIPs {
+		proxyHost, _, err := kubeadmutil.ParseHostPort(value)
+		if err != nil {
+			return nil, err
+		}
+		parseIP := net.ParseIP(proxyHost)
+		if parseIP == nil {
+			klog.Warningf("your kube-dns configuration contains a hostname %v. It will be omitted in the translation to CoreDNS as hostnames are unsupported", proxyHost)
+		} else {
+			forwardIPs[index] = value
+			index++
+		}
+	}
+	forwardIPs = forwardIPs[:index]
+
+	return forwardIPs, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Kube-dns now [accepts service name for stubdomain and nameserver](https://github.com/kubernetes/dns/pull/279), while CoreDNS does not support this feature.

As a result, a user having service name in stubdomains/nameserver in their kube-dns ConfigMap while migrating to CoreDNS will result in an invalid CoreDNS Config, resulting in a broken k8s cluster.

The translation will now detect a service name and omit it while translating to the equivalent CoreDNS Config and additionally warn the user that it has been omitted during translation since it's not supported.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/1473

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
 `StubDomains` and `Upstreamnameserver` which contains a service name will be omitted while translating to the equivalent CoreDNS config.
```
