### PR TITLE
Garbage collector should use a merge patch instead of Update

### DIFF
--- a/pkg/controller/garbagecollector/operations.go
+++ b/pkg/controller/garbagecollector/operations.go
@@ -17,6 +17,7 @@ limitations under the License.
 package garbagecollector
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -67,14 +68,6 @@ func (gc *GarbageCollector) getObject(item objectReference) (*unstructured.Unstr
 	return gc.dynamicClient.Resource(resource).Namespace(resourceDefaultNamespace(namespaced, item.Namespace)).Get(item.Name, metav1.GetOptions{})
 }
 
-func (gc *GarbageCollector) updateObject(item objectReference, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	resource, namespaced, err := gc.apiResource(item.APIVersion, item.Kind)
-	if err != nil {
-		return nil, err
-	}
-	return gc.dynamicClient.Resource(resource).Namespace(resourceDefaultNamespace(namespaced, item.Namespace)).Update(obj, metav1.UpdateOptions{})
-}
-
 func (gc *GarbageCollector) patchObject(item objectReference, patch []byte, pt types.PatchType) (*unstructured.Unstructured, error) {
 	resource, namespaced, err := gc.apiResource(item.APIVersion, item.Kind)
 	if err != nil {
@@ -83,8 +76,6 @@ func (gc *GarbageCollector) patchObject(item objectReference, patch []byte, pt t
 	return gc.dynamicClient.Resource(resource).Namespace(resourceDefaultNamespace(namespaced, item.Namespace)).Patch(item.Name, pt, patch, metav1.PatchOptions{})
 }
 
-// TODO: Using Patch when strategicmerge supports deleting an entry from a
-// slice of a base type.
 func (gc *GarbageCollector) removeFinalizer(owner *node, targetFinalizer string) error {
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		ownerObject, err := gc.getObject(owner.identity)
@@ -112,9 +103,18 @@ func (gc *GarbageCollector) removeFinalizer(owner *node, targetFinalizer string)
 			klog.V(5).Infof("the %s finalizer is already removed from object %s", targetFinalizer, owner.identity)
 			return nil
 		}
+
 		// remove the owner from dependent's OwnerReferences
-		ownerObject.SetFinalizers(newFinalizers)
-		_, err = gc.updateObject(owner.identity, ownerObject)
+		patch, err := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"resourceVersion": accessor.GetResourceVersion(),
+				"finalizers":      newFinalizers,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("unable to finalize %s due to an error serializing patch: %v", owner.identity, err)
+		}
+		_, err = gc.patchObject(owner.identity, patch, types.MergePatchType)
 		return err
 	})
 	if errors.IsConflict(err) {


### PR DESCRIPTION
Fix a TODO in GC controller that blocks using the new
PartialObjectMetadata flow (because we don't support PUT of
PartialObjectMetadata). This patch is equivalent to the previous
mutation.

Part of kubernetes/enhancements#929

/kind bug

```release-note
NONE
```