### PR TITLE
enable external sources in verify-shellcheck

### DIFF
--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -117,16 +117,26 @@ else
   fi
 fi
 
+# common arguments we'll pass to shellcheck
+SHELLCHECK_OPTIONS=(
+  # allow following sourced files that are not specified in the command,
+  # we need this because we specify one file at at time in order to trivially
+  # detect which files are failing
+  "--external-sources"
+  # include our disabled lints
+  "--exclude=${SHELLCHECK_DISABLED}"
+)
+
 # lint each script, tracking failures
 errors=()
 not_failing=()
 for f in "${all_shell_scripts[@]}"; do
   set +o errexit
   if ${HAVE_SHELLCHECK}; then
-    failedLint=$(shellcheck --exclude="${SHELLCHECK_DISABLED}" "${f}")
+    failedLint=$(shellcheck "${SHELLCHECK_OPTIONS[@]}" "${f}")
   else
     failedLint=$(docker exec -t ${SHELLCHECK_CONTAINER} \
-                 shellcheck --exclude="${SHELLCHECK_DISABLED}" "${f}")
+                 shellcheck "${SHELLCHECK_OPTIONS[@]}" "${f}")
   fi
   set -o errexit
   kube::util::array_contains "${f}" "${failing_files[@]}" && in_failing=$? || in_failing=$?


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: enables `--external-sources` in `hack/verify-shellcheck.sh`.

We need this because we lint individual files, and shellcheck will only follow files specified as input, we want it to follow sourced files with fixed paths without complaining spuriously and without adding shellcheck-specific comments to the sources.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

xref: https://github.com/kubernetes/kubernetes/pull/75912#discussion_r270617967

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig testing
/priority important-longterm