### PR TITLE
Fix besteffort pods for conflicting tolerations

### DIFF
--- a/plugin/pkg/admission/podtolerationrestriction/admission.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission.go
@@ -132,8 +132,9 @@ func (p *podTolerationsPlugin) Admit(a admission.Attributes, o admission.ObjectI
 			},
 		})
 	}
-	pod.Spec.Tolerations = finalTolerations
-
+	// Final merge of tolerations irrespective of pod type, if the user while creating pods gives
+	// conflicting tolerations(with same key+effect), the existing ones should be overwritten by latest one
+	pod.Spec.Tolerations = tolerations.MergeTolerations(finalTolerations, []api.Toleration{})
 	return p.Validate(a, o)
 }
 func (p *podTolerationsPlugin) Validate(a admission.Attributes, o admission.ObjectInterfaces) error {

--- a/plugin/pkg/admission/podtolerationrestriction/admission_test.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission_test.go
@@ -202,6 +202,18 @@ func TestPodAdmission(t *testing.T) {
 			testName: "added memoryPressure/DiskPressure for Burstable pod",
 		},
 		{
+			pod:                       bestEffortPod,
+			defaultClusterTolerations: []api.Toleration{},
+			namespaceTolerations:      []api.Toleration{},
+			whitelist:                 []api.Toleration{},
+			podTolerations:            []api.Toleration{{Key: "testKey", Operator: "Equal", Value: "testValue", Effect: "NoSchedule", TolerationSeconds: nil}, {Key: "testKey", Operator: "Equal", Value: "testValue1", Effect: "NoSchedule", TolerationSeconds: nil}},
+			mergedTolerations: []api.Toleration{
+				{Key: "testKey", Operator: "Equal", Value: "testValue1", Effect: "NoSchedule", TolerationSeconds: nil},
+			},
+			admit:    true,
+			testName: "Besteffort pod should overwrite for conflicting tolerations",
+		},
+		{
 			pod:                       guaranteedPod,
 			defaultClusterTolerations: []api.Toleration{},
 			namespaceTolerations:      []api.Toleration{{Key: "testKey", Operator: "Equal", Value: "testValue", Effect: "NoSchedule", TolerationSeconds: nil}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
As of now for best effort pods, we are allowing conflicting tolerations meaning, tolerations with same `Key, Effect` are being appended instead of overwritten. For example if a best effort pod is created with `Key:abc, Effect: NoSchedule, Value: Test1` and `Key:abc, Effect: NoSchedule. Value:Test2`, we are seeing 2 tolerations but in case of pods with other QoS tiers, we are seeing a pod with `Key:abc, Effect: NoSchedule. Value:Test2` because the Test2 overwrites the Test1 value. This PR fixes so that BE pods have consistent behaviour with other pods. 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Tolerations with the same key and effect will be merged into one which has the value of the latest toleration for best effort pods.
```
