### PR TITLE
deprecate state field of eventSeries on Event API

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -4172,6 +4172,7 @@ type EventSeries struct {
 	// Time of the last occurrence observed
 	LastObservedTime metav1.MicroTime
 	// State of this Series: Ongoing or Finished
+	// Deprecated. Planned removal for 1.18
 	State EventSeriesState
 }
 

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -1218,6 +1218,7 @@ message EventSeries {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastObservedTime = 2;
 
   // State of this Series: Ongoing or Finished
+  // Deprecated. Planned removal for 1.18
   optional string state = 3;
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4701,6 +4701,7 @@ type EventSeries struct {
 	// Time of the last occurrence observed
 	LastObservedTime metav1.MicroTime `json:"lastObservedTime,omitempty" protobuf:"bytes,2,name=lastObservedTime"`
 	// State of this Series: Ongoing or Finished
+	// Deprecated. Planned removal for 1.18
 	State EventSeriesState `json:"state,omitempty" protobuf:"bytes,3,name=state"`
 }
 

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -610,7 +610,7 @@ var map_EventSeries = map[string]string{
 	"":                 "EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.",
 	"count":            "Number of occurrences in this series up to the last heartbeat time",
 	"lastObservedTime": "Time of the last occurrence observed",
-	"state":            "State of this Series: Ongoing or Finished",
+	"state":            "State of this Series: Ongoing or Finished Deprecated. Planned removal for 1.18",
 }
 
 func (EventSeries) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/events/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/events/v1beta1/generated.proto
@@ -116,6 +116,7 @@ message EventSeries {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastObservedTime = 2;
 
   // Information whether this series is ongoing or finished.
+  // Deprecated. Planned removal for 1.18
   optional string state = 3;
 }
 

--- a/staging/src/k8s.io/api/events/v1beta1/types.go
+++ b/staging/src/k8s.io/api/events/v1beta1/types.go
@@ -96,6 +96,7 @@ type EventSeries struct {
 	// Time when last Event from the series was seen before last heartbeat.
 	LastObservedTime metav1.MicroTime `json:"lastObservedTime" protobuf:"bytes,2,opt,name=lastObservedTime"`
 	// Information whether this series is ongoing or finished.
+	// Deprecated. Planned removal for 1.18
 	State EventSeriesState `json:"state" protobuf:"bytes,3,opt,name=state"`
 }
 

--- a/staging/src/k8s.io/api/events/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/events/v1beta1/types_swagger_doc_generated.go
@@ -63,7 +63,7 @@ var map_EventSeries = map[string]string{
 	"":                 "EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.",
 	"count":            "Number of occurrences in this series up to the last heartbeat time",
 	"lastObservedTime": "Time when last Event from the series was seen before last heartbeat.",
-	"state":            "Information whether this series is ongoing or finished.",
+	"state":            "Information whether this series is ongoing or finished. Deprecated. Planned removal for 1.18",
 }
 
 func (EventSeries) SwaggerDoc() map[string]string {


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
The `series.state` field in the events.k8s.io/v1beta1 Event API is deprecated and will be removed in v1.18
```
