### PR TITLE
Automated cherry pick of #75781: kube-aggregator: bump openapi aggregation log level

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
@@ -99,7 +99,13 @@ func (c *AggregationController) processNextWorkItem() bool {
 		return false
 	}
 
-	klog.Infof("OpenAPI AggregationController: Processing item %s", key)
+	if aggregator.IsLocalAPIService(key.(string)) {
+		// for local delegation targets that are aggregated once per second, log at
+		// higher level to avoid flooding the log
+		klog.V(5).Infof("OpenAPI AggregationController: Processing item %s", key)
+	} else {
+		klog.Infof("OpenAPI AggregationController: Processing item %s", key)
+	}
 
 	action, err := c.syncHandler(key.(string))
 	if err == nil {


### PR DESCRIPTION
Cherry pick of #75781 on release-1.14.

#75781: kube-aggregator: bump openapi aggregation log level