### PR TITLE
Bump debian-iptables to v11.0.2.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -89,8 +89,8 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
   local arch=$1
-  local debian_base_version=0.4.1
-  local debian_iptables_version=v11.0.1
+  local debian_base_version=v1.0.0
+  local debian_iptables_version=v11.0.2
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets
   local targets=(

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -18,7 +18,7 @@ REGISTRY ?= staging-k8s.gcr.io
 IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
-TAG ?= 0.4.1
+TAG ?= v1.0.0
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,12 +16,12 @@
 
 REGISTRY?="staging-k8s.gcr.io"
 IMAGE=$(REGISTRY)/debian-iptables
-TAG?=v11.0.1
+TAG?=v11.0.2
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 TEMP_DIR:=$(shell mktemp -d)
 
-BASEIMAGE?=k8s.gcr.io/debian-base-$(ARCH):0.4.1
+BASEIMAGE?=k8s.gcr.io/debian-base-$(ARCH):v1.0.0
 
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -70,18 +70,18 @@ http_file(
 
 docker_pull(
     name = "debian-base-amd64",
-    digest = "sha256:8ccb65cd2dd7e0c24193d0742a20e4a673dbd11af5a33f16fcd471a31486866c",
+    digest = "sha256:5f25d97ece9076612b64bb551e12f1e39a520176b684e2d663ce1bd53c5d0618",
     registry = "k8s.gcr.io",
     repository = "debian-base-amd64",
-    tag = "0.4.1",  # ignored, but kept here for documentation
+    tag = "v1.0.0",  # ignored, but kept here for documentation
 )
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:9c41b4c326304b94eb96fdd2e181aa6e9995cc4642fcdfb570cedd73a419ba39",
+    digest = "sha256:adc40e9ec817c15d35b26d1d6aa4d0f8096fba4c99e26a026159bb0bc98c6a89",
     registry = "k8s.gcr.io",
     repository = "debian-iptables-amd64",
-    tag = "v11.0.1",  # ignored, but kept here for documentation
+    tag = "v11.0.2",  # ignored, but kept here for documentation
 )
 
 docker_pull(


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/priority critical-urgent
/sig release
/sig network

**What this PR does / why we need it**:
Follow up of https://github.com/kubernetes/kubernetes/pull/75845 to use debian-iptables:v11.0.2 as a manual cherrypick of https://github.com/kubernetes/kubernetes/pull/75997 for 1.13.

**Which issue(s) this PR fixes**:
Fixes #NONE

**Special notes for your reviewer**:
/assign @tallclair 

**Does this PR introduce a user-facing change?**:
```release-note
None
```
