### PR TITLE
Improve `kubectl auth can-i` command by warning users when they try access resource out of scope

### DIFF
--- a/pkg/kubectl/cmd/auth/BUILD
+++ b/pkg/kubectl/cmd/auth/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/printers:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/resource:go_default_library",
+        "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1:go_default_library",

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -761,6 +761,27 @@ runTests() {
 
     output_message=$(kubectl auth can-i get pods --subresource=log --quiet 2>&1 "${kube_flags[@]}"; echo $?)
     kube::test::if_has_string "${output_message}" '0'
+
+    # kubectl auth can-i get '*' does not warn about namespaced scope or print an error
+    output_message=$(kubectl auth can-i get '*' 2>&1 "${kube_flags[@]}")
+    kube::test::if_has_not_string "${output_message}" "Warning"
+
+    # kubectl auth can-i get foo does not print a namespaced warning message, and only prints a single lookup error
+    output_message=$(kubectl auth can-i get foo 2>&1 "${kube_flags[@]}")
+    kube::test::if_has_string "${output_message}" "Warning: the server doesn't have a resource type 'foo'"
+    kube::test::if_has_not_string "${output_message}" "Warning: resource 'foo' is not namespace scoped"
+
+    # kubectl auth can-i get pods does not print a namespaced warning message or a lookup error
+    output_message=$(kubectl auth can-i get pods 2>&1 "${kube_flags[@]}")
+    kube::test::if_has_not_string "${output_message}" "Warning"
+
+    # kubectl auth can-i get nodes prints a namespaced warning message
+    output_message=$(kubectl auth can-i get nodes 2>&1 "${kube_flags[@]}")
+    kube::test::if_has_string "${output_message}" "Warning: resource 'nodes' is not namespace scoped"
+
+    # kubectl auth can-i get nodes --all-namespaces does not print a namespaced warning message
+    output_message=$(kubectl auth can-i get nodes --all-namespaces 2>&1 "${kube_flags[@]}")
+    kube::test::if_has_not_string "${output_message}" "Warning: resource 'nodes' is not namespace scoped"
   fi
 
   # kubectl auth reconcile


### PR DESCRIPTION
 /kind feature


**What this PR does / why we need it**:
`kubectl auth can-i `command would not hint user when they try to access some resource out of scope. For example, try get namespace inside default namespace.It would be reject by api-server but `kubectl auth can-i get namespace --namespace=default` would give a `yes`. After this patch, a warning info would be given.



Fixes #75970 


```release-note
improve `kubectl auth can-i` command by warning users when they try access resource out of scope
```
