### PR TITLE
Add TLS support to kubemark

### DIFF
--- a/test/kubemark/resources/start-kubemark-master.sh
+++ b/test/kubemark/resources/start-kubemark-master.sh
@@ -469,9 +469,17 @@ EOF
 # Computes command line arguments to be passed to etcd.
 function compute-etcd-params {
 	local params="${ETCD_TEST_ARGS:-}"
+	params+=" --name=etcd-$(hostname -s)"
 	params+=" --listen-peer-urls=http://127.0.0.1:2380"
 	params+=" --advertise-client-urls=http://127.0.0.1:2379"
 	params+=" --listen-client-urls=http://0.0.0.0:2379"
+
+	# Enable apiserver->etcd auth.
+	params+=" --client-cert-auth"
+	params+=" --trusted-ca-file /etc/srv/kubernetes/etcd-apiserver-ca.crt"
+	params+=" --cert-file /etc/srv/kubernetes/etcd-apiserver-server.crt"
+	params+=" --key-file /etc/srv/kubernetes/etcd-apiserver-server.key"
+
 	params+=" --data-dir=/var/etcd/data"
 	params+=" ${ETCD_QUOTA_BYTES}"
 	echo "${params}"
@@ -480,6 +488,7 @@ function compute-etcd-params {
 # Computes command line arguments to be passed to etcd-events.
 function compute-etcd-events-params {
 	local params="${ETCD_TEST_ARGS:-}"
+	params+=" --name=etcd-$(hostname -s)"
 	params+=" --listen-peer-urls=http://127.0.0.1:2381"
 	params+=" --advertise-client-urls=http://127.0.0.1:4002"
 	params+=" --listen-client-urls=http://0.0.0.0:4002"
@@ -497,6 +506,11 @@ function compute-kube-apiserver-params {
 	elif [[ -n "${ETCD_SERVERS_OVERRIDES:-}" ]]; then
 		params+=" --etcd-servers-overrides=${ETCD_SERVERS_OVERRIDES:-}"
 	fi
+	# Enable apiserver->etcd auth.
+	params+=" --etcd-cafile=/etc/srv/kubernetes/etcd-apiserver-ca.crt"
+	params+=" --etcd-certfile=/etc/srv/kubernetes/etcd-apiserver-client.crt"
+	params+=" --etcd-keyfile=/etc/srv/kubernetes/etcd-apiserver-client.key"
+
 	params+=" --tls-cert-file=/etc/srv/kubernetes/server.cert"
 	params+=" --tls-private-key-file=/etc/srv/kubernetes/server.key"
 	params+=" --requestheader-client-ca-file=/etc/srv/kubernetes/aggr_ca.crt"

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -100,6 +100,7 @@ function generate-pki-config {
   gen-kube-bearertoken
   gen-kube-basicauth
   create-certs "${MASTER_IP}"
+  create-etcd-apiserver-certs "etcd-${MASTER_NAME}" "${MASTER_NAME}"
   KUBELET_TOKEN=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
   KUBE_PROXY_TOKEN=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
   NODE_PROBLEM_DETECTOR_TOKEN=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
@@ -122,6 +123,12 @@ function write-pki-config-to-master {
     sudo bash -c \"echo ${CA_CERT_BASE64} | base64 --decode > /home/kubernetes/k8s_auth_data/ca.crt\" && \
     sudo bash -c \"echo ${MASTER_CERT_BASE64} | base64 --decode > /home/kubernetes/k8s_auth_data/server.cert\" && \
     sudo bash -c \"echo ${MASTER_KEY_BASE64} | base64 --decode > /home/kubernetes/k8s_auth_data/server.key\" && \
+    sudo bash -c \"echo ${ETCD_APISERVER_CA_KEY_BASE64} | base64 --decode > /home/kubernetes/k8s_auth_data/etcd-apiserver-ca.key\" && \
+    sudo bash -c \"echo ${ETCD_APISERVER_CA_CERT_BASE64} | base64 --decode | gunzip > /home/kubernetes/k8s_auth_data/etcd-apiserver-ca.crt\" && \
+    sudo bash -c \"echo ${ETCD_APISERVER_SERVER_KEY_BASE64} | base64 --decode > /home/kubernetes/k8s_auth_data/etcd-apiserver-server.key\" && \
+    sudo bash -c \"echo ${ETCD_APISERVER_SERVER_CERT_BASE64} | base64 --decode | gunzip > /home/kubernetes/k8s_auth_data/etcd-apiserver-server.crt\" && \
+    sudo bash -c \"echo ${ETCD_APISERVER_CLIENT_KEY_BASE64} | base64 --decode > /home/kubernetes/k8s_auth_data/etcd-apiserver-client.key\" && \
+    sudo bash -c \"echo ${ETCD_APISERVER_CLIENT_CERT_BASE64} | base64 --decode | gunzip > /home/kubernetes/k8s_auth_data/etcd-apiserver-client.crt\" && \
     sudo bash -c \"echo ${REQUESTHEADER_CA_CERT_BASE64} | base64 --decode > /home/kubernetes/k8s_auth_data/aggr_ca.crt\" && \
     sudo bash -c \"echo ${PROXY_CLIENT_CERT_BASE64} | base64 --decode > /home/kubernetes/k8s_auth_data/proxy_client.crt\" && \
     sudo bash -c \"echo ${PROXY_CLIENT_KEY_BASE64} | base64 --decode > /home/kubernetes/k8s_auth_data/proxy_client.key\" && \


### PR DESCRIPTION
Since https://github.com/kubernetes/kubernetes/pull/70144 was merged, GCE is encrypting communication between etcd and apiserver. However, Kubemark was still using plain communication.
That is one of the reasons for the different between those two.

One of the hypothesis is that it may also contribute to the https://github.com/kubernetes/kubernetes/issues/75833 regression.

@mborsz @wenjiaswe 