### PR TITLE
Fix create secret generic paths examples

### DIFF
--- a/pkg/kubectl/cmd/create/create_secret.go
+++ b/pkg/kubectl/cmd/create/create_secret.go
@@ -61,13 +61,13 @@ var (
 	  kubectl create secret generic my-secret --from-file=path/to/bar
 
 	  # Create a new secret named my-secret with specified keys instead of names on disk
-	  kubectl create secret generic my-secret --from-file=ssh-privatekey=~/.ssh/id_rsa --from-file=ssh-publickey=~/.ssh/id_rsa.pub
+	  kubectl create secret generic my-secret --from-file=ssh-privatekey=path/to/id_rsa --from-file=ssh-publickey=path/to/id_rsa.pub
 
 	  # Create a new secret named my-secret with key1=supersecret and key2=topsecret
 	  kubectl create secret generic my-secret --from-literal=key1=supersecret --from-literal=key2=topsecret
 
 	  # Create a new secret named my-secret using a combination of a file and a literal
-	  kubectl create secret generic my-secret --from-file=ssh-privatekey=~/.ssh/id_rsa --from-literal=passphrase=topsecret
+	  kubectl create secret generic my-secret --from-file=ssh-privatekey=path/to/id_rsa --from-literal=passphrase=topsecret
 
 	  # Create a new secret named my-secret from an env file
 	  kubectl create secret generic my-secret --from-env-file=path/to/bar.env`))


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The example in `kubectl create secret` is misleading and does not work. Due to the fact that we're passing `key=value` pair bash does not expands `~` to user path, whereas `$HOME` does work. I've decided to make the path more generic like with the other examples.

**Special notes for your reviewer**:
/assign @mfojtik 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
