### PR TITLE
test/e2e/apps: fix panic in DaemonSet tests due to legacy scheme

### DIFF
--- a/test/e2e/apps/BUILD
+++ b/test/e2e/apps/BUILD
@@ -23,7 +23,6 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/test/e2e/apps",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/batch:go_default_library",

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	extensionsinternal "k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/controller/daemon"
@@ -78,12 +78,12 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 			}
 		}
 		if daemonsets, err := f.ClientSet.AppsV1().DaemonSets(f.Namespace.Name).List(metav1.ListOptions{}); err == nil {
-			framework.Logf("daemonset: %s", runtime.EncodeOrDie(legacyscheme.Codecs.LegacyCodec(legacyscheme.Scheme.PrioritizedVersionsAllGroups()...), daemonsets))
+			framework.Logf("daemonset: %s", runtime.EncodeOrDie(scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...), daemonsets))
 		} else {
 			framework.Logf("unable to dump daemonsets: %v", err)
 		}
 		if pods, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(metav1.ListOptions{}); err == nil {
-			framework.Logf("pods: %s", runtime.EncodeOrDie(legacyscheme.Codecs.LegacyCodec(legacyscheme.Scheme.PrioritizedVersionsAllGroups()...), pods))
+			framework.Logf("pods: %s", runtime.EncodeOrDie(scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...), pods))
 		} else {
 			framework.Logf("unable to dump pods: %v", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

after this PR merged:
https://github.com/kubernetes/kubernetes/pull/75616

i'm seeing panics in e2e/apps/daemon_sets.go
https://k8s-testgrid.appspot.com/sig-testing-kind#conformance,%20master%20(dev)

```
I0402 10:30:00.931] [91m[1mâ€¢! Panic in Spec Teardown (AfterEach) [32.997 seconds][0m
I0402 10:30:00.932] [sig-apps] Daemon set [Serial]
I0402 10:30:00.932] [90mtest/e2e/apps/framework.go:22[0m
I0402 10:30:00.932]   [91m[1mshould run and stop simple daemon [Conformance] [AfterEach][0m
I0402 10:30:00.932]   [90mtest/e2e/framework/framework.go:688[0m
I0402 10:30:00.932] 
I0402 10:30:00.932]   [91m[1mTest Panicked[0m
I0402 10:30:00.932]   [91mno kind is registered for the type v1.DaemonSetList in scheme "pkg/api/legacyscheme/scheme.go:29"[0m
I0402 10:30:00.932]   staging/src/k8s.io/apimachinery/pkg/runtime/codec.go:74
I0402 10:30:00.932] 
I0402 10:30:00.932]   [91mFull Stack Trace[0m
I0402 10:30:00.933]   	GOROOT/src/runtime/panic.go:522 +0x1b5
I0402 10:30:00.933]   k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime.EncodeOrDie(...)
I0402 10:30:00.933]   	test/e2e/apps/daemon_set.go:81 +0x1539
I0402 10:30:00.933]   k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc0007e7680, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
I0402 10:30:00.933]   	test/e2e/e2e.go:242 +0x237
I0402 10:30:00.933]   k8s.io/kubernetes/test/e2e.TestE2E(0xc001c87800)
I0402 10:30:00.933]   	test/e2e/e2e_test.go:96 +0x2b
I0402 10:30:00.933]   testing.tRunner(0xc001c87800, 0x4be8ca0)
I0402 10:30:00.933]   	GOROOT/src/testing/testing.go:865 +0xc0
I0402 10:30:00.933]   created by testing.(*T).Run
I0402 10:30:00.934]   	GOROOT/src/testing/testing.go:916 +0x35a
```

tested this fix locally and it *seems to* work.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/kind failing-test
/priority important-soon
@kubernetes/sig-apps-pr-reviews 
/cc @oomichi @andrewsykim 
