### PR TITLE
Restore volume tests using statefulset

### DIFF
--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -226,7 +226,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 		}
 
 		err := utilerrors.NewAggregate(errs)
-		Expect(err).NotTo(HaveOccurred(), "while cleaning up after test")
+		framework.ExpectNoError(err, "while cleaning up after test")
 	}
 
 	// The CSIDriverRegistry feature gate is needed for this test in Kubernetes 1.12.
@@ -360,7 +360,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 			attachKey := v1.ResourceName(volumeutil.GetCSIAttachLimitKey(m.provisioner))
 
 			nodeAttachLimit, err := checkNodeForLimits(nodeName, attachKey, m.cs)
-			Expect(err).NotTo(HaveOccurred(), "while fetching node %v", err)
+			framework.ExpectNoError(err, "while fetching node %v", err)
 
 			Expect(nodeAttachLimit).To(Equal(2))
 
@@ -379,7 +379,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 			_, _, pod3 := createPod()
 			Expect(pod3).NotTo(BeNil(), "while creating third pod")
 			err = waitForMaxVolumeCondition(pod3, m.cs)
-			Expect(err).NotTo(HaveOccurred(), "while waiting for max volume condition on pod : %+v", pod3)
+			framework.ExpectNoError(err, "while waiting for max volume condition on pod : %+v", pod3)
 		})
 	})
 
@@ -440,7 +440,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				By("Expanding current pvc")
 				newSize := resource.MustParse("6Gi")
 				pvc, err = expandPVCSize(pvc, newSize, m.cs)
-				Expect(err).NotTo(HaveOccurred(), "While updating pvc for more size")
+				framework.ExpectNoError(err, "While updating pvc for more size")
 				Expect(pvc).NotTo(BeNil())
 
 				pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
@@ -455,12 +455,12 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 
 				By("Waiting for persistent volume resize to finish")
 				err = waitForControllerVolumeResize(pvc, m.cs, csiResizeWaitPeriod)
-				Expect(err).NotTo(HaveOccurred(), "While waiting for CSI PV resize to finish")
+				framework.ExpectNoError(err, "While waiting for CSI PV resize to finish")
 
 				checkPVCSize := func() {
 					By("Waiting for PVC resize to finish")
 					pvc, err = waitForFSResize(pvc, m.cs)
-					Expect(err).NotTo(HaveOccurred(), "while waiting for PVC resize to finish")
+					framework.ExpectNoError(err, "while waiting for PVC resize to finish")
 
 					pvcConditions := pvc.Status.Conditions
 					Expect(len(pvcConditions)).To(Equal(0), "pvc should not have conditions")
@@ -472,7 +472,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				} else {
 					By("Checking for conditions on pvc")
 					pvc, err = m.cs.CoreV1().PersistentVolumeClaims(ns).Get(pvc.Name, metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred(), "While fetching pvc after controller resize")
+					framework.ExpectNoError(err, "While fetching pvc after controller resize")
 
 					inProgressConditions := pvc.Status.Conditions
 					if len(inProgressConditions) > 0 {
@@ -481,12 +481,12 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 
 					By("Deleting the previously created pod")
 					err = framework.DeletePodWithWait(f, m.cs, pod)
-					Expect(err).NotTo(HaveOccurred(), "while deleting pod for resizing")
+					framework.ExpectNoError(err, "while deleting pod for resizing")
 
 					By("Creating a new pod with same volume")
 					pod2, err := createPodWithPVC(pvc)
 					Expect(pod2).NotTo(BeNil(), "while creating pod for csi resizing")
-					Expect(err).NotTo(HaveOccurred(), "while recreating pod for resizing")
+					framework.ExpectNoError(err, "while recreating pod for resizing")
 
 					checkPVCSize()
 				}
@@ -531,7 +531,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				By("Expanding current pvc")
 				newSize := resource.MustParse("6Gi")
 				pvc, err = expandPVCSize(pvc, newSize, m.cs)
-				Expect(err).NotTo(HaveOccurred(), "While updating pvc for more size")
+				framework.ExpectNoError(err, "While updating pvc for more size")
 				Expect(pvc).NotTo(BeNil())
 
 				pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
@@ -541,11 +541,11 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 
 				By("Waiting for persistent volume resize to finish")
 				err = waitForControllerVolumeResize(pvc, m.cs, csiResizeWaitPeriod)
-				Expect(err).NotTo(HaveOccurred(), "While waiting for PV resize to finish")
+				framework.ExpectNoError(err, "While waiting for PV resize to finish")
 
 				By("Waiting for PVC resize to finish")
 				pvc, err = waitForFSResize(pvc, m.cs)
-				Expect(err).NotTo(HaveOccurred(), "while waiting for PVC to finish")
+				framework.ExpectNoError(err, "while waiting for PVC to finish")
 
 				pvcConditions := pvc.Status.Conditions
 				Expect(len(pvcConditions)).To(Equal(0), "pvc should not have conditions")
@@ -613,7 +613,7 @@ func startPausePod(cs clientset.Interface, t testsuites.StorageClassTest, node f
 
 	pvcClaims := []*v1.PersistentVolumeClaim{claim}
 	_, err = framework.WaitForPVClaimBoundPhase(cs, pvcClaims, framework.ClaimProvisionTimeout)
-	Expect(err).NotTo(HaveOccurred(), "Failed waiting for PVC to be bound %v", err)
+	framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1044,7 +1044,7 @@ func (c *cinderDriver) CreateVolume(config *testsuites.PerTestConfig, volType te
 	output, err := exec.Command("cinder", "create", "--display-name="+volumeName, "1").CombinedOutput()
 	outputString := string(output[:])
 	framework.Logf("cinder output:\n%s", outputString)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	// Parse 'id'' from stdout. Expected format:
 	// |     attachments     |                  []                  |
@@ -1220,7 +1220,7 @@ func (g *gcePdDriver) CreateVolume(config *testsuites.PerTestConfig, volType tes
 	}
 	By("creating a test gce pd volume")
 	vname, err := framework.CreatePDWithRetry()
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	return &gcePdVolume{
 		volumeName: vname,
 	}
@@ -1341,7 +1341,7 @@ func (v *vSphereDriver) CreateVolume(config *testsuites.PerTestConfig, volType t
 	vspheretest.Bootstrap(f)
 	nodeInfo := vspheretest.GetReadySchedulableRandomNodeInfo()
 	volumePath, err := nodeInfo.VSphere.CreateVolume(&vspheretest.VolumeOptions{}, nodeInfo.DataCenterRef)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	return &vSphereVolume{
 		volumePath: volumePath,
 		nodeInfo:   nodeInfo,
@@ -1460,7 +1460,7 @@ func (a *azureDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestCo
 func (a *azureDriver) CreateVolume(config *testsuites.PerTestConfig, volType testpatterns.TestVolType) testsuites.TestVolume {
 	By("creating a test azure disk volume")
 	volumeName, err := framework.CreatePDWithRetry()
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	return &azureVolume{
 		volumeName: volumeName,
 	}
@@ -1573,7 +1573,7 @@ func (a *awsDriver) CreateVolume(config *testsuites.PerTestConfig, volType testp
 	By("creating a test aws volume")
 	var err error
 	a.volumeName, err = framework.CreatePDWithRetry()
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err))
 }
 
 DeleteVolume() {
@@ -1687,9 +1687,9 @@ func (l *localDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestCo
 		filesystemType := "fs"
 		ssdCmd := fmt.Sprintf("ls -1 /mnt/disks/by-uuid/google-local-ssds-%s-%s/ | wc -l", ssdInterface, filesystemType)
 		res, err := l.hostExec.IssueCommandWithResult(ssdCmd, l.node)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		num, err := strconv.Atoi(strings.TrimSpace(res))
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		if num < 1 {
 			framework.Skipf("Requires at least 1 %s %s localSSD ", ssdInterface, filesystemType)
 		}

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -233,11 +233,11 @@ func (d *driverDefinition) GetDynamicProvisionStorageClass(config *testsuites.Pe
 	}
 
 	items, err := f.LoadFromManifests(d.StorageClass.FromFile)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "load storage class from %s", d.StorageClass.FromFile)
+	framework.ExpectNoError(err, "load storage class from %s", d.StorageClass.FromFile)
 	gomega.Expect(len(items)).To(gomega.Equal(1), "exactly one item from %s", d.StorageClass.FromFile)
 
 	err = f.PatchItems(items...)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "patch items")
+	framework.ExpectNoError(err, "patch items")
 
 	sc, ok := items[0].(*storagev1.StorageClass)
 	gomega.Expect(ok).To(gomega.BeTrue(), "storage class from %s", d.StorageClass.FromFile)

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -29,7 +29,6 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
-	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -308,22 +307,69 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 	Describe("Default StorageClass", func() {
 		Context("pods that use multiple volumes", func() {
 
+			AfterEach(func() {
+				framework.DeleteAllStatefulSets(c, ns)
+			})
+
 			It("should be reschedulable [Slow]", func() {
 				// Only run on providers with default storageclass
 				framework.SkipUnlessProviderIs("openstack", "gce", "gke", "vsphere", "azure")
 
 				numVols := 4
+				ssTester := framework.NewStatefulSetTester(c)
 
-				By("Creating pvcs")
-				claims := []*v1.PersistentVolumeClaim{}
+				By("Creating a StatefulSet pod to initialize data")
+				writeCmd := "true"
 				for i := 0; i < numVols; i++ {
-					pvc := framework.MakePersistentVolumeClaim(framework.PersistentVolumeClaimConfig{}, ns)
-					claims = append(claims, pvc)
+					writeCmd += fmt.Sprintf("&& touch %v", getVolumeFile(i))
+				}
+				writeCmd += "&& sleep 10000"
+
+				probe := &v1.Probe{
+					Handler: v1.Handler{
+						Exec: &v1.ExecAction{
+							// Check that the last file got created
+							Command: []string{"test", "-f", getVolumeFile(numVols - 1)},
+						},
+					},
+					InitialDelaySeconds: 1,
+					PeriodSeconds:       1,
 				}
 
-				By("Testing access to pvcs before and after pod recreation on differetn node")
-				testsuites.TestAccessMultipleVolumesAcrossPodRecreation(f, c, ns,
-					framework.NodeSelection{}, claims, false /* sameNode */)
+				mounts := []v1.VolumeMount{}
+				claims := []v1.PersistentVolumeClaim{}
+
+				for i := 0; i < numVols; i++ {
+					pvc := framework.MakePersistentVolumeClaim(framework.PersistentVolumeClaimConfig{}, ns)
+					pvc.Name = getVolName(i)
+					mounts = append(mounts, v1.VolumeMount{Name: pvc.Name, MountPath: getMountPath(i)})
+					claims = append(claims, *pvc)
+				}
+
+				spec := makeStatefulSetWithPVCs(ns, writeCmd, mounts, claims, probe)
+				ss, err := c.AppsV1().StatefulSets(ns).Create(spec)
+				Expect(err).NotTo(HaveOccurred())
+				ssTester.WaitForRunningAndReady(1, ss)
+
+				By("Deleting the StatefulSet but not the volumes")
+				// Scale down to 0 first so that the Delete is quick
+				ss, err = ssTester.Scale(ss, 0)
+				Expect(err).NotTo(HaveOccurred())
+				ssTester.WaitForStatusReplicas(ss, 0)
+				err = c.AppsV1().StatefulSets(ns).Delete(ss.Name, &metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Creating a new Statefulset and validating the data")
+				validateCmd := "true"
+				for i := 0; i < numVols; i++ {
+					validateCmd += fmt.Sprintf("&& test -f %v", getVolumeFile(i))
+				}
+				validateCmd += "&& sleep 10000"
+
+				spec = makeStatefulSetWithPVCs(ns, validateCmd, mounts, claims, probe)
+				ss, err = c.AppsV1().StatefulSets(ns).Create(spec)
+				Expect(err).NotTo(HaveOccurred())
+				ssTester.WaitForRunningAndReady(1, ss)
 			})
 		})
 	})

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -348,16 +348,16 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 
 				spec := makeStatefulSetWithPVCs(ns, writeCmd, mounts, claims, probe)
 				ss, err := c.AppsV1().StatefulSets(ns).Create(spec)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 				ssTester.WaitForRunningAndReady(1, ss)
 
 				By("Deleting the StatefulSet but not the volumes")
 				// Scale down to 0 first so that the Delete is quick
 				ss, err = ssTester.Scale(ss, 0)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 				ssTester.WaitForStatusReplicas(ss, 0)
 				err = c.AppsV1().StatefulSets(ns).Delete(ss.Name, &metav1.DeleteOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				By("Creating a new Statefulset and validating the data")
 				validateCmd := "true"
@@ -368,7 +368,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 
 				spec = makeStatefulSetWithPVCs(ns, validateCmd, mounts, claims, probe)
 				ss, err = c.AppsV1().StatefulSets(ns).Create(spec)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 				ssTester.WaitForRunningAndReady(1, ss)
 			})
 		})

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -201,7 +200,7 @@ func createGenericVolumeTestResource(driver TestDriver, config *PerTestConfig, p
 			By("creating a StorageClass " + r.sc.Name)
 			var err error
 			r.sc, err = cs.StorageV1().StorageClasses().Create(r.sc)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 
 			if r.sc != nil {
 				r.volSource, r.pv, r.pvc = createVolumeSourceWithPVCPVFromDynamicProvisionSC(
@@ -289,10 +288,10 @@ func createVolumeSourceWithPVCPV(
 
 	framework.Logf("Creating PVC and PV")
 	pv, pvc, err := framework.CreatePVCPV(f.ClientSet, pvConfig, pvcConfig, f.Namespace.Name, false)
-	Expect(err).NotTo(HaveOccurred(), "PVC, PV creation failed")
+	framework.ExpectNoError(err, "PVC, PV creation failed")
 
 	err = framework.WaitOnPVandPVC(f.ClientSet, f.Namespace.Name, pv, pvc)
-	Expect(err).NotTo(HaveOccurred(), "PVC, PV failed to bind")
+	framework.ExpectNoError(err, "PVC, PV failed to bind")
 
 	volSource := &v1.VolumeSource{
 		PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
@@ -323,20 +322,20 @@ func createVolumeSourceWithPVCPVFromDynamicProvisionSC(
 
 	var err error
 	pvc, err = cs.CoreV1().PersistentVolumeClaims(ns).Create(pvc)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	if !isDelayedBinding(sc) {
 		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, cs, pvc.Namespace, pvc.Name, framework.Poll, framework.ClaimProvisionTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	}
 
 	pvc, err = cs.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	var pv *v1.PersistentVolume
 	if !isDelayedBinding(sc) {
 		pv, err = cs.CoreV1().PersistentVolumes().Get(pvc.Spec.VolumeName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	}
 
 	volSource := &v1.VolumeSource{
@@ -380,7 +379,7 @@ func getClaim(claimSize string, ns string) *v1.PersistentVolumeClaim {
 func deleteStorageClass(cs clientset.Interface, className string) {
 	err := cs.StorageV1().StorageClasses().Delete(className, nil)
 	if err != nil && !apierrs.IsNotFound(err) {
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	}
 }
 

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -326,7 +325,7 @@ func testAccessMultipleVolumes(f *framework.Framework, cs clientset.Interface, n
 	defer func() {
 		framework.ExpectNoError(framework.DeletePodWithWait(f, cs, pod))
 	}()
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	byteLen := 64
 	for i, pvc := range pvcs {
@@ -349,7 +348,7 @@ func testAccessMultipleVolumes(f *framework.Framework, cs clientset.Interface, n
 	}
 
 	pod, err = cs.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred(), "get pod")
+	framework.ExpectNoError(err, "get pod")
 	return pod.Spec.NodeName
 }
 
@@ -400,10 +399,10 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 		defer func() {
 			framework.ExpectNoError(framework.DeletePodWithWait(f, cs, pod))
 		}()
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		pod, err = cs.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
 		pods = append(pods, pod)
-		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("get pod%d", index))
+		framework.ExpectNoError(err, fmt.Sprintf("get pod%d", index))
 		actualNodeName := pod.Spec.NodeName
 
 		// Set affinity depending on requiresSameNode

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -123,7 +123,7 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 
 		By("creating a StorageClass " + class.Name)
 		class, err := cs.StorageV1().StorageClasses().Create(class)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		defer func() {
 			framework.Logf("deleting storage class %s", class.Name)
 			framework.ExpectNoError(cs.StorageV1().StorageClasses().Delete(class.Name, nil))
@@ -131,7 +131,7 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 
 		By("creating a claim")
 		pvc, err = cs.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		defer func() {
 			framework.Logf("deleting claim %q/%q", pvc.Namespace, pvc.Name)
 			// typically this claim has already been deleted
@@ -141,20 +141,20 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 			}
 		}()
 		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, cs, pvc.Namespace, pvc.Name, framework.Poll, framework.ClaimProvisionTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("checking the claim")
 		// Get new copy of the claim
 		pvc, err = cs.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Get the bound PV
 		pv, err := cs.CoreV1().PersistentVolumes().Get(pvc.Spec.VolumeName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("creating a SnapshotClass")
 		vsc, err = dc.Resource(snapshotClassGVR).Create(vsc, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		defer func() {
 			framework.Logf("deleting SnapshotClass %s", vsc.GetName())
 			framework.ExpectNoError(dc.Resource(snapshotClassGVR).Delete(vsc.GetName(), nil))
@@ -164,7 +164,7 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 		snapshot := getSnapshot(pvc.Name, pvc.Namespace, vsc.GetName())
 
 		snapshot, err = dc.Resource(snapshotGVR).Namespace(snapshot.GetNamespace()).Create(snapshot, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		defer func() {
 			framework.Logf("deleting snapshot %q/%q", snapshot.GetNamespace(), snapshot.GetName())
 			// typically this snapshot has already been deleted
@@ -174,18 +174,18 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 			}
 		}()
 		err = WaitForSnapshotReady(dc, snapshot.GetNamespace(), snapshot.GetName(), framework.Poll, framework.SnapshotCreateTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("checking the snapshot")
 		// Get new copy of the snapshot
 		snapshot, err = dc.Resource(snapshotGVR).Namespace(snapshot.GetNamespace()).Get(snapshot.GetName(), metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Get the bound snapshotContent
 		snapshotSpec := snapshot.Object["spec"].(map[string]interface{})
 		snapshotContentName := snapshotSpec["snapshotContentName"].(string)
 		snapshotContent, err := dc.Resource(snapshotContentGVR).Get(snapshotContentName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		snapshotContentSpec := snapshotContent.Object["spec"].(map[string]interface{})
 		volumeSnapshotRef := snapshotContentSpec["volumeSnapshotRef"].(map[string]interface{})

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -439,7 +439,7 @@ func TestBasicSubpathFile(f *framework.Framework, contents string, pod *v1.Pod, 
 
 	By(fmt.Sprintf("Deleting pod %s", pod.Name))
 	err := framework.DeletePodWithWait(f, f.ClientSet, pod)
-	Expect(err).NotTo(HaveOccurred(), "while deleting pod")
+	framework.ExpectNoError(err, "while deleting pod")
 }
 
 func generateSuffixForPodName(s string) string {
@@ -699,7 +699,7 @@ func testReadFile(f *framework.Framework, file string, pod *v1.Pod, containerInd
 
 	By(fmt.Sprintf("Deleting pod %s", pod.Name))
 	err := framework.DeletePodWithWait(f, f.ClientSet, pod)
-	Expect(err).NotTo(HaveOccurred(), "while deleting pod")
+	framework.ExpectNoError(err, "while deleting pod")
 }
 
 func testPodFailSubpath(f *framework.Framework, pod *v1.Pod, allowContainerTerminationError bool) {
@@ -716,7 +716,7 @@ func testPodFailSubpathError(f *framework.Framework, pod *v1.Pod, errorMsg strin
 	}()
 	By("Checking for subpath error in container status")
 	err = waitForPodSubpathError(f, pod, allowContainerTerminationError)
-	Expect(err).NotTo(HaveOccurred(), "while waiting for subpath failure")
+	framework.ExpectNoError(err, "while waiting for subpath failure")
 }
 
 func findSubpathContainerName(pod *v1.Pod) string {

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -133,7 +132,7 @@ func (t *volumeIOTestSuite) defineTests(driver TestDriver, pattern testpatterns.
 			FSGroup: fsGroup,
 		}
 		err := testVolumeIO(f, cs, convertTestConfig(l.config), *l.resource.volSource, &podSec, testFile, fileSizes)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 }
 

--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -168,16 +168,16 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 
 				By("Creating sc")
 				l.sc, err = l.cs.StorageV1().StorageClasses().Create(l.sc)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				By("Creating pv and pvc")
 				l.pv, err = l.cs.CoreV1().PersistentVolumes().Create(l.pv)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				// Prebind pv
 				l.pvc.Spec.VolumeName = l.pv.Name
 				l.pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(l.pvc)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				framework.ExpectNoError(framework.WaitOnPVandPVC(l.cs, l.ns.Name, l.pv, l.pvc))
 
@@ -199,16 +199,16 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 
 				By("Creating sc")
 				l.sc, err = l.cs.StorageV1().StorageClasses().Create(l.sc)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				By("Creating pv and pvc")
 				l.pv, err = l.cs.CoreV1().PersistentVolumes().Create(l.pv)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				// Prebind pv
 				l.pvc.Spec.VolumeName = l.pv.Name
 				l.pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(l.pvc)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				framework.ExpectNoError(framework.WaitOnPVandPVC(l.cs, l.ns.Name, l.pv, l.pvc))
 
@@ -219,7 +219,7 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 				defer func() {
 					framework.ExpectNoError(framework.DeletePodWithWait(f, l.cs, pod))
 				}()
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				By("Checking if persistent volume exists as expected volume mode")
 				utils.CheckVolumeModeOfPath(pod, pattern.VolMode, "/mnt/volume1")
@@ -239,11 +239,11 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 
 				By("Creating sc")
 				l.sc, err = l.cs.StorageV1().StorageClasses().Create(l.sc)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				By("Creating pv and pvc")
 				l.pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(l.pvc)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, l.cs, l.pvc.Namespace, l.pvc.Name, framework.Poll, framework.ClaimProvisionTimeout)
 				Expect(err).To(HaveOccurred())
@@ -257,20 +257,20 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 
 				By("Creating sc")
 				l.sc, err = l.cs.StorageV1().StorageClasses().Create(l.sc)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				By("Creating pv and pvc")
 				l.pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(l.pvc)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, l.cs, l.pvc.Namespace, l.pvc.Name, framework.Poll, framework.ClaimProvisionTimeout)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				l.pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.pvc.Namespace).Get(l.pvc.Name, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				l.pv, err = l.cs.CoreV1().PersistentVolumes().Get(l.pvc.Spec.VolumeName, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				By("Creating pod")
 				pod, err := framework.CreateSecPodWithNodeSelection(l.cs, l.ns.Name, []*v1.PersistentVolumeClaim{l.pvc},
@@ -279,7 +279,7 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 				defer func() {
 					framework.ExpectNoError(framework.DeletePodWithWait(f, l.cs, pod))
 				}()
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				By("Checking if persistent volume exists as expected volume mode")
 				utils.CheckVolumeModeOfPath(pod, pattern.VolMode, "/mnt/volume1")

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -226,5 +225,5 @@ func testScriptInPod(
 
 	By(fmt.Sprintf("Deleting pod %s", pod.Name))
 	err := framework.DeletePodWithWait(f, f.ClientSet, pod)
-	Expect(err).NotTo(HaveOccurred(), "while deleting pod")
+	framework.ExpectNoError(err, "while deleting pod")
 }

--- a/test/e2e/storage/utils/local.go
+++ b/test/e2e/storage/utils/local.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -102,7 +101,7 @@ func (l *ltrMgr) setupLocalVolumeTmpfs(node *v1.Node, parameters map[string]stri
 	hostDir := l.getTestDir()
 	By(fmt.Sprintf("Creating tmpfs mount point on node %q at path %q", node.Name, hostDir))
 	err := l.hostExec.IssueCommand(fmt.Sprintf("mkdir -p %q && sudo mount -t tmpfs -o size=10m tmpfs-%q %q", hostDir, hostDir, hostDir), node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	return &LocalTestResource{
 		Node: node,
 		Path: hostDir,
@@ -112,11 +111,11 @@ func (l *ltrMgr) setupLocalVolumeTmpfs(node *v1.Node, parameters map[string]stri
 func (l *ltrMgr) cleanupLocalVolumeTmpfs(ltr *LocalTestResource) {
 	By(fmt.Sprintf("Unmount tmpfs mount point on node %q at path %q", ltr.Node.Name, ltr.Path))
 	err := l.hostExec.IssueCommand(fmt.Sprintf("sudo umount %q", ltr.Path), ltr.Node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	By("Removing the test directory")
 	err = l.hostExec.IssueCommand(fmt.Sprintf("rm -r %s", ltr.Path), ltr.Node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 }
 
 // createAndSetupLoopDevice creates an empty file and associates a loop devie with it.
@@ -131,14 +130,14 @@ func (l *ltrMgr) createAndSetupLoopDevice(dir string, node *v1.Node, size int) {
 	ddCmd := fmt.Sprintf("dd if=/dev/zero of=%s/file bs=4096 count=%d", dir, count)
 	losetupCmd := fmt.Sprintf("sudo losetup -f %s/file", dir)
 	err := l.hostExec.IssueCommand(fmt.Sprintf("%s && %s && %s", mkdirCmd, ddCmd, losetupCmd), node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 }
 
 // findLoopDevice finds loop device path by its associated storage directory.
 func (l *ltrMgr) findLoopDevice(dir string, node *v1.Node) string {
 	cmd := fmt.Sprintf("E2E_LOOP_DEV=$(sudo losetup | grep %s/file | awk '{ print $1 }') 2>&1 > /dev/null && echo ${E2E_LOOP_DEV}", dir)
 	loopDevResult, err := l.hostExec.IssueCommandWithResult(cmd, node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	return strings.TrimSpace(loopDevResult)
 }
 
@@ -159,7 +158,7 @@ func (l *ltrMgr) teardownLoopDevice(dir string, node *v1.Node) {
 	By(fmt.Sprintf("Tear down block device %q on node %q at path %s/file", loopDev, node.Name, dir))
 	losetupDeleteCmd := fmt.Sprintf("sudo losetup -d %s", loopDev)
 	err := l.hostExec.IssueCommand(losetupDeleteCmd, node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	return
 }
 
@@ -168,7 +167,7 @@ func (l *ltrMgr) cleanupLocalVolumeBlock(ltr *LocalTestResource) {
 	By(fmt.Sprintf("Removing the test directory %s", ltr.loopDir))
 	removeCmd := fmt.Sprintf("rm -r %s", ltr.loopDir)
 	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 }
 
 func (l *ltrMgr) setupLocalVolumeBlockFS(node *v1.Node, parameters map[string]string) *LocalTestResource {
@@ -178,7 +177,7 @@ func (l *ltrMgr) setupLocalVolumeBlockFS(node *v1.Node, parameters map[string]st
 	// Format and mount at loopDir and give others rwx for read/write testing
 	cmd := fmt.Sprintf("sudo mkfs -t ext4 %s && sudo mount -t ext4 %s %s && sudo chmod o+rwx %s", loopDev, loopDev, loopDir, loopDir)
 	err := l.hostExec.IssueCommand(cmd, node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	return &LocalTestResource{
 		Node:    node,
 		Path:    loopDir,
@@ -189,7 +188,7 @@ func (l *ltrMgr) setupLocalVolumeBlockFS(node *v1.Node, parameters map[string]st
 func (l *ltrMgr) cleanupLocalVolumeBlockFS(ltr *LocalTestResource) {
 	umountCmd := fmt.Sprintf("sudo umount %s", ltr.Path)
 	err := l.hostExec.IssueCommand(umountCmd, ltr.Node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	l.cleanupLocalVolumeBlock(ltr)
 }
 
@@ -197,7 +196,7 @@ func (l *ltrMgr) setupLocalVolumeDirectory(node *v1.Node, parameters map[string]
 	hostDir := l.getTestDir()
 	mkdirCmd := fmt.Sprintf("mkdir -p %s", hostDir)
 	err := l.hostExec.IssueCommand(mkdirCmd, node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	return &LocalTestResource{
 		Node: node,
 		Path: hostDir,
@@ -208,7 +207,7 @@ func (l *ltrMgr) cleanupLocalVolumeDirectory(ltr *LocalTestResource) {
 	By("Removing the test directory")
 	removeCmd := fmt.Sprintf("rm -r %s", ltr.Path)
 	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 }
 
 func (l *ltrMgr) setupLocalVolumeDirectoryLink(node *v1.Node, parameters map[string]string) *LocalTestResource {
@@ -216,7 +215,7 @@ func (l *ltrMgr) setupLocalVolumeDirectoryLink(node *v1.Node, parameters map[str
 	hostDirBackend := hostDir + "-backend"
 	cmd := fmt.Sprintf("mkdir %s && sudo ln -s %s %s", hostDirBackend, hostDirBackend, hostDir)
 	err := l.hostExec.IssueCommand(cmd, node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	return &LocalTestResource{
 		Node: node,
 		Path: hostDir,
@@ -229,14 +228,14 @@ func (l *ltrMgr) cleanupLocalVolumeDirectoryLink(ltr *LocalTestResource) {
 	hostDirBackend := hostDir + "-backend"
 	removeCmd := fmt.Sprintf("sudo rm -r %s && rm -r %s", hostDir, hostDirBackend)
 	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 }
 
 func (l *ltrMgr) setupLocalVolumeDirectoryBindMounted(node *v1.Node, parameters map[string]string) *LocalTestResource {
 	hostDir := l.getTestDir()
 	cmd := fmt.Sprintf("mkdir %s && sudo mount --bind %s %s", hostDir, hostDir, hostDir)
 	err := l.hostExec.IssueCommand(cmd, node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	return &LocalTestResource{
 		Node: node,
 		Path: hostDir,
@@ -248,7 +247,7 @@ func (l *ltrMgr) cleanupLocalVolumeDirectoryBindMounted(ltr *LocalTestResource) 
 	hostDir := ltr.Path
 	removeCmd := fmt.Sprintf("sudo umount %s && rm -r %s", hostDir, hostDir)
 	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 }
 
 func (l *ltrMgr) setupLocalVolumeDirectoryLinkBindMounted(node *v1.Node, parameters map[string]string) *LocalTestResource {
@@ -256,7 +255,7 @@ func (l *ltrMgr) setupLocalVolumeDirectoryLinkBindMounted(node *v1.Node, paramet
 	hostDirBackend := hostDir + "-backend"
 	cmd := fmt.Sprintf("mkdir %s && sudo mount --bind %s %s && sudo ln -s %s %s", hostDirBackend, hostDirBackend, hostDirBackend, hostDirBackend, hostDir)
 	err := l.hostExec.IssueCommand(cmd, node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	return &LocalTestResource{
 		Node: node,
 		Path: hostDir,
@@ -269,12 +268,12 @@ func (l *ltrMgr) cleanupLocalVolumeDirectoryLinkBindMounted(ltr *LocalTestResour
 	hostDirBackend := hostDir + "-backend"
 	removeCmd := fmt.Sprintf("sudo rm %s && sudo umount %s && rm -r %s", hostDir, hostDirBackend, hostDirBackend)
 	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 }
 
 func (l *ltrMgr) setupLocalVolumeGCELocalSSD(node *v1.Node, parameters map[string]string) *LocalTestResource {
 	res, err := l.hostExec.IssueCommandWithResult("ls /mnt/disks/by-uuid/google-local-ssds-scsi-fs/", node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	dirName := strings.Fields(res)[0]
 	hostDir := "/mnt/disks/by-uuid/google-local-ssds-scsi-fs/" + dirName
 	return &LocalTestResource{
@@ -287,7 +286,7 @@ func (l *ltrMgr) cleanupLocalVolumeGCELocalSSD(ltr *LocalTestResource) {
 	// This filesystem is attached in cluster initialization, we clean all files to make it reusable.
 	removeCmd := fmt.Sprintf("find '%s' -mindepth 1 -maxdepth 1 -print0 | xargs -r -0 rm -rf", ltr.Path)
 	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 }
 
 func (l *ltrMgr) Create(node *v1.Node, volumeType LocalVolumeType, parameters map[string]string) *LocalTestResource {

--- a/test/e2e/storage/utils/utils.go
+++ b/test/e2e/storage/utils/utils.go
@@ -63,11 +63,11 @@ func VerifyExecInPodSucceed(pod *v1.Pod, bashExec string) {
 	if err != nil {
 		if err, ok := err.(uexec.CodeExitError); ok {
 			exitCode := err.ExitStatus()
-			Expect(err).NotTo(HaveOccurred(),
+			framework.ExpectNoError(err,
 				"%q should succeed, but failed with exit code %d and error message %q",
 				bashExec, exitCode, err)
 		} else {
-			Expect(err).NotTo(HaveOccurred(),
+			framework.ExpectNoError(err,
 				"%q should succeed, but failed with error message %q",
 				bashExec, err)
 		}
@@ -84,7 +84,7 @@ func VerifyExecInPodFail(pod *v1.Pod, bashExec string, exitCode int) {
 				"%q should fail with exit code %d, but failed with exit code %d and error message %q",
 				bashExec, exitCode, actualExitCode, err)
 		} else {
-			Expect(err).NotTo(HaveOccurred(),
+			framework.ExpectNoError(err,
 				"%q should fail with exit code %d, but failed with error message %q",
 				bashExec, exitCode, err)
 		}
@@ -105,19 +105,19 @@ func KubeletCommand(kOp KubeletOpt, c clientset.Interface, pod *v1.Pod) {
 	kubeletPid := ""
 
 	nodeIP, err := framework.GetHostExternalAddress(c, pod)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	nodeIP = nodeIP + ":22"
 
 	framework.Logf("Checking if sudo command is present")
 	sshResult, err := framework.SSH("sudo --version", nodeIP, framework.TestContext.Provider)
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("SSH to Node %q errored.", pod.Spec.NodeName))
+	framework.ExpectNoError(err, fmt.Sprintf("SSH to Node %q errored.", pod.Spec.NodeName))
 	if !strings.Contains(sshResult.Stderr, "command not found") {
 		sudoPresent = true
 	}
 
 	framework.Logf("Checking if systemctl command is present")
 	sshResult, err = framework.SSH("systemctl --version", nodeIP, framework.TestContext.Provider)
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("SSH to Node %q errored.", pod.Spec.NodeName))
+	framework.ExpectNoError(err, fmt.Sprintf("SSH to Node %q errored.", pod.Spec.NodeName))
 	if !strings.Contains(sshResult.Stderr, "command not found") {
 		command = fmt.Sprintf("systemctl %s kubelet", string(kOp))
 		systemctlPresent = true
@@ -134,7 +134,7 @@ func KubeletCommand(kOp KubeletOpt, c clientset.Interface, pod *v1.Pod) {
 
 	framework.Logf("Attempting `%s`", command)
 	sshResult, err = framework.SSH(command, nodeIP, framework.TestContext.Provider)
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("SSH to Node %q errored.", pod.Spec.NodeName))
+	framework.ExpectNoError(err, fmt.Sprintf("SSH to Node %q errored.", pod.Spec.NodeName))
 	framework.LogSSHResult(sshResult)
 	Expect(sshResult.Code).To(BeZero(), "Failed to [%s] kubelet:\n%#v", string(kOp), sshResult)
 
@@ -178,7 +178,7 @@ func getKubeletMainPid(nodeIP string, sudoPresent bool, systemctlPresent bool) s
 	}
 	framework.Logf("Attempting `%s`", command)
 	sshResult, err := framework.SSH(command, nodeIP, framework.TestContext.Provider)
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("SSH to Node %q errored.", nodeIP))
+	framework.ExpectNoError(err, fmt.Sprintf("SSH to Node %q errored.", nodeIP))
 	framework.LogSSHResult(sshResult)
 	Expect(sshResult.Code).To(BeZero(), "Failed to get kubelet PID")
 	Expect(sshResult.Stdout).NotTo(BeEmpty(), "Kubelet Main PID should not be Empty")
@@ -191,7 +191,7 @@ func TestKubeletRestartsAndRestoresMount(c clientset.Interface, f *framework.Fra
 	file := "/mnt/_SUCCESS"
 	out, err := PodExec(clientPod, fmt.Sprintf("touch %s", file))
 	framework.Logf(out)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	By("Restarting kubelet")
 	KubeletCommand(KRestart, c, clientPod)
@@ -199,7 +199,7 @@ func TestKubeletRestartsAndRestoresMount(c clientset.Interface, f *framework.Fra
 	By("Testing that written file is accessible.")
 	out, err = PodExec(clientPod, fmt.Sprintf("cat %s", file))
 	framework.Logf(out)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	framework.Logf("Volume mount detected on pod %s and written file %s is readable post-restart.", clientPod.Name, file)
 }
 
@@ -207,20 +207,20 @@ func TestKubeletRestartsAndRestoresMount(c clientset.Interface, f *framework.Fra
 // forceDelete is true indicating whether the pod is forcefully deleted.
 func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, forceDelete bool, checkSubpath bool) {
 	nodeIP, err := framework.GetHostExternalAddress(c, clientPod)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	nodeIP = nodeIP + ":22"
 
 	By("Expecting the volume mount to be found.")
 	result, err := framework.SSH(fmt.Sprintf("mount | grep %s | grep -v volume-subpaths", clientPod.UID), nodeIP, framework.TestContext.Provider)
 	framework.LogSSHResult(result)
-	Expect(err).NotTo(HaveOccurred(), "Encountered SSH error.")
+	framework.ExpectNoError(err, "Encountered SSH error.")
 	Expect(result.Code).To(BeZero(), fmt.Sprintf("Expected grep exit code of 0, got %d", result.Code))
 
 	if checkSubpath {
 		By("Expecting the volume subpath mount to be found.")
 		result, err := framework.SSH(fmt.Sprintf("cat /proc/self/mountinfo | grep %s | grep volume-subpaths", clientPod.UID), nodeIP, framework.TestContext.Provider)
 		framework.LogSSHResult(result)
-		Expect(err).NotTo(HaveOccurred(), "Encountered SSH error.")
+		framework.ExpectNoError(err, "Encountered SSH error.")
 		Expect(result.Code).To(BeZero(), fmt.Sprintf("Expected grep exit code of 0, got %d", result.Code))
 	}
 
@@ -237,13 +237,13 @@ func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *f
 	} else {
 		err = c.CoreV1().Pods(clientPod.Namespace).Delete(clientPod.Name, &metav1.DeleteOptions{})
 	}
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	By("Starting the kubelet and waiting for pod to delete.")
 	KubeletCommand(KStart, c, clientPod)
 	err = f.WaitForPodNotFound(clientPod.Name, framework.PodDeleteTimeout)
 	if err != nil {
-		Expect(err).NotTo(HaveOccurred(), "Expected pod to be not found.")
+		framework.ExpectNoError(err, "Expected pod to be not found.")
 	}
 
 	if forceDelete {
@@ -255,7 +255,7 @@ func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *f
 	By("Expecting the volume mount not to be found.")
 	result, err = framework.SSH(fmt.Sprintf("mount | grep %s | grep -v volume-subpaths", clientPod.UID), nodeIP, framework.TestContext.Provider)
 	framework.LogSSHResult(result)
-	Expect(err).NotTo(HaveOccurred(), "Encountered SSH error.")
+	framework.ExpectNoError(err, "Encountered SSH error.")
 	Expect(result.Stdout).To(BeEmpty(), "Expected grep stdout to be empty (i.e. no mount found).")
 	framework.Logf("Volume unmounted on node %s", clientPod.Spec.NodeName)
 
@@ -263,7 +263,7 @@ func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *f
 		By("Expecting the volume subpath mount not to be found.")
 		result, err = framework.SSH(fmt.Sprintf("cat /proc/self/mountinfo | grep %s | grep volume-subpaths", clientPod.UID), nodeIP, framework.TestContext.Provider)
 		framework.LogSSHResult(result)
-		Expect(err).NotTo(HaveOccurred(), "Encountered SSH error.")
+		framework.ExpectNoError(err, "Encountered SSH error.")
 		Expect(result.Stdout).To(BeEmpty(), "Expected grep stdout to be empty (i.e. no subpath mount found).")
 		framework.Logf("Subpath volume unmounted on node %s", clientPod.Spec.NodeName)
 	}

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -278,7 +278,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 						Expect(volume).NotTo(BeNil(), "get bound PV")
 
 						err := checkGCEPD(volume, "pd-ssd")
-						Expect(err).NotTo(HaveOccurred(), "checkGCEPD pd-ssd")
+						framework.ExpectNoError(err, "checkGCEPD pd-ssd")
 					},
 				},
 				{
@@ -295,7 +295,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 						Expect(volume).NotTo(BeNil(), "get bound PV")
 
 						err := checkGCEPD(volume, "pd-standard")
-						Expect(err).NotTo(HaveOccurred(), "checkGCEPD pd-standard")
+						framework.ExpectNoError(err, "checkGCEPD pd-standard")
 					},
 				},
 				// AWS
@@ -314,7 +314,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 						Expect(volume).NotTo(BeNil(), "get bound PV")
 
 						err := checkAWSEBS(volume, "gp2", false)
-						Expect(err).NotTo(HaveOccurred(), "checkAWSEBS gp2")
+						framework.ExpectNoError(err, "checkAWSEBS gp2")
 					},
 				},
 				{
@@ -332,7 +332,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 						Expect(volume).NotTo(BeNil(), "get bound PV")
 
 						err := checkAWSEBS(volume, "io1", false)
-						Expect(err).NotTo(HaveOccurred(), "checkAWSEBS io1")
+						framework.ExpectNoError(err, "checkAWSEBS io1")
 					},
 				},
 				{
@@ -349,7 +349,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 						Expect(volume).NotTo(BeNil(), "get bound PV")
 
 						err := checkAWSEBS(volume, "sc1", false)
-						Expect(err).NotTo(HaveOccurred(), "checkAWSEBS sc1")
+						framework.ExpectNoError(err, "checkAWSEBS sc1")
 					},
 				},
 				{
@@ -366,7 +366,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 						Expect(volume).NotTo(BeNil(), "get bound PV")
 
 						err := checkAWSEBS(volume, "st1", false)
-						Expect(err).NotTo(HaveOccurred(), "checkAWSEBS st1")
+						framework.ExpectNoError(err, "checkAWSEBS st1")
 					},
 				},
 				{
@@ -383,7 +383,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 						Expect(volume).NotTo(BeNil(), "get bound PV")
 
 						err := checkAWSEBS(volume, "gp2", true)
-						Expect(err).NotTo(HaveOccurred(), "checkAWSEBS gp2 encrypted")
+						framework.ExpectNoError(err, "checkAWSEBS gp2 encrypted")
 					},
 				},
 				// OpenStack generic tests (works on all OpenStack deployments)
@@ -467,7 +467,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				class := newBetaStorageClass(*betaTest, "beta")
 				// we need to create the class manually, testDynamicProvisioning does not accept beta class
 				class, err := c.StorageV1beta1().StorageClasses().Create(class)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 				defer deleteStorageClass(c, class.Name)
 
 				betaTest.Client = c
@@ -496,7 +496,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					Expect(volume).NotTo(BeNil(), "get bound PV")
 
 					err := checkGCEPD(volume, "pd-standard")
-					Expect(err).NotTo(HaveOccurred(), "checkGCEPD")
+					framework.ExpectNoError(err, "checkGCEPD")
 				},
 			}
 			test.Class = newStorageClass(test, ns, "reclaimpolicy")
@@ -526,15 +526,15 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			managedZones := sets.NewString() // subset of allZones
 
 			gceCloud, err := gce.GetGCECloud()
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 
 			// Get all k8s managed zones (same as zones with nodes in them for test)
 			managedZones, err = gceCloud.GetAllZonesFromCloudProvider()
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 
 			// Get a list of all zones in the project
 			zones, err := gceCloud.ComputeServices().GA.Zones.List(framework.TestContext.CloudConfig.ProjectID).Do()
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			for _, z := range zones.Items {
 				allZones.Insert(z.Name)
 			}
@@ -557,14 +557,14 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			}
 			sc := newStorageClass(test, ns, suffix)
 			sc, err = c.StorageV1().StorageClasses().Create(sc)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			defer deleteStorageClass(c, sc.Name)
 
 			By("Creating a claim and expecting it to timeout")
 			pvc := newClaim(test, ns, suffix)
 			pvc.Spec.StorageClassName = &sc.Name
 			pvc, err = c.CoreV1().PersistentVolumeClaims(ns).Create(pvc)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			defer func() {
 				framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)
 			}()
@@ -594,7 +594,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 			class := newStorageClass(test, ns, "race")
 			class, err := c.StorageV1().StorageClasses().Create(class)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			defer deleteStorageClass(c, class.Name)
 
 			// To increase chance of detection, attempt multiple iterations
@@ -603,13 +603,13 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				claim := newClaim(test, ns, suffix)
 				claim.Spec.StorageClassName = &class.Name
 				tmpClaim, err := framework.CreatePVC(c, ns, claim)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 				framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, tmpClaim.Name, ns))
 			}
 
 			By(fmt.Sprintf("Checking for residual PersistentVolumes associated with StorageClass %s", class.Name))
 			residualPVs, err = waitForProvisionedVolumesDeleted(c, class.Name)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			// Cleanup the test resources before breaking
 			defer deleteProvisionedVolumesAndDisks(c, residualPVs)
 
@@ -695,7 +695,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 			By("waiting for the PV to get deleted")
 			err = framework.WaitForPersistentVolumeDeleted(c, pv.Name, 5*time.Second, framework.PVDeletingTimeout)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		})
 	})
 
@@ -786,7 +786,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			By("creating a claim with default storageclass and expecting it to timeout")
 			claim := newClaim(test, ns, "default")
 			claim, err := c.CoreV1().PersistentVolumeClaims(ns).Create(claim)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			defer func() {
 				framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, claim.Name, ns))
 			}()
@@ -796,7 +796,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			Expect(err).To(HaveOccurred())
 			framework.Logf(err.Error())
 			claim, err = c.CoreV1().PersistentVolumeClaims(ns).Get(claim.Name, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			Expect(claim.Status.Phase).To(Equal(v1.ClaimPending))
 		})
 
@@ -817,7 +817,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			By("creating a claim with default storageclass and expecting it to timeout")
 			claim := newClaim(test, ns, "default")
 			claim, err := c.CoreV1().PersistentVolumeClaims(ns).Create(claim)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			defer func() {
 				framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, claim.Name, ns))
 			}()
@@ -827,7 +827,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			Expect(err).To(HaveOccurred())
 			framework.Logf(err.Error())
 			claim, err = c.CoreV1().PersistentVolumeClaims(ns).Get(claim.Name, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			Expect(claim.Status.Phase).To(Equal(v1.ClaimPending))
 		})
 	})
@@ -872,7 +872,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			suffix := fmt.Sprintf("invalid-aws")
 			class := newStorageClass(test, ns, suffix)
 			class, err := c.StorageV1().StorageClasses().Create(class)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			defer func() {
 				framework.Logf("deleting storage class %s", class.Name)
 				framework.ExpectNoError(c.StorageV1().StorageClasses().Delete(class.Name, nil))
@@ -882,7 +882,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			claim := newClaim(test, ns, suffix)
 			claim.Spec.StorageClassName = &class.Name
 			claim, err = c.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(claim)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			defer func() {
 				framework.Logf("deleting claim %q/%q", claim.Namespace, claim.Name)
 				err = c.CoreV1().PersistentVolumeClaims(claim.Namespace).Delete(claim.Name, nil)
@@ -897,7 +897,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			// ClaimProvisionTimeout in the very same loop.
 			err = wait.Poll(time.Second, framework.ClaimProvisionTimeout, func() (bool, error) {
 				events, err := c.CoreV1().Events(claim.Namespace).List(metav1.ListOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 				for _, event := range events.Items {
 					if strings.Contains(event.Message, "failed to create encrypted volume: the volume disappeared after creation, most likely due to inaccessible KMS encryption key") {
 						return true, nil
@@ -919,7 +919,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				framework.Logf("The test missed event about failed provisioning, but checked that no volume was provisioned for %v", framework.ClaimProvisionTimeout)
 				err = nil
 			}
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		})
 	})
 	Describe("DynamicProvisioner delayed binding [Slow]", func() {
@@ -995,13 +995,13 @@ func getDefaultStorageClassName(c clientset.Interface) string {
 
 func verifyDefaultStorageClass(c clientset.Interface, scName string, expectedDefault bool) {
 	sc, err := c.StorageV1().StorageClasses().Get(scName, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	Expect(storageutil.IsDefaultAnnotation(sc.ObjectMeta)).To(Equal(expectedDefault))
 }
 
 func updateDefaultStorageClass(c clientset.Interface, scName string, defaultStr string) {
 	sc, err := c.StorageV1().StorageClasses().Get(scName, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	if defaultStr == "" {
 		delete(sc.Annotations, storageutil.BetaIsDefaultStorageClassAnnotation)
@@ -1015,7 +1015,7 @@ func updateDefaultStorageClass(c clientset.Interface, scName string, defaultStr 
 	}
 
 	sc, err = c.StorageV1().StorageClasses().Update(sc)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	expectedDefault := false
 	if defaultStr == "true" {
@@ -1223,7 +1223,7 @@ func waitForProvisionedVolumesDeleted(c clientset.Interface, scName string) ([]*
 func deleteStorageClass(c clientset.Interface, className string) {
 	err := c.StorageV1().StorageClasses().Delete(className, nil)
 	if err != nil && !apierrs.IsNotFound(err) {
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	}
 }
 

--- a/test/e2e/storage/vsphere/persistent_volumes-vsphere.go
+++ b/test/e2e/storage/vsphere/persistent_volumes-vsphere.go
@@ -76,7 +76,7 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere", func() {
 
 		if volumePath == "" {
 			volumePath, err = nodeInfo.VSphere.CreateVolume(&VolumeOptions{}, nodeInfo.DataCenterRef)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			pvConfig = framework.PersistentVolumeConfig{
 				NamePrefix: "vspherepv-",
 				Labels:     volLabel,
@@ -96,17 +96,17 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere", func() {
 		}
 		By("Creating the PV and PVC")
 		pv, pvc, err = framework.CreatePVPVC(c, pvConfig, pvcConfig, ns, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv, pvc))
 
 		By("Creating the Client Pod")
 		clientPod, err = framework.CreateClientPod(c, ns, pvc)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		node = clientPod.Spec.NodeName
 
 		By("Verify disk should be attached to the node")
 		isAttached, err := diskIsAttached(volumePath, node)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(isAttached).To(BeTrue(), "disk is not attached with the node")
 	})
 
@@ -207,10 +207,10 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere", func() {
 	It("should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume", func() {
 		By("Deleting the Namespace")
 		err := c.CoreV1().Namespaces().Delete(ns, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		err = framework.WaitForNamespacesDeleted(c, []string{ns}, 3*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Verifying Persistent Disk detaches")
 		waitForVSphereDiskToDetach(volumePath, node)

--- a/test/e2e/storage/vsphere/pvc_label_selector.go
+++ b/test/e2e/storage/vsphere/pvc_label_selector.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -81,21 +80,21 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:LabelSelector]", func() {
 		})
 		It("should bind volume with claim for given label", func() {
 			volumePath, pv_ssd, pvc_ssd, pvc_vvol, err = testSetupVSpherePVClabelselector(c, nodeInfo, ns, ssdlabels, vvollabels)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 
 			By("wait for the pvc_ssd to bind with pv_ssd")
 			framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv_ssd, pvc_ssd))
 
 			By("Verify status of pvc_vvol is pending")
 			err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, c, ns, pvc_vvol.Name, 3*time.Second, 300*time.Second)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 
 			By("delete pvc_ssd")
 			framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc_ssd.Name, ns), "Failed to delete PVC ", pvc_ssd.Name)
 
 			By("verify pv_ssd is deleted")
 			err = framework.WaitForPersistentVolumeDeleted(c, pv_ssd.Name, 3*time.Second, 300*time.Second)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			volumePath = ""
 
 			By("delete pvc_vvol")

--- a/test/e2e/storage/vsphere/vsphere_common.go
+++ b/test/e2e/storage/vsphere/vsphere_common.go
@@ -17,9 +17,11 @@ limitations under the License.
 package vsphere
 
 import (
-	. "github.com/onsi/gomega"
 	"os"
 	"strconv"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
@@ -72,6 +74,6 @@ func GetAndExpectStringEnvVar(varName string) string {
 func GetAndExpectIntEnvVar(varName string) int {
 	varValue := GetAndExpectStringEnvVar(varName)
 	varIntValue, err := strconv.Atoi(varValue)
-	Expect(err).NotTo(HaveOccurred(), "Error Parsing "+varName)
+	framework.ExpectNoError(err, "Error Parsing "+varName)
 	return varIntValue
 }

--- a/test/e2e/storage/vsphere/vsphere_scale.go
+++ b/test/e2e/storage/vsphere/vsphere_scale.go
@@ -131,7 +131,7 @@ var _ = utils.SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 			}
 			sc, err = client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec(scname, scParams, nil))
 			Expect(sc).NotTo(BeNil(), "Storage class is empty")
-			Expect(err).NotTo(HaveOccurred(), "Failed to create storage class")
+			framework.ExpectNoError(err, "Failed to create storage class")
 			defer client.StorageV1().StorageClasses().Delete(scname, nil)
 			scArrays[index] = sc
 		}
@@ -156,15 +156,15 @@ var _ = utils.SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 			pvcClaimList = append(pvcClaimList, getClaimsForPod(&pod, volumesPerPod)...)
 			By("Deleting pod")
 			err = framework.DeletePodWithWait(f, client, &pod)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}
 		By("Waiting for volumes to be detached from the node")
 		err = waitForVSphereDisksToDetach(nodeVolumeMap)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		for _, pvcClaim := range pvcClaimList {
 			err = framework.DeletePersistentVolumeClaim(client, pvcClaim, namespace)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}
 	})
 })
@@ -193,19 +193,19 @@ func VolumeCreateAndAttach(client clientset.Interface, namespace string, sc []*s
 		for i := 0; i < volumesPerPod; i++ {
 			By("Creating PVC using the Storage Class")
 			pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", sc[index%len(sc)]))
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			pvclaims[i] = pvclaim
 		}
 
 		By("Waiting for claim to be in bound phase")
 		persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating pod to attach PV to the node")
 		nodeSelector := nodeSelectorList[nodeSelectorIndex%len(nodeSelectorList)]
 		// Create pod to attach Volume to Node
 		pod, err := framework.CreatePod(client, namespace, map[string]string{nodeSelector.labelKey: nodeSelector.labelValue}, pvclaims, false, "")
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		for _, pv := range persistentvolumes {
 			nodeVolumeMap[pod.Spec.NodeName] = append(nodeVolumeMap[pod.Spec.NodeName], pv.Spec.VsphereVolume.VolumePath)

--- a/test/e2e/storage/vsphere/vsphere_volume_cluster_ds.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_cluster_ds.go
@@ -76,7 +76,7 @@ var _ = utils.SIGDescribe("Volume Provisioning On Clustered Datastore [Feature:v
 		volumeOptions.Datastore = clusterDatastore
 
 		volumePath, err := nodeInfo.VSphere.CreateVolume(volumeOptions, nodeInfo.DataCenterRef)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By("Deleting the vsphere volume")
@@ -87,13 +87,13 @@ var _ = utils.SIGDescribe("Volume Provisioning On Clustered Datastore [Feature:v
 
 		By("Creating pod")
 		pod, err := client.CoreV1().Pods(namespace).Create(podspec)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By("Waiting for pod to be ready")
 		Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(Succeed())
 
 		// get fresh pod info
 		pod, err = client.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		nodeName := pod.Spec.NodeName
 
 		By("Verifying volume is attached")
@@ -101,11 +101,11 @@ var _ = utils.SIGDescribe("Volume Provisioning On Clustered Datastore [Feature:v
 
 		By("Deleting pod")
 		err = framework.DeletePodWithWait(f, client, pod)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Waiting for volumes to be detached from the node")
 		err = waitForVSphereDiskToDetach(volumePath, nodeName)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 	/*

--- a/test/e2e/storage/vsphere/vsphere_volume_datastore.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_datastore.go
@@ -72,7 +72,7 @@ var _ = utils.SIGDescribe("Volume Provisioning on Datastore [Feature:vsphere]", 
 		Expect(err).To(HaveOccurred())
 		errorMsg := `Failed to provision volume with StorageClass \"` + DatastoreSCName + `\": The specified datastore ` + InvalidDatastore + ` is not a shared datastore across node VMs`
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 })
@@ -80,12 +80,12 @@ var _ = utils.SIGDescribe("Volume Provisioning on Datastore [Feature:vsphere]", 
 func invokeInvalidDatastoreTestNeg(client clientset.Interface, namespace string, scParameters map[string]string) error {
 	By("Creating Storage Class With Invalid Datastore")
 	storageclass, err := client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec(DatastoreSCName, scParameters, nil))
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create storage class with err: %v", err))
+	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
 	By("Creating PVC using the Storage Class")
 	pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 
 	By("Expect claim to fail provisioning volume")

--- a/test/e2e/storage/vsphere/vsphere_volume_diskformat.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_diskformat.go
@@ -108,14 +108,14 @@ func invokeTest(f *framework.Framework, client clientset.Interface, namespace st
 	By("Creating Storage Class With DiskFormat")
 	storageClassSpec := getVSphereStorageClassSpec("thinsc", scParameters, nil)
 	storageclass, err := client.StorageV1().StorageClasses().Create(storageClassSpec)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
 	By("Creating PVC using the Storage Class")
 	pvclaimSpec := getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass)
 	pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Create(pvclaimSpec)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	defer func() {
 		client.CoreV1().PersistentVolumeClaims(namespace).Delete(pvclaimSpec.Name, nil)
@@ -123,15 +123,15 @@ func invokeTest(f *framework.Framework, client clientset.Interface, namespace st
 
 	By("Waiting for claim to be in bound phase")
 	err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	// Get new copy of the claim
 	pvclaim, err = client.CoreV1().PersistentVolumeClaims(pvclaim.Namespace).Get(pvclaim.Name, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	// Get the bound PV
 	pv, err := client.CoreV1().PersistentVolumes().Get(pvclaim.Spec.VolumeName, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	/*
 		PV is required to be attached to the Node. so that using govmomi API we can grab Disk's Backing Info
@@ -141,14 +141,14 @@ func invokeTest(f *framework.Framework, client clientset.Interface, namespace st
 	// Create pod to attach Volume to Node
 	podSpec := getVSpherePodSpecWithClaim(pvclaim.Name, nodeKeyValueLabel, "while true ; do sleep 2 ; done")
 	pod, err := client.CoreV1().Pods(namespace).Create(podSpec)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	By("Waiting for pod to be running")
 	Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(Succeed())
 
 	isAttached, err := diskIsAttached(pv.Spec.VsphereVolume.VolumePath, nodeName)
 	Expect(isAttached).To(BeTrue())
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	By("Verify Disk Format")
 	Expect(verifyDiskFormat(client, nodeName, pv.Spec.VsphereVolume.VolumePath, diskFormat)).To(BeTrue(), "DiskFormat Verification Failed")
@@ -174,7 +174,7 @@ func verifyDiskFormat(client clientset.Interface, nodeName string, pvVolumePath 
 	nodeInfo := TestContext.NodeMapper.GetNodeInfo(nodeName)
 	vm := object.NewVirtualMachine(nodeInfo.VSphere.Client.Client, nodeInfo.VirtualMachineRef)
 	vmDevices, err := vm.Device(ctx)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	disks := vmDevices.SelectByType((*types.VirtualDisk)(nil))
 

--- a/test/e2e/storage/vsphere/vsphere_volume_disksize.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_disksize.go
@@ -70,7 +70,7 @@ var _ = utils.SIGDescribe("Volume Disk Size [Feature:vsphere]", func() {
 		Expect(err).To(HaveOccurred())
 		errorMsg := `Failed to provision volume with StorageClass \"` + DiskSizeSCName + `\": A specified parameter was not correct`
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 })
@@ -78,12 +78,12 @@ var _ = utils.SIGDescribe("Volume Disk Size [Feature:vsphere]", func() {
 func invokeInvalidDiskSizeTestNeg(client clientset.Interface, namespace string, scParameters map[string]string, diskSize string) error {
 	By("Creating Storage Class With invalid disk size")
 	storageclass, err := client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec(DiskSizeSCName, scParameters, nil))
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create storage class with err: %v", err))
+	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
 	By("Creating PVC using the Storage Class")
 	pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, diskSize, storageclass))
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 
 	By("Expect claim to fail provisioning volume")

--- a/test/e2e/storage/vsphere/vsphere_volume_fstype.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_fstype.go
@@ -104,7 +104,7 @@ func invokeTestForFstype(f *framework.Framework, client clientset.Interface, nam
 	// Create Pod and verify the persistent volume is accessible
 	pod := createPodAndVerifyVolumeAccessible(client, namespace, pvclaim, persistentvolumes)
 	_, err := framework.LookForStringInPodExec(namespace, pod.Name, []string{"/bin/cat", "/mnt/volume1/fstype"}, expectedContent, time.Minute)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	// Detach and delete volume
 	detachVolume(f, client, pod, persistentvolumes[0].Spec.VsphereVolume.VolumePath)
@@ -147,18 +147,18 @@ func invokeTestForInvalidFstype(f *framework.Framework, client clientset.Interfa
 
 func createVolume(client clientset.Interface, namespace string, scParameters map[string]string) (*v1.PersistentVolumeClaim, []*v1.PersistentVolume) {
 	storageclass, err := client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec("fstype", scParameters, nil))
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
 	By("Creating PVC using the Storage Class")
 	pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Create(getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
 	By("Waiting for claim to be in bound phase")
 	persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	return pvclaim, persistentvolumes
 }
 
@@ -168,7 +168,7 @@ func createPodAndVerifyVolumeAccessible(client clientset.Interface, namespace st
 	By("Creating pod to attach PV to the node")
 	// Create pod to attach Volume to Node
 	pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, ExecCommand)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	// Asserts: Right disk is attached to the pod
 	By("Verify the volume is accessible and available in the pod")

--- a/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
@@ -44,7 +44,7 @@ var _ = utils.SIGDescribe("Node Unregister [Feature:vsphere] [Slow] [Disruptive]
 		client = f.ClientSet
 		namespace = f.Namespace.Name
 		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(client, framework.TestContext.NodeSchedulableTimeout))
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		workingDir = os.Getenv("VSPHERE_WORKING_DIR")
 		Expect(workingDir).NotTo(BeEmpty())
 
@@ -69,10 +69,10 @@ var _ = utils.SIGDescribe("Node Unregister [Feature:vsphere] [Slow] [Disruptive]
 		defer cancel()
 
 		vmHost, err := vmObject.HostSystem(ctx)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		vmPool, err := vmObject.ResourcePool(ctx)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Unregister Node VM
 		By("Unregister a node VM")

--- a/test/e2e/storage/vsphere/vsphere_volume_ops_storm.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_ops_storm.go
@@ -66,7 +66,7 @@ var _ = utils.SIGDescribe("Volume Operations Storm [Feature:vsphere]", func() {
 		Expect(GetReadySchedulableNodeInfos()).NotTo(BeEmpty())
 		if os.Getenv("VOLUME_OPS_SCALE") != "" {
 			volume_ops_scale, err = strconv.Atoi(os.Getenv("VOLUME_OPS_SCALE"))
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		} else {
 			volume_ops_scale = DEFAULT_VOLUME_OPS_SCALE
 		}
@@ -79,7 +79,7 @@ var _ = utils.SIGDescribe("Volume Operations Storm [Feature:vsphere]", func() {
 		}
 		By("Deleting StorageClass")
 		err = client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 	It("should create pod with many volumes and verify no attach call fails", func() {
@@ -88,23 +88,23 @@ var _ = utils.SIGDescribe("Volume Operations Storm [Feature:vsphere]", func() {
 		scParameters := make(map[string]string)
 		scParameters["diskformat"] = "thin"
 		storageclass, err = client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec("thinsc", scParameters, nil))
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating PVCs using the Storage Class")
 		count := 0
 		for count < volume_ops_scale {
 			pvclaims[count], err = framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			count++
 		}
 
 		By("Waiting for all claims to be in bound phase")
 		persistentvolumes, err = framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating pod to attach PVs to the node")
 		pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, "")
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Verify all volumes are accessible and available in the pod")
 		verifyVSphereVolumesAccessible(client, pod, persistentvolumes)

--- a/test/e2e/storage/vsphere/vsphere_volume_perf.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_perf.go
@@ -147,7 +147,7 @@ func getTestStorageClasses(client clientset.Interface, policyName, datastoreName
 			sc, err = client.StorageV1().StorageClasses().Create(scWithDatastoreSpec)
 		}
 		Expect(sc).NotTo(BeNil())
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		scArrays[index] = sc
 	}
 	return scArrays
@@ -171,14 +171,14 @@ func invokeVolumeLifeCyclePerformance(f *framework.Framework, client clientset.I
 		for j := 0; j < volumesPerPod; j++ {
 			currsc := sc[((i*numPods)+j)%len(sc)]
 			pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", currsc))
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			pvclaims = append(pvclaims, pvclaim)
 		}
 		totalpvclaims = append(totalpvclaims, pvclaims)
 	}
 	for _, pvclaims := range totalpvclaims {
 		persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		totalpvs = append(totalpvs, persistentvolumes)
 	}
 	elapsed := time.Since(start)
@@ -189,7 +189,7 @@ func invokeVolumeLifeCyclePerformance(f *framework.Framework, client clientset.I
 	for i, pvclaims := range totalpvclaims {
 		nodeSelector := nodeSelectorList[i%len(nodeSelectorList)]
 		pod, err := framework.CreatePod(client, namespace, map[string]string{nodeSelector.labelKey: nodeSelector.labelValue}, pvclaims, false, "")
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		totalpods = append(totalpods, pod)
 
 		defer framework.DeletePodWithWait(f, client, pod)
@@ -205,7 +205,7 @@ func invokeVolumeLifeCyclePerformance(f *framework.Framework, client clientset.I
 	start = time.Now()
 	for _, pod := range totalpods {
 		err := framework.DeletePodWithWait(f, client, pod)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	}
 	elapsed = time.Since(start)
 	latency[DetachOp] = elapsed.Seconds()
@@ -217,14 +217,14 @@ func invokeVolumeLifeCyclePerformance(f *framework.Framework, client clientset.I
 	}
 
 	err := waitForVSphereDisksToDetach(nodeVolumeMap)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	By("Deleting the PVCs")
 	start = time.Now()
 	for _, pvclaims := range totalpvclaims {
 		for _, pvc := range pvclaims {
 			err = framework.DeletePersistentVolumeClaim(client, pvc.Name, namespace)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}
 	}
 	elapsed = time.Since(start)

--- a/test/e2e/storage/vsphere/vsphere_volume_placement.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_placement.go
@@ -61,7 +61,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		}
 		By("creating vmdk")
 		volumePath, err := vsp.CreateVolume(&VolumeOptions{}, nodeInfo.DataCenterRef)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		volumePaths = append(volumePaths, volumePath)
 	})
 
@@ -180,7 +180,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 	It("should create and delete pod with multiple volumes from same datastore", func() {
 		By("creating another vmdk")
 		volumePath, err := vsp.CreateVolume(&VolumeOptions{}, nodeInfo.DataCenterRef)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		volumePaths = append(volumePaths, volumePath)
 
 		By(fmt.Sprintf("Creating pod on the node: %v with volume: %v and volume: %v", node1Name, volumePaths[0], volumePaths[1]))
@@ -228,7 +228,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		volumeOptions.Datastore = GetAndExpectStringEnvVar(SecondSharedDatastore)
 		volumePath, err := vsp.CreateVolume(volumeOptions, nodeInfo.DataCenterRef)
 
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		volumePaths = append(volumePaths, volumePath)
 
 		By(fmt.Sprintf("Creating pod on the node: %v with volume :%v  and volume: %v", node1Name, volumePaths[0], volumePaths[1]))
@@ -295,7 +295,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		// Create another VMDK Volume
 		By("creating another vmdk")
 		volumePath, err := vsp.CreateVolume(&VolumeOptions{}, nodeInfo.DataCenterRef)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		volumePaths = append(volumePaths, volumePath)
 		testvolumePathsPodB = append(testvolumePathsPodA, volumePath)
 
@@ -358,14 +358,14 @@ func createPodWithVolumeAndNodeSelector(client clientset.Interface, namespace st
 	podspec := getVSpherePodSpecWithVolumePaths(volumePaths, nodeKeyValueLabel, nil)
 
 	pod, err = client.CoreV1().Pods(namespace).Create(podspec)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	By("Waiting for pod to be ready")
 	Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(Succeed())
 
 	By(fmt.Sprintf("Verify volume is attached to the node:%v", nodeName))
 	for _, volumePath := range volumePaths {
 		isAttached, err := diskIsAttached(volumePath, nodeName)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(isAttached).To(BeTrue(), "disk:"+volumePath+" is not attached with the node")
 	}
 	return pod

--- a/test/e2e/storage/vsphere/vsphere_volume_vpxd_restart.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_vpxd_restart.go
@@ -110,19 +110,19 @@ var _ = utils.SIGDescribe("Verify Volume Attach Through vpxd Restart [Feature:vs
 			for i, node := range nodes {
 				By(fmt.Sprintf("Creating test vsphere volume %d", i))
 				volumePath, err := node.nodeInfo.VSphere.CreateVolume(&VolumeOptions{}, node.nodeInfo.DataCenterRef)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 				volumePaths = append(volumePaths, volumePath)
 
 				By(fmt.Sprintf("Creating pod %d on node %v", i, node.name))
 				podspec := getVSpherePodSpecWithVolumePaths([]string{volumePath}, node.kvLabels, nil)
 				pod, err := client.CoreV1().Pods(namespace).Create(podspec)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				By(fmt.Sprintf("Waiting for pod %d to be ready", i))
 				Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(Succeed())
 
 				pod, err = client.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 				pods = append(pods, pod)
 
 				nodeName := pod.Spec.NodeName
@@ -133,7 +133,7 @@ var _ = utils.SIGDescribe("Verify Volume Attach Through vpxd Restart [Feature:vs
 				filePath := fmt.Sprintf("/mnt/volume1/%v_vpxd_restart_test_%v.txt", namespace, strconv.FormatInt(time.Now().UnixNano(), 10))
 				randomContent := fmt.Sprintf("Random Content -- %v", strconv.FormatInt(time.Now().UnixNano(), 10))
 				err = writeContentToPodFile(namespace, pod.Name, filePath, randomContent)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 				filePaths = append(filePaths, filePath)
 				fileContents = append(fileContents, randomContent)
 			}
@@ -141,14 +141,14 @@ var _ = utils.SIGDescribe("Verify Volume Attach Through vpxd Restart [Feature:vs
 			By("Stopping vpxd on the vCenter host")
 			vcAddress := vcHost + ":22"
 			err := invokeVCenterServiceControl("stop", vpxdServiceName, vcAddress)
-			Expect(err).NotTo(HaveOccurred(), "Unable to stop vpxd on the vCenter host")
+			framework.ExpectNoError(err, "Unable to stop vpxd on the vCenter host")
 
 			expectFilesToBeAccessible(namespace, pods, filePaths)
 			expectFileContentsToMatch(namespace, pods, filePaths, fileContents)
 
 			By("Starting vpxd on the vCenter host")
 			err = invokeVCenterServiceControl("start", vpxdServiceName, vcAddress)
-			Expect(err).NotTo(HaveOccurred(), "Unable to start vpxd on the vCenter host")
+			framework.ExpectNoError(err, "Unable to start vpxd on the vCenter host")
 
 			expectVolumesToBeAttached(pods, volumePaths)
 			expectFilesToBeAccessible(namespace, pods, filePaths)
@@ -161,15 +161,15 @@ var _ = utils.SIGDescribe("Verify Volume Attach Through vpxd Restart [Feature:vs
 
 				By(fmt.Sprintf("Deleting pod on node %s", nodeName))
 				err = framework.DeletePodWithWait(f, client, pod)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				By(fmt.Sprintf("Waiting for volume %s to be detached from node %s", volumePath, nodeName))
 				err = waitForVSphereDiskToDetach(volumePath, nodeName)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				By(fmt.Sprintf("Deleting volume %s", volumePath))
 				err = node.nodeInfo.VSphere.DeleteVolume(volumePath, node.nodeInfo.DataCenterRef)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 			}
 		}
 	})

--- a/test/e2e/storage/vsphere/vsphere_zone_support.go
+++ b/test/e2e/storage/vsphere/vsphere_zone_support.go
@@ -134,7 +134,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		Expect(err).To(HaveOccurred())
 		errorMsg := "Failed to find a shared datastore matching zone [" + zoneD + "]"
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
@@ -165,7 +165,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		err := verifyPVCCreationFails(client, namespace, scParameters, zones)
 		errorMsg := "The specified datastore " + scParameters[Datastore] + " does not match the provided zones : [" + zoneC + "]"
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
@@ -183,7 +183,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		err := verifyPVCCreationFails(client, namespace, scParameters, zones)
 		errorMsg := "No compatible datastores found that satisfy the storage policy requirements"
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
@@ -203,7 +203,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		err := verifyPVCCreationFails(client, namespace, scParameters, zones)
 		errorMsg := "User specified datastore is not compatible with the storagePolicy: \\\"" + nonCompatPolicy + "\\\"."
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
@@ -215,7 +215,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		err := verifyPVCCreationFails(client, namespace, scParameters, zones)
 		errorMsg := "The specified datastore " + scParameters[Datastore] + " does not match the provided zones : [" + zoneC + "]"
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
@@ -224,7 +224,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		err := verifyPVCCreationFails(client, namespace, nil, nil)
 		errorMsg := "No shared datastores found in the Kubernetes cluster"
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
@@ -234,7 +234,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		err := verifyPVCCreationFails(client, namespace, scParameters, nil)
 		errorMsg := "No shared datastores found in the Kubernetes cluster"
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
@@ -244,7 +244,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		err := verifyPVCCreationFails(client, namespace, scParameters, nil)
 		errorMsg := "No shared datastores found in the Kubernetes cluster"
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
@@ -255,7 +255,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		err := verifyPVCCreationFails(client, namespace, scParameters, nil)
 		errorMsg := "No shared datastores found in the Kubernetes cluster"
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
@@ -265,7 +265,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		err := verifyPVCCreationFails(client, namespace, nil, zones)
 		errorMsg := "Failed to find a shared datastore matching zone [" + zoneC + "]"
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
@@ -276,7 +276,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		err := verifyPVCCreationFails(client, namespace, nil, zones)
 		errorMsg := "Failed to find a shared datastore matching zone [" + zoneA + " " + zoneC + "]"
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
@@ -287,7 +287,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		err := verifyPVCCreationFails(client, namespace, scParameters, zones)
 		errorMsg := "Invalid value for " + Policy_HostFailuresToTolerate + "."
 		if !strings.Contains(err.Error(), errorMsg) {
-			Expect(err).NotTo(HaveOccurred(), errorMsg)
+			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
@@ -303,23 +303,23 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 
 func verifyPVCAndPodCreationSucceeds(client clientset.Interface, namespace string, scParameters map[string]string, zones []string) {
 	storageclass, err := client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec("zone-sc", scParameters, zones))
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create storage class with err: %v", err))
+	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
 	By("Creating PVC using the Storage Class")
 	pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
 	By("Waiting for claim to be in bound phase")
 	persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	By("Creating pod to attach PV to the node")
 	pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, "")
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	By("Verify persistent volume was created on the right zone")
 	verifyVolumeCreationOnRightZone(persistentvolumes, pod.Spec.NodeName, zones)
@@ -336,12 +336,12 @@ func verifyPVCAndPodCreationSucceeds(client clientset.Interface, namespace strin
 
 func verifyPVCCreationFails(client clientset.Interface, namespace string, scParameters map[string]string, zones []string) error {
 	storageclass, err := client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec("zone-sc", scParameters, zones))
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create storage class with err: %v", err))
+	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
 	By("Creating PVC using the Storage Class")
 	pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 
 	var pvclaims []*v1.PersistentVolumeClaim
@@ -358,19 +358,19 @@ func verifyPVCCreationFails(client clientset.Interface, namespace string, scPara
 
 func verifyPVZoneLabels(client clientset.Interface, namespace string, scParameters map[string]string, zones []string) {
 	storageclass, err := client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec("zone-sc", nil, zones))
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create storage class with err: %v", err))
+	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
 	By("Creating PVC using the storage class")
 	pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
 	By("Waiting for claim to be in bound phase")
 	persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	By("Verify zone information is present in the volume labels")
 	for _, pv := range persistentvolumes {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Restore volume tests using statefulset, which is removed by #74693.
The reasons for this change are:
  - to keep volume tests using statefulset,
  - to avoid failing tests for default storage class that are not updated to use delayed binding.

**Which issue(s) this PR fixes**:
Fixes #75775

**Special notes for your reviewer**:
/sig storage
@msau42 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
