### PR TITLE
refactor: extract historiesByRevision to daemon util

### DIFF
--- a/pkg/controller/daemon/update.go
+++ b/pkg/controller/daemon/update.go
@@ -169,7 +169,7 @@ func (dsc *DaemonSetsController) cleanupHistory(ds *apps.DaemonSet, old []*apps.
 	}
 
 	// Clean up old history from smallest to highest revision (from oldest to newest)
-	sort.Sort(historiesByRevision(old))
+	sort.Sort(util.HistoriesByRevision(old))
 	for _, history := range old {
 		if toKill <= 0 {
 			break
@@ -428,12 +428,4 @@ func (dsc *DaemonSetsController) getUnavailableNumbers(ds *apps.DaemonSet, nodeL
 	}
 	klog.V(4).Infof(" DaemonSet %s/%s, maxUnavailable: %d, numUnavailable: %d", ds.Namespace, ds.Name, maxUnavailable, numUnavailable)
 	return maxUnavailable, numUnavailable, nil
-}
-
-type historiesByRevision []*apps.ControllerRevision
-
-func (h historiesByRevision) Len() int      { return len(h) }
-func (h historiesByRevision) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
-func (h historiesByRevision) Less(i, j int) bool {
-	return h[i].Revision < h[j].Revision
 }

--- a/pkg/controller/daemon/util/BUILD
+++ b/pkg/controller/daemon/util/BUILD
@@ -8,7 +8,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["daemonset_util.go"],
+    srcs = [
+        "daemonset_util.go",
+        "histories_by_revision.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/controller/daemon/util",
     deps = [
         "//pkg/api/v1/pod:go_default_library",
@@ -36,11 +39,15 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["daemonset_util_test.go"],
+    srcs = [
+        "daemonset_util_test.go",
+        "histories_by_revision_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/features:go_default_library",
         "//pkg/scheduler/api:go_default_library",
+        "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/controller/daemon/util/histories_by_revision.go
+++ b/pkg/controller/daemon/util/histories_by_revision.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sort"
+
+	apps "k8s.io/api/apps/v1"
+)
+
+// HistoriesByRevision conforms sort.Interface and sorts controller revisions
+// in ascending order.
+type HistoriesByRevision []*apps.ControllerRevision
+
+var _ sort.Interface = &HistoriesByRevision{}
+
+func (h HistoriesByRevision) Len() int      { return len(h) }
+func (h HistoriesByRevision) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h HistoriesByRevision) Less(i, j int) bool {
+	return h[i].Revision < h[j].Revision
+}

--- a/pkg/controller/daemon/util/histories_by_revision_test.go
+++ b/pkg/controller/daemon/util/histories_by_revision_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sort"
+	"testing"
+
+	apps "k8s.io/api/apps/v1"
+)
+
+func TestSortHistoriesByReivision(t *testing.T) {
+	revisions := []int64{1, 4, 3, 2, 5, 100}
+
+	controllerRevisions := []*apps.ControllerRevision{}
+	for _, revision := range revisions {
+		controllerRevisions = append(controllerRevisions, &apps.ControllerRevision{
+			Revision: revision,
+		})
+	}
+
+	sort.Sort(HistoriesByRevision(controllerRevisions))
+
+	previous := int64(0)
+	for _, history := range controllerRevisions {
+		if history.Revision < previous {
+			t.Fatalf("sorted HistoriesByRevision list shoud be ascending")
+		}
+
+		previous = history.Revision
+	}
+}

--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -58,6 +58,7 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/kubectl",
     deps = [
+        "//pkg/controller/daemon/util:go_default_library",
         "//pkg/kubectl/apps:go_default_library",
         "//pkg/kubectl/describe/versioned:go_default_library",
         "//pkg/kubectl/scheme:go_default_library",

--- a/pkg/kubectl/rollback.go
+++ b/pkg/kubectl/rollback.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
+	daemonutil "k8s.io/kubernetes/pkg/controller/daemon/util"
 	kapps "k8s.io/kubernetes/pkg/kubectl/apps"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	deploymentutil "k8s.io/kubernetes/pkg/kubectl/util/deployment"
@@ -449,7 +450,7 @@ func findHistory(toRevision int64, allHistory []*appsv1.ControllerRevision) *app
 	var toHistory *appsv1.ControllerRevision
 	if toRevision == 0 {
 		// If toRevision == 0, find the latest revision (2nd max)
-		sort.Sort(historiesByRevision(allHistory))
+		sort.Sort(daemonutil.HistoriesByRevision(allHistory))
 		toHistory = allHistory[len(allHistory)-2]
 	} else {
 		for _, h := range allHistory {
@@ -474,13 +475,4 @@ func printPodTemplate(specTemplate *corev1.PodTemplateSpec) (string, error) {
 
 func revisionNotFoundErr(r int64) error {
 	return fmt.Errorf("unable to find specified revision %v in history", r)
-}
-
-// TODO: copied from daemon controller, should extract to a library
-type historiesByRevision []*appsv1.ControllerRevision
-
-func (h historiesByRevision) Len() int      { return len(h) }
-func (h historiesByRevision) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
-func (h historiesByRevision) Less(i, j int) bool {
-	return h[i].Revision < h[j].Revision
 }


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:

1. The `historiesByRevision` in kubectl was copied directly from daemonset and should be extracted into a library.
2. Add unit tests to verify `historiesByRevision` order direction.
3. Use `var _ sort.Interface = &HistoriesByRevision{}`  to ensure `historiesByRevision` implements `sort.Interface`

**Special notes for your reviewer**:

I'm not sure whether to put the `HistoriesByRevision` struct in daemon util is a good idea. If there's a better place, please let me know, and I'll update the PR.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
