### PR TITLE
patch-reset

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -217,7 +217,9 @@ func (r *Reset) Run(out io.Writer, client clientset.Interface, cfg *kubeadmapi.I
 
 		If your cluster was setup to utilize IPVS, run ipvsadm --clear (or similar)
 		to reset your system's IPVS tables.
-
+		
+		The reset process does not clean your kubeconfig files and you must remove them manually.
+		Please, check the contents of the $HOME/.kube/config file.
 	`)
 	fmt.Print(msg)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
When we reset cluster, the program does not automatically delete it ($HOME/.kube/config).
We should prompt the user how to check
**Which issue(s) this PR fixes**:
Fixes [kubeadm issue](https://github.com/kubernetes/kubeadm/issues/1480)

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```