### PR TITLE
Finish saving test results on failure

### DIFF
--- a/cluster/images/conformance/run_e2e.sh
+++ b/cluster/images/conformance/run_e2e.sh
@@ -62,5 +62,6 @@ set -x
 /usr/local/bin/ginkgo "${ginkgo_args[@]}" /usr/local/bin/e2e.test -- --disable-log-dump --repo-root=/kubernetes --provider="${E2E_PROVIDER}" --report-dir="${RESULTS_DIR}" --kubeconfig="${KUBECONFIG}" | tee "${RESULTS_DIR}"/e2e.log &
 set +x
 # $! is the pid of tee, not ginkgo
-wait "$(pgrep ginkgo)"
+wait "$(pgrep ginkgo)" && ret=0 || ret=$?
 saveResults
+exit ${ret}


### PR DESCRIPTION
The conformance image should be saving its results
regardless of the results of the tests. However,
with errexit set, when ginkgo gets test failures
it exits 1 which prevents saving the results
for Sonobuoy to pick up.

Fixes: #76036

/kind bug

**Special notes for your reviewer**:
Currently working on building this image and testing it works as expected.

**Does this PR introduce a user-facing change?**:
```release-note
Ensures the conformance test image saves results before exiting when ginkgo returns non-zero value.
```
