### PR TITLE
feat: skip updates in when update disruption with same meta and spec

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -309,7 +309,6 @@ func (dc *DisruptionController) addDb(obj interface{}) {
 }
 
 func (dc *DisruptionController) updateDb(old, cur interface{}) {
-	// TODO(mml) ignore updates where 'old' is equivalent to 'cur'.
 	pdb := cur.(*policy.PodDisruptionBudget)
 	klog.V(4).Infof("update DB %q", pdb.Name)
 	dc.enqueuePdb(pdb)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Updates PodDisruptionBudge only when needed.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
