### PR TITLE
test-cmd: Fixes erroneous integration test that usually passes accidentally

### DIFF
--- a/test/cmd/version.sh
+++ b/test/cmd/version.sh
@@ -37,7 +37,9 @@ run_kubectl_version_tests() {
 
   kube::log::status "Testing kubectl version: check client only output matches expected output"
   kube::test::version::object_to_file "Client" "--client" "${TEMP}/client_only_version_test"
-  kube::test::version::object_to_file "Client" "--client" "${TEMP}/server_client_only_version_test"
+  set +e pipefail   # Turn off bash options, since this command pipes empty text.
+  kube::test::version::object_to_file "Server" "--client" "${TEMP}/server_client_only_version_test"
+  set -e pipefail   # Reset bash options
   kube::test::version::diff_assert "${TEMP}/client_version_test" "eq" "${TEMP}/client_only_version_test" "the flag '--client' shows correct client info"
   kube::test::version::diff_assert "${TEMP}/server_version_test" "ne" "${TEMP}/server_client_only_version_test" "the flag '--client' correctly has no server version info"
 


### PR DESCRIPTION
* Fixes erroneous integration test that usually passes on accident.
* This test will have to be cherry-picked back to previous releases.
* The test is supposed to validate that `kubectl version --client` has Client information, but no Server information.
* Instead the test was passing because the build dates within the integration test for `kubectl` differed (almost always) from the `api-server` (note the BuildDate differs by 17 seconds in the following example):

**server_version_test**:
Major=1
Minor=15+
GitVersion=v1.15.0-alpha.0.1742+dd96b15e5d1de1-dirty
GitCommit=dd96b15e5d1de1923645ef17c05dfdfb616163bf
GitTreeState=dirty
BuildDate=2019-04-02T01=45=**56Z**
GoVersion=go1.12.1
Compiler=gc
Platform=linux/amd64

**server_client_only_version_test**:
Major=1
Minor=15+
GitVersion=v1.15.0-alpha.0.1742+dd96b15e5d1de1-dirty
GitCommit=dd96b15e5d1de1923645ef17c05dfdfb616163bf
GitTreeState=dirty
BuildDate=2019-04-02T01=45=**39Z**
GoVersion=go1.12.1
Compiler=gc
Platform=linux/amd64

```release-note
NONE
```

/kind bug
/sig cil
/sig testing