### PR TITLE
Fix kubelet start in local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -750,7 +750,7 @@ function start_kubelet {
 
     # shellcheck disable=SC2206
     all_kubelet_flags=(
-      "${priv_arg}"
+      ${priv_arg}
       "--v=${LOG_LEVEL}"
       "--vmodule=${LOG_SPEC}"
       "--chaos-chance=${CHAOS_CHANCE}"


### PR DESCRIPTION
Fixes #76048

Otherwise the empty "${priv_arg}" is interpreted as a non-flag argument and causes kubelet to fail to start.

/sig cluster-lifecycle
/assign @BenTheElder 
cc @roycaihw @janetkuo 