### PR TITLE
Simplify kubeadm bump version on TestEtcdSupportedVersion

### DIFF
--- a/cmd/kubeadm/app/constants/constants_test.go
+++ b/cmd/kubeadm/app/constants/constants_test.go
@@ -160,18 +160,13 @@ func TestEtcdSupportedVersion(t *testing.T) {
 			expectedError:     errors.New("Unsupported or unknown Kubernetes version(1.99.0)"),
 		},
 		{
-			kubernetesVersion: "1.12.1",
-			expectedVersion:   version.MustParseSemantic("3.2.24"),
+			kubernetesVersion: MinimumControlPlaneVersion.WithPatch(1).String(),
+			expectedVersion:   version.MustParseSemantic(SupportedEtcdVersion[uint8(MinimumControlPlaneVersion.Minor())]),
 			expectedError:     nil,
 		},
 		{
-			kubernetesVersion: "1.13.1",
-			expectedVersion:   version.MustParseSemantic("3.2.24"),
-			expectedError:     nil,
-		},
-		{
-			kubernetesVersion: "1.14.0",
-			expectedVersion:   version.MustParseSemantic("3.3.10"),
+			kubernetesVersion: CurrentKubernetesVersion.String(),
+			expectedVersion:   version.MustParseSemantic(SupportedEtcdVersion[uint8(CurrentKubernetesVersion.Minor())]),
 			expectedError:     nil,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref #https://github.com/kubernetes/kubeadm/issues/1260

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/priority important-longterm