### PR TITLE
Fix shellcheck failures of test/images/pets/redis-installer/on-start.sh

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -98,7 +98,6 @@
 ./test/e2e_node/environment/setup_host.sh
 ./test/e2e_node/gubernator.sh
 ./test/images/image-util.sh
-./test/images/pets/redis-installer/on-start.sh
 ./test/images/pets/zookeeper-installer/install.sh
 ./test/images/pets/zookeeper-installer/on-start.sh
 ./test/images/volume/gluster/run_gluster.sh

--- a/test/images/pets/redis-installer/on-start.sh
+++ b/test/images/pets/redis-installer/on-start.sh
@@ -27,7 +27,7 @@ PORT=6379
 while read -ra LINE; do
     if [[ "${LINE}" == *"${HOSTNAME}"* ]]; then
         sed -i -e "s|^bind.*$|bind ${LINE}|" ${CFG}
-    elif [ "$(/opt/redis/redis-cli -h $LINE info | grep role | sed 's,\r$,,')" = "role:master" ]; then
+    elif [ "$(/opt/redis/redis-cli -h "${LINE}" info | grep role | sed 's,\r$,,')" = "role:master" ]; then
         # TODO: More restrictive regex?
         sed -i -e "s|^# slaveof.*$|slaveof ${LINE} ${PORT}|" ${CFG}
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Fix shellcheck failures of test/images/pets/redis-installer/on-start.sh
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref: #72956

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
