### PR TITLE
Handle feature gate errors

### DIFF
--- a/pkg/features/BUILD
+++ b/pkg/features/BUILD
@@ -11,6 +11,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/features",
     deps = [
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/features:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/cloud-provider/features:go_default_library",

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -18,6 +18,7 @@ package features
 
 import (
 	apiextensionsfeatures "k8s.io/apiextensions-apiserver/pkg/features"
+	"k8s.io/apimachinery/pkg/util/runtime"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	cloudfeatures "k8s.io/cloud-provider/features"
@@ -436,7 +437,7 @@ const (
 )
 
 func init() {
-	utilfeature.DefaultMutableFeatureGate.Add(defaultKubernetesFeatureGates)
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultKubernetesFeatureGates))
 }
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -35,7 +35,9 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration) error 
 	// Make a local copy of the global feature gates and combine it with the gates set by this configuration.
 	// This allows us to validate the config against the set of gates it will actually run against.
 	localFeatureGate := utilfeature.DefaultFeatureGate.DeepCopy()
-	localFeatureGate.SetFromMap(kc.FeatureGates)
+	if err := localFeatureGate.SetFromMap(kc.FeatureGates); err != nil {
+		return err
+	}
 
 	if kc.NodeLeaseDurationSeconds <= 0 {
 		allErrors = append(allErrors, fmt.Errorf("invalid configuration: NodeLeaseDurationSeconds must be greater than 0"))

--- a/staging/src/k8s.io/apiserver/pkg/features/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/features/BUILD
@@ -10,7 +10,10 @@ go_library(
     srcs = ["kube_features.go"],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/features",
     importpath = "k8s.io/apiserver/pkg/features",
-    deps = ["//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+    ],
 )
 
 filegroup(

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -17,6 +17,8 @@ limitations under the License.
 package features
 
 import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
@@ -110,7 +112,7 @@ const (
 )
 
 func init() {
-	utilfeature.DefaultMutableFeatureGate.Add(defaultKubernetesFeatureGates)
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultKubernetesFeatureGates))
 }
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -108,7 +108,9 @@ func (e *E2EServices) startKubelet() (*server, error) {
 	klog.Info("Starting kubelet")
 
 	// set feature gates so we can check which features are enabled and pass the appropriate flags
-	utilfeature.DefaultMutableFeatureGate.SetFromMap(framework.TestContext.FeatureGates)
+	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(framework.TestContext.FeatureGates); err != nil {
+		return nil, err
+	}
 
 	// Build kubeconfig
 	kubeconfigPath, err := createKubeconfigCWD()

--- a/test/e2e_node/services/services.go
+++ b/test/e2e_node/services/services.go
@@ -109,7 +109,9 @@ func (e *E2EServices) Stop() {
 func RunE2EServices(t *testing.T) {
 	// Populate global DefaultFeatureGate with value from TestContext.FeatureGates.
 	// This way, statically-linked components see the same feature gate config as the test context.
-	utilfeature.DefaultMutableFeatureGate.SetFromMap(framework.TestContext.FeatureGates)
+	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(framework.TestContext.FeatureGates); err != nil {
+		t.Fatal(err)
+	}
 	e := newE2EServices()
 	if err := e.run(t); err != nil {
 		klog.Fatalf("Failed to run e2e services: %v", err)


### PR DESCRIPTION
Especially mismatch between apiserver and global gate default value went unnoticed and led to hard to debug test failures.