### PR TITLE
external-resizer in e2e tests should have access to leases

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/external-resizer/rbac.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-resizer/rbac.yaml
@@ -59,7 +59,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
-# Resizer must be able to work with end point in current namespace
+# Resizer must be able to work with leases in current namespace
 # if (and only if) leadership election is enabled
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -68,8 +68,8 @@ metadata:
   namespace: default
   name: external-resizer-cfg
 rules:
-- apiGroups: [""]
-  resources: ["endpoints"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
   verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In https://github.com/kubernetes-csi/external-resizer/pull/31 & https://github.com/kubernetes-csi/external-resizer/pull/32 we updated external-resizer to use leases based leader election which requires the e2e RBAC rules to be updated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
