### PR TITLE
Move DirectEncoder to runtime, rename, add .WithoutConversion() on CodecFactory

### DIFF
--- a/pkg/kubectl/cmd/set/BUILD
+++ b/pkg/kubectl/cmd/set/BUILD
@@ -76,7 +76,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/printers:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/resource:go_default_library",

--- a/pkg/kubectl/cmd/set/set_env_test.go
+++ b/pkg/kubectl/cmd/set/set_env_test.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	restclient "k8s.io/client-go/rest"
@@ -48,7 +47,7 @@ func TestSetEnvLocal(t *testing.T) {
 
 	tf.Client = &fake.RESTClient{
 		GroupVersion:         schema.GroupVersion{Version: ""},
-		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
 			return nil, nil
@@ -85,7 +84,7 @@ func TestSetMultiResourcesEnvLocal(t *testing.T) {
 
 	tf.Client = &fake.RESTClient{
 		GroupVersion:         schema.GroupVersion{Version: ""},
-		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
 			return nil, nil
@@ -448,7 +447,7 @@ func TestSetEnvRemote(t *testing.T) {
 
 			tf.Client = &fake.RESTClient{
 				GroupVersion:         input.groupVersion,
-				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
 					case p == input.path && m == http.MethodGet:
@@ -583,7 +582,7 @@ func TestSetEnvFromResource(t *testing.T) {
 			tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Version: ""}}}
 			tf.Client = &fake.RESTClient{
 				GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
-				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
 					case p == "/namespaces/test/configmaps/testconfigmap" && m == http.MethodGet:

--- a/pkg/kubectl/cmd/set/set_image_test.go
+++ b/pkg/kubectl/cmd/set/set_image_test.go
@@ -34,7 +34,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	restclient "k8s.io/client-go/rest"
@@ -49,7 +48,7 @@ func TestImageLocal(t *testing.T) {
 
 	tf.Client = &fake.RESTClient{
 		GroupVersion:         schema.GroupVersion{Version: ""},
-		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
 			return nil, nil
@@ -161,7 +160,7 @@ func TestSetMultiResourcesImageLocal(t *testing.T) {
 
 	tf.Client = &fake.RESTClient{
 		GroupVersion:         schema.GroupVersion{Version: ""},
-		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
 			return nil, nil
@@ -621,7 +620,7 @@ func TestSetImageRemote(t *testing.T) {
 
 			tf.Client = &fake.RESTClient{
 				GroupVersion:         input.groupVersion,
-				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
 					case p == input.path && m == http.MethodGet:
@@ -733,7 +732,7 @@ func TestSetImageRemoteWithSpecificContainers(t *testing.T) {
 
 			tf.Client = &fake.RESTClient{
 				GroupVersion:         input.groupVersion,
-				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
 					case p == input.path && m == http.MethodGet:

--- a/pkg/kubectl/cmd/set/set_resources_test.go
+++ b/pkg/kubectl/cmd/set/set_resources_test.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	restclient "k8s.io/client-go/rest"
@@ -48,7 +47,7 @@ func TestResourcesLocal(t *testing.T) {
 
 	tf.Client = &fake.RESTClient{
 		GroupVersion:         schema.GroupVersion{Version: ""},
-		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
 			return nil, nil
@@ -96,7 +95,7 @@ func TestSetMultiResourcesLimitsLocal(t *testing.T) {
 
 	tf.Client = &fake.RESTClient{
 		GroupVersion:         schema.GroupVersion{Version: ""},
-		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
 			return nil, nil
@@ -471,7 +470,7 @@ func TestSetResourcesRemote(t *testing.T) {
 
 			tf.Client = &fake.RESTClient{
 				GroupVersion:         input.groupVersion,
-				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
 					case p == input.path && m == http.MethodGet:

--- a/pkg/kubectl/cmd/set/set_serviceaccount_test.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount_test.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	restclient "k8s.io/client-go/rest"
@@ -104,7 +103,7 @@ func TestSetServiceAccountMultiLocal(t *testing.T) {
 
 	tf.Client = &fake.RESTClient{
 		GroupVersion:         schema.GroupVersion{Version: ""},
-		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
 			return nil, nil
@@ -322,7 +321,7 @@ func TestSetServiceAccountRemote(t *testing.T) {
 
 			tf.Client = &fake.RESTClient{
 				GroupVersion:         input.groupVersion,
-				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
 					case p == input.path && m == http.MethodGet:

--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -26,7 +26,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",

--- a/pkg/kubectl/cmd/util/kubectl_match_version.go
+++ b/pkg/kubectl/cmd/util/kubectl_match_version.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -124,7 +123,7 @@ func setKubernetesDefaults(config *rest.Config) error {
 		// This codec factory ensures the resources are not converted. Therefore, resources
 		// will not be round-tripped through internal versions. Defaulting does not happen
 		// on the client.
-		config.NegotiatedSerializer = &serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 	}
 	return rest.SetKubernetesDefaults(config)
 }

--- a/pkg/kubelet/certificate/bootstrap/BUILD
+++ b/pkg/kubelet/certificate/bootstrap/BUILD
@@ -27,7 +27,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubelet/certificate/bootstrap",
     deps = [
         "//staging/src/k8s.io/api/certificates/v1beta1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/pkg/kubelet/certificate/bootstrap/bootstrap.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/klog"
 
 	certificates "k8s.io/api/certificates/v1beta1"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -278,7 +277,7 @@ func verifyKeyData(data []byte) bool {
 }
 
 func waitForServer(cfg restclient.Config, deadline time.Duration) error {
-	cfg.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	cfg.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 	cfg.Timeout = 1 * time.Second
 	cli, err := restclient.UnversionedRESTClientFor(&cfg)
 	if err != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/scheme:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/cr_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/cr_client.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1"
 	"k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/scheme"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/table_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/table_test.go
@@ -154,7 +154,7 @@ func TestTableGet(t *testing.T) {
 		crConfig := *config
 		crConfig.GroupVersion = &gv
 		crConfig.APIPath = "/apis"
-		crConfig.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: codecs}
+		crConfig.NegotiatedSerializer = codecs.WithoutConversion()
 		crRestClient, err := rest.RESTClientFor(&crConfig)
 		if err != nil {
 			t.Fatal(err)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go
@@ -210,3 +210,50 @@ type defaultFramer struct{}
 
 func (defaultFramer) NewFrameReader(r io.ReadCloser) io.ReadCloser { return r }
 func (defaultFramer) NewFrameWriter(w io.Writer) io.Writer         { return w }
+
+// WithVersionEncoder serializes an object and ensures the GVK is set.
+type WithVersionEncoder struct {
+	Version GroupVersioner
+	Encoder
+	ObjectTyper
+}
+
+// Encode does not do conversion. It sets the gvk during serialization.
+func (e WithVersionEncoder) Encode(obj Object, stream io.Writer) error {
+	gvks, _, err := e.ObjectTyper.ObjectKinds(obj)
+	if err != nil {
+		if IsNotRegisteredError(err) {
+			return e.Encoder.Encode(obj, stream)
+		}
+		return err
+	}
+	kind := obj.GetObjectKind()
+	oldGVK := kind.GroupVersionKind()
+	gvk := gvks[0]
+	if e.Version != nil {
+		preferredGVK, ok := e.Version.KindForGroupVersionKinds(gvks)
+		if ok {
+			gvk = preferredGVK
+		}
+	}
+	kind.SetGroupVersionKind(gvk)
+	err = e.Encoder.Encode(obj, stream)
+	kind.SetGroupVersionKind(oldGVK)
+	return err
+}
+
+// WithoutVersionDecoder clears the group version kind of a deserialized object.
+type WithoutVersionDecoder struct {
+	Decoder
+}
+
+// Decode does not do conversion. It removes the gvk during deserialization.
+func (d WithoutVersionDecoder) Decode(data []byte, defaults *schema.GroupVersionKind, into Object) (Object, *schema.GroupVersionKind, error) {
+	obj, gvk, err := d.Decoder.Decode(data, defaults, into)
+	if obj != nil {
+		kind := obj.GetObjectKind()
+		// clearing the gvk is just a convention of a codec
+		kind.SetGroupVersionKind(schema.GroupVersionKind{})
+	}
+	return obj, gvk, err
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_test.go
@@ -32,7 +32,7 @@ import (
 	serializertesting "k8s.io/apimachinery/pkg/runtime/serializer/testing"
 	"k8s.io/apimachinery/pkg/util/diff"
 
-	"github.com/google/gofuzz"
+	fuzz "github.com/google/gofuzz"
 	flag "github.com/spf13/pflag"
 	"sigs.k8s.io/yaml"
 )
@@ -312,7 +312,7 @@ func TestDirectCodec(t *testing.T) {
 	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}))
 	info, _ := runtime.SerializerInfoForMediaType(cf.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	serializer := info.Serializer
-	df := DirectCodecFactory{cf}
+	df := cf.WithoutConversion()
 	ignoredGV, err := schema.ParseGroupVersion("ignored group/ignored version")
 	if err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
@@ -370,7 +370,7 @@ func TestDirectCodecEncode(t *testing.T) {
 		},
 	}
 
-	c := DirectEncoder{
+	c := runtime.WithVersionEncoder{
 		Version:     schema.GroupVersion{Group: "expected_group"},
 		Encoder:     &serializer,
 		ObjectTyper: &typer,

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization_test.go
@@ -169,7 +169,7 @@ func TestAuditAnnotation(t *testing.T) {
 	}
 
 	scheme := runtime.NewScheme()
-	negotiatedSerializer := serializer.DirectCodecFactory{CodecFactory: serializer.NewCodecFactory(scheme)}
+	negotiatedSerializer := serializer.NewCodecFactory(scheme).WithoutConversion()
 	for k, tc := range testcases {
 		audit := &auditinternal.Event{Level: auditinternal.LevelMetadata}
 		handler := WithAuthorization(&fakeHTTPHandler{}, tc.authorizer, negotiatedSerializer)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
@@ -76,7 +76,7 @@ func TestForbidden(t *testing.T) {
 	for _, test := range cases {
 		observer := httptest.NewRecorder()
 		scheme := runtime.NewScheme()
-		negotiatedSerializer := serializer.DirectCodecFactory{CodecFactory: serializer.NewCodecFactory(scheme)}
+		negotiatedSerializer := serializer.NewCodecFactory(scheme).WithoutConversion()
 		Forbidden(request.NewDefaultContext(), test.attributes, observer, &http.Request{}, test.reason, negotiatedSerializer)
 		result := string(observer.Body.Bytes())
 		if result != test.expected {

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/BUILD
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/BUILD
@@ -67,7 +67,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -284,7 +284,7 @@ func (b *Builder) WithScheme(scheme *runtime.Scheme, decodingVersions ...schema.
 	// if you specified versions, you're specifying a desire for external types, which you don't want to round-trip through
 	// internal types
 	if len(decodingVersions) > 0 {
-		negotiatedSerializer = &serializer.DirectCodecFactory{CodecFactory: codecFactory}
+		negotiatedSerializer = codecFactory.WithoutConversion()
 	}
 	b.negotiatedSerializer = negotiatedSerializer
 

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -39,7 +39,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/watch"
@@ -84,7 +83,7 @@ func fakeClientWith(testName string, t *testing.T, data map[string]string) FakeC
 	return func(version schema.GroupVersion) (RESTClient, error) {
 		return &fake.RESTClient{
 			GroupVersion:         corev1GV,
-			NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+			NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				p := req.URL.Path
 				q := req.URL.RawQuery

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/rest/fake"
 
 	// TODO we need to remove this linkage and create our own scheme
@@ -305,7 +304,7 @@ func TestHelperGet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client := &fake.RESTClient{
 				GroupVersion:         corev1GV,
-				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Resp:                 tt.Resp,
 				Err:                  tt.HttpErr,
 			}
@@ -386,7 +385,7 @@ func TestHelperList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client := &fake.RESTClient{
 				GroupVersion:         corev1GV,
-				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Resp:                 tt.Resp,
 				Err:                  tt.HttpErr,
 			}
@@ -597,7 +596,7 @@ func TestHelperReplace(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			client := &fake.RESTClient{
 				GroupVersion:         corev1GV,
-				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client:               tt.HTTPClient,
 				Resp:                 tt.Resp,
 				Err:                  tt.HttpErr,

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/BUILD
@@ -15,7 +15,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -76,7 +75,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/apps_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	v1 "k8s.io/api/apps/v1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -91,7 +90,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/BUILD
@@ -20,7 +20,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/apps/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/apps/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -81,7 +80,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/BUILD
@@ -22,7 +22,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/apps/v1beta2:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
@@ -20,7 +20,6 @@ package v1beta2
 
 import (
 	v1beta2 "k8s.io/api/apps/v1beta2"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -91,7 +90,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta2.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/auditregistration/v1alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/auditregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/auditregistration_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	v1alpha1 "k8s.io/api/auditregistration/v1alpha1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/BUILD
@@ -18,7 +18,6 @@ go_library(
     importpath = "k8s.io/client-go/kubernetes/typed/authentication/v1",
     deps = [
         "//staging/src/k8s.io/api/authentication/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/authentication_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	v1 "k8s.io/api/authentication/v1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/BUILD
@@ -18,7 +18,6 @@ go_library(
     importpath = "k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
     deps = [
         "//staging/src/k8s.io/api/authentication/v1beta1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/authentication/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/BUILD
@@ -24,7 +24,6 @@ go_library(
     importpath = "k8s.io/client-go/kubernetes/typed/authorization/v1",
     deps = [
         "//staging/src/k8s.io/api/authorization/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/authorization_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	v1 "k8s.io/api/authorization/v1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -86,7 +85,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/BUILD
@@ -24,7 +24,6 @@ go_library(
     importpath = "k8s.io/client-go/kubernetes/typed/authorization/v1beta1",
     deps = [
         "//staging/src/k8s.io/api/authorization/v1beta1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/authorization/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -86,7 +85,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/BUILD
@@ -18,7 +18,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	v1 "k8s.io/api/autoscaling/v1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/autoscaling/v2beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
@@ -20,7 +20,6 @@ package v2beta1
 
 import (
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v2beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/autoscaling/v2beta2:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
@@ -20,7 +20,6 @@ package v2beta2
 
 import (
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v2beta2.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/BUILD
@@ -18,7 +18,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/batch_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	v1 "k8s.io/api/batch/v1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/BUILD
@@ -18,7 +18,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/batch/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/batch/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/BUILD
@@ -18,7 +18,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/batch/v2alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/batch_client.go
@@ -20,7 +20,6 @@ package v2alpha1
 
 import (
 	v2alpha1 "k8s.io/api/batch/v2alpha1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v2alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/BUILD
@@ -19,7 +19,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/certificates/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/certificates/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/coordination/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/coordination_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	v1 "k8s.io/api/coordination/v1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/coordination/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/coordination/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/BUILD
@@ -44,7 +44,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/core_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/core_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	v1 "k8s.io/api/core/v1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -146,7 +145,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/api"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/events/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/events_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/events_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/events/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/BUILD
@@ -24,7 +24,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -96,7 +95,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/BUILD
@@ -18,7 +18,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/networking/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networking_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	v1 "k8s.io/api/networking/v1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/networking/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/networking/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/node/v1alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/node_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	v1alpha1 "k8s.io/api/node/v1alpha1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/node/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/node_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/node/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/BUILD
@@ -21,7 +21,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/policy/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -81,7 +80,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/BUILD
@@ -21,7 +21,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rbac_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	v1 "k8s.io/api/rbac/v1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -86,7 +85,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/BUILD
@@ -21,7 +21,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/rbac/v1alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -86,7 +85,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/BUILD
@@ -21,7 +21,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/rbac/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/rbac/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -86,7 +85,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/scheduling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	v1 "k8s.io/api/scheduling/v1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/BUILD
@@ -18,7 +18,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/scheduling/v1alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	v1alpha1 "k8s.io/api/scheduling/v1alpha1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/scheduling/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/scheduling/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/BUILD
@@ -18,7 +18,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/settings/v1alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/settings_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/settings_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	v1alpha1 "k8s.io/api/settings/v1alpha1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/BUILD
@@ -19,7 +19,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/storage/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	v1 "k8s.io/api/storage/v1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -76,7 +75,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/storage/v1alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	v1alpha1 "k8s.io/api/storage/v1alpha1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/BUILD
@@ -21,7 +21,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/storage/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/storage/v1beta1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -86,7 +85,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/rest/BUILD
+++ b/staging/src/k8s.io/client-go/rest/BUILD
@@ -25,7 +25,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",

--- a/staging/src/k8s.io/client-go/rest/client_test.go
+++ b/staging/src/k8s.io/client-go/rest/client_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -55,7 +54,7 @@ func TestSerializer(t *testing.T) {
 	contentConfig := ContentConfig{
 		ContentType:          "application/json",
 		GroupVersion:         &gv,
-		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 	}
 
 	serializer, err := createSerializers(contentConfig)
@@ -334,7 +333,7 @@ func restClient(testServer *httptest.Server) (*RESTClient, error) {
 		Host: testServer.URL,
 		ContentConfig: ContentConfig{
 			GroupVersion:         &v1.SchemeGroupVersion,
-			NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+			NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 		},
 		Username: "user",
 		Password: "pass",

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -43,7 +43,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -283,7 +282,7 @@ func defaultContentConfig() ContentConfig {
 	return ContentConfig{
 		ContentType:          "application/json",
 		GroupVersion:         &gvCopy,
-		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 	}
 }
 

--- a/staging/src/k8s.io/client-go/rest/watch/BUILD
+++ b/staging/src/k8s.io/client-go/rest/watch/BUILD
@@ -34,7 +34,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -26,7 +26,6 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	runtimejson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -38,7 +37,7 @@ import (
 // getDecoder mimics how k8s.io/client-go/rest.createSerializers creates a decoder
 func getDecoder() runtime.Decoder {
 	jsonSerializer := runtimejson.NewSerializer(runtimejson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, false)
-	directCodecFactory := serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	directCodecFactory := scheme.Codecs.WithoutConversion()
 	return directCodecFactory.DecoderToVersion(jsonSerializer, v1.SchemeGroupVersion)
 }
 

--- a/staging/src/k8s.io/client-go/rest/watch/encoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/encoder_test.go
@@ -25,7 +25,6 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	runtimejson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/watch"
@@ -36,7 +35,7 @@ import (
 // getEncoder mimics how k8s.io/client-go/rest.createSerializers creates a encoder
 func getEncoder() runtime.Encoder {
 	jsonSerializer := runtimejson.NewSerializer(runtimejson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, false)
-	directCodecFactory := serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	directCodecFactory := scheme.Codecs.WithoutConversion()
 	return directCodecFactory.EncoderForVersion(jsonSerializer, v1.SchemeGroupVersion)
 }
 

--- a/staging/src/k8s.io/client-go/scale/BUILD
+++ b/staging/src/k8s.io/client-go/scale/BUILD
@@ -48,7 +48,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/client-go/discovery/fake:go_default_library",
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",

--- a/staging/src/k8s.io/client-go/scale/client.go
+++ b/staging/src/k8s.io/client-go/scale/client.go
@@ -54,9 +54,7 @@ func NewForConfig(cfg *restclient.Config, mapper PreferredResourceMapper, resolv
 	// so that the RESTClientFor doesn't complain
 	cfg.GroupVersion = &schema.GroupVersion{}
 
-	cfg.NegotiatedSerializer = serializer.DirectCodecFactory{
-		CodecFactory: codecs,
-	}
+	cfg.NegotiatedSerializer = codecs.WithoutConversion()
 	if len(cfg.UserAgent) == 0 {
 		cfg.UserAgent = restclient.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/scale/client_test.go
+++ b/staging/src/k8s.io/client-go/scale/client_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	fakedisco "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/dynamic"
 	fakerest "k8s.io/client-go/rest/fake"
@@ -204,12 +203,10 @@ func fakeScaleClient(t *testing.T) (ScalesGetter, []schema.GroupResource) {
 	}
 
 	fakeClient := &fakerest.RESTClient{
-		Client: fakerest.CreateHTTPClient(fakeReqHandler),
-		NegotiatedSerializer: serializer.DirectCodecFactory{
-			CodecFactory: codecs,
-		},
-		GroupVersion:     schema.GroupVersion{},
-		VersionedAPIPath: "/not/a/real/path",
+		Client:               fakerest.CreateHTTPClient(fakeReqHandler),
+		NegotiatedSerializer: codecs.WithoutConversion(),
+		GroupVersion:         schema.GroupVersion{},
+		VersionedAPIPath:     "/not/a/real/path",
 	}
 
 	resolver := NewDiscoveryScaleKindResolver(fakeDiscoveryClient)

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/example_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/_examples/MixedCase/apis/example/v1"
 	"k8s.io/code-generator/_examples/MixedCase/clientset/versioned/scheme"
@@ -76,7 +75,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/example_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/_examples/apiserver/apis/example/v1"
 	"k8s.io/code-generator/_examples/apiserver/clientset/versioned/scheme"
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/example2_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/example2_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/_examples/apiserver/apis/example2/v1"
 	"k8s.io/code-generator/_examples/apiserver/clientset/versioned/scheme"
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/example_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/_examples/crd/apis/example/v1"
 	"k8s.io/code-generator/_examples/crd/clientset/versioned/scheme"
@@ -76,7 +75,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/example2_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/example2_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/_examples/crd/apis/example2/v1"
 	"k8s.io/code-generator/_examples/crd/clientset/versioned/scheme"
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
@@ -98,7 +98,6 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 		"apiPath":                        apiPath(g.group),
 		"schemaGroupVersion":             c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/runtime/schema", Name: "GroupVersion"}),
 		"runtimeAPIVersionInternal":      c.Universe.Variable(types.Name{Package: "k8s.io/apimachinery/pkg/runtime", Name: "APIVersionInternal"}),
-		"serializerDirectCodecFactory":   c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/runtime/serializer", Name: "DirectCodecFactory"}),
 		"restConfig":                     c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "Config"}),
 		"restDefaultKubernetesUserAgent": c.Universe.Function(types.Name{Package: "k8s.io/client-go/rest", Name: "DefaultKubernetesUserAgent"}),
 		"restRESTClientInterface":        c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "Interface"}),
@@ -236,7 +235,7 @@ func setConfigDefaults(config *$.restConfig|raw$) error {
 	gv := $.SchemeGroupVersion|raw$
 	config.GroupVersion =  &gv
 	config.APIPath = $.apiPath$
-	config.NegotiatedSerializer = $.serializerDirectCodecFactory|raw${CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = $.restDefaultKubernetesUserAgent|raw$()

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/BUILD
@@ -13,7 +13,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiregistration_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/BUILD
@@ -17,7 +17,6 @@ go_library(
     importpath = "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1",
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiregistration_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/BUILD
@@ -14,7 +14,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1:go_default_library",

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1alpha1 "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 	"k8s.io/metrics/pkg/client/clientset/versioned/scheme"
@@ -76,7 +75,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1:go_default_library",

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/clientset/versioned/scheme"
@@ -76,7 +75,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/versioned_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/versioned_client.go
@@ -63,7 +63,7 @@ func NewForVersionForConfig(c *rest.Config, mapper meta.RESTMapper, version sche
 		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
 	configShallowCopy.GroupVersion = &version
-	configShallowCopy.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	configShallowCopy.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	client, err := rest.RESTClientFor(&configShallowCopy)
 	if err != nil {

--- a/staging/src/k8s.io/metrics/pkg/client/external_metrics/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/external_metrics/BUILD
@@ -16,7 +16,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",

--- a/staging/src/k8s.io/metrics/pkg/client/external_metrics/client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/external_metrics/client.go
@@ -19,7 +19,6 @@ package external_metrics
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
@@ -46,7 +45,7 @@ func NewForConfig(c *rest.Config) (ExternalMetricsClient, error) {
 		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
 	configShallowCopy.GroupVersion = &v1beta1.SchemeGroupVersion
-	configShallowCopy.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	configShallowCopy.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	client, err := rest.RESTClientFor(&configShallowCopy)
 	if err != nil {

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/BUILD
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/BUILD
@@ -13,7 +13,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/node_client.go
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/node_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1alpha1 "k8s.io/node-api/pkg/apis/node/v1alpha1"
 	"k8s.io/node-api/pkg/client/clientset/versioned/scheme"
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/BUILD
@@ -14,7 +14,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
 	"k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
@@ -76,7 +75,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/BUILD
@@ -13,7 +13,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1beta1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1"
 	"k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/BUILD
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/BUILD
@@ -13,7 +13,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/samplecontroller_client.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/samplecontroller_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 	v1alpha1 "k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1"
 	"k8s.io/sample-controller/pkg/generated/clientset/versioned/scheme"
@@ -71,7 +70,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()


### PR DESCRIPTION
This refactor makes it easier for clients to move to a "no conversion" 
model.

/kind cleanup

In preparation for removing conversion from clients, we need to get
DirectEncoder to be more of an upfront decision in clients. Subsequent
PRs will remove conversion from client-go in the normal path.

```release-note
NONE
```