### PR TITLE
Automated cherry pick of #76099: GCE/Windows: disable stackdriver logging agent

### DIFF
--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -112,7 +112,8 @@ try {
   Set-EnvironmentVars
   Create-Directories
   Download-HelperScripts
-  InstallAndStart-LoggingAgent
+  # Disable Stackdrver logging until issue is fixed.
+  # InstallAndStart-LoggingAgent
 
   Create-DockerRegistryKey
   DownloadAndInstall-KubernetesBinaries


### PR DESCRIPTION
Cherry pick of #76099 on release-1.14.

#76099: GCE/Windows: disable stackdriver logging agent