### PR TITLE
Automated cherry pick of #76039: Finish saving test results on failure

### DIFF
--- a/cluster/images/conformance/run_e2e.sh
+++ b/cluster/images/conformance/run_e2e.sh
@@ -62,5 +62,6 @@ set -x
 /usr/local/bin/ginkgo "${ginkgo_args[@]}" /usr/local/bin/e2e.test -- --disable-log-dump --repo-root=/kubernetes --provider="${E2E_PROVIDER}" --report-dir="${RESULTS_DIR}" --kubeconfig="${KUBECONFIG}" | tee "${RESULTS_DIR}"/e2e.log &
 set +x
 # $! is the pid of tee, not ginkgo
-wait "$(pgrep ginkgo)"
+wait "$(pgrep ginkgo)" && ret=0 || ret=$?
 saveResults
+exit ${ret}


### PR DESCRIPTION
Cherry pick of #76039 on release-1.14.

#76039: Finish saving test results on failure

```release-note
Ensures the conformance test image saves results before exiting when ginkgo returns non-zero value.
```