### PR TITLE
Rename createLoadBalancerIfNeeded() to syncLoadBalancerIfNeeded()

### DIFF
--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -248,7 +248,7 @@ func (s *ServiceController) processServiceUpdate(cachedService *cachedService, s
 	}
 	// cache the service, we need the info for service deletion
 	cachedService.state = service
-	err := s.createLoadBalancerIfNeeded(key, service)
+	err := s.syncLoadBalancerIfNeeded(key, service)
 	if err != nil {
 		eventType := "CreatingLoadBalancerFailed"
 		message := "Error creating load balancer (will retry): "
@@ -269,10 +269,10 @@ func (s *ServiceController) processServiceUpdate(cachedService *cachedService, s
 	return nil
 }
 
-// createLoadBalancerIfNeeded ensures that service's status is synced up with loadbalancer
+// syncLoadBalancerIfNeeded ensures that service's status is synced up with loadbalancer
 // i.e. creates loadbalancer for service if requested and deletes loadbalancer if the service
 // doesn't want a loadbalancer no more. Returns whatever error occurred.
-func (s *ServiceController) createLoadBalancerIfNeeded(key string, service *v1.Service) error {
+func (s *ServiceController) syncLoadBalancerIfNeeded(key string, service *v1.Service) error {
 	// Note: It is safe to just call EnsureLoadBalancer.  But, on some clouds that requires a delete & create,
 	// which may involve service interruption.  Also, we would like user-friendly events.
 

--- a/pkg/controller/service/service_controller_test.go
+++ b/pkg/controller/service/service_controller_test.go
@@ -151,7 +151,7 @@ func TestCreateExternalLoadBalancer(t *testing.T) {
 
 	for _, item := range table {
 		controller, cloud, client := newController()
-		err := controller.createLoadBalancerIfNeeded("foo/bar", item.service)
+		err := controller.syncLoadBalancerIfNeeded("foo/bar", item.service)
 		if !item.expectErr && err != nil {
 			t.Errorf("unexpected error: %v", err)
 		} else if item.expectErr && err == nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Renaming this function to reduce confusion from the codes. Ref https://github.com/kubernetes/kubernetes/pull/54569/files/7783a1acb846fc184758d6271f3cf6e633daf773#r253165530.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE 

**Special notes for your reviewer**:
/assign @andrewsykim 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
