### PR TITLE
Prune directxman12 from metrics/autoscaling OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -240,7 +240,6 @@ aliases:
   sig-autoscaling-maintainers:
     - aleksandra-malinowska
     - bskiba
-    - DirectXMan12
     - MaciekPytel
     - mwielgus
   api-approvers:
@@ -309,7 +308,6 @@ aliases:
     - deads2k         # API Machinery
     - derekwaynecarr  # Node
     - dghubble        # On Premise
-    - directxman12    # Autoscaling
     - jdumars         # Architecture, Cluster Ops, Release
     - kow3ns          # Apps
     - lavalamp        # API Machinery

--- a/cluster/addons/cluster-monitoring/OWNERS
+++ b/cluster/addons/cluster-monitoring/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- DirectXMan12
 - kawych
 - piosz
 reviewers:
-- DirectXMan12
 - kawych
 - piosz

--- a/cluster/addons/metrics-server/OWNERS
+++ b/cluster/addons/metrics-server/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- DirectXMan12
 - kawych
 - piosz
 reviewers:
-- DirectXMan12
 - kawych
 - piosz

--- a/pkg/apis/autoscaling/OWNERS
+++ b/pkg/apis/autoscaling/OWNERS
@@ -18,4 +18,3 @@ reviewers:
 - mbohlool
 - david-mcmahon
 - jianhuiz
-- directxman12

--- a/pkg/controller/podautoscaler/OWNERS
+++ b/pkg/controller/podautoscaler/OWNERS
@@ -1,14 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- DirectXMan12
 - mwielgus
 - piosz
 - jszczepkowski
 - fgrzadkowski
 - MaciekPytel
 approvers:
-- DirectXMan12
 - mwielgus
 - piosz
 - jszczepkowski

--- a/staging/src/k8s.io/api/autoscaling/OWNERS
+++ b/staging/src/k8s.io/api/autoscaling/OWNERS
@@ -18,4 +18,3 @@ reviewers:
 - mbohlool
 - david-mcmahon
 - jianhuiz
-- directxman12

--- a/staging/src/k8s.io/metrics/OWNERS
+++ b/staging/src/k8s.io/metrics/OWNERS
@@ -1,5 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- DirectXMan12
 - piosz

--- a/test/e2e/instrumentation/OWNERS
+++ b/test/e2e/instrumentation/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- DirectXMan12
 - fabxc
 - fgrzadkowski
 - piosz


### PR DESCRIPTION
Since I'm not really working on metrics or autoscaling stuff any more, I
figured it was time to remove myself from the approvers list.

/kind cleanup

```release-note
NONE
```
