### PR TITLE
Fix shellcheck failures of zookeeper-installer/install.sh, etc

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -85,8 +85,6 @@
 ./test/e2e_node/environment/setup_host.sh
 ./test/e2e_node/gubernator.sh
 ./test/images/image-util.sh
-./test/images/pets/zookeeper-installer/install.sh
-./test/images/pets/zookeeper-installer/on-start.sh
 ./test/images/volume/gluster/run_gluster.sh
 ./test/images/volume/iscsi/create_block.sh
 ./test/images/volume/nfs/run_nfs.sh

--- a/test/images/pets/zookeeper-installer/install.sh
+++ b/test/images/pets/zookeeper-installer/install.sh
@@ -55,10 +55,10 @@ cp "${INSTALL_VOLUME}"/zookeeper/conf/zoo_sample.cfg "${INSTALL_VOLUME}"/zookeep
 
 # TODO: Should dynamic config be tied to the version?
 IFS="." read -ra RELEASE <<< "${VERSION}"
-if [ $(expr "${RELEASE[1]}") -gt 4 ]; then
+if [ "$(("${RELEASE[1]}"))" -gt 4 ]; then
     echo zookeeper-"${VERSION}" supports dynamic reconfiguration, enabling it
     echo "standaloneEnabled=false" >> "${INSTALL_VOLUME}"/zookeeper/conf/zoo.cfg
-    echo "dynamicConfigFile="${INSTALL_VOLUME}"/zookeeper/conf/zoo.cfg.dynamic" >> "${INSTALL_VOLUME}"/zookeeper/conf/zoo.cfg
+    echo "dynamicConfigFile=${INSTALL_VOLUME}/zookeeper/conf/zoo.cfg.dynamic" >> "${INSTALL_VOLUME}"/zookeeper/conf/zoo.cfg
 fi
 
 # TODO: This is a hack, netcat is convenient to have in the zookeeper container

--- a/test/images/pets/zookeeper-installer/on-start.sh
+++ b/test/images/pets/zookeeper-installer/on-start.sh
@@ -36,7 +36,7 @@ MY_ID_FILE=/tmp/zookeeper/myid
 HOSTNAME=$(hostname)
 
 while read -ra LINE; do
-    PEERS=("${PEERS[@]}" $LINE)
+    PEERS=("${PEERS[@]}" "$LINE")
 done
 
 # Don't add the first member as an observer
@@ -56,7 +56,7 @@ echo "" > "${CFG_BAK}"
 i=0
 LEADER=$HOSTNAME
 for peer in "${PEERS[@]}"; do
-    let i=i+1
+    (( i=i+1 ))
     if [[ "${peer}" == *"${HOSTNAME}"* ]]; then
       MY_ID=$i
       MY_NAME=${peer}
@@ -94,10 +94,10 @@ ADD_SERVER="server.$MY_ID=$MY_NAME:2888:3888:participant;0.0.0.0:2181"
 
 # Prove that we've actually joined the running cluster
 ITERATION=0
-until $(echo config | /opt/nc localhost 2181 | grep "${ADD_SERVER}" > /dev/null); do
+until echo config | /opt/nc localhost 2181 | grep "${ADD_SERVER}" > /dev/null; do
   echo $ITERATION] waiting for updated config to sync back to localhost
   sleep 1
-  let ITERATION=ITERATION+1
+  (( ITERATION=ITERATION+1 ))
   if [ $ITERATION -eq 20 ]; then
     exit 1
   fi


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Fix shellcheck failures of zookeeper-installer/install.sh, etc

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #72956

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
