### PR TITLE
test coverage for pod QOS

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -185,32 +185,17 @@ var _ = SIGDescribe("Pods Extended", func() {
 		framework.ConformanceIt("should be submitted and removed ", func() {
 			By("creating the pod")
 			name := "pod-qos-class-" + string(uuid.NewUUID())
-			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-					Labels: map[string]string{
-						"name": name,
-					},
+			resorces := v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name:  "nginx",
-							Image: imageutils.GetE2EImage(imageutils.Nginx),
-							Resources: v1.ResourceRequirements{
-								Limits: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse("100m"),
-									v1.ResourceMemory: resource.MustParse("100Mi"),
-								},
-								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse("100m"),
-									v1.ResourceMemory: resource.MustParse("100Mi"),
-								},
-							},
-						},
-					},
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
 				},
 			}
+			pod := getResourcePod(name, resorces)
 
 			By("submitting the pod to kubernetes")
 			podClient.Create(pod)
@@ -220,5 +205,60 @@ var _ = SIGDescribe("Pods Extended", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to query for pod")
 			Expect(pod.Status.QOSClass == v1.PodQOSGuaranteed)
 		})
+
+		It("should be set on Pods with matching resource requests and limits for memory", func() {
+			By("creating the pod")
+			name := "pod-qos-burstable-" + string(uuid.NewUUID())
+			resorces := v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			}
+			pod := getResourcePod(name, resorces)
+
+			By("submitting the pod to kubernetes")
+			podClient.Create(pod)
+
+			By("verifying QOS class is set on the pod")
+			pod, err := podClient.Get(name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to query for pod")
+			Expect(pod.Status.QOSClass == v1.PodQOSBurstable)
+
+			By("creating the pod")
+			name = "pod-qos-besteffort-" + string(uuid.NewUUID())
+			resorces = v1.ResourceRequirements{}
+			pod = getResourcePod(name, resorces)
+
+			By("submitting the pod to kubernetes")
+			podClient.Create(pod)
+
+			By("verifying QOS class is set on the pod")
+			pod, err = podClient.Get(name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to query for pod")
+			Expect(pod.Status.QOSClass == v1.PodQOSBestEffort)
+		})
 	})
 })
+
+func getResourcePod(name string, resorces v1.ResourceRequirements) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"name": name,
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:      "nginx",
+					Image:     imageutils.GetE2EImage(imageutils.Nginx),
+					Resources: resorces,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> 
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:This PR to cover test case for pod QOS Burstable scenario.

**Which issue(s) this PR fixes**: It a part of an umbrella issue #75935 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # a part of #75935 

**Special notes for your reviewer**: 
If requests or optionally limits are set (not equal to 0) for one or more resources across one or more containers, and they are not equal, then the pod is classified as Burstable. The pods QOSClass set to Burstable.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/area testing
/area node
/area conformance
@kubernetes/sig-node-pr-reviews 