### PR TITLE
Make pin-dependency.sh work with things other than docker

### DIFF
--- a/hack/pin-dependency.sh
+++ b/hack/pin-dependency.sh
@@ -56,10 +56,10 @@ fi
 
 # Add the require directive
 echo "Running: go get ${dep}@${sha}"
-go get "${dep}@${sha}"
+go get -d "${dep}@${sha}"
 
 # Find the resolved version
-rev=$(go mod edit -json | jq -r '.Require[] | select(.Path == "github.com/docker/docker") | .Version')
+rev=$(go mod edit -json | jq -r ".Require[] | select(.Path == \"${dep}\") | .Version")
 echo "Resolved to ${dep}@${rev}"
 
 # Add the replace directive


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Removes hard-coded check in pin-dependency.sh, fixes it to work with modules that don't have go files in their root

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @sttts 
