### PR TITLE
Ability for volume AttachablePlugin.CanAttach() to return both bool and error

### DIFF
--- a/pkg/controller/volume/attachdetach/testing/testvolumespec.go
+++ b/pkg/controller/volume/attachdetach/testing/testvolumespec.go
@@ -308,8 +308,8 @@ func (plugin *TestPlugin) NewDetacher() (volume.Detacher, error) {
 	return &detacher, nil
 }
 
-func (plugin *TestPlugin) CanAttach(spec *volume.Spec) bool {
-	return true
+func (plugin *TestPlugin) CanAttach(spec *volume.Spec) (bool, error) {
+	return true, nil
 }
 
 func (plugin *TestPlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {

--- a/pkg/volume/awsebs/attacher.go
+++ b/pkg/volume/awsebs/attacher.go
@@ -277,8 +277,8 @@ func (detacher *awsElasticBlockStoreDetacher) UnmountDevice(deviceMountPath stri
 	return mount.CleanupMountPoint(deviceMountPath, detacher.mounter, false)
 }
 
-func (plugin *awsElasticBlockStorePlugin) CanAttach(spec *volume.Spec) bool {
-	return true
+func (plugin *awsElasticBlockStorePlugin) CanAttach(spec *volume.Spec) (bool, error) {
+	return true, nil
 }
 
 func (plugin *awsElasticBlockStorePlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {

--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -238,8 +238,8 @@ func (plugin *azureDataDiskPlugin) NewDetacher() (volume.Detacher, error) {
 	}, nil
 }
 
-func (plugin *azureDataDiskPlugin) CanAttach(spec *volume.Spec) bool {
-	return true
+func (plugin *azureDataDiskPlugin) CanAttach(spec *volume.Spec) (bool, error) {
+	return true, nil
 }
 
 func (plugin *azureDataDiskPlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {

--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -406,8 +406,8 @@ func (detacher *cinderDiskDetacher) UnmountDevice(deviceMountPath string) error 
 	return mount.CleanupMountPoint(deviceMountPath, detacher.mounter, false)
 }
 
-func (plugin *cinderPlugin) CanAttach(spec *volume.Spec) bool {
-	return true
+func (plugin *cinderPlugin) CanAttach(spec *volume.Spec) (bool, error) {
+	return true, nil
 }
 
 func (plugin *cinderPlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -348,7 +348,10 @@ func TestAttacherWithCSIDriver(t *testing.T) {
 			csiAttacher := attacher.(*csiAttacher)
 			spec := volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, test.driver, "test-vol"), false)
 
-			pluginCanAttach := plug.CanAttach(spec)
+			pluginCanAttach, err := plug.CanAttach(spec)
+			if err != nil {
+				t.Fatalf("attacher.CanAttach failed: %s", err)
+			}
 			if pluginCanAttach != test.expectVolumeAttachment {
 				t.Errorf("attacher.CanAttach does not match expected attachment status %t", test.expectVolumeAttachment)
 			}
@@ -429,7 +432,10 @@ func TestAttacherWaitForVolumeAttachmentWithCSIDriver(t *testing.T) {
 			csiAttacher := attacher.(*csiAttacher)
 			spec := volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, test.driver, "test-vol"), false)
 
-			pluginCanAttach := plug.CanAttach(spec)
+			pluginCanAttach, err := plug.CanAttach(spec)
+			if err != nil {
+				t.Fatalf("plugin.CanAttach test failed: %s", err)
+			}
 			if !pluginCanAttach {
 				t.Log("plugin is not attachable")
 				return

--- a/pkg/volume/fc/attacher.go
+++ b/pkg/volume/fc/attacher.go
@@ -175,8 +175,8 @@ func (detacher *fcDetacher) UnmountDevice(deviceMountPath string) error {
 	return nil
 }
 
-func (plugin *fcPlugin) CanAttach(spec *volume.Spec) bool {
-	return true
+func (plugin *fcPlugin) CanAttach(spec *volume.Spec) (bool, error) {
+	return true, nil
 }
 
 func (plugin *fcPlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -256,8 +256,8 @@ func (plugin *flexVolumeAttachablePlugin) NewDeviceUnmounter() (volume.DeviceUnm
 	return plugin.NewDetacher()
 }
 
-func (plugin *flexVolumeAttachablePlugin) CanAttach(spec *volume.Spec) bool {
-	return true
+func (plugin *flexVolumeAttachablePlugin) CanAttach(spec *volume.Spec) (bool, error) {
+	return true, nil
 }
 
 func (plugin *flexVolumeAttachablePlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {

--- a/pkg/volume/gcepd/attacher.go
+++ b/pkg/volume/gcepd/attacher.go
@@ -350,8 +350,8 @@ func (detacher *gcePersistentDiskDetacher) UnmountDevice(deviceMountPath string)
 	return mount.CleanupMountPoint(deviceMountPath, detacher.host.GetMounter(gcePersistentDiskPluginName), false)
 }
 
-func (plugin *gcePersistentDiskPlugin) CanAttach(spec *volume.Spec) bool {
-	return true
+func (plugin *gcePersistentDiskPlugin) CanAttach(spec *volume.Spec) (bool, error) {
+	return true, nil
 }
 
 func (plugin *gcePersistentDiskPlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {

--- a/pkg/volume/iscsi/attacher.go
+++ b/pkg/volume/iscsi/attacher.go
@@ -176,8 +176,8 @@ func (detacher *iscsiDetacher) UnmountDevice(deviceMountPath string) error {
 	return nil
 }
 
-func (plugin *iscsiPlugin) CanAttach(spec *volume.Spec) bool {
-	return true
+func (plugin *iscsiPlugin) CanAttach(spec *volume.Spec) (bool, error) {
+	return true, nil
 }
 
 func (plugin *iscsiPlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {

--- a/pkg/volume/photon_pd/attacher.go
+++ b/pkg/volume/photon_pd/attacher.go
@@ -308,8 +308,8 @@ func (detacher *photonPersistentDiskDetacher) UnmountDevice(deviceMountPath stri
 	return mount.CleanupMountPoint(deviceMountPath, detacher.mounter, false)
 }
 
-func (plugin *photonPersistentDiskPlugin) CanAttach(spec *volume.Spec) bool {
-	return true
+func (plugin *photonPersistentDiskPlugin) CanAttach(spec *volume.Spec) (bool, error) {
+	return true, nil
 }
 
 func (plugin *photonPersistentDiskPlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -235,7 +235,7 @@ type AttachableVolumePlugin interface {
 	NewAttacher() (Attacher, error)
 	NewDetacher() (Detacher, error)
 	// CanAttach tests if provided volume spec is attachable
-	CanAttach(spec *Spec) bool
+	CanAttach(spec *Spec) (bool, error)
 }
 
 // DeviceMountableVolumePlugin is an extended interface of VolumePlugin and is used
@@ -891,7 +891,9 @@ func (pm *VolumePluginMgr) FindAttachablePluginBySpec(spec *Spec) (AttachableVol
 		return nil, err
 	}
 	if attachableVolumePlugin, ok := volumePlugin.(AttachableVolumePlugin); ok {
-		if attachableVolumePlugin.CanAttach(spec) {
+		if canAttach, err := attachableVolumePlugin.CanAttach(spec); err != nil {
+			return nil, err
+		} else if canAttach {
 			return attachableVolumePlugin, nil
 		}
 	}

--- a/pkg/volume/rbd/attacher.go
+++ b/pkg/volume/rbd/attacher.go
@@ -71,8 +71,8 @@ func (plugin *rbdPlugin) GetDeviceMountRefs(deviceMountPath string) ([]string, e
 	return mounter.GetMountRefs(deviceMountPath)
 }
 
-func (plugin *rbdPlugin) CanAttach(spec *volume.Spec) bool {
-	return true
+func (plugin *rbdPlugin) CanAttach(spec *volume.Spec) (bool, error) {
+	return true, nil
 }
 
 func (plugin *rbdPlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -492,8 +492,8 @@ func (plugin *FakeVolumePlugin) GetNewDetacherCallCount() int {
 	return plugin.NewDetacherCallCount
 }
 
-func (plugin *FakeVolumePlugin) CanAttach(spec *Spec) bool {
-	return true
+func (plugin *FakeVolumePlugin) CanAttach(spec *Spec) (bool, error) {
+	return true, nil
 }
 
 func (plugin *FakeVolumePlugin) CanDeviceMount(spec *Spec) (bool, error) {
@@ -654,8 +654,8 @@ func (f *FakeAttachableVolumePlugin) NewDetacher() (Detacher, error) {
 	return f.Plugin.NewDetacher()
 }
 
-func (f *FakeAttachableVolumePlugin) CanAttach(spec *Spec) bool {
-	return true
+func (f *FakeAttachableVolumePlugin) CanAttach(spec *Spec) (bool, error) {
+	return true, nil
 }
 
 var _ VolumePlugin = &FakeAttachableVolumePlugin{}

--- a/pkg/volume/vsphere_volume/attacher.go
+++ b/pkg/volume/vsphere_volume/attacher.go
@@ -295,8 +295,8 @@ func (detacher *vsphereVMDKDetacher) UnmountDevice(deviceMountPath string) error
 	return mount.CleanupMountPoint(deviceMountPath, detacher.mounter, false)
 }
 
-func (plugin *vsphereVolumePlugin) CanAttach(spec *volume.Spec) bool {
-	return true
+func (plugin *vsphereVolumePlugin) CanAttach(spec *volume.Spec) (bool, error) {
+	return true, nil
 }
 
 func (plugin *vsphereVolumePlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Ability to determine if a driver supports volume attach operation is important to CSI. This PR ensures that the determination of attachment capability fails is properly signaled to the volume API by returning an error.

**Which issue(s) this PR fixes**:
Fixes #75473

```release-note
NONE
```
