### PR TITLE
Update vendor cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-// This is a generated file.
+// This is a generated file. Do not edit directly.
 // Run hack/pin-dependency.sh to change pinned dependency versions.
 // Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 

--- a/staging/src/k8s.io/api/go.mod
+++ b/staging/src/k8s.io/api/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/api
 

--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/apiextensions-apiserver
 

--- a/staging/src/k8s.io/apimachinery/go.mod
+++ b/staging/src/k8s.io/apimachinery/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/apimachinery
 

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/apiserver
 

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/cli-runtime
 

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/client-go
 

--- a/staging/src/k8s.io/cloud-provider/go.mod
+++ b/staging/src/k8s.io/cloud-provider/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/cloud-provider
 

--- a/staging/src/k8s.io/cluster-bootstrap/go.mod
+++ b/staging/src/k8s.io/cluster-bootstrap/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/cluster-bootstrap
 

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/code-generator
 

--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/component-base
 

--- a/staging/src/k8s.io/cri-api/go.mod
+++ b/staging/src/k8s.io/cri-api/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/cri-api
 

--- a/staging/src/k8s.io/csi-translation-lib/go.mod
+++ b/staging/src/k8s.io/csi-translation-lib/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/csi-translation-lib
 

--- a/staging/src/k8s.io/kube-aggregator/go.mod
+++ b/staging/src/k8s.io/kube-aggregator/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/kube-aggregator
 

--- a/staging/src/k8s.io/kube-controller-manager/go.mod
+++ b/staging/src/k8s.io/kube-controller-manager/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/kube-controller-manager
 

--- a/staging/src/k8s.io/kube-proxy/go.mod
+++ b/staging/src/k8s.io/kube-proxy/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/kube-proxy
 

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/kube-scheduler
 

--- a/staging/src/k8s.io/kubelet/go.mod
+++ b/staging/src/k8s.io/kubelet/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/kubelet
 

--- a/staging/src/k8s.io/metrics/go.mod
+++ b/staging/src/k8s.io/metrics/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/metrics
 

--- a/staging/src/k8s.io/node-api/go.mod
+++ b/staging/src/k8s.io/node-api/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/node-api
 

--- a/staging/src/k8s.io/sample-apiserver/go.mod
+++ b/staging/src/k8s.io/sample-apiserver/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/sample-apiserver
 

--- a/staging/src/k8s.io/sample-cli-plugin/go.mod
+++ b/staging/src/k8s.io/sample-cli-plugin/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/sample-cli-plugin
 

--- a/staging/src/k8s.io/sample-controller/go.mod
+++ b/staging/src/k8s.io/sample-controller/go.mod
@@ -1,6 +1,4 @@
 // This is a generated file. Do not edit directly.
-// Run hack/pin-dependency.sh to change pinned dependency versions.
-// Run hack/update-vendor.sh to update go.mod files and the vendor directory.
 
 module k8s.io/sample-controller
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
* Removes comments from the staging repo go.mod files that don't make sense when published
* Detects and prints error messages if staging repos attempt to depend on k8s.io/kubernetes packages (as encountered in https://github.com/kubernetes/kubernetes/pull/76090)

Sample output when run on that PR:
```
Disallowed k8s.io/cri-api -> k8s.io/kubernetes dependencies exist via the following imports:
# k8s.io/kubernetes/pkg/apis/core
k8s.io/cri-api/pkg/streaming
k8s.io/kubernetes/pkg/kubelet/server/portforward
k8s.io/kubernetes/pkg/apis/core

# k8s.io/kubernetes/pkg/kubelet/server/portforward
k8s.io/cri-api/pkg/streaming
k8s.io/kubernetes/pkg/kubelet/server/portforward

# k8s.io/kubernetes/pkg/kubelet/server/remotecommand
k8s.io/cri-api/pkg/streaming
k8s.io/kubernetes/pkg/kubelet/server/remotecommand
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @sttts 