### PR TITLE
Call Done only on sync'ed key

### DIFF
--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -388,12 +388,12 @@ func (ssc *StatefulSetController) processNextWorkItem() bool {
 	if quit {
 		return false
 	}
-	defer ssc.queue.Done(key)
 	if err := ssc.sync(key.(string)); err != nil {
 		utilruntime.HandleError(fmt.Errorf("Error syncing StatefulSet %v, requeuing: %v", key.(string), err))
 		ssc.queue.AddRateLimited(key)
 	} else {
 		ssc.queue.Forget(key)
+		ssc.queue.Done(key)
 	}
 	return true
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently ssc.queue.Done(key) is called at the end of processNextWorkItem().
However, if the sync() fails, we call ssc.queue.AddRateLimited on the key.
In this case, the Done() should not be called.

```release-note
NONE
```
