### PR TITLE
kubectl create (role, job, cronjob) respect --namespace with --dry-run

### DIFF
--- a/pkg/kubectl/cmd/create/create_cronjob.go
+++ b/pkg/kubectl/cmd/create/create_cronjob.go
@@ -161,6 +161,7 @@ func (o *CreateCronJobOptions) Validate() error {
 func (o *CreateCronJobOptions) Run() error {
 	var cronjob *batchv1beta1.CronJob
 	cronjob = o.createCronJob()
+	cronjob.Namespace = o.Namespace
 
 	if !o.DryRun {
 		var err error

--- a/pkg/kubectl/cmd/create/create_job.go
+++ b/pkg/kubectl/cmd/create/create_job.go
@@ -190,6 +190,9 @@ func (o *CreateJobOptions) Run() error {
 
 		job = o.createJobFromCronJob(cronJob)
 	}
+
+	job.Namespace = o.Namespace
+
 	if !o.DryRun {
 		var err error
 		job, err = o.Client.Jobs(o.Namespace).Create(job)

--- a/pkg/kubectl/cmd/create/create_role.go
+++ b/pkg/kubectl/cmd/create/create_role.go
@@ -334,6 +334,7 @@ func (o *CreateRoleOptions) RunCreateRole() error {
 		return err
 	}
 	role.Rules = rules
+	role.Namespace = o.Namespace
 
 	// Create role.
 	if !o.DryRun {

--- a/pkg/kubectl/cmd/create/create_role_test.go
+++ b/pkg/kubectl/cmd/create/create_role_test.go
@@ -52,7 +52,8 @@ func TestCreateRole(t *testing.T) {
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
-					Name: roleName,
+					Name:      roleName,
+					Namespace: "test",
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -70,7 +71,8 @@ func TestCreateRole(t *testing.T) {
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
-					Name: roleName,
+					Name:      roleName,
+					Namespace: "test",
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -88,7 +90,8 @@ func TestCreateRole(t *testing.T) {
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
-					Name: roleName,
+					Name:      roleName,
+					Namespace: "test",
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -106,7 +109,8 @@ func TestCreateRole(t *testing.T) {
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
-					Name: roleName,
+					Name:      roleName,
+					Namespace: "test",
 				},
 				Rules: []rbac.PolicyRule{
 					{


### PR DESCRIPTION
Signed-off-by: Andrey Voronkov <voronkovaa@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
For `kubectl create role`, `kubectl create job`, `kubectl create cronjob` respect `--namespace` global option when doing Dry Run.
Constructions like `kubectl create role ... --dry-run -o yaml | kubectl apply -f -` are useful for Create or Update operations imitation inside the scripts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
I have not found them :(

**Special notes for your reviewer**:
Not a Go coder at all, so I cannot write appropriate tests, but here is system kubectl output:

## Role
### kubectl v1.14.0
```
kubectl create role --namespace test testrole --verb=* --resource=*.apps --dry-run -o yaml                                   
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  creationTimestamp: null
  name: testrole
rules:
- apiGroups:
  - apps
  resources:
  - '*'
  verbs:
  - '*'
```
### Built kubectl
```
_output/dockerized/bin/linux/amd64/kubectl create role --namespace test testrole --verb=* --resource=*.apps --dry-run -o yaml 
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  creationTimestamp: null
  name: testrole
  namespace: test
rules:
- apiGroups:
  - apps
  resources:
  - '*'
  verbs:
  - '*'
```

## Job
### kubectl v1.14.0
```
kubectl create job --namespace test testjob --image nginx:1.15.10-alpine --dry-run -o yaml
apiVersion: batch/v1
kind: Job
metadata:
  creationTimestamp: null
  name: testjob
spec:
  template:
    metadata:
      creationTimestamp: null
    spec:
      containers:
      - image: nginx:1.15.10-alpine
        name: testjob
        resources: {}
      restartPolicy: Never
status: {}
```
### Built kubectl
```
_output/dockerized/bin/linux/amd64/kubectl create job --namespace test testjob --image nginx:1.15.10-alpine --dry-run -o yaml
apiVersion: batch/v1
kind: Job
metadata:
  creationTimestamp: null
  name: testjob
  namespace: test
spec:
  template:
    metadata:
      creationTimestamp: null
    spec:
      containers:
      - image: nginx:1.15.10-alpine
        name: testjob
        resources: {}
      restartPolicy: Never
status: {}
```

## CronJob
### kubectl v1.14.0
```
kubectl create cronjob --namespace test testcronjob --image nginx:1.15.10-alpine --schedule "0 * * * *" --dry-run -o yaml
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  creationTimestamp: null
  name: testcronjob
spec:
  jobTemplate:
    metadata:
      creationTimestamp: null
      name: testcronjob
    spec:
      template:
        metadata:
          creationTimestamp: null
        spec:
          containers:
          - image: nginx:1.15.10-alpine
            name: testcronjob
            resources: {}
          restartPolicy: OnFailure
  schedule: 0 * * * *
status: {}
```
### Built kubectl
```
_output/dockerized/bin/linux/amd64/kubectl create cronjob --namespace test testcronjob --image nginx:1.15.10-alpine --schedule "0 * * * *" --dry-run -o yaml
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  creationTimestamp: null
  name: testcronjob
  namespace: test
spec:
  jobTemplate:
    metadata:
      creationTimestamp: null
      name: testcronjob
    spec:
      template:
        metadata:
          creationTimestamp: null
        spec:
          containers:
          - image: nginx:1.15.10-alpine
            name: testcronjob
            resources: {}
          restartPolicy: OnFailure
  schedule: 0 * * * *
status: {}
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
