### PR TITLE
use server-side printing in `kubectl get -w`

### DIFF
--- a/pkg/kubectl/cmd/get/BUILD
+++ b/pkg/kubectl/cmd/get/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",

--- a/pkg/kubectl/cmd/get/BUILD
+++ b/pkg/kubectl/cmd/get/BUILD
@@ -23,6 +23,7 @@ go_library(
         "get_flags.go",
         "humanreadable_flags.go",
         "sorter.go",
+        "table_printer.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/kubectl/cmd/get",
     visibility = ["//visibility:public"],

--- a/pkg/kubectl/cmd/get/get_test.go
+++ b/pkg/kubectl/cmd/get/get_test.go
@@ -502,9 +502,49 @@ c      0/0              0          <unknown>
 	}
 }
 
+func TestGetSortedObjectsUnstructuredTable(t *testing.T) {
+	unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(sortTestTableData()[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	unstructuredBytes, err := encjson.MarshalIndent(unstructuredMap, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// t.Log(string(unstructuredBytes))
+	body := ioutil.NopCloser(bytes.NewReader(unstructuredBytes))
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Resp:                 &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: body},
+	}
+	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &corev1.SchemeGroupVersion}}
+
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	cmd.SetOutput(buf)
+
+	// sorting with metedata.name
+	cmd.Flags().Set("sort-by", ".metadata.name")
+	cmd.Run(cmd, []string{"pods"})
+
+	expected := `NAME   CUSTOM
+a      custom-a
+b      custom-b
+c      custom-c
+`
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
+	}
+}
+
 func sortTestData() []runtime.Object {
 	return []runtime.Object{
 		&corev1.Pod{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 			ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "test", ResourceVersion: "10"},
 			Spec: corev1.PodSpec{
 				RestartPolicy:                 corev1.RestartPolicyAlways,
@@ -515,6 +555,7 @@ func sortTestData() []runtime.Object {
 			},
 		},
 		&corev1.Pod{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 			ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "test", ResourceVersion: "11"},
 			Spec: corev1.PodSpec{
 				RestartPolicy:                 corev1.RestartPolicyAlways,
@@ -525,6 +566,7 @@ func sortTestData() []runtime.Object {
 			},
 		},
 		&corev1.Pod{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 			ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "test", ResourceVersion: "9"},
 			Spec: corev1.PodSpec{
 				RestartPolicy:                 corev1.RestartPolicyAlways,
@@ -540,11 +582,17 @@ func sortTestData() []runtime.Object {
 func sortTestTableData() []runtime.Object {
 	return []runtime.Object{
 		&metav1beta1.Table{
-			TypeMeta: metav1.TypeMeta{Kind: "Table"},
+			TypeMeta: metav1.TypeMeta{APIVersion: "meta.k8s.io/v1beta1", Kind: "Table"},
+			ColumnDefinitions: []metav1beta1.TableColumnDefinition{
+				{Name: "NAME", Type: "string", Format: "name"},
+				{Name: "CUSTOM", Type: "string", Format: ""},
+			},
 			Rows: []metav1beta1.TableRow{
 				{
+					Cells: []interface{}{"c", "custom-c"},
 					Object: runtime.RawExtension{
 						Object: &corev1.Pod{
+							TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 							ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "test", ResourceVersion: "10"},
 							Spec: corev1.PodSpec{
 								RestartPolicy:                 corev1.RestartPolicyAlways,
@@ -557,8 +605,10 @@ func sortTestTableData() []runtime.Object {
 					},
 				},
 				{
+					Cells: []interface{}{"b", "custom-b"},
 					Object: runtime.RawExtension{
 						Object: &corev1.Pod{
+							TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 							ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "test", ResourceVersion: "11"},
 							Spec: corev1.PodSpec{
 								RestartPolicy:                 corev1.RestartPolicyAlways,
@@ -571,8 +621,10 @@ func sortTestTableData() []runtime.Object {
 					},
 				},
 				{
+					Cells: []interface{}{"a", "custom-a"},
 					Object: runtime.RawExtension{
 						Object: &corev1.Pod{
+							TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 							ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "test", ResourceVersion: "9"},
 							Spec: corev1.PodSpec{
 								RestartPolicy:                 corev1.RestartPolicyAlways,

--- a/pkg/kubectl/cmd/get/get_test.go
+++ b/pkg/kubectl/cmd/get/get_test.go
@@ -1403,6 +1403,113 @@ foo    0/0              0          <unknown>
 	}
 }
 
+func TestWatchResourceTable(t *testing.T) {
+	columns := []metav1beta1.TableColumnDefinition{
+		{Name: "Name", Type: "string", Format: "name", Description: "the name", Priority: 0},
+		{Name: "Active", Type: "boolean", Description: "active", Priority: 0},
+	}
+
+	listTable := &metav1beta1.Table{
+		TypeMeta:          metav1.TypeMeta{APIVersion: "meta.k8s.io/v1beta1", Kind: "Table"},
+		ColumnDefinitions: columns,
+		Rows: []metav1beta1.TableRow{
+			{
+				Cells: []interface{}{"a", true},
+				Object: runtime.RawExtension{
+					Object: &corev1.Pod{
+						TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+						ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "test", ResourceVersion: "10"},
+					},
+				},
+			},
+			{
+				Cells: []interface{}{"b", true},
+				Object: runtime.RawExtension{
+					Object: &corev1.Pod{
+						TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+						ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "test", ResourceVersion: "20"},
+					},
+				},
+			},
+		},
+	}
+
+	events := []watch.Event{
+		{
+			Type: watch.Added,
+			Object: &metav1beta1.Table{
+				TypeMeta:          metav1.TypeMeta{APIVersion: "meta.k8s.io/v1beta1", Kind: "Table"},
+				ColumnDefinitions: columns, // first event includes the columns
+				Rows: []metav1beta1.TableRow{{
+					Cells: []interface{}{"a", false},
+					Object: runtime.RawExtension{
+						Object: &corev1.Pod{
+							TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+							ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "test", ResourceVersion: "30"},
+						},
+					},
+				}},
+			},
+		},
+		{
+			Type: watch.Deleted,
+			Object: &metav1beta1.Table{
+				ColumnDefinitions: []metav1beta1.TableColumnDefinition{},
+				Rows: []metav1beta1.TableRow{{
+					Cells: []interface{}{"b", false},
+					Object: runtime.RawExtension{
+						Object: &corev1.Pod{
+							TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+							ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "test", ResourceVersion: "40"},
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/namespaces/test/pods":
+				if req.URL.Query().Get("watch") != "true" && req.URL.Query().Get("fieldSelector") == "" {
+					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, listTable)}, nil
+				}
+				if req.URL.Query().Get("watch") == "true" && req.URL.Query().Get("fieldSelector") == "" {
+					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: watchBody(codec, events)}, nil
+				}
+				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
+				return nil, nil
+			default:
+				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	cmd.SetOutput(buf)
+
+	cmd.Flags().Set("watch", "true")
+	cmd.Run(cmd, []string{"pods"})
+
+	expected := `NAME   ACTIVE
+a      true
+b      true
+a      false
+b      false
+`
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
+	}
+}
+
 func TestWatchResourceIdentifiedByFile(t *testing.T) {
 	pods, events := watchTestData()
 
@@ -1538,7 +1645,9 @@ func watchBody(codec runtime.Codec, events []watch.Event) io.ReadCloser {
 	buf := bytes.NewBuffer([]byte{})
 	enc := restclientwatch.NewEncoder(streaming.NewEncoder(buf, codec), codec)
 	for i := range events {
-		enc.Encode(&events[i])
+		if err := enc.Encode(&events[i]); err != nil {
+			panic(err)
+		}
 	}
 	return json.Framer.NewFrameReader(ioutil.NopCloser(buf))
 }

--- a/pkg/kubectl/cmd/get/table_printer.go
+++ b/pkg/kubectl/cmd/get/table_printer.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/klog"
+)
+
+// TablePrinter decodes table objects into typed objects before delegating to another printer.
+// Non-table types are simply passed through
+type TablePrinter struct {
+	Delegate printers.ResourcePrinter
+}
+
+func (t *TablePrinter) PrintObj(obj runtime.Object, writer io.Writer) error {
+	table, err := decodeIntoTable(obj)
+	if err == nil {
+		return t.Delegate.PrintObj(table, writer)
+	}
+	// if we are unable to decode server response into a v1beta1.Table,
+	// fallback to client-side printing with whatever info the server returned.
+	klog.V(2).Infof("Unable to decode server response into a Table. Falling back to hardcoded types: %v", err)
+	return t.Delegate.PrintObj(obj, writer)
+}
+
+func decodeIntoTable(obj runtime.Object) (runtime.Object, error) {
+	if obj.GetObjectKind().GroupVersionKind().Group != metav1beta1.GroupName {
+		return nil, fmt.Errorf("attempt to decode non-Table object into a v1beta1.Table")
+	}
+	if obj.GetObjectKind().GroupVersionKind().Kind != "Table" {
+		return nil, fmt.Errorf("attempt to decode non-Table object into a v1beta1.Table")
+	}
+
+	unstr, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("attempt to decode non-Unstructured object")
+	}
+	table := &metav1beta1.Table{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstr.Object, table); err != nil {
+		return nil, err
+	}
+
+	for i := range table.Rows {
+		row := &table.Rows[i]
+		if row.Object.Raw == nil || row.Object.Object != nil {
+			continue
+		}
+		converted, err := runtime.Decode(unstructured.UnstructuredJSONScheme, row.Object.Raw)
+		if err != nil {
+			return nil, err
+		}
+		row.Object.Object = converted
+	}
+
+	return table, nil
+}

--- a/pkg/kubectl/scheme/BUILD
+++ b/pkg/kubectl/scheme/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//staging/src/k8s.io/api/storage/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",

--- a/pkg/kubectl/scheme/install.go
+++ b/pkg/kubectl/scheme/install.go
@@ -45,6 +45,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -56,6 +57,7 @@ import (
 func init() {
 	// Register external types for Scheme
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(metav1beta1.AddToScheme(Scheme))
 	utilruntime.Must(scheme.AddToScheme(Scheme))
 
 	utilruntime.Must(Scheme.SetVersionPriority(corev1.SchemeGroupVersion))

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1/register.go
@@ -39,6 +39,12 @@ var scheme = runtime.NewScheme()
 var ParameterCodec = runtime.NewParameterCodec(scheme)
 
 func init() {
+	if err := AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+}
+
+func AddToScheme(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Table{},
 		&TableOptions{},
@@ -46,11 +52,9 @@ func init() {
 		&PartialObjectMetadataList{},
 	)
 
-	if err := scheme.AddConversionFuncs(
+	return scheme.AddConversionFuncs(
 		Convert_Slice_string_To_v1beta1_IncludeObjectPolicy,
-	); err != nil {
-		panic(err)
-	}
+	)
 
 	// register manually. This usually goes through the SchemeBuilder, which we cannot use here.
 	//scheme.AddGeneratedDeepCopyFuncs(GetGeneratedDeepCopyFuncs()...)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Requests and handles server-side print events for `kubectl get -w`

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/66538

**Does this PR introduce a user-facing change?**:
```release-note
`kubectl get -w` now prints custom resource definitions with custom print columns
```

/sig cli
/cc @smarterclayton @seans3 