### PR TITLE
Revert "[Distroless] Convert the GCE manifests for master containers."

### DIFF
--- a/cluster/gce/gci/apiserver_manifest_test.go
+++ b/cluster/gce/gci/apiserver_manifest_test.go
@@ -93,12 +93,11 @@ func (c *kubeAPIServerManifestTestCase) invokeTest(e kubeAPIServerEnv, kubeEnv s
 
 func TestEncryptionProviderFlag(t *testing.T) {
 	var (
-		//  command": [
-		//   "/usr/local/bin/kube-apiserver " - Index 0,
-		//   "--flag1=val1",   - Index 1,
-		//   "--flag2=val2",   - Index 2,
-		//   ...
-		//   "--flagN=valN",   - Index N,
+		//	command": [
+		//   "/bin/sh", - Index 0
+		//   "-c",      - Index 1
+		//   "exec /usr/local/bin/kube-apiserver " - Index 2
+		execArgsIndex        = 2
 		encryptionConfigFlag = "--encryption-provider-config"
 	)
 
@@ -132,15 +131,10 @@ func TestEncryptionProviderFlag(t *testing.T) {
 
 			c.invokeTest(e, deployHelperEnv)
 
-			var flagIsInArg bool
-			var flag, execArgs string
-			for _, execArgs = range c.pod.Spec.Containers[0].Args[1:] {
-				if strings.Contains(execArgs, encryptionConfigFlag) {
-					flagIsInArg = true
-					flag = fmt.Sprintf("%s=%s", encryptionConfigFlag, e.EncryptionProviderConfigPath)
-					break
-				}
-			}
+			execArgs := c.pod.Spec.Containers[0].Command[execArgsIndex]
+			flagIsInArg := strings.Contains(execArgs, encryptionConfigFlag)
+			flag := fmt.Sprintf("%s=%s", encryptionConfigFlag, e.EncryptionProviderConfigPath)
+
 			switch {
 			case tc.wantFlag && !flagIsInArg:
 				t.Fatalf("Got %q,\n want flags to contain %q", execArgs, flag)

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -25,24 +25,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-function convert-manifest-params {
-  # A helper function to convert the manifest args from a string to a list of
-  # flag arguments.
-  # Old format:
-  #   command=["/bin/sh", "-c", "exec KUBE_EXEC_BINARY --param1=val1 --param2-val2"].
-  # New format:
-  #   command=["KUBE_EXEC_BINARY"]  # No shell dependencies.
-  #   args=["--param1=val1", "--param2-val2"]
-  IFS=' ' read -ra FLAGS <<< "$1"
-  params=""
-  for flag in "${FLAGS[@]}"; do
-    params+="\n\"$flag\","
-  done
-  if [ ! -z $params ]; then
-    echo "${params::-1}"  #  drop trailing comma
-  fi
-}
-
 function setup-os-params {
   # Reset core_pattern. On GCI, the default core_pattern pipes the core dumps to
   # /sbin/crash_reporter which is more restrictive in saving crash dumps. So for
@@ -1868,9 +1850,6 @@ function start-kube-apiserver {
   # params is passed by reference, so no "$"
   setup-etcd-encryption "${src_file}" params
 
-  params+=" --log-file=${KUBE_API_SERVER_LOG_PATH:-/var/log/kube-apiserver.log}"
-  params+=" --logtostderr=false"
-  params="$(convert-manifest-params "${params}")"
   # Evaluate variables.
   local -r kube_apiserver_docker_tag="${KUBE_API_SERVER_DOCKER_TAG:-$(cat /home/kubernetes/kube-docker-files/kube-apiserver.docker_tag)}"
   sed -i -e "s@{{params}}@${params}@g" "${src_file}"
@@ -2052,8 +2031,7 @@ function apply-encryption-config() {
 function start-kube-controller-manager {
   echo "Start kubernetes controller-manager"
   create-kubecontrollermanager-kubeconfig
-  local LOG_PATH=/var/log/kube-controller-manager.log
-  prepare-log-file "${LOG_PATH}"
+  prepare-log-file /var/log/kube-controller-manager.log
   # Calculate variables and assemble the command line.
   local params="${CONTROLLER_MANAGER_TEST_LOG_LEVEL:-"--v=2"} ${CONTROLLER_MANAGER_TEST_ARGS:-} ${CLOUD_CONFIG_OPT}"
   params+=" --use-service-account-credentials"
@@ -2081,7 +2059,7 @@ function start-kube-controller-manager {
     params+=" --concurrent-service-syncs=${CONCURRENT_SERVICE_SYNCS}"
   fi
   if [[ "${NETWORK_PROVIDER:-}" == "kubenet" ]]; then
-    params+=" --allocate-node-cidrs"
+    params+=" --allocate-node-cidrs=true"
   elif [[ -n "${ALLOCATE_NODE_CIDRS:-}" ]]; then
     params+=" --allocate-node-cidrs=${ALLOCATE_NODE_CIDRS}"
   fi
@@ -2112,13 +2090,9 @@ function start-kube-controller-manager {
     params+=" --pv-recycler-pod-template-filepath-hostpath=$PV_RECYCLER_OVERRIDE_TEMPLATE"
   fi
   if [[ -n "${RUN_CONTROLLERS:-}" ]]; then
-    # Trim the `RUN_CONTROLLERS` value. This field is quoted which is
-    # incompatible with the `convert-manifest-params` format.
-    params+=" --controllers=${RUN_CONTROLLERS//\'}"
+    params+=" --controllers=${RUN_CONTROLLERS}"
   fi
-  params+=" --log-file=${LOG_PATH}"
-  params+=" --logtostderr=false"
-  params="$(convert-manifest-params "${params}")"
+
   local -r kube_rc_docker_tag=$(cat /home/kubernetes/kube-docker-files/kube-controller-manager.docker_tag)
   local container_env=""
   if [[ -n "${ENABLE_CACHE_MUTATION_DETECTOR:-}" ]]; then
@@ -2153,8 +2127,7 @@ function start-kube-controller-manager {
 function start-kube-scheduler {
   echo "Start kubernetes scheduler"
   create-kubescheduler-kubeconfig
-  local LOG_PATH=/var/log/kube-scheduler.log
-  prepare-log-file "${LOG_PATH}"
+  prepare-log-file /var/log/kube-scheduler.log
 
   # Calculate variables and set them in the manifest.
   params="${SCHEDULER_TEST_LOG_LEVEL:-"--v=2"} ${SCHEDULER_TEST_ARGS:-}"
@@ -2170,10 +2143,6 @@ function start-kube-scheduler {
     params+=" --use-legacy-policy-config"
     params+=" --policy-config-file=/etc/srv/kubernetes/kube-scheduler/policy-config"
   fi
-
-  params+=" --log-file=${LOG_PATH}"
-  params+=" --logtostderr=false"
-  params="$(convert-manifest-params "${params}")"
   local -r kube_scheduler_docker_tag=$(cat "${KUBE_HOME}/kube-docker-files/kube-scheduler.docker_tag")
 
   # Remove salt comments and replace variables with values.

--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -25,12 +25,10 @@
       }
     },
     "command": [
-      "/usr/local/bin/kube-apiserver"
-    ],
-    "args": [
-      "--allow-privileged={{pillar['allow_privileged']}}",
-      {{params}}
-    ],
+                 "/bin/sh",
+                 "-c",
+                 "exec /usr/local/bin/kube-apiserver {{params}} --allow-privileged={{pillar['allow_privileged']}} 1>>/var/log/kube-apiserver.log 2>&1"
+               ],
     {{container_env}}
     "livenessProbe": {
       "httpGet": {

--- a/cluster/gce/manifests/kube-controller-manager.manifest
+++ b/cluster/gce/manifests/kube-controller-manager.manifest
@@ -25,11 +25,10 @@
       }
     },
     "command": [
-      "/usr/local/bin/kube-controller-manager"
-    ],
-    "args": [
-      {{params}}
-    ],
+                 "/bin/sh",
+                 "-c",
+                 "exec /usr/local/bin/kube-controller-manager {{params}} 1>>/var/log/kube-controller-manager.log 2>&1"
+               ],
     {{container_env}}
     "livenessProbe": {
       "httpGet": {

--- a/cluster/gce/manifests/kube-scheduler.manifest
+++ b/cluster/gce/manifests/kube-scheduler.manifest
@@ -25,11 +25,10 @@
       }
     },
     "command": [
-      "/usr/local/bin/kube-scheduler"
-    ],
-    "args": [
-      {{params}}
-    ],
+                 "/bin/sh",
+                 "-c",
+                 "exec /usr/local/bin/kube-scheduler {{params}} 1>>/var/log/kube-scheduler.log 2>&1"
+               ],
     "livenessProbe": {
       "httpGet": {
         "host": "127.0.0.1",


### PR DESCRIPTION
Reverts kubernetes/kubernetes#75624

This PR broke log rotation in scalability tests e.g.:
https://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-performance/1114075638949482502/artifacts/gce-scale-cluster-master/
there is only one 'kube-apiserver.log' and no 'kube-apiserver.log.gz*'.

The issue is that klog's --log-file truncates file after reaching 1.8GiB of data so there is no way to find data older than 1.8GiB.
See https://github.com/kubernetes/klog/blob/master/klog_file.go#L104

/cc @wojtek-t 