### PR TITLE
Allow extenders to access the root paths of webhook servers without redirection

### DIFF
--- a/pkg/scheduler/core/extender.go
+++ b/pkg/scheduler/core/extender.go
@@ -390,7 +390,12 @@ func (h *HTTPExtender) send(action string, args interface{}, result interface{})
 		return err
 	}
 
-	url := strings.TrimRight(h.extenderURL, "/") + "/" + action
+	var url string
+	if action == "/" {
+		url = strings.TrimRight(h.extenderURL, "/")
+	} else {
+		url = strings.TrimRight(h.extenderURL, "/") + "/" + action
+	}
 
 	req, err := http.NewRequest("POST", url, bytes.NewReader(out))
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Enable users to set the root path of the webhook server, like `http://example.com:8080`, as a target of scheduler extenders in policy files.

Currently enabling/disabling extenders is switched whether `{filter,prioritize,preempt,bind}Verb` in the policy is empty of not. It means that when you set the values as:

- `"urlPrefix": "http://example.com:8080"`
- `"filterVerb": ""`

then the filter extender will be disabled.

On the other hand, when you set:

- `"urlPrefix": "http://example.com:8080"`
- `"filterVerb": "/"`

they result in `http://example.com:8080//`, and usually redirected to `http://example.com:8080`. But actually the `net/http` package the scheduler uses inside seems to redirect an original POST request as GET.

This PR makes the scheduler access to `http://example.com:8080` directly when `filterVerb` is `/`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Allow extenders to access the root paths of webhook servers without redirection
```

/sig scheduling