### PR TITLE
admission: add FinalizerRestriction admission

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/BUILD
@@ -79,6 +79,7 @@ filegroup(
         "//staging/src/k8s.io/apiserver/pkg/admission/configuration:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/admission/initializer:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/admission/metrics:all-srcs",
+        "//staging/src/k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/errors:all-srcs",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction/BUILD
@@ -1,0 +1,46 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["admission.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction",
+    importpath = "k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["admission_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction/admission.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package finalizerrestriction
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/initializer"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/klog"
+)
+
+const (
+	// PluginName indicates the name of admission plugin
+	PluginName = "FinalizerRestriction"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return &FinalizerRestriction{}, nil
+	})
+}
+
+// FinalizerRestriction is an implementation of admission Interface.
+// It restricts on who can add/remove finalizer on resources.
+type FinalizerRestriction struct {
+	*admission.Handler
+
+	authorizer authorizer.Authorizer
+}
+
+var _ admission.Interface = &FinalizerRestriction{}
+var _ initializer.WantsAuthorizer = &FinalizerRestriction{}
+
+// SetAuthorizer injects the authorizer
+func (r *FinalizerRestriction) SetAuthorizer(authorizer authorizer.Authorizer) {
+	r.authorizer = authorizer
+}
+
+// ValidateInitialization verifies the authorizer injection.
+func (r *FinalizerRestriction) ValidateInitialization() error {
+	if r.authorizer == nil {
+		return fmt.Errorf("missing authorizer")
+	}
+	return nil
+}
+
+// Admit decides whether the finalizer can be added or removed.
+func (r *FinalizerRestriction) Admit(a admission.Attributes, o admission.ObjectInterfaces) error {
+	if a.GetOperation() != admission.Create && a.GetOperation() != admission.Update {
+		return nil
+	}
+	if a.GetSubresource() != "" {
+		return nil
+	}
+
+	obj, err := meta.Accessor(a.GetObject())
+	if err != nil {
+		klog.V(2).Infof("can not get meta accessor: %s", err)
+		return nil
+	}
+
+	newFinalizers := sets.NewString(obj.GetFinalizers()...)
+	oldFinalizers := sets.NewString()
+
+	if a.GetOldObject() != nil {
+		oldObj, err := meta.Accessor(a.GetOldObject())
+		if err != nil {
+			klog.V(2).Infof("can not get meta accessor for old object: %s", err)
+			return nil
+		}
+		oldFinalizers.Insert(oldObj.GetFinalizers()...)
+	}
+
+	union := newFinalizers.Union(oldFinalizers)
+	intersection := newFinalizers.Intersection(oldFinalizers)
+
+	for _, finalizer := range union.Difference(intersection).List() {
+		attr := authorizer.AttributesRecord{
+			User:            a.GetUserInfo(),
+			Verb:            "finalize",
+			Namespace:       a.GetNamespace(),
+			Name:            finalizer,
+			APIGroup:        a.GetResource().Group,
+			Resource:        a.GetResource().Resource,
+			ResourceRequest: true,
+		}
+		decision, reason, err := r.authorizer.Authorize(attr)
+		if err != nil {
+			klog.V(5).Infof("cannot authorize for finalizing %s: %s, %s", finalizer, reason, err)
+		}
+		if decision == authorizer.DecisionAllow {
+			continue
+		}
+		return admission.NewForbidden(a, fmt.Errorf("not allowed to finalize %s", finalizer))
+	}
+
+	return nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction/admission_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package finalizerrestriction
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+type simpleAuthorizer struct {
+	allowedFinalizers []string
+}
+
+func (s *simpleAuthorizer) Authorize(a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	if a.GetVerb() != "finalize" {
+		return authorizer.DecisionDeny, "", fmt.Errorf("unsupported verb")
+	}
+	for a.GetUser() == nil {
+		return authorizer.DecisionDeny, "", fmt.Errorf("user info is missing")
+	}
+	for _, finalizer := range s.allowedFinalizers {
+		if finalizer == a.GetName() {
+			return authorizer.DecisionAllow, "", nil
+		}
+	}
+	return authorizer.DecisionDeny, "not allowed", nil
+}
+
+func TestAdmit(t *testing.T) {
+	var tests = []struct {
+		name        string
+		operation   admission.Operation
+		object      runtime.Object
+		oldObject   runtime.Object
+		subresource string
+		allowed     bool
+	}{
+		{
+			name:      "ignore non create and non update operation",
+			operation: admission.Delete,
+			allowed:   true,
+		},
+		{
+			name:        "ignore subresource request",
+			operation:   admission.Update,
+			subresource: "status",
+			allowed:     true,
+		},
+		{
+			name:      "allow finalizing foo in creation",
+			operation: admission.Create,
+			object: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"foo"},
+				},
+			},
+			oldObject: nil,
+			allowed:   true,
+		},
+		{
+			name:      "disallow finalizing bar in creation",
+			operation: admission.Create,
+			object: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"foo", "bar"},
+				},
+			},
+			oldObject: nil,
+			allowed:   false,
+		},
+		{
+			name:      "allow finalizing when adding foo",
+			operation: admission.Create,
+			object: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{},
+				},
+			},
+			oldObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"foo"},
+				},
+			},
+			allowed: true,
+		},
+		{
+			name:      "allow finalizing when removing foo",
+			operation: admission.Create,
+			object: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"foo"},
+				},
+			},
+			oldObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{},
+				},
+			},
+			allowed: true,
+		},
+		{
+			name:      "disallow finalizing when adding bar",
+			operation: admission.Create,
+			object: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"foo"},
+				},
+			},
+			oldObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"foo", "bar"},
+				},
+			},
+			allowed: false,
+		},
+		{
+			name:      "disallow finalizing when removing bar",
+			operation: admission.Create,
+			object: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"foo", "bar"},
+				},
+			},
+			oldObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"foo"},
+				},
+			},
+			allowed: false,
+		},
+	}
+
+	admitter := &FinalizerRestriction{
+		authorizer: &simpleAuthorizer{
+			allowedFinalizers: []string{"foo"},
+		},
+	}
+	for _, test := range tests {
+		err := admitter.Admit(admission.NewAttributesRecord(
+			test.object,
+			test.oldObject,
+			schema.GroupVersionKind{},
+			"",
+			"",
+			schema.GroupVersionResource{},
+			test.subresource,
+			test.operation,
+			false,
+			&user.DefaultInfo{Name: "bar"},
+		), nil)
+		if test.allowed && err != nil {
+			t.Errorf("%s: should be alloed but got error: %s", test.name, err)
+		}
+		if !test.allowed && err == nil {
+			t.Errorf("%s: should be disallowed", test.name)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -73,6 +73,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/waitgroup:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/metrics:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
 	admissionmetrics "k8s.io/apiserver/pkg/admission/metrics"
+	finalizerrestriction "k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction"
 	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
 	mutatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
 	validatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
@@ -81,8 +82,8 @@ func NewAdmissionOptions() *AdmissionOptions {
 		// admission plugins. The apiserver always runs the validating ones
 		// after all the mutating ones, so their relative order in this list
 		// doesn't matter.
-		RecommendedPluginOrder: []string{lifecycle.PluginName, mutatingwebhook.PluginName, validatingwebhook.PluginName},
-		DefaultOffPlugins:      sets.NewString(),
+		RecommendedPluginOrder: []string{lifecycle.PluginName, mutatingwebhook.PluginName, finalizerrestriction.PluginName, validatingwebhook.PluginName},
+		DefaultOffPlugins:      sets.NewString(finalizerrestriction.PluginName),
 	}
 	server.RegisterAllAdmissionPlugins(options.Plugins)
 	return options

--- a/staging/src/k8s.io/apiserver/pkg/server/plugins.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/plugins.go
@@ -19,6 +19,7 @@ package server
 // This file exists to force the desired plugin implementations to be linked into genericapi pkg.
 import (
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/finalizerrestriction"
 	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
 	mutatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
 	validatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
@@ -27,6 +28,7 @@ import (
 // RegisterAllAdmissionPlugins registers all admission plugins
 func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	lifecycle.Register(plugins)
+	finalizerrestriction.Register(plugins)
 	validatingwebhook.Register(plugins)
 	mutatingwebhook.Register(plugins)
 }


### PR DESCRIPTION
FinalizerRestriction is a new generic admission which works with
any k8s resources as long as it is `meta.Accessor`. This admission
checks whether there is any new finalizers added during creation,
or any new added or removed finalizers during updating. This relies
on the authorization mechanism to check whether the user can do
this finalizing action.

/kind feature
/sig api-machinery

```release-note
add FinalizerRestriction admission to protect finalizers
```
