### PR TITLE
Graduate SupportNodePidsLimit to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -418,7 +418,7 @@ const (
 	CSIMigrationAWS utilfeature.Feature = "CSIMigrationAWS"
 
 	// owner: @RobertKrawitz
-	// alpha: v1.14
+	// beta: v1.15
 	//
 	// Implement support for limiting pids in nodes
 	SupportNodePidsLimit utilfeature.Feature = "SupportNodePidsLimit"
@@ -479,7 +479,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	ResourceLimitsPriorityFunction:              {Default: false, PreRelease: utilfeature.Alpha},
 	SupportIPVSProxyMode:                        {Default: true, PreRelease: utilfeature.GA},
 	SupportPodPidsLimit:                         {Default: true, PreRelease: utilfeature.Beta},
-	SupportNodePidsLimit:                        {Default: false, PreRelease: utilfeature.Alpha},
+	SupportNodePidsLimit:                        {Default: true, PreRelease: utilfeature.Beta},
 	HyperVContainer:                             {Default: false, PreRelease: utilfeature.Alpha},
 	ScheduleDaemonSetPods:                       {Default: true, PreRelease: utilfeature.Beta},
 	TokenRequest:                                {Default: true, PreRelease: utilfeature.Beta},

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/stats/pidlimit"
@@ -40,7 +39,6 @@ import (
 )
 
 func setDesiredConfiguration(initialConfig *kubeletconfig.KubeletConfiguration) {
-	initialConfig.FeatureGates[string(features.SupportNodePidsLimit)] = true
 	initialConfig.EnforceNodeAllocatable = []string{"pods", kubeReservedCgroup, systemReservedCgroup}
 	initialConfig.SystemReserved = map[string]string{
 		string(v1.ResourceCPU):    "100m",


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This graduates process ID limiting for nodes (https://github.com/kubernetes/kubernetes/pull/73651) to beta, per plan.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
As of Kubernetes 1.15, the SupportNodePidsLimit feature introduced as alpha in Kubernetes 1.14 is now beta, and the ability to utilize it is enabled by default.  It is no longer necessary to set the feature gate `SupportNodePidsLimit=true`.  In all other respects, this functionality behaves as it did in Kubernetes 1.14.
```
