### PR TITLE
Replace syscall.Execve with exec.Command.

### DIFF
--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -125,7 +125,7 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 			name:             "test that a plugin executable is found based on command args",
 			args:             []string{"kubectl", "foo", "--bar"},
 			expectPlugin:     "plugin/testdata/kubectl-foo",
-			expectPluginArgs: []string{"foo", "--bar"},
+			expectPluginArgs: []string{"--bar"},
 		},
 		{
 			name: "test that a plugin does not execute over an existing command by the same name",
@@ -158,7 +158,7 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 			}
 
 			if len(pluginsHandler.withArgs) != len(test.expectPluginArgs) {
-				t.Fatalf("unexpected plugin execution args: expedcted %q, got %q", test.expectPluginArgs, pluginsHandler.withArgs)
+				t.Fatalf("unexpected plugin execution args: expected %q, got %q", test.expectPluginArgs, pluginsHandler.withArgs)
 			}
 		})
 	}

--- a/test/cmd/plugins.sh
+++ b/test/cmd/plugins.sh
@@ -44,6 +44,10 @@ run_plugins_tests() {
   output_message=$(PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins" kubectl foo)
   kube::test::if_has_string "${output_message}" 'plugin foo'
 
+  # check arguments passed to the plugin
+  output_message=$(PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/bar" kubectl bar arg1)
+  kube::test::if_has_string "${output_message}" 'test/fixtures/pkg/kubectl/plugins/bar/kubectl-bar arg1'
+
   # ensure that a kubectl command supersedes a plugin that overshadows it
   output_message=$(PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/version" kubectl version)
   kube::test::if_has_string "${output_message}" 'Client Version'

--- a/test/fixtures/pkg/kubectl/plugins/bar/kubectl-bar
+++ b/test/fixtures/pkg/kubectl/plugins/bar/kubectl-bar
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "I am plugin bar called with args $0 $@"


### PR DESCRIPTION
Use exec.Command instead of syscall.Execve to launch plugin.
On windows syscall.Execve fails.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Uses exec.Command instead of execve to start plugin.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/603

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
