### PR TITLE
Use read lock for PriorityQueue#PendingPods

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -702,8 +702,8 @@ func (p *PriorityQueue) NominatedPodsForNode(nodeName string) []*v1.Pod {
 // PendingPods returns all the pending pods in the queue. This function is
 // used for debugging purposes in the scheduler cache dumper and comparer.
 func (p *PriorityQueue) PendingPods() []*v1.Pod {
-	p.lock.Lock()
-	defer p.lock.Unlock()
+	p.lock.RLock()
+	defer p.lock.RUnlock()
 	result := []*v1.Pod{}
 	for _, pInfo := range p.activeQ.List() {
 		result = append(result, pInfo.(*podInfo).pod)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
PriorityQueue#PendingPods only performs read operations. Using read lock should suffice.

```release-note
NONE
```
