### PR TITLE
Break out of loop in removeZone when zone is found

### DIFF
--- a/pkg/scheduler/internal/cache/node_tree.go
+++ b/pkg/scheduler/internal/cache/node_tree.go
@@ -127,6 +127,7 @@ func (nt *NodeTree) removeZone(zone string) {
 	for i, z := range nt.zones {
 		if z == zone {
 			nt.zones = append(nt.zones[:i], nt.zones[i+1:]...)
+			break
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
After the zone is found, we can break out of the loop in NodeTree#removeZone

```release-note
NONE
```
