### PR TITLE
Fix the formatting string

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
@@ -715,7 +715,7 @@ func TestCacherListerWatcher(t *testing.T) {
 	}
 	pl, ok := obj.(*example.PodList)
 	if !ok {
-		t.Fatalf("Expected PodList but got %t", pl)
+		t.Fatalf("Expected PodList but got %v", pl)
 	}
 	if len(pl.Items) != 3 {
 		t.Errorf("Expected PodList of length 3 but got %d", len(pl.Items))
@@ -744,7 +744,7 @@ func TestCacherListerWatcherPagination(t *testing.T) {
 	}
 	limit1, ok := obj1.(*example.PodList)
 	if !ok {
-		t.Fatalf("Expected PodList but got %t", limit1)
+		t.Fatalf("Expected PodList but got %v", limit1)
 	}
 	if len(limit1.Items) != 2 {
 		t.Errorf("Expected PodList of length 2 but got %d", len(limit1.Items))
@@ -758,7 +758,7 @@ func TestCacherListerWatcherPagination(t *testing.T) {
 	}
 	limit2, ok := obj2.(*example.PodList)
 	if !ok {
-		t.Fatalf("Expected PodList but got %t", limit2)
+		t.Fatalf("Expected PodList but got %v", limit2)
 	}
 	if limit2.Continue != "" {
 		t.Errorf("Expected list not to have Continue, but got %s", limit1.Continue)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/76234

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
