### PR TITLE
change default 5s ttl to 30s for coredns to be same with kube-dns/dnsmasq

### DIFF
--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -68,6 +68,7 @@ data:
             pods insecure
             upstream
             fallthrough in-addr.arpa ip6.arpa
+            ttl 30
         }
         prometheus :9153
         forward . /etc/resolv.conf

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -68,6 +68,7 @@ data:
             pods insecure
             upstream
             fallthrough in-addr.arpa ip6.arpa
+            ttl 30
         }
         prometheus :9153
         forward . /etc/resolv.conf

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -68,6 +68,7 @@ data:
             pods insecure
             upstream
             fallthrough in-addr.arpa ip6.arpa
+            ttl 30
         }
         prometheus :9153
         forward . /etc/resolv.conf

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -318,6 +318,7 @@ data:
            pods insecure
            upstream
            fallthrough in-addr.arpa ip6.arpa
+           ttl 30
         }{{ .Federation }}
         prometheus :9153
         forward . {{ .UpstreamNameserver }}

--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -71,6 +71,7 @@ func (t *dnsFederationsConfigMapTest) run() {
             pods insecure
             upstream
             fallthrough in-addr.arpa ip6.arpa
+            ttl 30
         }
         federation %v {
            abc def.com
@@ -86,6 +87,7 @@ func (t *dnsFederationsConfigMapTest) run() {
             pods insecure
             upstream
             fallthrough in-addr.arpa ip6.arpa
+            ttl 30
         }
         federation %v {
            ghi xyz.com
@@ -235,6 +237,7 @@ func (t *dnsNameserverTest) run(isIPv6 bool) {
            pods insecure
            upstream
            fallthrough in-addr.arpa ip6.arpa
+           ttl 30
         }
         forward . %v
     }
@@ -333,6 +336,7 @@ func (t *dnsPtrFwdTest) run(isIPv6 bool) {
            pods insecure
            upstream
            fallthrough in-addr.arpa ip6.arpa
+           ttl 30
         }
         forward . %v
     }`, framework.TestContext.ClusterDNSDomain, t.dnsServerPod.Status.PodIP),
@@ -443,6 +447,7 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
            pods insecure
            upstream
            fallthrough in-addr.arpa ip6.arpa
+           ttl 30
         }
         forward . %v
     }`, framework.TestContext.ClusterDNSDomain, t.dnsServerPod.Status.PodIP),


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

According to https://coredns.io/plugins/kubernetes/,  coredns uses 5s ttl for kubernetes zone by default, this isn't consistent with 30s ttl in dnsmasq based kube-dns.  Although https://github.com/kubernetes/dns/blob/master/docs/specification.md doesn't specify the value for ttl, it's better to keep it same,  actually this issue confused me a lot when I did benchmark against two kubernetes cluster, one uses dnsmasq, one uses coredns, I spent a lot of time to locate the root cause.

**Special notes for your reviewer**:

I use  kube-dns only for k8s service,  I'm not sure whether this change is appropriate for other kinds of k8s resources such as k8s pod.

**Does this PR introduce a user-facing change?**:

```release-note
Default TTL for DNS records in kubernetes zone is changed from 5s to 30s to keep consistent with old dnsmasq based kube-dns. The TTL can be customized with command `kubectl edit -n kube-system configmap/coredns`.
```