### PR TITLE
Fix storage CSIDriverSpec field is immutable

### DIFF
--- a/pkg/registry/storage/csidriver/storage/storage_test.go
+++ b/pkg/registry/storage/csidriver/storage/storage_test.go
@@ -101,6 +101,11 @@ func TestUpdate(t *testing.T) {
 	test.TestUpdate(
 		// valid
 		validNewCSIDriver("foo"),
+		// update func
+		func(obj runtime.Object) runtime.Object {
+			object := obj.(*storageapi.CSIDriver)
+			return object
+		},
 		//invalid update
 		func(obj runtime.Object) runtime.Object {
 			object := obj.(*storageapi.CSIDriver)


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug
> /kind failing-test

**What this PR does / why we need it**:
``make check WHAT=./pkg/registry/storage/csidriver/storage GOFLAGS=-v KUBE_TEST_ARGS='-run ^TestUpdate$'``:
```
resttest.go:543: unexpected error: CSIDriver.storage.k8s.io "foo2" is invalid: spec: Invalid value: storage.CSIDriverSpec{AttachRequired:(*bool)(0xc0001f2702), PodInfoOnMount:(*bool)(0xc0001f2703)}: field is immutable
resttest.go:117: object does not have ObjectMeta: object does not implement the Object interfaces
```
**Which issue(s) this PR fixes**:

Fixes #76236 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None
