### PR TITLE
Produce map according to the shorter array in haveOverlap

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -1095,6 +1095,9 @@ func PodFitsHostPorts(pod *v1.Pod, meta PredicateMetadata, nodeInfo *schedulerno
 
 // search two arrays and return true if they have at least one common element; return false otherwise
 func haveOverlap(a1, a2 []string) bool {
+	if len(a1) > len(a2) {
+		(a1, a2) = (a2, a1)
+	}
 	m := map[string]bool{}
 
 	for _, val := range a1 {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In predicates, we use auxiliary map to check overlap in haveOverlap.
This PR chooses the shorter array to produce the map which consumes less memory while keeping the time complexity the same.

```release-note
NONE
```
