### PR TITLE
promote e2e should wait gracefully terminated pod until preStop hook completes the process to conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -203,6 +203,7 @@ test/e2e/node/events.go: "should be sent by kubelets and the scheduler about pod
 test/e2e/node/pods.go: "should be submitted and removed"
 test/e2e/node/pods.go: "should be submitted and removed"
 test/e2e/node/pre_stop.go: "should call prestop when killing a pod"
+test/e2e/node/pre_stop.go: "should wait gracefully terminated pod until preStop hook completes the process"
 test/e2e/scheduling/predicates.go: "validates resource limits of pods that are allowed to run"
 test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if not matching"
 test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if matching"

--- a/test/e2e/node/pre_stop.go
+++ b/test/e2e/node/pre_stop.go
@@ -178,7 +178,12 @@ var _ = SIGDescribe("PreStop", func() {
 		testPreStop(f.ClientSet, f.Namespace.Name)
 	})
 
-	ginkgo.It("graceful pod terminated should wait until preStop hook completes the process", func() {
+	/*
+		Release : v1.15
+		Testname: Pods, prestop hook with graceful termination
+		Description: Create a pod with prestop lifecycle, terminate the pod with graceful period seconds. Wait up to the graceful termination period seconds, then verify the pod is in running state after the graceful termination period seconds.
+	*/
+	framework.ConformanceIt("should wait gracefully terminated pod until preStop hook completes the process", func() {
 		gracefulTerminationPeriodSeconds := int64(30)
 		ginkgo.By("creating the pod")
 		name := "pod-prestop-hook-" + string(uuid.NewUUID())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
>
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
promote e2e should wait gracefully terminated pod until preStop hook completes the process to conformance
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This PR to promote e2e should wait gracefully terminated pod until preStop hook completes the process to conformance
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/area conformance
/area testing
@kubernetes/cncf-conformance-wg 
@spiffxp @brahmaroutu 