### PR TITLE
Fix golint failures of test/e2e/framework/framework.go

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -105,7 +105,7 @@ type Framework struct {
 	cleanupHandle CleanupActionHandle
 
 	// configuration for framework's client
-	Options FrameworkOptions
+	Options Options
 
 	// Place where various additional data is stored during test run to be printed to ReportDir,
 	// or stdout if ReportDir is not set once test ends.
@@ -122,8 +122,8 @@ type TestDataSummary interface {
 	PrintJSON() string
 }
 
-// FrameworkOptions is a struct for managing test framework options.
-type FrameworkOptions struct {
+// Options is a struct for managing test framework options.
+type Options struct {
 	ClientQPS    float32
 	ClientBurst  int
 	GroupVersion *schema.GroupVersion
@@ -132,7 +132,7 @@ type FrameworkOptions struct {
 // NewDefaultFramework makes a new framework and sets up a BeforeEach/AfterEach for
 // you (you can write additional before/after each functions).
 func NewDefaultFramework(baseName string) *Framework {
-	options := FrameworkOptions{
+	options := Options{
 		ClientQPS:   20,
 		ClientBurst: 50,
 	}
@@ -140,7 +140,7 @@ func NewDefaultFramework(baseName string) *Framework {
 }
 
 // NewFramework creates a test framework.
-func NewFramework(baseName string, options FrameworkOptions, client clientset.Interface) *Framework {
+func NewFramework(baseName string, options Options, client clientset.Interface) *Framework {
 	f := &Framework{
 		BaseName:                 baseName,
 		AddonResourceConstraints: make(map[string]ResourceConstraint),
@@ -667,7 +667,7 @@ func kubectlExecWithRetry(namespace string, podName, containerName string, args 
 
 		return stdOutBytes, stdErrBytes, err
 	}
-	err := fmt.Errorf("Failed: kubectl exec failed %d times with \"i/o timeout\". Giving up.", maxKubectlExecRetries)
+	err := fmt.Errorf("Failed: kubectl exec failed %d times with \"i/o timeout\". Giving up", maxKubectlExecRetries)
 	return nil, nil, err
 }
 

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -54,7 +54,7 @@ const (
 var _ = SIGDescribe("Proxy", func() {
 	version := "v1"
 	Context("version "+version, func() {
-		options := framework.FrameworkOptions{
+		options := framework.Options{
 			ClientQPS: -1.0,
 		}
 		f := framework.NewFramework("proxy", options, nil)

--- a/test/e2e/scalability/density.go
+++ b/test/e2e/scalability/density.go
@@ -475,7 +475,7 @@ var _ = SIGDescribe("Density", func() {
 		Expect(missingMeasurements <= MaxMissingPodStartupMeasurements).To(Equal(true))
 	})
 
-	options := framework.FrameworkOptions{
+	options := framework.Options{
 		ClientQPS:   50.0,
 		ClientBurst: 100,
 	}

--- a/test/e2e/scalability/load.go
+++ b/test/e2e/scalability/load.go
@@ -133,7 +133,7 @@ var _ = SIGDescribe("Load capacity", func() {
 
 	// Explicitly put here, to delete namespace at the end of the test
 	// (after measuring latency metrics, etc.).
-	options := framework.FrameworkOptions{
+	options := framework.Options{
 		ClientQPS:   float32(math.Max(50.0, float64(2*throughput))),
 		ClientBurst: int(math.Max(100.0, float64(4*throughput))),
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Fix golint failures of test/e2e/framework/framework.go

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/priority important-soon
