### PR TITLE
Fix some golint failures of e2e/network/[d-k]*.go

### DIFF
--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -53,7 +53,7 @@ type dnsTestCommon struct {
 	cm *v1.ConfigMap
 }
 
-func newDnsTestCommon() dnsTestCommon {
+func newDNSTestCommon() dnsTestCommon {
 	return dnsTestCommon{
 		f:  framework.NewDefaultFramework("dns-config-map"),
 		ns: "kube-system",
@@ -137,9 +137,8 @@ func (t *dnsTestCommon) runDig(dnsName, target string) []string {
 
 	if stdout == "" {
 		return []string{}
-	} else {
-		return strings.Split(stdout, "\n")
 	}
+	return strings.Split(stdout, "\n")
 }
 
 func (t *dnsTestCommon) setConfigMap(cm *v1.ConfigMap) {

--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -35,7 +35,7 @@ type dnsFederationsConfigMapTest struct {
 }
 
 var (
-	googleDnsHostname = "google-public-dns-a.google.com"
+	googleDNSHostname = "google-public-dns-a.google.com"
 	// The ConfigMap update mechanism takes longer than the standard
 	// wait.ForeverTestTimeout.
 	moreForeverTestTimeout = 2 * 60 * time.Second
@@ -43,7 +43,7 @@ var (
 
 var _ = SIGDescribe("DNS configMap federations [Feature:Federation]", func() {
 
-	t := &dnsFederationsConfigMapTest{dnsTestCommon: newDnsTestCommon()}
+	t := &dnsFederationsConfigMapTest{dnsTestCommon: newDNSTestCommon()}
 
 	It("should be able to change federation configuration [Slow][Serial]", func() {
 		t.c = t.f.ClientSet
@@ -314,13 +314,13 @@ func (t *dnsPtrFwdTest) run(isIPv6 bool) {
 	if isIPv6 {
 		t.checkDNSRecordFrom(
 			"2001:4860:4860::8888",
-			func(actual []string) bool { return len(actual) == 1 && actual[0] == googleDnsHostname+"." },
+			func(actual []string) bool { return len(actual) == 1 && actual[0] == googleDNSHostname+"." },
 			"ptr-record",
 			moreForeverTestTimeout)
 	} else {
 		t.checkDNSRecordFrom(
 			"8.8.8.8",
-			func(actual []string) bool { return len(actual) == 1 && actual[0] == googleDnsHostname+"." },
+			func(actual []string) bool { return len(actual) == 1 && actual[0] == googleDNSHostname+"." },
 			"ptr-record",
 			moreForeverTestTimeout)
 	}
@@ -401,7 +401,7 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
 
 	f := t.f
 	serviceName := "dns-externalname-upstream-test"
-	externalNameService := framework.CreateServiceSpec(serviceName, googleDnsHostname, false, nil)
+	externalNameService := framework.CreateServiceSpec(serviceName, googleDNSHostname, false, nil)
 	if _, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(externalNameService); err != nil {
 		Fail(fmt.Sprintf("Failed when creating service: %v", err))
 	}
@@ -421,7 +421,7 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
 		t.checkDNSRecordFrom(
 			fmt.Sprintf("%s.%s.svc.%s", serviceName, f.Namespace.Name, framework.TestContext.ClusterDNSDomain),
 			func(actual []string) bool {
-				return len(actual) >= 1 && actual[0] == googleDnsHostname+"."
+				return len(actual) >= 1 && actual[0] == googleDNSHostname+"."
 			},
 			"cluster-dns-ipv6",
 			moreForeverTestTimeout)
@@ -429,7 +429,7 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
 		t.checkDNSRecordFrom(
 			fmt.Sprintf("%s.%s.svc.%s", serviceName, f.Namespace.Name, framework.TestContext.ClusterDNSDomain),
 			func(actual []string) bool {
-				return len(actual) >= 1 && actual[0] == googleDnsHostname+"."
+				return len(actual) >= 1 && actual[0] == googleDNSHostname+"."
 			},
 			"cluster-dns",
 			moreForeverTestTimeout)
@@ -478,7 +478,7 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
 var _ = SIGDescribe("DNS configMap nameserver [IPv4]", func() {
 
 	Context("Change stubDomain", func() {
-		nsTest := &dnsNameserverTest{dnsTestCommon: newDnsTestCommon()}
+		nsTest := &dnsNameserverTest{dnsTestCommon: newDNSTestCommon()}
 
 		It("should be able to change stubDomain configuration [Slow][Serial]", func() {
 			nsTest.c = nsTest.f.ClientSet
@@ -487,7 +487,7 @@ var _ = SIGDescribe("DNS configMap nameserver [IPv4]", func() {
 	})
 
 	Context("Forward PTR lookup", func() {
-		fwdTest := &dnsPtrFwdTest{dnsTestCommon: newDnsTestCommon()}
+		fwdTest := &dnsPtrFwdTest{dnsTestCommon: newDNSTestCommon()}
 
 		It("should forward PTR records lookup to upstream nameserver [Slow][Serial]", func() {
 			fwdTest.c = fwdTest.f.ClientSet
@@ -496,7 +496,7 @@ var _ = SIGDescribe("DNS configMap nameserver [IPv4]", func() {
 	})
 
 	Context("Forward external name lookup", func() {
-		externalNameTest := &dnsExternalNameTest{dnsTestCommon: newDnsTestCommon()}
+		externalNameTest := &dnsExternalNameTest{dnsTestCommon: newDNSTestCommon()}
 
 		It("should forward externalname lookup to upstream nameserver [Slow][Serial]", func() {
 			externalNameTest.c = externalNameTest.f.ClientSet
@@ -508,7 +508,7 @@ var _ = SIGDescribe("DNS configMap nameserver [IPv4]", func() {
 var _ = SIGDescribe("DNS configMap nameserver [Feature:Networking-IPv6]", func() {
 
 	Context("Change stubDomain", func() {
-		nsTest := &dnsNameserverTest{dnsTestCommon: newDnsTestCommon()}
+		nsTest := &dnsNameserverTest{dnsTestCommon: newDNSTestCommon()}
 
 		It("should be able to change stubDomain configuration [Slow][Serial]", func() {
 			nsTest.c = nsTest.f.ClientSet
@@ -517,7 +517,7 @@ var _ = SIGDescribe("DNS configMap nameserver [Feature:Networking-IPv6]", func()
 	})
 
 	Context("Forward PTR lookup", func() {
-		fwdTest := &dnsPtrFwdTest{dnsTestCommon: newDnsTestCommon()}
+		fwdTest := &dnsPtrFwdTest{dnsTestCommon: newDNSTestCommon()}
 
 		It("should forward PTR records lookup to upstream nameserver [Slow][Serial]", func() {
 			fwdTest.c = fwdTest.f.ClientSet
@@ -526,7 +526,7 @@ var _ = SIGDescribe("DNS configMap nameserver [Feature:Networking-IPv6]", func()
 	})
 
 	Context("Forward external name lookup", func() {
-		externalNameTest := &dnsExternalNameTest{dnsTestCommon: newDnsTestCommon()}
+		externalNameTest := &dnsExternalNameTest{dnsTestCommon: newDNSTestCommon()}
 
 		It("should forward externalname lookup to upstream nameserver [Slow][Serial]", func() {
 			externalNameTest.c = externalNameTest.f.ClientSet

--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -39,7 +39,7 @@ const (
 	dnsReadyTimeout = time.Minute
 )
 
-const queryDnsPythonTemplate string = `
+const queryDNSPythonTemplate string = `
 import socket
 try:
 	socket.gethostbyname('%s')
@@ -131,8 +131,8 @@ var _ = SIGDescribe("ClusterDns [Feature:Example]", func() {
 		}
 		podName := pods.Items[0].Name
 
-		queryDns := fmt.Sprintf(queryDnsPythonTemplate, backendSvcName+"."+namespaces[0].Name)
-		_, err = framework.LookForStringInPodExec(namespaces[0].Name, podName, []string{"python", "-c", queryDns}, "ok", dnsReadyTimeout)
+		queryDNS := fmt.Sprintf(queryDNSPythonTemplate, backendSvcName+"."+namespaces[0].Name)
+		_, err = framework.LookForStringInPodExec(namespaces[0].Name, podName, []string{"python", "-c", queryDNS}, "ok", dnsReadyTimeout)
 		Expect(err).NotTo(HaveOccurred(), "waiting for output from pod exec")
 
 		updatedPodYaml := prepareResourceWithReplacedString(frontendPodYaml, fmt.Sprintf("dns-backend.development.svc.%s", framework.TestContext.ClusterDNSDomain), fmt.Sprintf("dns-backend.%s.svc.%s", namespaces[0].Name, framework.TestContext.ClusterDNSDomain))

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -41,8 +41,8 @@ const (
 )
 
 var _ = SIGDescribe("Firewall rule", func() {
-	var firewall_test_name = "firewall-test"
-	f := framework.NewDefaultFramework(firewall_test_name)
+	var firewallTestName = "firewall-test"
+	f := framework.NewDefaultFramework(firewallTestName)
 
 	var cs clientset.Interface
 	var cloudConfig framework.CloudConfig

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -489,10 +489,9 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 				if int(deploy.Status.UpdatedReplicas) == replicas {
 					if res.Len() == replicas {
 						return true, nil
-					} else {
-						framework.Logf("Expecting %d different responses, but got %d.", replicas, res.Len())
-						return false, nil
 					}
+					framework.Logf("Expecting %d different responses, but got %d.", replicas, res.Len())
+					return false, nil
 
 				} else {
 					framework.Logf("Waiting for rolling update to finished. Keep sending traffic.")
@@ -928,7 +927,7 @@ func executeBacksideBacksideHTTPSTest(f *framework.Framework, jig *ingress.TestJ
 	Expect(err).NotTo(HaveOccurred(), "Failed to verify backside re-encryption ingress")
 }
 
-func detectHttpVersionAndSchemeTest(f *framework.Framework, jig *ingress.TestJig, address, version, scheme string) {
+func detectHTTPVersionAndSchemeTest(f *framework.Framework, jig *ingress.TestJig, address, version, scheme string) {
 	timeoutClient := &http.Client{Timeout: ingress.IngressReqTimeout}
 	resp := ""
 	err := wait.PollImmediate(framework.LoadBalancerPollInterval, framework.LoadBalancerPollTimeout, func() (bool, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Fix some golint failures of e2e/network/[d-k]*.go



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/priority important-soon