### PR TITLE
Set sane defaults for the proxy transport

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -30,6 +30,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"golang.org/x/net/http2"
 	"k8s.io/klog"
@@ -442,4 +443,20 @@ func CloneHeader(in http.Header) http.Header {
 		out[key] = newValues
 	}
 	return out
+}
+
+// NewDefaultTransport returns a new instance of http.DefaultTransport
+func NewDefaultTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	v1informers "k8s.io/client-go/informers/core/v1"
@@ -102,15 +103,12 @@ func NewAvailableConditionController(
 
 	// construct an http client that will ignore TLS verification (if someone owns the network and messes with your status
 	// that's not so bad) and sets a very short timeout.
-	discoveryClient := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-		// the request should happen quickly.
-		Timeout: 5 * time.Second,
-	}
+	discoveryClient := &http.Client{Timeout: 5 * time.Second}
 	if proxyTransport != nil {
 		discoveryClient.Transport = proxyTransport
+	} else {
+		transport := utilnet.NewDefaultTransport()
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	c.discoveryClient = discoveryClient
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
This PR sets "sane" defaults for the `http.Transport` which gets created for the proxy transport (Used when communicating to Nodes, Extension API servers - and potentially more).

We've seen timeouts in the `AvailableController` when it does the discovery of extension API servers:
```
E0406 20:48:14.164885       1 available_controller.go:316] v1beta1.metrics.k8s.io failed with: Get https://10.47.244.118:443: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```
`10.47.244.118` Is a virtual IP which points to 2 instances of the metrics-server.

The timeouts occure whenever on of the metrics-server instances get killed (Probably the one, the Kube API server has a connection to).
The `AvailableController` now only receives timeouts for the next 15-20 min, despite another instance of the metrics-server is alive.
When doing a `curl https://10.47.244.118:443` from the API server instance, everything works fine, which is why i assume the used http.Transport to be causing issues.

The `http.Transport` has some defaults which might be undesirable:
- https://github.com/pmorie/go-open-service-broker-client/issues/132
- https://github.com/golang/go/issues/26013

Regarding testing:
I'm able to reproduce the bug in our environment (Loodse/Kubermatic - Kubernetes in Kubernetes) but didn't had the time to test this in other environments.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
