### PR TITLE
Add type alias for DirectCodecFactory -> WithoutConversionCodecFactory

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -256,3 +256,7 @@ func (f WithoutConversionCodecFactory) DecoderToVersion(serializer runtime.Decod
 		Decoder: serializer,
 	}
 }
+
+// DirectCodecFactory was renamed to WithoutConversionCodecFactory in 1.15.
+// TODO: remove in 1.16.
+type DirectCodecFactory = WithoutConversionCodecFactory

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -234,8 +234,10 @@ func (c *codec) Encode(obj runtime.Object, w io.Writer) error {
 	return err
 }
 
-// DirectEncoder was movend and renamed in 1.15 and will be removed in 1.16.
+// DirectEncoder was moved and renamed to runtime.WithVersionEncoder in 1.15.
+// TODO: remove in 1.16.
 type DirectEncoder = runtime.WithVersionEncoder
 
-// DirectDecoder was movend and renamed in 1.15 and will be removed in 1.16.
+// DirectDecoder was moved and renamed to runtime.WithoutVersionDecoder in 1.15.
+// TODO: remove in 1.16.
 type DirectDecoder = runtime.WithoutVersionDecoder


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds a type alias for the legacy DirectCodecFactory type to ease client transitions

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/kubernetes/pull/76098#pullrequestreview-223645375

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```