### PR TITLE
Remove preshared cert test for Ingress-GCE

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -189,10 +189,6 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			Expect(hcAfterSync.HttpHealthCheck.RequestPath).To(Equal(hcToChange.HttpHealthCheck.RequestPath))
 		})
 
-		It("should create ingress with pre-shared certificate", func() {
-			executePresharedCertTest(f, jig, "")
-		})
-
 		It("should support multiple TLS certs", func() {
 			By("Creating an ingress with no certs.")
 			jig.CreateIngress(filepath.Join(ingress.IngressManifestPath, "multiple-certs"), ns, map[string]string{


### PR DESCRIPTION
/kind cleanup

Added to k/ingress-gce in https://github.com/kubernetes/ingress-gce/pull/671

```release-note
None
```
