### PR TITLE
Remove legacy table printing and decoding

### DIFF
--- a/pkg/kubectl/cmd/get/humanreadable_flags.go
+++ b/pkg/kubectl/cmd/get/humanreadable_flags.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 )
@@ -73,8 +72,6 @@ func (f *HumanPrintFlags) ToPrinter(outputFormat string) (printers.ResourcePrint
 		return nil, genericclioptions.NoCompatiblePrinterError{Options: f, AllowedFormats: f.AllowedFormats()}
 	}
 
-	decoder := scheme.Codecs.UniversalDecoder()
-
 	showKind := false
 	if f.ShowKind != nil {
 		showKind = *f.ShowKind
@@ -90,7 +87,7 @@ func (f *HumanPrintFlags) ToPrinter(outputFormat string) (printers.ResourcePrint
 		columnLabels = *f.ColumnLabels
 	}
 
-	p := printers.NewHumanReadablePrinter(decoder, printers.PrintOptions{
+	p := printers.NewHumanReadablePrinter(printers.PrintOptions{
 		Kind:          f.Kind,
 		WithKind:      showKind,
 		NoHeaders:     f.NoHeaders,

--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/printers/humanreadable_test.go
+++ b/pkg/printers/humanreadable_test.go
@@ -61,7 +61,6 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 			name: "no tablecolumndefinition and includeheader flase",
 			h: &handlerEntry{
 				columnDefinitions: []metav1beta1.TableColumnDefinition{},
-				printRows:         true,
 				printFunc:         printFunc,
 			},
 			opt: PrintOptions{},
@@ -75,7 +74,6 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 			name: "no tablecolumndefinition and includeheader true",
 			h: &handlerEntry{
 				columnDefinitions: []metav1beta1.TableColumnDefinition{},
-				printRows:         true,
 				printFunc:         printFunc,
 			},
 			opt: PrintOptions{},
@@ -89,7 +87,6 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 			name: "have tablecolumndefinition and includeheader true",
 			h: &handlerEntry{
 				columnDefinitions: testNamespaceColumnDefinitions,
-				printRows:         true,
 				printFunc:         printFunc,
 			},
 			opt: PrintOptions{},
@@ -103,7 +100,6 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 			name: "print namespace and withnamespace true, should not print header",
 			h: &handlerEntry{
 				columnDefinitions: testNamespaceColumnDefinitions,
-				printRows:         true,
 				printFunc:         printFunc,
 			},
 			opt: PrintOptions{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cleans up legacy table printing and decoding.
* all rest handlers now print table rows
* decoding to typed objects can be done externally if needed

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery cli
/cc @smarterclayton @seans3 