### PR TITLE
proxy/userspace: add dcbw and danwinship to OWNERS approvers

### DIFF
--- a/pkg/proxy/userspace/OWNERS
+++ b/pkg/proxy/userspace/OWNERS
@@ -1,9 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+- thockin
+- dcbw
+- danwinship
 reviewers:
 - thockin
 - lavalamp
 - smarterclayton
 - freehan
+- dcbw
+- danwinship
 labels:
 - sig/network


### PR DESCRIPTION
Per recommendation of @thockin:

https://github.com/kubernetes/kubernetes/pull/71735#pullrequestreview-189515580

```
IMO this code is as dead as it could be. The only significant user is OpenShift as far as I know. I'd rather never touch it again, but I know that is not realistic.

Also, it seems like maybe this could be broken into a couple commits for easier review?

I raised some questions about this design, but I think you should add yourselves as approvers in OWNERS for this subdir. If it evolves, I will lose context on the impl. I don't think it is covered by e2e, either (more argument for breaking it to a separate repo and having its own e2e tests)
```

```release-note
NONE
```
@thockin @smarterclayton 