### PR TITLE
If pod unready do not show endpoints

### DIFF
--- a/pkg/kubectl/describe/versioned/describe.go
+++ b/pkg/kubectl/describe/versioned/describe.go
@@ -4433,6 +4433,9 @@ func formatEndpoints(endpoints *corev1.Endpoints, ports sets.String) string {
 	count := 0
 	for i := range endpoints.Subsets {
 		ss := &endpoints.Subsets[i]
+		if len(ss.NotReadyAddresses) != 0 {
+			continue
+		}
 		if len(ss.Ports) == 0 {
 			// It's possible to have headless services with no ports.
 			for i := range ss.Addresses {


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Unready Pods should not appear in the Endpoints of the service

**Which issue(s) this PR fixes**:
Fixes #75889 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
None
```
