### PR TITLE
Add JUnitReporter to kubeadm e2e test

### DIFF
--- a/test/e2e_kubeadm/BUILD
+++ b/test/e2e_kubeadm/BUILD
@@ -34,6 +34,8 @@ go_test(
         "//staging/src/k8s.io/cluster-bootstrap/token/api:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/config:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/reporters:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",

--- a/test/e2e_kubeadm/e2e_kubeadm_suite_test.go
+++ b/test/e2e_kubeadm/e2e_kubeadm_suite_test.go
@@ -18,13 +18,17 @@ package e2e_kubeadm
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/gomega"
 	"github.com/spf13/pflag"
 
+	morereporters "github.com/onsi/ginkgo/reporters"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -42,7 +46,19 @@ func TestMain(m *testing.M) {
 }
 
 func TestE2E(t *testing.T) {
-	reporters := []ginkgo.Reporter{}
 	gomega.RegisterFailHandler(ginkgo.Fail)
+	reporters := []ginkgo.Reporter{}
+	reportDir := framework.TestContext.ReportDir
+	if reportDir != "" {
+		// Create the directory if it doesn't already exists
+		if err := os.MkdirAll(reportDir, 0755); err != nil {
+			t.Fatalf("Failed creating report directory: %v", err)
+		} else {
+			// Configure a junit reporter to write to the directory
+			junitFile := fmt.Sprintf("junit_%s_%02d.xml", framework.TestContext.ReportPrefix, config.GinkgoConfig.ParallelNode)
+			junitPath := filepath.Join(reportDir, junitFile)
+			reporters = append(reporters, morereporters.NewJUnitReporter(junitPath))
+		}
+	}
 	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "E2EKubeadm suite", reporters)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR Adds support for JUnitReporter to the kubeadm e2e test (similar to what implemented for e2e node test).

This is required to get the kubeadm e2e results properly reported in the test grid

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cluster-lifecycle
/area kubeadm
/priority backlog

@kubernetes/sig-cluster-lifecycle-pr-reviews
/assign @neolit123 
/cc @ereslibre @rosti