### PR TITLE
add aliases for api approvers/reviewers by SIG area

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -234,15 +234,13 @@ aliases:
     - smarterclayton
     - soltysh
     - tnozicka
-  sig-apps-api-approvers:
-    - erictune
-    - smarterclayton
   sig-autoscaling-maintainers:
     - aleksandra-malinowska
     - bskiba
     - DirectXMan12
     - MaciekPytel
     - mwielgus
+
   api-approvers:
     - erictune
     - lavalamp
@@ -250,6 +248,56 @@ aliases:
     - thockin
     - liggitt
     # - bgrant0607 # manual escalations only
+
+  # subsets of api-approvers by sig area to help focus approval requests to those with domain knowledge
+  sig-api-machinery-api-approvers:
+    - lavalamp
+    - liggitt
+    - smarterclayton
+
+  sig-apps-api-approvers:
+    - erictune
+    - lavalamp
+    - liggitt
+    - smarterclayton
+
+  sig-auth-api-approvers:
+    - liggitt
+    - smarterclayton
+
+  sig-cli-api-reviewers:
+    - liggitt
+    - smarterclayton
+
+  sig-cloud-provider-api-approvers:
+    - liggitt
+    - thockin
+
+  sig-cluster-lifecycle-api-approvers:
+    - liggitt
+    - smarterclayton
+
+  sig-network-api-approvers:
+    - smarterclayton
+    - thockin
+
+  sig-node-api-approvers:
+    - smarterclayton
+    - thockin
+
+  sig-scheduling-api-approvers:
+    - lavalamp
+    - smarterclayton
+    - thockin
+
+  sig-storage-api-approvers:
+    - liggitt
+    - thockin
+
+  sig-windows-api-approvers:
+    - smarterclayton
+    - thockin
+
   api-reviewers:
     - erictune
     - lavalamp
@@ -287,6 +335,54 @@ aliases:
     - piosz
     - jsafrane
     - jbeda
+
+  # api-reviewers targeted by sig area
+  # see https://git.k8s.io/community/sig-architecture/api-review-process.md#training-reviews
+  
+  # sig-api-machinery-api-reviewers:
+  #   - 
+  #   - 
+  
+  # sig-apps-api-reviewers:
+  #   - 
+  #   - 
+  
+  # sig-auth-api-reviewers:
+  #   - 
+  #   - 
+  
+  # sig-cli-api-reviewers:
+  #   - 
+  #   - 
+  
+  # sig-cloud-provider-api-reviewers:
+  #   - 
+  #   - 
+  
+  # sig-cluster-lifecycle-api-reviewers:
+  #   - 
+  #   - 
+  
+  # sig-network-api-reviewers:
+  #   - 
+  #   - 
+  
+  # sig-node-api-reviewers:
+  #   - 
+  #   - 
+  
+  # sig-scheduling-api-reviewers:
+  #   - 
+  #   - 
+  
+  # sig-storage-api-reviewers:
+  #   - 
+  #   - 
+  
+  # sig-windows-api-reviewers:
+  #   - 
+  #   - 
+
   dep-approvers:
     - apelisse
     - BenTheElder


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds aliases to help target API approval by SIG area

Will follow up with a PR adding reviewer aliases by SIG, identifying individuals participating in API review shadowing:
* have domain expertise in the SIG's area and related APIs
* are familiar with the [API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md) and [API changes](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md) docs
* are actively involved in performing or shadowing API reviews

I'll fill in those aliases based on feedback from SIG/subproject leads

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
