### PR TITLE
golint fixes for cmd-proxy

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -142,10 +142,10 @@ pkg/kubectl/cmd/expose
 pkg/kubectl/cmd/get
 pkg/kubectl/cmd/help
 pkg/kubectl/cmd/label
+pkg/kubectl/cmd/logs
 pkg/kubectl/cmd/patch
 pkg/kubectl/cmd/plugin
 pkg/kubectl/cmd/portforward
-pkg/kubectl/cmd/proxy
 pkg/kubectl/cmd/replace
 pkg/kubectl/cmd/rollingupdate
 pkg/kubectl/cmd/rollout

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -142,7 +142,6 @@ pkg/kubectl/cmd/expose
 pkg/kubectl/cmd/get
 pkg/kubectl/cmd/help
 pkg/kubectl/cmd/label
-pkg/kubectl/cmd/logs
 pkg/kubectl/cmd/patch
 pkg/kubectl/cmd/plugin
 pkg/kubectl/cmd/portforward

--- a/pkg/kubectl/cmd/proxy/proxy.go
+++ b/pkg/kubectl/cmd/proxy/proxy.go
@@ -70,6 +70,9 @@ var (
 		kubectl proxy --api-prefix=/k8s-api`))
 )
 
+//NewCmdProxy creates a new kubectl proxy command with
+//a help string, short and long descriptions, example use case, and the
+//function to actually exectute the command.
 func NewCmdProxy(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-prefix=prefix]",
@@ -97,6 +100,18 @@ func NewCmdProxy(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 	return cmd
 }
 
+//RunProxy sanity checks and runs a kubectl proxy command
+//
+//RunProxy will error if:
+// - both a port and unix socket are specified, only at most one should be
+// - the input command cannot generate a valid REST config
+//
+//RunProxy will log warnings if
+// - the directory specified by the www flag (the static file server flag) is not actually a directory
+// - the directory specified by the www flag cannot be stat'd
+// - the disable-filter flag is passed and kubectl proxy is run on an accessible port
+//
+//Otherwise RunProxy will start a proxy with the supplied configuration
 func RunProxy(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 	path := cmdutil.GetFlagString(cmd, "unix-socket")
 	port := cmdutil.GetFlagInt(cmd, "port")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes golint failures in pkg/kubectl/cmd/proxy

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:
This is the first time I'll be contributing to the kubernetes code base, let me know if I've missed any steps, thanks! Had to close the first one as I messed up the git history with the wrong email

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE

```
