### PR TITLE
Fix test failures in volume provisioning

### DIFF
--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -373,6 +373,9 @@ func PVWriteReadSingleNodeCheck(client clientset.Interface, claim *v1.Persistent
 	}
 	command += " || (mount | grep 'on /mnt/test'; false)"
 
+	if framework.NodeOSDistroIs("windows") {
+		command = "select-string 'hello world' /mnt/test/data"
+	}
 	RunInPodWithVolume(client, claim.Namespace, claim.Name, "pvc-volume-tester-reader", command, framework.NodeSelection{Name: actualNodeName})
 
 	return volume


### PR DESCRIPTION
For windows, the command such as "mount" and "grep" do not work for
windows node, this PR is fix the test issue by removing those commands
and change it windows ones if the node OS is windows.

