### PR TITLE
Add NewStrictUniversalDecoder() as a temporary, strict equivalent of CodecFactory.UniversalDecoder()

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -206,7 +206,7 @@ func (f CodecFactory) UniversalDecoder(versions ...schema.GroupVersion) runtime.
 	} else {
 		versioner = schema.GroupVersions(versions)
 	}
-	return f.CodecForVersions(nil, f.universal, nil, versioner)
+	return f.CodecForVersions(nil, f.universal, runtime.DisabledGroupVersioner, versioner)
 }
 
 // CodecForVersions creates a codec with the provided serializer. If an object is decoded and its group is not in the list,
@@ -225,12 +225,12 @@ func (f CodecFactory) CodecForVersions(encoder runtime.Encoder, decoder runtime.
 
 // DecoderToVersion returns a decoder that targets the provided group version.
 func (f CodecFactory) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
-	return f.CodecForVersions(nil, decoder, nil, gv)
+	return f.CodecForVersions(nil, decoder, runtime.DisabledGroupVersioner, gv)
 }
 
 // EncoderForVersion returns an encoder that targets the provided group version.
 func (f CodecFactory) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
-	return f.CodecForVersions(encoder, nil, gv, nil)
+	return f.CodecForVersions(encoder, nil, gv, runtime.InternalGroupVersioner)
 }
 
 // WithoutConversionCodecFactory is a CodecFactory that will explicitly ignore requests to perform conversion.

--- a/staging/src/k8s.io/component-base/config/BUILD
+++ b/staging/src/k8s.io/component-base/config/BUILD
@@ -24,6 +24,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//staging/src/k8s.io/component-base/config/serializer:all-srcs",
         "//staging/src/k8s.io/component-base/config/v1alpha1:all-srcs",
         "//staging/src/k8s.io/component-base/config/validation:all-srcs",
     ],

--- a/staging/src/k8s.io/component-base/config/serializer/BUILD
+++ b/staging/src/k8s.io/component-base/config/serializer/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["decode.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/component-base/config/serializer",
+    importpath = "k8s.io/component-base/config/serializer",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/recognizer:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/component-base/config/serializer/decode.go
+++ b/staging/src/k8s.io/component-base/config/serializer/decode.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serializer
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/recognizer"
+)
+
+// strictSerializerExtensions are for serializers that are conditionally compiled in.
+// Note that this is a separate variable from serializer.CodecFactory.
+var strictSerializerExtensions = []func(*runtime.Scheme) (serializerType, bool){}
+
+// NewStrictUniversalDecoder returns a runtime.Decoder which operates in a strict manner.
+// This Decoder is capable of decoding all known API objects in all known formats. It is used by clients that do not need
+// to encode objects but want to deserialize API objects stored on disk. It only decodes objects in groups registered
+// with the scheme. GroupVersions may be passed in `versions` to specify alternate versions of objects to return.
+// Populating `versions` is optional; a zero-length `versions` will result in runtime.InternalGroupVersioner -- this matches
+// behavior of serializer.CodecFactory.UniversalDecoder().
+// If any versions are specified, unrecognized groups will be returned in the version they are encoded as (no conversion).
+// This decoder performs defaulting.
+//
+// This constructor is not included in serializer.CodecFactory because all runtime Decode operations are intended to be strict in the future.
+// The current strict checking implementation is not fit for the hot-path of the apiserver due to performance reasons.
+// This constructor is a temporary solution until we can rely on serializer.CodecFactory.UniversalDecoder() to return Strict errors.
+//
+// TODO: the decoder will eventually be removed in favor of dealing with objects in their versioned form
+// TODO: only accept a group versioner
+func NewStrictUniversalDecoder(scheme *runtime.Scheme, versions []schema.GroupVersion) runtime.Decoder {
+	var versioner runtime.GroupVersioner
+	if len(versions) == 0 {
+		versioner = runtime.InternalGroupVersioner
+	} else {
+		versioner = schema.GroupVersions(versions)
+	}
+
+	codecs := serializer.NewCodecFactory(scheme)
+
+	serializers := newStrictSerializersForScheme(scheme, json.DefaultMetaFactory)
+	yamlStrictSerializer := newStrictUniversalDeserializer(scheme, serializers)
+
+	return codecs.CodecForVersions(nil, yamlStrictSerializer, runtime.DisabledGroupVersioner, versioner)
+}
+
+// serializerType is an exact copy of serializer.CodecFactory.serializerType
+type serializerType struct {
+	AcceptContentTypes []string
+	ContentType        string
+	FileExtensions     []string
+	// EncodesAsText should be true if this content type can be represented safely in UTF-8
+	EncodesAsText bool
+
+	Serializer       runtime.Serializer
+	PrettySerializer runtime.Serializer
+
+	AcceptStreamContentTypes []string
+	StreamContentType        string
+
+	Framer           runtime.Framer
+	StreamSerializer runtime.Serializer
+}
+
+// newStrictUniversalDeserializer is a paired-down version of serializer.CodecFactory.newCodecFactory() that only returns f.universal.
+// It is functionally similar to serializer.CodecFactory.UniversalDeserializer().
+// This Decoder does not perform defaulting
+func newStrictUniversalDeserializer(scheme *runtime.Scheme, serializers []serializerType) runtime.Decoder {
+	decoders := make([]runtime.Decoder, 0, len(serializers))
+	for _, d := range serializers {
+		decoders = append(decoders, d.Serializer)
+	}
+	return recognizer.NewDecoder(decoders...)
+}
+
+// newStrictSerializersForScheme is a strict variant of serializer.CodecFactory.newSerializersForScheme()
+func newStrictSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory) []serializerType {
+	jsonSerializer := json.NewSerializerWithOptions(
+		mf, scheme, scheme,
+		json.SerializerOptions{Yaml: false, Pretty: false, Strict: true},
+	)
+	jsonPrettySerializer := json.NewSerializerWithOptions(
+		mf, scheme, scheme,
+		json.SerializerOptions{Yaml: false, Pretty: true, Strict: true},
+	)
+	yamlSerializer := json.NewSerializerWithOptions(
+		mf, scheme, scheme,
+		json.SerializerOptions{Yaml: true, Pretty: false, Strict: true},
+	)
+
+	serializers := []serializerType{
+		{
+			AcceptContentTypes: []string{"application/json"},
+			ContentType:        "application/json",
+			FileExtensions:     []string{"json"},
+			EncodesAsText:      true,
+			Serializer:         jsonSerializer,
+			PrettySerializer:   jsonPrettySerializer,
+
+			Framer:           json.Framer,
+			StreamSerializer: jsonSerializer,
+		},
+		{
+			AcceptContentTypes: []string{"application/yaml"},
+			ContentType:        "application/yaml",
+			FileExtensions:     []string{"yaml"},
+			EncodesAsText:      true,
+			Serializer:         yamlSerializer,
+		},
+	}
+
+	for _, fn := range strictSerializerExtensions {
+		if serializer, ok := fn(scheme); ok {
+			serializers = append(serializers, serializer)
+		}
+	}
+	return serializers
+}


### PR DESCRIPTION
/kind api-change
@kubernetes/wg-component-standard 

**What this PR does / why we need it**:
This patch implements a `NewStrictUniversalDecoder` constructor independently from CodecFactory
since future work aims to integrate strict behavior directly into all of apimachinery by default.

Supporting types and functions were copied over and modified to implement a
Decoder with full feature parity.

This patch depends on the first commit of #74111.

Tracking issue: https://github.com/kubernetes/kubernetes/issues/75426

**Special notes for your reviewer**:
I'm not confident this is the best approach.
This patch aims for fully feature parity with the current Decoder.
With that comes complexity.
Supporting features like `versions`, `strictSerializerExtensions`, and the fallthrough decoders may not be necessary.

It looks like I should add tests similar to this one:
https://github.com/kubernetes/kubernetes/blob/f9b32d7/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/sparse_test.go
Let me know if that looks right.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```