### PR TITLE
Refactor and clean up e2e/framework/exec_util.go

### DIFF
--- a/test/e2e/framework/exec_util.go
+++ b/test/e2e/framework/exec_util.go
@@ -33,12 +33,10 @@ import (
 
 // ExecOptions passed to ExecWithOptions
 type ExecOptions struct {
-	Command []string
-
+	Command       []string
 	Namespace     string
 	PodName       string
 	ContainerName string
-
 	Stdin         io.Reader
 	CaptureStdout bool
 	CaptureStderr bool
@@ -85,11 +83,10 @@ func (f *Framework) ExecWithOptions(options ExecOptions) (string, string, error)
 // specified container and return stdout, stderr and error
 func (f *Framework) ExecCommandInContainerWithFullOutput(podName, containerName string, cmd ...string) (string, string, error) {
 	return f.ExecWithOptions(ExecOptions{
-		Command:       cmd,
-		Namespace:     f.Namespace.Name,
-		PodName:       podName,
-		ContainerName: containerName,
-
+		Command:            cmd,
+		Namespace:          f.Namespace.Name,
+		PodName:            podName,
+		ContainerName:      containerName,
 		Stdin:              nil,
 		CaptureStdout:      true,
 		CaptureStderr:      true,
@@ -114,14 +111,14 @@ func (f *Framework) ExecShellInContainer(podName, containerName string, cmd stri
 
 func (f *Framework) execCommandInPod(podName string, cmd ...string) string {
 	pod, err := f.PodClient().Get(podName, metav1.GetOptions{})
-	ExpectNoError(err, "failed to get pod")
+	ExpectNoError(err, "failed to get pod %v", podName)
 	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
 	return f.ExecCommandInContainer(podName, pod.Spec.Containers[0].Name, cmd...)
 }
 
 func (f *Framework) execCommandInPodWithFullOutput(podName string, cmd ...string) (string, string, error) {
 	pod, err := f.PodClient().Get(podName, metav1.GetOptions{})
-	ExpectNoError(err, "failed to get pod")
+	ExpectNoError(err, "failed to get pod %v", podName)
 	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
 	return f.ExecCommandInContainerWithFullOutput(podName, pod.Spec.Containers[0].Name, cmd...)
 }
@@ -131,7 +128,7 @@ func (f *Framework) ExecShellInPod(podName string, cmd string) string {
 	return f.execCommandInPod(podName, "/bin/sh", "-c", cmd)
 }
 
-// ExecShellInPodWithFullOutput executes the specified command on the pod with returing return stdout, stderr and error.
+// ExecShellInPodWithFullOutput executes the specified command on the Pod and returns stdout, stderr and error.
 func (f *Framework) ExecShellInPodWithFullOutput(podName string, cmd string) (string, string, error) {
 	return f.execCommandInPodWithFullOutput(podName, "/bin/sh", "-c", cmd)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Refactor and clean up e2e/framework/exec_util.go

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #76206 (parent issue #75601 )

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
