### PR TITLE
kubeadm: disable the kube-proxy DaemonSet on non-Linux nodes

### DIFF
--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -112,5 +112,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - operator: Exists
+      nodeSelector:
+        beta.kubernetes.io/os: linux
 `
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Windows worker nodes run kube-proxy as a Windows service.
In the future the kube-proxy DaemonSet might run on Windows nodes
too, but for now a temporary measure is needed to disable it.

Add a linux node selector in the kube-proxy manifest spec.
Similar was done already for CoreDNS.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/1393

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: disable the kube-proxy DaemonSet on non-Linux nodes. This step is required to support Windows worker nodes.
```

/kind cleanup
/priority important-longterm
@kubernetes/sig-cluster-lifecycle-pr-reviews 
/assign @timothysc @fabriziopandini 
cc @PatrickLang 
