### PR TITLE
make pin-dependency.sh only work at the module level

### DIFF
--- a/hack/pin-dependency.sh
+++ b/hack/pin-dependency.sh
@@ -64,7 +64,7 @@ mkdir -p "${_tmp}"
 
 # Add the require directive
 echo "Running: go get ${dep}@${sha}"
-go get -d "${dep}@${sha}"
+go get -m -d "${dep}@${sha}"
 
 # Find the resolved version
 rev=$(go mod edit -json | jq -r ".Require[] | select(.Path == \"${dep}\") | .Version")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Ensures pin-dependency.sh operates at the module level

**Special notes for your reviewer**:

Helps https://github.com/kubernetes/kubernetes/pull/76291 get a smaller go.mod diff

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @cblecker @dims