### PR TITLE
Escape quotes for user provided passwords used in basic auth.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -569,7 +569,9 @@ function create-master-auth {
       # append_or_replace_prefixed_line.
       rm "${basic_auth_csv}"
     fi
-    append_or_replace_prefixed_line "${basic_auth_csv}" "${KUBE_PASSWORD},${KUBE_USER},"      "admin,system:masters"
+    # escape quotes
+    KUBE_PASSWORD_ESC=$(echo $KUBE_PASSWORD | sed s/\"/\\\\\"/g)
+    append_or_replace_prefixed_line "${basic_auth_csv}" "${KUBE_PASSWORD_ESC},${KUBE_USER},"      "admin,system:masters"
   fi
 
   local -r known_tokens_csv="${auth_dir}/known_tokens.csv"


### PR DESCRIPTION
Without this the master won't start up if the password contains a quote.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
If customer is using basic auth and they provide the password and the password contains a double quote the master won't start up.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I repeated this issue with

$ gcloud container clusters create --num-nodes=1 --machine-type=g1-small --async --password=tamasr123\"@testing --username=tamasr tamasr-test-1

which results in error

$ gcloud container clusters list 
NAME           LOCATION       MASTER_VERSION  MASTER_IP     MACHINE_TYPE  NODE_VERSION   NUM_NODES  STATUS
tamasr-test-1  us-central1-c  1.11.7-gke.12   34.66.20.164  g1-small      1.11.7-gke.12  1          ERROR

I applied the change in this PR directly on the failed master and rerun configure-helper.sh. This time the script succeeded in writing the password. I verified this with

$ gcloud container clusters describe tamasr-test-1
addonsConfig:
  kubernetesDashboard:
    disabled: true
...
masterAuth:
  clientCertificate: ...
  password: tamasr123"@testing
  username: tamasr  

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes bug that prevents startup of the master, when customer is using basic auth and provides their own password and the password contains a double quote.
```
