### PR TITLE
Fix concurrent map write access in Portworx create volume call

### DIFF
--- a/pkg/volume/portworx/portworx_util.go
+++ b/pkg/volume/portworx/portworx_util.go
@@ -72,10 +72,12 @@ func (util *portworxVolumeUtil) CreateVolume(p *portworxVolumeProvisioner) (stri
 	}
 
 	// Pass all parameters as volume labels for Portworx server-side processing
-	if len(p.options.Parameters) > 0 {
-		spec.VolumeLabels = p.options.Parameters
-	} else {
+	if spec.VolumeLabels == nil {
 		spec.VolumeLabels = make(map[string]string, 0)
+	}
+
+	for k, v := range p.options.Parameters {
+		spec.VolumeLabels[k] = v
 	}
 
 	// Update the requested size in the spec


### PR DESCRIPTION
Fixes #76340

Signed-off-by: Harsh Desai <harsh@portworx.com>


**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**: 

Fixes a crash in controller manager due to concurrent map access in the Portworx volume driver create call

**Which issue(s) this PR fixes**:
Fixes #76340

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: NONE

```release-note
Fix issue in Portworx volume driver causing controller manager to crash
```
