### PR TITLE
kubelet: dockershim: fix image removal/untagging and add logging

### DIFF
--- a/pkg/kubelet/dockershim/docker_image_test.go
+++ b/pkg/kubelet/dockershim/docker_image_test.go
@@ -39,7 +39,6 @@ func TestRemoveImage(t *testing.T) {
 			[]libdocker.CalledDetail{
 				libdocker.NewCalledDetail("inspect_image", nil),
 				libdocker.NewCalledDetail("remove_image", []interface{}{"foo", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
-				libdocker.NewCalledDetail("remove_image", []interface{}{"1111", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
 			},
 		},
 		"multiple tags": {
@@ -48,7 +47,6 @@ func TestRemoveImage(t *testing.T) {
 				libdocker.NewCalledDetail("inspect_image", nil),
 				libdocker.NewCalledDetail("remove_image", []interface{}{"foo", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
 				libdocker.NewCalledDetail("remove_image", []interface{}{"bar", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
-				libdocker.NewCalledDetail("remove_image", []interface{}{"2222", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
 			},
 		},
 		"single tag multiple repo digests": {
@@ -58,7 +56,6 @@ func TestRemoveImage(t *testing.T) {
 				libdocker.NewCalledDetail("remove_image", []interface{}{"foo", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
 				libdocker.NewCalledDetail("remove_image", []interface{}{"foo@3333", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
 				libdocker.NewCalledDetail("remove_image", []interface{}{"example.com/foo@3333", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
-				libdocker.NewCalledDetail("remove_image", []interface{}{"3333", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
 			},
 		},
 		"no tags multiple repo digests": {
@@ -67,7 +64,13 @@ func TestRemoveImage(t *testing.T) {
 				libdocker.NewCalledDetail("inspect_image", nil),
 				libdocker.NewCalledDetail("remove_image", []interface{}{"foo@4444", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
 				libdocker.NewCalledDetail("remove_image", []interface{}{"example.com/foo@4444", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
-				libdocker.NewCalledDetail("remove_image", []interface{}{"4444", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
+			},
+		},
+		"no tags or digests": {
+			dockertypes.ImageInspect{ID: "5555"},
+			[]libdocker.CalledDetail{
+				libdocker.NewCalledDetail("inspect_image", nil),
+				libdocker.NewCalledDetail("remove_image", []interface{}{"5555", dockertypes.ImageRemoveOptions{PruneChildren: true}}),
 			},
 		},
 	}


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/70647 fixed an image GC issue where images could not be removed if tags/digests from more than one repo referenced the same image.

However, this late review comment is valid https://github.com/kubernetes/kubernetes/pull/70647/files#r261004631. If the image is removed by untagging references, the removal of the image at the end is not needed because the removal of the last reference will cause it to be deleted.  This causes an error to propogate up when the image removal was actually successful.

This PR only does the direct removal of the image if there are no references to it.  Otherwise, removing all the references removes the image as well.  I also add logging so that people wondering why their references are being blown away have some idea what happened.  `V(5)` is consistent with the level of other debug messages in the image GC code.

@dashpole @smarterclayton @derekwaynecarr @stevekuznetsov @rphillips @RobertKrawitz @bparees @corvus-ch 