### PR TITLE
Promote 'watch-consistency' e2e test to be a conformance test

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -13,6 +13,7 @@ test/e2e/apimachinery/watch.go: "should observe add, update, and delete watch no
 test/e2e/apimachinery/watch.go: "should be able to start watching from a specific resource version"
 test/e2e/apimachinery/watch.go: "should be able to restart watching from the last resource version observed by the previous watch"
 test/e2e/apimachinery/watch.go: "should observe an object deletion if it stops meeting the requirements of the selector"
+test/e2e/apimachinery/watch.go: "should receive events on concurrent watches in same order"
 test/e2e/apps/daemon_set.go: "should run and stop simple daemon"
 test/e2e/apps/daemon_set.go: "should run and stop complex daemon"
 test/e2e/apps/daemon_set.go: "should retry creating failed daemon pods"

--- a/test/e2e/apimachinery/watch.go
+++ b/test/e2e/apimachinery/watch.go
@@ -321,11 +321,12 @@ var _ = SIGDescribe("Watchers", func() {
 
 	/*
 	   Testname: watch-consistency
+	   Release : v1.15
 	   Description: Ensure that concurrent watches are consistent with each other by initiating an additional watch
 	   for events received from the first watch, initiated at the resource version of the event, and checking that all
 	   resource versions of all events match. Events are produced from writes on a background goroutine.
 	*/
-	It("should receive events on concurrent watches in same order", func() {
+	framework.ConformanceIt("should receive events on concurrent watches in same order", func() {
 		c := f.ClientSet
 		ns := f.Namespace.Name
 


### PR DESCRIPTION
We had originally intended for this test to be part of conformance but wanted to give it some bake time. It's now been running fine since Oct. 2018 so let's make it part of the conformance suite.

Fixes https://github.com/kubernetes/kubernetes/issues/67717

/kind cleanup
/priority important-longterm
/sig api-machinery

```release-note
NONE
```
