### PR TITLE
[reapply] Perform GCE log rotation check every 5 minutes

### DIFF
--- a/cluster/gce/gci/master.yaml
+++ b/cluster/gce/gci/master.yaml
@@ -83,10 +83,10 @@ write_files:
     owner: root
     content: |
       [Unit]
-      Description=Hourly kube-logrotate invocation
+      Description=kube-logrotate invocation
 
       [Timer]
-      OnCalendar=hourly
+      OnCalendar=*-*-* *:00/5:00
 
       [Install]
       WantedBy=kubernetes.target


### PR DESCRIPTION
Per https://github.com/kubernetes/klog/issues/55#issuecomment-481465253, reapply #72062 which was rolled back just before 1.14 was released due to the advanced audit test which has since been marked as flaky and is no longer blocking this change.

**What this PR does / why we need it**:

```release-note
Reduce GCE log rotation check from 1 hour to every 5 minutes.  Rotation policy is unchanged (new day starts, log file size > 100MB).
```

/priority important-longterm
/area platform/gce
/kind cleanup
/sig gcp

cc @yuwenma @timstclair @wojtek-t @dims 