### PR TITLE
Follow-up of #71136: Switch system priority class usage to versioned (v1) api

### DIFF
--- a/pkg/apis/scheduling/BUILD
+++ b/pkg/apis/scheduling/BUILD
@@ -1,16 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_library",
-    "go_test",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
-        "helpers.go",
         "register.go",
         "types.go",
         "zz_generated.deepcopy.go",
@@ -44,11 +39,4 @@ filegroup(
         "//pkg/apis/scheduling/validation:all-srcs",
     ],
     tags = ["automanaged"],
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["helpers_test.go"],
-    embed = [":go_default_library"],
-    deps = ["//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library"],
 )

--- a/pkg/apis/scheduling/v1/BUILD
+++ b/pkg/apis/scheduling/v1/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "defaults.go",
         "doc.go",
+        "helpers.go",
         "register.go",
         "zz_generated.conversion.go",
         "zz_generated.defaults.go",
@@ -17,6 +18,7 @@ go_library(
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/scheduling/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
@@ -40,14 +42,19 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["defaults_test.go"],
+    srcs = [
+        "defaults_test.go",
+        "helpers_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/api/testapi:go_default_library",
+        "//pkg/apis/scheduling:go_default_library",
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/scheduling/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",

--- a/pkg/apis/scheduling/v1/helpers_test.go
+++ b/pkg/apis/scheduling/v1/helpers_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,18 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scheduling
+package v1
 
 import (
 	"testing"
 
+	v1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/scheduling"
 )
 
 func TestIsKnownSystemPriorityClass(t *testing.T) {
 	tests := []struct {
 		name     string
-		pc       *PriorityClass
+		pc       *v1.PriorityClass
 		expected bool
 	}{
 		{
@@ -35,11 +37,11 @@ func TestIsKnownSystemPriorityClass(t *testing.T) {
 		},
 		{
 			name: "non-system priority class",
-			pc: &PriorityClass{
+			pc: &v1.PriorityClass{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: SystemNodeCritical,
+					Name: scheduling.SystemNodeCritical,
 				},
-				Value:       SystemCriticalPriority, // This is the value of system cluster critical
+				Value:       scheduling.SystemCriticalPriority, // This is the value of system cluster critical
 				Description: "Used for system critical pods that must not be moved from their current node.",
 			},
 			expected: false,
@@ -47,7 +49,7 @@ func TestIsKnownSystemPriorityClass(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if is, err := IsKnownSystemPriorityClass(test.pc); test.expected != is {
+		if is, err := IsKnownSystemPriorityClass(test.pc.Name, test.pc.Value, test.pc.GlobalDefault); test.expected != is {
 			t.Errorf("Test [%v]: Expected %v, but got %v. Error: %v", test.name, test.expected, is, err)
 		}
 	}

--- a/pkg/apis/scheduling/validation/BUILD
+++ b/pkg/apis/scheduling/validation/BUILD
@@ -12,6 +12,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/scheduling:go_default_library",
+        "//pkg/apis/scheduling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
@@ -24,6 +25,7 @@ go_library(
     deps = [
         "//pkg/apis/core/validation:go_default_library",
         "//pkg/apis/scheduling:go_default_library",
+        "//pkg/apis/scheduling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],

--- a/pkg/apis/scheduling/validation/validation.go
+++ b/pkg/apis/scheduling/validation/validation.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
+	schedulingapiv1 "k8s.io/kubernetes/pkg/apis/scheduling/v1"
 )
 
 // ValidatePriorityClass tests whether required fields in the PriorityClass are
@@ -34,7 +35,7 @@ func ValidatePriorityClass(pc *scheduling.PriorityClass) field.ErrorList {
 	// If the priorityClass starts with a system prefix, it must be one of the
 	// predefined system priority classes.
 	if strings.HasPrefix(pc.Name, scheduling.SystemPriorityClassPrefix) {
-		if is, err := scheduling.IsKnownSystemPriorityClass(pc); !is {
+		if is, err := schedulingapiv1.IsKnownSystemPriorityClass(pc.Name, pc.Value, pc.GlobalDefault); !is {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("metadata", "name"), "priority class names with '"+scheduling.SystemPriorityClassPrefix+"' prefix are reserved for system use only. error: "+err.Error()))
 		}
 	} else if pc.Value > scheduling.HighestUserDefinablePriority {

--- a/pkg/apis/scheduling/validation/validation_test.go
+++ b/pkg/apis/scheduling/validation/validation_test.go
@@ -22,10 +22,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
+	schedulingapiv1 "k8s.io/kubernetes/pkg/apis/scheduling/v1"
 )
 
 func TestValidatePriorityClass(t *testing.T) {
-	spcs := scheduling.SystemPriorityClasses()
+	spcs := schedulingapiv1.SystemPriorityClasses()
 	successCases := map[string]scheduling.PriorityClass{
 		"no description": {
 			ObjectMeta: metav1.ObjectMeta{Name: "tier1", Namespace: ""},

--- a/pkg/registry/scheduling/priorityclass/storage/BUILD
+++ b/pkg/registry/scheduling/priorityclass/storage/BUILD
@@ -12,6 +12,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/scheduling:go_default_library",
+        "//pkg/apis/scheduling/v1:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
@@ -31,6 +32,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/registry/scheduling/priorityclass/storage",
     deps = [
         "//pkg/apis/scheduling:go_default_library",
+        "//pkg/apis/scheduling/v1:go_default_library",
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",

--- a/pkg/registry/scheduling/priorityclass/storage/storage.go
+++ b/pkg/registry/scheduling/priorityclass/storage/storage.go
@@ -26,6 +26,7 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
+	schedulingapiv1 "k8s.io/kubernetes/pkg/apis/scheduling/v1"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
@@ -68,7 +69,7 @@ func (r *REST) ShortNames() []string {
 
 // Delete ensures that system priority classes are not deleted.
 func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	for _, spc := range scheduling.SystemPriorityClasses() {
+	for _, spc := range schedulingapiv1.SystemPriorityClasses() {
 		if name == spc.Name {
 			return nil, false, apierrors.NewForbidden(scheduling.Resource("priorityclasses"), spc.Name, errors.New("this is a system priority class and cannot be deleted"))
 		}

--- a/pkg/registry/scheduling/priorityclass/storage/storage_test.go
+++ b/pkg/registry/scheduling/priorityclass/storage/storage_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
+	schedulingapiv1 "k8s.io/kubernetes/pkg/apis/scheduling/v1"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
 
@@ -118,8 +119,12 @@ func TestDeleteSystemPriorityClass(t *testing.T) {
 	defer storage.Store.DestroyFunc()
 	key := "test/system-node-critical"
 	ctx := genericapirequest.NewContext()
-	pc := scheduling.SystemPriorityClasses()[0]
-	if err := storage.Store.Storage.Create(ctx, key, pc, nil, 0, false); err != nil {
+	pc := schedulingapiv1.SystemPriorityClasses()[0]
+	internalPc := &scheduling.PriorityClass{}
+	if err := schedulingapiv1.Convert_v1_PriorityClass_To_scheduling_PriorityClass(pc, internalPc, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.Store.Storage.Create(ctx, key, internalPc, nil, 0, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, _, err := storage.Delete(ctx, pc.Name, rest.ValidateAllObjectFunc, nil); err == nil {

--- a/pkg/registry/scheduling/rest/BUILD
+++ b/pkg/registry/scheduling/rest/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//pkg/apis/scheduling/v1alpha1:go_default_library",
         "//pkg/apis/scheduling/v1beta1:go_default_library",
         "//pkg/registry/scheduling/priorityclass/storage:go_default_library",
-        "//staging/src/k8s.io/api/scheduling/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
@@ -25,7 +24,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/storage:go_default_library",
-        "//staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/plugin/pkg/admission/priority/BUILD
+++ b/plugin/pkg/admission/priority/BUILD
@@ -35,6 +35,7 @@ go_library(
     deps = [
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/scheduling:go_default_library",
+        "//pkg/apis/scheduling/v1:go_default_library",
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/scheduling/v1:go_default_library",

--- a/plugin/pkg/admission/priority/admission.go
+++ b/plugin/pkg/admission/priority/admission.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
+	schedulingapiv1 "k8s.io/kubernetes/pkg/apis/scheduling/v1"
 	"k8s.io/kubernetes/pkg/features"
 )
 
@@ -144,7 +145,7 @@ func priorityClassPermittedInNamespace(priorityClassName string, namespace strin
 	// Only allow system priorities in the system namespace. This is to prevent abuse or incorrect
 	// usage of these priorities. Pods created at these priorities could preempt system critical
 	// components.
-	for _, spc := range scheduling.SystemPriorityClasses() {
+	for _, spc := range schedulingapiv1.SystemPriorityClasses() {
 		if spc.Name == priorityClassName && namespace != metav1.NamespaceSystem {
 			return false
 		}


### PR DESCRIPTION
/kind cleanup
/cc @liggitt

Fixes https://github.com/kubernetes/kubernetes/issues/84246

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
