### PR TITLE
Follow-up of #71136: Clean up unused vars in codegen scripts

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -40,7 +40,6 @@ informergen=$(kube::util::find-binary "informer-gen")
 
 GROUP_VERSIONS=(${KUBE_AVAILABLE_GROUP_VERSIONS})
 GV_DIRS=()
-INTERNAL_DIRS=()
 for gv in "${GROUP_VERSIONS[@]}"; do
   # add items, but strip off any leading apis/ you find to match command expectations
   api_dir=$(kube::util::group-version-to-pkg-path "${gv}")
@@ -55,19 +54,9 @@ for gv in "${GROUP_VERSIONS[@]}"; do
     fi
 
   GV_DIRS+=("${pkg_dir}")
-
-  # collect internal groups
-  int_group="${pkg_dir%/*}/"
-  if [[ "${pkg_dir}" = core/* ]]; then
-    int_group="api/"
-  fi
-    if ! [[ " ${INTERNAL_DIRS[@]:-} " =~ " ${int_group} " ]]; then
-      INTERNAL_DIRS+=("${int_group}")
-    fi
 done
 # delimit by commas for the command
 GV_DIRS_CSV=$(IFS=',';echo "${GV_DIRS[*]// /,}";IFS=$)
-INTERNAL_DIRS_CSV=$(IFS=',';echo "${INTERNAL_DIRS[*]// /,}";IFS=$)
 
 # This can be called with one flag, --verify-only, so it works for both the
 # update- and verify- scripts.


### PR DESCRIPTION
/kind cleanup
/cc @liggitt

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
