### PR TITLE
Remove duplicate victim pods from scheduler extender

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -338,7 +338,7 @@ func (g *genericScheduler) Preempt(pod *v1.Pod, nodeLister algorithm.NodeLister,
 	// lets scheduler find another place for them.
 	nominatedPods := g.getLowerPriorityNominatedPods(pod, candidateNode.Name)
 	if nodeInfo, ok := g.nodeInfoSnapshot.NodeInfoMap[candidateNode.Name]; ok {
-		return nodeInfo.Node(), nodeToVictims[candidateNode].Pods, nominatedPods, nil
+		return nodeInfo.Node(), util.DeduplicatePods(nodeToVictims[candidateNode].Pods), nominatedPods, nil
 	}
 
 	return nil, nil, nil, fmt.Errorf(

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -106,6 +106,20 @@ func GetEarliestPodStartTime(victims *api.Victims) *metav1.Time {
 	return earliestPodStartTime
 }
 
+// DeduplicatePods removes the duplicate pods given an array of pods.
+func DeduplicatePods(pods []*v1.Pod) []*v1.Pod {
+	podMap := make(map[*v1.Pod]bool)
+	for _, pod := range pods {
+		podMap[pod] = true
+	}
+
+	returnedPods := make([]*v1.Pod, len(podMap))
+	for pod := range podMap {
+		returnedPods = append(returnedPods, pod)
+	}
+	return returnedPods
+}
+
 // SortableList is a list that implements sort.Interface.
 type SortableList struct {
 	Items    []interface{}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Removes duplicate victim pods from scheduler extender. 
Scheduler extenders can introduce duplicate victims, which causes delete API to be called twice.
Take the test for instance, https://github.com/kubernetes/kubernetes/blob/release-1.14/pkg/scheduler/core/extender_test.go#L166
```
                         //Append new victims to original victims
			nodeToVictimsCopy[node].Pods = append(victims.Pods, extenderVictimPods...)
```
and then in https://github.com/kubernetes/kubernetes/blob/release-1.14/pkg/scheduler/scheduler.go#L318
the below for loop can invoke DeletePod(victim) for a pod more than once.
```
		for _, victim := range victims {
			if err := sched.config.PodPreemptor.DeletePod(victim); err != nil {
				klog.Errorf("Error preempting pod %v/%v: %v", victim.Namespace, victim.Name, err)
				return "", err
			}
			sched.config.Recorder.Eventf(victim, v1.EventTypeNormal, "Preempted", "by %v/%v on node %v", preemptor.Namespace, preemptor.Name, nodeName)
		}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
