### PR TITLE
Misc fix for scheduler test cases

### DIFF
--- a/pkg/scheduler/algorithm/priorities/least_requested_test.go
+++ b/pkg/scheduler/algorithm/priorities/least_requested_test.go
@@ -145,7 +145,7 @@ func TestLeastRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: schedulerapi.MaxPriority}},
-			name:         "no resources requested, pods scheduled",
+			name:         "no resources requested, pods scheduled without resources",
 			pods: []*v1.Pod{
 				{Spec: machine1Spec, ObjectMeta: metav1.ObjectMeta{Labels: labels2}},
 				{Spec: machine1Spec, ObjectMeta: metav1.ObjectMeta{Labels: labels1}},
@@ -240,6 +240,17 @@ func TestLeastRequested(t *testing.T) {
 			},
 		},
 		{
+			/*
+				Node1 scores on 0-10 scale
+				CPU Score: 0
+				Memory Score: 0
+				Node1 Score: 0
+
+				Node2 scores on 0-10 scale
+				CPU Score: 0
+				Memory Score: 0
+				Node2 Score: 0
+			*/
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 0, 0), makeNode("machine2", 0, 0)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}},

--- a/pkg/scheduler/algorithm/priorities/most_requested_test.go
+++ b/pkg/scheduler/algorithm/priorities/most_requested_test.go
@@ -114,13 +114,13 @@ func TestMostRequested(t *testing.T) {
 		{
 			/*
 				Node1 scores (used resources) on 0-10 scale
-				CPU Score: (0 * 10  / 4000 = 0
+				CPU Score: (0 * 10) / 4000 = 0
 				Memory Score: (0 * 10) / 10000 = 0
 				Node1 Score: (0 + 0) / 2 = 0
 
 				Node2 scores (used resources) on 0-10 scale
-				CPU Score: (0 * 10 / 4000 = 0
-				Memory Score: (0 * 10 / 10000 = 0
+				CPU Score: (0 * 10) / 4000 = 0
+				Memory Score: (0 * 10) / 10000 = 0
 				Node2 Score: (0 + 0) / 2 = 0
 			*/
 			pod:          &v1.Pod{Spec: noResources},
@@ -131,12 +131,12 @@ func TestMostRequested(t *testing.T) {
 		{
 			/*
 				Node1 scores on 0-10 scale
-				CPU Score: (3000 * 10 / 4000 = 7.5
+				CPU Score: (3000 * 10) / 4000 = 7.5 -> 7
 				Memory Score: (5000 * 10) / 10000 = 5
-				Node1 Score: (7.5 + 5) / 2 = 6
+				Node1 Score: (7 + 5) / 2 = 6
 
 				Node2 scores on 0-10 scale
-				CPU Score: (3000 * 10 / 6000 = 5
+				CPU Score: (3000 * 10) / 6000 = 5
 				Memory Score: (5000 * 10 / 10000 = 5
 				Node2 Score: (5 + 5) / 2 = 5
 			*/
@@ -149,13 +149,13 @@ func TestMostRequested(t *testing.T) {
 			/*
 				Node1 scores on 0-10 scale
 				CPU Score: (6000 * 10) / 10000 = 6
-				Memory Score: (0 * 10) / 20000 = 10
+				Memory Score: (0 * 10) / 20000 = 0
 				Node1 Score: (6 + 0) / 2 = 3
 
 				Node2 scores on 0-10 scale
 				CPU Score: (6000 * 10) / 10000 = 6
-				Memory Score: (5000 * 10) / 20000 = 2.5
-				Node2 Score: (6 + 2.5) / 2 = 4
+				Memory Score: (5000 * 10) / 20000 = 2.5 -> 2
+				Node2 Score: (6 + 2) / 2 = 4
 			*/
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
@@ -172,8 +172,8 @@ func TestMostRequested(t *testing.T) {
 			/*
 				Node1 scores on 0-10 scale
 				CPU Score: (6000 * 10) / 10000 = 6
-				Memory Score: (5000 * 10) / 20000 = 2.5
-				Node1 Score: (6 + 2.5) / 2 = 4
+				Memory Score: (5000 * 10) / 20000 = 2.5 -> 2
+				Node1 Score: (6 + 2) / 2 = 4
 
 				Node2 scores on 0-10 scale
 				CPU Score: (6000 * 10) / 10000 = 6
@@ -204,7 +204,7 @@ func TestMostRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: bigCPUAndMemory},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 10000, 8000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 4}, {Host: "machine2", Score: 2}},
-			name:         "resources requested with more than the node, pods scheduled with resources",
+			name:         "resources requested more than the node, nothing scheduled",
 		},
 	}
 

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -153,7 +153,7 @@ func (f *FakeExtender) ProcessPreemption(
 
 	for node, victims := range nodeToVictimsCopy {
 		// Try to do preemption on extender side.
-		extenderVictimPods, extendernPDBViolations, fits, err := f.selectVictimsOnNodeByExtender(pod, node, nodeNameToInfo)
+		extenderVictimPods, extenderPDBViolations, fits, err := f.selectVictimsOnNodeByExtender(pod, node, nodeNameToInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -164,13 +164,13 @@ func (f *FakeExtender) ProcessPreemption(
 		} else {
 			// Append new victims to original victims
 			nodeToVictimsCopy[node].Pods = append(victims.Pods, extenderVictimPods...)
-			nodeToVictimsCopy[node].NumPDBViolations = victims.NumPDBViolations + extendernPDBViolations
+			nodeToVictimsCopy[node].NumPDBViolations = victims.NumPDBViolations + extenderPDBViolations
 		}
 	}
 	return nodeToVictimsCopy, nil
 }
 
-// selectVictimsOnNodeByExtender checks the given nodes->pods map with predicates on extender's side.
+// selectVictimsOnNodeByExtender checks the given node->pods map with predicates on extender's side.
 // Returns:
 // 1. More victim pods (if any) amended by preemption phase of extender.
 // 2. Number of violating victim (used to calculate PDB).
@@ -214,7 +214,6 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(
 			removePod(p)
 		}
 	}
-	potentialVictims.Sort()
 
 	// If the new pod does not fit after removing all the lower priority pods,
 	// we are almost done and this node is not suitable for preemption.
@@ -225,6 +224,8 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(
 	if !fits {
 		return nil, 0, false, nil
 	}
+
+	potentialVictims.Sort()
 
 	var victims []*v1.Pod
 


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
* 1. Fix incorrect test name in `most_requested_test.go`, it should be `resources requested more than the node, nothing scheduled` instead of `resources requested with more than the node, pods scheduled with resources`.
* 2. Fix typos in  `most_requested_test.go` and `least_requested_test.go`
* 3. In `extender_test.go`, move `potentialVictims.Sort()` after `fits, err := f.runPredicate(pod, nodeInfoCopy.Node())` for the scheduler extender example.
* 4. Fix typos in `extender_test.go`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
