### PR TITLE
kubeadm: use correct expected key when checking test results

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -364,7 +364,7 @@ func TestWriteKeyFilesIfNotExist(t *testing.T) {
 		}
 
 		//TODO: check if there is a better method to compare keys
-		if resultingKey.D == key.D {
+		if resultingKey.D == test.expectedKey.D {
 			t.Error("created key does not match expected key")
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Resulting key needs to be compared with the expected key which
was set for the test case, not just a key.

**Special notes for your reviewer**:
I'm going to rework a bit the key comparison in the scope of https://github.com/kubernetes/kubeadm/issues/984. Apparently comparing keys' primes is not the best way to compare keys.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
