### PR TITLE
[WIP] Use atomic to replace lock

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -488,9 +488,7 @@ func (g *genericScheduler) findNodesThatFit(pod *v1.Pod, nodes []*v1.Node) ([]*v
 				g.alwaysCheckAllPredicates,
 			)
 			if err != nil {
-				predicateResultLock.Lock()
-				errs[err.Error()]++
-				predicateResultLock.Unlock()
+				atomic.AddInt32(errs[err.Error()], 1)
 				return
 			}
 			if fits {

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -488,6 +488,14 @@ func (g *genericScheduler) findNodesThatFit(pod *v1.Pod, nodes []*v1.Node) ([]*v
 				g.alwaysCheckAllPredicates,
 			)
 			if err != nil {
+				if _, ok := errs[err.Error()]; !ok {
+					predicateResultLock.Lock()
+					// double check
+					if _, ok := errs[err.Error()]; !ok {
+						errs[err.Error()] = new(int32)
+					}
+					predicateResultLock.Unlock()
+				}
 				atomic.AddInt32(errs[err.Error()], 1)
 				return
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/util/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/errors/errors.go
@@ -24,7 +24,7 @@ import (
 )
 
 // MessageCountMap contains occurrence for each error message.
-type MessageCountMap map[string]int
+type MessageCountMap map[string]*int32
 
 // Aggregate represents an object that contains multiple errors, but does not
 // necessarily have singular semantic meaning.
@@ -186,8 +186,8 @@ func CreateAggregateFromMessageCountMap(m MessageCountMap) Aggregate {
 	result := make([]error, 0, len(m))
 	for errStr, count := range m {
 		var countStr string
-		if count > 1 {
-			countStr = fmt.Sprintf(" (repeated %v times)", count)
+		if *count > int32(1) {
+			countStr = fmt.Sprintf(" (repeated %v times)", *count)
 		}
 		result = append(result, fmt.Errorf("%v%v", errStr, countStr))
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/errors/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/errors/errors_test.go
@@ -328,6 +328,8 @@ func TestFlatten(t *testing.T) {
 }
 
 func TestCreateAggregateFromMessageCountMap(t *testing.T) {
+	var errCount1 int32 =1
+	var errCount2 int32 =2
 	testCases := []struct {
 		name     string
 		mcm      MessageCountMap
@@ -335,17 +337,17 @@ func TestCreateAggregateFromMessageCountMap(t *testing.T) {
 	}{
 		{
 			"input has single instance of one message",
-			MessageCountMap{"abc": 1},
+			MessageCountMap{"abc": &errCount1},
 			aggregate{fmt.Errorf("abc")},
 		},
 		{
 			"input has multiple messages",
-			MessageCountMap{"abc": 2, "ghi": 1},
+			MessageCountMap{"abc": &errCount2, "ghi": &errCount1},
 			aggregate{fmt.Errorf("abc (repeated 2 times)"), fmt.Errorf("ghi")},
 		},
 		{
 			"input has multiple messages",
-			MessageCountMap{"ghi": 1, "abc": 2},
+			MessageCountMap{"ghi": &errCount1, "abc": &errCount2},
 			aggregate{fmt.Errorf("abc (repeated 2 times)"), fmt.Errorf("ghi")},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind design
/sig scheduling

**What this PR does / why we need it**:

Use atomic to replace lock, can improve the performance, as https://github.com/kubernetes/kubernetes/pull/76243 mentioned

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

/assign @bsalamat
/assign @Huang-Wei 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
