### PR TITLE
crd-openapi-publishing: in e2e query apiserver instances for HA

### DIFF
--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -71,6 +71,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//staging/src/k8s.io/client-go/util/keyutil:go_default_library",
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",


### PR DESCRIPTION
In HA setups we don't know when all instances have seen a CRD change and have updated their OpenAPI spec. This PR probabilistically queries /openapi/v2 ten times (with etag support) and only proceeds if all 10 requests have the expected change. This is the best we can do without a coordination mechanism. It will reduce flakes.