### PR TITLE
kubeadm: add support for ECDSA keys

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/certs_test.go
+++ b/cmd/kubeadm/app/cmd/alpha/certs_test.go
@@ -209,11 +209,13 @@ func TestRunRenewCommands(t *testing.T) {
 					t.Errorf("couldn't verify renewed cert: %v", err)
 				}
 
-				pubKey, ok := newCert.PublicKey.(*rsa.PublicKey)
-				if !ok {
+				switch pubKey := newCert.PublicKey.(type) {
+				case *rsa.PublicKey:
+					if pubKey.N.Cmp(newKey.(*rsa.PrivateKey).N) != 0 {
+						t.Error("private key does not match public key")
+					}
+				default:
 					t.Errorf("unknown public key type %T", newCert.PublicKey)
-				} else if pubKey.N.Cmp(newKey.N) != 0 {
-					t.Error("private key does not match public key")
 				}
 			}
 

--- a/cmd/kubeadm/app/phases/certs/BUILD
+++ b/cmd/kubeadm/app/phases/certs/BUILD
@@ -20,6 +20,7 @@ go_test(
         "//cmd/kubeadm/app/util/pkiutil:go_default_library",
         "//cmd/kubeadm/test:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
+        "//staging/src/k8s.io/client-go/util/keyutil:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],

--- a/cmd/kubeadm/app/phases/certs/certlist.go
+++ b/cmd/kubeadm/app/phases/certs/certlist.go
@@ -17,7 +17,7 @@ limitations under the License.
 package certs
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 
 	"github.com/pkg/errors"
@@ -54,7 +54,7 @@ func (k *KubeadmCert) GetConfig(ic *kubeadmapi.InitConfiguration) (*certutil.Con
 }
 
 // CreateFromCA makes and writes a certificate using the given CA cert and key.
-func (k *KubeadmCert) CreateFromCA(ic *kubeadmapi.InitConfiguration, caCert *x509.Certificate, caKey *rsa.PrivateKey) error {
+func (k *KubeadmCert) CreateFromCA(ic *kubeadmapi.InitConfiguration, caCert *x509.Certificate, caKey crypto.Signer) error {
 	cfg, err := k.GetConfig(ic)
 	if err != nil {
 		return errors.Wrapf(err, "couldn't create %q certificate", k.Name)
@@ -80,7 +80,7 @@ func (k *KubeadmCert) CreateFromCA(ic *kubeadmapi.InitConfiguration, caCert *x50
 }
 
 // CreateAsCA creates a certificate authority, writing the files to disk and also returning the created CA so it can be used to sign child certs.
-func (k *KubeadmCert) CreateAsCA(ic *kubeadmapi.InitConfiguration) (*x509.Certificate, *rsa.PrivateKey, error) {
+func (k *KubeadmCert) CreateAsCA(ic *kubeadmapi.InitConfiguration) (*x509.Certificate, crypto.Signer, error) {
 	cfg, err := k.GetConfig(ic)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "couldn't get configuration for %q CA certificate", k.Name)
@@ -114,7 +114,7 @@ func (t CertificateTree) CreateTree(ic *kubeadmapi.InitConfiguration) error {
 			return err
 		}
 
-		var caKey *rsa.PrivateKey
+		var caKey crypto.Signer
 
 		caCert, err := pkiutil.TryLoadCertFromDisk(ic.CertificatesDir, ca.BaseName)
 		if err == nil {

--- a/cmd/kubeadm/app/phases/certs/renewal/certsapi.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/certsapi.go
@@ -17,7 +17,7 @@ limitations under the License.
 package renewal
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
@@ -51,7 +51,7 @@ func NewCertsAPIRenawal(client kubernetes.Interface) Interface {
 }
 
 // Renew takes a certificate using the cert and key.
-func (r *CertsAPIRenewal) Renew(cfg *certutil.Config) (*x509.Certificate, *rsa.PrivateKey, error) {
+func (r *CertsAPIRenewal) Renew(cfg *certutil.Config) (*x509.Certificate, crypto.Signer, error) {
 	reqTmp := &x509.CertificateRequest{
 		Subject: pkix.Name{
 			CommonName:   cfg.CommonName,

--- a/cmd/kubeadm/app/phases/certs/renewal/filerenewal.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/filerenewal.go
@@ -17,7 +17,7 @@ limitations under the License.
 package renewal
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 
 	certutil "k8s.io/client-go/util/cert"
@@ -27,11 +27,11 @@ import (
 // FileRenewal renews a certificate using local certs
 type FileRenewal struct {
 	caCert *x509.Certificate
-	caKey  *rsa.PrivateKey
+	caKey  crypto.Signer
 }
 
 // NewFileRenewal takes a certificate pair to construct the Interface.
-func NewFileRenewal(caCert *x509.Certificate, caKey *rsa.PrivateKey) Interface {
+func NewFileRenewal(caCert *x509.Certificate, caKey crypto.Signer) Interface {
 	return &FileRenewal{
 		caCert: caCert,
 		caKey:  caKey,
@@ -39,6 +39,6 @@ func NewFileRenewal(caCert *x509.Certificate, caKey *rsa.PrivateKey) Interface {
 }
 
 // Renew takes a certificate using the cert and key
-func (r *FileRenewal) Renew(cfg *certutil.Config) (*x509.Certificate, *rsa.PrivateKey, error) {
+func (r *FileRenewal) Renew(cfg *certutil.Config) (*x509.Certificate, crypto.Signer, error) {
 	return pkiutil.NewCertAndKey(r.caCert, r.caKey, cfg)
 }

--- a/cmd/kubeadm/app/phases/certs/renewal/interface.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/interface.go
@@ -17,7 +17,7 @@ limitations under the License.
 package renewal
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 
 	certutil "k8s.io/client-go/util/cert"
@@ -25,5 +25,5 @@ import (
 
 // Interface represents a standard way to renew a certificate.
 type Interface interface {
-	Renew(*certutil.Config) (*x509.Certificate, *rsa.PrivateKey, error)
+	Renew(*certutil.Config) (*x509.Certificate, crypto.Signer, error)
 }

--- a/cmd/kubeadm/app/phases/certs/renewal/renewal_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/renewal_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package renewal
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"net"
@@ -113,7 +113,7 @@ func defaultReactionFunc(obj runtime.Object) k8stesting.ReactionFunc {
 	}
 }
 
-func getCertReq(t *testing.T, caCert *x509.Certificate, caKey *rsa.PrivateKey) *certsapi.CertificateSigningRequest {
+func getCertReq(t *testing.T, caCert *x509.Certificate, caKey crypto.Signer) *certsapi.CertificateSigningRequest {
 	cert, _, err := pkiutil.NewCertAndKey(caCert, caKey, &certutil.Config{
 		CommonName: "testcert",
 		AltNames: certutil.AltNames{

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -18,7 +18,7 @@ package kubeconfig
 
 import (
 	"bytes"
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -41,7 +41,7 @@ import (
 
 // clientCertAuth struct holds info required to build a client certificate to provide authentication info in a kubeconfig object
 type clientCertAuth struct {
-	CAKey         *rsa.PrivateKey
+	CAKey         crypto.Signer
 	Organizations []string
 }
 

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -18,7 +18,7 @@ package kubeconfig
 
 import (
 	"bytes"
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -621,7 +621,7 @@ func TestValidateKubeconfigsForExternalCA(t *testing.T) {
 }
 
 // setupdKubeConfigWithClientAuth is a test utility function that wraps buildKubeConfigFromSpec for building a KubeConfig object With ClientAuth
-func setupdKubeConfigWithClientAuth(t *testing.T, caCert *x509.Certificate, caKey *rsa.PrivateKey, APIServer, clientName, clustername string, organizations ...string) *clientcmdapi.Config {
+func setupdKubeConfigWithClientAuth(t *testing.T, caCert *x509.Certificate, caKey crypto.Signer, APIServer, clientName, clustername string, organizations ...string) *clientcmdapi.Config {
 	spec := &kubeConfigSpec{
 		CACert:     caCert,
 		APIServer:  APIServer,

--- a/cmd/kubeadm/app/util/certs/util.go
+++ b/cmd/kubeadm/app/util/certs/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package certs
 
 import (
+	"crypto"
 	"crypto/rsa"
 	"crypto/x509"
 	"net"
@@ -30,7 +31,7 @@ import (
 
 // SetupCertificateAuthorithy is a utility function for kubeadm testing that creates a
 // CertificateAuthorithy cert/key pair
-func SetupCertificateAuthorithy(t *testing.T) (*x509.Certificate, *rsa.PrivateKey) {
+func SetupCertificateAuthorithy(t *testing.T) (*x509.Certificate, crypto.Signer) {
 	caCert, caKey, err := pkiutil.NewCertificateAuthority(&certutil.Config{CommonName: "kubernetes"})
 	if err != nil {
 		t.Fatalf("failure while generating CA certificate and key: %v", err)
@@ -130,7 +131,7 @@ func AssertCertificateHasIPAddresses(t *testing.T, cert *x509.Certificate, IPAdd
 }
 
 // CreateCACert creates a generic CA cert.
-func CreateCACert(t *testing.T) (*x509.Certificate, *rsa.PrivateKey) {
+func CreateCACert(t *testing.T) (*x509.Certificate, crypto.Signer) {
 	certCfg := &certutil.Config{CommonName: "kubernetes"}
 	cert, key, err := pkiutil.NewCertificateAuthority(certCfg)
 	if err != nil {
@@ -140,7 +141,7 @@ func CreateCACert(t *testing.T) (*x509.Certificate, *rsa.PrivateKey) {
 }
 
 // CreateTestCert makes a generic certificate with the given CA and alternative names.
-func CreateTestCert(t *testing.T, caCert *x509.Certificate, caKey *rsa.PrivateKey, altNames certutil.AltNames) (*x509.Certificate, *rsa.PrivateKey, *certutil.Config) {
+func CreateTestCert(t *testing.T, caCert *x509.Certificate, caKey crypto.Signer, altNames certutil.AltNames) (*x509.Certificate, crypto.Signer, *certutil.Config) {
 	config := &certutil.Config{
 		CommonName: "testCert",
 		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package pkiutil
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -49,27 +52,38 @@ func TestNewCertificateAuthority(t *testing.T) {
 
 func TestNewCertAndKey(t *testing.T) {
 	var tests = []struct {
-		name      string
-		caKeySize int
-		expected  bool
+		name       string
+		keyGenFunc func() (crypto.Signer, error)
+		expected   bool
 	}{
 		{
-			name:      "RSA key too small",
-			caKeySize: 128,
-			expected:  false,
+			name: "RSA key too small",
+			keyGenFunc: func() (crypto.Signer, error) {
+				return rsa.GenerateKey(rand.Reader, 128)
+			},
+			expected: false,
 		},
 		{
-			name:      "Should succeed",
-			caKeySize: 2048,
-			expected:  true,
+			name: "RSA should succeed",
+			keyGenFunc: func() (crypto.Signer, error) {
+				return rsa.GenerateKey(rand.Reader, 2048)
+			},
+			expected: true,
+		},
+		{
+			name: "ECDSA should succeed",
+			keyGenFunc: func() (crypto.Signer, error) {
+				return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			},
+			expected: true,
 		},
 	}
 
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			caKey, err := rsa.GenerateKey(rand.Reader, rt.caKeySize)
+			caKey, err := rt.keyGenFunc()
 			if err != nil {
-				t.Fatalf("Couldn't create rsa Private Key")
+				t.Fatalf("Couldn't create Private Key")
 			}
 			caCert := &x509.Certificate{}
 			config := &certutil.Config{
@@ -375,49 +389,66 @@ func TestTryLoadCertFromDisk(t *testing.T) {
 }
 
 func TestTryLoadKeyFromDisk(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Couldn't create tmpdir")
-	}
-	defer os.RemoveAll(tmpdir)
-
-	_, caKey, err := NewCertificateAuthority(&certutil.Config{CommonName: "kubernetes"})
-	if err != nil {
-		t.Errorf(
-			"failed to create cert and key with an error: %v",
-			err,
-		)
-	}
-	err = WriteKey(tmpdir, "foo", caKey)
-	if err != nil {
-		t.Errorf(
-			"failed to write cert and key with an error: %v",
-			err,
-		)
-	}
 
 	var tests = []struct {
-		desc     string
-		path     string
-		name     string
-		expected bool
+		desc       string
+		pathSuffix string
+		name       string
+		keyGenFunc func() (crypto.Signer, error)
+		expected   bool
 	}{
 		{
-			desc:     "empty path and name",
-			path:     "",
-			name:     "",
+			desc:       "empty path and name",
+			pathSuffix: "somegarbage",
+			name:       "",
+			keyGenFunc: func() (crypto.Signer, error) {
+				return rsa.GenerateKey(rand.Reader, 2048)
+			},
 			expected: false,
 		},
 		{
-			desc:     "valid path and name",
-			path:     tmpdir,
-			name:     "foo",
+			desc:       "RSA valid path and name",
+			pathSuffix: "",
+			name:       "foo",
+			keyGenFunc: func() (crypto.Signer, error) {
+				return rsa.GenerateKey(rand.Reader, 2048)
+			},
+			expected: true,
+		},
+		{
+			desc:       "ECDSA valid path and name",
+			pathSuffix: "",
+			name:       "foo",
+			keyGenFunc: func() (crypto.Signer, error) {
+				return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			},
 			expected: true,
 		},
 	}
 	for _, rt := range tests {
 		t.Run(rt.desc, func(t *testing.T) {
-			_, actual := TryLoadKeyFromDisk(rt.path, rt.name)
+			tmpdir, err := ioutil.TempDir("", "")
+			if err != nil {
+				t.Fatalf("Couldn't create tmpdir")
+			}
+			defer os.RemoveAll(tmpdir)
+
+			caKey, err := rt.keyGenFunc()
+			if err != nil {
+				t.Errorf(
+					"failed to create key with an error: %v",
+					err,
+				)
+			}
+
+			err = WriteKey(tmpdir, "foo", caKey)
+			if err != nil {
+				t.Errorf(
+					"failed to write key with an error: %v",
+					err,
+				)
+			}
+			_, actual := TryLoadKeyFromDisk(tmpdir+rt.pathSuffix, rt.name)
 			if (actual == nil) != rt.expected {
 				t.Errorf(
 					"failed TryLoadCertAndKeyFromDisk:\n\texpected: %t\n\t  actual: %t",


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently kubeadm generates or accepts pre-generated RSA keys only. This PR lets kubeadm accept aslo pre-generated ECDSA keys and cerificates.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/984

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: add optional ECDSA support.
kubeadm still generates RSA keys when deploying a node, but also accepts ECDSA
keys if they exist already in the directory specified in --cert-dir option.
```
