### PR TITLE
scheduler: rename metric name of pending pods

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -195,7 +195,7 @@ var (
 	pendingPods = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: SchedulerSubsystem,
-			Name:      "pending_pods_total",
+			Name:      "pending_pods",
 			Help:      "Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableQ.",
 		}, []string{"queue"})
 	ActivePods        = pendingPods.With(prometheus.Labels{"queue": "active"})


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scheduling
/sig instrumentation
/assign @brancz 

**What this PR does / why we need it**:

This is a followup of https://github.com/kubernetes/kubernetes/pull/75501#pullrequestreview-225099825.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
