### PR TITLE
remove pkg/credentialprovider from cloud provider import restrictions

### DIFF
--- a/pkg/cloudprovider/providers/.import-restrictions
+++ b/pkg/cloudprovider/providers/.import-restrictions
@@ -15,9 +15,7 @@
 			"SelectorRegexp": "k8s[.]io/kubernetes",
 			"AllowedPrefixes": [
 				"k8s.io/kubernetes/pkg/cloudprovider/providers",
-				"k8s.io/kubernetes/pkg/credentialprovider",
-				"k8s.io/kubernetes/pkg/util/mount",
-				"k8s.io/kubernetes/pkg/version"
+				"k8s.io/kubernetes/pkg/util/mount"
 			],
 			"ForbiddenPrefixes": []
 		}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes credential providers from import restrictions for cloud provider since it was removed in https://github.com/kubernetes/kubernetes/pull/75587 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
