### PR TITLE
Update addon-manager to use debian-base:v1.0.0

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 9.0.1  (Wed April 10 2019 Zihong Zheng <zihongz@google.com>)
+ - Update to use debian-base:v1.0.0.
+
 ### Version 9.0  (Wed January 16 2019 Jordan Liggitt <liggitt@google.com>)
  - Prune workload resources via apps/v1 APIs
  - Update kubectl to v1.13.2.

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,10 +15,10 @@
 IMAGE=staging-k8s.gcr.io/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v9.0
+VERSION=v9.0.1
 KUBECTL_VERSION?=v1.13.2
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.4.1
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):v1.0.0
 
 SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Rebasing addon-manager on debian-base:v1.0.0 to pick up some CVE fixes (picking up #75678).

The manifest update will come as a follow-up.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related  issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE

**Special notes for your reviewer**:
/assigm @tallclair 
cc @jingyih

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
