### PR TITLE
Add feature gates for switching between the legacy inflight limiting

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -519,6 +519,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	genericfeatures.APIListChunking:         {Default: true, PreRelease: utilfeature.Beta},
 	genericfeatures.DryRun:                  {Default: true, PreRelease: utilfeature.Beta},
 	genericfeatures.ServerSideApply:         {Default: false, PreRelease: utilfeature.Alpha},
+	genericfeatures.RequestManagement:       {Default: false, PreRelease: utilfeature.Alpha},
 
 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -115,6 +115,13 @@ const (
 	//
 	// Enables support for watch bookmark events.
 	WatchBookmark utilfeature.Feature = "WatchBookmark"
+
+	// owner: @MikeSpreitzer @yue9944882
+	// alpha: v1.15
+	//
+	//
+	// Enables managing request concurrency with prioritization and fairness at each server
+	RequestManagement utilfeature.Feature = "RequestManagement"
 )
 
 func init() {
@@ -137,4 +144,5 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	WinOverlay:              {Default: false, PreRelease: utilfeature.Alpha},
 	WinDSR:                  {Default: false, PreRelease: utilfeature.Alpha},
 	WatchBookmark:           {Default: false, PreRelease: utilfeature.Alpha},
+	RequestManagement:       {Default: false, PreRelease: utilfeature.Alpha},
 }


### PR DESCRIPTION
/cc @deads2k @lavalamp @MikeSpreitzer @aaron-prindle 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
