### PR TITLE
Promote existing E2E test to ensure successful job completion after initial failure to conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -25,6 +25,7 @@ test/e2e/apps/deployment.go: "RecreateDeployment should delete old pods and crea
 test/e2e/apps/deployment.go: "deployment should delete old replica sets"
 test/e2e/apps/deployment.go: "deployment should support rollover"
 test/e2e/apps/deployment.go: "deployment should support proportional scaling"
+test/e2e/apps/job.go: "should run a job to completion when tasks sometimes fail and are locally restarted"
 test/e2e/apps/job.go: "should delete a job"
 test/e2e/apps/rc.go: "should serve a basic image on each replica with a public image"
 test/e2e/apps/rc.go: "should surface a failure condition on a common issue like exceeded quota"

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -83,8 +83,13 @@ var _ = SIGDescribe("Job", func() {
 		framework.ExpectNoError(err, "failed to get PodList for job %s in namespace: %s", job.Name, f.Namespace.Name)
 	})
 
-	// Pods sometimes fail, but eventually succeed.
-	ginkgo.It("should run a job to completion when tasks sometimes fail and are locally restarted", func() {
+	/*
+		Release : v1.16
+		Testname: Jobs, completion after task failure
+		Description: Explicitly cause the tasks to fail once initially. After restarting, the Job MUST
+		execute to completion.
+	*/
+	framework.ConformanceIt("should run a job to completion when tasks sometimes fail and are locally restarted", func() {
 		ginkgo.By("Creating a job")
 		// One failure, then a success, local restarts.
 		// We can't use the random failure approach used by the


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
 /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: This PR requests to promote an existing E2E test for Jobs to conformance. This test verifies that the job is completed successfully after initial failures

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
1. The E2E test takes approximately 20 seconds for execution.
2. The test is found to be non-flaky and non-disruptive in nature.

**Does this PR introduce a user-facing change?**: NONE

release-note-none

/area conformance

cc @brahmaroutu @mgdevstack 