### PR TITLE
Fix for #75567

### DIFF
--- a/cluster/addons/addon-manager/Dockerfile
+++ b/cluster/addons/addon-manager/Dockerfile
@@ -17,7 +17,6 @@ FROM BASEIMAGE
 RUN clean-install bash
 
 ADD kube-addons.sh /opt/
-ADD namespace.yaml /opt/
 ADD kubectl /usr/local/bin/
 
 CMD ["/opt/kube-addons.sh"]

--- a/cluster/addons/addon-manager/README.md
+++ b/cluster/addons/addon-manager/README.md
@@ -22,9 +22,6 @@ have this label but without `addonmanager.kubernetes.io/mode=EnsureExists` will 
 treated as "reconcile class addons" for now.
 - Resources under `$ADDON_PATH` need to have either one of these two labels.
 Otherwise it will be omitted.
-- The above label and namespace rule does not stand for `/opt/namespace.yaml` and
-resources under `/etc/kubernetes/admission-controls/`. addon-manager will attempt to
-create them regardless during startup.
 
 #### How to release
 

--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -210,9 +210,6 @@ function is_leader() {
 # managed result of that. Start everything below that directory.
 log INFO "== Kubernetes addon manager started at $(date -Is) with ADDON_CHECK_INTERVAL_SEC=${ADDON_CHECK_INTERVAL_SEC} =="
 
-# Create the namespace that will be used to host the cluster-level add-ons.
-start_addon /opt/namespace.yaml 100 10 "" &
-
 # Wait for the default service account to be created in the kube-system namespace.
 token_found=""
 while [ -z "${token_found}" ]; do

--- a/cluster/addons/addon-manager/namespace.yaml
+++ b/cluster/addons/addon-manager/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kube-system


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes the issue where kube-system namespace was recreated by addon manager.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #75567

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
