### PR TITLE
Fix code-generator compatibility with Windows

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
@@ -18,6 +18,7 @@ limitations under the License.
 package generators
 
 import (
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -25,7 +26,7 @@ import (
 	"k8s.io/code-generator/cmd/client-gen/generators/fake"
 	"k8s.io/code-generator/cmd/client-gen/generators/scheme"
 	"k8s.io/code-generator/cmd/client-gen/generators/util"
-	"k8s.io/code-generator/cmd/client-gen/path"
+	kpath "k8s.io/code-generator/cmd/client-gen/path"
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 	codegennamer "k8s.io/code-generator/pkg/namer"
 	"k8s.io/gengo/args"
@@ -128,7 +129,7 @@ func DefaultNameSystem() string {
 }
 
 func packageForGroup(gv clientgentypes.GroupVersion, typeList []*types.Type, clientsetPackage string, groupPackageName string, groupGoName string, apiPath string, srcTreePath string, inputPackage string, boilerplate []byte) generator.Package {
-	groupVersionClientPackage := filepath.Join(clientsetPackage, "typed", strings.ToLower(groupPackageName), strings.ToLower(gv.Version.NonEmpty()))
+	groupVersionClientPackage := path.Join(clientsetPackage, "typed", strings.ToLower(groupPackageName), strings.ToLower(gv.Version.NonEmpty()))
 	return &generator.DefaultPackage{
 		PackageName: strings.ToLower(gv.Version.NonEmpty()),
 		PackagePath: groupVersionClientPackage,
@@ -224,7 +225,7 @@ func packageForClientset(customArgs *clientgenargs.CustomArgs, clientsetPackage 
 }
 
 func packageForScheme(customArgs *clientgenargs.CustomArgs, clientsetPackage string, srcTreePath string, groupGoNames map[clientgentypes.GroupVersion]string, boilerplate []byte) generator.Package {
-	schemePackage := filepath.Join(clientsetPackage, "scheme")
+	schemePackage := path.Join(clientsetPackage, "scheme")
 
 	// create runtime.Registry for internal client because it has to know about group versions
 	internalClient := false
@@ -330,7 +331,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 	gvToTypes := map[clientgentypes.GroupVersion][]*types.Type{}
 	groupGoNames := make(map[clientgentypes.GroupVersion]string)
 	for gv, inputDir := range customArgs.GroupVersionPackages() {
-		p := context.Universe.Package(path.Vendorless(inputDir))
+		p := context.Universe.Package(kpath.Vendorless(inputDir))
 
 		// If there's a comment of the form "// +groupGoName=SomeUniqueShortName", use that as
 		// the Go group identifier in CamelCase. It defaults
@@ -369,7 +370,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 	}
 
 	var packageList []generator.Package
-	clientsetPackage := filepath.Join(arguments.OutputPackagePath, customArgs.ClientsetName)
+	clientsetPackage := path.Join(arguments.OutputPackagePath, customArgs.ClientsetName)
 
 	packageList = append(packageList, packageForClientset(customArgs, clientsetPackage, groupGoNames, boilerplate))
 	packageList = append(packageList, packageForScheme(customArgs, clientsetPackage, arguments.OutputBase, groupGoNames, boilerplate))

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/fake_client_generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/fake_client_generator.go
@@ -17,22 +17,22 @@ limitations under the License.
 package fake
 
 import (
-	"path/filepath"
+	"path"
 	"strings"
 
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/types"
 
 	clientgenargs "k8s.io/code-generator/cmd/client-gen/args"
-	scheme "k8s.io/code-generator/cmd/client-gen/generators/scheme"
+	"k8s.io/code-generator/cmd/client-gen/generators/scheme"
 	"k8s.io/code-generator/cmd/client-gen/generators/util"
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 )
 
 func PackageForGroup(gv clientgentypes.GroupVersion, typeList []*types.Type, clientsetPackage string, groupPackageName string, groupGoName string, inputPackage string, boilerplate []byte) generator.Package {
-	outputPackage := filepath.Join(clientsetPackage, "typed", strings.ToLower(groupPackageName), strings.ToLower(gv.Version.NonEmpty()), "fake")
+	outputPackage := path.Join(clientsetPackage, "typed", strings.ToLower(groupPackageName), strings.ToLower(gv.Version.NonEmpty()), "fake")
 	// TODO: should make this a function, called by here and in client-generator.go
-	realClientPackage := filepath.Join(clientsetPackage, "typed", strings.ToLower(groupPackageName), strings.ToLower(gv.Version.NonEmpty()))
+	realClientPackage := path.Join(clientsetPackage, "typed", strings.ToLower(groupPackageName), strings.ToLower(gv.Version.NonEmpty()))
 	return &generator.DefaultPackage{
 		PackageName: "fake",
 		PackagePath: outputPackage,
@@ -89,7 +89,7 @@ func PackageForClientset(customArgs *clientgenargs.CustomArgs, clientsetPackage 
 		// TODO: we'll generate fake clientset for different release in the future.
 		// Package name and path are hard coded for now.
 		PackageName: "fake",
-		PackagePath: filepath.Join(clientsetPackage, "fake"),
+		PackagePath: path.Join(clientsetPackage, "fake"),
 		HeaderText:  boilerplate,
 		PackageDocumentation: []byte(
 			`// This package has the automatically generated fake clientset.

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
@@ -19,7 +19,7 @@ package fake
 import (
 	"fmt"
 	"io"
-	"path/filepath"
+	"path"
 	"strings"
 
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
@@ -60,8 +60,8 @@ func (g *genClientset) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
 	for _, group := range g.groups {
 		for _, version := range group.Versions {
-			groupClientPackage := filepath.Join(g.fakeClientsetPackage, "typed", strings.ToLower(group.PackageName), strings.ToLower(version.NonEmpty()))
-			fakeGroupClientPackage := filepath.Join(groupClientPackage, "fake")
+			groupClientPackage := path.Join(g.fakeClientsetPackage, "typed", strings.ToLower(group.PackageName), strings.ToLower(version.NonEmpty()))
+			fakeGroupClientPackage := path.Join(groupClientPackage, "fake")
 
 			groupAlias := strings.ToLower(g.groupGoNames[clientgentypes.GroupVersion{Group: group.Group, Version: version.Version}])
 			imports = append(imports, fmt.Sprintf("%s%s \"%s\"", groupAlias, strings.ToLower(version.NonEmpty()), groupClientPackage))

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_group.go
@@ -19,7 +19,7 @@ package fake
 import (
 	"fmt"
 	"io"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"k8s.io/gengo/generator"
@@ -64,7 +64,7 @@ func (g *genFakeForGroup) Namers(c *generator.Context) namer.NameSystems {
 func (g *genFakeForGroup) Imports(c *generator.Context) (imports []string) {
 	imports = g.imports.ImportLines()
 	if len(g.types) != 0 {
-		imports = append(imports, fmt.Sprintf("%s \"%s\"", strings.ToLower(filepath.Base(g.realClientPackage)), g.realClientPackage))
+		imports = append(imports, fmt.Sprintf("%s \"%s\"", strings.ToLower(path.Base(g.realClientPackage)), g.realClientPackage))
 	}
 	return imports
 }
@@ -90,7 +90,7 @@ func (g *genFakeForGroup) GenerateType(c *generator.Context, t *types.Type, w io
 			"type":              t,
 			"GroupGoName":       g.groupGoName,
 			"Version":           namer.IC(g.version),
-			"realClientPackage": strings.ToLower(filepath.Base(g.realClientPackage)),
+			"realClientPackage": strings.ToLower(path.Base(g.realClientPackage)),
 		}
 		if tags.NonNamespaced {
 			sw.Do(getterImplNonNamespaced, wrapper)

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
@@ -18,7 +18,7 @@ package fake
 
 import (
 	"io"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"k8s.io/gengo/generator"
@@ -26,7 +26,7 @@ import (
 	"k8s.io/gengo/types"
 
 	"k8s.io/code-generator/cmd/client-gen/generators/util"
-	"k8s.io/code-generator/cmd/client-gen/path"
+	kpath "k8s.io/code-generator/cmd/client-gen/path"
 )
 
 // genFakeForType produces a file for each top-level type.
@@ -86,7 +86,7 @@ func hasObjectMeta(t *types.Type) bool {
 // GenerateType makes the body of a file implementing the individual typed client for type t.
 func (g *genFakeForType) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
-	pkg := filepath.Base(t.Name.Package)
+	pkg := path.Base(t.Name.Package)
 	tags, err := util.ParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
 	if err != nil {
 		return err
@@ -102,7 +102,7 @@ func (g *genFakeForType) GenerateType(c *generator.Context, t *types.Type, w io.
 	}
 
 	// allow user to define a group name that's different from the one parsed from the directory.
-	p := c.Universe.Package(path.Vendorless(g.inputPackage))
+	p := c.Universe.Package(kpath.Vendorless(g.inputPackage))
 	if override := types.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
 		groupName = override[0]
 	}

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
@@ -19,7 +19,7 @@ package generators
 import (
 	"fmt"
 	"io"
-	"path/filepath"
+	"path"
 	"strings"
 
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
@@ -58,7 +58,7 @@ func (g *genClientset) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
 	for _, group := range g.groups {
 		for _, version := range group.Versions {
-			typedClientPath := filepath.Join(g.clientsetPackage, "typed", strings.ToLower(group.PackageName), strings.ToLower(version.NonEmpty()))
+			typedClientPath := path.Join(g.clientsetPackage, "typed", strings.ToLower(group.PackageName), strings.ToLower(version.NonEmpty()))
 			groupAlias := strings.ToLower(g.groupGoNames[clientgentypes.GroupVersion{Group: group.Group, Version: version.Version}])
 			imports = append(imports, fmt.Sprintf("%s%s \"%s\"", groupAlias, strings.ToLower(version.NonEmpty()), typedClientPath))
 		}

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
@@ -18,14 +18,14 @@ package generators
 
 import (
 	"io"
-	"path/filepath"
+	"path"
 
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
 
 	"k8s.io/code-generator/cmd/client-gen/generators/util"
-	"k8s.io/code-generator/cmd/client-gen/path"
+	kpath "k8s.io/code-generator/cmd/client-gen/path"
 )
 
 // genGroup produces a file for a group client, e.g. ExtensionsClient for the extension group.
@@ -64,7 +64,7 @@ func (g *genGroup) Namers(c *generator.Context) namer.NameSystems {
 
 func (g *genGroup) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, g.imports.ImportLines()...)
-	imports = append(imports, filepath.Join(g.clientsetPackage, "scheme"))
+	imports = append(imports, path.Join(g.clientsetPackage, "scheme"))
 	return
 }
 
@@ -83,7 +83,7 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 		groupName = ""
 	}
 	// allow user to define a group name that's different from the one parsed from the directory.
-	p := c.Universe.Package(path.Vendorless(g.inputPackage))
+	p := c.Universe.Package(kpath.Vendorless(g.inputPackage))
 	if override := types.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
 		groupName = override[0]
 	}
@@ -102,7 +102,7 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 		"restDefaultKubernetesUserAgent": c.Universe.Function(types.Name{Package: "k8s.io/client-go/rest", Name: "DefaultKubernetesUserAgent"}),
 		"restRESTClientInterface":        c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "Interface"}),
 		"restRESTClientFor":              c.Universe.Function(types.Name{Package: "k8s.io/client-go/rest", Name: "RESTClientFor"}),
-		"SchemeGroupVersion":             c.Universe.Variable(types.Name{Package: path.Vendorless(g.inputPackage), Name: "SchemeGroupVersion"}),
+		"SchemeGroupVersion":             c.Universe.Variable(types.Name{Package: kpath.Vendorless(g.inputPackage), Name: "SchemeGroupVersion"}),
 	}
 	sw.Do(groupInterfaceTemplate, m)
 	sw.Do(groupClientTemplate, m)

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
@@ -18,7 +18,7 @@ package generators
 
 import (
 	"io"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"k8s.io/gengo/generator"
@@ -73,7 +73,7 @@ func genStatus(t *types.Type) bool {
 // GenerateType makes the body of a file implementing the individual typed client for type t.
 func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
-	pkg := filepath.Base(t.Name.Package)
+	pkg := path.Base(t.Name.Package)
 	tags, err := util.ParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
 	if err != nil {
 		return err
@@ -141,7 +141,7 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 		"PatchType":            c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/types", Name: "PatchType"}),
 		"watchInterface":       c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/watch", Name: "Interface"}),
 		"RESTClientInterface":  c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "Interface"}),
-		"schemeParameterCodec": c.Universe.Variable(types.Name{Package: filepath.Join(g.clientsetPackage, "scheme"), Name: "ParameterCodec"}),
+		"schemeParameterCodec": c.Universe.Variable(types.Name{Package: path.Join(g.clientsetPackage, "scheme"), Name: "ParameterCodec"}),
 	}
 
 	sw.Do(getterComment, m)

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/scheme/generator_for_scheme.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/scheme/generator_for_scheme.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
-	"k8s.io/code-generator/cmd/client-gen/path"
+	kpath "k8s.io/code-generator/cmd/client-gen/path"
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
@@ -66,14 +67,14 @@ func (g *GenScheme) Imports(c *generator.Context) (imports []string) {
 			if g.CreateRegistry {
 				// import the install package for internal clientsets instead of the type package with register.go
 				if version.Version != "" {
-					packagePath = filepath.Dir(packagePath)
+					packagePath = path.Dir(packagePath)
 				}
-				packagePath = filepath.Join(packagePath, "install")
+				packagePath = path.Join(packagePath, "install")
 
-				imports = append(imports, fmt.Sprintf("%s \"%s\"", groupAlias, path.Vendorless(packagePath)))
+				imports = append(imports, fmt.Sprintf("%s \"%s\"", groupAlias, kpath.Vendorless(packagePath)))
 				break
 			} else {
-				imports = append(imports, fmt.Sprintf("%s%s \"%s\"", groupAlias, strings.ToLower(version.Version.NonEmpty()), path.Vendorless(packagePath)))
+				imports = append(imports, fmt.Sprintf("%s%s \"%s\"", groupAlias, strings.ToLower(version.Version.NonEmpty()), kpath.Vendorless(packagePath)))
 			}
 		}
 	}

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/groupinterface.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/groupinterface.go
@@ -18,7 +18,7 @@ package generators
 
 import (
 	"io"
-	"path/filepath"
+	"path"
 	"strings"
 
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
@@ -70,7 +70,7 @@ func (g *groupInterfaceGenerator) GenerateType(c *generator.Context, t *types.Ty
 	versions := make([]versionData, 0, len(g.groupVersions.Versions))
 	for _, version := range g.groupVersions.Versions {
 		gv := clientgentypes.GroupVersion{Group: g.groupVersions.Group, Version: version.Version}
-		versionPackage := filepath.Join(g.outputPackage, strings.ToLower(gv.Version.NonEmpty()))
+		versionPackage := path.Join(g.outputPackage, strings.ToLower(gv.Version.NonEmpty()))
 		iface := c.Universe.Type(types.Name{Package: versionPackage, Name: "Interface"})
 		versions = append(versions, versionData{
 			Name:      namer.IC(version.Version.NonEmpty()),

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
@@ -86,7 +86,7 @@ func isInternal(m types.Member) bool {
 }
 
 func packageForInternalInterfaces(base string) string {
-	return filepath.Join(base, "internalinterfaces")
+	return path.Join(base, "internalinterfaces")
 }
 
 func vendorless(p string) string {
@@ -108,11 +108,11 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		klog.Fatalf("Wrong CustomArgs type: %T", arguments.CustomArgs)
 	}
 
-	internalVersionPackagePath := filepath.Join(arguments.OutputPackagePath)
-	externalVersionPackagePath := filepath.Join(arguments.OutputPackagePath)
+	internalVersionPackagePath := path.Join(arguments.OutputPackagePath)
+	externalVersionPackagePath := path.Join(arguments.OutputPackagePath)
 	if !customArgs.SingleDirectory {
-		internalVersionPackagePath = filepath.Join(arguments.OutputPackagePath, "internalversion")
-		externalVersionPackagePath = filepath.Join(arguments.OutputPackagePath, "externalversions")
+		internalVersionPackagePath = path.Join(arguments.OutputPackagePath, "internalversion")
+		externalVersionPackagePath = path.Join(arguments.OutputPackagePath, "externalversions")
 	}
 
 	var packageList generator.Packages
@@ -284,7 +284,7 @@ func factoryInterfacePackage(basePackage string, boilerplate []byte, clientSetPa
 }
 
 func groupPackage(basePackage string, groupVersions clientgentypes.GroupVersions, boilerplate []byte) generator.Package {
-	packagePath := filepath.Join(basePackage, groupVersions.PackageName)
+	packagePath := path.Join(basePackage, groupVersions.PackageName)
 	groupPkgName := strings.Split(string(groupVersions.PackageName), ".")[0]
 
 	return &generator.DefaultPackage{
@@ -311,7 +311,7 @@ func groupPackage(basePackage string, groupVersions clientgentypes.GroupVersions
 }
 
 func versionPackage(basePackage string, groupPkgName string, gv clientgentypes.GroupVersion, groupGoName string, boilerplate []byte, typesToGenerate []*types.Type, clientSetPackage, listersPackage string) generator.Package {
-	packagePath := filepath.Join(basePackage, groupPkgName, strings.ToLower(gv.Version.NonEmpty()))
+	packagePath := path.Join(basePackage, groupPkgName, strings.ToLower(gv.Version.NonEmpty()))
 
 	return &generator.DefaultPackage{
 		PackageName: strings.ToLower(gv.Version.NonEmpty()),


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR fixes code-generator client-gen and informer-gen compatibility with Windows by replacing `filepath.Join` calls with `path.Join` so forward slashes are always used for package paths instead of backslashes.

Without these fixes, when code-generator is run on Windows, the following errors are produced:
```
W0411 09:10:28.282185   11556 import_tracker.go:48] Warning: backslash used in import path 'k8s.io\sample-controller\pkg\generated\clientset\versioned\scheme', this is unsupported.

F0411 09:10:28.298188   11556 main.go:64] Error: Failed executing generator: some packages had errors:
errors in package "k8s.io\\sample-controller\\pkg\\generated\\clientset\\versioned":
unable to format file "C:\\Users\\koen\\Projects\\Go\\src\\k8s.io\\sample-controller\\pkg\\generated\\clientset\\versioned\\clientset.go" (7:40: unknown escape sequence (and 5 more errors)).

errors in package "k8s.io\\sample-controller\\pkg\\generated\\clientset\\versioned\\fake":
unable to format file "C:\\Users\\koen\\Projects\\Go\\src\\k8s.io\\sample-controller\\pkg\\generated\\clientset\\versioned\\fake\\clientset_generated.go" (6:40: unknown escape sequence (and 17 more errors)).
```

```release-note
NONE
```