### PR TITLE
Promote e2e "verifying service's sessionAffinity for ClusterIP and NodePort services" to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1644,12 +1644,106 @@
     the NodePort.
   release: v1.16
   file: test/e2e/network/service.go
+- testname: Service, NodePort type, session affinity to None
+  codename: '[sig-network] Services should be able to switch session affinity for
+    NodePort service [LinuxOnly] [Conformance]'
+  description: 'Create a service of type "NodePort" and provide service port and protocol.
+    Service''s sessionAffinity is set to "ClientIP". Service creation MUST be successful
+    by assigning a "ClusterIP" to the service and allocating NodePort on all the nodes.
+    Create a Replication Controller to ensure that 3 pods are running and are targeted
+    by the service to serve hostname of the pod when requests are sent to the service.
+    Create another pod to make requests to the service. Update the service''s sessionAffinity
+    to "None". Service update MUST be successful. When a requests are made to the
+    service on node''s IP and NodePort, service MUST be able serve the hostname from
+    any pod of the replica. When service''s sessionAffinily is updated back to "ClientIP",
+    service MUST serve the hostname from the same pod of the replica for all consecutive
+    requests. Service MUST be reachable over serviceName and the ClusterIP on servicePort.
+    Service MUST also be reachable over node''s IP on NodePort. [LinuxOnly]: Windows
+    does not support session affinity.'
+  release: v1.19
+  file: test/e2e/network/service.go
+- testname: Service, ClusterIP type, session affinity to None
+  codename: '[sig-network] Services should be able to switch session affinity for
+    service with type clusterIP [LinuxOnly] [Conformance]'
+  description: 'Create a service of type "ClusterIP". Service''s sessionAffinity is
+    set to "ClientIP". Service creation MUST be successful by assigning "ClusterIP"
+    to the service. Create a Replication Controller to ensure that 3 pods are running
+    and are targeted by the service to serve hostname of the pod when requests are
+    sent to the service. Create another pod to make requests to the service. Update
+    the service''s sessionAffinity to "None". Service update MUST be successful. When
+    a requests are made to the service, it MUST be able serve the hostname from any
+    pod of the replica. When service''s sessionAffinily is updated back to "ClientIP",
+    service MUST serve the hostname from the same pod of the replica for all consecutive
+    requests. Service MUST be reachable over serviceName and the ClusterIP on servicePort.
+    [LinuxOnly]: Windows does not support session affinity.'
+  release: v1.19
+  file: test/e2e/network/service.go
 - testname: Find Kubernetes Service in default Namespace
   codename: '[sig-network] Services should find a service from listing all namespaces
     [Conformance]'
   description: List all Services in all Namespaces, response MUST include a Service
     named Kubernetes with the Namespace of default.
   release: v1.18
+  file: test/e2e/network/service.go
+- testname: Service, NodePort type, session affinity to ClientIP with timeout
+  codename: '[sig-network] Services should have session affinity timeout work for
+    NodePort service [LinuxOnly] [Conformance]'
+  description: 'Create a service of type "NodePort" and provide service port and protocol.
+    Service''s sessionAffinity is set to "ClientIP" and session affinity timeout is
+    set. Service creation MUST be successful by assigning a "ClusterIP" to service
+    and allocating NodePort on all nodes. Create a Replication Controller to ensure
+    that 3 pods are running and are targeted by the service to serve hostname of the
+    pod when requests are sent to the service. Create another pod to make requests
+    to the service on node''s IP and NodePort. Service MUST serve the hostname from
+    the same pod of the replica for all consecutive requests until timeout. After
+    timeout, requests MUST be served from different pods of the replica. Service MUST
+    be reachable over serviceName and the ClusterIP on servicePort. Service MUST also
+    be reachable over node''s IP on NodePort. [LinuxOnly]: Windows does not support
+    session affinity.'
+  release: v1.19
+  file: test/e2e/network/service.go
+- testname: Service, ClusterIP type, session affinity to ClientIP with timeout
+  codename: '[sig-network] Services should have session affinity timeout work for
+    service with type clusterIP [LinuxOnly] [Conformance]'
+  description: 'Create a service of type "ClusterIP". Service''s sessionAffinity is
+    set to "ClientIP" and session affinity timeout is set. Service creation MUST be
+    successful by assigning "ClusterIP" to the service. Create a Replication Controller
+    to ensure that 3 pods are running and are targeted by the service to serve hostname
+    of the pod when requests are sent to the service. Create another pod to make requests
+    to the service. Service MUST serve the hostname from the same pod of the replica
+    for all consecutive requests until timeout expires. After timeout, requests MUST
+    be served from different pods of the replica. Service MUST be reachable over serviceName
+    and the ClusterIP on servicePort. [LinuxOnly]: Windows does not support session
+    affinity.'
+  release: v1.19
+  file: test/e2e/network/service.go
+- testname: Service, NodePort type, session affinity to ClientIP
+  codename: '[sig-network] Services should have session affinity work for NodePort
+    service [LinuxOnly] [Conformance]'
+  description: 'Create a service of type "NodePort" and provide service port and protocol.
+    Service''s sessionAffinity is set to "ClientIP". Service creation MUST be successful
+    by assigning a "ClusterIP" to service and allocating NodePort on all nodes. Create
+    a Replication Controller to ensure that 3 pods are running and are targeted by
+    the service to serve hostname of the pod when a requests are sent to the service.
+    Create another pod to make requests to the service on node''s IP and NodePort.
+    Service MUST serve the hostname from the same pod of the replica for all consecutive
+    requests. Service MUST be reachable over serviceName and the ClusterIP on servicePort.
+    Service MUST also be reachable over node''s IP on NodePort. [LinuxOnly]: Windows
+    does not support session affinity.'
+  release: v1.19
+  file: test/e2e/network/service.go
+- testname: Service, ClusterIP type, session affinity to ClientIP
+  codename: '[sig-network] Services should have session affinity work for service
+    with type clusterIP [LinuxOnly] [Conformance]'
+  description: 'Create a service of type "ClusterIP". Service''s sessionAffinity is
+    set to "ClientIP". Service creation MUST be successful by assigning "ClusterIP"
+    to the service. Create a Replication Controller to ensure that 3 pods are running
+    and are targeted by the service to serve hostname of the pod when requests are
+    sent to the service. Create another pod to make requests to the service. Service
+    MUST serve the hostname from the same pod of the replica for all consecutive requests.
+    Service MUST be reachable over serviceName and the ClusterIP on servicePort. [LinuxOnly]:
+    Windows does not support session affinity.'
+  release: v1.19
   file: test/e2e/network/service.go
 - testname: Kubernetes Service
   codename: '[sig-network] Services should provide secure master service  [Conformance]'

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2356,43 +2356,96 @@ var _ = SIGDescribe("Services", func() {
 		}
 	})
 
-	// [LinuxOnly]: Windows does not support session affinity.
-	ginkgo.It("should have session affinity work for service with type clusterIP [LinuxOnly]", func() {
+	/*
+		Release: v1.19
+		Testname: Service, ClusterIP type, session affinity to ClientIP
+		Description: Create a service of type "ClusterIP". Service's sessionAffinity is set to "ClientIP". Service creation MUST be successful by assigning "ClusterIP" to the service.
+		Create a Replication Controller to ensure that 3 pods are running and are targeted by the service to serve hostname of the pod when requests are sent to the service.
+		Create another pod to make requests to the service. Service MUST serve the hostname from the same pod of the replica for all consecutive requests.
+		Service MUST be reachable over serviceName and the ClusterIP on servicePort.
+		[LinuxOnly]: Windows does not support session affinity.
+	*/
+	framework.ConformanceIt("should have session affinity work for service with type clusterIP [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-clusterip")
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		execAffinityTestForNonLBService(f, cs, svc)
 	})
 
-	// [LinuxOnly]: Windows does not support session affinity.
-	ginkgo.It("should have session affinity timeout work for service with type clusterIP [LinuxOnly]", func() {
+	/*
+		Release: v1.19
+		Testname: Service, ClusterIP type, session affinity to ClientIP with timeout
+		Description: Create a service of type "ClusterIP". Service's sessionAffinity is set to "ClientIP" and session affinity timeout is set. Service creation MUST be successful by assigning "ClusterIP" to the service.
+		Create a Replication Controller to ensure that 3 pods are running and are targeted by the service to serve hostname of the pod when requests are sent to the service.
+		Create another pod to make requests to the service. Service MUST serve the hostname from the same pod of the replica for all consecutive requests until timeout expires.
+		After timeout, requests MUST be served from different pods of the replica.
+		Service MUST be reachable over serviceName and the ClusterIP on servicePort.
+		[LinuxOnly]: Windows does not support session affinity.
+	*/
+	framework.ConformanceIt("should have session affinity timeout work for service with type clusterIP [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-clusterip-timeout")
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		execAffinityTestForSessionAffinityTimeout(f, cs, svc)
 	})
 
-	// [LinuxOnly]: Windows does not support session affinity.
-	ginkgo.It("should be able to switch session affinity for service with type clusterIP [LinuxOnly]", func() {
+	/*
+		Release: v1.19
+		Testname: Service, ClusterIP type, session affinity to None
+		Description: Create a service of type "ClusterIP". Service's sessionAffinity is set to "ClientIP". Service creation MUST be successful by assigning "ClusterIP" to the service.
+		Create a Replication Controller to ensure that 3 pods are running and are targeted by the service to serve hostname of the pod when requests are sent to the service.
+		Create another pod to make requests to the service. Update the service's sessionAffinity to "None". Service update MUST be successful. When a requests are made to the service, it MUST be able serve the hostname from any pod of the replica.
+		When service's sessionAffinily is updated back to "ClientIP", service MUST serve the hostname from the same pod of the replica for all consecutive requests.
+		Service MUST be reachable over serviceName and the ClusterIP on servicePort.
+		[LinuxOnly]: Windows does not support session affinity.
+	*/
+	framework.ConformanceIt("should be able to switch session affinity for service with type clusterIP [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-clusterip-transition")
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		execAffinityTestForNonLBServiceWithTransition(f, cs, svc)
 	})
 
-	// [LinuxOnly]: Windows does not support session affinity.
-	ginkgo.It("should have session affinity work for NodePort service [LinuxOnly]", func() {
+	/*
+		Release: v1.19
+		Testname: Service, NodePort type, session affinity to ClientIP
+		Description: Create a service of type "NodePort" and provide service port and protocol. Service's sessionAffinity is set to "ClientIP". Service creation MUST be successful by assigning a "ClusterIP" to service and allocating NodePort on all nodes.
+		Create a Replication Controller to ensure that 3 pods are running and are targeted by the service to serve hostname of the pod when a requests are sent to the service.
+		Create another pod to make requests to the service on node's IP and NodePort. Service MUST serve the hostname from the same pod of the replica for all consecutive requests.
+		Service MUST be reachable over serviceName and the ClusterIP on servicePort. Service MUST also be reachable over node's IP on NodePort.
+		[LinuxOnly]: Windows does not support session affinity.
+	*/
+	framework.ConformanceIt("should have session affinity work for NodePort service [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-nodeport")
 		svc.Spec.Type = v1.ServiceTypeNodePort
 		execAffinityTestForNonLBService(f, cs, svc)
 	})
 
-	// [LinuxOnly]: Windows does not support session affinity.
-	ginkgo.It("should have session affinity timeout work for NodePort service [LinuxOnly]", func() {
+	/*
+		Release: v1.19
+		Testname: Service, NodePort type, session affinity to ClientIP with timeout
+		Description: Create a service of type "NodePort" and provide service port and protocol. Service's sessionAffinity is set to "ClientIP" and session affinity timeout is set.
+		Service creation MUST be successful by assigning a "ClusterIP" to service and allocating NodePort on all nodes.
+		Create a Replication Controller to ensure that 3 pods are running and are targeted by the service to serve hostname of the pod when requests are sent to the service.
+		Create another pod to make requests to the service on node's IP and NodePort. Service MUST serve the hostname from the same pod of the replica for all consecutive requests until timeout.
+		After timeout, requests MUST be served from different pods of the replica.
+		Service MUST be reachable over serviceName and the ClusterIP on servicePort. Service MUST also be reachable over node's IP on NodePort.
+		[LinuxOnly]: Windows does not support session affinity.
+	*/
+	framework.ConformanceIt("should have session affinity timeout work for NodePort service [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-nodeport-timeout")
 		svc.Spec.Type = v1.ServiceTypeNodePort
 		execAffinityTestForSessionAffinityTimeout(f, cs, svc)
 	})
 
-	// [LinuxOnly]: Windows does not support session affinity.
-	ginkgo.It("should be able to switch session affinity for NodePort service [LinuxOnly]", func() {
+	/*
+		Release: v1.19
+		Testname: Service, NodePort type, session affinity to None
+		Description: Create a service of type "NodePort" and provide service port and protocol. Service's sessionAffinity is set to "ClientIP". Service creation MUST be successful by assigning a "ClusterIP" to the service and allocating NodePort on all the nodes.
+		Create a Replication Controller to ensure that 3 pods are running and are targeted by the service to serve hostname of the pod when requests are sent to the service.
+		Create another pod to make requests to the service. Update the service's sessionAffinity to "None". Service update MUST be successful. When a requests are made to the service on node's IP and NodePort, service MUST be able serve the hostname from any pod of the replica.
+		When service's sessionAffinily is updated back to "ClientIP", service MUST serve the hostname from the same pod of the replica for all consecutive requests.
+		Service MUST be reachable over serviceName and the ClusterIP on servicePort. Service MUST also be reachable over node's IP on NodePort.
+		[LinuxOnly]: Windows does not support session affinity.
+	*/
+	framework.ConformanceIt("should be able to switch session affinity for NodePort service [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-nodeport-transition")
 		svc.Spec.Type = v1.ServiceTypeNodePort
 		execAffinityTestForNonLBServiceWithTransition(f, cs, svc)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

 /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Promotes following e2e to Conformance as they verify important functional behavior of service's session affinity for ClusterIP and NodePort type of services. 
1. [sig-network] Services should have session affinity work for service with type clusterIP
[Execution Time: ~57 Sec]
2. [sig-network] Services should be able to switch session affinity for service with type clusterIP
[Execution Time: ~68 Sec]
3. [sig-network] Services should have session affinity work for NodePort service
[Execution Time: ~55 Sec]
4. [sig-network] Services should be able to switch session affinity for NodePort service
[Execution Time: ~58 Sec]
5. [sig-network] Services should have session affinity timeout work for service with type clusterIP
[Execution Time: ~30 Sec]
6. [sig-network] Services should have session affinity timeout work for NodePort service
[Execution Time: ~50 Sec]

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
- These e2e might fail on Windows as they are using `wget -T` flag, which is not supported on Windows at this moment.
- No flakes found on Kind cluster. (Testgrid flake links would be added in comment after few days of observation)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
/area conformance
/sig testing
@kubernetes/sig-node-pr-reviews
@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg