### PR TITLE
Move ExecMount to pkg/volume/util/exec

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -110,6 +110,7 @@ go_library(
         "//pkg/volume:go_default_library",
         "//pkg/volume/csi:go_default_library",
         "//pkg/volume/util:go_default_library",
+        "//pkg/volume/util/exec:go_default_library",
         "//pkg/volume/util/subpath:go_default_library",
         "//pkg/volume/util/types:go_default_library",
         "//pkg/volume/util/volumepathhandler:go_default_library",

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
+	execmnt "k8s.io/kubernetes/pkg/volume/util/exec"
 	"k8s.io/kubernetes/pkg/volume/util/subpath"
 )
 
@@ -230,7 +231,7 @@ func (kvh *kubeletVolumeHost) GetMounter(pluginName string) mount.Interface {
 	if exec == nil {
 		return kvh.kubelet.mounter
 	}
-	return mount.NewExecMounter(exec, kvh.kubelet.mounter)
+	return execmnt.NewExecMounter(exec, kvh.kubelet.mounter)
 }
 
 func (kvh *kubeletVolumeHost) GetHostName() string {

--- a/pkg/util/mount/BUILD
+++ b/pkg/util/mount/BUILD
@@ -5,8 +5,6 @@ go_library(
     srcs = [
         "doc.go",
         "exec.go",
-        "exec_mount.go",
-        "exec_mount_unsupported.go",
         "fake.go",
         "mount.go",
         "mount_helper_common.go",
@@ -38,7 +36,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
-        "exec_mount_test.go",
         "mount_helper_test.go",
         "mount_linux_test.go",
         "mount_test.go",

--- a/pkg/volume/util/BUILD
+++ b/pkg/volume/util/BUILD
@@ -84,6 +84,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/volume/util/exec:all-srcs",
         "//pkg/volume/util/fs:all-srcs",
         "//pkg/volume/util/nestedpendingoperations:all-srcs",
         "//pkg/volume/util/nsenter:all-srcs",

--- a/pkg/volume/util/exec/BUILD
+++ b/pkg/volume/util/exec/BUILD
@@ -1,0 +1,74 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "exec_mount.go",
+        "exec_mount_unsupported.go",
+    ],
+    importpath = "k8s.io/kubernetes/pkg/volume/util/exec",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//pkg/util/mount:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "//pkg/util/mount:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "//pkg/util/mount:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "//pkg/util/mount:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//pkg/util/mount:go_default_library",
+            "//vendor/k8s.io/klog:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "//pkg/util/mount:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "//pkg/util/mount:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "//pkg/util/mount:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "//pkg/util/mount:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "//pkg/util/mount:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:windows": [
+            "//pkg/util/mount:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["exec_mount_test.go"],
+    embed = [":go_default_library"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//pkg/util/mount:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/volume/util/exec/exec_mount.go
+++ b/pkg/volume/util/exec/exec_mount.go
@@ -34,6 +34,8 @@ type execMounter struct {
 	exec           mount.Exec
 }
 
+// NewExecMounter returns a mounter that uses provided Exec interface to mount and
+// unmount a filesystem. For all other calls it uses a wrapped mounter.
 func NewExecMounter(exec mount.Exec, wrapped mount.Interface) mount.Interface {
 	return &execMounter{
 		wrappedMounter: wrapped,
@@ -66,7 +68,7 @@ func (m *execMounter) doExecMount(source, target, fstype string, options []strin
 	output, err := m.exec.Run("mount", mountArgs...)
 	klog.V(5).Infof("Exec mounted %v: %v: %s", mountArgs, err, string(output))
 	if err != nil {
-		return fmt.Errorf("mount failed: %v\nMounting command: %s\nMounting arguments: %s %s %s %v\nOutput: %s\n",
+		return fmt.Errorf("mount failed: %v\nMounting command: %s\nMounting arguments: %s %s %s %v\nOutput: %s",
 			err, "mount", source, target, fstype, options, string(output))
 	}
 

--- a/pkg/volume/util/exec/exec_mount_test.go
+++ b/pkg/volume/util/exec/exec_mount_test.go
@@ -16,13 +16,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mount
+package exec
 
 import (
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
+
+	"k8s.io/kubernetes/pkg/util/mount"
 )
 
 var (
@@ -33,7 +35,7 @@ var (
 )
 
 func TestMount(t *testing.T) {
-	exec := NewFakeExec(func(cmd string, args ...string) ([]byte, error) {
+	exec := mount.NewFakeExec(func(cmd string, args ...string) ([]byte, error) {
 		if cmd != "mount" {
 			t.Errorf("expected mount command, got %q", cmd)
 		}
@@ -45,7 +47,7 @@ func TestMount(t *testing.T) {
 		return nil, nil
 	})
 
-	wrappedMounter := &fakeMounter{FakeMounter: &FakeMounter{}, t: t}
+	wrappedMounter := &fakeMounter{FakeMounter: &mount.FakeMounter{}, t: t}
 	mounter := NewExecMounter(exec, wrappedMounter)
 
 	mounter.Mount(sourcePath, destinationPath, fsType, mountOptions)
@@ -53,7 +55,7 @@ func TestMount(t *testing.T) {
 
 func TestBindMount(t *testing.T) {
 	cmdCount := 0
-	exec := NewFakeExec(func(cmd string, args ...string) ([]byte, error) {
+	exec := mount.NewFakeExec(func(cmd string, args ...string) ([]byte, error) {
 		cmdCount++
 		if cmd != "mount" {
 			t.Errorf("expected mount command, got %q", cmd)
@@ -73,14 +75,14 @@ func TestBindMount(t *testing.T) {
 		return nil, nil
 	})
 
-	wrappedMounter := &fakeMounter{FakeMounter: &FakeMounter{}, t: t}
+	wrappedMounter := &fakeMounter{FakeMounter: &mount.FakeMounter{}, t: t}
 	mounter := NewExecMounter(exec, wrappedMounter)
 	bindOptions := append(mountOptions, "bind")
 	mounter.Mount(sourcePath, destinationPath, fsType, bindOptions)
 }
 
 func TestUnmount(t *testing.T) {
-	exec := NewFakeExec(func(cmd string, args ...string) ([]byte, error) {
+	exec := mount.NewFakeExec(func(cmd string, args ...string) ([]byte, error) {
 		if cmd != "umount" {
 			t.Errorf("expected unmount command, got %q", cmd)
 		}
@@ -92,7 +94,7 @@ func TestUnmount(t *testing.T) {
 		return nil, nil
 	})
 
-	wrappedMounter := &fakeMounter{&FakeMounter{}, t}
+	wrappedMounter := &fakeMounter{&mount.FakeMounter{}, t}
 	mounter := NewExecMounter(exec, wrappedMounter)
 
 	mounter.Unmount(destinationPath)
@@ -100,7 +102,7 @@ func TestUnmount(t *testing.T) {
 
 /* Fake wrapped mounter */
 type fakeMounter struct {
-	*FakeMounter
+	*mount.FakeMounter
 	t *testing.T
 }
 

--- a/pkg/volume/util/exec/exec_mount_unsupported.go
+++ b/pkg/volume/util/exec/exec_mount_unsupported.go
@@ -16,18 +16,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mount
+package exec
 
 import (
 	"errors"
 	"os"
+
+	"k8s.io/kubernetes/pkg/util/mount"
 )
 
 type execMounter struct{}
 
 // ExecMounter is a mounter that uses provided Exec interface to mount and
 // unmount a filesystem. For all other calls it uses a wrapped mounter.
-func NewExecMounter(exec Exec, wrapped Interface) Interface {
+func NewExecMounter(exec mount.Exec, wrapped mount.Interface) mount.Interface {
 	return &execMounter{}
 }
 
@@ -39,11 +41,11 @@ func (mounter *execMounter) Unmount(target string) error {
 	return nil
 }
 
-func (mounter *execMounter) List() ([]MountPoint, error) {
-	return []MountPoint{}, nil
+func (mounter *execMounter) List() ([]mount.MountPoint, error) {
+	return []mount.MountPoint{}, nil
 }
 
-func (mounter *execMounter) IsMountPointMatch(mp MountPoint, dir string) bool {
+func (mounter *execMounter) IsMountPointMatch(mp mount.MountPoint, dir string) bool {
 	return (mp.Path == dir)
 }
 
@@ -67,8 +69,8 @@ func (mounter *execMounter) MakeRShared(path string) error {
 	return nil
 }
 
-func (mounter *execMounter) GetFileType(pathname string) (FileType, error) {
-	return FileType("fake"), errors.New("not implemented")
+func (mounter *execMounter) GetFileType(pathname string) (mount.FileType, error) {
+	return mount.FileType("fake"), errors.New("not implemented")
 }
 
 func (mounter *execMounter) MakeDir(pathname string) error {

--- a/pkg/volume/util/exec/exec_mount_unsupported.go
+++ b/pkg/volume/util/exec/exec_mount_unsupported.go
@@ -27,7 +27,7 @@ import (
 
 type execMounter struct{}
 
-// ExecMounter is a mounter that uses provided Exec interface to mount and
+// NewExecMounter returns a mounter that uses provided Exec interface to mount and
 // unmount a filesystem. For all other calls it uses a wrapped mounter.
 func NewExecMounter(exec mount.Exec, wrapped mount.Interface) mount.Interface {
 	return &execMounter{}
@@ -85,7 +85,7 @@ func (mounter *execMounter) ExistsPath(pathname string) (bool, error) {
 	return true, errors.New("not implemented")
 }
 
-func (m *execMounter) EvalHostSymlinks(pathname string) (string, error) {
+func (mounter *execMounter) EvalHostSymlinks(pathname string) (string, error) {
 	return "", errors.New("not implemented")
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/sig storage
/assign @msau42 @jsafrane @ddebroy 

**What this PR does / why we need it**:
This patch moves the ExecMounter found in `pkg/util/mount` to
`pkg/volume/util/exec`. This is done in preparation for `pkg/util/mount` to
move out of tree. This specific implementation of `mount.Interface` is only
used internally to K8s and does not need to move out of tree.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
This is another step in making #68513 be a lot simpler.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

