### PR TITLE
Follow up of #76126

### DIFF
--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -131,7 +131,7 @@ push() {
   export DOCKER_CLI_EXPERIMENTAL="enabled"
   # Make archs list into image manifest. Eg: 'amd64 ppc64le' to '${REGISTRY}/${IMAGE}-amd64:${TAG} ${REGISTRY}/${IMAGE}-ppc64le:${TAG}'
   manifest=$(echo "$archs" | ${SED} -e "s~[^ ]*~$REGISTRY\/$IMAGE\-&:$TAG~g")
-  docker manifest create --amend "${REGISTRY}/${IMAGE}:${TAG}" "${manifest}"
+  docker manifest create --amend "${REGISTRY}/${IMAGE}:${TAG}" ${manifest}
   for arch in ${archs}; do
     docker manifest annotate --arch "${arch}" "${REGISTRY}/${IMAGE}:${TAG}" "${REGISTRY}/${IMAGE}-${arch}:${TAG}"
   done


### PR DESCRIPTION
/kind bug

#76126 breaks the test image build. Running `make all-push WHAT=webhook`, it returns error message "invalid referent format".

The broken line is https://github.com/kubernetes/kubernetes/blob/ca55432599904fa764898913be2ab8482e85d3aa/test/images/image-util.sh#L134.

The root cause is that `${manifest}` is a list of images, quoting it making docker treat the list as the name of a single image, and it's invalid to have spaces in the image name.

For example, without the quotes around `${manifest}`, the command expands as:
```bash
docker manifest create --amend gcr.io/kubernetes-e2e-test-images/webhook:1.15v1 gcr.io/kubernetes-e2e-test-images/webhook-amd64:1.15v1 gcr.io/kubernetes-e2e-test-images/webhook-arm:1.15v1 gcr.io/kubernetes-e2e-test-images/webhook-arm64:1.15v1 gcr.io/kubernetes-e2e-test-images/webhook-ppc64le:1.15v1
```

With the quotes, the command is invalid:
```bash
docker manifest create --amend "gcr.io/kubernetes-e2e-test-images/webhook:1.15v1" "gcr.io/kubernetes-e2e-test-images/webhook-amd64:1.15v1 gcr.io/kubernetes-e2e-test-images/webhook-arm:1.15v1 gcr.io/kubernetes-e2e-test-images/webhook-arm64:1.15v1 gcr.io/kubernetes-e2e-test-images/webhook-ppc64le:1.15v1"
```

/priority important-soon
/assign @SataQiu @listx
/sig testing