### PR TITLE
Do not delete pod object immediately if it has volume resources

### DIFF
--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -265,6 +265,26 @@ func TestCheckGracefulDelete(t *testing.T) {
 			},
 			gracePeriod: 0,
 		},
+		{
+			in: &api.Pod{
+				Spec: api.PodSpec{
+					Volumes:  []api.Volume{{Name: "vol", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}}},
+					NodeName: "node1",
+				},
+				Status: api.PodStatus{Phase: api.PodSucceeded},
+			},
+			gracePeriod: 0,
+		},
+		{
+			in: &api.Pod{
+				Spec: api.PodSpec{
+					Volumes:  []api.Volume{{Name: "vol", VolumeSource: api.VolumeSource{PersistentVolumeClaim: &api.PersistentVolumeClaimVolumeSource{}}}},
+					NodeName: "node1",
+				},
+				Status: api.PodStatus{Phase: api.PodSucceeded},
+			},
+			gracePeriod: defaultGracePeriod,
+		},
 	}
 	for _, tc := range tcs {
 		out := &metav1.DeleteOptions{GracePeriodSeconds: &defaultGracePeriod}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig storage

**What this PR does / why we need it**:
When a pod object that has volume resources is deleted immediately instead of waiting for volumes to be unmounted, this can break the storage protection feature for volume types that do not have deletion protection built-in, such as nfs.

**Which issue(s) this PR fixes**:
Fixes #74372

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
When a pod object that has volume resources is deleted do not set the grace period to zero.
```
