### PR TITLE
Enable PVC as DataSource for PVC creation

### DIFF
--- a/pkg/api/persistentvolumeclaim/util.go
+++ b/pkg/api/persistentvolumeclaim/util.go
@@ -55,11 +55,15 @@ func dataSourceInUse(oldPVCSpec *core.PersistentVolumeClaimSpec) bool {
 
 func dataSourceIsEnabled(pvcSpec *core.PersistentVolumeClaimSpec) bool {
 	if pvcSpec.DataSource != nil {
-		if pvcSpec.DataSource.Kind == "PersistentVolumeClaim" && utilfeature.DefaultFeatureGate.Enabled(features.VolumeDataSource) {
+		if pvcSpec.DataSource.Kind == "PersistentVolumeClaim" &&
+			*pvcSpec.DataSource.APIGroup == "" &&
+			utilfeature.DefaultFeatureGate.Enabled(features.VolumePVCDataSource) {
 			return true
 
 		}
-		if pvcSpec.DataSource.Kind == "VolumeSnapshot" && utilfeature.DefaultFeatureGate.Enabled(features.VolumeSnapshotDataSource) {
+		if pvcSpec.DataSource.Kind == "VolumeSnapshot" &&
+			*pvcSpec.DataSource.APIGroup == "snapshot.storage.k8s.io" &&
+			utilfeature.DefaultFeatureGate.Enabled(features.VolumeSnapshotDataSource) {
 			return true
 
 		}

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -416,11 +416,14 @@ type PersistentVolumeClaimSpec struct {
 	// This is a beta feature.
 	// +optional
 	VolumeMode *PersistentVolumeMode
-	// This field requires the VolumeSnapshotDataSource alpha feature gate to be
-	// enabled and currently VolumeSnapshot is the only supported data source.
-	// If the provisioner can support VolumeSnapshot data source, it will create
-	// a new volume and data will be restored to the volume at the same time.
-	// If the provisioner does not support VolumeSnapshot data source, volume will
+	// This field can be used to specify either:
+	// * An existing VolumeSnapshot
+	// * An existing Volume (PVC, Clone operation)
+	// In order to use either of these DataSource types, the appropriate feature gate
+	// must be enabled (VolumeSnapshotDataSource, VolumeDataSource)
+	// If the provisioner can support the specified data source, it will create
+	// a new volume based on the contents of the specified PVC or Snapshot.
+	// If the provisioner does not support the specified data source, the volume will
 	// not be created and the failure will be reported as an event.
 	// In the future, we plan to support more data source types and the behavior
 	// of the provisioner may change.

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -417,10 +417,10 @@ type PersistentVolumeClaimSpec struct {
 	// +optional
 	VolumeMode *PersistentVolumeMode
 	// This field can be used to specify either:
-	// * An existing VolumeSnapshot
-	// * An existing Volume (PVC, Clone operation)
+	// * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+	// * An existing PVC (""/PersistentVolumeClaim)
 	// In order to use either of these DataSource types, the appropriate feature gate
-	// must be enabled (VolumeSnapshotDataSource, VolumeDataSource)
+	// must be enabled (VolumeSnapshotDataSource, VolumePVCDataSource)
 	// If the provisioner can support the specified data source, it will create
 	// a new volume based on the contents of the specified PVC or Snapshot.
 	// If the provisioner does not support the specified data source, the volume will

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -1524,6 +1524,7 @@ var supportedVolumeModes = sets.NewString(string(core.PersistentVolumeBlock), st
 
 var supportedDataSourceAPIGroupKinds = map[schema.GroupKind]bool{
 	{Group: "snapshot.storage.k8s.io", Kind: "VolumeSnapshot"}: true,
+	{Group: "", Kind: "PersistentVolumeClaim"}:                 true,
 }
 
 func ValidatePersistentVolume(pv *core.PersistentVolume) field.ErrorList {

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -13172,7 +13172,7 @@ func testDataSourceInSpec(name string, kind string, apiGroup string) *core.Persi
 	return &dataSourceInSpec
 }
 
-func TestAlphaVolumeDataSource(t *testing.T) {
+func TestAlphaVolumePVCDataSource(t *testing.T) {
 	successTestCases := []core.PersistentVolumeClaimSpec{
 		*testDataSourceInSpec("test_snapshot", "VolumeSnapshot", "snapshot.storage.k8s.io"),
 		*testDataSourceInSpec("test_pvc", "PersistentVolumeClaim", ""),

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -13149,3 +13149,48 @@ func TestValidateOrSetClientIPAffinityConfig(t *testing.T) {
 func boolPtr(b bool) *bool {
 	return &b
 }
+
+func testDataSourceInSpec(name string, kind string, apiGroup string) *core.PersistentVolumeClaimSpec {
+	scName := "csi-plugin"
+	dataSourceInSpec := core.PersistentVolumeClaimSpec{
+		AccessModes: []core.PersistentVolumeAccessMode{
+			core.ReadOnlyMany,
+		},
+		Resources: core.ResourceRequirements{
+			Requests: core.ResourceList{
+				core.ResourceName(core.ResourceStorage): resource.MustParse("10G"),
+			},
+		},
+		StorageClassName: &scName,
+		DataSource: &core.TypedLocalObjectReference{
+			APIGroup: &apiGroup,
+			Kind:     kind,
+			Name:     name,
+		},
+	}
+
+	return &dataSourceInSpec
+}
+
+func TestAlphaVolumeDataSource(t *testing.T) {
+	successTestCases := []core.PersistentVolumeClaimSpec{
+		*testDataSourceInSpec("test_snapshot", "VolumeSnapshot", "snapshot.storage.k8s.io"),
+		*testDataSourceInSpec("test_pvc", "PersistentVolumeClaim", ""),
+	}
+	failedTestCases := []core.PersistentVolumeClaimSpec{
+		*testDataSourceInSpec("", "VolumeSnapshot", "snapshot.storage.k8s.io"),
+		*testDataSourceInSpec("test_snapshot", "PersistentVolumeClaim", "snapshot.storage.k8s.io"),
+		*testDataSourceInSpec("test_snapshot", "VolumeSnapshot", "storage.k8s.io"),
+	}
+
+	for _, tc := range successTestCases {
+		if errs := ValidatePersistentVolumeClaimSpec(&tc, field.NewPath("spec")); len(errs) != 0 {
+			t.Errorf("expected success: %v", errs)
+		}
+	}
+	for _, tc := range failedTestCases {
+		if errs := ValidatePersistentVolumeClaimSpec(&tc, field.NewPath("spec")); len(errs) == 0 {
+			t.Errorf("expected failure: %v", errs)
+		}
+	}
+}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -13145,3 +13145,52 @@ func TestValidateOrSetClientIPAffinityConfig(t *testing.T) {
 		}
 	}
 }
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func testDataSourceInSpec(name string, kind string, apiGroup string) *core.PersistentVolumeClaimSpec {
+	scName := "csi-plugin"
+	dataSourceInSpec := core.PersistentVolumeClaimSpec{
+		AccessModes: []core.PersistentVolumeAccessMode{
+			core.ReadOnlyMany,
+		},
+		Resources: core.ResourceRequirements{
+			Requests: core.ResourceList{
+				core.ResourceName(core.ResourceStorage): resource.MustParse("10G"),
+			},
+		},
+		StorageClassName: &scName,
+		DataSource: &core.TypedLocalObjectReference{
+			APIGroup: &apiGroup,
+			Kind:     kind,
+			Name:     name,
+		},
+	}
+
+	return &dataSourceInSpec
+}
+
+func TestAlphaVolumeDataSource(t *testing.T) {
+	successTestCases := []core.PersistentVolumeClaimSpec{
+		*testDataSourceInSpec("test_snapshot", "VolumeSnapshot", "snapshot.storage.k8s.io"),
+		*testDataSourceInSpec("test_pvc", "PersistentVolumeClaim", ""),
+	}
+	failedTestCases := []core.PersistentVolumeClaimSpec{
+		*testDataSourceInSpec("", "VolumeSnapshot", "snapshot.storage.k8s.io"),
+		*testDataSourceInSpec("test_snapshot", "PersistentVolumeClaim", "snapshot.storage.k8s.io"),
+		*testDataSourceInSpec("test_snapshot", "VolumeSnapshot", "storage.k8s.io"),
+	}
+
+	for _, tc := range successTestCases {
+		if errs := ValidatePersistentVolumeClaimSpec(&tc, field.NewPath("spec")); len(errs) != 0 {
+			t.Errorf("expected success: %v", errs)
+		}
+	}
+	for _, tc := range failedTestCases {
+		if errs := ValidatePersistentVolumeClaimSpec(&tc, field.NewPath("spec")); len(errs) == 0 {
+			t.Errorf("expected failure: %v", errs)
+		}
+	}
+}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -434,6 +434,12 @@ const (
 	//
 	// Enables the OpenStack Cinder in-tree driver to OpenStack Cinder CSI Driver migration feature.
 	CSIMigrationOpenStack utilfeature.Feature = "CSIMigrationOpenStack"
+
+	// owner: @j-griffith
+	// alpha: v1.14
+	//
+	// Enable data source support (applies to all supported types, snapshots, populators and PVCs).
+	VolumeDataSource utilfeature.Feature = "VolumeDataSource"
 )
 
 func init() {
@@ -504,6 +510,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	NodeLease:                                   {Default: true, PreRelease: utilfeature.Beta},
 	SCTPSupport:                                 {Default: false, PreRelease: utilfeature.Alpha},
 	VolumeSnapshotDataSource:                    {Default: false, PreRelease: utilfeature.Alpha},
+	VolumeDataSource:                            {Default: false, PreRelease: utilfeature.Alpha},
 	ProcMountType:                               {Default: false, PreRelease: utilfeature.Alpha},
 	TTLAfterFinished:                            {Default: false, PreRelease: utilfeature.Alpha},
 	KubeletPodResources:                         {Default: false, PreRelease: utilfeature.Alpha},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -436,10 +436,10 @@ const (
 	CSIMigrationOpenStack utilfeature.Feature = "CSIMigrationOpenStack"
 
 	// owner: @j-griffith
-	// alpha: v1.14
+	// alpha: v1.15
 	//
-	// Enable data source support (applies to all supported types, snapshots, populators and PVCs).
-	VolumeDataSource utilfeature.Feature = "VolumeDataSource"
+	// Enable support for specifying an existing PVC as a DataSource
+	VolumePVCDataSource utilfeature.Feature = "VolumePVCDataSource"
 )
 
 func init() {
@@ -510,7 +510,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	NodeLease:                                   {Default: true, PreRelease: utilfeature.Beta},
 	SCTPSupport:                                 {Default: false, PreRelease: utilfeature.Alpha},
 	VolumeSnapshotDataSource:                    {Default: false, PreRelease: utilfeature.Alpha},
-	VolumeDataSource:                            {Default: false, PreRelease: utilfeature.Alpha},
+	VolumePVCDataSource:                         {Default: false, PreRelease: utilfeature.Alpha},
 	ProcMountType:                               {Default: false, PreRelease: utilfeature.Alpha},
 	TTLAfterFinished:                            {Default: false, PreRelease: utilfeature.Alpha},
 	KubeletPodResources:                         {Default: false, PreRelease: utilfeature.Alpha},


### PR DESCRIPTION
This enables the ability to specify and existing PVC as a DataSource in
a new PVC Spec (eg "clone" and existing volume).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

Currently the only valid input Kind for PVC DataSource is "VolumeSnapshot", this feature adds the ability to also specify a DataSource Kind of "PersistentVolumeClaim".

This results in the ability for a user to specify intent to clone and existing PVC, it does NOT implement cloning functionality in Kubernetes; that's left to the external csi provisioner and plugins.  It does however provide a mechanism to request a clone operation to the csi-provisioner and ultimately the csi plugin that the original PVC is allocated from.

Currently (as of 1.14) a user is able to enter a DataSource with any information they wish, however if it's not of the type "VolumeSnapshot" and the "VolumeSnapshotDataSource" feature gate is not enabled, the input is nilled and silently ignored.  This change follows the same pattern, via  the "VolumeDataSource" feature gate.

**Which issue(s) this PR fixes**:

Implements [enhancement/KEP 642](https://github.com/kubernetes/enhancements/pull/642)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
This change enables a user to specify a DataSource/Kind of type "PersistentVolumeClaim" in their PVC spec.  This can then be detected by the external csi-provisioner and plugins if capable.
```
