### PR TITLE
Add DataSource to PVC describe

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
@@ -1534,6 +1534,11 @@ func describePersistentVolumeClaim(pvc *corev1.PersistentVolumeClaim, events *co
 		if pvc.Spec.VolumeMode != nil {
 			w.Write(LEVEL_0, "VolumeMode:\t%v\n", *pvc.Spec.VolumeMode)
 		}
+		if pvc.Spec.DataSource != nil {
+			w.Write(LEVEL_0, "DataSource:\n")
+			w.Write(LEVEL_1, "Name:\t%v\n", pvc.Spec.DataSource.Name)
+			w.Write(LEVEL_1, "Kind:\t%v\n", pvc.Spec.DataSource.Kind)
+		}
 		printPodsMultiline(w, "Mounted By", mountPods)
 
 		if len(pvc.Status.Conditions) > 0 {


### PR DESCRIPTION
 /kind bug


**What this PR does / why we need it**:
This change adds non nil DataSource entries of a PVC to the `describe pvc` output.  Currently there's no real way to know for sure if you submitted an invalid or unsupported DataSource Kind if it was accepted or not.

For example, using the Hostpath driver, I can enter any info I want as DataSource Kind and Name and the volume is succesfully created/bound.  Of course the info I supplied is filtered out, but I don't have any way of knowing that via the API.

In the case of valid entries (ie VolumeSnapshot and a supporting CSI Plugin) again there's no information after creation to make it clear to me that the PVC was in fact valid and created with the DataSource that I specified.

**Which issue(s) this PR fixes**:

Fixes #76460             

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Non nil DataSource entries on PVC's are now displayed as part of `describe pvc` output.
```
