### PR TITLE
Clean deprecated metrics

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -285,7 +285,6 @@ func (m *cgroupManagerImpl) Destroy(cgroupConfig *CgroupConfig) error {
 	start := time.Now()
 	defer func() {
 		metrics.CgroupManagerDuration.WithLabelValues("destroy").Observe(metrics.SinceInSeconds(start))
-		metrics.DeprecatedCgroupManagerLatency.WithLabelValues("destroy").Observe(metrics.SinceInMicroseconds(start))
 	}()
 
 	cgroupPaths := m.buildCgroupPaths(cgroupConfig.Name)
@@ -413,7 +412,6 @@ func (m *cgroupManagerImpl) Update(cgroupConfig *CgroupConfig) error {
 	start := time.Now()
 	defer func() {
 		metrics.CgroupManagerDuration.WithLabelValues("update").Observe(metrics.SinceInSeconds(start))
-		metrics.DeprecatedCgroupManagerLatency.WithLabelValues("update").Observe(metrics.SinceInMicroseconds(start))
 	}()
 
 	// Extract the cgroup resource parameters
@@ -449,7 +447,6 @@ func (m *cgroupManagerImpl) Create(cgroupConfig *CgroupConfig) error {
 	start := time.Now()
 	defer func() {
 		metrics.CgroupManagerDuration.WithLabelValues("create").Observe(metrics.SinceInSeconds(start))
-		metrics.DeprecatedCgroupManagerLatency.WithLabelValues("create").Observe(metrics.SinceInMicroseconds(start))
 	}()
 
 	resources := m.toResources(cgroupConfig.ResourceParameters)

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -393,7 +393,6 @@ func (m *ManagerImpl) Allocate(node *schedulernodeinfo.NodeInfo, attrs *lifecycl
 func (m *ManagerImpl) Register(ctx context.Context, r *pluginapi.RegisterRequest) (*pluginapi.Empty, error) {
 	klog.Infof("Got registration request from device plugin with resource name %q", r.ResourceName)
 	metrics.DevicePluginRegistrationCount.WithLabelValues(r.ResourceName).Inc()
-	metrics.DeprecatedDevicePluginRegistrationCount.WithLabelValues(r.ResourceName).Inc()
 	var versionCompatible bool
 	for _, v := range pluginapi.SupportedVersions {
 		if r.Version == v {
@@ -814,7 +813,6 @@ func (m *ManagerImpl) allocateContainerResources(pod *v1.Pod, container *v1.Cont
 		klog.V(3).Infof("Making allocation request for devices %v for device plugin %s", devs, resource)
 		resp, err := eI.e.allocate(devs)
 		metrics.DevicePluginAllocationDuration.WithLabelValues(resource).Observe(metrics.SinceInSeconds(startRPCTime))
-		metrics.DeprecatedDevicePluginAllocationLatency.WithLabelValues(resource).Observe(metrics.SinceInMicroseconds(startRPCTime))
 		if err != nil {
 			// In case of allocation failure, we want to restore m.allocatedDevices
 			// to the actual allocated state from m.podDevices.

--- a/pkg/kubelet/dockershim/libdocker/instrumented_client.go
+++ b/pkg/kubelet/dockershim/libdocker/instrumented_client.go
@@ -42,9 +42,7 @@ func NewInstrumentedInterface(dockerClient Interface) Interface {
 // recordOperation records the duration of the operation.
 func recordOperation(operation string, start time.Time) {
 	metrics.DockerOperations.WithLabelValues(operation).Inc()
-	metrics.DeprecatedDockerOperations.WithLabelValues(operation).Inc()
 	metrics.DockerOperationsLatency.WithLabelValues(operation).Observe(metrics.SinceInSeconds(start))
-	metrics.DeprecatedDockerOperationsLatency.WithLabelValues(operation).Observe(metrics.SinceInMicroseconds(start))
 }
 
 // recordError records error for metric if an error occurred.
@@ -52,11 +50,9 @@ func recordError(operation string, err error) {
 	if err != nil {
 		if _, ok := err.(operationTimeout); ok {
 			metrics.DockerOperationsTimeout.WithLabelValues(operation).Inc()
-			metrics.DeprecatedDockerOperationsTimeout.WithLabelValues(operation).Inc()
 		}
 		// Docker operation timeout error is also a docker error, so we don't add else here.
 		metrics.DockerOperationsErrors.WithLabelValues(operation).Inc()
-		metrics.DeprecatedDockerOperationsErrors.WithLabelValues(operation).Inc()
 	}
 }
 

--- a/pkg/kubelet/dockershim/metrics/metrics.go
+++ b/pkg/kubelet/dockershim/metrics/metrics.go
@@ -96,11 +96,6 @@ func Register() {
 	})
 }
 
-// SinceInMicroseconds gets the time since the specified start in microseconds.
-func SinceInMicroseconds(start time.Time) float64 {
-	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
-}
-
 // SinceInSeconds gets the time since the specified start in seconds.
 func SinceInSeconds(start time.Time) float64 {
 	return time.Since(start).Seconds()

--- a/pkg/kubelet/dockershim/metrics/metrics.go
+++ b/pkg/kubelet/dockershim/metrics/metrics.go
@@ -34,15 +34,6 @@ const (
 	// DockerOperationsTimeoutKey is the key for the operation timeout metrics.
 	DockerOperationsTimeoutKey = "docker_operations_timeout_total"
 
-	// DeprecatedDockerOperationsKey is the deprecated key for docker operation metrics.
-	DeprecatedDockerOperationsKey = "docker_operations"
-	// DeprecatedDockerOperationsLatencyKey is the deprecated key for the operation latency metrics.
-	DeprecatedDockerOperationsLatencyKey = "docker_operations_latency_microseconds"
-	// DeprecatedDockerOperationsErrorsKey is the deprecated key for the operation error metrics.
-	DeprecatedDockerOperationsErrorsKey = "docker_operations_errors"
-	// DeprecatedDockerOperationsTimeoutKey is the deprecated key for the operation timeout metrics.
-	DeprecatedDockerOperationsTimeoutKey = "docker_operations_timeout"
-
 	// Keep the "kubelet" subsystem for backward compatibility.
 	kubeletSubsystem = "kubelet"
 )
@@ -91,53 +82,6 @@ var (
 		},
 		[]string{"operation_type"},
 	)
-
-	// DeprecatedDockerOperationsLatency collects operation latency numbers by operation
-	// type.
-	DeprecatedDockerOperationsLatency = metrics.NewSummaryVec(
-		&metrics.SummaryOpts{
-			Subsystem:         kubeletSubsystem,
-			Name:              DeprecatedDockerOperationsLatencyKey,
-			Help:              "Latency in microseconds of Docker operations. Broken down by operation type.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"operation_type"},
-	)
-	// DeprecatedDockerOperations collects operation counts by operation type.
-	DeprecatedDockerOperations = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Subsystem:         kubeletSubsystem,
-			Name:              DeprecatedDockerOperationsKey,
-			Help:              "Cumulative number of Docker operations by operation type.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"operation_type"},
-	)
-	// DeprecatedDockerOperationsErrors collects operation errors by operation
-	// type.
-	DeprecatedDockerOperationsErrors = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Subsystem:         kubeletSubsystem,
-			Name:              DeprecatedDockerOperationsErrorsKey,
-			Help:              "Cumulative number of Docker operation errors by operation type.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"operation_type"},
-	)
-	// DeprecatedDockerOperationsTimeout collects operation timeouts by operation type.
-	DeprecatedDockerOperationsTimeout = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Subsystem:         kubeletSubsystem,
-			Name:              DeprecatedDockerOperationsTimeoutKey,
-			Help:              "Cumulative number of Docker operation timeout by operation type.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"operation_type"},
-	)
 )
 
 var registerMetrics sync.Once
@@ -149,10 +93,6 @@ func Register() {
 		legacyregistry.MustRegister(DockerOperations)
 		legacyregistry.MustRegister(DockerOperationsErrors)
 		legacyregistry.MustRegister(DockerOperationsTimeout)
-		legacyregistry.MustRegister(DeprecatedDockerOperationsLatency)
-		legacyregistry.MustRegister(DeprecatedDockerOperations)
-		legacyregistry.MustRegister(DeprecatedDockerOperationsErrors)
-		legacyregistry.MustRegister(DeprecatedDockerOperationsTimeout)
 	})
 }
 

--- a/pkg/kubelet/dockershim/network/metrics/metrics.go
+++ b/pkg/kubelet/dockershim/network/metrics/metrics.go
@@ -58,11 +58,6 @@ func Register() {
 	})
 }
 
-// SinceInMicroseconds gets the time since the specified start in microseconds.
-func SinceInMicroseconds(start time.Time) float64 {
-	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
-}
-
 // SinceInSeconds gets the time since the specified start in seconds.
 func SinceInSeconds(start time.Time) float64 {
 	return time.Since(start).Seconds()

--- a/pkg/kubelet/dockershim/network/metrics/metrics.go
+++ b/pkg/kubelet/dockershim/network/metrics/metrics.go
@@ -29,8 +29,6 @@ const (
 	NetworkPluginOperationsKey = "network_plugin_operations"
 	// NetworkPluginOperationsLatencyKey is the key for the operation latency metrics.
 	NetworkPluginOperationsLatencyKey = "network_plugin_operations_duration_seconds"
-	// DeprecatedNetworkPluginOperationsLatencyKey is the deprecated key for the operation latency metrics.
-	DeprecatedNetworkPluginOperationsLatencyKey = "network_plugin_operations_latency_microseconds"
 
 	// Keep the "kubelet" subsystem for backward compatibility.
 	kubeletSubsystem = "kubelet"
@@ -49,19 +47,6 @@ var (
 		},
 		[]string{"operation_type"},
 	)
-
-	// DeprecatedNetworkPluginOperationsLatency collects operation latency numbers by operation
-	// type.
-	DeprecatedNetworkPluginOperationsLatency = metrics.NewSummaryVec(
-		&metrics.SummaryOpts{
-			Subsystem:         kubeletSubsystem,
-			Name:              DeprecatedNetworkPluginOperationsLatencyKey,
-			Help:              "Latency in microseconds of network plugin operations. Broken down by operation type.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"operation_type"},
-	)
 )
 
 var registerMetrics sync.Once
@@ -70,7 +55,6 @@ var registerMetrics sync.Once
 func Register() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(NetworkPluginOperationsLatency)
-		legacyregistry.MustRegister(DeprecatedNetworkPluginOperationsLatency)
 	})
 }
 

--- a/pkg/kubelet/dockershim/network/plugins.go
+++ b/pkg/kubelet/dockershim/network/plugins.go
@@ -381,7 +381,6 @@ func (pm *PluginManager) podUnlock(fullPodName string) {
 // recordOperation records operation and duration
 func recordOperation(operation string, start time.Time) {
 	metrics.NetworkPluginOperationsLatency.WithLabelValues(operation).Observe(metrics.SinceInSeconds(start))
-	metrics.DeprecatedNetworkPluginOperationsLatency.WithLabelValues(operation).Observe(metrics.SinceInMicroseconds(start))
 }
 
 func (pm *PluginManager) GetPodNetworkStatus(podNamespace, podName string, id kubecontainer.ContainerID) (*PodNetworkStatus, error) {

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -363,7 +363,6 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 		timeObserved := observations[t.Signal].time
 		if !timeObserved.IsZero() {
 			metrics.EvictionStatsAge.WithLabelValues(string(t.Signal)).Observe(metrics.SinceInSeconds(timeObserved.Time))
-			metrics.DeprecatedEvictionStatsAge.WithLabelValues(string(t.Signal)).Observe(metrics.SinceInMicroseconds(timeObserved.Time))
 		}
 	}
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1522,7 +1522,6 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 			// This is the first time we are syncing the pod. Record the latency
 			// since kubelet first saw the pod if firstSeenTime is set.
 			metrics.PodWorkerStartDuration.Observe(metrics.SinceInSeconds(firstSeenTime))
-			metrics.DeprecatedPodWorkerStartLatency.Observe(metrics.SinceInMicroseconds(firstSeenTime))
 		} else {
 			klog.V(3).Infof("First seen time not recorded for pod %q", pod.UID)
 		}
@@ -1547,7 +1546,6 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 	if !ok || existingStatus.Phase == v1.PodPending && apiPodStatus.Phase == v1.PodRunning &&
 		!firstSeenTime.IsZero() {
 		metrics.PodStartDuration.Observe(metrics.SinceInSeconds(firstSeenTime))
-		metrics.DeprecatedPodStartLatency.Observe(metrics.SinceInMicroseconds(firstSeenTime))
 	}
 
 	runnable := kl.canRunPod(pod)
@@ -2027,7 +2025,6 @@ func (kl *Kubelet) dispatchWork(pod *v1.Pod, syncType kubetypes.SyncPodType, mir
 		OnCompleteFunc: func(err error) {
 			if err != nil {
 				metrics.PodWorkerDuration.WithLabelValues(syncType.String()).Observe(metrics.SinceInSeconds(start))
-				metrics.DeprecatedPodWorkerLatency.WithLabelValues(syncType.String()).Observe(metrics.SinceInMicroseconds(start))
 			}
 		},
 	})

--- a/pkg/kubelet/kuberuntime/instrumented_services.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services.go
@@ -49,16 +49,13 @@ func newInstrumentedImageManagerService(service internalapi.ImageManagerService)
 // recordOperation records the duration of the operation.
 func recordOperation(operation string, start time.Time) {
 	metrics.RuntimeOperations.WithLabelValues(operation).Inc()
-	metrics.DeprecatedRuntimeOperations.WithLabelValues(operation).Inc()
 	metrics.RuntimeOperationsDuration.WithLabelValues(operation).Observe(metrics.SinceInSeconds(start))
-	metrics.DeprecatedRuntimeOperationsLatency.WithLabelValues(operation).Observe(metrics.SinceInMicroseconds(start))
 }
 
 // recordError records error for metric if an error occurred.
 func recordError(operation string, err error) {
 	if err != nil {
 		metrics.RuntimeOperationsErrors.WithLabelValues(operation).Inc()
-		metrics.DeprecatedRuntimeOperationsErrors.WithLabelValues(operation).Inc()
 	}
 }
 

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -34,45 +34,33 @@ import (
 
 // This const block defines the metric names for the kubelet metrics.
 const (
-	KubeletSubsystem                     = "kubelet"
-	NodeNameKey                          = "node_name"
-	NodeLabelKey                         = "node"
-	PodWorkerDurationKey                 = "pod_worker_duration_seconds"
-	PodStartDurationKey                  = "pod_start_duration_seconds"
-	CgroupManagerOperationsKey           = "cgroup_manager_duration_seconds"
-	PodWorkerStartDurationKey            = "pod_worker_start_duration_seconds"
-	PLEGRelistDurationKey                = "pleg_relist_duration_seconds"
-	PLEGDiscardEventsKey                 = "pleg_discard_events"
-	PLEGRelistIntervalKey                = "pleg_relist_interval_seconds"
-	PLEGLastSeenKey                      = "pleg_last_seen_seconds"
-	EvictionsKey                         = "evictions"
-	EvictionStatsAgeKey                  = "eviction_stats_age_seconds"
-	PreemptionsKey                       = "preemptions"
-	DeprecatedPodWorkerLatencyKey        = "pod_worker_latency_microseconds"
-	DeprecatedPodStartLatencyKey         = "pod_start_latency_microseconds"
-	DeprecatedCgroupManagerOperationsKey = "cgroup_manager_latency_microseconds"
-	DeprecatedPodWorkerStartLatencyKey   = "pod_worker_start_latency_microseconds"
-	DeprecatedPLEGRelistLatencyKey       = "pleg_relist_latency_microseconds"
-	DeprecatedPLEGRelistIntervalKey      = "pleg_relist_interval_microseconds"
-	DeprecatedEvictionStatsAgeKey        = "eviction_stats_age_microseconds"
-	VolumeStatsCapacityBytesKey          = "volume_stats_capacity_bytes"
-	VolumeStatsAvailableBytesKey         = "volume_stats_available_bytes"
-	VolumeStatsUsedBytesKey              = "volume_stats_used_bytes"
-	VolumeStatsInodesKey                 = "volume_stats_inodes"
-	VolumeStatsInodesFreeKey             = "volume_stats_inodes_free"
-	VolumeStatsInodesUsedKey             = "volume_stats_inodes_used"
+	KubeletSubsystem             = "kubelet"
+	NodeNameKey                  = "node_name"
+	NodeLabelKey                 = "node"
+	PodWorkerDurationKey         = "pod_worker_duration_seconds"
+	PodStartDurationKey          = "pod_start_duration_seconds"
+	CgroupManagerOperationsKey   = "cgroup_manager_duration_seconds"
+	PodWorkerStartDurationKey    = "pod_worker_start_duration_seconds"
+	PLEGRelistDurationKey        = "pleg_relist_duration_seconds"
+	PLEGDiscardEventsKey         = "pleg_discard_events"
+	PLEGRelistIntervalKey        = "pleg_relist_interval_seconds"
+	PLEGLastSeenKey              = "pleg_last_seen_seconds"
+	EvictionsKey                 = "evictions"
+	EvictionStatsAgeKey          = "eviction_stats_age_seconds"
+	PreemptionsKey               = "preemptions"
+	VolumeStatsCapacityBytesKey  = "volume_stats_capacity_bytes"
+	VolumeStatsAvailableBytesKey = "volume_stats_available_bytes"
+	VolumeStatsUsedBytesKey      = "volume_stats_used_bytes"
+	VolumeStatsInodesKey         = "volume_stats_inodes"
+	VolumeStatsInodesFreeKey     = "volume_stats_inodes_free"
+	VolumeStatsInodesUsedKey     = "volume_stats_inodes_used"
 	// Metrics keys of remote runtime operations
-	RuntimeOperationsKey                  = "runtime_operations_total"
-	RuntimeOperationsDurationKey          = "runtime_operations_duration_seconds"
-	RuntimeOperationsErrorsKey            = "runtime_operations_errors_total"
-	DeprecatedRuntimeOperationsKey        = "runtime_operations"
-	DeprecatedRuntimeOperationsLatencyKey = "runtime_operations_latency_microseconds"
-	DeprecatedRuntimeOperationsErrorsKey  = "runtime_operations_errors"
+	RuntimeOperationsKey         = "runtime_operations_total"
+	RuntimeOperationsDurationKey = "runtime_operations_duration_seconds"
+	RuntimeOperationsErrorsKey   = "runtime_operations_errors_total"
 	// Metrics keys of device plugin operations
-	DevicePluginRegistrationCountKey           = "device_plugin_registration_total"
-	DevicePluginAllocationDurationKey          = "device_plugin_alloc_duration_seconds"
-	DeprecatedDevicePluginRegistrationCountKey = "device_plugin_registration_count"
-	DeprecatedDevicePluginAllocationLatencyKey = "device_plugin_alloc_latency_microseconds"
+	DevicePluginRegistrationCountKey  = "device_plugin_registration_total"
+	DevicePluginAllocationDurationKey = "device_plugin_alloc_duration_seconds"
 
 	// Metric keys for node config
 	AssignedConfigKey             = "node_config_assigned"
@@ -289,146 +277,6 @@ var (
 		},
 		[]string{"resource_name"},
 	)
-	// DeprecatedPodWorkerLatency is a Summary that tracks the latency (in microseconds) to sync a single pod.
-	// Broken down by operation type. This metric is deprecated.
-	DeprecatedPodWorkerLatency = metrics.NewSummaryVec(
-		&metrics.SummaryOpts{
-			Subsystem:         KubeletSubsystem,
-			Name:              DeprecatedPodWorkerLatencyKey,
-			Help:              "Latency in microseconds to sync a single pod. Broken down by operation type: create, update, or sync",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"operation_type"},
-	)
-	// DeprecatedPodStartLatency is a Summary that tracks the latency (in microseconds) for a single pod to go from pending to running.
-	// This metric is deprecated.
-	DeprecatedPodStartLatency = metrics.NewSummary(
-		&metrics.SummaryOpts{
-			Subsystem:         KubeletSubsystem,
-			Name:              DeprecatedPodStartLatencyKey,
-			Help:              "Latency in microseconds for a single pod to go from pending to running.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-	)
-	// DeprecatedCgroupManagerLatency is a Summary that tracks the latency (in microseconds) for cgroup manager operations to complete.
-	// Broken down by operation type. This metric is deprecated.
-	DeprecatedCgroupManagerLatency = metrics.NewSummaryVec(
-		&metrics.SummaryOpts{
-			Subsystem:         KubeletSubsystem,
-			Name:              DeprecatedCgroupManagerOperationsKey,
-			Help:              "Latency in microseconds for cgroup manager operations. Broken down by method.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"operation_type"},
-	)
-	// DeprecatedPodWorkerStartLatency is a Summary that tracks the latency (in microseconds) from seeing a pod to starting a worker.
-	// This metric is deprecated.
-	DeprecatedPodWorkerStartLatency = metrics.NewSummary(
-		&metrics.SummaryOpts{
-			Subsystem:         KubeletSubsystem,
-			Name:              DeprecatedPodWorkerStartLatencyKey,
-			Help:              "Latency in microseconds from seeing a pod to starting a worker.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-	)
-	// DeprecatedPLEGRelistLatency is a Summary that tracks the latency (in microseconds) for relisting pods in PLEG.
-	// This metric is deprecated.
-	DeprecatedPLEGRelistLatency = metrics.NewSummary(
-		&metrics.SummaryOpts{
-			Subsystem:         KubeletSubsystem,
-			Name:              DeprecatedPLEGRelistLatencyKey,
-			Help:              "Latency in microseconds for relisting pods in PLEG.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-	)
-	// DeprecatedPLEGRelistInterval is a Summary that tracks the interval (in microseconds) between relistings in PLEG.
-	// This metric is deprecated.
-	DeprecatedPLEGRelistInterval = metrics.NewSummary(
-		&metrics.SummaryOpts{
-			Subsystem:         KubeletSubsystem,
-			Name:              DeprecatedPLEGRelistIntervalKey,
-			Help:              "Interval in microseconds between relisting in PLEG.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-	)
-	// DeprecatedRuntimeOperations is a Counter that tracks the cumulative number of remote runtime operations.
-	// Broken down by operation type. This metric is deprecated.
-	DeprecatedRuntimeOperations = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Subsystem:         KubeletSubsystem,
-			Name:              DeprecatedRuntimeOperationsKey,
-			Help:              "Cumulative number of runtime operations by operation type.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"operation_type"},
-	)
-	// DeprecatedRuntimeOperationsLatency is a Summary that tracks the latency (in microseconds) of remote runtime operations
-	// to complete. Broken down by operation type. This metric is deprecated.
-	DeprecatedRuntimeOperationsLatency = metrics.NewSummaryVec(
-		&metrics.SummaryOpts{
-			Subsystem:         KubeletSubsystem,
-			Name:              DeprecatedRuntimeOperationsLatencyKey,
-			Help:              "Latency in microseconds of runtime operations. Broken down by operation type.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"operation_type"},
-	)
-	// DeprecatedRuntimeOperationsErrors is a Counter that tracks the cumulative number of remote runtime operation errors.
-	// Broken down by operation type. This metric is deprecated.
-	DeprecatedRuntimeOperationsErrors = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Subsystem:         KubeletSubsystem,
-			Name:              DeprecatedRuntimeOperationsErrorsKey,
-			Help:              "Cumulative number of runtime operation errors by operation type.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"operation_type"},
-	)
-	// DeprecatedEvictionStatsAge is a Summary that tracks the time (in microseconds) between when stats are collected and when a pod
-	// is evicted based on those stats. Broken down by eviction signal. This metric is deprecated.
-	DeprecatedEvictionStatsAge = metrics.NewSummaryVec(
-		&metrics.SummaryOpts{
-			Subsystem:         KubeletSubsystem,
-			Name:              DeprecatedEvictionStatsAgeKey,
-			Help:              "Time between when stats are collected, and when pod is evicted based on those stats by eviction signal",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"eviction_signal"},
-	)
-	// DeprecatedDevicePluginRegistrationCount is a Counter that tracks the cumulative number of device plugin registrations.
-	// Broken down by resource name. This metric is deprecated.
-	DeprecatedDevicePluginRegistrationCount = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Subsystem:         KubeletSubsystem,
-			Name:              DeprecatedDevicePluginRegistrationCountKey,
-			Help:              "Cumulative number of device plugin registrations. Broken down by resource name.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"resource_name"},
-	)
-	// DeprecatedDevicePluginAllocationLatency is a Summary that tracks the latncy (in microseconds) for serving device plugin allocation requests.
-	// Broken down by resource name. This metric is deprecated.
-	DeprecatedDevicePluginAllocationLatency = metrics.NewSummaryVec(
-		&metrics.SummaryOpts{
-			Subsystem:         KubeletSubsystem,
-			Name:              DeprecatedDevicePluginAllocationLatencyKey,
-			Help:              "Latency in microseconds to serve a device plugin Allocation request. Broken down by resource name.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"resource_name"},
-	)
 
 	// Metrics for node config
 
@@ -542,18 +390,6 @@ func Register(containerCache kubecontainer.RuntimeCache, collectors ...metrics.S
 		legacyregistry.MustRegister(Preemptions)
 		legacyregistry.MustRegister(DevicePluginRegistrationCount)
 		legacyregistry.MustRegister(DevicePluginAllocationDuration)
-		legacyregistry.MustRegister(DeprecatedPodWorkerLatency)
-		legacyregistry.MustRegister(DeprecatedPodStartLatency)
-		legacyregistry.MustRegister(DeprecatedCgroupManagerLatency)
-		legacyregistry.MustRegister(DeprecatedPodWorkerStartLatency)
-		legacyregistry.MustRegister(DeprecatedPLEGRelistLatency)
-		legacyregistry.MustRegister(DeprecatedPLEGRelistInterval)
-		legacyregistry.MustRegister(DeprecatedRuntimeOperations)
-		legacyregistry.MustRegister(DeprecatedRuntimeOperationsLatency)
-		legacyregistry.MustRegister(DeprecatedRuntimeOperationsErrors)
-		legacyregistry.MustRegister(DeprecatedEvictionStatsAge)
-		legacyregistry.MustRegister(DeprecatedDevicePluginRegistrationCount)
-		legacyregistry.MustRegister(DeprecatedDevicePluginAllocationLatency)
 		legacyregistry.MustRegister(RunningContainerCount)
 		legacyregistry.MustRegister(RunningPodCount)
 		if utilfeature.DefaultFeatureGate.Enabled(features.DynamicKubeletConfig) {

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -409,11 +409,6 @@ func GetGather() metrics.Gatherer {
 	return legacyregistry.DefaultGatherer
 }
 
-// SinceInMicroseconds gets the time since the specified start in microseconds.
-func SinceInMicroseconds(start time.Time) float64 {
-	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
-}
-
 // SinceInSeconds gets the time since the specified start in seconds.
 func SinceInSeconds(start time.Time) float64 {
 	return time.Since(start).Seconds()

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -192,13 +192,11 @@ func (g *GenericPLEG) relist() {
 
 	if lastRelistTime := g.getRelistTime(); !lastRelistTime.IsZero() {
 		metrics.PLEGRelistInterval.Observe(metrics.SinceInSeconds(lastRelistTime))
-		metrics.DeprecatedPLEGRelistInterval.Observe(metrics.SinceInMicroseconds(lastRelistTime))
 	}
 
 	timestamp := g.clock.Now()
 	defer func() {
 		metrics.PLEGRelistDuration.Observe(metrics.SinceInSeconds(timestamp))
-		metrics.DeprecatedPLEGRelistLatency.Observe(metrics.SinceInMicroseconds(timestamp))
 	}()
 
 	// Get all the pods.

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -793,7 +793,6 @@ func (proxier *Proxier) syncProxyRules() {
 	start := time.Now()
 	defer func() {
 		metrics.SyncProxyRulesLatency.Observe(metrics.SinceInSeconds(start))
-		metrics.DeprecatedSyncProxyRulesLatency.Observe(metrics.SinceInMicroseconds(start))
 		klog.V(4).Infof("syncProxyRules took %v", time.Since(start))
 	}()
 

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1020,7 +1020,6 @@ func (proxier *Proxier) syncProxyRules() {
 	start := time.Now()
 	defer func() {
 		metrics.SyncProxyRulesLatency.Observe(metrics.SinceInSeconds(start))
-		metrics.DeprecatedSyncProxyRulesLatency.Observe(metrics.SinceInMicroseconds(start))
 		klog.V(4).Infof("syncProxyRules took %v", time.Since(start))
 	}()
 

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -38,18 +38,6 @@ var (
 		},
 	)
 
-	// DeprecatedSyncProxyRulesLatency is the latency of one round of kube-proxy syncing proxy rules.
-	DeprecatedSyncProxyRulesLatency = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:         kubeProxySubsystem,
-			Name:              "sync_proxy_rules_latency_microseconds",
-			Help:              "SyncProxyRules latency in microseconds",
-			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-	)
-
 	// SyncProxyRulesLastTimestamp is the timestamp proxy rules were last
 	// successfully synced.
 	SyncProxyRulesLastTimestamp = metrics.NewGauge(
@@ -145,7 +133,6 @@ var registerMetricsOnce sync.Once
 func RegisterMetrics() {
 	registerMetricsOnce.Do(func() {
 		legacyregistry.MustRegister(SyncProxyRulesLatency)
-		legacyregistry.MustRegister(DeprecatedSyncProxyRulesLatency)
 		legacyregistry.MustRegister(SyncProxyRulesLastTimestamp)
 		legacyregistry.MustRegister(NetworkProgrammingLatency)
 		legacyregistry.MustRegister(EndpointChangesPending)

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -143,11 +143,6 @@ func RegisterMetrics() {
 	})
 }
 
-// SinceInMicroseconds gets the time since the specified start in microseconds.
-func SinceInMicroseconds(start time.Time) float64 {
-	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
-}
-
 // SinceInSeconds gets the time since the specified start in seconds.
 func SinceInSeconds(start time.Time) float64 {
 	return time.Since(start).Seconds()

--- a/pkg/proxy/winkernel/metrics.go
+++ b/pkg/proxy/winkernel/metrics.go
@@ -36,17 +36,6 @@ var (
 		},
 	)
 
-	DeprecatedSyncProxyRulesLatency = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:         kubeProxySubsystem,
-			Name:              "sync_proxy_rules_latency_microseconds",
-			Help:              "SyncProxyRules latency in microseconds",
-			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-	)
-
 	// SyncProxyRulesLastTimestamp is the timestamp proxy rules were last
 	// successfully synced.
 	SyncProxyRulesLastTimestamp = metrics.NewGauge(
@@ -64,7 +53,6 @@ var registerMetricsOnce sync.Once
 func RegisterMetrics() {
 	registerMetricsOnce.Do(func() {
 		legacyregistry.MustRegister(SyncProxyRulesLatency)
-		legacyregistry.MustRegister(DeprecatedSyncProxyRulesLatency)
 		legacyregistry.MustRegister(SyncProxyRulesLastTimestamp)
 	})
 }

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -1002,7 +1002,6 @@ func (proxier *Proxier) syncProxyRules() {
 	start := time.Now()
 	defer func() {
 		SyncProxyRulesLatency.Observe(metrics.SinceInSeconds(start))
-		DeprecatedSyncProxyRulesLatency.Observe(metrics.SinceInMicroseconds(start))
 		klog.V(4).Infof("syncProxyRules took %v", time.Since(start))
 	}()
 	// don't sync rules till we've received services and endpoints

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -211,15 +211,12 @@ func (g *genericScheduler) Schedule(ctx context.Context, state *framework.CycleS
 	}
 	trace.Step("Running postfilter plugins done")
 	metrics.DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration.Observe(metrics.SinceInSeconds(startPredicateEvalTime))
-	metrics.DeprecatedSchedulingAlgorithmPredicateEvaluationDuration.Observe(metrics.SinceInMicroseconds(startPredicateEvalTime))
 	metrics.DeprecatedSchedulingDuration.WithLabelValues(metrics.PredicateEvaluation).Observe(metrics.SinceInSeconds(startPredicateEvalTime))
-	metrics.DeprecatedSchedulingLatency.WithLabelValues(metrics.PredicateEvaluation).Observe(metrics.SinceInSeconds(startPredicateEvalTime))
 
 	startPriorityEvalTime := time.Now()
 	// When only one node after predicate, just use it.
 	if len(filteredNodes) == 1 {
 		metrics.DeprecatedSchedulingAlgorithmPriorityEvaluationSecondsDuration.Observe(metrics.SinceInSeconds(startPriorityEvalTime))
-		metrics.DeprecatedSchedulingAlgorithmPriorityEvaluationDuration.Observe(metrics.SinceInMicroseconds(startPriorityEvalTime))
 		return ScheduleResult{
 			SuggestedHost:  filteredNodes[0].Name,
 			EvaluatedNodes: 1 + len(filteredNodesStatuses),
@@ -233,9 +230,7 @@ func (g *genericScheduler) Schedule(ctx context.Context, state *framework.CycleS
 	}
 
 	metrics.DeprecatedSchedulingAlgorithmPriorityEvaluationSecondsDuration.Observe(metrics.SinceInSeconds(startPriorityEvalTime))
-	metrics.DeprecatedSchedulingAlgorithmPriorityEvaluationDuration.Observe(metrics.SinceInMicroseconds(startPriorityEvalTime))
 	metrics.DeprecatedSchedulingDuration.WithLabelValues(metrics.PriorityEvaluation).Observe(metrics.SinceInSeconds(startPriorityEvalTime))
-	metrics.DeprecatedSchedulingLatency.WithLabelValues(metrics.PriorityEvaluation).Observe(metrics.SinceInSeconds(startPriorityEvalTime))
 
 	host, err := g.selectHost(priorityList)
 	trace.Step("Prioritizing done")

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -290,11 +290,6 @@ func Reset() {
 	DeprecatedSchedulingDuration.Reset()
 }
 
-// SinceInMicroseconds gets the time since the specified start in microseconds.
-func SinceInMicroseconds(start time.Time) float64 {
-	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
-}
-
 // SinceInSeconds gets the time since the specified start in seconds.
 func SinceInSeconds(start time.Time) float64 {
 	return time.Since(start).Seconds()

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -30,8 +30,6 @@ const (
 	SchedulerSubsystem = "scheduler"
 	// DeprecatedSchedulingDurationName - scheduler duration metric name which is deprecated
 	DeprecatedSchedulingDurationName = "scheduling_duration_seconds"
-	// DeprecatedSchedulingLatencyName - scheduler latency metric name which is deprecated
-	DeprecatedSchedulingLatencyName = "scheduling_latency_seconds"
 
 	// OperationLabel - operation label name
 	OperationLabel = "operation"
@@ -76,19 +74,6 @@ var (
 		},
 		[]string{OperationLabel},
 	)
-	DeprecatedSchedulingLatency = metrics.NewSummaryVec(
-		&metrics.SummaryOpts{
-			Subsystem: SchedulerSubsystem,
-			Name:      DeprecatedSchedulingLatencyName,
-			Help:      "Scheduling latency in seconds split by sub-parts of the scheduling operation",
-			// Make the sliding window of 5h.
-			// TODO: The value for this should be based on some SLI definition (long term).
-			MaxAge:            5 * time.Hour,
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{OperationLabel},
-	)
 	E2eSchedulingLatency = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
@@ -98,16 +83,6 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
-	DeprecatedE2eSchedulingLatency = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:         SchedulerSubsystem,
-			Name:              "e2e_scheduling_latency_microseconds",
-			Help:              "E2e scheduling latency in microseconds (scheduling algorithm + binding)",
-			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-	)
 	SchedulingAlgorithmLatency = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
@@ -115,16 +90,6 @@ var (
 			Help:           "Scheduling algorithm latency in seconds",
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
-		},
-	)
-	DeprecatedSchedulingAlgorithmLatency = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:         SchedulerSubsystem,
-			Name:              "scheduling_algorithm_latency_microseconds",
-			Help:              "Scheduling algorithm latency in microseconds",
-			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
 		},
 	)
 	DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration = metrics.NewHistogram(
@@ -137,16 +102,6 @@ var (
 			DeprecatedVersion: "1.18.0",
 		},
 	)
-	DeprecatedSchedulingAlgorithmPredicateEvaluationDuration = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:         SchedulerSubsystem,
-			Name:              "scheduling_algorithm_predicate_evaluation",
-			Help:              "Scheduling algorithm predicate evaluation duration in microseconds",
-			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-	)
 	DeprecatedSchedulingAlgorithmPriorityEvaluationSecondsDuration = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem:         SchedulerSubsystem,
@@ -155,16 +110,6 @@ var (
 			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel:    metrics.ALPHA,
 			DeprecatedVersion: "1.18.0",
-		},
-	)
-	DeprecatedSchedulingAlgorithmPriorityEvaluationDuration = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:         SchedulerSubsystem,
-			Name:              "scheduling_algorithm_priority_evaluation",
-			Help:              "Scheduling algorithm priority evaluation duration in microseconds",
-			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
 		},
 	)
 	SchedulingAlgorithmPreemptionEvaluationDuration = metrics.NewHistogram(
@@ -176,16 +121,6 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
-	DeprecatedSchedulingAlgorithmPreemptionEvaluationDuration = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:         SchedulerSubsystem,
-			Name:              "scheduling_algorithm_preemption_evaluation",
-			Help:              "Scheduling algorithm preemption evaluation duration in microseconds",
-			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-	)
 	BindingLatency = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
@@ -193,16 +128,6 @@ var (
 			Help:           "Binding latency in seconds",
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
-		},
-	)
-	DeprecatedBindingLatency = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:         SchedulerSubsystem,
-			Name:              "binding_latency_microseconds",
-			Help:              "Binding latency in microseconds",
-			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
 		},
 	)
 	PreemptionVictims = metrics.NewHistogram(
@@ -307,19 +232,12 @@ var (
 	metricsList = []metrics.Registerable{
 		scheduleAttempts,
 		DeprecatedSchedulingDuration,
-		DeprecatedSchedulingLatency,
 		E2eSchedulingLatency,
-		DeprecatedE2eSchedulingLatency,
 		SchedulingAlgorithmLatency,
-		DeprecatedSchedulingAlgorithmLatency,
 		BindingLatency,
-		DeprecatedBindingLatency,
 		DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration,
-		DeprecatedSchedulingAlgorithmPredicateEvaluationDuration,
 		DeprecatedSchedulingAlgorithmPriorityEvaluationSecondsDuration,
-		DeprecatedSchedulingAlgorithmPriorityEvaluationDuration,
 		SchedulingAlgorithmPreemptionEvaluationDuration,
-		DeprecatedSchedulingAlgorithmPreemptionEvaluationDuration,
 		PreemptionVictims,
 		PreemptionAttempts,
 		pendingPods,
@@ -370,7 +288,6 @@ func UnschedulablePods() metrics.GaugeMetric {
 // Reset resets metrics
 func Reset() {
 	DeprecatedSchedulingDuration.Reset()
-	DeprecatedSchedulingLatency.Reset()
 }
 
 // SinceInMicroseconds gets the time since the specified start in microseconds.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -540,9 +540,7 @@ func (sched *Scheduler) bind(ctx context.Context, assumed *v1.Pod, targetNode st
 	}
 
 	metrics.BindingLatency.Observe(metrics.SinceInSeconds(bindingStart))
-	metrics.DeprecatedBindingLatency.Observe(metrics.SinceInMicroseconds(bindingStart))
 	metrics.DeprecatedSchedulingDuration.WithLabelValues(metrics.Binding).Observe(metrics.SinceInSeconds(bindingStart))
-	metrics.DeprecatedSchedulingLatency.WithLabelValues(metrics.Binding).Observe(metrics.SinceInSeconds(bindingStart))
 	sched.Recorder.Eventf(assumed, nil, v1.EventTypeNormal, "Scheduled", "Binding", "Successfully assigned %v/%v to %v", assumed.Namespace, assumed.Name, targetNode)
 	return nil
 }
@@ -585,9 +583,7 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 				sched.preempt(schedulingCycleCtx, state, fwk, pod, fitError)
 				metrics.PreemptionAttempts.Inc()
 				metrics.SchedulingAlgorithmPreemptionEvaluationDuration.Observe(metrics.SinceInSeconds(preemptionStartTime))
-				metrics.DeprecatedSchedulingAlgorithmPreemptionEvaluationDuration.Observe(metrics.SinceInMicroseconds(preemptionStartTime))
 				metrics.DeprecatedSchedulingDuration.WithLabelValues(metrics.PreemptionEvaluation).Observe(metrics.SinceInSeconds(preemptionStartTime))
-				metrics.DeprecatedSchedulingLatency.WithLabelValues(metrics.PreemptionEvaluation).Observe(metrics.SinceInSeconds(preemptionStartTime))
 			}
 			// Pod did not fit anywhere, so it is counted as a failure. If preemption
 			// succeeds, the pod should get counted as a success the next time we try to
@@ -600,7 +596,6 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 		return
 	}
 	metrics.SchedulingAlgorithmLatency.Observe(metrics.SinceInSeconds(start))
-	metrics.DeprecatedSchedulingAlgorithmLatency.Observe(metrics.SinceInMicroseconds(start))
 	// Tell the cache to assume that a pod now is running on a given node, even though it hasn't been bound yet.
 	// This allows us to keep scheduling without waiting on binding to occur.
 	assumedPodInfo := podInfo.DeepCopy()
@@ -698,7 +693,6 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 
 		err := sched.bind(bindingCycleCtx, assumedPod, scheduleResult.SuggestedHost, state)
 		metrics.E2eSchedulingLatency.Observe(metrics.SinceInSeconds(start))
-		metrics.DeprecatedE2eSchedulingLatency.Observe(metrics.SinceInMicroseconds(start))
 		if err != nil {
 			metrics.PodScheduleErrors.Inc()
 			// trigger un-reserve plugins to clean up state associated with the reserved Pod

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -282,6 +282,7 @@ func MonitorRequest(req *http.Request, verb, group, version, resource, subresour
 	reportedVerb := cleanVerb(verb, req)
 	dryRun := cleanDryRun(req.URL)
 	client := cleanUserAgent(utilnet.GetHTTPClient(req))
+	elapsedMicroseconds := float64(elapsed / time.Microsecond)
 	elapsedSeconds := elapsed.Seconds()
 	requestCounter.WithLabelValues(reportedVerb, dryRun, group, version, resource, subresource, scope, component, client, contentType, codeToString(httpCode)).Inc()
 	deprecatedRequestCounter.WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component, client, contentType, codeToString(httpCode)).Inc()

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -74,6 +74,7 @@ var (
 		// should be all lowercase and separated by underscores.
 		[]string{"verb", "dry_run", "group", "version", "resource", "subresource", "scope", "component", "client", "contentType", "code"},
 	)
+	// TODO(logicalhan): remove this deprecated metrics after fixing the dependencies
 	deprecatedRequestCounter = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Name:              "apiserver_request_count",
@@ -104,17 +105,7 @@ var (
 		},
 		[]string{"verb", "dry_run", "group", "version", "resource", "subresource", "scope", "component"},
 	)
-	deprecatedRequestLatencies = compbasemetrics.NewHistogramVec(
-		&compbasemetrics.HistogramOpts{
-			Name: "apiserver_request_latencies",
-			Help: "Response latency distribution in microseconds for each verb, group, version, resource, subresource, scope and component.",
-			// Use buckets ranging from 125 ms to 8 seconds.
-			Buckets:           compbasemetrics.ExponentialBuckets(125000, 2.0, 7),
-			StabilityLevel:    compbasemetrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component"},
-	)
+	// TODO(wojtek-t): remove this deprecated metrics after fixing the dependencies
 	deprecatedRequestLatenciesSummary = compbasemetrics.NewSummaryVec(
 		&compbasemetrics.SummaryOpts{
 			Name: "apiserver_request_latencies_summary",
@@ -143,15 +134,6 @@ var (
 			Name:           "apiserver_dropped_requests_total",
 			Help:           "Number of requests dropped with 'Try again later' response",
 			StabilityLevel: compbasemetrics.ALPHA,
-		},
-		[]string{"requestKind"},
-	)
-	DeprecatedDroppedRequests = compbasemetrics.NewCounterVec(
-		&compbasemetrics.CounterOpts{
-			Name:              "apiserver_dropped_requests",
-			Help:              "Number of requests dropped with 'Try again later' response",
-			StabilityLevel:    compbasemetrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"requestKind"},
 	)
@@ -207,11 +189,9 @@ var (
 		deprecatedRequestCounter,
 		longRunningRequestGauge,
 		requestLatencies,
-		deprecatedRequestLatencies,
 		deprecatedRequestLatenciesSummary,
 		responseSizes,
 		DroppedRequests,
-		DeprecatedDroppedRequests,
 		RegisteredWatchers,
 		WatchEvents,
 		WatchEventsSizes,
@@ -307,7 +287,6 @@ func MonitorRequest(req *http.Request, verb, group, version, resource, subresour
 	requestCounter.WithLabelValues(reportedVerb, dryRun, group, version, resource, subresource, scope, component, client, contentType, codeToString(httpCode)).Inc()
 	deprecatedRequestCounter.WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component, client, contentType, codeToString(httpCode)).Inc()
 	requestLatencies.WithLabelValues(reportedVerb, dryRun, group, version, resource, subresource, scope, component).Observe(elapsedSeconds)
-	deprecatedRequestLatencies.WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component).Observe(elapsedMicroseconds)
 	deprecatedRequestLatenciesSummary.WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component).Observe(elapsedMicroseconds)
 	// We are only interested in response sizes of read requests.
 	if verb == "GET" || verb == "LIST" {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -282,7 +282,6 @@ func MonitorRequest(req *http.Request, verb, group, version, resource, subresour
 	reportedVerb := cleanVerb(verb, req)
 	dryRun := cleanDryRun(req.URL)
 	client := cleanUserAgent(utilnet.GetHTTPClient(req))
-	elapsedMicroseconds := float64(elapsed / time.Microsecond)
 	elapsedSeconds := elapsed.Seconds()
 	requestCounter.WithLabelValues(reportedVerb, dryRun, group, version, resource, subresource, scope, component, client, contentType, codeToString(httpCode)).Inc()
 	deprecatedRequestCounter.WithLabelValues(reportedVerb, group, version, resource, subresource, scope, component, client, contentType, codeToString(httpCode)).Inc()

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
@@ -173,10 +173,8 @@ func WithMaxInFlightLimit(
 				// We need to split this data between buckets used for throttling.
 				if isMutatingRequest {
 					metrics.DroppedRequests.WithLabelValues(metrics.MutatingKind).Inc()
-					metrics.DeprecatedDroppedRequests.WithLabelValues(metrics.MutatingKind).Inc()
 				} else {
 					metrics.DroppedRequests.WithLabelValues(metrics.ReadOnlyKind).Inc()
-					metrics.DeprecatedDroppedRequests.WithLabelValues(metrics.ReadOnlyKind).Inc()
 				}
 				metrics.RecordRequestTermination(r, requestInfo, metrics.APIServerComponent, http.StatusTooManyRequests)
 				tooManyRequests(r, w)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -49,16 +49,6 @@ var (
 		},
 		[]string{"resource"},
 	)
-
-	deprecatedEtcdRequestLatenciesSummary = compbasemetrics.NewSummaryVec(
-		&compbasemetrics.SummaryOpts{
-			Name:              "etcd_request_latencies_summary",
-			Help:              "Etcd request latency summary in microseconds for each operation and object type.",
-			StabilityLevel:    compbasemetrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"operation", "type"},
-	)
 )
 
 var registerMetrics sync.Once
@@ -69,9 +59,6 @@ func Register() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(etcdRequestLatency)
 		legacyregistry.MustRegister(objectCounts)
-
-		// TODO(danielqsj): Remove the following metrics, they are deprecated
-		legacyregistry.MustRegister(deprecatedEtcdRequestLatenciesSummary)
 	})
 }
 
@@ -83,19 +70,11 @@ func UpdateObjectCount(resourcePrefix string, count int64) {
 // RecordEtcdRequestLatency sets the etcd_request_duration_seconds metrics.
 func RecordEtcdRequestLatency(verb, resource string, startTime time.Time) {
 	etcdRequestLatency.WithLabelValues(verb, resource).Observe(sinceInSeconds(startTime))
-	deprecatedEtcdRequestLatenciesSummary.WithLabelValues(verb, resource).Observe(sinceInMicroseconds(startTime))
 }
 
 // Reset resets the etcd_request_duration_seconds metric.
 func Reset() {
 	etcdRequestLatency.Reset()
-
-	deprecatedEtcdRequestLatenciesSummary.Reset()
-}
-
-// sinceInMicroseconds gets the time since the specified start in microseconds.
-func sinceInMicroseconds(start time.Time) float64 {
-	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
 }
 
 // sinceInSeconds gets the time since the specified start in seconds.

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
@@ -65,18 +65,6 @@ var (
 		[]string{"transformation_type", "transformer_prefix", "status"},
 	)
 
-	deprecatedTransformerFailuresTotal = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Namespace:         namespace,
-			Subsystem:         subsystem,
-			Name:              "transformation_failures_total",
-			Help:              "Total number of failed transformation operations.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.15.0",
-		},
-		[]string{"transformation_type"},
-	)
-
 	envelopeTransformationCacheMissTotal = metrics.NewCounter(
 		&metrics.CounterOpts{
 			Namespace:      namespace,
@@ -115,7 +103,6 @@ func RegisterMetrics() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(transformerLatencies)
 		legacyregistry.MustRegister(transformerOperationsTotal)
-		legacyregistry.MustRegister(deprecatedTransformerFailuresTotal)
 		legacyregistry.MustRegister(envelopeTransformationCacheMissTotal)
 		legacyregistry.MustRegister(dataKeyGenerationLatencies)
 		legacyregistry.MustRegister(dataKeyGenerationFailuresTotal)
@@ -130,8 +117,6 @@ func RecordTransformation(transformationType, transformerPrefix string, start ti
 	switch {
 	case err == nil:
 		transformerLatencies.WithLabelValues(transformationType).Observe(sinceInSeconds(start))
-	default:
-		deprecatedTransformerFailuresTotal.WithLabelValues(transformationType).Inc()
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
@@ -53,20 +53,6 @@ var (
 		},
 		[]string{"transformation_type"},
 	)
-	deprecatedTransformerLatencies = metrics.NewHistogramVec(
-		&metrics.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "transformation_latencies_microseconds",
-			Help:      "Latencies in microseconds of value transformation operations.",
-			// In-process transformations (ex. AES CBC) complete on the order of 20 microseconds. However, when
-			// external KMS is involved latencies may climb into milliseconds.
-			Buckets:           metrics.ExponentialBuckets(5, 2, 14),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-		[]string{"transformation_type"},
-	)
 
 	transformerOperationsTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
@@ -111,17 +97,7 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
-	deprecatedDataKeyGenerationLatencies = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Namespace:         namespace,
-			Subsystem:         subsystem,
-			Name:              "data_key_generation_latencies_microseconds",
-			Help:              "Latencies in microseconds of data encryption key(DEK) generation operations.",
-			Buckets:           metrics.ExponentialBuckets(5, 2, 14),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.14.0",
-		},
-	)
+
 	dataKeyGenerationFailuresTotal = metrics.NewCounter(
 		&metrics.CounterOpts{
 			Namespace:      namespace,
@@ -138,12 +114,10 @@ var registerMetrics sync.Once
 func RegisterMetrics() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(transformerLatencies)
-		legacyregistry.MustRegister(deprecatedTransformerLatencies)
 		legacyregistry.MustRegister(transformerOperationsTotal)
 		legacyregistry.MustRegister(deprecatedTransformerFailuresTotal)
 		legacyregistry.MustRegister(envelopeTransformationCacheMissTotal)
 		legacyregistry.MustRegister(dataKeyGenerationLatencies)
-		legacyregistry.MustRegister(deprecatedDataKeyGenerationLatencies)
 		legacyregistry.MustRegister(dataKeyGenerationFailuresTotal)
 	})
 }
@@ -156,7 +130,6 @@ func RecordTransformation(transformationType, transformerPrefix string, start ti
 	switch {
 	case err == nil:
 		transformerLatencies.WithLabelValues(transformationType).Observe(sinceInSeconds(start))
-		deprecatedTransformerLatencies.WithLabelValues(transformationType).Observe(sinceInMicroseconds(start))
 	default:
 		deprecatedTransformerFailuresTotal.WithLabelValues(transformationType).Inc()
 	}
@@ -175,7 +148,6 @@ func RecordDataKeyGeneration(start time.Time, err error) {
 	}
 
 	dataKeyGenerationLatencies.Observe(sinceInSeconds(start))
-	deprecatedDataKeyGenerationLatencies.Observe(sinceInMicroseconds(start))
 }
 
 // sinceInMicroseconds gets the time since the specified start in microseconds.

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
@@ -150,11 +150,6 @@ func RecordDataKeyGeneration(start time.Time, err error) {
 	dataKeyGenerationLatencies.Observe(sinceInSeconds(start))
 }
 
-// sinceInMicroseconds gets the time since the specified start in microseconds.
-func sinceInMicroseconds(start time.Time) float64 {
-	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
-}
-
 // sinceInSeconds gets the time since the specified start in seconds.
 func sinceInSeconds(start time.Time) float64 {
 	return time.Since(start).Seconds()

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics_test.go
@@ -105,7 +105,6 @@ func TestTotals(t *testing.T) {
 			tt.prefix.TransformToStorage([]byte("value"), nil)
 			tt.prefix.TransformFromStorage([]byte("k8s:enc:kms:v1:value"), nil)
 			defer transformerOperationsTotal.Reset()
-			defer deprecatedTransformerFailuresTotal.Reset()
 			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tt.want), tt.metrics...); err != nil {
 				t.Fatal(err)
 			}

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics.go
@@ -131,16 +131,14 @@ func (m *defaultQueueMetrics) updateUnfinishedWork() {
 	var total float64
 	var oldest float64
 	for _, t := range m.processingStartTimes {
-		age := m.sinceInMicroseconds(t)
+		age := m.sinceInSeconds(t)
 		total += age
 		if age > oldest {
 			oldest = age
 		}
 	}
-	// Convert to seconds; microseconds is unhelpfully granular for this.
-	total /= 1000000
 	m.unfinishedWorkSeconds.Set(total)
-	m.longestRunningProcessor.Set(oldest / 1000000)
+	m.longestRunningProcessor.Set(oldest)
 }
 
 type noMetrics struct{}
@@ -149,11 +147,6 @@ func (noMetrics) add(item t)            {}
 func (noMetrics) get(item t)            {}
 func (noMetrics) done(item t)           {}
 func (noMetrics) updateUnfinishedWork() {}
-
-// Gets the time since the specified start in microseconds.
-func (m *defaultQueueMetrics) sinceInMicroseconds(start time.Time) float64 {
-	return float64(m.clock.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
-}
 
 // Gets the time since the specified start in seconds.
 func (m *defaultQueueMetrics) sinceInSeconds(start time.Time) float64 {

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -167,22 +167,6 @@ func (m *testMetricsProvider) NewRetriesMetric(name string) CounterMetric {
 	return &m.retries
 }
 
-func TestSinceInMicroseconds(t *testing.T) {
-	mp := testMetricsProvider{}
-	c := clock.NewFakeClock(time.Now())
-	mf := queueMetricsFactory{metricsProvider: &mp}
-	m := mf.newQueueMetrics("test", c)
-	dqm := m.(*defaultQueueMetrics)
-
-	for _, i := range []int{1, 50, 100, 500, 1000, 10000, 100000, 1000000} {
-		n := c.Now()
-		c.Step(time.Duration(i) * time.Microsecond)
-		if e, a := float64(i), dqm.sinceInMicroseconds(n); e != a {
-			t.Errorf("Expected %v, got %v", e, a)
-		}
-	}
-}
-
 func TestMetrics(t *testing.T) {
 	mp := testMetricsProvider{}
 	t0 := time.Unix(0, 0)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
/sig instrumentation

**What this PR does / why we need it**:

As the deprecation plan of [kubernetes metrics overhaul](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md#deprecation-plan), we should remove the deprecated metrics in v1.18.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The following deprecated metrics are removed, please convert to the corresponding metrics:
1. The following replacement metrics are available from v1.14.0:
* `rest_client_request_latency_seconds` -> `rest_client_request_duration_seconds`
* `scheduler_scheduling_latency_seconds` -> `scheduler_scheduling_duration_seconds `
* `docker_operations` -> `docker_operations_total`
* `docker_operations_latency_microseconds` -> `docker_operations_duration_seconds`
* `docker_operations_errors` -> `docker_operations_errors_total`
* `docker_operations_timeout` -> `docker_operations_timeout_total`
* `network_plugin_operations_latency_microseconds` -> `network_plugin_operations_duration_seconds`
* `kubelet_pod_worker_latency_microseconds` -> `kubelet_pod_worker_duration_seconds`
* `kubelet_pod_start_latency_microseconds` -> `kubelet_pod_start_duration_seconds`
* `kubelet_cgroup_manager_latency_microseconds` -> `kubelet_cgroup_manager_duration_seconds`
* `kubelet_pod_worker_start_latency_microseconds` -> `kubelet_pod_worker_start_duration_seconds`
* `kubelet_pleg_relist_latency_microseconds` -> `kubelet_pleg_relist_duration_seconds`
* `kubelet_pleg_relist_interval_microseconds` -> `kubelet_pleg_relist_interval_seconds`
* `kubelet_eviction_stats_age_microseconds` -> `kubelet_eviction_stats_age_seconds`
* `kubelet_runtime_operations` -> `kubelet_runtime_operations_total`
* `kubelet_runtime_operations_latency_microseconds` -> `kubelet_runtime_operations_duration_seconds`
* `kubelet_runtime_operations_errors` -> `kubelet_runtime_operations_errors_total`
* `kubelet_device_plugin_registration_count` -> `kubelet_device_plugin_registration_total`
* `kubelet_device_plugin_alloc_latency_microseconds` -> `kubelet_device_plugin_alloc_duration_seconds`
* `scheduler_e2e_scheduling_latency_microseconds` -> `scheduler_e2e_scheduling_duration_seconds`
* `scheduler_scheduling_algorithm_latency_microseconds` -> `scheduler_scheduling_algorithm_duration_seconds`
* `scheduler_scheduling_algorithm_predicate_evaluation` -> `scheduler_scheduling_algorithm_predicate_evaluation_seconds`
* `scheduler_scheduling_algorithm_priority_evaluation` -> `scheduler_scheduling_algorithm_priority_evaluation_seconds`
* `scheduler_scheduling_algorithm_preemption_evaluation` -> `scheduler_scheduling_algorithm_preemption_evaluation_seconds`
* `scheduler_binding_latency_microseconds` -> `scheduler_binding_duration_seconds`
* `kubeproxy_sync_proxy_rules_latency_microseconds` -> `kubeproxy_sync_proxy_rules_duration_seconds`
* `apiserver_request_latencies` -> `apiserver_request_duration_seconds`
* `apiserver_dropped_requests` -> `apiserver_dropped_requests_total`
* `etcd_request_latencies_summary` -> `etcd_request_duration_seconds`
* `apiserver_storage_transformation_latencies_microseconds ` -> `apiserver_storage_transformation_duration_seconds`
* `apiserver_storage_data_key_generation_latencies_microseconds` -> `apiserver_storage_data_key_generation_duration_seconds`
* `apiserver_request_count` -> `apiserver_request_total`
* `apiserver_request_latencies_summary`
2. The following replacement metrics are available from v1.15.0:
* `apiserver_storage_transformation_failures_total` -> `apiserver_storage_transformation_operations_total`
```
