### PR TITLE
Fail start-kubemark.sh on master or hollow nodes set-up errors

### DIFF
--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -494,6 +494,7 @@ function start-master {
   start-master-components
 }
 start-master &
+start_master_pid=$!
 
 # Setup for hollow-nodes.
 function start-hollow-nodes {
@@ -503,8 +504,11 @@ function start-hollow-nodes {
   wait-for-hollow-nodes-to-run-or-timeout
 }
 start-hollow-nodes &
+start_hollow_nodes_pid=$!
 
-wait
+wait $start_master_pid || { echo "Failed to start kubemark master" ; exit 1 ; }
+wait $start_hollow_nodes_pid ||{ echo "Failed to start hollow nodes" ; exit 1 ; }
+
 echo ""
 echo "Master IP: ${MASTER_IP}"
 echo "Password to kubemark master: ${KUBE_PASSWORD}"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
It fails the start-kubemark.sh script in case of kubemark master or hollow nodes setup errors.
Ref. https://github.com/kubernetes/kubernetes/issues/76490


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
