### PR TITLE
kubeadm: check all available CA certs against pinned certs

### DIFF
--- a/cmd/kubeadm/app/discovery/token/token_test.go
+++ b/cmd/kubeadm/app/discovery/token/token_test.go
@@ -102,23 +102,24 @@ func TestParsePEMCert(t *testing.T) {
 	}{
 		{"invalid certificate data", []byte{0}, false},
 		{"certificate with junk appended", []byte(testCertPEM + "\nABC"), false},
-		{"multiple certificates", []byte(testCertPEM + "\n" + testCertPEM), false},
+		{"multiple certificates", []byte(testCertPEM + "\n" + testCertPEM), true},
 		{"valid", []byte(testCertPEM), true},
+		{"empty input", []byte{}, false},
 	} {
-		cert, err := parsePEMCert(testCase.input)
+		certs, err := parsePEMCerts(testCase.input)
 		if testCase.expectValid {
 			if err != nil {
 				t.Errorf("failed TestParsePEMCert(%s): unexpected error %v", testCase.name, err)
 			}
-			if cert == nil {
+			if certs == nil {
 				t.Errorf("failed TestParsePEMCert(%s): returned nil", testCase.name)
 			}
 		} else {
 			if err == nil {
 				t.Errorf("failed TestParsePEMCert(%s): expected an error", testCase.name)
 			}
-			if cert != nil {
-				t.Errorf("failed TestParsePEMCert(%s): expected not to get a certificate back, but got one", testCase.name)
+			if certs != nil {
+				t.Errorf("failed TestParsePEMCert(%s): expected not to get a certificate back, but got some", testCase.name)
 			}
 		}
 	}

--- a/cmd/kubeadm/app/util/pubkeypin/pubkeypin.go
+++ b/cmd/kubeadm/app/util/pubkeypin/pubkeypin.go
@@ -61,12 +61,18 @@ func (s *Set) Allow(pubKeyHashes ...string) error {
 	return nil
 }
 
-// Check if a certificate matches one of the public keys in the set
-func (s *Set) Check(certificate *x509.Certificate) error {
-	if s.checkSHA256(certificate) {
-		return nil
+// CheckAny checks if at least one certificate matches one of the public keys in the set
+func (s *Set) CheckAny(certificates []*x509.Certificate) error {
+	var hashes []string
+
+	for _, certificate := range certificates {
+		if s.checkSHA256(certificate) {
+			return nil
+		}
+
+		hashes = append(hashes, Hash(certificate))
 	}
-	return errors.Errorf("public key %s not pinned", Hash(certificate))
+	return errors.Errorf("none of the public keys %q are pinned", strings.Join(hashes, ":"))
 }
 
 // Empty returns true if the Set contains no pinned public keys.

--- a/cmd/kubeadm/app/util/pubkeypin/pubkeypin_test.go
+++ b/cmd/kubeadm/app/util/pubkeypin/pubkeypin_test.go
@@ -121,7 +121,7 @@ func TestSet(t *testing.T) {
 		return
 	}
 
-	err = s.Check(testCert(t, testCertPEM))
+	err = s.CheckAny([]*x509.Certificate{testCert(t, testCertPEM)})
 	if err == nil {
 		t.Error("expected test cert to not be allowed (yet)")
 		return
@@ -133,13 +133,13 @@ func TestSet(t *testing.T) {
 		return
 	}
 
-	err = s.Check(testCert(t, testCertPEM))
+	err = s.CheckAny([]*x509.Certificate{testCert(t, testCertPEM)})
 	if err != nil {
 		t.Errorf("expected test cert to be allowed, but got back: %v", err)
 		return
 	}
 
-	err = s.Check(testCert(t, testCert2PEM))
+	err = s.CheckAny([]*x509.Certificate{testCert(t, testCert2PEM)})
 	if err == nil {
 		t.Error("expected the second test cert to be disallowed")
 		return


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently kubeadm produces an error upon parsing multiple certificates stored in the cluster-info configmap resulting in https://github.com/kubernetes/kubeadm/issues/1399. Yet it's expected to check all available certificates in a scenario like CA key rotation. So, check all available CA certs against pinned certificate hashes.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/1399

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
