### PR TITLE
tests: Adds configurable pod DNS nameservers and search list test

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4873,6 +4873,25 @@ func (f *Framework) NewTestPod(name string, requests v1.ResourceList, limits v1.
 	}
 }
 
+// NewAgnhostPod returns a pod that uses the agnhost image. The image's binary supports various subcommands
+// that behave the same, no matter the underlying OS.
+func (f *Framework) NewAgnhostPod(name string, args ...string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "agnhost",
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  args,
+				},
+			},
+		},
+	}
+}
+
 // CreateEmptyFileOnPod creates empty file at given path on the pod.
 func CreateEmptyFileOnPod(namespace string, podName string, filePath string) error {
 	_, err := RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), podName, "--", "/bin/sh", "-c", fmt.Sprintf("touch %s", filePath))

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -361,6 +361,54 @@ var _ = SIGDescribe("DNS", func() {
 		validateTargetedProbeOutput(f, pod3, []string{wheezyFileName, jessieFileName}, svc.Spec.ClusterIP)
 	})
 
+	It("should support configurable pod DNS nameservers", func() {
+		By("Creating a pod with dnsPolicy=None and customized dnsConfig...")
+		testServerIP := "1.1.1.1"
+		testSearchPath := "resolv.conf.local"
+		testAgnhostPod := f.NewAgnhostPod(f.Namespace.Name, "pause")
+		testAgnhostPod.Spec.DNSPolicy = v1.DNSNone
+		testAgnhostPod.Spec.DNSConfig = &v1.PodDNSConfig{
+			Nameservers: []string{testServerIP},
+			Searches:    []string{testSearchPath},
+		}
+		testAgnhostPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(testAgnhostPod)
+		Expect(err).NotTo(HaveOccurred(), "failed to create pod: %s", testAgnhostPod.Name)
+		framework.Logf("Created pod %v", testAgnhostPod)
+		defer func() {
+			framework.Logf("Deleting pod %s...", testAgnhostPod.Name)
+			if err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(testAgnhostPod.Name, metav1.NewDeleteOptions(0)); err != nil {
+				framework.Failf("Failed to delete pod %s: %v", testAgnhostPod.Name, err)
+			}
+		}()
+		Expect(f.WaitForPodRunning(testAgnhostPod.Name)).NotTo(HaveOccurred(), "failed to wait for pod %s to be running", testAgnhostPod.Name)
+
+		runCommand := func(arg string) string {
+			cmd := []string{"/agnhost", arg}
+			stdout, stderr, err := f.ExecWithOptions(framework.ExecOptions{
+				Command:       cmd,
+				Namespace:     f.Namespace.Name,
+				PodName:       testAgnhostPod.Name,
+				ContainerName: "agnhost",
+				CaptureStdout: true,
+				CaptureStderr: true,
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to run command '/agnhost %s' on pod, stdout: %v, stderr: %v, err: %v", arg, stdout, stderr, err)
+			return stdout
+		}
+
+		By("Verifying customized DNS suffix list is configured on pod...")
+		stdout := runCommand("dns-suffix")
+		if !strings.Contains(stdout, testSearchPath) {
+			framework.Failf("customized DNS suffix list not found configured in pod, expected to contain: %s, got: %s", testSearchPath, stdout)
+		}
+
+		By("Verifying customized DNS server is configured on pod...")
+		stdout = runCommand("dns-server-list")
+		if !strings.Contains(stdout, testServerIP) {
+			framework.Failf("customized DNS server not found in configured in pod, expected to contain: %s, got: %s", testServerIP, stdout)
+		}
+	})
+
 	It("should support configurable pod resolv.conf", func() {
 		By("Preparing a test DNS service with injected DNS names...")
 		testInjectedIP := "1.1.1.1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind feature

/sig testing
/sig windows

**What this PR does / why we need it**:

This test creates a pod with custom DNS configurations and expects
them to be set in the containers.

The test pod is using the agnhost image, which can output the container's
DNS configurations that the test checks.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related #73425
Related #74985
Depends On: #76507

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
