### PR TITLE
stop clearing GOPATH in vendor scripts

### DIFF
--- a/hack/lint-dependencies.sh
+++ b/hack/lint-dependencies.sh
@@ -23,8 +23,6 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 # Explicitly opt into go modules, even though we're inside a GOPATH directory
 export GO111MODULE=on
-# Explicitly clear GOPATH, to ensure nothing this script calls makes use of that path info
-export GOPATH=
 # Explicitly clear GOFLAGS, since GOFLAGS=-mod=vendor breaks dependency resolution while rebuilding vendor
 export GOFLAGS=
 # Detect problematic GOPROXY settings that prevent lookup of dependencies

--- a/hack/update-vendor.sh
+++ b/hack/update-vendor.sh
@@ -23,8 +23,6 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 # Explicitly opt into go modules, even though we're inside a GOPATH directory
 export GO111MODULE=on
-# Explicitly clear GOPATH, to ensure nothing this script calls makes use of that path info
-export GOPATH=
 # Explicitly clear GOFLAGS, since GOFLAGS=-mod=vendor breaks dependency resolution while rebuilding vendor
 export GOFLAGS=
 # Ensure sort order doesn't depend on locale

--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -63,8 +63,8 @@ mkdir -p "${_kubetmp}"
 git archive --format=tar --prefix=kubernetes/ "$(git write-tree)" | (cd "${_kubetmp}" && tar xf -)
 _kubetmp="${_kubetmp}/kubernetes"
 
-# Do all our work with an unset GOPATH
-export GOPATH=
+# Do all our work in module mode
+export GO111MODULE=on
 
 pushd "${_kubetmp}" > /dev/null 2>&1
   # Destroy deps in the copy of the kube tree


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
ensures developers can run hack/update-vendor.sh, no matter their GOPATH/GOROOT environment

we were only doing this to be doubly sure that only modules were being used.
just depend on export GO111MODULE=on for that.

if unset, go defaults to $HOME/go, and fails if $GOROOT is also set to the same directory

```release-note
NONE
```

/cc @apelisse 