### PR TITLE
Add more nil checks to metav1.Time and MicroTime

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
@@ -41,11 +41,6 @@ func (t *MicroTime) DeepCopyInto(out *MicroTime) {
 	*out = *t
 }
 
-// String returns the representation of the time.
-func (t MicroTime) String() string {
-	return t.Time.String()
-}
-
 // NewMicroTime returns a wrapped instance of the provided time
 func NewMicroTime(time time.Time) MicroTime {
 	return MicroTime{time}
@@ -72,22 +67,40 @@ func (t *MicroTime) IsZero() bool {
 
 // Before reports whether the time instant t is before u.
 func (t *MicroTime) Before(u *MicroTime) bool {
-	return t.Time.Before(u.Time)
+	if t != nil && u != nil {
+		return t.Time.Before(u.Time)
+	}
+	return false
 }
 
 // Equal reports whether the time instant t is equal to u.
 func (t *MicroTime) Equal(u *MicroTime) bool {
-	return t.Time.Equal(u.Time)
+	if t == nil && u == nil {
+		return true
+	}
+	if t != nil && u != nil {
+		return t.Time.Equal(u.Time)
+	}
+	return false
 }
 
 // BeforeTime reports whether the time instant t is before second-lever precision u.
 func (t *MicroTime) BeforeTime(u *Time) bool {
-	return t.Time.Before(u.Time)
+	if t != nil && u != nil {
+		return t.Time.Before(u.Time)
+	}
+	return false
 }
 
 // EqualTime reports whether the time instant t is equal to second-lever precision u.
 func (t *MicroTime) EqualTime(u *Time) bool {
-	return t.Time.Equal(u.Time)
+	if t == nil && u == nil {
+		return true
+	}
+	if t != nil && u != nil {
+		return t.Time.Equal(u.Time)
+	}
+	return false
 }
 
 // UnixMicro returns the local time corresponding to the given Unix time

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
@@ -57,50 +57,24 @@ func NowMicro() MicroTime {
 	return MicroTime{time.Now()}
 }
 
-// IsZero returns true if the value is nil or time is zero.
-func (t *MicroTime) IsZero() bool {
-	if t == nil {
-		return true
-	}
-	return t.Time.IsZero()
-}
-
 // Before reports whether the time instant t is before u.
-func (t *MicroTime) Before(u *MicroTime) bool {
-	if t != nil && u != nil {
-		return t.Time.Before(u.Time)
-	}
-	return false
+func (t MicroTime) Before(u MicroTime) bool {
+	return t.Time.Before(u.Time)
 }
 
 // Equal reports whether the time instant t is equal to u.
-func (t *MicroTime) Equal(u *MicroTime) bool {
-	if t == nil && u == nil {
-		return true
-	}
-	if t != nil && u != nil {
-		return t.Time.Equal(u.Time)
-	}
-	return false
+func (t MicroTime) Equal(u MicroTime) bool {
+	return t.Time.Equal(u.Time)
 }
 
 // BeforeTime reports whether the time instant t is before second-lever precision u.
-func (t *MicroTime) BeforeTime(u *Time) bool {
-	if t != nil && u != nil {
-		return t.Time.Before(u.Time)
-	}
-	return false
+func (t MicroTime) BeforeTime(u Time) bool {
+	return t.Time.Before(u.Time)
 }
 
 // EqualTime reports whether the time instant t is equal to second-lever precision u.
-func (t *MicroTime) EqualTime(u *Time) bool {
-	if t == nil && u == nil {
-		return true
-	}
-	if t != nil && u != nil {
-		return t.Time.Equal(u.Time)
-	}
-	return false
+func (t MicroTime) EqualTime(u Time) bool {
+	return t.Time.Equal(u.Time)
 }
 
 // UnixMicro returns the local time corresponding to the given Unix time

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
@@ -57,24 +57,50 @@ func NowMicro() MicroTime {
 	return MicroTime{time.Now()}
 }
 
+// IsZero returns true if the value is nil or time is zero.
+func (t *MicroTime) IsZero() bool {
+	if t == nil {
+		return true
+	}
+	return t.Time.IsZero()
+}
+
 // Before reports whether the time instant t is before u.
-func (t MicroTime) Before(u MicroTime) bool {
-	return t.Time.Before(u.Time)
+func (t *MicroTime) Before(u *MicroTime) bool {
+	if t != nil && u != nil {
+		return t.Time.Before(u.Time)
+	}
+	return false
 }
 
 // Equal reports whether the time instant t is equal to u.
-func (t MicroTime) Equal(u MicroTime) bool {
-	return t.Time.Equal(u.Time)
+func (t *MicroTime) Equal(u *MicroTime) bool {
+	if t == nil && u == nil {
+		return true
+	}
+	if t != nil && u != nil {
+		return t.Time.Equal(u.Time)
+	}
+	return false
 }
 
 // BeforeTime reports whether the time instant t is before second-lever precision u.
-func (t MicroTime) BeforeTime(u Time) bool {
-	return t.Time.Before(u.Time)
+func (t *MicroTime) BeforeTime(u *Time) bool {
+	if t != nil && u != nil {
+		return t.Time.Before(u.Time)
+	}
+	return false
 }
 
 // EqualTime reports whether the time instant t is equal to second-lever precision u.
-func (t MicroTime) EqualTime(u Time) bool {
-	return t.Time.Equal(u.Time)
+func (t *MicroTime) EqualTime(u *Time) bool {
+	if t == nil && u == nil {
+		return true
+	}
+	if t != nil && u != nil {
+		return t.Time.Equal(u.Time)
+	}
+	return false
 }
 
 // UnixMicro returns the local time corresponding to the given Unix time

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time_test.go
@@ -140,115 +140,73 @@ func TestMicroTimeProto(t *testing.T) {
 
 func TestMicroTimeEqual(t *testing.T) {
 	t1 := NewMicroTime(time.Now())
-	cases := []struct {
-		name   string
-		x      *MicroTime
-		y      *MicroTime
-		result bool
-	}{
-		{"nil =? nil", nil, nil, true},
-		{"!nil =? !nil", &t1, &t1, true},
-		{"nil =? !nil", nil, &t1, false},
-		{"!nil =? nil", &t1, nil, false},
-	}
+	t2 := NewMicroTime(time.Now().Add(time.Second))
 
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			result := c.x.Equal(c.y)
-			if result != c.result {
-				t.Errorf("Failed equality test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
-			}
-		})
+	if !t1.Equal(t1) {
+		t.Errorf("Failed equality test for '%v', '%v': t1 should equal t1", t1, t1)
+	}
+	if t1.Equal(t2) {
+		t.Errorf("Failed equality test for '%v', '%v': t1 should not equal t2", t1, t2)
 	}
 }
 
 func TestMicroTimeEqualTime(t *testing.T) {
 	t1 := NewMicroTime(time.Now())
 	t2 := NewTime(t1.Time)
-	cases := []struct {
-		name   string
-		x      *MicroTime
-		y      *Time
-		result bool
-	}{
-		{"nil =? nil", nil, nil, true},
-		{"!nil =? !nil", &t1, &t2, true},
-		{"nil =? !nil", nil, &t2, false},
-		{"!nil =? nil", &t1, nil, false},
-	}
+	t3 := NewTime(time.Now().Add(time.Second))
 
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			result := c.x.EqualTime(c.y)
-			if result != c.result {
-				t.Errorf("Failed equality test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
-			}
-		})
+	if !t1.EqualTime(t2) {
+		t.Errorf("Failed equality test for '%v', '%v': t1 should equal t2", t1, t1)
+	}
+	if t1.EqualTime(t3) {
+		t.Errorf("Failed equality test for '%v', '%v': t1 should not equal t3", t1, t2)
 	}
 }
 
 func TestMicroTimeBefore(t *testing.T) {
-	t1 := NewMicroTime(time.Now())
+	tBefore := NewMicroTime(time.Now())
+	tAfter := NewMicroTime(tBefore.Time.Add(time.Second))
 	cases := []struct {
-		name string
-		x    *MicroTime
-		y    *MicroTime
+		name   string
+		x      MicroTime
+		y      MicroTime
+		result bool
 	}{
-		{"nil <? nil", nil, nil},
-		{"!nil <? !nil", &t1, &t1},
-		{"nil <? !nil", nil, &t1},
-		{"!nil <? nil", &t1, nil},
+		{"tBefore <? tBefore", tBefore, tBefore, false},
+		{"tBefore <? tAfter", tBefore, tAfter, true},
+		{"tAfter <? tBefore", tAfter, tBefore, false},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			result := c.x.Before(c.y)
-			if result {
-				t.Errorf("Failed before test for '%v', '%v': expected false, got %+v", c.x, c.y, result)
+			if result != c.result {
+				t.Errorf("Failed before test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
 			}
 		})
 	}
 }
 func TestMicroTimeBeforeTime(t *testing.T) {
-	t1 := NewMicroTime(time.Now())
-	t2 := NewTime(t1.Time)
+	tNow := NewMicroTime(time.Now())
+	tAfter := NewTime(tNow.Time.Add(time.Second))
+	tBefore := NewTime(tNow.Time.Add(-time.Second))
+	tTimeNow := NewTime(tNow.Time)
 	cases := []struct {
-		name string
-		x    *MicroTime
-		y    *Time
+		name   string
+		x      MicroTime
+		y      Time
+		result bool
 	}{
-		{"nil <? nil", nil, nil},
-		{"!nil <? !nil", &t1, &t2},
-		{"nil <? !nil", nil, &t2},
-		{"!nil <? nil", &t1, nil},
+		{"tNow <? tAfter", tNow, tAfter, true},
+		{"tNow <? tBefore", tNow, tBefore, false},
+		{"tNow <? tTimeNow", tNow, tTimeNow, false},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			result := c.x.BeforeTime(c.y)
-			if result {
-				t.Errorf("Failed before test for '%v', '%v': expected false, got %+v", c.x, c.y, result)
-			}
-		})
-	}
-}
-
-func TestMicroTimeIsZero(t *testing.T) {
-	t1 := NewMicroTime(time.Now())
-	cases := []struct {
-		name   string
-		x      *MicroTime
-		result bool
-	}{
-		{"nil =? 0", nil, true},
-		{"!nil =? 0", &t1, false},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			result := c.x.IsZero()
 			if result != c.result {
-				t.Errorf("Failed equality test for '%v': expected %+v, got %+v", c.x, c.result, result)
+				t.Errorf("Failed before test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time_test.go
@@ -140,73 +140,115 @@ func TestMicroTimeProto(t *testing.T) {
 
 func TestMicroTimeEqual(t *testing.T) {
 	t1 := NewMicroTime(time.Now())
-	t2 := NewMicroTime(time.Now().Add(time.Second))
-
-	if !t1.Equal(t1) {
-		t.Errorf("Failed equality test for '%v', '%v': t1 should equal t1", t1, t1)
+	cases := []struct {
+		name   string
+		x      *MicroTime
+		y      *MicroTime
+		result bool
+	}{
+		{"nil =? nil", nil, nil, true},
+		{"!nil =? !nil", &t1, &t1, true},
+		{"nil =? !nil", nil, &t1, false},
+		{"!nil =? nil", &t1, nil, false},
 	}
-	if t1.Equal(t2) {
-		t.Errorf("Failed equality test for '%v', '%v': t1 should not equal t2", t1, t2)
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.Equal(c.y)
+			if result != c.result {
+				t.Errorf("Failed equality test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
+			}
+		})
 	}
 }
 
 func TestMicroTimeEqualTime(t *testing.T) {
 	t1 := NewMicroTime(time.Now())
 	t2 := NewTime(t1.Time)
-	t3 := NewTime(time.Now().Add(time.Second))
-
-	if !t1.EqualTime(t2) {
-		t.Errorf("Failed equality test for '%v', '%v': t1 should equal t2", t1, t1)
+	cases := []struct {
+		name   string
+		x      *MicroTime
+		y      *Time
+		result bool
+	}{
+		{"nil =? nil", nil, nil, true},
+		{"!nil =? !nil", &t1, &t2, true},
+		{"nil =? !nil", nil, &t2, false},
+		{"!nil =? nil", &t1, nil, false},
 	}
-	if t1.EqualTime(t3) {
-		t.Errorf("Failed equality test for '%v', '%v': t1 should not equal t3", t1, t2)
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.EqualTime(c.y)
+			if result != c.result {
+				t.Errorf("Failed equality test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
+			}
+		})
 	}
 }
 
 func TestMicroTimeBefore(t *testing.T) {
-	tBefore := NewMicroTime(time.Now())
-	tAfter := NewMicroTime(tBefore.Time.Add(time.Second))
+	t1 := NewMicroTime(time.Now())
 	cases := []struct {
-		name   string
-		x      MicroTime
-		y      MicroTime
-		result bool
+		name string
+		x    *MicroTime
+		y    *MicroTime
 	}{
-		{"tBefore <? tBefore", tBefore, tBefore, false},
-		{"tBefore <? tAfter", tBefore, tAfter, true},
-		{"tAfter <? tBefore", tAfter, tBefore, false},
+		{"nil <? nil", nil, nil},
+		{"!nil <? !nil", &t1, &t1},
+		{"nil <? !nil", nil, &t1},
+		{"!nil <? nil", &t1, nil},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			result := c.x.Before(c.y)
-			if result != c.result {
-				t.Errorf("Failed before test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
+			if result {
+				t.Errorf("Failed before test for '%v', '%v': expected false, got %+v", c.x, c.y, result)
 			}
 		})
 	}
 }
 func TestMicroTimeBeforeTime(t *testing.T) {
-	tNow := NewMicroTime(time.Now())
-	tAfter := NewTime(tNow.Time.Add(time.Second))
-	tBefore := NewTime(tNow.Time.Add(-time.Second))
-	tTimeNow := NewTime(tNow.Time)
+	t1 := NewMicroTime(time.Now())
+	t2 := NewTime(t1.Time)
 	cases := []struct {
-		name   string
-		x      MicroTime
-		y      Time
-		result bool
+		name string
+		x    *MicroTime
+		y    *Time
 	}{
-		{"tNow <? tAfter", tNow, tAfter, true},
-		{"tNow <? tBefore", tNow, tBefore, false},
-		{"tNow <? tTimeNow", tNow, tTimeNow, false},
+		{"nil <? nil", nil, nil},
+		{"!nil <? !nil", &t1, &t2},
+		{"nil <? !nil", nil, &t2},
+		{"!nil <? nil", &t1, nil},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			result := c.x.BeforeTime(c.y)
+			if result {
+				t.Errorf("Failed before test for '%v', '%v': expected false, got %+v", c.x, c.y, result)
+			}
+		})
+	}
+}
+
+func TestMicroTimeIsZero(t *testing.T) {
+	t1 := NewMicroTime(time.Now())
+	cases := []struct {
+		name   string
+		x      *MicroTime
+		result bool
+	}{
+		{"nil =? 0", nil, true},
+		{"!nil =? 0", &t1, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.IsZero()
 			if result != c.result {
-				t.Errorf("Failed before test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
+				t.Errorf("Failed equality test for '%v': expected %+v, got %+v", c.x, c.result, result)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time_test.go
@@ -190,9 +190,9 @@ func TestMicroTimeEqualTime(t *testing.T) {
 func TestMicroTimeBefore(t *testing.T) {
 	t1 := NewMicroTime(time.Now())
 	cases := []struct {
-		name   string
-		x      *MicroTime
-		y      *MicroTime
+		name string
+		x    *MicroTime
+		y    *MicroTime
 	}{
 		{"nil <? nil", nil, nil},
 		{"!nil <? !nil", &t1, &t1},
@@ -213,9 +213,9 @@ func TestMicroTimeBeforeTime(t *testing.T) {
 	t1 := NewMicroTime(time.Now())
 	t2 := NewTime(t1.Time)
 	cases := []struct {
-		name   string
-		x      *MicroTime
-		y      *Time
+		name string
+		x    *MicroTime
+		y    *Time
 	}{
 		{"nil <? nil", nil, nil},
 		{"!nil <? !nil", &t1, &t2},
@@ -247,7 +247,7 @@ func TestMicroTimeIsZero(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			result := c.x.IsZero()
-			if result != c.result{
+			if result != c.result {
 				t.Errorf("Failed equality test for '%v': expected %+v, got %+v", c.x, c.result, result)
 			}
 		})

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time_test.go
@@ -137,3 +137,119 @@ func TestMicroTimeProto(t *testing.T) {
 		}
 	}
 }
+
+func TestMicroTimeEqual(t *testing.T) {
+	t1 := NewMicroTime(time.Now())
+	cases := []struct {
+		name   string
+		x      *MicroTime
+		y      *MicroTime
+		result bool
+	}{
+		{"nil =? nil", nil, nil, true},
+		{"!nil =? !nil", &t1, &t1, true},
+		{"nil =? !nil", nil, &t1, false},
+		{"!nil =? nil", &t1, nil, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.Equal(c.y)
+			if result != c.result {
+				t.Errorf("Failed equality test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
+			}
+		})
+	}
+}
+
+func TestMicroTimeEqualTime(t *testing.T) {
+	t1 := NewMicroTime(time.Now())
+	t2 := NewTime(t1.Time)
+	cases := []struct {
+		name   string
+		x      *MicroTime
+		y      *Time
+		result bool
+	}{
+		{"nil =? nil", nil, nil, true},
+		{"!nil =? !nil", &t1, &t2, true},
+		{"nil =? !nil", nil, &t2, false},
+		{"!nil =? nil", &t1, nil, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.EqualTime(c.y)
+			if result != c.result {
+				t.Errorf("Failed equality test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
+			}
+		})
+	}
+}
+
+func TestMicroTimeBefore(t *testing.T) {
+	t1 := NewMicroTime(time.Now())
+	cases := []struct {
+		name   string
+		x      *MicroTime
+		y      *MicroTime
+	}{
+		{"nil <? nil", nil, nil},
+		{"!nil <? !nil", &t1, &t1},
+		{"nil <? !nil", nil, &t1},
+		{"!nil <? nil", &t1, nil},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.Before(c.y)
+			if result {
+				t.Errorf("Failed before test for '%v', '%v': expected false, got %+v", c.x, c.y, result)
+			}
+		})
+	}
+}
+func TestMicroTimeBeforeTime(t *testing.T) {
+	t1 := NewMicroTime(time.Now())
+	t2 := NewTime(t1.Time)
+	cases := []struct {
+		name   string
+		x      *MicroTime
+		y      *Time
+	}{
+		{"nil <? nil", nil, nil},
+		{"!nil <? !nil", &t1, &t2},
+		{"nil <? !nil", nil, &t2},
+		{"!nil <? nil", &t1, nil},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.BeforeTime(c.y)
+			if result {
+				t.Errorf("Failed before test for '%v', '%v': expected false, got %+v", c.x, c.y, result)
+			}
+		})
+	}
+}
+
+func TestMicroTimeIsZero(t *testing.T) {
+	t1 := NewMicroTime(time.Now())
+	cases := []struct {
+		name   string
+		x      *MicroTime
+		result bool
+	}{
+		{"nil =? 0", nil, true},
+		{"!nil =? 0", &t1, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.IsZero()
+			if result != c.result{
+				t.Errorf("Failed equality test for '%v': expected %+v, got %+v", c.x, c.result, result)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
@@ -41,11 +41,6 @@ func (t *Time) DeepCopyInto(out *Time) {
 	*out = *t
 }
 
-// String returns the representation of the time.
-func (t Time) String() string {
-	return t.Time.String()
-}
-
 // NewTime returns a wrapped instance of the provided time
 func NewTime(time time.Time) Time {
 	return Time{time}
@@ -72,7 +67,10 @@ func (t *Time) IsZero() bool {
 
 // Before reports whether the time instant t is before u.
 func (t *Time) Before(u *Time) bool {
-	return t.Time.Before(u.Time)
+	if t != nil && u != nil {
+		return t.Time.Before(u.Time)
+	}
+	return false
 }
 
 // Equal reports whether the time instant t is equal to u.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
@@ -57,31 +57,14 @@ func Now() Time {
 	return Time{time.Now()}
 }
 
-// IsZero returns true if the value is nil or time is zero.
-func (t *Time) IsZero() bool {
-	if t == nil {
-		return true
-	}
-	return t.Time.IsZero()
-}
-
 // Before reports whether the time instant t is before u.
-func (t *Time) Before(u *Time) bool {
-	if t != nil && u != nil {
-		return t.Time.Before(u.Time)
-	}
-	return false
+func (t Time) Before(u Time) bool {
+	return t.Time.Before(u.Time)
 }
 
 // Equal reports whether the time instant t is equal to u.
-func (t *Time) Equal(u *Time) bool {
-	if t == nil && u == nil {
-		return true
-	}
-	if t != nil && u != nil {
-		return t.Time.Equal(u.Time)
-	}
-	return false
+func (t Time) Equal(u Time) bool {
+	return t.Time.Equal(u.Time)
 }
 
 // Unix returns the local time corresponding to the given Unix time

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
@@ -57,14 +57,31 @@ func Now() Time {
 	return Time{time.Now()}
 }
 
+// IsZero returns true if the value is nil or time is zero.
+func (t *Time) IsZero() bool {
+	if t == nil {
+		return true
+	}
+	return t.Time.IsZero()
+}
+
 // Before reports whether the time instant t is before u.
-func (t Time) Before(u Time) bool {
-	return t.Time.Before(u.Time)
+func (t *Time) Before(u *Time) bool {
+	if t != nil && u != nil {
+		return t.Time.Before(u.Time)
+	}
+	return false
 }
 
 // Equal reports whether the time instant t is equal to u.
-func (t Time) Equal(u Time) bool {
-	return t.Time.Equal(u.Time)
+func (t *Time) Equal(u *Time) bool {
+	if t == nil && u == nil {
+		return true
+	}
+	if t != nil && u != nil {
+		return t.Time.Equal(u.Time)
+	}
+	return false
 }
 
 // Unix returns the local time corresponding to the given Unix time

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
@@ -174,67 +174,35 @@ func TestTimeProto(t *testing.T) {
 
 func TestTimeEqual(t *testing.T) {
 	t1 := NewTime(time.Now())
-	cases := []struct {
-		name   string
-		x      *Time
-		y      *Time
-		result bool
-	}{
-		{"nil =? nil", nil, nil, true},
-		{"!nil =? !nil", &t1, &t1, true},
-		{"nil =? !nil", nil, &t1, false},
-		{"!nil =? nil", &t1, nil, false},
-	}
+	t2 := NewTime(time.Now().Add(time.Second))
 
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			result := c.x.Equal(c.y)
-			if result != c.result {
-				t.Errorf("Failed equality test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
-			}
-		})
+	if !t1.Equal(t1) {
+		t.Errorf("Failed equality test for '%v', '%v': t1 should equal t1", t1, t1)
+	}
+	if t1.Equal(t2) {
+		t.Errorf("Failed equality test for '%v', '%v': t1 should not equal t2", t1, t2)
 	}
 }
 
 func TestTimeBefore(t *testing.T) {
-	t1 := NewTime(time.Now())
+	tBefore := NewTime(time.Now())
+	tAfter := NewTime(tBefore.Time.Add(time.Second))
 	cases := []struct {
-		name string
-		x    *Time
-		y    *Time
+		name   string
+		x      Time
+		y      Time
+		result bool
 	}{
-		{"nil <? nil", nil, nil},
-		{"!nil <? !nil", &t1, &t1},
-		{"nil <? !nil", nil, &t1},
-		{"!nil <? nil", &t1, nil},
+		{"tBefore <? tBefore", tBefore, tBefore, false},
+		{"tBefore <? tAfter", tBefore, tAfter, true},
+		{"tAfter <? tBefore", tAfter, tBefore, false},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			result := c.x.Before(c.y)
-			if result {
-				t.Errorf("Failed equality test for '%v', '%v': expected false, got %+v", c.x, c.y, result)
-			}
-		})
-	}
-}
-
-func TestTimeIsZero(t *testing.T) {
-	t1 := NewTime(time.Now())
-	cases := []struct {
-		name   string
-		x      *Time
-		result bool
-	}{
-		{"nil =? 0", nil, true},
-		{"!nil =? 0", &t1, false},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			result := c.x.IsZero()
 			if result != c.result {
-				t.Errorf("Failed equality test for '%v': expected %+v, got %+v", c.x, c.result, result)
+				t.Errorf("Failed before test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
@@ -174,35 +174,67 @@ func TestTimeProto(t *testing.T) {
 
 func TestTimeEqual(t *testing.T) {
 	t1 := NewTime(time.Now())
-	t2 := NewTime(time.Now().Add(time.Second))
-
-	if !t1.Equal(t1) {
-		t.Errorf("Failed equality test for '%v', '%v': t1 should equal t1", t1, t1)
+	cases := []struct {
+		name   string
+		x      *Time
+		y      *Time
+		result bool
+	}{
+		{"nil =? nil", nil, nil, true},
+		{"!nil =? !nil", &t1, &t1, true},
+		{"nil =? !nil", nil, &t1, false},
+		{"!nil =? nil", &t1, nil, false},
 	}
-	if t1.Equal(t2) {
-		t.Errorf("Failed equality test for '%v', '%v': t1 should not equal t2", t1, t2)
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.Equal(c.y)
+			if result != c.result {
+				t.Errorf("Failed equality test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
+			}
+		})
 	}
 }
 
 func TestTimeBefore(t *testing.T) {
-	tBefore := NewTime(time.Now())
-	tAfter := NewTime(tBefore.Time.Add(time.Second))
+	t1 := NewTime(time.Now())
 	cases := []struct {
-		name   string
-		x      Time
-		y      Time
-		result bool
+		name string
+		x    *Time
+		y    *Time
 	}{
-		{"tBefore <? tBefore", tBefore, tBefore, false},
-		{"tBefore <? tAfter", tBefore, tAfter, true},
-		{"tAfter <? tBefore", tAfter, tBefore, false},
+		{"nil <? nil", nil, nil},
+		{"!nil <? !nil", &t1, &t1},
+		{"nil <? !nil", nil, &t1},
+		{"!nil <? nil", &t1, nil},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			result := c.x.Before(c.y)
+			if result {
+				t.Errorf("Failed equality test for '%v', '%v': expected false, got %+v", c.x, c.y, result)
+			}
+		})
+	}
+}
+
+func TestTimeIsZero(t *testing.T) {
+	t1 := NewTime(time.Now())
+	cases := []struct {
+		name   string
+		x      *Time
+		result bool
+	}{
+		{"nil =? 0", nil, true},
+		{"!nil =? 0", &t1, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.IsZero()
 			if result != c.result {
-				t.Errorf("Failed before test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
+				t.Errorf("Failed equality test for '%v': expected %+v, got %+v", c.x, c.result, result)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
@@ -199,9 +199,9 @@ func TestTimeEqual(t *testing.T) {
 func TestTimeBefore(t *testing.T) {
 	t1 := NewTime(time.Now())
 	cases := []struct {
-		name   string
-		x      *Time
-		y      *Time
+		name string
+		x    *Time
+		y    *Time
 	}{
 		{"nil <? nil", nil, nil},
 		{"!nil <? !nil", &t1, &t1},
@@ -233,7 +233,7 @@ func TestTimeIsZero(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			result := c.x.IsZero()
-			if result != c.result{
+			if result != c.result {
 				t.Errorf("Failed equality test for '%v': expected %+v, got %+v", c.x, c.result, result)
 			}
 		})

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
@@ -195,3 +195,47 @@ func TestTimeEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestTimeBefore(t *testing.T) {
+	t1 := NewTime(time.Now())
+	cases := []struct {
+		name   string
+		x      *Time
+		y      *Time
+	}{
+		{"nil <? nil", nil, nil},
+		{"!nil <? !nil", &t1, &t1},
+		{"nil <? !nil", nil, &t1},
+		{"!nil <? nil", &t1, nil},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.Before(c.y)
+			if result {
+				t.Errorf("Failed equality test for '%v', '%v': expected false, got %+v", c.x, c.y, result)
+			}
+		})
+	}
+}
+
+func TestTimeIsZero(t *testing.T) {
+	t1 := NewTime(time.Now())
+	cases := []struct {
+		name   string
+		x      *Time
+		result bool
+	}{
+		{"nil =? 0", nil, true},
+		{"!nil =? 0", &t1, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.IsZero()
+			if result != c.result{
+				t.Errorf("Failed equality test for '%v': expected %+v, got %+v", c.x, c.result, result)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/test/apis_meta_v1_unstructed_unstructure_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/test/apis_meta_v1_unstructed_unstructure_test.go
@@ -207,11 +207,11 @@ func TestUnstructuredGetters(t *testing.T) {
 		t.Errorf("GetSelfLink() = %s, want %s", got, want)
 	}
 
-	if got, want := unstruct.GetCreationTimestamp(), metav1.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC); !got.Equal(want) {
+	if got, want := unstruct.GetCreationTimestamp(), metav1.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC); !got.Equal(&want) {
 		t.Errorf("GetCreationTimestamp() = %s, want %s", got, want)
 	}
 
-	if got, want := unstruct.GetDeletionTimestamp(), metav1.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC); got == nil || !got.Equal(want) {
+	if got, want := unstruct.GetDeletionTimestamp(), metav1.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC); got == nil || !got.Equal(&want) {
 		t.Errorf("GetDeletionTimestamp() = %s, want %s", got, want)
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/test/apis_meta_v1_unstructed_unstructure_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/test/apis_meta_v1_unstructed_unstructure_test.go
@@ -207,11 +207,11 @@ func TestUnstructuredGetters(t *testing.T) {
 		t.Errorf("GetSelfLink() = %s, want %s", got, want)
 	}
 
-	if got, want := unstruct.GetCreationTimestamp(), metav1.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC); !got.Equal(&want) {
+	if got, want := unstruct.GetCreationTimestamp(), metav1.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC); !got.Equal(want) {
 		t.Errorf("GetCreationTimestamp() = %s, want %s", got, want)
 	}
 
-	if got, want := unstruct.GetDeletionTimestamp(), metav1.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC); got == nil || !got.Equal(&want) {
+	if got, want := unstruct.GetDeletionTimestamp(), metav1.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC); got == nil || !got.Equal(want) {
 		t.Errorf("GetDeletionTimestamp() = %s, want %s", got, want)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes SIGSEGV on (Micro)Time calls with nil pointers.
Clean up redundant calls to `.String()` in Time/MicroTime.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
Co-authored-by: Ben Fuller <bfuller@pivotal.io>