### PR TITLE
Limit the read length of ioutil.ReadAll in `pkg/kubelet` and `pkg/probe`

### DIFF
--- a/pkg/kubelet/cm/BUILD
+++ b/pkg/kubelet/cm/BUILD
@@ -88,6 +88,7 @@ go_library(
             "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
             "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd:go_default_library",
             "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
+            "//vendor/k8s.io/utils/io:go_default_library",
             "//vendor/k8s.io/utils/path:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:nacl": [

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -61,6 +61,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/oom"
 	"k8s.io/kubernetes/pkg/util/procfs"
 	utilsysctl "k8s.io/kubernetes/pkg/util/sysctl"
+	utilio "k8s.io/utils/io"
 	utilpath "k8s.io/utils/path"
 )
 
@@ -76,6 +77,7 @@ const (
 	dockerPidFile         = "/var/run/docker.pid"
 	containerdProcessName = "docker-containerd"
 	containerdPidFile     = "/run/docker/libcontainerd/docker-containerd.pid"
+	maxPidFileLength      = 1 << 10 // 1KB
 )
 
 var (
@@ -682,7 +684,7 @@ func getPidFromPidFile(pidFile string) (int, error) {
 	}
 	defer file.Close()
 
-	data, err := ioutil.ReadAll(file)
+	data, err := utilio.ReadAtMost(file, maxPidFileLength)
 	if err != nil {
 		return 0, fmt.Errorf("error reading pid file %s: %v", pidFile, err)
 	}

--- a/pkg/kubelet/config/BUILD
+++ b/pkg/kubelet/config/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/utils/io:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:linux": [
             "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",

--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -43,6 +43,10 @@ import (
 	"k8s.io/klog"
 )
 
+const (
+	maxConfigLength = 10 * 1 << 20 // 10MB
+)
+
 // Generate a pod name that is unique among nodes by appending the nodeName.
 func generatePodName(name string, nodeName types.NodeName) string {
 	return fmt.Sprintf("%s-%s", name, strings.ToLower(string(nodeName)))

--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -19,7 +19,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -33,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	utilio "k8s.io/utils/io"
 )
 
 type podEventType int
@@ -215,7 +215,7 @@ func (s *sourceFile) extractFromFile(filename string) (pod *v1.Pod, err error) {
 	}
 	defer file.Close()
 
-	data, err := ioutil.ReadAll(file)
+	data, err := utilio.ReadAtMost(file, maxConfigLength)
 	if err != nil {
 		return pod, err
 	}

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -20,7 +20,6 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
+	utilio "k8s.io/utils/io"
 )
 
 type sourceURL struct {
@@ -93,7 +93,7 @@ func (s *sourceURL) extractFromURL() error {
 		return err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := utilio.ReadAtMost(resp.Body, maxConfigLength)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubelet/lifecycle/BUILD
+++ b/pkg/kubelet/lifecycle/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/utils/io:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/network/dns/BUILD
+++ b/pkg/kubelet/network/dns/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/utils/io:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 
 	"k8s.io/klog"
+	utilio "k8s.io/utils/io"
 )
 
 var (
@@ -47,6 +48,10 @@ const (
 	podDNSCluster podDNSType = iota
 	podDNSHost
 	podDNSNone
+)
+
+const (
+	maxResolveConfLength = 10 * 1 << 20 // 10MB
 )
 
 // Configurer is used for setting up DNS resolver configuration when launching pods.
@@ -193,7 +198,7 @@ func (c *Configurer) CheckLimitsForResolvConf() {
 // parseResolvConf reads a resolv.conf file from the given reader, and parses
 // it into nameservers, searches and options, possibly returning an error.
 func parseResolvConf(reader io.Reader) (nameservers []string, searches []string, options []string, err error) {
-	file, err := ioutil.ReadAll(reader)
+	file, err := utilio.ReadAtMost(reader, maxResolveConfLength)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/probe/http/BUILD
+++ b/pkg/probe/http/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//pkg/version:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/utils/io:go_default_library",
     ],
 )
 

--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -30,6 +29,11 @@ import (
 	"k8s.io/kubernetes/pkg/version"
 
 	"k8s.io/klog"
+	utilio "k8s.io/utils/io"
+)
+
+const (
+	maxRespBodyLength = 10 * 1 << 10 // 10KB
 )
 
 // New creates Prober that will skip TLS verification while probing.
@@ -107,7 +111,7 @@ func DoHTTPProbe(url *url.URL, headers http.Header, client GetHTTPInterface) (pr
 		return probe.Failure, err.Error(), nil
 	}
 	defer res.Body.Close()
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := utilio.ReadAtMost(res.Body, maxRespBodyLength)
 	if err != nil {
 		return probe.Failure, "", err
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

/sig node

**What this PR does / why we need it**:
Limit the read length of `ioutil.ReadAll` with `io.LimitReader` in `pkg/kubelet` and `pkg/probe`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Limit the response body length of http readiness/liveness probes to 10KB; 
```
