### PR TITLE
Limit the read length of ioutil.ReadAll in `pkg/credentialprovider` 

### DIFF
--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -18,6 +18,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"io"
 	"io/ioutil"
 	"os"
@@ -38,7 +39,10 @@ import (
 var flagConfigFile = pflag.String("azure-container-registry-config", "",
 	"Path to the file containing Azure container registry configuration information.")
 
-const dummyRegistryEmail = "name@contoso.com"
+const (
+	dummyRegistryEmail = "name@contoso.com"
+	maxReadLength      = 10 * 1 << 20 // 10MB
+)
 
 var containerRegistryUrls = []string{"*.azurecr.io", "*.azurecr.cn", "*.azurecr.de", "*.azurecr.us"}
 
@@ -117,9 +121,13 @@ func parseConfig(configReader io.Reader) (*auth.AzureAuthConfig, error) {
 		return &config, nil
 	}
 
-	configContents, err := ioutil.ReadAll(configReader)
+	limitedReader := &io.LimitedReader{R: configReader, N: maxReadLength}
+	configContents, err := ioutil.ReadAll(limitedReader)
 	if err != nil {
 		return nil, err
+	}
+	if limitedReader.N <= 0 {
+		return nil, errors.New("the read limit is reached")
 	}
 	err = yaml.Unmarshal(configContents, &config)
 	if err != nil {

--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -19,7 +19,9 @@ package credentialprovider
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -28,6 +30,10 @@ import (
 	"sync"
 
 	"k8s.io/klog"
+)
+
+const (
+	maxReadLength = 10 * 1 << 20 // 10MB
 )
 
 // DockerConfigJson represents ~/.docker/config.json file info
@@ -195,9 +201,14 @@ func ReadUrl(url string, client *http.Client, header *http.Header) (body []byte,
 		}
 	}
 
-	contents, err := ioutil.ReadAll(resp.Body)
+	limitedReader := &io.LimitedReader{R: resp.Body, N: maxReadLength}
+	contents, err := ioutil.ReadAll(limitedReader)
 	if err != nil {
 		return nil, err
+	}
+
+	if limitedReader.N <= 0 {
+		return nil, errors.New("the read limit is reached")
 	}
 
 	return contents, nil


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Limit the read length of `ioutil.ReadAll` with `io.LimitReader` in `pkg/credentialprovider` .

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
