### PR TITLE
Use `io.CopyN` to limit the size of the data to be copied

### DIFF
--- a/pkg/kubelet/logs/container_log_manager.go
+++ b/pkg/kubelet/logs/container_log_manager.go
@@ -349,7 +349,7 @@ func (c *containerLogManager) compressLog(log string) error {
 	defer f.Close()
 	w := gzip.NewWriter(f)
 	defer w.Close()
-	if _, err := io.Copy(w, r); err != nil {
+	if _, err := io.CopyN(w, r, c.policy.MaxSize); err != nil {
 		return fmt.Errorf("failed to compress %q to %q: %v", log, tmpLog, err)
 	}
 	compressedLog := log + compressSuffix


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Use `io.CopyN` instead of `io.Copy` to limit the size of the data to be copied

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
