### PR TITLE
Revert "Fix shellcheck failures of hack/update-gofmt.sh hack/update-translations.sh"

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -48,7 +48,9 @@
 ./hack/update-generated-kms-dockerized.sh
 ./hack/update-generated-protobuf-dockerized.sh
 ./hack/update-generated-runtime-dockerized.sh
+./hack/update-gofmt.sh
 ./hack/update-openapi-spec.sh
+./hack/update-translations.sh
 ./hack/update-vendor.sh
 ./hack/verify-api-groups.sh
 ./hack/verify-boilerplate.sh

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::verify_go_version
@@ -44,4 +44,4 @@ find_files() {
 }
 
 GOFMT="gofmt -s -w"
-find_files | xargs "${GOFMT}"
+find_files | xargs ${GOFMT}

--- a/hack/update-translations.sh
+++ b/hack/update-translations.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
 KUBECTL_FILES="pkg/kubectl/cmd/*.go pkg/kubectl/cmd/*/*.go"
@@ -61,7 +61,7 @@ fi
 
 if [[ "${generate_pot}" == "true" ]]; then
   echo "Extracting strings to POT"
-  go-xgettext -k=i18n.T "${KUBECTL_FILES}" > tmp.pot
+  go-xgettext -k=i18n.T ${KUBECTL_FILES} > tmp.pot
   perl -pi -e 's/CHARSET/UTF-8/' tmp.pot
   perl -pi -e 's/\\\(/\\\\\(/g' tmp.pot
   perl -pi -e 's/\\\)/\\\\\)/g' tmp.pot
@@ -78,10 +78,10 @@ fi
 if [[ "${generate_mo}" == "true" ]]; then
   echo "Generating .po and .mo files"
   for x in translations/*/*/*/*.po; do
-    msgcat -s "${x}" > tmp.po
-    mv tmp.po "${x}"
+    msgcat -s ${x} > tmp.po
+    mv tmp.po ${x}
     echo "generating .mo file for: ${x}"
-    msgfmt "${x}" -o "$(dirname "${x}")/$(basename "${x}" .po).mo"
+    msgfmt ${x} -o "$(dirname ${x})/$(basename ${x} .po).mo"
   done
 fi
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#76314

This PR is broken. Specifically, the quotes around ${GOFMT} are erroneous. Please ensure `hack/update-gofmt.sh` actually works before merging.

```release-note
NONE
```

```
xargs: gofmt -s -w: No such file or directory
!!! [0412 15:50:36] Call tree:
!!! [0412 15:50:36]  1: hack/update-gofmt.sh:47 find_files(...)
!!! Error in hack/update-gofmt.sh:31
  Error in hack/update-gofmt.sh:31. '((i<3-1))' exited with status 141
Call stack:
  1: hack/update-gofmt.sh:31 find_files(...)
  2: hack/update-gofmt.sh:47 main(...)
Exiting with status 1
!!! Error in hack/update-gofmt.sh:47
  Error in hack/update-gofmt.sh:47. 'xargs "${GOFMT}"' exited with status 1 127
Call stack:
  1: hack/update-gofmt.sh:47 main(...)
Exiting with status 1
```
