### PR TITLE
Bump coreos/go-semver

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1436,7 +1436,7 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-semver/semver",
-			"Comment": "v0.2.0-9-ge214231b295a8e",
+			"Comment": "v0.3.0",
 			"Rev": "e214231b295a8ea9479f11b70b35d5acf3556d9b"
 		},
 		{


### PR DESCRIPTION
The https://github.com/coreos/go-semver/ dependency has formally release
v0.3.0 at commit e214231b295a8ea9479f11b70b35d5acf3556d9b.  This is the
commit point we've been using, but the hack/verify-godeps.sh script
notices the discrepancy and causes ci-kubernetes-verify job to fail.

Fixes: #76526

Signed-off-by: Tim Pepper <tpepper@vmware.com>

```release-note
NONE
```
