### PR TITLE
Return proper error from sync

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -203,6 +203,7 @@ func (c *AvailableConditionController) sync(key string) error {
 			if port.Port == servicePort {
 				foundPort = true
 				portName = port.Name
+				break
 			}
 		}
 		if !foundPort {

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -220,14 +220,18 @@ func (c *AvailableConditionController) sync(key string) error {
 			availableCondition.Reason = "EndpointsNotFound"
 			availableCondition.Message = fmt.Sprintf("cannot find endpoints for service/%s in %q", apiService.Spec.Service.Name, apiService.Spec.Service.Namespace)
 			apiregistration.SetAPIServiceCondition(apiService, availableCondition)
-			_, err := updateAPIServiceStatus(c.apiServiceClient, originalAPIService, apiService)
+			if _, err2 := updateAPIServiceStatus(c.apiServiceClient, originalAPIService, apiService); err2 != nil {
+				klog.Errorf("cannot update API service status: %v", err2)
+			}
 			return err
 		} else if err != nil {
 			availableCondition.Status = apiregistration.ConditionUnknown
 			availableCondition.Reason = "EndpointsAccessError"
 			availableCondition.Message = fmt.Sprintf("service/%s in %q cannot be checked due to: %v", apiService.Spec.Service.Name, apiService.Spec.Service.Namespace, err)
 			apiregistration.SetAPIServiceCondition(apiService, availableCondition)
-			_, err := updateAPIServiceStatus(c.apiServiceClient, originalAPIService, apiService)
+			if _, err2 := updateAPIServiceStatus(c.apiServiceClient, originalAPIService, apiService); err2 != nil {
+				klog.Errorf("cannot update API service status: %v", err2)
+			}
 			return err
 		}
 		hasActiveEndpoints := false


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
For AvailableConditionController#sync, when err is not nil we call updateAPIServiceStatus and return the error.
However, the err is assigned the return value from call to updateAPIServiceStatus before returning.
This means that though the call to updateAPIServiceStatus may be successful, its return value would be nonetheless returned to caller of sync.

```release-note
NONE
```
