### PR TITLE
Check error return from net.ParseCIDR

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1716,8 +1716,8 @@ func (proxier *Proxier) isIPInExcludeCIDRs(ip net.IP) bool {
 	// make sure it does not fall within an excluded CIDR range.
 	for _, excludedCIDR := range proxier.excludeCIDRs {
 		// Any validation of this CIDR already should have occurred.
-		_, n, _ := net.ParseCIDR(excludedCIDR)
-		if n.Contains(ip) {
+		_, n, err := net.ParseCIDR(excludedCIDR)
+		if err == nil && n.Contains(ip) {
 			return true
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The error return value from net.ParseCIDR is not checked in isIPInExcludeCIDRs.

This PR adds the check for the error return.

```release-note
NONE
```
