### PR TITLE
propagate pinned versions to staging repos, output cleanup commands

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -40,6 +40,7 @@
 ./hack/make-rules/update.sh
 ./hack/make-rules/verify.sh
 ./hack/make-rules/vet.sh
+./hack/pin-dependency.sh
 ./hack/test-integration.sh
 ./hack/test-update-storage-objects.sh
 ./hack/update-generated-kms-dockerized.sh

--- a/hack/lint-dependencies.sh
+++ b/hack/lint-dependencies.sh
@@ -56,7 +56,7 @@ unused=$(comm -23 \
 if [[ -n "${unused}" ]]; then
   echo ""
   echo "Pinned module versions that aren't actually used:"
-  echo "${unused}"
+  echo "${unused}" | xargs -L 1 echo 'GO111MODULE=on go mod edit -dropreplace'
 fi
 
 if [[ -n "${unused}${outdated}" ]]; then


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

* when pinning a version, propagates the version to staging repos that use that dependency. this ensures we can downgrade a pinned version without the staging repos artificially bumping up the "preferred" version.
* outputs commands to drop unneeded replace directives in lint script

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @dims
/priority backlog
/sig api-machinery