### PR TITLE
Add completion support for kubectl plugins

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/completion/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/completion/BUILD
@@ -7,6 +7,8 @@ go_library(
     importpath = "k8s.io/kubectl/pkg/cmd/completion",
     visibility = ["//visibility:public"],
     deps = [
+        "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
+        "//staging/src/k8s.io/kubectl/pkg/cmd/plugin:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/util:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/i18n:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/templates:go_default_library",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
@@ -19,9 +19,14 @@ package completion
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/cmd/plugin"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -127,6 +132,7 @@ func RunCompletion(out io.Writer, boilerPlate string, cmd *cobra.Command, args [
 	if !found {
 		return cmdutil.UsageErrorf(cmd, "Unsupported shell type %q.", args[0])
 	}
+	addPluginCommands(cmd.Root())
 
 	return run(out, boilerPlate, cmd.Parent())
 }
@@ -311,4 +317,48 @@ _complete kubectl 2>/dev/null
 `
 	out.Write([]byte(zshTail))
 	return nil
+}
+
+// addPluginCommand adds plugin commands under the given command so that
+// completion includes them
+func addPluginCommands(kubectl *cobra.Command) {
+	streams := genericclioptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    ioutil.Discard,
+		ErrOut: ioutil.Discard,
+	}
+
+	o := &plugin.PluginListOptions{IOStreams: streams}
+	o.Complete(kubectl)
+	plugins, _ := o.ListPlugins()
+
+	for _, plugin := range plugins {
+		plugin = filepath.Base(plugin)
+		args := []string{}
+
+		// Plugins are named "kubectl-<name>" or with more - such as
+		// "kubectl-<name>-<subcmd1>..."
+		for _, arg := range strings.Split(plugin, "-")[1:] {
+			// Underscores (_) in plugin's filename are replaced with dashes(-)
+			// e.g. foo_bar -> foo-bar
+			args = append(args, strings.Replace(arg, "_", "-", -1))
+		}
+
+		// In order to avoid that the same plugin command is added,
+		// find the lowest command given args from the root command
+		parentCmd, remainingArgs, _ := kubectl.Find(args)
+		if parentCmd == nil {
+			parentCmd = kubectl
+		}
+
+		for _, remainingArg := range remainingArgs {
+			cmd := &cobra.Command{
+				Use: remainingArg,
+				// A Run is required for it to be a valid command
+				Run: func(cmd *cobra.Command, args []string) {},
+			}
+			parentCmd.AddCommand(cmd)
+			parentCmd = cmd
+		}
+	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
@@ -107,54 +107,27 @@ func (o *PluginListOptions) Complete(cmd *cobra.Command) error {
 }
 
 func (o *PluginListOptions) Run() error {
-	pluginsFound := false
-	isFirstFile := true
-	pluginErrors := []error{}
-	pluginWarnings := 0
+	plugins, pluginErrors := o.ListPlugins()
 
-	for _, dir := range uniquePathsList(o.PluginPaths) {
-		files, err := ioutil.ReadDir(dir)
-		if err != nil {
-			if _, ok := err.(*os.PathError); ok {
-				fmt.Fprintf(o.ErrOut, "Unable read directory %q from your PATH: %v. Skipping...", dir, err)
-				continue
-			}
-
-			pluginErrors = append(pluginErrors, fmt.Errorf("error: unable to read directory %q in your PATH: %v", dir, err))
-			continue
-		}
-
-		for _, f := range files {
-			if f.IsDir() {
-				continue
-			}
-			if !hasValidPrefix(f.Name(), ValidPluginFilenamePrefixes) {
-				continue
-			}
-
-			if isFirstFile {
-				fmt.Fprintf(o.ErrOut, "The following compatible plugins are available:\n\n")
-				pluginsFound = true
-				isFirstFile = false
-			}
-
-			pluginPath := f.Name()
-			if !o.NameOnly {
-				pluginPath = filepath.Join(dir, pluginPath)
-			}
-
-			fmt.Fprintf(o.Out, "%s\n", pluginPath)
-			if errs := o.Verifier.Verify(filepath.Join(dir, f.Name())); len(errs) != 0 {
-				for _, err := range errs {
-					fmt.Fprintf(o.ErrOut, "  - %s\n", err)
-					pluginWarnings++
-				}
-			}
-		}
+	if len(plugins) > 0 {
+		fmt.Fprintf(o.ErrOut, "The following compatible plugins are available:\n\n")
+	} else {
+		pluginErrors = append(pluginErrors, fmt.Errorf("error: unable to find any kubectl plugins in your PATH"))
 	}
 
-	if !pluginsFound {
-		pluginErrors = append(pluginErrors, fmt.Errorf("error: unable to find any kubectl plugins in your PATH"))
+	pluginWarnings := 0
+	for _, pluginPath := range plugins {
+		if o.NameOnly {
+			fmt.Fprintf(o.Out, "%s\n", filepath.Base(pluginPath))
+		} else {
+			fmt.Fprintf(o.Out, "%s\n", pluginPath)
+		}
+		if errs := o.Verifier.Verify(pluginPath); len(errs) != 0 {
+			for _, err := range errs {
+				fmt.Fprintf(o.ErrOut, "  - %s\n", err)
+				pluginWarnings++
+			}
+		}
 	}
 
 	if pluginWarnings > 0 {
@@ -174,6 +147,38 @@ func (o *PluginListOptions) Run() error {
 	}
 
 	return nil
+}
+
+// ListPlugins returns list of plugin paths.
+func (o *PluginListOptions) ListPlugins() ([]string, []error) {
+	plugins := []string{}
+	errors := []error{}
+
+	for _, dir := range uniquePathsList(o.PluginPaths) {
+		files, err := ioutil.ReadDir(dir)
+		if err != nil {
+			if _, ok := err.(*os.PathError); ok {
+				fmt.Fprintf(o.ErrOut, "Unable read directory %q from your PATH: %v. Skipping...", dir, err)
+				continue
+			}
+
+			errors = append(errors, fmt.Errorf("error: unable to read directory %q in your PATH: %v", dir, err))
+			continue
+		}
+
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			if !hasValidPrefix(f.Name(), ValidPluginFilenamePrefixes) {
+				continue
+			}
+
+			plugins = append(plugins, filepath.Join(dir, f.Name()))
+		}
+	}
+
+	return plugins, errors
 }
 
 // pathVerifier receives a path and determines if it is valid or not

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -164,6 +166,34 @@ func TestPluginPathsAreValid(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestListPlugins(t *testing.T) {
+	pluginPath, _ := filepath.Abs("./testdata")
+	expectPlugins := []string{
+		filepath.Join(pluginPath, "kubectl-foo"),
+		filepath.Join(pluginPath, "kubectl-version"),
+	}
+
+	verifier := newFakePluginPathVerifier()
+	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	pluginPaths := []string{pluginPath}
+
+	o := &PluginListOptions{
+		Verifier:  verifier,
+		IOStreams: ioStreams,
+
+		PluginPaths: pluginPaths,
+	}
+
+	plugins, errs := o.ListPlugins()
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	if !reflect.DeepEqual(expectPlugins, plugins) {
+		t.Fatalf("saw unexpected plugins. Expecting %v, got %v", expectPlugins, plugins)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This commit allows us to get bash/zsh completion for kubectl plugins.

For example, with the use of a plugin named 'kubectl-krew', completing
   kubectl k<kbd>tab</kbd>
will include 'krew' in the list of possible completions.

Because bash completion is generated by Cobra, this commit took the
approach of registering every plugin as a Cobra command.  This makes
Cobra include each plugin command into the completion script.
For efficiency, searching for plugins and registering them as Cobra
commands is only done when running the command 'kubectl completion',
which is the only time we need it.

You can try completion for kubectl plugins with the following steps:
```
# create and install kubectl-foo-bar-baz plugin
$ mkdir -p $HOME/bin
$ export PATH="$HOME/bin:$PATH"
$ echo '#!/bin/bash\n\necho "My first command-line argument was $1"' > $HOME/bin/kubectl-foo-bar-baz
$ kubectl foo bar baz hello
My first command-line argument was hello

# build the kubectl
$ make kubectl

# Load the kubectl completion code
$ . /usr/local/etc/profile.d/bash_completion.sh
$ source <(_output/bin/kubectl completion bash)

# try completion for kubectl plugins
$ kubectl f<tab><tab>
```

And I tested this PR with both bash and zsh.

/ref https://github.com/kubernetes/kubernetes/issues/74178, https://github.com/kubernetes-sigs/krew/issues/155

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/585

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support completion for kubectl plugins.
```
