### PR TITLE
[e2e] Clean up e2e/framework/upgrade_util.go

### DIFF
--- a/test/e2e/framework/upgrade_util.go
+++ b/test/e2e/framework/upgrade_util.go
@@ -34,7 +34,7 @@ func RealVersion(s string) (string, error) {
 	Logf("Getting real version for %q", s)
 	v, _, err := RunCmd(path.Join(TestContext.RepoRoot, "hack/get-build.sh"), "-v", s)
 	if err != nil {
-		return v, err
+		return v, fmt.Errorf("error getting real version for %q: %v", s, err)
 	}
 	Logf("Version for %q is %q", s, v)
 	return strings.TrimPrefix(strings.TrimSpace(v), "v"), nil
@@ -46,14 +46,13 @@ func traceRouteToMaster() {
 		Logf("Could not find traceroute program")
 		return
 	}
-
 	cmd := exec.Command(path, "-I", GetMasterHost())
 	out, err := cmd.Output()
 	if len(out) != 0 {
 		Logf(string(out))
 	}
 	if exiterr, ok := err.(*exec.ExitError); err != nil && ok {
-		Logf("error while running traceroute: %s", exiterr.Stderr)
+		Logf("Error while running traceroute: %s", exiterr.Stderr)
 	}
 }
 
@@ -78,8 +77,7 @@ func CheckMasterVersion(c clientset.Interface, want string) error {
 	// got  looks like: v0.19.3-815-g50e67d4034e858-dirty
 	got := strings.TrimPrefix(v.GitVersion, "v")
 	if !strings.HasPrefix(got, want) {
-		return fmt.Errorf("master had kube-apiserver version %s which does not start with %s",
-			got, want)
+		return fmt.Errorf("master had kube-apiserver version %s which does not start with %s", got, want)
 	}
 	Logf("Master is at version %s", want)
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Reference issue #76206 (parent issue #75601 )

**Special notes for your reviewer**:

Considering move this file to `framework/cluster` package

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
