### PR TITLE
Update container_gc.go to fix kubelet config 'minimun-container-ttl-duration' compute by finish timestamp of the contariner

### DIFF
--- a/pkg/kubelet/dockertools/container_gc.go
+++ b/pkg/kubelet/dockertools/container_gc.go
@@ -143,7 +143,11 @@ func (cgc *containerGC) evictableContainers(minAge time.Duration) (containersByE
 		if err != nil {
 			glog.Errorf("Failed to parse Created timestamp %q for container %q", data.Created, container.ID)
 		}
-		if newestGCTime.Before(created) {
+		finishedAt, err := ParseDockerTimestamp(data.State.FinishedAt)
+		if err != nil {
+			glog.Errorf("Failed to parse FinishedAt timestamp %q for container %q", data.State.FinishedAt, container.ID)
+		}
+		if newestGCTime.Before(finishedAt) {
 			continue
 		}
 


### PR DESCRIPTION
Update container_gc.go to fix kubelet config 'minimun-container-ttl-duration' compute by finish timestamp of the contariner

What type of PR is this?
 /kind bug

What this PR does / why we need it:
before this fix, the kubelet config 'minimun-container-ttl-duration' compute by created timestamp of the contariner

Which issue(s) this PR fixes:
NONE

release-note
v1.5.9
