### PR TITLE
Revert accidentally pushed e2e images

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -238,9 +238,9 @@ func initImageConfigs() map[int]Config {
 	configs[ServeHostname] = Config{e2eRegistry, "serve-hostname", "1.1"}
 	configs[TestWebserver] = Config{e2eRegistry, "test-webserver", "1.0"}
 	configs[VolumeNFSServer] = Config{e2eRegistry, "volume/nfs", "1.0"}
-	configs[VolumeISCSIServer] = Config{"quay.io", "jsafrane/iscsi-test", "2.0"}
+	configs[VolumeISCSIServer] = Config{e2eRegistry, "volume/iscsi", "2.0"}
 	configs[VolumeGlusterServer] = Config{e2eRegistry, "volume/gluster", "1.0"}
-	configs[VolumeRBDServer] = Config{"quay.io", "jsafrane/rbd-test", "2.0"}
+	configs[VolumeRBDServer] = Config{e2eRegistry, "volume/rbd", "1.0.1"}
 	return configs
 }
 


### PR DESCRIPTION
This reverts commit 5f9756c3ce11023f50074868ab0625ca294aad39.

In #73739 I accidentally pushed a commit that allows to run e2e tests with images from my image repository instead of gcr.io/kubernetes-e2e-test-images.

**What type of PR is this?**
/kind cleanup

```release-note
NONE
```

@listx @ixdy, can you also please build & upload gcr.io/kubernetes-e2e-test-images/volume/iscsi:2.0 ?
