### PR TITLE
Fix typo in kube-proxy-migration-e2e test

### DIFF
--- a/test/e2e/upgrades/kube_proxy_migration.go
+++ b/test/e2e/upgrades/kube_proxy_migration.go
@@ -46,7 +46,7 @@ type KubeProxyUpgradeTest struct {
 // Name returns the tracking name of the test.
 func (KubeProxyUpgradeTest) Name() string { return "[sig-network] kube-proxy-upgrade" }
 
-// Setup verifies kube-proxy static pods is running before uprgade.
+// Setup verifies kube-proxy static pods is running before upgrade.
 func (t *KubeProxyUpgradeTest) Setup(f *framework.Framework) {
 	ginkgo.By("Waiting for kube-proxy static pods running and ready")
 	gomega.Expect(waitForKubeProxyStaticPodsRunning(f.ClientSet)).NotTo(gomega.HaveOccurred())
@@ -78,7 +78,7 @@ type KubeProxyDowngradeTest struct {
 // Name returns the tracking name of the test.
 func (KubeProxyDowngradeTest) Name() string { return "[sig-network] kube-proxy-downgrade" }
 
-// Setup verifies kube-proxy DaemonSet is running before uprgade.
+// Setup verifies kube-proxy DaemonSet is running before upgrade.
 func (t *KubeProxyDowngradeTest) Setup(f *framework.Framework) {
 	ginkgo.By("Waiting for kube-proxy DaemonSet running and ready")
 	gomega.Expect(waitForKubeProxyDaemonSetRunning(f.ClientSet)).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
**What type of PR is this?** 
/kind cleanup

**What this PR does / why we need it**:
s/uprgade/upgrade

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
