### PR TITLE
update the output of install-etcd.sh, show how to export the environment of etcd

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -112,9 +112,9 @@ kube::etcd::install() {
 
     cd "${KUBE_ROOT}/third_party" || return 1
     if [[ $(readlink etcd) == etcd-v${ETCD_VERSION}-${os}-* ]]; then
-      kube::log::info "etcd v${ETCD_VERSION} already installed at path:"
-      kube::log::info "$(pwd)/$(readlink etcd)"
-      return  # already installed
+      kube::log::info "etcd v${ETCD_VERSION} already installed. To use:"
+      kube::log::info "export PATH=\"$(pwd)/etcd:\${PATH}\""
+      return  #already installed
     fi
 
     if [[ ${os} == "darwin" ]]; then
@@ -133,6 +133,6 @@ kube::etcd::install() {
       rm "${download_file}"
     fi
     kube::log::info "etcd v${ETCD_VERSION} installed. To use:"
-    kube::log::info "export PATH=$(pwd)/etcd:\${PATH}"
+    kube::log::info "export PATH=\"$(pwd)/etcd:\${PATH}\""
   )
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
/sig cli

**What this PR does / why we need it**:
To start a local/fake cluster, what we need to do is run "hack/install-etcd.sh" first and then run "hack/local-up-cluster.sh".

If the "install-etcd.sh" is executed before, what we get is like:
etcd v3.3.10 already installed at path:
/opt/src/k8s.io/kubernetes/third_party/etcd-v3.3.10-linux-amd64

This information is not enough/convenient to run "local-up-cluster.sh" again as user needs to set the the etcd information into environment variable PATH before running this command. The current output is not user friendly to a new kubernetes user (like me).

To fix this issue, the new message will be as following when the etcd is already installed:
etcd v3.3.10 already installed. To use:
export PATH=/opt/src/k8s.io/kubernetes/third_party/etcd:${PATH}

**Which issue(s) this PR fixes**:
Fixes # NONE

**Does this PR introduce a user-facing change?**:
NONE
