### PR TITLE
Improve NewStreamWatcher() compatibility

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher_test.go
@@ -63,7 +63,7 @@ func TestStreamWatcher(t *testing.T) {
 	}
 
 	fd := fakeDecoder{items: make(chan Event, 5)}
-	sw := NewStreamWatcher(fd, nil)
+	sw := NewStreamWatcherWithErrorReporter(fd, nil)
 
 	for _, item := range table {
 		fd.items <- item
@@ -86,7 +86,7 @@ func TestStreamWatcher(t *testing.T) {
 func TestStreamWatcherError(t *testing.T) {
 	fd := fakeDecoder{err: fmt.Errorf("test error")}
 	fr := &fakeReporter{}
-	sw := NewStreamWatcher(fd, fr)
+	sw := NewStreamWatcherWithErrorReporter(fd, fr)
 	evt, ok := <-sw.ResultChan()
 	if !ok {
 		t.Fatalf("unexpected close")

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -595,7 +595,7 @@ func (r *Request) WatchWithSpecificDecoders(wrapperDecoderFn func(io.ReadCloser)
 		return nil, fmt.Errorf("for request %s, got status: %v", url, resp.StatusCode)
 	}
 	wrapperDecoder := wrapperDecoderFn(resp.Body)
-	return watch.NewStreamWatcher(
+	return watch.NewStreamWatcherWithErrorReporter(
 		restclientwatch.NewDecoder(wrapperDecoder, embeddedDecoder),
 		// use 500 to indicate that the cause of the error is unknown - other error codes
 		// are more specific to HTTP interactions, and set a reason


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Avoids breaking the NewStreamWatcher() signature

```release-note
NONE
```

/cc @smarterclayton
/priority important-soon
/sig api-machinery