### PR TITLE
dockershim: Fix negotiating docker API version

### DIFF
--- a/pkg/kubelet/dockershim/libdocker/kube_docker_client.go
+++ b/pkg/kubelet/dockershim/libdocker/kube_docker_client.go
@@ -85,15 +85,12 @@ func newKubeDockerClient(dockerClient *dockerapi.Client, requestTimeout, imagePu
 		timeout:                   requestTimeout,
 		imagePullProgressDeadline: imagePullProgressDeadline,
 	}
+
 	// Notice that this assumes that docker is running before kubelet is started.
-	v, err := k.Version()
-	if err != nil {
-		klog.Errorf("failed to retrieve docker version: %v", err)
-		klog.Warningf("Using empty version for docker client, this may sometimes cause compatibility issue.")
-	} else {
-		// Update client version with real api version.
-		dockerClient.NegotiateAPIVersionPing(dockertypes.Ping{APIVersion: v.APIVersion})
-	}
+	ctx, cancel := k.getTimeoutContext()
+	defer cancel()
+	dockerClient.NegotiateAPIVersion(ctx)
+
 	return k
 }
 


### PR DESCRIPTION
API version negotiation needs to happen before any meaningful docker
calls, including simple commands such as "/version".

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
See #https://github.com/kubernetes/kubernetes/pull/75843#issuecomment-483346844

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
