### PR TITLE
Skip storage tests that depend on default SC - if no default SC is found

### DIFF
--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -94,6 +94,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		// StorageClass and a dynamic provisioner.
 		ginkgo.It("should provide basic identity", func() {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
+			framework.SkipIfNoDefaultStorageClass(c)
 			*(ss.Spec.Replicas) = 3
 			sst := framework.NewStatefulSetTester(c)
 			sst.PauseNewPods(ss)
@@ -133,6 +134,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		// StorageClass and a dynamic provisioner.
 		ginkgo.It("should adopt matching orphans and release non-matching pods", func() {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
+			framework.SkipIfNoDefaultStorageClass(c)
 			*(ss.Spec.Replicas) = 1
 			sst := framework.NewStatefulSetTester(c)
 			sst.PauseNewPods(ss)
@@ -218,6 +220,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		// StorageClass and a dynamic provisioner.
 		ginkgo.It("should not deadlock when a pod's predecessor fails", func() {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
+			framework.SkipIfNoDefaultStorageClass(c)
 			*(ss.Spec.Replicas) = 2
 			sst := framework.NewStatefulSetTester(c)
 			sst.PauseNewPods(ss)
@@ -254,6 +257,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		// StorageClass and a dynamic provisioner.
 		ginkgo.It("should perform rolling updates and roll backs of template modifications with PVCs", func() {
 			ginkgo.By("Creating a new StatefulSet with PVCs")
+			framework.SkipIfNoDefaultStorageClass(c)
 			*(ss.Spec.Replicas) = 3
 			rollbackTest(c, ns, ss)
 		})

--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//pkg/apis/batch:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/extensions:go_default_library",
+        "//pkg/apis/storage/v1/util:go_default_library",
         "//pkg/client/conditions:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/controller/deployment/util:go_default_library",

--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
+	storageutil "k8s.io/kubernetes/pkg/apis/storage/v1/util"
 	"k8s.io/kubernetes/pkg/volume/util"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -1020,4 +1021,34 @@ func GetBoundPV(client clientset.Interface, pvc *v1.PersistentVolumeClaim) (*v1.
 	// Get the bound PV
 	pv, err := client.CoreV1().PersistentVolumes().Get(claim.Spec.VolumeName, metav1.GetOptions{})
 	return pv, err
+}
+
+// GetDefaultStorageClassName returns default storageClass or return error
+func GetDefaultStorageClassName(c clientset.Interface) (string, error) {
+	list, err := c.StorageV1().StorageClasses().List(metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("Error listing storage classes: %v", err)
+	}
+	var scName string
+	for _, sc := range list.Items {
+		if storageutil.IsDefaultAnnotation(sc.ObjectMeta) {
+			if len(scName) != 0 {
+				return "", fmt.Errorf("Multiple default storage classes found: %q and %q", scName, sc.Name)
+			}
+			scName = sc.Name
+		}
+	}
+	if len(scName) == 0 {
+		return "", fmt.Errorf("No default storage class found")
+	}
+	Logf("Default storage class: %q", scName)
+	return scName, nil
+}
+
+// SkipIfNoDefaultStorageClass skips tests if no default SC can be found.
+func SkipIfNoDefaultStorageClass(c clientset.Interface) {
+	_, err := GetDefaultStorageClassName(c)
+	if err != nil {
+		Skipf("error finding default storageClass : %v", err)
+	}
 }

--- a/test/e2e/storage/pvc_protection.go
+++ b/test/e2e/storage/pvc_protection.go
@@ -48,12 +48,11 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 
 		By("Creating a PVC")
 		suffix := "pvc-protection"
-		defaultSC := getDefaultStorageClassName(client)
+		framework.SkipIfNoDefaultStorageClass(client)
 		testStorageClass := testsuites.StorageClassTest{
 			ClaimSize: "1Gi",
 		}
 		pvc = newClaim(testStorageClass, nameSpace, suffix)
-		pvc.Spec.StorageClassName = &defaultSC
 		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)
 		framework.ExpectNoError(err, "Error creating PVC")
 		pvcCreatedAndNotDeleted = true

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -52,17 +52,19 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 	BeforeEach(func() {
 		c = f.ClientSet
 		ns = f.Namespace.Name
+		var err error
 		framework.SkipUnlessProviderIs("gce", "gke", "aws")
-		defaultScName = getDefaultStorageClassName(c)
-		verifyDefaultStorageClass(c, defaultScName, true)
-
+		defaultScName, err = framework.GetDefaultStorageClassName(c)
+		if err != nil {
+			framework.Failf(err.Error())
+		}
 		test := testsuites.StorageClassTest{
 			Name:      "default",
 			ClaimSize: "2Gi",
 		}
 
 		pvc = newClaim(test, ns, "default")
-		var err error
+
 		metricsGrabber, err = metrics.NewMetricsGrabber(c, nil, true, false, true, false, false)
 
 		if err != nil {


### PR DESCRIPTION
Other tests that check for default storageclass also
check for cloudprovider such as gce, aws and openstack
and hence are already skipped in bare metal environments.

But this particular test keeps failing because no such check exists.

fixes https://github.com/kubernetes/kubernetes/issues/76623

/sig storage

cc @kubernetes/sig-storage-misc 