### PR TITLE
Suppress registering GCE LB provider flag if missing on CommandLine.

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -86,9 +87,12 @@ the cloud specific control loops shipped with Kubernetes.`,
 	namedFlagSets := s.Flags(KnownControllers(), ControllersDisabledByDefault.List())
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
-	// hoist this flag from the global flagset to preserve the commandline until
-	// the gce cloudprovider is removed.
-	globalflag.Register(namedFlagSets.FlagSet("generic"), "cloud-provider-gce-lb-src-cidrs")
+
+	if flag.CommandLine.Lookup("cloud-provider-gce-lb-src-cidrs") != nil {
+		// hoist this flag from the global flagset to preserve the commandline until
+		// the gce cloudprovider is removed.
+		globalflag.Register(namedFlagSets.FlagSet("generic"), "cloud-provider-gce-lb-src-cidrs")
+	}
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes an issue with the GCE-specific `cloud-provider-gce-lb-src-cidrs` flag being added by default that breaks external cloud providers.

**Which issue(s) this PR fixes**:
Fixes #76205

**Does this PR introduce a user-facing change?**:
```release-note
GCE-only flag `cloud-provider-gce-lb-src-cidrs` becomes optional for external cloud providers.
```

/sig cloud-provider

Verified on DigitalOcean's CCM [currently being updated to 1.14.1](https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/209).

/cc @dims @andrewsykim 