### PR TITLE
Reenable Stackdriver 1.9.

### DIFF
--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -112,8 +112,7 @@ try {
   Set-EnvironmentVars
   Create-Directories
   Download-HelperScripts
-  # Disable Stackdrver logging until issue is fixed.
-  # InstallAndStart-LoggingAgent
+  InstallAndStart-LoggingAgent
 
   Create-DockerRegistryKey
   DownloadAndInstall-KubernetesBinaries

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1059,7 +1059,7 @@ function Create-DockerRegistryKey {
 # TODO(pjh): move the Stackdriver logging agent code below into a separate
 # module; it was put here temporarily to avoid disrupting the file layout in
 # the K8s release machinery.
-$STACKDRIVER_VERSION = 'v1-8'
+$STACKDRIVER_VERSION = 'v1-9'
 $STACKDRIVER_ROOT = 'C:\Program Files (x86)\Stackdriver'
 
 # Install and start the Stackdriver logging agent according to


### PR DESCRIPTION
/kind feature

This PR reenables the Stackdriver logging agent on Windows nodes brought up in clusters on GCE. It uses the recently released version 1-9 of the Windows Stackdriver agent.

Currently being tested in https://testgrid.k8s.io/google-windows#windows-prototype&width=20 (http://go/gh/kubernetes/kubernetes/commit/03b48d25992d5701f5e5971ed5fbd2cb9bd1e230).

```release-note
NONE
```