### PR TITLE
Add missing node.address != "" condition in tests

### DIFF
--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -320,7 +320,7 @@ func (j *ServiceTestJig) CreateLoadBalancerService(namespace, serviceName string
 func GetNodeAddresses(node *v1.Node, addressType v1.NodeAddressType) (ips []string) {
 	for j := range node.Status.Addresses {
 		nodeAddress := &node.Status.Addresses[j]
-		if nodeAddress.Type == addressType {
+		if nodeAddress.Type == addressType && nodeAddress.Address != "" {
 			ips = append(ips, nodeAddress.Address)
 		}
 	}

--- a/test/e2e/framework/ssh.go
+++ b/test/e2e/framework/ssh.go
@@ -245,7 +245,7 @@ func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*SSHResult,
 	Logf("Getting external IP address for %s", node.Name)
 	host := ""
 	for _, a := range node.Status.Addresses {
-		if a.Type == v1.NodeExternalIP {
+		if a.Type == v1.NodeExternalIP && a.Address != "" {
 			host = net.JoinHostPort(a.Address, sshPort)
 			break
 		}
@@ -254,7 +254,7 @@ func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*SSHResult,
 	if host == "" {
 		// No external IPs were found, let's try to use internal as plan B
 		for _, a := range node.Status.Addresses {
-			if a.Type == v1.NodeInternalIP {
+			if a.Type == v1.NodeInternalIP && a.Address != "" {
 				host = net.JoinHostPort(a.Address, sshPort)
 				break
 			}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3424,7 +3424,7 @@ func NodeAddresses(nodelist *v1.NodeList, addrType v1.NodeAddressType) []string 
 	hosts := []string{}
 	for _, n := range nodelist.Items {
 		for _, addr := range n.Status.Addresses {
-			if addr.Type == addrType {
+			if addr.Type == addrType && addr.Address != "" {
 				hosts = append(hosts, addr.Address)
 				break
 			}
@@ -4942,7 +4942,7 @@ func GetNodeExternalIP(node *v1.Node) (string, error) {
 	Logf("Getting external IP address for %s", node.Name)
 	host := ""
 	for _, a := range node.Status.Addresses {
-		if a.Type == v1.NodeExternalIP {
+		if a.Type == v1.NodeExternalIP && a.Address != "" {
 			host = net.JoinHostPort(a.Address, sshPort)
 			break
 		}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
It adds missing node.address != "" conditions in test code that provides node addresses of a given type.
It turns out to be a frequent bug that is revealed when nodes don't have external IP addresses.
In the test we assume that in such case there won't be any addresses of type 'NodeExternalIp', which is invalid. 
In such case the address of type 'NodeExternalIP' is still present, but with the empty 'Address' field.

Ref. https://github.com/kubernetes/kubernetes/issues/76374

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
