### PR TITLE
update k8s.gcr.io/k8s-dns-node-cache image version

### DIFF
--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -111,7 +111,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: k8s.gcr.io/k8s-dns-node-cache:1.15.0
+        image: k8s.gcr.io/k8s-dns-node-cache:1.15.1
         resources:
           limits:
             memory: 30Mi


### PR DESCRIPTION
v1.15.0 is affected by https://github.com/kubernetes/dns/issues/282

```release-note
k8s-dns-node-cache image version v1.15.1
```