### PR TITLE
Refactor RetrieveValidatedConfigInfo to reduce its complexity

### DIFF
--- a/cmd/kubeadm/app/discovery/token/BUILD
+++ b/cmd/kubeadm/app/discovery/token/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//staging/src/k8s.io/cluster-bootstrap/token/api:go_default_library",


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Cyclomatic complexity 21 of function RetrieveValidatedConfigInfo(), it's so high, I refactor it to reduce its complexity. I extract two function from "RetrieveValidatedConfigInfo", “getInsecureKubeconfigBytes“ and “getSecureKubeconfig”.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

/release-note-none
/priority backlog
