### PR TITLE
Delete unused struct, nodeEnumerator

### DIFF
--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -707,24 +707,6 @@ func MakeDefaultErrorFunc(client clientset.Interface, backoff *internalqueue.Pod
 	}
 }
 
-// nodeEnumerator allows a cache.Poller to enumerate items in a v1.NodeList
-type nodeEnumerator struct {
-	*v1.NodeList
-}
-
-// Len returns the number of items in the node list.
-func (ne *nodeEnumerator) Len() int {
-	if ne.NodeList == nil {
-		return 0
-	}
-	return len(ne.Items)
-}
-
-// Get returns the item (and ID) with the particular index.
-func (ne *nodeEnumerator) Get(index int) interface{} {
-	return &ne.Items[index]
-}
-
 type binder struct {
 	Client clientset.Interface
 }

--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -296,32 +296,6 @@ func TestDefaultErrorFunc(t *testing.T) {
 	}
 }
 
-func TestNodeEnumerator(t *testing.T) {
-	testList := &v1.NodeList{
-		Items: []v1.Node{
-			{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "bar"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "baz"}},
-		},
-	}
-	me := nodeEnumerator{testList}
-
-	if e, a := 3, me.Len(); e != a {
-		t.Fatalf("expected %v, got %v", e, a)
-	}
-	for i := range testList.Items {
-		t.Run(fmt.Sprintf("node enumerator/%v", i), func(t *testing.T) {
-			gotObj := me.Get(i)
-			if e, a := testList.Items[i].Name, gotObj.(*v1.Node).Name; e != a {
-				t.Errorf("Expected %v, got %v", e, a)
-			}
-			if e, a := &testList.Items[i], gotObj; !reflect.DeepEqual(e, a) {
-				t.Errorf("Expected %#v, got %v#", e, a)
-			}
-		})
-	}
-}
-
 func TestBind(t *testing.T) {
 	table := []struct {
 		name    string


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
nodeEnumerator is unused, I delete it.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

/release-note-none
/priority backlog