### PR TITLE
Remove http.CloseNotifier

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -167,10 +167,9 @@ func decorateResponseWriter(responseWriter http.ResponseWriter, ev *auditinterna
 
 	// check if the ResponseWriter we're wrapping is the fancy one we need
 	// or if the basic is sufficient
-	_, cn := responseWriter.(http.CloseNotifier)
 	_, fl := responseWriter.(http.Flusher)
 	_, hj := responseWriter.(http.Hijacker)
-	if cn && fl && hj {
+	if fl && hj {
 		return &fancyResponseWriterDelegator{delegate}
 	}
 	return delegate
@@ -219,15 +218,10 @@ func (a *auditResponseWriter) WriteHeader(code int) {
 	a.ResponseWriter.WriteHeader(code)
 }
 
-// fancyResponseWriterDelegator implements http.CloseNotifier, http.Flusher and
-// http.Hijacker which are needed to make certain http operation (e.g. watch, rsh, etc)
-// working.
+// fancyResponseWriterDelegator implements http.Flusher and http.Hijacker
+// which are needed to make certain http operation (e.g. watch, rsh, etc) working.
 type fancyResponseWriterDelegator struct {
 	*auditResponseWriter
-}
-
-func (f *fancyResponseWriterDelegator) CloseNotify() <-chan bool {
-	return f.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 
 func (f *fancyResponseWriterDelegator) Flush() {
@@ -247,6 +241,5 @@ func (f *fancyResponseWriterDelegator) Hijack() (net.Conn, *bufio.ReadWriter, er
 	return f.ResponseWriter.(http.Hijacker).Hijack()
 }
 
-var _ http.CloseNotifier = &fancyResponseWriterDelegator{}
 var _ http.Flusher = &fancyResponseWriterDelegator{}
 var _ http.Hijacker = &fancyResponseWriterDelegator{}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -85,8 +85,6 @@ type fancyResponseWriter struct {
 	simpleResponseWriter
 }
 
-func (*fancyResponseWriter) CloseNotify() <-chan bool { return nil }
-
 func (*fancyResponseWriter) Flush() {}
 
 func (*fancyResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) { return nil, nil, nil }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -173,13 +173,6 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	cn, ok := w.(http.CloseNotifier)
-	if !ok {
-		err := fmt.Errorf("unable to start watch - can't get http.CloseNotifier: %#v", w)
-		utilruntime.HandleError(err)
-		s.Scope.err(errors.NewInternalError(err), w, req)
-		return
-	}
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		err := fmt.Errorf("unable to start watch - can't get http.Flusher: %#v", w)
@@ -216,7 +209,7 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	ch := s.Watching.ResultChan()
 	for {
 		select {
-		case <-cn.CloseNotify():
+		case <-req.Context().Done():
 			return
 		case <-timeoutCh:
 			return

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -258,11 +258,10 @@ func InstrumentRouteFunc(verb, group, version, resource, subresource, scope, com
 
 		delegate := &ResponseWriterDelegator{ResponseWriter: response.ResponseWriter}
 
-		_, cn := response.ResponseWriter.(http.CloseNotifier)
 		_, fl := response.ResponseWriter.(http.Flusher)
 		_, hj := response.ResponseWriter.(http.Hijacker)
 		var rw http.ResponseWriter
-		if cn && fl && hj {
+		if fl && hj {
 			rw = &fancyResponseWriterDelegator{delegate}
 		} else {
 			rw = delegate
@@ -282,10 +281,9 @@ func InstrumentHandlerFunc(verb, group, version, resource, subresource, scope, c
 
 		delegate := &ResponseWriterDelegator{ResponseWriter: w}
 
-		_, cn := w.(http.CloseNotifier)
 		_, fl := w.(http.Flusher)
 		_, hj := w.(http.Hijacker)
-		if cn && fl && hj {
+		if fl && hj {
 			w = &fancyResponseWriterDelegator{delegate}
 		} else {
 			w = delegate
@@ -395,10 +393,6 @@ func (r *ResponseWriterDelegator) ContentLength() int {
 
 type fancyResponseWriterDelegator struct {
 	*ResponseWriterDelegator
-}
-
-func (f *fancyResponseWriterDelegator) CloseNotify() <-chan bool {
-	return f.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 
 func (f *fancyResponseWriterDelegator) Flush() {

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/compression.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/compression.go
@@ -141,11 +141,6 @@ func (c *compressionResponseWriter) WriteHeader(status int) {
 	c.writer.WriteHeader(status)
 }
 
-// CloseNotify is part of http.CloseNotifier interface
-func (c *compressionResponseWriter) CloseNotify() <-chan bool {
-	return c.writer.(http.CloseNotifier).CloseNotify()
-}
-
 // Close the underlying compressor
 func (c *compressionResponseWriter) Close() error {
 	if c.compressorClosed() {

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -190,11 +190,6 @@ func (rl *respLogger) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return rl.w.(http.Hijacker).Hijack()
 }
 
-// CloseNotify implements http.CloseNotifier
-func (rl *respLogger) CloseNotify() <-chan bool {
-	return rl.w.(http.CloseNotifier).CloseNotify()
-}
-
 func (rl *respLogger) recordStatus(status int) {
 	rl.status = status
 	rl.statusRecorded = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`http.CloseNotifier` was deprecated since [go v1.11](https://github.com/golang/go/commit/00ebfcde7f3b6e63447e2a3962975e0a8c3729dd#diff-bf538ad0b0c9263061db13ca6d8f324e) :
```
// Deprecated: the CloseNotifier interface predates Go's context package.
// New code should use Request.Context instead.
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #76469

**Special notes for your reviewer**:

As we can see from https://github.com/kubernetes/kubernetes/search?q=CloseNotifier&unscoped_q=CloseNotifier, only `k/apiserver` and `k/apimachinery` contain `CloseNotifier`.

xref https://github.com/grpc-ecosystem/grpc-gateway/pull/795, it maybe safe to clean them directly.
In some cases that cannot be clean directly, use `req.Context().Done()` to replace.

This cleanup excludes `k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go`, because `http.CloseNotifier` is required by `httputil.ReverseProxy`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Cleanup http.CloseNotifier in apiserver. 
```
