### PR TITLE
fix(kubelet, logs): change format specifier

### DIFF
--- a/pkg/kubelet/kuberuntime/logs/logs.go
+++ b/pkg/kubelet/kuberuntime/logs/logs.go
@@ -381,7 +381,7 @@ func ReadLogs(ctx context.Context, path, containerID string, opts *LogOptions, r
 				klog.V(2).Infof("Finish parsing log file %q, hit bytes limit %d(bytes)", path, opts.bytes)
 				return nil
 			}
-			klog.Errorf("Failed with err %v when writing log for log file %q: %+v", err, path, msg)
+			klog.Errorf("Failed with err %v when writing log for log file %q: %q", err, path, msg)
 			return err
 		}
 	}

--- a/pkg/kubelet/kuberuntime/logs/logs.go
+++ b/pkg/kubelet/kuberuntime/logs/logs.go
@@ -381,7 +381,7 @@ func ReadLogs(ctx context.Context, path, containerID string, opts *LogOptions, r
 				klog.V(2).Infof("Finish parsing log file %q, hit bytes limit %d(bytes)", path, opts.bytes)
 				return nil
 			}
-			klog.Errorf("Failed with err %v when writing log for log file %q: %q", err, path, msg)
+			klog.Errorf("Failed with err %v when writing log for log file %q: %s", err, path, msg.log)
 			return err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: utkarshmani1997 <utkarshmani1997@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
I have found that the kubelet was printing the logs in []bytes, which is
not readable, this is happening since `%+v` is being used. This PR will fix
the logs.
Output from the logs: 
```
Failed with err write tcp 10.200.0.85:10250->10.200.0.87:58918: write: connection       reset by peer when writing log for log file "/var/log/pods/d08ee327-5ef3-11e9-a7cf-525400451066/nginx-ingress-controller/0.log": &{timestamp:{wall:361813941 ext      :63690998724 loc:<nil>} stream:stderr log:[50 48 49 57 47 48 52 47 49 54 32 48 56 58 48 53 58 50 52 32 91 105 110 102 111 93 32 52 55 50 51 35 52 55 50 51 58 32       42 51 50 50 48 57 51 57 32 91 108 117 97 93 32 98 97 108 97 110 99 101 114 46 108 117 97 58 55 50 58 32 115 121 110 99 95 98 97 99 107 101 110 100 40 41 58 32 11      6 104 101 114 101 32 105 115 32 110 111 32 101 110 100 112 111 105 110 116 32 102 111 114 32 98 97 99 107 101 110 100 32 105 110 116 101 114 119 97 118 101 45 54       50 55 45 99 109 45 97 99 109 101 45 104 116 116 112 45 115 111 108 118 101 114 45 119 119 54 113 122 45 56 48 56 57 46 32 83 107 105 112 112 105 110 103 46 46 4      6 44 32 99 111 110 116 101 120 116 58 32 110 103 120 46 116 105 109 101 114 10]}
```
Go playground link: https://play.golang.org/p/vQHmQlwy6qr

**Does this PR introduce a user-facing change?**:
```
NONE
```
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

/assign @utkarshmani1997