### PR TITLE
Fix shellcheck failures of cluster/gce/gci/shutdown.sh

### DIFF
--- a/cluster/gce/gci/shutdown.sh
+++ b/cluster/gce/gci/shutdown.sh
@@ -16,7 +16,7 @@
 
 # A script that let's gci preemptible nodes gracefully terminate in the event of a VM shutdown.
 preemptible=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/scheduling/preemptible" -H "Metadata-Flavor: Google")
-if [ ${preemptible} == "TRUE" ]; then
+if [ "${preemptible}" == "TRUE" ]; then
     echo "Shutting down! Sleeping for a minute to let the node gracefully terminate"
     # https://cloud.google.com/compute/docs/instances/stopping-or-deleting-an-instance#delete_timeout
     sleep 30

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -11,7 +11,6 @@
 ./cluster/gce/gci/flexvolume_node_setup.sh
 ./cluster/gce/gci/health-monitor.sh
 ./cluster/gce/gci/master-helper.sh
-./cluster/gce/gci/shutdown.sh
 ./cluster/gce/list-resources.sh
 ./cluster/gce/upgrade-aliases.sh
 ./cluster/gce/upgrade.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Fix shellcheck failures of cluster/gce/gci/shutdown.sh

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #72956

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/priority important-soon