### PR TITLE
Fix kubectl version --client=true

### DIFF
--- a/pkg/kubectl/cmd/version/version.go
+++ b/pkg/kubectl/cmd/version/version.go
@@ -88,6 +88,9 @@ func NewCmdVersion(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 // Complete completes all the required options
 func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 	var err error
+	if o.ClientOnly {
+		return nil
+	}
 	o.discoveryClient, err = f.ToDiscoveryClient()
 	// if we had an empty rest.Config, continue and just print out client information.
 	// if we had an error other than being unable to build a rest.Config, fail.


### PR DESCRIPTION
Getting the client version fails if the kubeconfig is invalid:

 $ kubectl version --client=true
 Error in configuration:
 * unable to read client-cert .../client.crt: no such file or directory
 * unable to read client-key .../client.key: no such file or directory
 * unable to read certificate-authority .../ca.crt: no such file or directory

Update to match behaviour on v1.10.13 and earlier:

 $ kubectl version --client=true
 Client Version: version.Info{Major:"1", ...}

Ref. https://github.com/kubernetes/kubernetes/issues/76661

```release-note
NONE
``` 