### PR TITLE
Add SIG Scheduling API reviewers to OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -371,9 +371,9 @@ aliases:
   #   - 
   #   - 
   
-  # sig-scheduling-api-reviewers:
-  #   - 
-  #   - 
+  sig-scheduling-api-reviewers:
+      - bsalamat
+      - k82cn
   
   # sig-storage-api-reviewers:
   #   - 


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig scheduling
