### PR TITLE
Updates OWNERS files and OWNERS_ALIASES for SIG Apps 

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -223,14 +223,20 @@ aliases:
     - nicksardo
     - thockin
     - rramkumar1
+  sig-apps-approvers:
+    - kow3ns
+    - janetkuo
+    - soltysh
+    - tnozicka
+    - erictune
+    - smarterclayton
   sig-apps-reviewers:
     - enisoc
     - erictune
     - foxish
     - janetkuo
     - kow3ns
-    - lukaszo
-    - mfojtik
+    - mortent
     - smarterclayton
     - soltysh
     - tnozicka

--- a/pkg/controller/cronjob/OWNERS
+++ b/pkg/controller/cronjob/OWNERS
@@ -1,12 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- erictune
-- janetkuo
-- soltysh
+- sig-apps-approvers
 reviewers:
-- erictune
-- janetkuo
-- soltysh
+- sig-apps-reviewers
 labels:
 - sig/apps

--- a/pkg/controller/daemon/OWNERS
+++ b/pkg/controller/daemon/OWNERS
@@ -1,14 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- mikedanese
-- janetkuo
-- k82cn
+- sig-apps-approvers
 reviewers:
-- janetkuo
-- lukaszo
-- mikedanese
-- tnozicka
-- k82cn
+- sig-apps-reviewers
 labels:
 - sig/apps

--- a/pkg/controller/deployment/OWNERS
+++ b/pkg/controller/deployment/OWNERS
@@ -1,14 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- janetkuo
-- nikhiljindal
-- kargakis
-- mfojtik
+- sig-apps-approvers
 reviewers:
-- janetkuo
-- kargakis
-- mfojtik
-- tnozicka
+- sig-apps-reviewers
 labels:
 - sig/apps

--- a/pkg/controller/disruption/OWNERS
+++ b/pkg/controller/disruption/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+- sig-apps-approvers
 reviewers:
 - sig-apps-reviewers
 labels:

--- a/pkg/controller/replicaset/OWNERS
+++ b/pkg/controller/replicaset/OWNERS
@@ -1,13 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- caesarxuchao
-- lavalamp
-- enisoc
+- sig-apps-approvers
 reviewers:
-- caesarxuchao
-- lavalamp
-- tnozicka
-- enisoc
+- sig-apps-reviewers
 labels:
 - sig/apps

--- a/pkg/controller/replication/OWNERS
+++ b/pkg/controller/replication/OWNERS
@@ -1,13 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- caesarxuchao
-- lavalamp
-- enisoc
+- sig-apps-approvers
 reviewers:
-- caesarxuchao
-- lavalamp
-- tnozicka
-- enisoc
+- sig-apps-reviewers
 labels:
 - sig/apps

--- a/pkg/controller/statefulset/OWNERS
+++ b/pkg/controller/statefulset/OWNERS
@@ -1,17 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- enisoc
-- foxish
-- janetkuo
-- kow3ns
-- smarterclayton
+- sig-apps-approvers
 reviewers:
-- enisoc
-- foxish
-- janetkuo
-- kow3ns
-- smarterclayton
-- tnozicka
+- sig-apps-reviewers
 labels:
 - sig/apps
+


### PR DESCRIPTION
As discussed, in sig-apps, sig-architecture, steering committee, community meeting, dev ex, etc. We will attempt to clean up the OWNERS files related to SIG Apps and make the responsibilities of approvers and reviewers more general.

- kow3ns, janetkuo are included as approvers based on being TLs for SIG Apps
- soltysh, tnozicka are included as approvers based on long term contribution and active participation in this role across much of the API surface
- smarterclayton, erictune are included as emeritus contributors (both of them are approvers in higher level owners files anyway)

The next step is to clean up our contributor guidelines to make the roles, responsibilities, and contribution guidelines more clear.

/kind cleanup
```release-note
NONE
```
