### PR TITLE
Replace false with "exit 1" under hack/

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -94,7 +94,7 @@ else
     echo 'checking by adding it to hack/.golint_failures (if your reviewer is okay with it).'
     echo
   } >&2
-  false
+  exit 1
 fi
 
 if [[ ${#not_failing[@]} -gt 0 ]]; then
@@ -106,7 +106,7 @@ if [[ ${#not_failing[@]} -gt 0 ]]; then
     done
     echo
   } >&2
-  false
+  exit 1
 fi
 
 if [[ ${#gone[@]} -gt 0 ]]; then
@@ -118,5 +118,5 @@ if [[ ${#gone[@]} -gt 0 ]]; then
     done
     echo
   } >&2
-  false
+  exit 1
 fi

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -169,7 +169,7 @@ else
     echo 'checking by adding it to hack/.shellcheck_failures (if your reviewer is okay with it).'
     echo
   } >&2
-  false
+  exit 1
 fi
 
 if [[ ${#not_failing[@]} -gt 0 ]]; then
@@ -181,7 +181,7 @@ if [[ ${#not_failing[@]} -gt 0 ]]; then
     done
     echo
   } >&2
-  false
+  exit 1
 fi
 
 # Check that all failing_packages actually still exist
@@ -199,5 +199,5 @@ if [[ ${#gone[@]} -gt 0 ]]; then
     done
     echo
   } >&2
-  false
+  exit 1
 fi


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Some scripts contained `false` for returning 1 to callers instead of
`exit 1` and that works like:

```
  $ false
  $ echo $?
  1
  $
```

But that made confusion in a PR review process.
So this replaces `false` with `exit 1` for long-term maintenance.

**Special notes for your reviewer**:

This comes from a PR https://github.com/kubernetes/kubernetes/pull/76622

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
