### PR TITLE
Removes test-only skipTabWriter from HumanReadablePrinter

### DIFF
--- a/pkg/printers/humanreadable.go
+++ b/pkg/printers/humanreadable.go
@@ -61,7 +61,6 @@ type HumanReadablePrinter struct {
 	options        PrintOptions
 	lastType       interface{}
 	lastColumns    []metav1beta1.TableColumnDefinition
-	skipTabWriter  bool
 }
 
 var _ PrintHandler = &HumanReadablePrinter{}
@@ -80,13 +79,6 @@ func NewTablePrinter() *HumanReadablePrinter {
 	return &HumanReadablePrinter{
 		handlerMap: make(map[reflect.Type]*handlerEntry),
 	}
-}
-
-// AddTabWriter sets whether the PrintObj function will format with tabwriter (true
-// by default).
-func (a *HumanReadablePrinter) AddTabWriter(t bool) *HumanReadablePrinter {
-	a.skipTabWriter = !t
-	return a
 }
 
 func (a *HumanReadablePrinter) With(fns ...func(PrintHandler)) *HumanReadablePrinter {
@@ -226,7 +218,7 @@ func printHeader(columnNames []string, w io.Writer) error {
 // PrintObj prints the obj in a human-friendly format according to the type of the obj.
 func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) error {
 	w, found := output.(*tabwriter.Writer)
-	if !found && !h.skipTabWriter {
+	if !found {
 		w = GetNewTabWriter(output)
 		output = w
 		defer w.Flush()

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -1477,32 +1477,32 @@ func TestPrintPodTable(t *testing.T) {
 	}{
 		{
 			obj: runningPod, opts: printers.PrintOptions{},
-			expect: "NAME\tREADY\tSTATUS\tRESTARTS\tAGE\ntest1\t1/2\tRunning\t6\t<unknown>\n",
+			expect: "NAME    READY   STATUS    RESTARTS   AGE\ntest1   1/2     Running   6          <unknown>\n",
 		},
 		{
 			obj: runningPod, opts: printers.PrintOptions{WithKind: true, Kind: schema.GroupKind{Kind: "Pod"}},
-			expect: "NAME\tREADY\tSTATUS\tRESTARTS\tAGE\npod/test1\t1/2\tRunning\t6\t<unknown>\n",
+			expect: "NAME        READY   STATUS    RESTARTS   AGE\npod/test1   1/2     Running   6          <unknown>\n",
 		},
 		{
 			obj: runningPod, opts: printers.PrintOptions{ShowLabels: true},
-			expect: "NAME\tREADY\tSTATUS\tRESTARTS\tAGE\tLABELS\ntest1\t1/2\tRunning\t6\t<unknown>\ta=1,b=2\n",
+			expect: "NAME    READY   STATUS    RESTARTS   AGE         LABELS\ntest1   1/2     Running   6          <unknown>   a=1,b=2\n",
 		},
 		{
 			obj: &api.PodList{Items: []api.Pod{*runningPod, *failedPod}}, opts: printers.PrintOptions{ColumnLabels: []string{"a"}},
-			expect: "NAME\tREADY\tSTATUS\tRESTARTS\tAGE\tA\ntest1\t1/2\tRunning\t6\t<unknown>\t1\ntest2\t1/2\tFailed\t6\t<unknown>\t\n",
+			expect: "NAME    READY   STATUS    RESTARTS   AGE         A\ntest1   1/2     Running   6          <unknown>   1\ntest2   1/2     Failed    6          <unknown>   \n",
 		},
 		{
 			obj: runningPod, opts: printers.PrintOptions{NoHeaders: true},
-			expect: "test1\t1/2\tRunning\t6\t<unknown>\n",
+			expect: "test1   1/2   Running   6     <unknown>\n",
 		},
 		{
 			obj: failedPod, opts: printers.PrintOptions{},
-			expect:       "NAME\tREADY\tSTATUS\tRESTARTS\tAGE\ntest2\t1/2\tFailed\t6\t<unknown>\n",
+			expect:       "NAME    READY   STATUS   RESTARTS   AGE\ntest2   1/2     Failed   6          <unknown>\n",
 			ignoreLegacy: true, // filtering is not done by the printer in the legacy path
 		},
 		{
 			obj: failedPod, opts: printers.PrintOptions{},
-			expect: "NAME\tREADY\tSTATUS\tRESTARTS\tAGE\ntest2\t1/2\tFailed\t6\t<unknown>\n",
+			expect: "NAME    READY   STATUS   RESTARTS   AGE\ntest2   1/2     Failed   6          <unknown>\n",
 		},
 	}
 
@@ -1513,7 +1513,7 @@ func TestPrintPodTable(t *testing.T) {
 		}
 		verifyTable(t, table)
 		buf := &bytes.Buffer{}
-		p := printers.NewHumanReadablePrinter(test.opts).With(AddHandlers).AddTabWriter(false)
+		p := printers.NewHumanReadablePrinter(test.opts).With(AddHandlers)
 		if err := p.PrintObj(table, buf); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
* The server-side table generation functionality in `humanreadable.go` will eventually be separated from the client-side table printing functionality. This is another step in that direction.
* Removes test-only `skipTabWriter` field from HumanReadablePrinter
* Removes test-only AddTabWriter() function from `humanreadable.go`

Helps address:
kubernetes/kubectl#80

```release-note
NONE
```
/kind cleanup
/assign
