### PR TITLE
AWS: Allow detected node name to be overridden by cloud config.

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -539,6 +539,10 @@ type CloudConfig struct {
 		// RouteTableID enables using a specific RouteTable
 		RouteTableID string
 
+		// Override the reported node name. This is most useful when running the master
+		// components in a different AWS account or cloud provider.
+		NodeName string
+
 		// RoleARN is the IAM role to assume when interaction with AWS APIs.
 		RoleARN string
 
@@ -1245,6 +1249,11 @@ func newAWSCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 		}
 		awsCloud.selfAWSInstance = selfAWSInstance
 		awsCloud.vpcID = selfAWSInstance.vpcID
+	}
+
+	if nodeName := cfg.Global.NodeName; nodeName != "" {
+		klog.Infof("Using configured node name %q", nodeName)
+		awsCloud.selfAWSInstance.nodeName = types.NodeName(nodeName)
 	}
 
 	if cfg.Global.KubernetesClusterTag != "" || cfg.Global.KubernetesClusterID != "" {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
See description of https://github.com/kubernetes/kubernetes/issues/76688 for context.

This is most useful when operating the control plane in a different AWS
account, but also has applications for standalone Kubelets in
infrastructure where the node name is semantically meaningful.

**Which issue(s) this PR fixes**:
Fixes #76688 

**Does this PR introduce a user-facing change?**:
```release-note
Added support for node name overrides in the AWS provider cloud config.
```
