### PR TITLE
Warn to stderr when we encounter PathError listing plugins

### DIFF
--- a/pkg/kubectl/cmd/plugin/BUILD
+++ b/pkg/kubectl/cmd/plugin/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//pkg/kubectl/util/templates:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/kubectl/cmd/plugin/plugin.go
+++ b/pkg/kubectl/cmd/plugin/plugin.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/klog"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
@@ -116,8 +115,8 @@ func (o *PluginListOptions) Run() error {
 	for _, dir := range uniquePathsList(o.PluginPaths) {
 		files, err := ioutil.ReadDir(dir)
 		if err != nil {
-			if _, ok := err.(*os.PathError); ok && strings.Contains(err.Error(), "no such file") {
-				klog.V(3).Infof("unable to find directory %q in your PATH. Skipping...", dir)
+			if _, ok := err.(*os.PathError); ok {
+				fmt.Fprintf(o.ErrOut, "Unable read directory %q from your PATH: %v. Skipping...", dir, err)
 				continue
 			}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We are already skipping errors when reading directories on unix systems, but that condition fails on Windows machines. This PR adds windows exception when reading directory.

**Special notes for your reviewer**:
/assign @mfojtik @juanvallejo 


```release-note
NONE
```
