### PR TITLE
Use read lock for ServiceHasEndpoints

### DIFF
--- a/pkg/proxy/userspace/roundrobin.go
+++ b/pkg/proxy/userspace/roundrobin.go
@@ -122,8 +122,8 @@ func isSessionAffinity(affinity *affinityPolicy) bool {
 
 // ServiceHasEndpoints checks whether a service entry has endpoints.
 func (lb *LoadBalancerRR) ServiceHasEndpoints(svcPort proxy.ServicePortName) bool {
-	lb.lock.Lock()
-	defer lb.lock.Unlock()
+	lb.lock.RLock()
+	defer lb.lock.RUnlock()
 	state, exists := lb.services[svcPort]
 	// TODO: while nothing ever assigns nil to the map, *some* of the code using the map
 	// checks for it.  The code should all follow the same convention.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently ServiceHasEndpoints obtains the write lock of the load balancer.

This PR changes to read lock for higher efficiency.

```release-note
NONE
```
