### PR TITLE
Remove kubectl exec deprecated -p/--pod flag

### DIFF
--- a/pkg/kubectl/cmd/exec/exec.go
+++ b/pkg/kubectl/cmd/exec/exec.go
@@ -24,7 +24,6 @@ import (
 
 	dockerterm "github.com/docker/docker/pkg/term"
 	"github.com/spf13/cobra"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -32,6 +31,7 @@ import (
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
@@ -95,8 +95,6 @@ func NewCmdExec(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		},
 	}
 	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodExecTimeout)
-	cmd.Flags().StringVarP(&options.PodName, "pod", "p", options.PodName, "Pod name")
-	cmd.Flags().MarkDeprecated("pod", "This flag is deprecated and will be removed in future. Use exec POD_NAME instead.")
 	// TODO support UID
 	cmd.Flags().StringVarP(&options.ContainerName, "container", "c", options.ContainerName, "Container name. If omitted, the first container in the pod will be chosen")
 	cmd.Flags().BoolVarP(&options.Stdin, "stdin", "i", options.Stdin, "Pass stdin to the container")
@@ -168,18 +166,12 @@ type ExecOptions struct {
 // Complete verifies command line arguments and loads data from the command environment
 func (p *ExecOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn []string, argsLenAtDash int) error {
 	// Let kubectl exec follow rules for `--`, see #13004 issue
-	if len(p.PodName) == 0 && (len(argsIn) == 0 || argsLenAtDash == 0) {
+	if len(argsIn) == 0 || argsLenAtDash == 0 {
 		return cmdutil.UsageErrorf(cmd, execUsageStr)
 	}
-	if len(p.PodName) != 0 {
-		if len(argsIn) < 1 {
-			return cmdutil.UsageErrorf(cmd, execUsageStr)
-		}
-		p.Command = argsIn
-	} else {
-		p.ResourceName = argsIn[0]
-		p.Command = argsIn[1:]
-	}
+
+	p.ResourceName = argsIn[0]
+	p.Command = argsIn[1:]
 
 	var err error
 

--- a/pkg/kubectl/cmd/exec/exec_test.go
+++ b/pkg/kubectl/cmd/exec/exec_test.go
@@ -34,6 +34,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/client-go/tools/remotecommand"
+
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util/term"
@@ -81,15 +82,6 @@ func TestPodAndContainer(t *testing.T) {
 			argsLenAtDash: -1,
 			expectError:   true,
 			name:          "no cmd, w/ container",
-			obj:           execPod(),
-		},
-		{
-			p:             &ExecOptions{StreamOptions: StreamOptions{PodName: "foo"}},
-			args:          []string{"cmd"},
-			argsLenAtDash: -1,
-			expectedPod:   "foo",
-			expectedArgs:  []string{"cmd"},
-			name:          "pod in flags",
 			obj:           execPod(),
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

`--pod/-p` flag was marked as deprecated flag since https://github.com/kubernetes/kubernetes/pull/66558 now it's enough time to remove it after marking the flag as deprecated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

ping @soltysh 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove deprecated --pod/-p flag from kubectl exec. The flag has been marked as deprecated since k8s version v1.12
```
