### PR TITLE
Fix Vsphere rouding up of volume size

### DIFF
--- a/pkg/volume/vsphere_volume/vsphere_volume_util.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util.go
@@ -94,11 +94,12 @@ func (util *VsphereDiskUtil) CreateVolume(v *vsphereVolumeProvisioner, selectedZ
 	}
 
 	capacity := v.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	// vSphere works with kilobytes, convert to KiB with rounding up
-	volSizeKiB, err := volumehelpers.RoundUpToKiBInt(capacity)
+	// vSphere works with KiB, but its minimum allocation unit is 1 MiB
+	volSizeMiB, err := volumehelpers.RoundUpToMiBInt(capacity)
 	if err != nil {
 		return nil, err
 	}
+	volSizeKiB := volSizeMiB * 1024
 	name := volumeutil.GenerateVolumeName(v.options.ClusterName, v.options.PVName, 255)
 	volumeOptions := &vclib.VolumeOptions{
 		CapacityKB: volSizeKiB,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Storage plugins treat numbers-only storage size as bytes, however, they round it up to the nearest allocation unit, which is vendor-dependant. The Vsphere plugin, on the other hand, rounds the value up to at least 1 KiB and dispatches the request to the server. Since Vsphere's minimum allocation size is 1 MiB, the request returns an error.

This PR changes the Vsphere plugin so it acts like the other storage plugins. Even though the rounding might not be ideal (doing something different from what was requested by the user), we should have consistency across the the storage plugins.

```release-note
NONE
```

/sig storage
