### PR TITLE
Pin GCE Windows node image to 1809 v20190312.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2031,7 +2031,9 @@ function create-node-template() {
   if [[ "${os}" == 'linux' ]]; then
       node_image_flags="--image-project ${NODE_IMAGE_PROJECT} --image ${NODE_IMAGE}"
   elif [[ "${os}" == 'windows' ]]; then
-      node_image_flags="--image-project ${WINDOWS_NODE_IMAGE_PROJECT} --image-family ${WINDOWS_NODE_IMAGE_FAMILY}"
+      # TODO(pjh): revert back to using WINDOWS_NODE_IMAGE_FAMILY instead of
+      # pinning to the v20190312 image once #76666 is resolved.
+      node_image_flags="--image-project ${WINDOWS_NODE_IMAGE_PROJECT} --image=windows-server-1809-dc-core-for-containers-v20190312"
   else
       echo "Unknown OS ${os}" >&2
       exit 1


### PR DESCRIPTION
/kind bug

This is to work around https://github.com/kubernetes/kubernetes/issues/76666.

```release-note
Windows nodes on GCE use a known-working 1809 image rather than the latest 1809 image.
```