### PR TITLE
Adding support to fakeClient: Filter by labels and fields*

### DIFF
--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -484,9 +484,7 @@ func filterByNamespaceAndName(objs []runtime.Object, ns, name string) ([]runtime
 }
 
 // filterList returns all objects in the collection matched by the namespace and the provided ListRestrictions/Selectors
-// Only metadata.name/metadata.namespace are valid field.Selector for all CRD:
-// https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
-// metadata.namespace is checked independent of the field.Selector, in case not provided
+// Only filter by label.Selector since arbitrary field selectors are not yet supported in K8s
 func filterList(objs []runtime.Object, ns string, lr ListRestrictions) ([]runtime.Object, error) {
 	var res []runtime.Object
 
@@ -498,13 +496,8 @@ func filterList(objs []runtime.Object, ns string, lr ListRestrictions) ([]runtim
 		if ns != "" && acc.GetNamespace() != ns {
 			continue
 		}
-		if !lr.Labels.Empty() && lr.Labels.Matches(labels.Set(acc.GetLabels())) {
+		if !lr.Labels.Matches(labels.Set(acc.GetLabels())) {
 			continue
-		}
-		if name, found := lr.Fields.RequiresExactMatch("metadata.name");found {
-			if name != acc.GetName() {
-				continue
-			}
 		}
 		res = append(res, obj)
 	}

--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -483,11 +483,10 @@ func filterByNamespaceAndName(objs []runtime.Object, ns, name string) ([]runtime
 	return res, nil
 }
 
-// filterList returns all objects in the collection matched by the namespace and the provided selectors
-// All labels will be match, assuming the labels.Selector is non empty
-// Only metadata.name/metadata.namespace are available field.Selector for all CRD:
+// filterList returns all objects in the collection matched by the namespace and the provided ListRestrictions/Selectors
+// Only metadata.name/metadata.namespace are valid field.Selector for all CRD:
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
-// Namespace is checked independent of the field.Selector, in case not provided
+// metadata.namespace is checked independent of the field.Selector, in case not provided
 func filterList(objs []runtime.Object, ns string, lr ListRestrictions) ([]runtime.Object, error) {
 	var res []runtime.Object
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> 
/kind feature
> /kind flake

**What this PR does / why we need it**:
Adds support to filter list responses from the fake client by labels and fields* (from the user perspective: `metav1.ListOptions{LabelSelector: labelSelector,FieldSelector: fieldSelector}`) on the default reactor. Although, https://github.com/kubernetes/kubernetes/issues/53459 is still open, in the future, implementation for fields can be added easily since the ListRestrictions type is passed into the filter method. I think implementing an end-user test that uses `NewSimpleClientset` from `k8s.io/client-go/kubernetes/fake` makes the most sense. I don't know where these test should live so I have omitted them for the moment. https://github.com/tektoncd/pipeline/blob/master/pkg/client/clientset/versioned/typed/pipeline/v1alpha1/fake/fake_pipelinerun.go#L50 <- Here within Tekton, you can see nearly the exact same functionality as this proposal was done as a post List() "filter" after invoking the action against the fakeClient (obtained using `NewSimpleClientset`).
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/client-go/issues/326

**Special notes for your reviewer**:
As mentioned here: https://github.com/kubernetes/client-go/issues/326, the fake client does not filter List responses appropriately. The default reactor specified within `NewSimpleClientset` has a lot of functionality so it doesn't make such sense to recreate this just to add filtering as should be standard. There was a related update (https://github.com/kubernetes/client-go/issues/500#issuecomment-482136428), but I can't really see any sense in modifying the stored objects (maybe deleting all the objects that don't comply, but then my object tracker has essentially been corrupted from a list query) to pass onto another reactor (presumably with `PrependReactor`). The first/default reactor (https://github.com/kubernetes/client-go/blob/2e1a3ed22ac512a9bebce0e119b82062c6be22ac/kubernetes/fake/clientset_generated.go#L116) has all the necessary information to be able to filter Lists by labels and fields:

https://github.com/kubernetes/client-go/blob/c4c6ef336ec35c5a7ed031e499fbacb262d5b670/testing/fixture.go#L85
```
type ListActionImpl struct {
	ActionImpl
	Kind             schema.GroupVersionKind
	Name             string
	ListRestrictions ListRestrictions
}
type ListRestrictions struct {
	Labels labels.Selector
	Fields fields.Selector
}
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
