### PR TITLE
Two bugfixes in installTunneler

### DIFF
--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -129,7 +129,6 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/integer:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -89,7 +89,6 @@ import (
 	"k8s.io/kubernetes/pkg/serviceaccount"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/klog"
 
 	// RESTStorage installers


### PR DESCRIPTION
Two bug fixes: 
1. We should at least log something out if we fail to register our health check instead of pretending it didn't happen
2. If we're going to go through the trouble of making a metric, we should probably actually register it. Also, I've gone ahead and deleted the deprecated version of the metric since no one can be broken by changing a metric that they never see.

**What type of PR is this?**

/kind bug
/kind cleanup

```release-note
NONE
```
/sig api-machinery instrumentation
