### PR TITLE
Split humanreadble.go into tablegenerator.go and tableprinter.go

### DIFF
--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -9,8 +9,9 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
-        "humanreadable.go",
         "interface.go",
+        "tablegenerator.go",
+        "tableprinter.go",
         "tabwriter.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/printers",
@@ -45,10 +46,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["humanreadable_test.go"],
+    srcs = ["tableprinter_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/apis/core:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/printers/tablegenerator.go
+++ b/pkg/printers/tablegenerator.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+type TableGenerator interface {
+	GenerateTable(obj runtime.Object, options PrintOptions) (*metav1beta1.Table, error)
+}
+
+type PrintHandler interface {
+	TableHandler(columns []metav1beta1.TableColumnDefinition, printFunc interface{}) error
+	DefaultTableHandler(columns []metav1beta1.TableColumnDefinition, printFunc interface{}) error
+}
+
+type handlerEntry struct {
+	columnDefinitions []metav1beta1.TableColumnDefinition
+	printFunc         reflect.Value
+	args              []reflect.Value
+}
+
+// HumanReadablePrinter is an implementation of ResourcePrinter which attempts to provide
+// more elegant output. It is not threadsafe, but you may call PrintObj repeatedly; headers
+// will only be printed if the object type changes. This makes it useful for printing items
+// received from watches.
+type HumanReadablePrinter struct {
+	handlerMap     map[reflect.Type]*handlerEntry
+	defaultHandler *handlerEntry
+	options        PrintOptions
+	lastType       interface{}
+	lastColumns    []metav1beta1.TableColumnDefinition
+}
+
+var _ TableGenerator = &HumanReadablePrinter{}
+var _ PrintHandler = &HumanReadablePrinter{}
+
+// NewTableGenerator creates a HumanReadablePrinter suitable for calling GenerateTable().
+func NewTableGenerator() *HumanReadablePrinter {
+	return &HumanReadablePrinter{
+		handlerMap: make(map[reflect.Type]*handlerEntry),
+	}
+}
+
+func (a *HumanReadablePrinter) With(fns ...func(PrintHandler)) *HumanReadablePrinter {
+	for _, fn := range fns {
+		fn(a)
+	}
+	return a
+}
+
+// GenerateTable returns a table for the provided object, using the printer registered for that type. It returns
+// a table that includes all of the information requested by options, but will not remove rows or columns. The
+// caller is responsible for applying rules related to filtering rows or columns.
+func (h *HumanReadablePrinter) GenerateTable(obj runtime.Object, options PrintOptions) (*metav1beta1.Table, error) {
+	t := reflect.TypeOf(obj)
+	handler, ok := h.handlerMap[t]
+	if !ok {
+		return nil, fmt.Errorf("no table handler registered for this type %v", t)
+	}
+
+	args := []reflect.Value{reflect.ValueOf(obj), reflect.ValueOf(options)}
+	results := handler.printFunc.Call(args)
+	if !results[1].IsNil() {
+		return nil, results[1].Interface().(error)
+	}
+
+	var columns []metav1beta1.TableColumnDefinition
+	if !options.NoHeaders {
+		columns = handler.columnDefinitions
+		if !options.Wide {
+			columns = make([]metav1beta1.TableColumnDefinition, 0, len(handler.columnDefinitions))
+			for i := range handler.columnDefinitions {
+				if handler.columnDefinitions[i].Priority != 0 {
+					continue
+				}
+				columns = append(columns, handler.columnDefinitions[i])
+			}
+		}
+	}
+	table := &metav1beta1.Table{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "",
+		},
+		ColumnDefinitions: columns,
+		Rows:              results[0].Interface().([]metav1beta1.TableRow),
+	}
+	if m, err := meta.ListAccessor(obj); err == nil {
+		table.ResourceVersion = m.GetResourceVersion()
+		table.SelfLink = m.GetSelfLink()
+		table.Continue = m.GetContinue()
+	} else {
+		if m, err := meta.CommonAccessor(obj); err == nil {
+			table.ResourceVersion = m.GetResourceVersion()
+			table.SelfLink = m.GetSelfLink()
+		}
+	}
+	if err := decorateTable(table, options); err != nil {
+		return nil, err
+	}
+	return table, nil
+}
+
+// TableHandler adds a print handler with a given set of columns to HumanReadablePrinter instance.
+// See ValidateRowPrintHandlerFunc for required method signature.
+func (h *HumanReadablePrinter) TableHandler(columnDefinitions []metav1beta1.TableColumnDefinition, printFunc interface{}) error {
+	printFuncValue := reflect.ValueOf(printFunc)
+	if err := ValidateRowPrintHandlerFunc(printFuncValue); err != nil {
+		utilruntime.HandleError(fmt.Errorf("unable to register print function: %v", err))
+		return err
+	}
+	entry := &handlerEntry{
+		columnDefinitions: columnDefinitions,
+		printFunc:         printFuncValue,
+	}
+
+	objType := printFuncValue.Type().In(0)
+	if _, ok := h.handlerMap[objType]; ok {
+		err := fmt.Errorf("registered duplicate printer for %v", objType)
+		utilruntime.HandleError(err)
+		return err
+	}
+	h.handlerMap[objType] = entry
+	return nil
+}
+
+// DefaultTableHandler registers a set of columns and a print func that is given a chance to process
+// any object without an explicit handler. Only the most recently set print handler is used.
+// See ValidateRowPrintHandlerFunc for required method signature.
+func (h *HumanReadablePrinter) DefaultTableHandler(columnDefinitions []metav1beta1.TableColumnDefinition, printFunc interface{}) error {
+	printFuncValue := reflect.ValueOf(printFunc)
+	if err := ValidateRowPrintHandlerFunc(printFuncValue); err != nil {
+		utilruntime.HandleError(fmt.Errorf("unable to register print function: %v", err))
+		return err
+	}
+	entry := &handlerEntry{
+		columnDefinitions: columnDefinitions,
+		printFunc:         printFuncValue,
+	}
+
+	h.defaultHandler = entry
+	return nil
+}
+
+// ValidateRowPrintHandlerFunc validates print handler signature.
+// printFunc is the function that will be called to print an object.
+// It must be of the following type:
+//  func printFunc(object ObjectType, options PrintOptions) ([]metav1beta1.TableRow, error)
+// where ObjectType is the type of the object that will be printed, and the first
+// return value is an array of rows, with each row containing a number of cells that
+// match the number of columns defined for that printer function.
+func ValidateRowPrintHandlerFunc(printFunc reflect.Value) error {
+	if printFunc.Kind() != reflect.Func {
+		return fmt.Errorf("invalid print handler. %#v is not a function", printFunc)
+	}
+	funcType := printFunc.Type()
+	if funcType.NumIn() != 2 || funcType.NumOut() != 2 {
+		return fmt.Errorf("invalid print handler." +
+			"Must accept 2 parameters and return 2 value.")
+	}
+	if funcType.In(1) != reflect.TypeOf((*PrintOptions)(nil)).Elem() ||
+		funcType.Out(0) != reflect.TypeOf((*[]metav1beta1.TableRow)(nil)).Elem() ||
+		funcType.Out(1) != reflect.TypeOf((*error)(nil)).Elem() {
+		return fmt.Errorf("invalid print handler. The expected signature is: "+
+			"func handler(obj %v, options PrintOptions) ([]metav1beta1.TableRow, error)", funcType.In(0))
+	}
+	return nil
+}

--- a/pkg/printers/tableprinter_test.go
+++ b/pkg/printers/tableprinter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
 var testNamespaceColumnDefinitions = []metav1beta1.TableColumnDefinition{
@@ -34,7 +34,7 @@ var testNamespaceColumnDefinitions = []metav1beta1.TableColumnDefinition{
 	{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 }
 
-func testPrintNamespace(obj *api.Namespace, options PrintOptions) ([]metav1beta1.TableRow, error) {
+func testPrintNamespace(obj *corev1.Namespace, options PrintOptions) ([]metav1beta1.TableRow, error) {
 	if options.WithNamespace {
 		return nil, fmt.Errorf("namespace is not namespaced")
 	}
@@ -64,7 +64,7 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 				printFunc:         printFunc,
 			},
 			opt: PrintOptions{},
-			obj: &api.Namespace{
+			obj: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			},
 			includeHeader: false,
@@ -77,7 +77,7 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 				printFunc:         printFunc,
 			},
 			opt: PrintOptions{},
-			obj: &api.Namespace{
+			obj: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			},
 			includeHeader: true,
@@ -90,7 +90,7 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 				printFunc:         printFunc,
 			},
 			opt: PrintOptions{},
-			obj: &api.Namespace{
+			obj: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			},
 			includeHeader: true,
@@ -105,7 +105,7 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 			opt: PrintOptions{
 				WithNamespace: true,
 			},
-			obj: &api.Namespace{
+			obj: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			},
 			includeHeader: true,


### PR DESCRIPTION
* The server-side table generation functionality in `humanreadable.go` will eventually be separated from the client-side table printing functionality. This is another step in that direction.
* Splits `humanreadable.go` into server-side table generation, `tablegenerator.go`, and client-side table printing, `tableprinter.go`. NOTE: There are common elements between these two parts that will have to be further teased apart in future PRs.
* Moves `humanreadable_test.go` to `tableprinter_test.go`

Helps fix:
https://github.com/kubernetes/kubectl/issues/80

```release-note
NONE
```

/kind cleanup
/sig cli
/assign

