### PR TITLE
Pick up security patches for fluentd-gcp-scaler by upgrading to version 0.5.2

### DIFF
--- a/cluster/addons/fluentd-gcp/scaler-deployment.yaml
+++ b/cluster/addons/fluentd-gcp/scaler-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: fluentd-gcp-scaler
       containers:
       - name: fluentd-gcp-scaler
-        image: k8s.gcr.io/fluentd-gcp-scaler:0.5.1
+        image: k8s.gcr.io/fluentd-gcp-scaler:0.5.2
         command:
           - /scaler.sh
           - --ds-name=fluentd-gcp-{{ fluentd_gcp_yaml_version }}


### PR DESCRIPTION
/kind bug

```release-note
[fluentd-gcp addon] Bump fluentd-gcp-scaler to v0.5.2 to pick up security fixes.
```
/assign @x13n 