### PR TITLE
Fix binding of pre-bound PVs with wrong storage class

### DIFF
--- a/pkg/controller/volume/persistentvolume/binder_test.go
+++ b/pkg/controller/volume/persistentvolume/binder_test.go
@@ -589,6 +589,16 @@ func TestSync(t *testing.T) {
 			newClaimArray("claim13-5", "uid13-5", "1Gi", "volume13-5", v1.ClaimBound, nil, annBoundByController, annBindCompleted),
 			noevents, noerrors, testSyncClaim,
 		},
+		{
+			// syncVolume does not bind claim requesting class to a prebound PV with no class.
+			// class = ""
+			"13-6 - prebound PV with class",
+			newVolumeArray("volume13-6", "1Gi", "", "claim13-6", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold),
+			newVolumeArray("volume13-6", "1Gi", "", "claim13-6", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold),
+			newClaimArray("claim13-6", "uid13-6", "1Gi", "", v1.ClaimPending, nil),
+			newClaimArray("claim13-6", "uid13-6", "1Gi", "", v1.ClaimPending, nil),
+			noevents, noerrors, testSyncClaim,
+		},
 	}
 
 	runSyncTests(t, tests, []*storage.StorageClass{

--- a/pkg/controller/volume/persistentvolume/index.go
+++ b/pkg/controller/volume/persistentvolume/index.go
@@ -168,6 +168,11 @@ func findMatchingVolume(
 			continue
 		}
 
+		// filter out different StorageClasses
+		if volume.Spec.StorageClassName != requestedClass {
+			continue
+		}
+
 		// check if PV's DeletionTimeStamp is set, if so, skip this volume.
 		if utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection) {
 			if volume.ObjectMeta.DeletionTimestamp != nil {


### PR DESCRIPTION
PV pre-bound to a PVC should not be bound to the PVC if the PVC expects a different storage class.

PV:
```
 spec:
  claimRef:
    name: nfsclaim1
    namespace: default
  storageClassName: ""
```
PVC:

```
metadata:
  name: nfsclaim1
  namespace: default
spec:
  storageClassName: "foo"
```

PVC requests different class than the PV provides -> they should not get bound together.

/kind bug

```release-note
NONE
```
