### PR TITLE
Create the "internal" firewall rule for kubemark master.

### DIFF
--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -102,6 +102,13 @@ function create-master-instance-with-resources {
     --target-tags "${MASTER_TAG}" \
     --allow "tcp:443" &
 
+  run-gcloud-compute-with-retries firewall-rules create "${MASTER_NAME}-internal" \
+    --project "${PROJECT}" \
+    --network "${NETWORK}" \
+    --source-ranges "10.0.0.0/8" \
+    --target-tags "${MASTER_TAG}" \
+    --allow "tcp:1-2379,tcp:2382-65535,udp:1-65535,icmp" &
+
   wait
 }
 
@@ -133,6 +140,10 @@ function delete-master-instance-and-resources {
       --quiet || true
 
   gcloud compute firewall-rules delete "${MASTER_NAME}-https" \
+	  --project "${PROJECT}" \
+	  --quiet || true
+
+  gcloud compute firewall-rules delete "${MASTER_NAME}-internal" \
 	  --project "${PROJECT}" \
 	  --quiet || true
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
Creates the "internal" firewall rule for kubemark master when setting up kubemark clusters.

This is equivalent to the "internal" firewall rule that is created for the regular masters.
The main reason for doing it is to allow prometheus scraping metrics from various kubemark master components, e.g. kubelet.

Ref. https://github.com/kubernetes/perf-tests/issues/503

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
