### PR TITLE
Set CPU metrics for init containers under containerd

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -357,6 +357,7 @@ func (p *criStatsProvider) makeContainerStats(
 	} else {
 		result.CPU.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
 		result.CPU.UsageCoreNanoSeconds = Uint64Ptr(0)
+		result.CPU.UsageNanoCores = Uint64Ptr(0)
 	}
 	if stats.Memory != nil {
 		result.Memory.Time = metav1.NewTime(time.Unix(0, stats.Memory.Timestamp))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
metrics-server doesn't return metrics for pods with init containers
under containerd because they have incomplete CPU metrics returned by
the kubelet /stats/summary API.

This problem has been fixed in 1.14 (#74336), but the cherry-picks
dropped the usageNanoCores metric.

This change adds the missing usageNanoCores metric for init containers
in Kubernetes v1.12.

**Which issue(s) this PR fixes**:
Fixes #76292

**Special notes for your reviewer**:
Copies PR #76503 for release-1.12.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
