### PR TITLE
Add kube-proxy e2e test for services with no endpoints

### DIFF
--- a/test/e2e/framework/networking_utils.go
+++ b/test/e2e/framework/networking_utils.go
@@ -994,12 +994,12 @@ func PokeUDP(host string, port int, request string, params *UDPPokeParams) UDPPo
 	return ret
 }
 
-// TestHitNodesFromOutside checkes HTTP connectivity from outside.
+// TestHitNodesFromOutside checks HTTP connectivity from outside.
 func TestHitNodesFromOutside(externalIP string, httpPort int32, timeout time.Duration, expectedHosts sets.String) error {
 	return TestHitNodesFromOutsideWithCount(externalIP, httpPort, timeout, expectedHosts, 1)
 }
 
-// TestHitNodesFromOutsideWithCount checkes HTTP connectivity from outside with count.
+// TestHitNodesFromOutsideWithCount checks HTTP connectivity from outside with count.
 func TestHitNodesFromOutsideWithCount(externalIP string, httpPort int32, timeout time.Duration, expectedHosts sets.String,
 	countToSucceed int) error {
 	Logf("Waiting up to %v for satisfying expectedHosts for %v times", timeout, countToSucceed)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds e2e test to verify that kube-proxy doesn't let in traffic from a loadbalancer to a service with no endpoints.  Different from https://github.com/kubernetes/kubernetes/pull/72561 which doesn't use an external LB as far as I can tell.

Added due to:
https://github.com/kubernetes/kubernetes/pull/72534

**Special notes for your reviewer**:
The plan is to cherry pick this to 1.11, 1.12, and 1.13 like as is being done with https://github.com/kubernetes/kubernetes/pull/72534.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
