### PR TITLE
Use read lock in ready#check

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -1245,7 +1245,7 @@ type ready struct {
 }
 
 func newReady() *ready {
-	return &ready{c: sync.NewCond(&sync.Mutex{})}
+	return &ready{c: sync.NewCond(&sync.RWMutex{})}
 }
 
 func (r *ready) wait() {
@@ -1259,8 +1259,9 @@ func (r *ready) wait() {
 // TODO: Make check() function more sophisticated, in particular
 // allow it to behave as "waitWithTimeout".
 func (r *ready) check() bool {
-	r.c.L.Lock()
-	defer r.c.L.Unlock()
+	rwMutex := r.c.L.(*sync.RWMutex)
+	rwMutex.RLock()
+	defer rwMutex.RUnlock()
 	return r.ok
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
ready#check of cacher reads the value of ok.
We can utilize read lock for this operation.

Looking at the 3 calls to the check() func, none of the caller is involved with wait().

```release-note
NONE
```
