### PR TITLE
Fix shellcheck in hack/lib/golang.sh

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -27,7 +27,6 @@
 ./hack/cherry_pick_pull.sh
 ./hack/ginkgo-e2e.sh
 ./hack/grab-profiles.sh
-./hack/lib/golang.sh
 ./hack/lib/init.sh
 ./hack/lib/swagger.sh
 ./hack/lib/test.sh

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -372,7 +372,7 @@ EOF
 
 # Ensure the go tool exists and is a viable version.
 kube::golang::verify_go_version() {
-  if [[ -z "$(which go)" ]]; then
+  if [[ -z "$(command -v go)" ]]; then
     kube::log::usage_from_stdin <<EOF
 Can't find 'go' in PATH, please fix and retry.
 See http://golang.org/doc/install for installation instructions.
@@ -693,6 +693,10 @@ kube::golang::build_binaries() {
     host_platform=$(kube::golang::host_platform)
 
     local goflags goldflags goasmflags gogcflags
+    # If GOLDFLAGS is unset, then set it to the a default of "-s -w".
+    # Disable SC2153 for this, as it will throw a warning that the local
+    # variable goldflags will exist, and it suggest changing it to this.
+    # shellcheck disable=SC2153
     goldflags="${GOLDFLAGS=-s -w} $(kube::version::ldflags)"
     goasmflags="-trimpath=${KUBE_ROOT}"
     gogcflags="${GOGCFLAGS:-} -trimpath=${KUBE_ROOT}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds a shellcheck directive to ignore the specific error introduced in https://github.com/kubernetes/kubernetes/pull/76651

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
