### PR TITLE
Implement CodecFactoryOptions allowing clients to opt-in to Pretty encoders and Strict Decoders

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -108,8 +108,6 @@ func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, option
 // CodecFactory provides methods for retrieving codecs and serializers for specific
 // versions and content types.
 type CodecFactory struct {
-	options CodecFactoryOptions
-
 	scheme      *runtime.Scheme
 	serializers []serializerType
 	universal   runtime.Decoder
@@ -120,9 +118,9 @@ type CodecFactory struct {
 
 // CodecFactoryOptions holds the options for configuring CodecFactory behavior
 type CodecFactoryOptions struct {
-	// Strict: configures all serializers in strict mode
+	// Strict configures all serializers in strict mode
 	Strict bool
-	// Pretty: includes a pretty serializer along with the non-pretty one
+	// Pretty includes a pretty serializer along with the non-pretty one
 	Pretty bool
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -64,41 +64,37 @@ func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, option
 		StreamSerializer: jsonSerializer,
 	}
 	if options.Pretty {
-		jsonPrettySerializer := json.NewSerializerWithOptions(
+		jsonSerializerType.PrettySerializer = json.NewSerializerWithOptions(
 			mf, scheme, scheme,
 			json.SerializerOptions{Yaml: false, Pretty: true, Strict: options.Strict},
 		)
-		jsonSerializerType.PrettySerializer = jsonPrettySerializer
 	}
 
 	yamlSerializer := json.NewSerializerWithOptions(
 		mf, scheme, scheme,
 		json.SerializerOptions{Yaml: true, Pretty: false, Strict: options.Strict},
 	)
-	yamlSerializerType := serializerType{
-		AcceptContentTypes: []string{runtime.ContentTypeYAML},
-		ContentType:        runtime.ContentTypeYAML,
-		FileExtensions:     []string{"yaml"},
-		EncodesAsText:      true,
-		Serializer:         yamlSerializer,
-	}
-
 	protoSerializer := protobuf.NewSerializer(scheme, scheme)
 	protoRawSerializer := protobuf.NewRawSerializer(scheme, scheme)
-	protoSerializerType := serializerType{
-		AcceptContentTypes: []string{runtime.ContentTypeProtobuf},
-		ContentType:        runtime.ContentTypeProtobuf,
-		FileExtensions:     []string{"pb"},
-		Serializer:         protoSerializer,
-
-		Framer:           protobuf.LengthDelimitedFramer,
-		StreamSerializer: protoRawSerializer,
-	}
 
 	serializers := []serializerType{
 		jsonSerializerType,
-		yamlSerializerType,
-		protoSerializerType,
+		{
+			AcceptContentTypes: []string{runtime.ContentTypeYAML},
+			ContentType:        runtime.ContentTypeYAML,
+			FileExtensions:     []string{"yaml"},
+			EncodesAsText:      true,
+			Serializer:         yamlSerializer,
+		},
+		{
+			AcceptContentTypes: []string{runtime.ContentTypeProtobuf},
+			ContentType:        runtime.ContentTypeProtobuf,
+			FileExtensions:     []string{"pb"},
+			Serializer:         protoSerializer,
+
+			Framer:           protobuf.LengthDelimitedFramer,
+			StreamSerializer: protoRawSerializer,
+		},
 	}
 
 	for _, fn := range serializerExtensions {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -161,30 +161,16 @@ func DisableStrict(options *CodecFactoryOptions) {
 //
 // Mutators can be passed to change the CodecFactoryOptions before construction of the factory.
 // It is recommended to explicitly pass mutators instead of relying on defaults.
-// Legacy Behavior: when no mutators are passed, `WithPretty` is enabled and `WithStrict` is disabled.
+// By default, Pretty is enabled -- this is conformant with previously supported behavior.
 //
 // TODO: allow other codecs to be compiled in?
 // TODO: accept a scheme interface
 func NewCodecFactory(scheme *runtime.Scheme, mutators ...CodecFactoryOptionsMutator) CodecFactory {
-	options := CodecFactoryOptions{}
-	if len(mutators) == 0 {
-		// Legacy behavior
-		EnablePretty(&options)
-		DisableStrict(&options)
-	}
+	options := CodecFactoryOptions{Pretty: true}
 	for _, fn := range mutators {
 		fn(&options)
 	}
-	return NewCodecFactoryWithOptions(scheme, options)
-}
 
-// NewCodecFactoryWithOptions provides methods for retrieving serializers for the supported wire formats
-// and conversion wrappers to define preferred internal and external versions. In the future,
-// as the internal version is used less, callers may instead use a defaulting serializer and
-// only convert objects which are shared internally (Status, common API machinery).
-// TODO: allow other codecs to be compiled in?
-// TODO: accept a scheme interface
-func NewCodecFactoryWithOptions(scheme *runtime.Scheme, options CodecFactoryOptions) CodecFactory {
 	serializers := newSerializersForScheme(scheme, json.DefaultMetaFactory, options)
 	return newCodecFactory(scheme, serializers)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_test.go
@@ -87,7 +87,7 @@ func GetTestScheme() (*runtime.Scheme, runtime.Codec) {
 
 	s.AddUnversionedTypes(externalGV, &metav1.Status{})
 
-	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: false}))
+	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: true}))
 	codec := cf.LegacyCodec(schema.GroupVersion{Version: "v1"})
 	return s, codec
 }
@@ -145,11 +145,11 @@ func TestTypes(t *testing.T) {
 
 func TestVersionedEncoding(t *testing.T) {
 	s, _ := GetTestScheme()
-	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: false}))
+	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: true}))
 	info, _ := runtime.SerializerInfoForMediaType(cf.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	encoder := info.Serializer
 
-	codec := cf.CodecForVersions(encoder, nil, schema.GroupVersion{Version: "v2"}, nil)
+	codec := cf.EncoderForVersion(encoder, schema.GroupVersion{Version: "v2"})
 	out, err := runtime.Encode(codec, &serializertesting.TestType1{})
 	if err != nil {
 		t.Fatal(err)
@@ -158,14 +158,14 @@ func TestVersionedEncoding(t *testing.T) {
 		t.Fatal(string(out))
 	}
 
-	codec = cf.CodecForVersions(encoder, nil, schema.GroupVersion{Version: "v3"}, nil)
+	codec = cf.EncoderForVersion(encoder, schema.GroupVersion{Version: "v3"})
 	_, err = runtime.Encode(codec, &serializertesting.TestType1{})
 	if err == nil {
 		t.Fatal(err)
 	}
 
 	// unversioned encode with no versions is written directly to wire
-	codec = cf.CodecForVersions(encoder, nil, runtime.InternalGroupVersioner, nil)
+	codec = cf.EncoderForVersion(encoder, runtime.InternalGroupVersioner)
 	out, err = runtime.Encode(codec, &serializertesting.TestType1{})
 	if err != nil {
 		t.Fatal(err)
@@ -196,6 +196,23 @@ func TestMultipleNames(t *testing.T) {
 	}
 }
 
+func TestStrictOption(t *testing.T) {
+	s, _ := GetTestScheme()
+	duplicateKeys := `{"myKindKey":"TestType3","myVersionKey":"v1","myVersionKey":"v1","A":"value"}`
+
+	strictCodec := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: true})).LegacyCodec()
+	_, _, err := strictCodec.Decode([]byte(duplicateKeys), nil, nil)
+	if !runtime.IsStrictDecodingError(err) {
+		t.Fatalf("StrictDecodingError not returned on object with duplicate keys: %v, type: %v", err, reflect.TypeOf(err))
+	}
+
+	nonStrictCodec := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: false})).LegacyCodec()
+	_, _, err = nonStrictCodec.Decode([]byte(duplicateKeys), nil, nil)
+	if runtime.IsStrictDecodingError(err) {
+		t.Fatalf("Non-Strict decoder returned a StrictDecodingError: %v", err)
+	}
+}
+
 func TestConvertTypesWhenDefaultNamesMatch(t *testing.T) {
 	internalGV := schema.GroupVersion{Version: runtime.APIVersionInternal}
 	externalGV := schema.GroupVersion{Version: "v1"}
@@ -219,7 +236,7 @@ func TestConvertTypesWhenDefaultNamesMatch(t *testing.T) {
 	expect := &serializertesting.TestType1{A: "test"}
 
 	codec := newCodecFactory(
-		s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: false}),
+		s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: true}),
 	).LegacyCodec(schema.GroupVersion{Version: "v1"})
 
 	obj, err := runtime.Decode(codec, data)
@@ -311,7 +328,7 @@ func GetDirectCodecTestScheme() *runtime.Scheme {
 
 func TestDirectCodec(t *testing.T) {
 	s := GetDirectCodecTestScheme()
-	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: false}))
+	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: true}))
 	info, _ := runtime.SerializerInfoForMediaType(cf.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	serializer := info.Serializer
 	df := cf.WithoutConversion()

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_test.go
@@ -87,7 +87,7 @@ func GetTestScheme() (*runtime.Scheme, runtime.Codec) {
 
 	s.AddUnversionedTypes(externalGV, &metav1.Status{})
 
-	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}))
+	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: false}))
 	codec := cf.LegacyCodec(schema.GroupVersion{Version: "v1"})
 	return s, codec
 }
@@ -145,7 +145,7 @@ func TestTypes(t *testing.T) {
 
 func TestVersionedEncoding(t *testing.T) {
 	s, _ := GetTestScheme()
-	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}))
+	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: false}))
 	info, _ := runtime.SerializerInfoForMediaType(cf.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	encoder := info.Serializer
 
@@ -218,7 +218,9 @@ func TestConvertTypesWhenDefaultNamesMatch(t *testing.T) {
 	}
 	expect := &serializertesting.TestType1{A: "test"}
 
-	codec := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{})).LegacyCodec(schema.GroupVersion{Version: "v1"})
+	codec := newCodecFactory(
+		s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: false}),
+	).LegacyCodec(schema.GroupVersion{Version: "v1"})
 
 	obj, err := runtime.Decode(codec, data)
 	if err != nil {
@@ -309,7 +311,7 @@ func GetDirectCodecTestScheme() *runtime.Scheme {
 
 func TestDirectCodec(t *testing.T) {
 	s := GetDirectCodecTestScheme()
-	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}))
+	cf := newCodecFactory(s, newSerializersForScheme(s, testMetaFactory{}, CodecFactoryOptions{Pretty: true, Strict: false}))
 	info, _ := runtime.SerializerInfoForMediaType(cf.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	serializer := info.Serializer
 	df := cf.WithoutConversion()


### PR DESCRIPTION
/kind api-change
@kubernetes/wg-component-standard 

**What this PR does / why we need it**:
This patch introduces a new CodecFactory constructor that's capable of building different collections of Serializers.
Note that this diverges from the current design where an initialized CodecFactory is a kitchen sink holding many forms of useful Serilaizers in a non-customizeable way.

This approach is a suggested solution from this thread:
https://groups.google.com/d/msg/kubernetes-sig-api-machinery/R4Iiz3rOYd0/O6aX15_AAQAJ

A universal, defaulting, strict decoder is needed for Component Config efforts. 
Future work aims to make strict behavior the default -- right now it's not implemented in a way that is performant enough for the apiserver.

This patch adds a deprecation notice for `NewCodecFactory()`.
For now, uses of this public constructor remain unchanged, and the tests are still exercising it.
It's been modified, however, to simply wrap the `WithOptions` version.

Tracking issue: https://github.com/kubernetes/kubernetes/issues/75426

**Edit:**
I've added another commit implementing option mutator funcs for the `NewCodecFactory`.
This allows us to keep using that constructor without deprecating it.
We can squash this into the previous commit if we agree we want this.
Note that it adds maintenance overhead to `CodecFactoryOptions` since each new option will require at least 2 new functions for booleans, and potentially many many more for other types.
The user can always implement their own function when calling the constructor, but this is clunky.

**Special notes for your reviewer**:
I'm not sure I like how verbose this incantation is:
```go
codecs.NewCodecFactoryWithOptions(
    scheme,
    codecs.CodecFactoryOptions{Pretty: true, Strict: true},
)
```
It's much longer than before.
If you have feedback on naming, it would be beneficial to make this not look so intimidating.

Note as well that the tests should be modified to exercise the non-Pretty and Strict paths.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```