### PR TITLE
Add --config=remote and --config=remote-cache modes for bazel

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -39,3 +39,32 @@ build:cross:linux_arm --config=repo_infra_crosstool --platforms=@io_bazel_rules_
 build:cross:linux_arm64 --config=repo_infra_crosstool --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 --cpu=arm64
 build:cross:linux_ppc64le --config=repo_infra_crosstool --platforms=@io_bazel_rules_go//go/toolchain:linux_ppc64le --cpu=ppc64le
 build:cross:linux_s390x --config=repo_infra_crosstool --platforms=@io_bazel_rules_go//go/toolchain:linux_s390x --cpu=s390x
+
+# --config=remote-cache enables a remote bazel cache
+# Note needs a --remote_instance_name=projects/PROJ/instances/default_instance flag
+build:remote-cache --remote_cache=remotebuildexecution.googleapis.com
+build:remote-cache --tls_enabled=true
+build:remote-cache --remote_timeout=3600
+build:remote-cache --auth_enabled=true
+
+# --config=remote adds remote execution to the --config=remote-cache
+# Note needs a --remote_instance_name=projects/PROJ/instances/default_instance flag
+build:remote --config=remote-cache
+build:remote --remote_executor=remotebuildexecution.googleapis.com
+build:remote --jobs=500
+build:remote --host_javabase=@rbe_default//java:jdk
+build:remote --javabase=@rbe_default//java:jdk
+build:remote --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --crosstool_top=@rbe_default//cc:toolchain
+build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:remote --extra_toolchains=@rbe_default//config:cc-toolchain
+build:remote --extra_execution_platforms=:rbe_with_network
+build:remote --host_platform=:rbe_with_network
+build:remote --platforms=:rbe_with_network
+build:remote --spawn_strategy=remote
+build:remote --strategy=Javac=remote
+build:remote --strategy=Closure=remote
+build:remote --strategy=Genrule=remote
+build:remote --define=EXECUTOR=remote
+

--- a/build/root/BUILD.root
+++ b/build/root/BUILD.root
@@ -106,3 +106,15 @@ genrule(
     cmd = "grep ^STABLE_BUILD_SCM_REVISION bazel-out/stable-status.txt | awk '{print $$2}' >$@",
     stamp = 1,
 )
+
+platform(
+    name = "rbe_with_network",
+    parents = ["@rbe_default//config:platform"],
+    remote_execution_properties = """
+      properties: {
+        name: "dockerNetwork"
+        value: "standard"
+      }
+      {PARENT_REMOTE_EXECUTION_PROPERTIES}
+    """,
+)

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -2,6 +2,20 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 load("//build:workspace_mirror.bzl", "mirror")
 
 http_archive(
+    name = "bazel_toolchains",
+    sha256 = "8d43844d1d4447be2a108834771d617a1ad2a107f1680190bfe44925e7bf530e",
+    strip_prefix = "bazel-toolchains-4c003ad45e8a2d829ffc40e3aecfb6b8577a9406",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/4c003ad45e8a2d829ffc40e3aecfb6b8577a9406.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/4c003ad45e8a2d829ffc40e3aecfb6b8577a9406.tar.gz",
+    ],
+)
+
+load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+
+rbe_autoconfig(name = "rbe_default")
+
+http_archive(
     name = "bazel_skylib",
     sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
     strip_prefix = "bazel-skylib-0.6.0",


### PR DESCRIPTION
/assign @mikedanese 

Enables remote execution on bazel (requires providing your own instance)
```shell
bazel test //pkg/... --config=remote \
  --remote_instance_name=projects/AN_RBE_PROJ/instances/default_instance
```

`--config=remote-cache` should allow us to simplify/improve our caching solution as well, potentially obviating [greenhouse](https://github.com/kubernetes/test-infra/tree/master/greenhouse).

Builds on similar work happening in test-infra:
* https://github.com/kubernetes/test-infra/commits/master/rbe.bazelrc
* https://testgrid.k8s.io/presubmits-test-infra#bazel-rbe

<!--
```release-note
NONE
```
-->