### PR TITLE
[metrics-server addon] Restore connecting to nodes via IP addresses

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -57,6 +57,7 @@ spec:
         # Remove these lines for non-GKE clusters, and when GKE supports token-based auth.
         - --kubelet-port=10255
         - --deprecated-kubelet-completely-insecure=true
+        - --kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP
         ports:
         - containerPort: 443
           name: https


### PR DESCRIPTION
This preference list matches is used to pick prefered field from k8s
node object. It was introduced in metrics-server 0.3 and changed default
behaviour to use DNS instead of IP addresses. It was merged into k8s
1.12 and caused breaking change by introducing dependency on DNS
configuration.

/assign @x13n 
/cc @DirectXMan12 
/sig instrumentation

```release-note
[metrics-server addon] Restore connecting to nodes via IP addresses
```
