### PR TITLE
add more details instruction after `kube init`

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -56,7 +56,8 @@ var (
 		  mkdir -p $HOME/.kube
 		  sudo cp -i {{.KubeConfigPath}} $HOME/.kube/config
 		  sudo chown $(id -u):$(id -g) $HOME/.kube/config
-
+                  export KUBECONFIG=$HOME/.kube/admin.conf
+				  
 		You should now deploy a pod network to the cluster.
 		Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
 		  https://kubernetes.io/docs/concepts/cluster-administration/addons/


### PR DESCRIPTION
we need set KUBECONFIG env after `kube init` success, so that kubectl can work normal. So I add this instruction for users
