### PR TITLE
images: Adds GOARM to images' Makefiles

### DIFF
--- a/test/images/agnhost/Makefile
+++ b/test/images/agnhost/Makefile
@@ -15,6 +15,7 @@
 SRCS=agnhost
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
+GOARM ?= 7
 GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 export

--- a/test/images/apparmor-loader/Makefile
+++ b/test/images/apparmor-loader/Makefile
@@ -15,6 +15,7 @@
 SRCS=loader
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
+GOARM ?= 7
 GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 export

--- a/test/images/metadata-concealment/Makefile
+++ b/test/images/metadata-concealment/Makefile
@@ -15,6 +15,7 @@
 SRCS=check_metadata_concealment
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
+GOARM ?= 7
 GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 export

--- a/test/images/nonewprivs/Makefile
+++ b/test/images/nonewprivs/Makefile
@@ -15,6 +15,7 @@
 SRCS = nnp
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
+GOARM ?= 7
 GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 export

--- a/test/images/pets/peer-finder/Makefile
+++ b/test/images/pets/peer-finder/Makefile
@@ -15,6 +15,7 @@
 SRCS = peer-finder
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
+GOARM ?= 7
 GOLANG_VERSION ?= latest
 SRC_DIR = pets/peer-finder
 export

--- a/test/images/pets/redis-installer/Makefile
+++ b/test/images/pets/redis-installer/Makefile
@@ -15,6 +15,7 @@
 SRCS = peer-finder
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
+GOARM ?= 7
 GOLANG_VERSION ?= latest
 SRC_DIR = pets/peer-finder
 export

--- a/test/images/pets/zookeeper-installer/Makefile
+++ b/test/images/pets/zookeeper-installer/Makefile
@@ -15,6 +15,7 @@
 SRCS = peer-finder
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
+GOARM ?= 7
 GOLANG_VERSION ?= latest
 SRC_DIR = pets/peer-finder
 export

--- a/test/images/resource-consumer/Makefile
+++ b/test/images/resource-consumer/Makefile
@@ -15,6 +15,7 @@
 SRCS = consumer consume-cpu/consume-cpu
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
+GOARM ?= 7
 GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 export

--- a/test/images/sample-device-plugin/Makefile
+++ b/test/images/sample-device-plugin/Makefile
@@ -15,6 +15,7 @@
 SRCS=sampledeviceplugin
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
+GOARM ?= 7
 GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 export


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/sig testing

**What this PR does / why we need it**:

In order to build the image binaries, the GOARM variable is required,
but not all Makefiles have it defined, causing the make to fail on
those images.

This adds the require GOARM variable to the Makefiles in question.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #76827

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
