### PR TITLE
fix test cases expected

### DIFF
--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -109,18 +109,18 @@ func Test_getProxyMode(t *testing.T) {
 			kernelCompat:    true,
 			expected:        proxyModeIPTables,
 		},
-		{ // flag says ipvs, required kernel modules are set by GetKernelVersionAndIPVSMods()
+		{ // flag says ipvs, required kernel modules are not installed, fallback on iptables mode
 			flag:            "ipvs",
 			kmods:           []string{"foo", "bar", "baz"},
 			ipsetVersion:    ipvs.MinIPSetCheckVersion,
 			iptablesVersion: iptables.MinCheckVersion,
 			kernelCompat:    true,
-			expected:        proxyModeIPVS,
+			expected:        proxyModeIPTables,
 		},
-		{ // flag says ipvs, required kernel modules are set by GetKernelVersionAndIPVSMods(), ipset and iptables version too old, fallback on userspace mode
+		{ // flag says ipvs, required kernel modules are not installed, iptables version too old, fallback on userspace mode
 			flag:            "ipvs",
 			kmods:           []string{"foo", "bar", "baz"},
-			ipsetVersion:    "0.0.0",
+			ipsetVersion:    ipvs.MinIPSetCheckVersion,
 			iptablesVersion: "0.0.0",
 			kernelCompat:    true,
 			expected:        proxyModeUserspace,

--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -109,18 +109,18 @@ func Test_getProxyMode(t *testing.T) {
 			kernelCompat:    true,
 			expected:        proxyModeIPTables,
 		},
-		{ // flag says ipvs, required kernel modules are not installed, fallback on iptables mode
+		{ // flag says ipvs, required kernel modules are set by GetKernelVersionAndIPVSMods()
 			flag:            "ipvs",
 			kmods:           []string{"foo", "bar", "baz"},
 			ipsetVersion:    ipvs.MinIPSetCheckVersion,
 			iptablesVersion: iptables.MinCheckVersion,
 			kernelCompat:    true,
-			expected:        proxyModeIPTables,
+			expected:        proxyModeIPVS,
 		},
-		{ // flag says ipvs, required kernel modules are not installed, iptables version too old, fallback on userspace mode
+		{ // flag says ipvs, required kernel modules are set by GetKernelVersionAndIPVSMods(), ipset and iptables version too old, fallback on userspace mode
 			flag:            "ipvs",
 			kmods:           []string{"foo", "bar", "baz"},
-			ipsetVersion:    ipvs.MinIPSetCheckVersion,
+			ipsetVersion:    "0.0.0",
 			iptablesVersion: "0.0.0",
 			kernelCompat:    true,
 			expected:        proxyModeUserspace,

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -30,7 +30,7 @@ import (
 
 	"k8s.io/klog"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -523,6 +523,9 @@ func CanUseIPVSProxier(handle KernelHandler, ipsetver IPSetVersioner) (bool, err
 	loadModules := sets.NewString()
 	linuxKernelHandler := NewLinuxKernelHandler()
 	_, ipvsModules, _ := utilipvs.GetKernelVersionAndIPVSMods(linuxKernelHandler.executor)
+	if len(ipvsModules) == 0 {
+		return false, fmt.Errorf("error getting installed ipvs required kernel modules with linux kernel handler")
+	}
 	wantModules.Insert(ipvsModules...)
 	loadModules.Insert(mods...)
 	modules := wantModules.Difference(loadModules).UnsortedList()


### PR DESCRIPTION
**What type of PR is this?**
> /kind failing-test

**What this PR does / why we need it**:
Fix the failing test.
Case[12] and Case[13] expected the result is not ipvs then kmods set invalid modules, but ``GetKernelVersionAndIPVSMods()`` func has set the correct loaded modules.
```
k8s.io/kubernetes/cmd/kube-proxy/app/server_others_test.go:144: Case[12] Expected "iptables", got "ipvs"
k8s.io/kubernetes/cmd/kube-proxy/app/server_others_test.go:144: Case[13] Expected "iptables", got "ipvs"
```
https://github.com/kubernetes/kubernetes/blob/61fa0fd44a3513b94d7c29ff859340804c107ea0/cmd/kube-proxy/app/server_others_test.go#L112-L127
https://github.com/kubernetes/kubernetes/blob/61fa0fd44a3513b94d7c29ff859340804c107ea0/pkg/util/ipvs/ipvs.go#L143-L147
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
