### PR TITLE
kubeadm: cleanup unused func

### DIFF
--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -59,21 +59,6 @@ type kubeConfigSpec struct {
 	ClientCertAuth *clientCertAuth
 }
 
-// CreateInitKubeConfigFiles will create and write to disk all kubeconfig files necessary in the kubeadm init phase
-// to establish the control plane, including also the admin kubeconfig file.
-// If kubeconfig files already exists, they are used only if evaluated equal; otherwise an error is returned.
-func CreateInitKubeConfigFiles(outDir string, cfg *kubeadmapi.InitConfiguration) error {
-	klog.V(1).Infoln("creating all kubeconfig files")
-	return createKubeConfigFiles(
-		outDir,
-		cfg,
-		kubeadmconstants.AdminKubeConfigFileName,
-		kubeadmconstants.KubeletKubeConfigFileName,
-		kubeadmconstants.ControllerManagerKubeConfigFileName,
-		kubeadmconstants.SchedulerKubeConfigFileName,
-	)
-}
-
 // CreateJoinControlPlaneKubeConfigFiles will create and write to disk the kubeconfig files required by kubeadm
 // join --control-plane workflow, plus the admin kubeconfig file used by the administrator and kubeadm itself; the
 // kubelet.conf file must not be created because it will be created and signed by the kubelet TLS bootstrap process.

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -289,16 +289,6 @@ func TestCreateKubeconfigFilesAndWrappers(t *testing.T) {
 			},
 			expectedError: true,
 		},
-		{ // Test CreateInitKubeConfigFiles (wrapper to createKubeConfigFile)
-			name:                     "CreateInitKubeConfigFiles",
-			createKubeConfigFunction: CreateInitKubeConfigFiles,
-			expectedFiles: []string{
-				kubeadmconstants.AdminKubeConfigFileName,
-				kubeadmconstants.KubeletKubeConfigFileName,
-				kubeadmconstants.ControllerManagerKubeConfigFileName,
-				kubeadmconstants.SchedulerKubeConfigFileName,
-			},
-		},
 		{ // Test CreateJoinControlPlaneKubeConfigFiles (wrapper to createKubeConfigFile)
 			name:                     "CreateJoinControlPlaneKubeConfigFiles",
 			createKubeConfigFunction: CreateJoinControlPlaneKubeConfigFiles,


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR remove an unused func from the kubeadm code base.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cluster-lifecycle
/area kubeadm
/priority backlog
@kubernetes/sig-cluster-lifecycle-pr-reviews 