### PR TITLE
Fixed a kubemark panic when hollow-node is morphed as proxy

### DIFF
--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	goflag "flag"
 	"fmt"
 	"math/rand"
@@ -185,7 +186,9 @@ func run(config *hollowNodeConfig) {
 		}
 		iptInterface := fakeiptables.NewFake()
 		sysctl := fakesysctl.NewFake()
-		execer := &fakeexec.FakeExec{}
+		execer := &fakeexec.FakeExec{
+			LookPathFunc: func(_ string) (string, error) { return "", errors.New("fake execer") },
+		}
 		eventBroadcaster := record.NewBroadcaster()
 		recorder := eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{Component: "kube-proxy", Host: config.NodeName})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig scalability
/assign @shyamjvs @wojtek-t 

**What this PR does / why we need it**:

Kubemark is used widely in perf tests of control plane components such as apiserver, scheduler, etc. But recently I found it paniced when morphed as proxy.

Another solution is to use `os/exec` to lookup the real path, but it doesn't work b/c of other fake objs, in particular it will panic again at:

https://github.com/kubernetes/kubernetes/blob/746fea0428a2090fb7e9cfe10f18f050c7dc5bdb/vendor/k8s.io/utils/exec/testing/fake_exec.go#L42

**Which issue(s) this PR fixes**:

Fixes #69735.

**Special notes for your reviewer**:

I haven't figured out from which release kubemark started not to function.

**Updated:** this issue exists in v1.12.7.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed a kubemark panic when hollow-node is morphed as proxy.
```
