### PR TITLE
kubeadm: fix certs renewal during upgrade

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/BUILD
+++ b/cmd/kubeadm/app/phases/upgrade/BUILD
@@ -15,7 +15,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
-        "//cmd/kubeadm/app/apis/kubeadm/v1beta2:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/images:go_default_library",
         "//cmd/kubeadm/app/phases/addons/dns:go_default_library",
@@ -45,7 +44,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
-        "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -17,7 +17,6 @@ limitations under the License.
 package upgrade
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -29,15 +28,12 @@ import (
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
-	certutil "k8s.io/client-go/util/cert"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/proxy"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo"
 	nodebootstraptoken "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
-	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
 	patchnodephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/patchnode"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig"
@@ -101,11 +97,6 @@ func PerformPostUpgradeTasks(client clientset.Interface, cfg *kubeadmapi.InitCon
 		errs = append(errs, err)
 	}
 
-	// Rotate the kube-apiserver cert and key if needed
-	if err := BackupAPIServerCertIfNeeded(cfg, dryRun); err != nil {
-		errs = append(errs, err)
-	}
-
 	// Upgrade kube-dns/CoreDNS and kube-proxy
 	if err := dns.EnsureDNSAddon(&cfg.ClusterConfiguration, client); err != nil {
 		errs = append(errs, err)
@@ -150,37 +141,6 @@ func removeOldDNSDeploymentIfAnotherDNSIsUsed(cfg *kubeadmapi.ClusterConfigurati
 		}
 		return nil
 	}, 10)
-}
-
-// BackupAPIServerCertIfNeeded rotates the kube-apiserver certificate if older than 180 days
-func BackupAPIServerCertIfNeeded(cfg *kubeadmapi.InitConfiguration, dryRun bool) error {
-	certAndKeyDir := kubeadmapiv1beta2.DefaultCertificatesDir
-	shouldBackup, err := shouldBackupAPIServerCertAndKey(certAndKeyDir)
-	if err != nil {
-		// Don't fail the upgrade phase if failing to determine to backup kube-apiserver cert and key.
-		return errors.Wrap(err, "[postupgrade] WARNING: failed to determine to backup kube-apiserver cert and key")
-	}
-
-	if !shouldBackup {
-		return nil
-	}
-
-	// If dry-running, just say that this would happen to the user and exit
-	if dryRun {
-		fmt.Println("[postupgrade] Would rotate the API server certificate and key.")
-		return nil
-	}
-
-	// Don't fail the upgrade phase if failing to backup kube-apiserver cert and key, just continue rotating the cert
-	// TODO: We might want to reconsider this choice.
-	if err := backupAPIServerCertAndKey(certAndKeyDir); err != nil {
-		fmt.Printf("[postupgrade] WARNING: failed to backup kube-apiserver cert and key: %v\n", err)
-	}
-	return certsphase.CreateCertAndKeyFilesWithCA(
-		&certsphase.KubeadmCertAPIServer,
-		&certsphase.KubeadmCertRootCA,
-		cfg,
-	)
 }
 
 func writeKubeletConfigFiles(client clientset.Interface, cfg *kubeadmapi.InitConfiguration, newK8sVer *version.Version, dryRun bool) error {
@@ -228,20 +188,6 @@ func GetKubeletDir(dryRun bool) (string, error) {
 	return kubeadmconstants.KubeletRunDirectory, nil
 }
 
-// backupAPIServerCertAndKey backups the old cert and key of kube-apiserver to a specified directory.
-func backupAPIServerCertAndKey(certAndKeyDir string) error {
-	subDir := filepath.Join(certAndKeyDir, "expired")
-	if err := os.Mkdir(subDir, 0700); err != nil {
-		return errors.Wrapf(err, "failed to created backup directory %s", subDir)
-	}
-
-	filesToMove := map[string]string{
-		filepath.Join(certAndKeyDir, kubeadmconstants.APIServerCertName): filepath.Join(subDir, kubeadmconstants.APIServerCertName),
-		filepath.Join(certAndKeyDir, kubeadmconstants.APIServerKeyName):  filepath.Join(subDir, kubeadmconstants.APIServerKeyName),
-	}
-	return moveFiles(filesToMove)
-}
-
 // moveFiles moves files from one directory to another.
 func moveFiles(files map[string]string) error {
 	filesToRecover := map[string]string{}
@@ -263,22 +209,4 @@ func rollbackFiles(files map[string]string, originalErr error) error {
 		}
 	}
 	return errors.Errorf("couldn't move these files: %v. Got errors: %v", files, errorsutil.NewAggregate(errs))
-}
-
-// shouldBackupAPIServerCertAndKey checks if the cert of kube-apiserver will be expired in 180 days.
-func shouldBackupAPIServerCertAndKey(certAndKeyDir string) (bool, error) {
-	apiServerCert := filepath.Join(certAndKeyDir, kubeadmconstants.APIServerCertName)
-	certs, err := certutil.CertsFromFile(apiServerCert)
-	if err != nil {
-		return false, errors.Wrapf(err, "couldn't load the certificate file %s", apiServerCert)
-	}
-	if len(certs) == 0 {
-		return false, errors.New("no certificate data found")
-	}
-
-	if time.Since(certs[0].NotBefore) > expiry {
-		return true, nil
-	}
-
-	return false, nil
 }

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
@@ -21,39 +21,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 )
-
-func TestBackupAPIServerCertAndKey(t *testing.T) {
-	tmpdir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpdir)
-	os.Chmod(tmpdir, 0766)
-
-	certPath := filepath.Join(tmpdir, constants.APIServerCertName)
-	certFile, err := os.OpenFile(certPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
-	if err != nil {
-		t.Fatalf("Failed to create cert file %s: %v", certPath, err)
-	}
-	defer certFile.Close()
-
-	keyPath := filepath.Join(tmpdir, constants.APIServerKeyName)
-	keyFile, err := os.OpenFile(keyPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
-	if err != nil {
-		t.Fatalf("Failed to create key file %s: %v", keyPath, err)
-	}
-	defer keyFile.Close()
-
-	if err := backupAPIServerCertAndKey(tmpdir); err != nil {
-		t.Fatalf("Failed to backup cert and key in dir %s: %v", tmpdir, err)
-	}
-}
 
 func TestMoveFiles(t *testing.T) {
 	tmpdir := testutil.SetupTempDir(t)
@@ -126,61 +99,5 @@ func TestRollbackFiles(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), errString) {
 		t.Fatalf("Expected error contains %q, got %v", errString, err)
-	}
-}
-
-func TestShouldBackupAPIServerCertAndKey(t *testing.T) {
-	cfg := &kubeadmapi.InitConfiguration{
-		LocalAPIEndpoint: kubeadmapi.APIEndpoint{AdvertiseAddress: "1.2.3.4"},
-		ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-			Networking: kubeadmapi.Networking{ServiceSubnet: "10.96.0.0/12", DNSDomain: "cluster.local"},
-		},
-		NodeRegistration: kubeadmapi.NodeRegistrationOptions{Name: "test-node"},
-	}
-
-	for desc, test := range map[string]struct {
-		adjustedExpiry time.Duration
-		expected       bool
-	}{
-		"default: cert not older than 180 days doesn't needs to backup": {
-			expected: false,
-		},
-		"cert older than 180 days need to backup": {
-			adjustedExpiry: expiry + 100*time.Hour,
-			expected:       true,
-		},
-	} {
-		t.Run(desc, func(t *testing.T) {
-			tmpdir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpdir)
-			cfg.CertificatesDir = tmpdir
-
-			caCert, caKey, err := certsphase.KubeadmCertRootCA.CreateAsCA(cfg)
-			if err != nil {
-				t.Fatalf("failed creation of ca cert and key: %v", err)
-			}
-			caCert.NotBefore = caCert.NotBefore.Add(-test.adjustedExpiry).UTC()
-
-			err = certsphase.KubeadmCertAPIServer.CreateFromCA(cfg, caCert, caKey)
-			if err != nil {
-				t.Fatalf("Test %s: failed creation of cert and key: %v", desc, err)
-			}
-
-			certAndKey := []string{filepath.Join(tmpdir, constants.APIServerCertName), filepath.Join(tmpdir, constants.APIServerKeyName)}
-			for _, path := range certAndKey {
-				if _, err := os.Stat(path); os.IsNotExist(err) {
-					t.Fatalf("Test %s: %s not exist: %v", desc, path, err)
-				}
-			}
-
-			shouldBackup, err := shouldBackupAPIServerCertAndKey(tmpdir)
-			if err != nil {
-				t.Fatalf("Test %s: failed to check shouldBackupAPIServerCertAndKey: %v", desc, err)
-			}
-
-			if shouldBackup != test.expected {
-				t.Fatalf("Test %s: shouldBackupAPIServerCertAndKey expected %v, got %v", desc, test.expected, shouldBackup)
-			}
-		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
as of today, kubeadm does not implement a consistent approach for certs renewal during upgrades:
- certificates signed by etcd-ca are renewed every upgrade
- apiserver certificate is upgraded only after 180 days after creation (and in post upgrade, so probably not picked up by the api server :-(
- apiserver-kubelet-client and front-proxy-client certificate are not renewed at all

This PR fixes this by implementing a consistent approach by renewing all the certificates used by one component before upgrading the component itself.
If the component e.g. etcd does not change version during upgrades, related certificates are not updated.

Certificate renewal during kubeadm upgrade is skipped in case of external-ca (because kubeadm can't do certificate renewal without the ca key)

**Which issue(s) this PR fixes**:
Rif https://github.com/kubernetes/kubeadm/issues/1361

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: kubeadm upgrade now renews all the certificates used by one component before upgrading the component itself, with the exception of certificates signed by external CAs. User can eventually opt-out from certificate renewal during upgrades by setting the new flag --certificate-renewal to false.
```
/sig cluster-lifecycle
/area kubeadm
/priority important-soon
@kubernetes/sig-cluster-lifecycle-pr-reviews