### PR TITLE
add metadata.uid as a selector for pods api

### DIFF
--- a/pkg/apis/core/field_constants.go
+++ b/pkg/apis/core/field_constants.go
@@ -21,6 +21,7 @@ package core
 const (
 	NodeUnschedulableField = "spec.unschedulable"
 	ObjectNameField        = "metadata.name"
+	ObjectUidField         = "metadata.uid"
 	PodHostField           = "spec.nodeName"
 	PodStatusField         = "status.phase"
 	SecretTypeField        = "type"

--- a/pkg/apis/core/v1/conversion.go
+++ b/pkg/apis/core/v1/conversion.go
@@ -59,6 +59,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name",
+				"metadata.uid",
 				"metadata.namespace",
 				"spec.nodeName",
 				"spec.restartPolicy",
@@ -501,7 +502,8 @@ func AddFieldLabelConversionsForSecret(scheme *runtime.Scheme) error {
 			switch label {
 			case "type",
 				"metadata.namespace",
-				"metadata.name":
+				"metadata.name",
+				"metadata.uid":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/converter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/converter.go
@@ -104,7 +104,7 @@ type crConverter struct {
 func (c *crConverter) ConvertFieldLabel(gvk schema.GroupVersionKind, label, value string) (string, string, error) {
 	// We currently only support metadata.namespace and metadata.name.
 	switch {
-	case label == "metadata.name":
+	case label == "metadata.name" || label == "metadata.uid":
 		return label, value, nil
 	case !c.clusterScoped && label == "metadata.namespace":
 		return label, value, nil

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
@@ -166,11 +166,13 @@ func objectMetaFieldsSet(objectMeta metav1.Object, namespaceScoped bool) fields.
 	if namespaceScoped {
 		return fields.Set{
 			"metadata.name":      objectMeta.GetName(),
+			"metadata.uid":       string(objectMeta.GetUID()),
 			"metadata.namespace": objectMeta.GetNamespace(),
 		}
 	}
 	return fields.Set{
 		"metadata.name": objectMeta.GetName(),
+		"metadata":      string(objectMeta.GetUID()),
 	}
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/conversion.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/conversion.go
@@ -34,6 +34,8 @@ func DefaultMetaV1FieldSelectorConversion(label, value string) (string, string, 
 	switch label {
 	case "metadata.name":
 		return label, value, nil
+	case "metadata.uid":
+		return label, value, nil
 	case "metadata.namespace":
 		return label, value, nil
 	default:

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/matcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/matcher.go
@@ -26,10 +26,12 @@ func ObjectMetaFieldsSet(objectMeta *metav1.ObjectMeta, hasNamespaceField bool) 
 	if !hasNamespaceField {
 		return fields.Set{
 			"metadata.name": objectMeta.Name,
+			"metadata.uid":  objectMeta.UID,
 		}
 	}
 	return fields.Set{
 		"metadata.name":      objectMeta.Name,
+		"metadata.uid":       objectMeta.UID,
 		"metadata.namespace": objectMeta.Namespace,
 	}
 }
@@ -37,6 +39,7 @@ func ObjectMetaFieldsSet(objectMeta *metav1.ObjectMeta, hasNamespaceField bool) 
 // AdObjectMetaField add fields that represent the ObjectMeta to source.
 func AddObjectMetaFieldsSet(source fields.Set, objectMeta *metav1.ObjectMeta, hasNamespaceField bool) fields.Set {
 	source["metadata.name"] = objectMeta.Name
+	source["metadata.uid"] = objectMeta.UID
 	if hasNamespaceField {
 		source["metadata.namespace"] = objectMeta.Namespace
 	}


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
support user to query pods based on metadata uid as a selector.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
API: enable query pod based on metadata uid
```
