### PR TITLE
Fix malformed JUNIT XML with shellcheck failures

### DIFF
--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -123,6 +123,13 @@ else
   fi
 fi
 
+# if KUBE_JUNIT_REPORT_DIR is set, disable colorized output.
+# Colorized output causes malformed XML in the JUNIT report.
+SHELLCHECK_COLORIZED_OUTPUT="auto"
+if [[ -n "${KUBE_JUNIT_REPORT_DIR:-}" ]]; then
+  SHELLCHECK_COLORIZED_OUTPUT="never"
+fi
+
 # common arguments we'll pass to shellcheck
 SHELLCHECK_OPTIONS=(
   # allow following sourced files that are not specified in the command,
@@ -131,6 +138,8 @@ SHELLCHECK_OPTIONS=(
   "--external-sources"
   # include our disabled lints
   "--exclude=${SHELLCHECK_DISABLED}"
+  # set colorized output
+  "--color=${SHELLCHECK_COLORIZED_OUTPUT}"
 )
 
 # lint each script, tracking failures


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes junit report output when `verify-shellcheck.sh` detects a failure. Colourized output was messing things up.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
