### PR TITLE
Declare sync.Mutex for MatchingCache#mutex

### DIFF
--- a/pkg/controller/lookup_cache.go
+++ b/pkg/controller/lookup_cache.go
@@ -48,7 +48,7 @@ type equivalenceLabelObj struct {
 
 // MatchingCache save label and selector matching relationship
 type MatchingCache struct {
-	mutex sync.RWMutex
+	mutex sync.Mutex
 	cache *lru.Cache
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
MatchingCache#mutex is currently declared as RWMutex.
From the comment of GetMatchingObject, it is clear that we always take write lock.

This PR declares MatchingCache#mutex as Mutex.

```release-note
NONE
```
