### PR TITLE
Fix golint failures of pkg/controller/certificates/approver, etc

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -65,7 +65,6 @@ pkg/cloudprovider/providers/vsphere
 pkg/controller
 pkg/controller/apis/config/v1alpha1
 pkg/controller/certificates
-pkg/controller/certificates/approver
 pkg/controller/certificates/signer
 pkg/controller/certificates/signer/config/v1alpha1
 pkg/controller/cloud

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -288,7 +288,6 @@ pkg/registry/networking/rest
 pkg/registry/node/rest
 pkg/registry/policy/poddisruptionbudget/storage
 pkg/registry/policy/rest
-pkg/registry/rbac/clusterrole
 pkg/registry/rbac/clusterrole/policybased
 pkg/registry/rbac/clusterrolebinding
 pkg/registry/rbac/clusterrolebinding/policybased

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -358,7 +358,6 @@ pkg/volume/scaleio
 pkg/volume/storageos
 pkg/volume/testing
 pkg/volume/util/fs
-pkg/volume/util/recyclerclient
 pkg/volume/util/volumepathhandler
 pkg/volume/vsphere_volume
 plugin/pkg/admission/antiaffinity

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -293,7 +293,6 @@ pkg/registry/rbac/clusterrolebinding
 pkg/registry/rbac/clusterrolebinding/policybased
 pkg/registry/rbac/reconciliation
 pkg/registry/rbac/rest
-pkg/registry/rbac/role
 pkg/registry/rbac/role/policybased
 pkg/registry/rbac/rolebinding
 pkg/registry/rbac/rolebinding/policybased

--- a/pkg/controller/certificates/approver/sarapprove.go
+++ b/pkg/controller/certificates/approver/sarapprove.go
@@ -42,6 +42,7 @@ type sarApprover struct {
 	recognizers []csrRecognizer
 }
 
+// NewCSRApprovingController creates a new CSRApprovingController.
 func NewCSRApprovingController(client clientset.Interface, csrInformer certificatesinformers.CertificateSigningRequestInformer) *certificates.CertificateController {
 	approver := &sarApprover{
 		client:      client,

--- a/pkg/registry/rbac/clusterrole/doc.go
+++ b/pkg/registry/rbac/clusterrole/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package certificates provides Registry interface and its RESTStorage
+// Package clusterrole provides Registry interface and its RESTStorage
 // implementation for storing ClusterRole objects.
 package clusterrole // import "k8s.io/kubernetes/pkg/registry/rbac/clusterrole"

--- a/pkg/registry/rbac/clusterrole/registry.go
+++ b/pkg/registry/rbac/clusterrole/registry.go
@@ -61,6 +61,7 @@ type AuthorizerAdapter struct {
 	Registry Registry
 }
 
+// GetClusterRole returns the corresponding ClusterRole by name
 func (a AuthorizerAdapter) GetClusterRole(name string) (*rbacv1.ClusterRole, error) {
 	return a.Registry.GetClusterRole(genericapirequest.NewContext(), name, &metav1.GetOptions{})
 }

--- a/pkg/registry/rbac/clusterrole/strategy.go
+++ b/pkg/registry/rbac/clusterrole/strategy.go
@@ -34,7 +34,7 @@ type strategy struct {
 	names.NameGenerator
 }
 
-// strategy is the default logic that applies when creating and updating
+// Strategy is the default logic that applies when creating and updating
 // ClusterRole objects.
 var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
 

--- a/pkg/registry/rbac/role/doc.go
+++ b/pkg/registry/rbac/role/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package certificates provides Registry interface and its RESTStorage
+// Package role provides Registry interface and its RESTStorage
 // implementation for storing Role objects.
 package role // import "k8s.io/kubernetes/pkg/registry/rbac/role"

--- a/pkg/registry/rbac/role/registry.go
+++ b/pkg/registry/rbac/role/registry.go
@@ -61,6 +61,7 @@ type AuthorizerAdapter struct {
 	Registry Registry
 }
 
+// GetRole returns the corresponding Role by name in specified namespace
 func (a AuthorizerAdapter) GetRole(namespace, name string) (*rbacv1.Role, error) {
 	return a.Registry.GetRole(genericapirequest.WithNamespace(genericapirequest.NewContext(), namespace), name, &metav1.GetOptions{})
 }

--- a/pkg/registry/rbac/role/strategy.go
+++ b/pkg/registry/rbac/role/strategy.go
@@ -34,7 +34,7 @@ type strategy struct {
 	names.NameGenerator
 }
 
-// strategy is the default logic that applies when creating and updating
+// Strategy is the default logic that applies when creating and updating
 // Role objects.
 var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
 

--- a/pkg/volume/util/recyclerclient/recycler_client.go
+++ b/pkg/volume/util/recyclerclient/recycler_client.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/klog"
 )
 
+// RecycleEventRecorder is a func that defines how to record RecycleEvent.
 type RecycleEventRecorder func(eventtype, message string)
 
 // RecycleVolumeByWatchingPodUntilCompletion is intended for use with volume
@@ -127,9 +128,8 @@ func waitForPod(pod *v1.Pod, recyclerClient recyclerClient, podCh <-chan watch.E
 				if pod.Status.Phase == v1.PodFailed {
 					if pod.Status.Message != "" {
 						return fmt.Errorf(pod.Status.Message)
-					} else {
-						return fmt.Errorf("pod failed, pod.Status.Message unknown.")
 					}
+					return fmt.Errorf("pod failed, pod.Status.Message unknown")
 				}
 
 			case watch.Deleted:
@@ -238,9 +238,8 @@ func (c *realRecyclerClient) WatchPod(name, namespace string, stopChannel chan s
 			case eventEvent, ok := <-eventWatch.ResultChan():
 				if !ok {
 					return
-				} else {
-					eventCh <- eventEvent
 				}
+				eventCh <- eventEvent
 			}
 		}
 	}()
@@ -256,9 +255,8 @@ func (c *realRecyclerClient) WatchPod(name, namespace string, stopChannel chan s
 			case podEvent, ok := <-podWatch.ResultChan():
 				if !ok {
 					return
-				} else {
-					eventCh <- podEvent
 				}
+				eventCh <- podEvent
 			}
 		}
 	}()

--- a/pkg/volume/util/recyclerclient/recycler_client_test.go
+++ b/pkg/volume/util/recyclerclient/recycler_client_test.go
@@ -210,9 +210,8 @@ func (c *mockRecyclerClient) CreatePod(pod *v1.Pod) (*v1.Pod, error) {
 func (c *mockRecyclerClient) GetPod(name, namespace string) (*v1.Pod, error) {
 	if c.pod != nil {
 		return c.pod, nil
-	} else {
-		return nil, fmt.Errorf("pod does not exist")
 	}
+	return nil, fmt.Errorf("pod does not exist")
 }
 
 func (c *mockRecyclerClient) DeletePod(name, namespace string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Fix golint failures of 
- pkg/controller/certificates/approver
- pkg/registry/rbac/role
- pkg/registry/rbac/clusterrole
- pkg/volume/util/recyclerclient

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
