### PR TITLE
Revert cherry-pick PR #76529

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -356,36 +356,39 @@ func NewProxier(ipt utiliptables.Interface,
 }
 
 type iptablesJumpChain struct {
-	table     utiliptables.Table
-	dstChain  utiliptables.Chain
-	srcChain  utiliptables.Chain
-	comment   string
-	extraArgs []string
+	table       utiliptables.Table
+	chain       utiliptables.Chain
+	sourceChain utiliptables.Chain
+	comment     string
+	extraArgs   []string
 }
 
 var iptablesJumpChains = []iptablesJumpChain{
 	{utiliptables.TableFilter, kubeExternalServicesChain, utiliptables.ChainInput, "kubernetes externally-visible service portals", []string{"-m", "conntrack", "--ctstate", "NEW"}},
-	{utiliptables.TableFilter, kubeServicesChain, utiliptables.ChainForward, "kubernetes service portals", []string{"-m", "conntrack", "--ctstate", "NEW"}},
 	{utiliptables.TableFilter, kubeServicesChain, utiliptables.ChainOutput, "kubernetes service portals", []string{"-m", "conntrack", "--ctstate", "NEW"}},
-	{utiliptables.TableFilter, kubeServicesChain, utiliptables.ChainInput, "kubernetes service portals", []string{"-m", "conntrack", "--ctstate", "NEW"}},
-	{utiliptables.TableFilter, kubeForwardChain, utiliptables.ChainForward, "kubernetes forwarding rules", nil},
 	{utiliptables.TableNAT, kubeServicesChain, utiliptables.ChainOutput, "kubernetes service portals", nil},
 	{utiliptables.TableNAT, kubeServicesChain, utiliptables.ChainPrerouting, "kubernetes service portals", nil},
 	{utiliptables.TableNAT, kubePostroutingChain, utiliptables.ChainPostrouting, "kubernetes postrouting rules", nil},
+	{utiliptables.TableFilter, kubeForwardChain, utiliptables.ChainForward, "kubernetes forwarding rules", nil},
 }
 
-var iptablesCleanupOnlyChains = []iptablesJumpChain{}
+var iptablesCleanupOnlyChains = []iptablesJumpChain{
+	// Present in kube 1.6 - 1.9. Removed by #56164 in favor of kubeExternalServicesChain
+	{utiliptables.TableFilter, kubeServicesChain, utiliptables.ChainInput, "kubernetes service portals", nil},
+	// Present in kube <= 1.9. Removed by #60306 in favor of rule with extraArgs
+	{utiliptables.TableFilter, kubeServicesChain, utiliptables.ChainOutput, "kubernetes service portals", nil},
+}
 
 // CleanupLeftovers removes all iptables rules and chains created by the Proxier
 // It returns true if an error was encountered. Errors are logged.
 func CleanupLeftovers(ipt utiliptables.Interface) (encounteredError bool) {
 	// Unlink our chains
-	for _, jump := range append(iptablesJumpChains, iptablesCleanupOnlyChains...) {
-		args := append(jump.extraArgs,
-			"-m", "comment", "--comment", jump.comment,
-			"-j", string(jump.dstChain),
+	for _, chain := range append(iptablesJumpChains, iptablesCleanupOnlyChains...) {
+		args := append(chain.extraArgs,
+			"-m", "comment", "--comment", chain.comment,
+			"-j", string(chain.chain),
 		)
-		if err := ipt.DeleteRule(jump.table, jump.srcChain, args...); err != nil {
+		if err := ipt.DeleteRule(chain.table, chain.sourceChain, args...); err != nil {
 			if !utiliptables.IsNotFoundError(err) {
 				glog.Errorf("Error removing pure-iptables proxy rule: %v", err)
 				encounteredError = true
@@ -659,17 +662,17 @@ func (proxier *Proxier) syncProxyRules() {
 	glog.V(3).Infof("Syncing iptables rules")
 
 	// Create and link the kube chains.
-	for _, jump := range iptablesJumpChains {
-		if _, err := proxier.iptables.EnsureChain(jump.table, jump.dstChain); err != nil {
-			glog.Errorf("Failed to ensure that %s chain %s exists: %v", jump.table, jump.dstChain, err)
+	for _, chain := range iptablesJumpChains {
+		if _, err := proxier.iptables.EnsureChain(chain.table, chain.chain); err != nil {
+			glog.Errorf("Failed to ensure that %s chain %s exists: %v", chain.table, kubeServicesChain, err)
 			return
 		}
-		args := append(jump.extraArgs,
-			"-m", "comment", "--comment", jump.comment,
-			"-j", string(jump.dstChain),
+		args := append(chain.extraArgs,
+			"-m", "comment", "--comment", chain.comment,
+			"-j", string(chain.chain),
 		)
-		if _, err := proxier.iptables.EnsureRule(utiliptables.Prepend, jump.table, jump.srcChain, args...); err != nil {
-			glog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", jump.table, jump.srcChain, jump.dstChain, err)
+		if _, err := proxier.iptables.EnsureRule(utiliptables.Prepend, chain.table, chain.sourceChain, args...); err != nil {
+			glog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", chain.table, chain.sourceChain, chain.chain, err)
 			return
 		}
 	}
@@ -827,7 +830,6 @@ func (proxier *Proxier) syncProxyRules() {
 			}
 			writeLine(proxier.natRules, append(args, "-j", string(svcChain))...)
 		} else {
-			// No endpoints.
 			writeLine(proxier.filterRules,
 				"-A", string(kubeServicesChain),
 				"-m", "comment", "--comment", fmt.Sprintf(`"%s has no endpoints"`, svcNameString),
@@ -898,7 +900,6 @@ func (proxier *Proxier) syncProxyRules() {
 				// This covers cases like GCE load-balancers which get added to the local routing table.
 				writeLine(proxier.natRules, append(dstLocalOnlyArgs, "-j", string(svcChain))...)
 			} else {
-				// No endpoints.
 				writeLine(proxier.filterRules,
 					"-A", string(kubeExternalServicesChain),
 					"-m", "comment", "--comment", fmt.Sprintf(`"%s has no endpoints"`, svcNameString),
@@ -911,10 +912,10 @@ func (proxier *Proxier) syncProxyRules() {
 		}
 
 		// Capture load-balancer ingress.
-		fwChain := svcInfo.serviceFirewallChainName
-		for _, ingress := range svcInfo.LoadBalancerStatus.Ingress {
-			if ingress.IP != "" {
-				if hasEndpoints {
+		if hasEndpoints {
+			fwChain := svcInfo.serviceFirewallChainName
+			for _, ingress := range svcInfo.LoadBalancerStatus.Ingress {
+				if ingress.IP != "" {
 					// create service firewall chain
 					if chain, ok := existingNATChains[fwChain]; ok {
 						writeBytesLine(proxier.natChains, chain)
@@ -975,19 +976,10 @@ func (proxier *Proxier) syncProxyRules() {
 					// If the packet was able to reach the end of firewall chain, then it did not get DNATed.
 					// It means the packet cannot go thru the firewall, then mark it for DROP
 					writeLine(proxier.natRules, append(args, "-j", string(KubeMarkDropChain))...)
-				} else {
-					// No endpoints.
-					writeLine(proxier.filterRules,
-						"-A", string(kubeServicesChain),
-						"-m", "comment", "--comment", fmt.Sprintf(`"%s has no endpoints"`, svcNameString),
-						"-m", protocol, "-p", protocol,
-						"-d", utilproxy.ToCIDR(net.ParseIP(ingress.IP)),
-						"--dport", strconv.Itoa(svcInfo.Port),
-						"-j", "REJECT",
-					)
 				}
 			}
 		}
+		// FIXME: do we need REJECT rules for load-balancer ingress if !hasEndpoints?
 
 		// Capture nodeports.  If we had more than 2 rules it might be
 		// worthwhile to make a new per-service chain for nodeport rules, but
@@ -1069,7 +1061,6 @@ func (proxier *Proxier) syncProxyRules() {
 					writeLine(proxier.natRules, append(args, "-j", string(svcXlbChain))...)
 				}
 			} else {
-				// No endpoints.
 				writeLine(proxier.filterRules,
 					"-A", string(kubeExternalServicesChain),
 					"-m", "comment", "--comment", fmt.Sprintf(`"%s has no endpoints"`, svcNameString),

--- a/test/e2e/framework/networking_utils.go
+++ b/test/e2e/framework/networking_utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -707,127 +708,88 @@ func CheckReachabilityFromPod(expectToBeReachable bool, timeout time.Duration, n
 	Expect(err).NotTo(HaveOccurred())
 }
 
-type HTTPPokeParams struct {
-	Timeout        time.Duration
-	ExpectCode     int // default = 200
-	BodyContains   string
-	RetriableCodes []int
+// Does an HTTP GET, but does not reuse TCP connections
+// This masks problems where the iptables rule has changed, but we don't see it
+// This is intended for relatively quick requests (status checks), so we set a short (5 seconds) timeout
+func httpGetNoConnectionPool(url string) (*http.Response, error) {
+	return httpGetNoConnectionPoolTimeout(url, 5*time.Second)
 }
 
-type HTTPPokeResult struct {
-	Status HTTPPokeStatus
-	Code   int    // HTTP code: 0 if the connection was not made
-	Error  error  // if there was any error
-	Body   []byte // if code != 0
+func httpGetNoConnectionPoolTimeout(url string, timeout time.Duration) (*http.Response, error) {
+	tr := utilnet.SetTransportDefaults(&http.Transport{
+		DisableKeepAlives: true,
+	})
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   timeout,
+	}
+
+	return client.Get(url)
 }
 
-type HTTPPokeStatus string
+func TestReachableHTTP(ip string, port int, request string, expect string) (bool, error) {
+	return TestReachableHTTPWithContent(ip, port, request, expect, nil)
+}
 
-const (
-	HTTPSuccess HTTPPokeStatus = "Success"
-	HTTPError   HTTPPokeStatus = "UnknownError"
-	// Any time we add new errors, we should audit all callers of this.
-	HTTPTimeout     HTTPPokeStatus = "TimedOut"
-	HTTPRefused     HTTPPokeStatus = "ConnectionRefused"
-	HTTPRetryCode   HTTPPokeStatus = "RetryCode"
-	HTTPWrongCode   HTTPPokeStatus = "WrongCode"
-	HTTPBadResponse HTTPPokeStatus = "BadResponse"
-)
+func TestReachableHTTPWithRetriableErrorCodes(ip string, port int, request string, expect string, retriableErrCodes []int) (bool, error) {
+	return TestReachableHTTPWithContentTimeoutWithRetriableErrorCodes(ip, port, request, expect, nil, retriableErrCodes, time.Second*5)
+}
 
-// PokeHTTP tries to connect to a host on a port for a given URL path.  Callers
-// can specify additional success parameters, if desired.
-//
-// The result status will be characterized as precisely as possible, given the
-// known users of this.
-//
-// The result code will be zero in case of any failure to connect, or non-zero
-// if the HTTP transaction completed (even if the other test params make this a
-// failure).
-//
-// The result error will be populated for any status other than Success.
-//
-// The result body will be populated if the HTTP transaction was completed, even
-// if the other test params make this a failure).
-func PokeHTTP(host string, port int, path string, params *HTTPPokeParams) HTTPPokeResult {
-	hostPort := net.JoinHostPort(host, strconv.Itoa(port))
-	url := fmt.Sprintf("http://%s%s", hostPort, path)
+func TestReachableHTTPWithContent(ip string, port int, request string, expect string, content *bytes.Buffer) (bool, error) {
+	return TestReachableHTTPWithContentTimeout(ip, port, request, expect, content, 5*time.Second)
+}
 
-	ret := HTTPPokeResult{}
+func TestReachableHTTPWithContentTimeout(ip string, port int, request string, expect string, content *bytes.Buffer, timeout time.Duration) (bool, error) {
+	return TestReachableHTTPWithContentTimeoutWithRetriableErrorCodes(ip, port, request, expect, content, []int{}, timeout)
+}
 
-	// Sanity check inputs, because it has happened.  These are the only things
-	// that should hard fail the test - they are basically ASSERT()s.
-	if host == "" {
-		Failf("Got empty host for HTTP poke (%s)", url)
-		return ret
+func TestReachableHTTPWithContentTimeoutWithRetriableErrorCodes(ip string, port int, request string, expect string, content *bytes.Buffer, retriableErrCodes []int, timeout time.Duration) (bool, error) {
+
+	ipPort := net.JoinHostPort(ip, strconv.Itoa(port))
+	url := fmt.Sprintf("http://%s%s", ipPort, request)
+	if ip == "" {
+		Failf("Got empty IP for reachability check (%s)", url)
+		return false, nil
 	}
 	if port == 0 {
-		Failf("Got port==0 for HTTP poke (%s)", url)
-		return ret
+		Failf("Got port==0 for reachability check (%s)", url)
+		return false, nil
 	}
 
-	// Set default params.
-	if params == nil {
-		params = &HTTPPokeParams{}
-	}
-	if params.ExpectCode == 0 {
-		params.ExpectCode = http.StatusOK
-	}
+	Logf("Testing HTTP reachability of %v", url)
 
-	Logf("Poking %q", url)
-
-	resp, err := httpGetNoConnectionPoolTimeout(url, params.Timeout)
+	resp, err := httpGetNoConnectionPoolTimeout(url, timeout)
 	if err != nil {
-		ret.Error = err
-		neterr, ok := err.(net.Error)
-		if ok && neterr.Timeout() {
-			ret.Status = HTTPTimeout
-		} else if strings.Contains(err.Error(), "connection refused") {
-			ret.Status = HTTPRefused
-		} else {
-			ret.Status = HTTPError
-		}
-		Logf("Poke(%q): %v", url, err)
-		return ret
+		Logf("Got error testing for reachability of %s: %v", url, err)
+		return false, nil
 	}
-
-	ret.Code = resp.StatusCode
-
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		ret.Status = HTTPError
-		ret.Error = fmt.Errorf("error reading HTTP body: %v", err)
-		Logf("Poke(%q): %v", url, ret.Error)
-		return ret
+		Logf("Got error reading response from %s: %v", url, err)
+		return false, nil
 	}
-	ret.Body = make([]byte, len(body))
-	copy(ret.Body, body)
-
-	if resp.StatusCode != params.ExpectCode {
-		for _, code := range params.RetriableCodes {
+	if resp.StatusCode != 200 {
+		for _, code := range retriableErrCodes {
 			if resp.StatusCode == code {
-				ret.Error = fmt.Errorf("retriable status code: %d", resp.StatusCode)
-				ret.Status = HTTPRetryCode
-				Logf("Poke(%q): %v", url, ret.Error)
-				return ret
+				Logf("Got non-success status %q when trying to access %s, but the error code is retriable", resp.Status, url)
+				return false, nil
 			}
 		}
-		ret.Status = HTTPWrongCode
-		ret.Error = fmt.Errorf("bad status code: %d", resp.StatusCode)
-		Logf("Poke(%q): %v", url, ret.Error)
-		return ret
+		return false, fmt.Errorf("received non-success return status %q trying to access %s; got body: %s",
+			resp.Status, url, string(body))
 	}
-
-	if params.BodyContains != "" && !strings.Contains(string(body), params.BodyContains) {
-		ret.Status = HTTPBadResponse
-		ret.Error = fmt.Errorf("response does not contain expected substring: %q", string(body))
-		Logf("Poke(%q): %v", url, ret.Error)
-		return ret
+	if !strings.Contains(string(body), expect) {
+		return false, fmt.Errorf("received response body without expected substring %q: %s", expect, string(body))
 	}
+	if content != nil {
+		content.Write(body)
+	}
+	return true, nil
+}
 
-	ret.Status = HTTPSuccess
-	Logf("Poke(%q): success", url)
-	return ret
+func TestNotReachableHTTP(ip string, port int) (bool, error) {
+	return TestNotReachableHTTPTimeout(ip, port, 5*time.Second)
 }
 
 func TestNotReachableHTTPTimeout(ip string, port int, timeout time.Duration) (bool, error) {
@@ -853,140 +815,90 @@ func TestNotReachableHTTPTimeout(ip string, port int, timeout time.Duration) (bo
 	return false, nil
 }
 
-// Does an HTTP GET, but does not reuse TCP connections
-// This masks problems where the iptables rule has changed, but we don't see it
-func httpGetNoConnectionPoolTimeout(url string, timeout time.Duration) (*http.Response, error) {
-	tr := utilnet.SetTransportDefaults(&http.Transport{
-		DisableKeepAlives: true,
-	})
-	client := &http.Client{
-		Transport: tr,
-		Timeout:   timeout,
-	}
-
-	return client.Get(url)
-}
-
-type UDPPokeParams struct {
-	Timeout  time.Duration
-	Response string
-}
-
-type UDPPokeResult struct {
-	Status   UDPPokeStatus
-	Error    error  // if there was any error
-	Response []byte // if code != 0
-}
-
-type UDPPokeStatus string
-
-const (
-	UDPSuccess UDPPokeStatus = "Success"
-	UDPError   UDPPokeStatus = "UnknownError"
-	// Any time we add new errors, we should audit all callers of this.
-	UDPTimeout     UDPPokeStatus = "TimedOut"
-	UDPRefused     UDPPokeStatus = "ConnectionRefused"
-	UDPBadResponse UDPPokeStatus = "BadResponse"
-)
-
-// PokeUDP tries to connect to a host on a port and send the given request. Callers
-// can specify additional success parameters, if desired.
-//
-// The result status will be characterized as precisely as possible, given the
-// known users of this.
-//
-// The result error will be populated for any status other than Success.
-//
-// The result response will be populated if the UDP transaction was completed, even
-// if the other test params make this a failure).
-func PokeUDP(host string, port int, request string, params *UDPPokeParams) UDPPokeResult {
-	hostPort := net.JoinHostPort(host, strconv.Itoa(port))
-	url := fmt.Sprintf("udp://%s", hostPort)
-
-	ret := UDPPokeResult{}
-
-	// Sanity check inputs, because it has happened.  These are the only things
-	// that should hard fail the test - they are basically ASSERT()s.
-	if host == "" {
-		Failf("Got empty host for UDP poke (%s)", url)
-		return ret
+func TestReachableUDP(ip string, port int, request string, expect string) (bool, error) {
+	ipPort := net.JoinHostPort(ip, strconv.Itoa(port))
+	uri := fmt.Sprintf("udp://%s", ipPort)
+	if ip == "" {
+		Failf("Got empty IP for reachability check (%s)", uri)
+		return false, nil
 	}
 	if port == 0 {
-		Failf("Got port==0 for UDP poke (%s)", url)
-		return ret
+		Failf("Got port==0 for reachability check (%s)", uri)
+		return false, nil
 	}
 
-	// Set default params.
-	if params == nil {
-		params = &UDPPokeParams{}
-	}
+	Logf("Testing UDP reachability of %v", uri)
 
-	Logf("Poking %v", url)
-
-	con, err := net.Dial("udp", hostPort)
+	con, err := net.Dial("udp", ipPort)
 	if err != nil {
-		ret.Status = UDPError
-		ret.Error = err
-		Logf("Poke(%q): %v", url, err)
-		return ret
+		return false, fmt.Errorf("Failed to dial %s: %v", ipPort, err)
 	}
 
 	_, err = con.Write([]byte(fmt.Sprintf("%s\n", request)))
 	if err != nil {
-		ret.Error = err
-		neterr, ok := err.(net.Error)
-		if ok && neterr.Timeout() {
-			ret.Status = UDPTimeout
-		} else if strings.Contains(err.Error(), "connection refused") {
-			ret.Status = UDPRefused
-		} else {
-			ret.Status = UDPError
-		}
-		Logf("Poke(%q): %v", url, err)
-		return ret
+		return false, fmt.Errorf("Failed to send request: %v", err)
 	}
 
-	if params.Timeout != 0 {
-		err = con.SetDeadline(time.Now().Add(params.Timeout))
-		if err != nil {
-			ret.Status = UDPError
-			ret.Error = err
-			Logf("Poke(%q): %v", url, err)
-			return ret
-		}
-	}
+	var buf []byte = make([]byte, len(expect)+1)
 
-	bufsize := len(params.Response) + 1
-	if bufsize == 0 {
-		bufsize = 4096
-	}
-	var buf []byte = make([]byte, bufsize)
-	n, err := con.Read(buf)
+	err = con.SetDeadline(time.Now().Add(3 * time.Second))
 	if err != nil {
-		ret.Error = err
-		neterr, ok := err.(net.Error)
-		if ok && neterr.Timeout() {
-			ret.Status = UDPTimeout
-		} else if strings.Contains(err.Error(), "connection refused") {
-			ret.Status = UDPRefused
-		} else {
-			ret.Status = UDPError
-		}
-		Logf("Poke(%q): %v", url, err)
-		return ret
-	}
-	ret.Response = buf[0:n]
-
-	if params.Response != "" && string(ret.Response) != params.Response {
-		ret.Status = UDPBadResponse
-		ret.Error = fmt.Errorf("response does not match expected string: %q", string(ret.Response))
-		Logf("Poke(%q): %v", url, ret.Error)
-		return ret
+		return false, fmt.Errorf("Failed to set deadline: %v", err)
 	}
 
-	ret.Status = UDPSuccess
-	Logf("Poke(%q): success", url)
-	return ret
+	_, err = con.Read(buf)
+	if err != nil {
+		return false, nil
+	}
+
+	if !strings.Contains(string(buf), expect) {
+		return false, fmt.Errorf("Failed to retrieve %q, got %q", expect, string(buf))
+	}
+
+	Logf("Successfully reached %v", uri)
+	return true, nil
+}
+
+func TestNotReachableUDP(ip string, port int, request string) (bool, error) {
+	ipPort := net.JoinHostPort(ip, strconv.Itoa(port))
+	uri := fmt.Sprintf("udp://%s", ipPort)
+	if ip == "" {
+		Failf("Got empty IP for reachability check (%s)", uri)
+		return false, nil
+	}
+	if port == 0 {
+		Failf("Got port==0 for reachability check (%s)", uri)
+		return false, nil
+	}
+
+	Logf("Testing UDP non-reachability of %v", uri)
+
+	con, err := net.Dial("udp", ipPort)
+	if err != nil {
+		Logf("Confirmed that %s is not reachable", uri)
+		return true, nil
+	}
+
+	_, err = con.Write([]byte(fmt.Sprintf("%s\n", request)))
+	if err != nil {
+		Logf("Confirmed that %s is not reachable", uri)
+		return true, nil
+	}
+
+	var buf []byte = make([]byte, 1)
+
+	err = con.SetDeadline(time.Now().Add(3 * time.Second))
+	if err != nil {
+		return false, fmt.Errorf("Failed to set deadline: %v", err)
+	}
+
+	_, err = con.Read(buf)
+	if err != nil {
+		Logf("Confirmed that %s is not reachable", uri)
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func TestHitNodesFromOutside(externalIP string, httpPort int32, timeout time.Duration, expectedHosts sets.String) error {
@@ -999,12 +911,13 @@ func TestHitNodesFromOutsideWithCount(externalIP string, httpPort int32, timeout
 	hittedHosts := sets.NewString()
 	count := 0
 	condition := func() (bool, error) {
-		result := PokeHTTP(externalIP, int(httpPort), "/hostname", &HTTPPokeParams{Timeout: 1 * time.Second})
-		if result.Status != HTTPSuccess {
+		var respBody bytes.Buffer
+		reached, err := TestReachableHTTPWithContentTimeout(externalIP, int(httpPort), "/hostname", "", &respBody,
+			1*time.Second)
+		if err != nil || !reached {
 			return false, nil
 		}
-
-		hittedHost := strings.TrimSpace(string(result.Body))
+		hittedHost := strings.TrimSpace(respBody.String())
 		if !expectedHosts.Has(hittedHost) {
 			Logf("Error hitting unexpected host: %v, reset counter: %v", hittedHost, count)
 			count = 0

--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -598,7 +598,6 @@ func (j *ServiceTestJig) waitForConditionOrFail(namespace, name string, timeout 
 // name as the jig and runs the "netexec" container.
 func (j *ServiceTestJig) newRCTemplate(namespace string) *v1.ReplicationController {
 	var replicas int32 = 1
-	var grace int64 = 3 // so we don't race with kube-proxy when scaling up/down
 
 	rc := &v1.ReplicationController{
 		ObjectMeta: metav1.ObjectMeta{
@@ -630,7 +629,7 @@ func (j *ServiceTestJig) newRCTemplate(namespace string) *v1.ReplicationControll
 							},
 						},
 					},
-					TerminationGracePeriodSeconds: &grace,
+					TerminationGracePeriodSeconds: new(int64),
 				},
 			},
 		},
@@ -711,28 +710,6 @@ func (j *ServiceTestJig) RunOrFail(namespace string, tweak func(rc *v1.Replicati
 		Failf("Failed waiting for pods to be running: %v", err)
 	}
 	return result
-}
-
-func (j *ServiceTestJig) Scale(namespace string, replicas int) {
-	rc := j.Name
-	scale, err := j.Client.CoreV1().ReplicationControllers(namespace).GetScale(rc, metav1.GetOptions{})
-	if err != nil {
-		Failf("Failed to get scale for RC %q: %v", rc, err)
-	}
-
-	scale.Spec.Replicas = int32(replicas)
-	_, err = j.Client.CoreV1().ReplicationControllers(namespace).UpdateScale(rc, scale)
-	if err != nil {
-		Failf("Failed to scale RC %q: %v", rc, err)
-	}
-	pods, err := j.waitForPodsCreated(namespace, replicas)
-	if err != nil {
-		Failf("Failed waiting for pods: %v", err)
-	}
-	if err := j.waitForPodsReady(namespace, pods); err != nil {
-		Failf("Failed waiting for pods to be running: %v", err)
-	}
-	return
 }
 
 func (j *ServiceTestJig) waitForPdbReady(namespace string) error {
@@ -873,19 +850,9 @@ func (j *ServiceTestJig) TestReachableHTTP(host string, port int, timeout time.D
 }
 
 func (j *ServiceTestJig) TestReachableHTTPWithRetriableErrorCodes(host string, port int, retriableErrCodes []int, timeout time.Duration) {
-	pollfn := func() (bool, error) {
-		result := PokeHTTP(host, port, "/echo?msg=hello",
-			&HTTPPokeParams{
-				BodyContains:   "hello",
-				RetriableCodes: retriableErrCodes,
-			})
-		if result.Status == HTTPSuccess {
-			return true, nil
-		}
-		return false, nil // caller can retry
-	}
-
-	if err := wait.PollImmediate(Poll, timeout, pollfn); err != nil {
+	if err := wait.PollImmediate(Poll, timeout, func() (bool, error) {
+		return TestReachableHTTPWithRetriableErrorCodes(host, port, "/echo?msg=hello", "hello", retriableErrCodes)
+	}); err != nil {
 		if err == wait.ErrWaitTimeout {
 			Failf("Could not reach HTTP service through %v:%v after %v", host, port, timeout)
 		} else {
@@ -895,87 +862,36 @@ func (j *ServiceTestJig) TestReachableHTTPWithRetriableErrorCodes(host string, p
 }
 
 func (j *ServiceTestJig) TestNotReachableHTTP(host string, port int, timeout time.Duration) {
-	pollfn := func() (bool, error) {
-		result := PokeHTTP(host, port, "/", nil)
-		if result.Code == 0 {
-			return true, nil
-		}
-		return false, nil // caller can retry
-	}
-
-	if err := wait.PollImmediate(Poll, timeout, pollfn); err != nil {
-		Failf("HTTP service %v:%v reachable after %v: %v", host, port, timeout, err)
-	}
-}
-
-func (j *ServiceTestJig) TestRejectedHTTP(host string, port int, timeout time.Duration) {
-	pollfn := func() (bool, error) {
-		result := PokeHTTP(host, port, "/", nil)
-		if result.Status == HTTPRefused {
-			return true, nil
-		}
-		return false, nil // caller can retry
-	}
-
-	if err := wait.PollImmediate(Poll, timeout, pollfn); err != nil {
-		Failf("HTTP service %v:%v not rejected: %v", host, port, err)
+	if err := wait.PollImmediate(Poll, timeout, func() (bool, error) { return TestNotReachableHTTP(host, port) }); err != nil {
+		Failf("Could still reach HTTP service through %v:%v after %v: %v", host, port, timeout, err)
 	}
 }
 
 func (j *ServiceTestJig) TestReachableUDP(host string, port int, timeout time.Duration) {
-	pollfn := func() (bool, error) {
-		result := PokeUDP(host, port, "echo hello", &UDPPokeParams{
-			Timeout:  3 * time.Second,
-			Response: "hello",
-		})
-		if result.Status == UDPSuccess {
-			return true, nil
-		}
-		return false, nil // caller can retry
-	}
-
-	if err := wait.PollImmediate(Poll, timeout, pollfn); err != nil {
+	if err := wait.PollImmediate(Poll, timeout, func() (bool, error) { return TestReachableUDP(host, port, "echo hello", "hello") }); err != nil {
 		Failf("Could not reach UDP service through %v:%v after %v: %v", host, port, timeout, err)
 	}
 }
 
 func (j *ServiceTestJig) TestNotReachableUDP(host string, port int, timeout time.Duration) {
-	pollfn := func() (bool, error) {
-		result := PokeUDP(host, port, "echo hello", &UDPPokeParams{Timeout: 3 * time.Second})
-		if result.Status != UDPSuccess && result.Status != UDPError {
-			return true, nil
-		}
-		return false, nil // caller can retry
-	}
-	if err := wait.PollImmediate(Poll, timeout, pollfn); err != nil {
-		Failf("UDP service %v:%v reachable after %v: %v", host, port, timeout, err)
-	}
-}
-
-func (j *ServiceTestJig) TestRejectedUDP(host string, port int, timeout time.Duration) {
-	pollfn := func() (bool, error) {
-		result := PokeUDP(host, port, "echo hello", &UDPPokeParams{Timeout: 3 * time.Second})
-		if result.Status == UDPRefused {
-			return true, nil
-		}
-		return false, nil // caller can retry
-	}
-	if err := wait.PollImmediate(Poll, timeout, pollfn); err != nil {
-		Failf("UDP service %v:%v not rejected: %v", host, port, err)
+	if err := wait.PollImmediate(Poll, timeout, func() (bool, error) { return TestNotReachableUDP(host, port, "echo hello") }); err != nil {
+		Failf("Could still reach UDP service through %v:%v after %v: %v", host, port, timeout, err)
 	}
 }
 
 func (j *ServiceTestJig) GetHTTPContent(host string, port int, timeout time.Duration, url string) bytes.Buffer {
 	var body bytes.Buffer
+	var err error
 	if pollErr := wait.PollImmediate(Poll, timeout, func() (bool, error) {
-		result := PokeHTTP(host, port, url, nil)
-		if result.Status == HTTPSuccess {
-			body.Write(result.Body)
-			return true, nil
+		var result bool
+		result, err = TestReachableHTTPWithContent(host, port, url, "", &body)
+		if err != nil {
+			Logf("Error hitting %v:%v%v, retrying: %v", host, port, url, err)
+			return false, nil
 		}
-		return false, nil
+		return result, nil
 	}); pollErr != nil {
-		Failf("Could not reach HTTP service through %v:%v%v after %v: %v", host, port, url, timeout, pollErr)
+		Failf("Could not reach HTTP service through %v:%v%v after %v: %v", host, port, url, timeout, err)
 	}
 	return body
 }
@@ -988,7 +904,7 @@ func testHTTPHealthCheckNodePort(ip string, port int, request string) (bool, err
 		return false, fmt.Errorf("Invalid input ip or port")
 	}
 	Logf("Testing HTTP health check on %v", url)
-	resp, err := httpGetNoConnectionPoolTimeout(url, 5*time.Second)
+	resp, err := httpGetNoConnectionPool(url)
 	if err != nil {
 		Logf("Got error testing for reachability of %s: %v", url, err)
 		return false, err

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -18,7 +18,6 @@ package network
 
 import (
 	"fmt"
-	"time"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -183,13 +182,3 @@ var _ = SIGDescribe("Firewall rule", func() {
 		Expect(flag).To(BeTrue())
 	})
 })
-
-func assertNotReachableHTTPTimeout(ip string, port int, timeout time.Duration) {
-	result := framework.PokeHTTP(ip, port, "/", &framework.HTTPPokeParams{Timeout: timeout})
-	if result.Status == framework.HTTPError {
-		framework.Failf("Unexpected error checking for reachability of %s:%d: %v", ip, port, result.Error)
-	}
-	if result.Code != 0 {
-		framework.Failf("Was unexpectedly able to reach %s:%d", ip, port)
-	}
-}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Revert cherry-pick PR #76529: This reverts commit 535e3ad8319013eb0ade43f6a7b4f8d5c74874a7, reversing changes made to 336d7877e7ebc6db449d2aaa55458f2f0678fc3e.

This is because #76529 is making the test [[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]Changes](https://testgrid.k8s.io/sig-release-1.12-blocking#gce-cos-1.12-slow) failing.

@spencerhance  Please create a separate cherry pick PR after fixing the test failures.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/kind failing-test