### PR TITLE
fix shellcheck failures on and verify-test-featuregates.sh

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -42,7 +42,6 @@
 ./hack/verify-codegen.sh
 ./hack/verify-golint.sh
 ./hack/verify-no-vendor-cycles.sh
-./hack/verify-test-featuregates.sh
 ./test/cmd/apply.sh
 ./test/cmd/apps.sh
 ./test/cmd/authorization.sh

--- a/hack/verify-openapi-spec.sh
+++ b/hack/verify-openapi-spec.sh
@@ -32,7 +32,7 @@ _tmp="${KUBE_ROOT}/_tmp"
 
 mkdir -p "${_tmp}"
 cp -a "${SPECROOT}" "${TMP_SPECROOT}"
-trap 'cp -a "${TMP_SPECROOT}" "${SPECROOT}"/..; rm -rf "${_tmp}"' EXIT SIGINT
+trap 'cp -a ${TMP_SPECROOT} ${SPECROOT}/..; rm -rf ${_tmp}' EXIT SIGINT
 rm "${SPECROOT}"/*
 cp "${TMP_SPECROOT}/BUILD" "${SPECROOT}/BUILD"
 cp "${TMP_SPECROOT}/README.md" "${SPECROOT}/README.md"

--- a/hack/verify-test-featuregates.sh
+++ b/hack/verify-test-featuregates.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 cd "${KUBE_ROOT}"
@@ -26,7 +26,7 @@ cd "${KUBE_ROOT}"
 rc=0
 
 # find test files accessing the mutable global feature gate or interface
-direct_sets=$(grep -n --include *_test.go -R 'MutableFeatureGate' . 2>/dev/null) || true
+direct_sets=$(grep -n --include './*_test.go' -R 'MutableFeatureGate' . 2>/dev/null) || true
 if [[ -n "${direct_sets}" ]]; then
   echo "Test files may not access mutable global feature gates directly:" >&2
   echo "${direct_sets}" >&2
@@ -38,7 +38,7 @@ if [[ -n "${direct_sets}" ]]; then
 fi
 
 # find test files calling SetFeatureGateDuringTest and not calling the result
-missing_defers=$(grep -n --include *_test.go -R 'SetFeatureGateDuringTest' . 2>/dev/null | egrep -v "defer .*\\)\\(\\)$") || true
+missing_defers=$(grep -n --include './*_test.go' -R 'SetFeatureGateDuringTest' . 2>/dev/null | grep -E -v "defer .*\\)\\(\\)$") || true
 if [[ -n "${missing_defers}" ]]; then
   echo "Invalid invocations of utilfeaturetesting.SetFeatureGateDuringTest():" >&2
   echo "${missing_defers}" >&2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
/kind cleanup
/priority backlog
/kind cleanup
/sig testing

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #72956

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
