### PR TITLE
reduce memory allocations in GetAllEventsSinceThreadUnsafe

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -45,6 +45,10 @@ import (
 	utilfeaturetesting "k8s.io/apiserver/pkg/util/feature/testing"
 )
 
+var (
+	objectType = reflect.TypeOf(&v1.Pod{})
+)
+
 // verifies the cacheWatcher.process goroutine is properly cleaned up even if
 // the writes to cacheWatcher.result channel is blocked.
 func TestCacheWatcherCleanupNotBlockedByResult(t *testing.T) {
@@ -67,8 +71,8 @@ func TestCacheWatcherCleanupNotBlockedByResult(t *testing.T) {
 	}
 	// set the size of the buffer of w.result to 0, so that the writes to
 	// w.result is blocked.
-	w = newCacheWatcher(0, filter, forget, testVersioner{}, time.Now(), false)
-	go w.process(context.Background(), initEvents, 0)
+	w = newCacheWatcher(0, filter, forget, testVersioner{}, time.Now(), false, objectType)
+	go w.process(context.Background(), newCacheEventsIterator(initEvents), 0)
 	w.Stop()
 	if err := wait.PollImmediate(1*time.Second, 5*time.Second, func() (bool, error) {
 		lock.RLock()
@@ -187,8 +191,8 @@ TestCase:
 			testCase.events[j].ResourceVersion = uint64(j) + 1
 		}
 
-		w := newCacheWatcher(0, filter, forget, testVersioner{}, time.Now(), false)
-		go w.process(context.Background(), testCase.events, 0)
+		w := newCacheWatcher(0, filter, forget, testVersioner{}, time.Now(), false, objectType)
+		go w.process(context.Background(), newCacheEventsIterator(testCase.events), 0)
 
 		ch := w.ResultChan()
 		for j, event := range testCase.expected {
@@ -466,7 +470,7 @@ func TestCacheWatcherStoppedInAnotherGoroutine(t *testing.T) {
 	// timeout to zero and run the Stop goroutine concurrently.
 	// May sure that the watch will not be blocked on Stop.
 	for i := 0; i < maxRetriesToProduceTheRaceCondition; i++ {
-		w = newCacheWatcher(0, filter, forget, testVersioner{}, time.Now(), false)
+		w = newCacheWatcher(0, filter, forget, testVersioner{}, time.Now(), false, objectType)
 		go w.Stop()
 		select {
 		case <-done:
@@ -478,7 +482,7 @@ func TestCacheWatcherStoppedInAnotherGoroutine(t *testing.T) {
 	deadline := time.Now().Add(time.Hour)
 	// After that, verifies the cacheWatcher.process goroutine works correctly.
 	for i := 0; i < maxRetriesToProduceTheRaceCondition; i++ {
-		w = newCacheWatcher(2, filter, emptyFunc, testVersioner{}, deadline, false)
+		w = newCacheWatcher(2, filter, emptyFunc, testVersioner{}, deadline, false, objectType)
 		w.input <- &watchCacheEvent{Object: &v1.Pod{}, ResourceVersion: uint64(i + 1)}
 		ctx, _ := context.WithDeadline(context.Background(), deadline)
 		go w.process(ctx, nil, 0)
@@ -498,7 +502,7 @@ func TestTimeBucketWatchersBasic(t *testing.T) {
 	forget := func() {}
 
 	newWatcher := func(deadline time.Time) *cacheWatcher {
-		return newCacheWatcher(0, filter, forget, testVersioner{}, deadline, true)
+		return newCacheWatcher(0, filter, forget, testVersioner{}, deadline, true, objectType)
 	}
 
 	clock := clock.NewFakeClock(time.Now())


### PR DESCRIPTION
Ref #73958

Reduce memory copy by improving the cyclic buffer of events.

@wojtek-t