### PR TITLE
webhook: support exec auth plugin

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/authentication.go
@@ -196,6 +196,9 @@ func restConfigFromKubeconfig(configAuthInfo *clientcmdapi.AuthInfo) (*rest.Conf
 		config.Username = configAuthInfo.Username
 		config.Password = configAuthInfo.Password
 	}
+	if configAuthInfo.Exec != nil {
+		config.ExecProvider = configAuthInfo.Exec.DeepCopy()
+	}
 	if configAuthInfo.AuthProvider != nil {
 		return nil, fmt.Errorf("auth provider not supported")
 	}


### PR DESCRIPTION
This allows webhook static kubeconfig to use an exec auth plugin to
configure authentication.

https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers

```release-note
NONE
```

cc @liggitt 
