### PR TITLE
MOD: support wildcard DNS for apiserver certSANs

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -308,8 +308,10 @@ func ValidateCertSANs(altnames []string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for _, altname := range altnames {
 		if errs := validation.IsDNS1123Subdomain(altname); len(errs) != 0 {
-			if net.ParseIP(altname) == nil {
-				allErrs = append(allErrs, field.Invalid(fldPath, altname, fmt.Sprintf("altname is not a valid IP address or DNS label: %s", strings.Join(errs, "; "))))
+			if errs2 := validation.IsWildcardDNS1123Subdomain(altname); len(errs2) != 0 {
+				if net.ParseIP(altname) == nil {
+					allErrs = append(allErrs, field.Invalid(fldPath, altname, fmt.Sprintf("altname is not a valid IP address or DNS label or Wildcard DNS label: %s; %s", strings.Join(errs, "; "), strings.Join(errs2, "; "))))
+				}
 			}
 		}
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -310,7 +310,7 @@ func ValidateCertSANs(altnames []string, fldPath *field.Path) field.ErrorList {
 		if errs := validation.IsDNS1123Subdomain(altname); len(errs) != 0 {
 			if errs2 := validation.IsWildcardDNS1123Subdomain(altname); len(errs2) != 0 {
 				if net.ParseIP(altname) == nil {
-					allErrs = append(allErrs, field.Invalid(fldPath, altname, fmt.Sprintf("altname is not a valid IP address or DNS label or Wildcard DNS label: %s; %s", strings.Join(errs, "; "), strings.Join(errs2, "; "))))
+					allErrs = append(allErrs, field.Invalid(fldPath, altname, fmt.Sprintf("altname is not a valid IP address, DNS label or a DNS label with subdomain wildcards: %s; %s", strings.Join(errs, "; "), strings.Join(errs2, "; "))))
 				}
 			}
 		}

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -144,6 +144,11 @@ func TestValidateCertSANs(t *testing.T) {
 		{[]string{"my-hostname2", "my.other.subdomain", "10.0.0.10"}, true},    // supported
 		{[]string{"my-hostname", "my.subdomain", "2001:db8::4"}, true},         // supported
 		{[]string{"my-hostname2", "my.other.subdomain", "2001:db8::10"}, true}, // supported
+		{[]string{"*.my-hostname2", "*.my.other.subdomain"}, true},             // supported Wildcard DNS label
+		{[]string{"**.my-hostname2", "my.other.subdomain"}, false},             // not a Wildcard DNS label
+		{[]string{"*.*.my-hostname2", "my.other.subdomain"}, false},            // not a Wildcard DNS label
+		{[]string{"a.*.my-hostname2", "my.other.subdomain"}, false},            // not a Wildcard DNS label
+		{[]string{"*", "my.other.subdomain", "2001:db8::10"}, false},           // not a Wildcard DNS label
 	}
 	for _, rt := range tests {
 		actual := ValidateCertSANs(rt.sans, nil)

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
@@ -443,12 +443,15 @@ func getAltNames(cfg *kubeadmapi.InitConfiguration, certName string) (*certutil.
 // altNames is passed in with a pointer, and the struct is modified
 // valid IP address strings are parsed and added to altNames.IPs as net.IP's
 // RFC-1123 compliant DNS strings are added to altNames.DNSNames as strings
+// RFC-1123 compliant wildcard DNS strings are added to altNames.DNSNames as strings
 // certNames is used to print user facing warnings and should be the name of the cert the altNames will be used for
 func appendSANsToAltNames(altNames *certutil.AltNames, SANs []string, certName string) {
 	for _, altname := range SANs {
 		if ip := net.ParseIP(altname); ip != nil {
 			altNames.IPs = append(altNames.IPs, ip)
 		} else if len(validation.IsDNS1123Subdomain(altname)) == 0 {
+			altNames.DNSNames = append(altNames.DNSNames, altname)
+		} else if len(validation.IsWildcardDNS1123Subdomain(altname)) == 0 {
 			altNames.DNSNames = append(altNames.DNSNames, altname)
 		} else {
 			fmt.Printf(

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
@@ -673,3 +673,31 @@ func TestGetEtcdPeerAltNames(t *testing.T) {
 		})
 	}
 }
+
+func TestAppendSANsToAltNames(t *testing.T) {
+	var tests = []struct {
+		sans     []string
+		expected int
+	}{
+		{[]string{}, 0},
+		{[]string{"abc"}, 1},
+		{[]string{"*.abc"}, 1},
+		{[]string{"**.abc"}, 0},
+		{[]string{"a.*.bc"}, 0},
+		{[]string{"a.*.bc", "abc.def"}, 1},
+		{[]string{"a*.bc", "abc.def"}, 1},
+	}
+	for _, rt := range tests {
+		altNames := certutil.AltNames{}
+		appendSANsToAltNames(&altNames, rt.sans, "foo")
+		actual := len(altNames.DNSNames)
+		if actual != rt.expected {
+			t.Errorf(
+				"failed AppendSANsToAltNames Numbers:\n\texpected: %d\n\t  actual: %d",
+				rt.expected,
+				actual,
+			)
+		}
+	}
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:

It support wildcard certSANs for apiServer, the same as the normal https certificates.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: support sub-domain wildcards in certificate SANs
```
