### PR TITLE
Use e2e.test binary instead of test/e2e in example invocations

### DIFF
--- a/test/e2e/storage/external/README.md
+++ b/test/e2e/storage/external/README.md
@@ -30,11 +30,11 @@ are added for that driver with `External Storage [Driver: <Name>]` as
 prefix.
 
 To run just those tests for the example above, put that content into
-`/tmp/hostpath-testdriver.yaml` and invoke:
+`/tmp/hostpath-testdriver.yaml`, ensure `e2e.test` is in your PATH or current directory (downloaded from a test tarball like https://storage.googleapis.com/kubernetes-release/release/v1.14.0/kubernetes-test-linux-amd64.tar.gz or built via `make WHAT=test/e2e/e2e.test`), and invoke:
 
     ginkgo -p -focus='External.Storage.*csi-hostpath' \
            -skip='\[Feature:|\[Disruptive\]' \
-           ./test/e2e \
+           e2e.test \
            -- \
            -storage.testdriver=/tmp/hostpath-testdriver.yaml
 
@@ -44,6 +44,6 @@ supports them, for example snapshotting:
 
     ginkgo -p -focus='External.Storage.*csi-hostpath.*\[Feature:VolumeSnapshotDataSource\]' \
            -skip='\[Disruptive\]' \
-           ./test/e2e \
+           e2e.test \
            -- \
            -storage.testdriver=/tmp/hostpath-testdriver.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:  ~the example invocation should use the binary instead of ginkgo because ideally the reader will only need to download the e2e.test binary and not need to clone the repo and/or have ginkgo in their PATH~
test/e2e assumes the user has cloned k/k and is working inside it, we want to document the case where the user has downloaded the binary and doesn't need to wait for anything to build

/sig storage

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
