### PR TITLE
PluginWatcher: use RWMutex to repalce Mutex

### DIFF
--- a/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
@@ -44,7 +44,7 @@ type Watcher struct {
 	fsWatcher      *fsnotify.Watcher
 	wg             sync.WaitGroup
 
-	mutex       sync.Mutex
+	mutex       sync.RWMutex
 	handlers    map[string]PluginHandler
 	plugins     map[string]pathInfo
 	pluginsPool map[string]map[string]*sync.Mutex // map[pluginType][pluginName]
@@ -78,8 +78,8 @@ func (w *Watcher) AddHandler(pluginType string, handler PluginHandler) {
 }
 
 func (w *Watcher) getHandler(pluginType string) (PluginHandler, bool) {
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
+	w.mutex.RLock()
+	defer w.mutex.RUnlock()
 
 	h, ok := w.handlers[pluginType]
 	return h, ok
@@ -381,8 +381,8 @@ func (w *Watcher) deRegisterPlugin(socketPath, pluginType, pluginName string) {
 }
 
 func (w *Watcher) getPlugin(socketPath string) (pathInfo, bool) {
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
+	w.mutex.RLock()
+	defer w.mutex.RUnlock()
 
 	plugin, ok := w.plugins[socketPath]
 	return plugin, ok


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

PluginWatcher: use RWMute to repalce Mutex to achieve better performance because RWMutex offers the increased granular control.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
