### PR TITLE
CCM and cloud-provider=external should set node NodeNetworkUnavailable

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -265,7 +265,7 @@ func (kl *Kubelet) initialNode() (*v1.Node, error) {
 		node.Spec.Taints = nodeTaints
 	}
 	// Initially, set NodeNetworkUnavailable to true.
-	if kl.providerRequiresNetworkingConfiguration() {
+	if kl.providerRequiresNetworkingConfiguration() || kl.externalCloudProvider {
 		node.Status.Conditions = append(node.Status.Conditions, v1.NodeCondition{
 			Type:               v1.NodeNetworkUnavailable,
 			Status:             v1.ConditionTrue,


### PR DESCRIPTION
When we use cloud-controller-manager, kubelets specifying “—cloud-provider=external”.
Some cloud-controller-manager (E.g alicloud) will create route info and set NodeNetworkUnavailable to “false”.
So kubelet should init with NodeNetworkUnavailable Condition while specifying “—cloud-provider=external”.This can make this node filtered by predicates in scheduler.And after cloud-controller-manager finish creating route and change NodeNetworkUnavailable,this node will not filtered.

/kind bug

/sig  cloud-provider


```release-note
NONE
```
