### PR TITLE
Update OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -391,8 +391,8 @@ sig-storage-api-reviewers:
 
   
   # sig-windows-api-reviewers:
-  #   - 
-  #   - 
+    - patricklang
+    - michmike
 
   dep-approvers:
     - apelisse

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -384,13 +384,13 @@ aliases:
       - bsalamat
       - k82cn
   
-sig-storage-api-reviewers:
+  sig-storage-api-reviewers:
     - saad-ali
     - msau42
     - jsafrane
 
   
-sig-windows-api-reviewers:
+  sig-windows-api-reviewers:
     - patricklang
     - michmike
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -390,7 +390,7 @@ sig-storage-api-reviewers:
     - jsafrane
 
   
-  # sig-windows-api-reviewers:
+sig-windows-api-reviewers:
     - patricklang
     - michmike
 


### PR DESCRIPTION
adding API reviewers for sig-windows

**Does this PR introduce a user-facing change?**:
```
NONE
```

