### PR TITLE
Fix golint failures of pkg/volume/util/recyclerclient

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -354,7 +354,6 @@ pkg/volume/scaleio
 pkg/volume/storageos
 pkg/volume/testing
 pkg/volume/util/fs
-pkg/volume/util/recyclerclient
 pkg/volume/util/volumepathhandler
 pkg/volume/vsphere_volume
 plugin/pkg/admission/antiaffinity

--- a/pkg/volume/util/recyclerclient/recycler_client.go
+++ b/pkg/volume/util/recyclerclient/recycler_client.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/klog"
 )
 
+// RecycleEventRecorder is a func that defines how to record RecycleEvent.
 type RecycleEventRecorder func(eventtype, message string)
 
 // RecycleVolumeByWatchingPodUntilCompletion is intended for use with volume
@@ -127,9 +128,8 @@ func waitForPod(pod *v1.Pod, recyclerClient recyclerClient, podCh <-chan watch.E
 				if pod.Status.Phase == v1.PodFailed {
 					if pod.Status.Message != "" {
 						return fmt.Errorf(pod.Status.Message)
-					} else {
-						return fmt.Errorf("pod failed, pod.Status.Message unknown.")
 					}
+					return fmt.Errorf("pod failed, pod.Status.Message unknown")
 				}
 
 			case watch.Deleted:
@@ -238,9 +238,8 @@ func (c *realRecyclerClient) WatchPod(name, namespace string, stopChannel chan s
 			case eventEvent, ok := <-eventWatch.ResultChan():
 				if !ok {
 					return
-				} else {
-					eventCh <- eventEvent
 				}
+				eventCh <- eventEvent
 			}
 		}
 	}()
@@ -256,9 +255,8 @@ func (c *realRecyclerClient) WatchPod(name, namespace string, stopChannel chan s
 			case podEvent, ok := <-podWatch.ResultChan():
 				if !ok {
 					return
-				} else {
-					eventCh <- podEvent
 				}
+				eventCh <- podEvent
 			}
 		}
 	}()

--- a/pkg/volume/util/recyclerclient/recycler_client_test.go
+++ b/pkg/volume/util/recyclerclient/recycler_client_test.go
@@ -210,9 +210,8 @@ func (c *mockRecyclerClient) CreatePod(pod *v1.Pod) (*v1.Pod, error) {
 func (c *mockRecyclerClient) GetPod(name, namespace string) (*v1.Pod, error) {
 	if c.pod != nil {
 		return c.pod, nil
-	} else {
-		return nil, fmt.Errorf("pod does not exist")
 	}
+	return nil, fmt.Errorf("pod does not exist")
 }
 
 func (c *mockRecyclerClient) DeletePod(name, namespace string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Fix golint failures of pkg/volume/util/recyclerclient

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
