### PR TITLE
Fix golint failures in cmd/cloud-controller-manager/app/apis/config/v1alpha1

### DIFF
--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults.go
@@ -28,7 +28,8 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-func SetDefaults_CloudControllerManagerConfiguration(obj *CloudControllerManagerConfiguration) {
+// SetDefaultsCloudControllerManagerConfiguration sets the default configuration specific to the cloud-controller-manager.
+func SetDefaultsCloudControllerManagerConfiguration(obj *CloudControllerManagerConfiguration) {
 	zero := metav1.Duration{}
 	if obj.NodeStatusUpdateFrequency == zero {
 		obj.NodeStatusUpdateFrequency = metav1.Duration{Duration: 5 * time.Minute}

--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults_test.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults_test.go
@@ -21,14 +21,14 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestCloudControllerManagerDefaultsRoundTrip(t *testing.T) {
 	ks1 := &CloudControllerManagerConfiguration{}
-	SetDefaults_CloudControllerManagerConfiguration(ks1)
+	SetDefaultsCloudControllerManagerConfiguration(ks1)
 	cm, err := convertObjToConfigMap("CloudControllerManagerConfiguration", ks1)
 	if err != nil {
 		t.Errorf("unexpected ConvertObjToConfigMap error %v", err)

--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/types.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/types.go
@@ -23,6 +23,7 @@ import (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// CloudControllerManagerConfiguration contains elements describing cloud-controller manager.
 type CloudControllerManagerConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/zz_generated.defaults.go
@@ -36,7 +36,7 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 }
 
 func SetObjectDefaults_CloudControllerManagerConfiguration(in *CloudControllerManagerConfiguration) {
-	SetDefaults_CloudControllerManagerConfiguration(in)
+	SetDefaultsCloudControllerManagerConfiguration(in)
 	configv1alpha1.SetDefaults_KubeCloudSharedConfiguration(&in.KubeCloudShared)
 	configv1alpha1.SetDefaults_ServiceControllerConfiguration(&in.ServiceController)
 }

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -1,4 +1,3 @@
-cmd/cloud-controller-manager/app/apis/config/v1alpha1
 cmd/kube-apiserver/app
 cmd/kube-controller-manager/app
 cmd/kube-proxy/app


### PR DESCRIPTION

Part of #68026.

Adds comments to exported function. Renames SetDefaults_CloudControllerManagerConfiguration to SetDefaultsCloudControllerManagerConfiguration and updates all references.

/sig api-machinery
/kind cleanup

```release-note
NONE
```
