### PR TITLE
Split TestLoopbackHostPort into 2 tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config_selfclient_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_selfclient_test.go
@@ -21,7 +21,15 @@ import (
 	"testing"
 )
 
-func TestLoopbackHostPort(t *testing.T) {
+func TestLoopbackHostPortIPv4(t *testing.T) {
+	_, ipv6only, err := isIPv6LoopbackSupported()
+	if err != nil {
+		t.Fatalf("fail to enumerate network interface, %s", err)
+	}
+	if ipv6only {
+		t.Fatalf("no ipv4 loopback interface")
+	}
+
 	host, port, err := LoopbackHostPort("1.2.3.4:443")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -43,8 +51,17 @@ func TestLoopbackHostPort(t *testing.T) {
 	if port != "443" {
 		t.Fatalf("expected 443 as port, got %q", port)
 	}
+}
+func TestLoopbackHostPortIPv6(t *testing.T) {
+	ipv6, _, err := isIPv6LoopbackSupported()
+	if err != nil {
+		t.Fatalf("fail to enumerate network interface, %s", err)
+	}
+	if !ipv6 {
+		t.Fatalf("no ipv6 loopback interface")
+	}
 
-	host, port, err = LoopbackHostPort("[ff06:0:0:0:0:0:0:c3]:443")
+	host, port, err := LoopbackHostPort("[ff06:0:0:0:0:0:0:c3]:443")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -62,8 +79,28 @@ func TestLoopbackHostPort(t *testing.T) {
 	if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() || ip.To4() != nil {
 		t.Fatalf("expected IPv6 host to be loopback, got %q", host)
 	}
-
 	if port != "443" {
 		t.Fatalf("expected 443 as port, got %q", port)
 	}
+}
+
+func isIPv6LoopbackSupported() (ipv6 bool, ipv6only bool, err error) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false, false, err
+	}
+	ipv4 := false
+	for _, address := range addrs {
+		ipnet, ok := address.(*net.IPNet)
+		if !ok || !ipnet.IP.IsLoopback() {
+			continue
+		}
+		if ipnet.IP.To4() == nil {
+			ipv6 = true
+			continue
+		}
+		ipv4 = true
+	}
+	ipv6only = ipv6 && !ipv4
+	return ipv6, ipv6only, nil
 }


### PR DESCRIPTION
firstly, split into two tests: TestLoopbackHostPortIPv4 and  TestLoopbackHostPortIPv6.
then improve error handling, going to fail with explicit error message when run host
that does not support ipv6 or ipv4



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug
> /kind failing-test
> /kind flake

**What this PR does / why we need it**:
fixing a failing test on host that does not support ipv6 loopback.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes: #76393

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
N/A
```


cc @freehan @spiffxp  @dims @timothysc @lavalamp