### PR TITLE
Fix RuntimeClass proto generation

### DIFF
--- a/staging/src/k8s.io/api/node/v1alpha1/doc.go
+++ b/staging/src/k8s.io/api/node/v1alpha1/doc.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+// +k8s:protobuf-gen=package
 // +k8s:openapi-gen=true
 
 // +groupName=node.k8s.io

--- a/staging/src/k8s.io/api/node/v1beta1/doc.go
+++ b/staging/src/k8s.io/api/node/v1beta1/doc.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+// +k8s:protobuf-gen=package
 // +k8s:openapi-gen=true
 
 // +groupName=node.k8s.io


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Protobuf wasn't being correctly generated for the node.k8s.io API group. There weren't any changes that needed to be regenerated, but this was causing https://github.com/kubernetes/kubernetes/pull/75744 to fail.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @caesarxuchao 
/priority important-soon
/sig apimachinery