### PR TITLE
scheduler: fix perf downgrade of cases without presence of (anti-)affinity pods

### DIFF
--- a/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -19,6 +19,7 @@ package priorities
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -63,7 +64,7 @@ type podAffinityPriorityMap struct {
 	nodes []*v1.Node
 	// counts store the mapping from node name to so-far computed score of
 	// the node.
-	counts map[string]float64
+	counts map[string]*int64
 	// The first error that we faced.
 	firstError error
 }
@@ -71,7 +72,7 @@ type podAffinityPriorityMap struct {
 func newPodAffinityPriorityMap(nodes []*v1.Node) *podAffinityPriorityMap {
 	return &podAffinityPriorityMap{
 		nodes:  nodes,
-		counts: make(map[string]float64, len(nodes)),
+		counts: make(map[string]*int64, len(nodes)),
 	}
 }
 
@@ -83,7 +84,7 @@ func (p *podAffinityPriorityMap) setError(err error) {
 	}
 }
 
-func (p *podAffinityPriorityMap) processTerm(term *v1.PodAffinityTerm, podDefiningAffinityTerm, podToCheck *v1.Pod, fixedNode *v1.Node, weight float64) {
+func (p *podAffinityPriorityMap) processTerm(term *v1.PodAffinityTerm, podDefiningAffinityTerm, podToCheck *v1.Pod, fixedNode *v1.Node, weight int64) {
 	namespaces := priorityutil.GetNamespacesFromPodAffinityTerm(podDefiningAffinityTerm, term)
 	selector, err := metav1.LabelSelectorAsSelector(term.LabelSelector)
 	if err != nil {
@@ -92,22 +93,18 @@ func (p *podAffinityPriorityMap) processTerm(term *v1.PodAffinityTerm, podDefini
 	}
 	match := priorityutil.PodMatchesTermsNamespaceAndSelector(podToCheck, namespaces, selector)
 	if match {
-		func() {
-			p.Lock()
-			defer p.Unlock()
-			for _, node := range p.nodes {
-				if priorityutil.NodesHaveSameTopologyKey(node, fixedNode, term.TopologyKey) {
-					p.counts[node.Name] += weight
-				}
+		for _, node := range p.nodes {
+			if priorityutil.NodesHaveSameTopologyKey(node, fixedNode, term.TopologyKey) {
+				atomic.AddInt64(p.counts[node.Name], weight)
 			}
-		}()
+		}
 	}
 }
 
 func (p *podAffinityPriorityMap) processTerms(terms []v1.WeightedPodAffinityTerm, podDefiningAffinityTerm, podToCheck *v1.Pod, fixedNode *v1.Node, multiplier int) {
 	for i := range terms {
 		term := &terms[i]
-		p.processTerm(&term.PodAffinityTerm, podDefiningAffinityTerm, podToCheck, fixedNode, float64(term.Weight*int32(multiplier)))
+		p.processTerm(&term.PodAffinityTerm, podDefiningAffinityTerm, podToCheck, fixedNode, int64(term.Weight*int32(multiplier)))
 	}
 }
 
@@ -121,17 +118,17 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 	hasAffinityConstraints := affinity != nil && affinity.PodAffinity != nil
 	hasAntiAffinityConstraints := affinity != nil && affinity.PodAntiAffinity != nil
 
-	allNodeNames := make([]string, 0, len(nodeNameToInfo))
-	for name := range nodeNameToInfo {
-		allNodeNames = append(allNodeNames, name)
-	}
-
-	// convert the topology key based weights to the node name based weights
-	var maxCount float64
-	var minCount float64
 	// priorityMap stores the mapping from node name to so-far computed score of
 	// the node.
 	pm := newPodAffinityPriorityMap(nodes)
+	allNodeNames := make([]string, 0, len(nodeNameToInfo))
+	for name := range nodeNameToInfo {
+		allNodeNames = append(allNodeNames, name)
+		pm.counts[name] = new(int64)
+	}
+
+	// convert the topology key based weights to the node name based weights
+	var maxCount, minCount int64
 
 	processPod := func(existingPod *v1.Pod) error {
 		existingPodNode, err := ipa.info.GetNodeInfo(existingPod.Spec.NodeName)
@@ -172,7 +169,7 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 				//	terms = append(terms, existingPodAffinity.PodAffinity.RequiredDuringSchedulingRequiredDuringExecution...)
 				//}
 				for _, term := range terms {
-					pm.processTerm(&term, existingPod, pod, existingPodNode, float64(ipa.hardPodAffinityWeight))
+					pm.processTerm(&term, existingPod, pod, existingPodNode, int64(ipa.hardPodAffinityWeight))
 				}
 			}
 			// For every soft pod affinity term of <existingPod>, if <pod> matches the term,
@@ -217,11 +214,11 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 	}
 
 	for _, node := range nodes {
-		if pm.counts[node.Name] > maxCount {
-			maxCount = pm.counts[node.Name]
+		if *pm.counts[node.Name] > maxCount {
+			maxCount = *pm.counts[node.Name]
 		}
-		if pm.counts[node.Name] < minCount {
-			minCount = pm.counts[node.Name]
+		if *pm.counts[node.Name] < minCount {
+			minCount = *pm.counts[node.Name]
 		}
 	}
 
@@ -230,7 +227,7 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 	for _, node := range nodes {
 		fScore := float64(0)
 		if (maxCount - minCount) > 0 {
-			fScore = float64(schedulerapi.MaxPriority) * ((pm.counts[node.Name] - minCount) / (maxCount - minCount))
+			fScore = float64(schedulerapi.MaxPriority) * (float64(*pm.counts[node.Name]-minCount) / float64(maxCount-minCount))
 		}
 		result = append(result, schedulerapi.HostPriority{Host: node.Name, Score: int(fScore)})
 		if klog.V(10) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig scheduling
/assign @bsalamat @ravisantoshgudimetla 

**What this PR does / why we need it**:

- **Some background:** #76243 was introduced to improve pod affinity, but it sorts of [regress](https://github.com/kubernetes/kubernetes/pull/76243#issuecomment-482662126) other usecases, so we [reverted](https://github.com/kubernetes/kubernetes/pull/76547) that PR.

- **Root cause of old PR**: For a typical kubemark test, it just runs some regular workloads. No affinity pods are involved in. With that said, the mutex in inter-podaffinity priority is actually a non-op. So, what's the exact overhead old pr brings in? I did a [test](https://gist.github.com/Huang-Wei/a41fe872347e5dd54aaada036f8dda40) and it turns out the allocation of *int64 pointer for each node is the culprit.

- **How this PR fixes the issue**: This PR introduces a dynamic init mechanism for those *int64 pointers. Then in the final score calculation phase, if it's not inited, we simply assign score 0 to it.

- **Benchmark tests for Inter-PodAffinity Priority**: [It](https://docs.google.com/spreadsheets/d/1n4IYssqpeIN1-n7lQjyiFN1sJJdMrU_2WoyQ4VGBcVc/edit?usp=sharing) shows old PR has 60%+ overhead (for cases without affinity pods), and new(this) PR has zero overhead.

- **Can this PR still help PodAffinity cases**: Yes.

**Which issue(s) this PR fixes**:

A robust version of #76243.

**Special notes for your reviewer**:

If you have already reviewed the old PR, just take a look at commit 4bc5476.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

(I guess we shouldn't mention it in release-note again, yes or no?)
