### PR TITLE
AWS EBS provisioner should get node zone info from k8s

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/BUILD
@@ -84,6 +84,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/cloud-provider/volume:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -57,7 +57,7 @@ import (
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/tools/record"
-	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/cloud-provider"
 	nodehelpers "k8s.io/cloud-provider/node/helpers"
 	servicehelpers "k8s.io/cloud-provider/service/helpers"
 	cloudvolume "k8s.io/cloud-provider/volume"
@@ -204,6 +204,16 @@ const volumeAttachmentStuck = "VolumeAttachmentStuck"
 
 // Indicates that a node has volumes stuck in attaching state and hence it is not fit for scheduling more pods
 const nodeWithImpairedVolumes = "NodeWithImpairedVolumes"
+
+const (
+	// These constants help to identify if a node is a master or a minion
+	labelKeyNodeRole    = "kubernetes.io/role"
+	nodeMasterRole      = "master"
+	nodeMinionRole      = "node"
+	labelKeyNodeMaster  = "node-role.kubernetes.io/master"
+	labelKeyNodeCompute = "node-role.kubernetes.io/compute"
+	labelKeyNodeMinion  = "node-role.kubernetes.io/node"
+)
 
 const (
 	// volumeAttachmentConsecutiveErrorLimit is the number of consecutive errors we will ignore when waiting for a volume to attach/detach
@@ -1598,69 +1608,77 @@ func (c *Cloud) InstanceType(ctx context.Context, nodeName types.NodeName) (stri
 // GetCandidateZonesForDynamicVolume retrieves  a list of all the zones in which nodes are running
 // It currently involves querying all instances
 func (c *Cloud) GetCandidateZonesForDynamicVolume() (sets.String, error) {
-	// We don't currently cache this; it is currently used only in volume
-	// creation which is expected to be a comparatively rare occurrence.
+	zones := sets.NewString()
 
-	// TODO: Caching / expose v1.Nodes to the cloud provider?
-	// TODO: We could also query for subnets, I think
-
-	// Note: It is more efficient to call the EC2 API twice with different tag
-	// filters than to call it once with a tag filter that results in a logical
-	// OR. For really large clusters the logical OR will result in EC2 API rate
-	// limiting.
-	instances := []*ec2.Instance{}
-
-	baseFilters := []*ec2.Filter{newEc2Filter("instance-state-name", "running")}
-
-	filters := c.tagging.addFilters(baseFilters)
-	di, err := c.describeInstances(filters)
+	// TODO: list from cache?
+	nodes, err := c.kubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
+		klog.Errorf("Failed to get nodes from api server: %#v", err)
 		return nil, err
 	}
 
-	instances = append(instances, di...)
-
-	if c.tagging.usesLegacyTags {
-		filters = c.tagging.addLegacyFilters(baseFilters)
-		di, err = c.describeInstances(filters)
-		if err != nil {
-			return nil, err
-		}
-
-		instances = append(instances, di...)
-	}
-
-	if len(instances) == 0 {
-		return nil, fmt.Errorf("no instances returned")
-	}
-
-	zones := sets.NewString()
-
-	for _, instance := range instances {
-		// We skip over master nodes, if the installation tool labels them with one of the well-known master labels
-		// This avoids creating a volume in a zone where only the master is running - e.g. #34583
-		// This is a short-term workaround until the scheduler takes care of zone selection
-		master := false
-		for _, tag := range instance.Tags {
-			tagKey := aws.StringValue(tag.Key)
-			if awsTagNameMasterRoles.Has(tagKey) {
-				master = true
-			}
-		}
-
-		if master {
-			klog.V(4).Infof("Ignoring master instance %q in zone discovery", aws.StringValue(instance.InstanceId))
+	for _, n := range nodes.Items {
+		if !c.isNodeReady(&n) {
+			klog.V(4).Infof("Ignoring not ready node %q in zone discovery", n.Name)
 			continue
 		}
-
-		if instance.Placement != nil {
-			zone := aws.StringValue(instance.Placement.AvailabilityZone)
-			zones.Insert(zone)
+		// In some cluster provisioning software, a node can be both a minion and a master. Therefore we white-list
+		// here, and only filter out node that is not minion AND is labeled as master explicitly
+		if c.isMinionNode(&n) || !c.isMasterNode(&n) {
+			if zone, ok := n.Labels[v1.LabelZoneFailureDomain]; ok {
+				zones.Insert(zone)
+			} else {
+				klog.Warningf("Node %s does not have zone label, ignore for zone discovery.", n.Name)
+			}
+		} else {
+			klog.V(4).Infof("Ignoring master node %q in zone discovery", n.Name)
 		}
 	}
 
 	klog.V(2).Infof("Found instances in zones %s", zones)
 	return zones, nil
+}
+
+// isNodeReady checks node condition and return true if NodeReady is marked as true
+func (c *Cloud) isNodeReady(node *v1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == v1.NodeReady {
+			return c.Status == v1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// isMasterNode checks if the node is labeled as master
+func (c *Cloud) isMasterNode(node *v1.Node) bool {
+	// Master node has one or more of the following labels:
+	//
+	// 	kubernetes.io/role: master
+	//	node-role.kubernetes.io/master: ""
+	//	node-role.kubernetes.io/master: "true"
+	if val, ok := node.Labels[labelKeyNodeMaster]; ok && val != "false" {
+		return true
+	} else if role, ok := node.Labels[labelKeyNodeRole]; ok && role == nodeMasterRole {
+		return true
+	}
+	return false
+}
+
+// isMinionNode checks if the node is labeled as minion
+func (c *Cloud) isMinionNode(node *v1.Node) bool {
+	// Minion node has one or more oof the following labels:
+	//
+	// 	kubernetes.io/role: "node"
+	//	node-role.kubernetes.io/compute: "true"
+	//	node-role.kubernetes.io/node: ""
+	if val, ok := node.Labels[labelKeyNodeMinion]; ok && val != "false" {
+		return true
+	} else if val, ok := node.Labels[labelKeyNodeCompute]; ok && val != "false" {
+		return true
+	} else if role, ok := node.Labels[labelKeyNodeRole]; ok && role == nodeMinionRole {
+		return true
+	}
+	return false
 }
 
 // GetZone implements Zones.GetZone


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR changed the implementation of `GetCandidateZonesForDynamicVolume()` in aws library to get information from k8s master instead of cloud provider. This eliminates all calls to cloud provider and allows us to provision volume much faster - without this change, we were only able to create 1 PVC every 2~5 sec to avoid too many `Server.Unavailable` from ec2, but with this change, we are able to create 50 PVCs at a time, all PVC got bound within 30sec, and all related Pods started running within 90sec.

**Which issue(s) this PR fixes**:
Fixes #76975

**Special notes for your reviewer**:
1. Please provide insights about whether we should fall back to querying cloud provider if we don't find zone labels.
2. Semantic wide I think since this call is no longer related with aws, and could be moved to `aws_ebs.go`, but since we are already adding k8s api exposure in aws library, and this also includes minimum change, I think just changing `GetCandidateZonesForDynamicVolume()` could be the best fix.


**Release note:**
```release-note
`aws-cloud-provider` service account in the `kube-system` namespace need to be granted with list node permission with this optimization
```

/assign @zhan849 @mcrute @justinsb @micahhausler
