### PR TITLE
Fix a condition a Failure Status is returned but treated as success.

### DIFF
--- a/pkg/kubectl/cmd/create/create.go
+++ b/pkg/kubectl/cmd/create/create.go
@@ -97,11 +97,11 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 	o := NewCreateOptions(ioStreams)
 
 	cmd := &cobra.Command{
-		Use:                   "create -f FILENAME",
+		Use: "create -f FILENAME",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Create a resource from a file or from stdin."),
-		Long:                  createLong,
-		Example:               createExample,
+		Short:   i18n.T("Create a resource from a file or from stdin."),
+		Long:    createLong,
+		Example: createExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames, o.FilenameOptions.Kustomize) {
 				ioStreams.ErrOut.Write([]byte("Error: must specify one of -f and -k\n\n"))
@@ -453,6 +453,11 @@ func (o *CreateSubcommandOptions) Run() error {
 		actualObject, err := o.DynamicClient.Resource(mapping.Resource).Namespace(o.Namespace).Create(asUnstructured, metav1.CreateOptions{})
 		if err != nil {
 			return err
+		}
+
+		status, ok := actualObject.(*metav1.Status)
+		if ok && status.Status == "Failure" {
+			return fmt.Errorf("An error occured creating the object (%s)", status.Message)
 		}
 
 		// ensure we pass a versioned object to the printer


### PR DESCRIPTION
/kind bug

So if an admission controller rejects a request, it returns `200` and a `Status` object with `Status.Status` set to `Failure`.

In this situation, this doesn't show up as an error, and kubectl behaves as if the object was created (which it wasn't) and prints the Status object (which isn't the object that the user expects)

Fix this, by testing to see if the returned object is a `Status` and looking for the return field, and converting to an `error` if appropriate.

```release-note
Fix a bug in kubectl where a `Failure` status would be reported as success.
```
