### PR TITLE
specify azure file share name in azure file plugin

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_file.go
+++ b/pkg/cloudprovider/providers/azure/azure_file.go
@@ -60,8 +60,12 @@ func (f *azureFileClient) createFileShare(accountName, accountKey, name string, 
 	}
 	share := fileClient.GetShareReference(name)
 	share.Properties.Quota = sizeGiB
-	if err = share.Create(nil); err != nil {
+	newlyCreated, err := share.CreateIfNotExists(nil)
+	if err != nil {
 		return fmt.Errorf("failed to create file share, err: %v", err)
+	}
+	if !newlyCreated {
+		klog.V(2).Infof("file share(%s) under account(%s) already exists", name, accountName)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR let user
 - could specify azure file share name in azure file plugin
 - use existing azure file share  in azure file plugin

```
---
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: azurefile
provisioner: kubernetes.io/azure-file
parameters:
  skuName: Standard_LRS
  resourceGroup: EXISTING_RESOURCE_GROUP_NAME
  storageAccount: EXISTING_STORAGE_ACCOUNT_NAME
  shareName: SHARE_NAME
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #76986

**Special notes for your reviewer**:
add shareName param in azure file storage class

**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
specify azure file share name in azure file plugin
```

/kind bug
/assign @feiskyer 
/priority important-soon
/sig azure

/test pull-kubernetes-e2e-aks-engine-azure