### PR TITLE
Fix golint failures of pkg/registry/rbac/clusterrole

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -285,7 +285,6 @@ pkg/registry/networking/rest
 pkg/registry/node/rest
 pkg/registry/policy/poddisruptionbudget/storage
 pkg/registry/policy/rest
-pkg/registry/rbac/clusterrole
 pkg/registry/rbac/clusterrole/policybased
 pkg/registry/rbac/clusterrolebinding
 pkg/registry/rbac/clusterrolebinding/policybased

--- a/pkg/registry/rbac/clusterrole/doc.go
+++ b/pkg/registry/rbac/clusterrole/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package certificates provides Registry interface and its RESTStorage
+// Package clusterrole provides Registry interface and its RESTStorage
 // implementation for storing ClusterRole objects.
 package clusterrole // import "k8s.io/kubernetes/pkg/registry/rbac/clusterrole"

--- a/pkg/registry/rbac/clusterrole/registry.go
+++ b/pkg/registry/rbac/clusterrole/registry.go
@@ -61,6 +61,7 @@ type AuthorizerAdapter struct {
 	Registry Registry
 }
 
+// GetClusterRole returns the corresponding ClusterRole by name
 func (a AuthorizerAdapter) GetClusterRole(name string) (*rbacv1.ClusterRole, error) {
 	return a.Registry.GetClusterRole(genericapirequest.NewContext(), name, &metav1.GetOptions{})
 }

--- a/pkg/registry/rbac/clusterrole/strategy.go
+++ b/pkg/registry/rbac/clusterrole/strategy.go
@@ -34,7 +34,7 @@ type strategy struct {
 	names.NameGenerator
 }
 
-// strategy is the default logic that applies when creating and updating
+// Strategy is the default logic that applies when creating and updating
 // ClusterRole objects.
 var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Fix golint failures of pkg/registry/rbac/clusterrole

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
