### PR TITLE
Recogize status error in 200 response after decoding in dynamic client

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/BUILD
+++ b/staging/src/k8s.io/client-go/dynamic/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = ["client_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
@@ -33,6 +34,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/dynamic",
     importpath = "k8s.io/client-go/dynamic",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",


### PR DESCRIPTION
/kind bug
/sig api-machinery
/cc @kubernetes/sig-api-machinery-misc 

@brendandburns 

Fixes: #76984

when server is returning error w/ a status object in a 200 response, the dynamic should unpack the unstructured object and take out the error. note that in the non-dynamic client, we're decoding using the dynamic decoder so the status will be recognized. 

https://github.com/kubernetes/kubernetes/blob/5a790bce3b222b7fd1ef1225e3b20700c577088a/staging/src/k8s.io/client-go/rest/request.go#L1112-L1124



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
