### PR TITLE
proxy: ipvs improvements

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -168,8 +168,12 @@ const sysctlForward = "net/ipv4/ip_forward"
 const sysctlArpIgnore = "net/ipv4/conf/all/arp_ignore"
 const sysctlArpAnnounce = "net/ipv4/conf/all/arp_announce"
 
-const ipvsServiceSchedulerAnnotation = "proxy.ipvs.alpha.k8s.io/scheduler"
-const ipvsServiceLocalEndpointWeightAnnotation = "proxy.ipvs.alpha.k8s.io/local-endpoint-weight"
+// ipvsServiceSchedulerAnnotation allows specifying ipvs scheduler name per service.
+// The valid values are: rr, wrr, lc, wlc, lblc, lblcr, sh, dh, sed, nq.
+const ipvsServiceSchedulerAnnotation = "kube-proxy.kubernetes.io/ipvs-scheduler"
+// ipvsServiceLocalEndpointWeightAnnotation allows specifying a weight for ipvs real server
+// that located in on the current node.
+const ipvsServiceLocalEndpointWeightAnnotation = "kube-proxy.kubernetes.io/ipvs-local-endpoint-weight"
 
 // Proxier is an ipvs based proxy for connections between a localhost:lport
 // and services that provide the actual backends.

--- a/pkg/proxy/ipvs/testing/util.go
+++ b/pkg/proxy/ipvs/testing/util.go
@@ -36,8 +36,9 @@ type ExpectedVirtualServer struct {
 
 // ExpectedRealServer is the expected ipvs RealServer
 type ExpectedRealServer struct {
-	IP   string
-	Port uint16
+	IP     string
+	Port   uint16
+	Weight int
 }
 
 // ExpectedIptablesChain is a map of expected iptables chain and jump rules

--- a/pkg/proxy/ipvs/testing/util.go
+++ b/pkg/proxy/ipvs/testing/util.go
@@ -23,13 +23,15 @@ import (
 // ExpectedVirtualServer is the expected ipvs rules with VirtualServer and RealServer
 // VSNum is the expected ipvs virtual server number
 // IP:Port protocol is the expected ipvs vs info
+// Scheduler is a virtual server scheduler method
 // RS is the RealServer of this expected VirtualServer
 type ExpectedVirtualServer struct {
-	VSNum    int
-	IP       string
-	Port     uint16
-	Protocol string
-	RS       []ExpectedRealServer
+	VSNum     int
+	IP        string
+	Port      uint16
+	Protocol  string
+	Scheduler string
+	RS        []ExpectedRealServer
 }
 
 // ExpectedRealServer is the expected ipvs RealServer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind feature


**What this PR does / why we need it**:
1. Sometimes it is useful to specify ipvs scheduler per service. This patch addresses this issue by adding a new annotation to the service spec. See another feature request #58329
2. Sometimes it is preferable to route traffic to local real servers. For example, if we have dns servers. This patch also addresses this issue by adding a new annotation to the service spec.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #58329

**Special notes for your reviewer**:
Maybe it worth to split this pr into two ones? Let me know, please.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
