### PR TITLE
Copy object sent to validating admission

### DIFF
--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -89,7 +89,7 @@ func (r *EvictionREST) Create(ctx context.Context, obj runtime.Object, createVal
 	pod := obj.(*api.Pod)
 
 	if createValidation != nil {
-		if err := createValidation(eviction); err != nil {
+		if err := createValidation(eviction.DeepCopyObject()); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -150,7 +150,7 @@ func (r *BindingREST) Create(ctx context.Context, obj runtime.Object, createVali
 	}
 
 	if createValidation != nil {
-		if err := createValidation(binding); err != nil {
+		if err := createValidation(binding.DeepCopyObject()); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Copies objects before sending them to validating admission. Matches other calls to createValidation()

**Special notes for your reviewer**:
Follow-up from https://github.com/kubernetes/kubernetes/pull/76910

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/priority important-soon
/sig api-machinery
/cc @sbezverk