### PR TITLE
Make the error slightly more readable

### DIFF
--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -132,6 +132,9 @@ func checkErr(err error, handleErr func(string, int)) {
 	case kerrors.IsInvalid(err):
 		details := err.(*kerrors.StatusError).Status().Details
 		s := fmt.Sprintf("The %s %q is invalid", details.Kind, details.Name)
+		if len(details.Kind) == 0 && len(details.Name) == 0 {
+			s = "The request is invalid"
+		}
 		if len(details.Causes) > 0 {
 			errs := statusCausesToAggrError(details.Causes)
 			handleErr(MultilineError(s+": ", errs), DefaultErrorExitCode)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig cli
/priority important-longterm

**What this PR does / why we need it**:
It may happen (usually when invoking patch operation) that the Kind and/or Name will be empty, in those cases we're getting nasty:
`The  "" is invalid`

This fixes the error to slightly more readable form:
`The request is invalid`

**Special notes for your reviewer**:
/assign @juanvallejo 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
