### PR TITLE
Check error when copying from pod

### DIFF
--- a/pkg/kubectl/cmd/cp/cp.go
+++ b/pkg/kubectl/cmd/cp/cp.go
@@ -300,7 +300,8 @@ func (o *CopyOptions) copyFromPod(src, dest fileSpec) error {
 
 	go func() {
 		defer outStream.Close()
-		o.execute(options)
+		err := o.execute(options)
+		cmdutil.CheckErr(err)
 	}()
 	prefix := getPrefix(src.File)
 	prefix = path.Clean(prefix)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When copying from pods we do not print errors if they happen, but when the other direction is being used we nicely inform user of any error. For example when specifying non-existent pod copying to a pod will report:
`Error from server (BadRequest): container xyz is not valid for abc`
whereas in the other direction we're getting:
`error: myfile no such file or directory` 
which is error further down when untarring. 

**Special notes for your reviewer**:
/assign @juanvallejo 

**Does this PR introduce a user-facing change?**:
```release-note
Report cp errors consistently 
```
