### PR TITLE
Cancel checkNode when there are errors

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -491,6 +491,7 @@ func (g *genericScheduler) findNodesThatFit(pod *v1.Pod, nodes []*v1.Node) ([]*v
 				predicateResultLock.Lock()
 				errs[err.Error()]++
 				predicateResultLock.Unlock()
+				cancel()
 				return
 			}
 			if fits {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
For genericScheduler#findNodesThatFit, upon return from workqueue.ParallelizeUntil, we check whether there was error.
If there was error, filtered nodes are not used.

This means we can cancel checkNode processing when there is error.

```release-note
NONE
```
