### PR TITLE
enable proxy admission-webhook and aggr-apiserver to Headless Service

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/proxy.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/proxy.go
@@ -96,8 +96,12 @@ func ResolveCluster(services listersv1.ServiceLister, namespace, id string, port
 	}
 
 	switch {
+	// use service domain for Headless Service
 	case svc.Spec.Type == v1.ServiceTypeClusterIP && svc.Spec.ClusterIP == v1.ClusterIPNone:
-		return nil, fmt.Errorf(`cannot route to service with ClusterIP "None"`)
+		return &url.URL{
+			Scheme: "https",
+			Host:   net.JoinHostPort(fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace), fmt.Sprintf("%d", port)),
+		}, nil
 	// use IP from a clusterIP for these service types
 	case svc.Spec.Type == v1.ServiceTypeClusterIP, svc.Spec.Type == v1.ServiceTypeLoadBalancer, svc.Spec.Type == v1.ServiceTypeNodePort:
 		svcPort, err := findServicePort(svc, port)


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

enable kube-apiserver to proxy admission-webhook and aggr-apiserver to Headless Service

**Which issue(s) this PR fixes**:

Fixes #77018 

**Special notes for your reviewer**:

nothing yet.

**Does this PR introduce a user-facing change?**:

NONE

```release-note
enable kube-apiserver to proxy admission-webhook and aggr-apiserver to Headless Service
```
