### PR TITLE
Bundle multiple creation observations

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -148,6 +148,7 @@ type ControllerExpectationsInterface interface {
 	ExpectCreations(controllerKey string, adds int) error
 	ExpectDeletions(controllerKey string, dels int) error
 	CreationObserved(controllerKey string)
+	CreationsObserved(controllerKey string, add int)
 	DeletionObserved(controllerKey string)
 	RaiseExpectations(controllerKey string, add, del int)
 	LowerExpectations(controllerKey string, add, del int)
@@ -249,6 +250,10 @@ func (r *ControllerExpectations) RaiseExpectations(controllerKey string, add, de
 // CreationObserved atomically decrements the `add` expectation count of the given controller.
 func (r *ControllerExpectations) CreationObserved(controllerKey string) {
 	r.LowerExpectations(controllerKey, 1, 0)
+}
+
+func (r *ControllerExpectations) CreationsObserved(controllerKey string, add int) {
+	r.LowerExpectations(controllerKey, add, 0)
 }
 
 // DeletionObserved atomically decrements the `del` expectation count of the given controller.

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -797,10 +797,8 @@ func (jm *JobController) manageJob(activePods []*v1.Pod, succeeded int32, job *b
 			if errorCount < len(errCh) && skippedPods > 0 {
 				klog.V(2).Infof("Slow-start failure. Skipping creation of %d pods, decrementing expectations for job %q/%q", skippedPods, job.Namespace, job.Name)
 				active -= skippedPods
-				for i := int32(0); i < skippedPods; i++ {
-					// Decrement the expected number of creates because the informer won't observe this pod
-					jm.expectations.CreationObserved(jobKey)
-				}
+				// Decrement the expected number of creates because the informer won't observe this pod
+				jm.expectations.CreationsObserved(jobKey, int(skippedPods))
 				// The skipped pods will be retried later. The next controller resync will
 				// retry the slow start process.
 				break


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently jm.expectations.CreationObserved is called multiple times in JobController#manageJob with addition of 1.

This PR groups the calls into one with number of additions properly set.

```release-note
NONE
```
