### PR TITLE
Changed KubernetesDir to a constant

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -33,9 +33,6 @@ import (
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 )
 
-// KubernetesDir is the directory Kubernetes owns for storing various configuration files
-// This semi-constant MUST NOT be modified during runtime. It's a variable solely for use in unit testing.
-var KubernetesDir = "/etc/kubernetes"
 
 const (
 	// ManifestsSubDirName defines directory name to store manifests
@@ -353,6 +350,10 @@ const (
 
 	// KubeadmCertsSecret specifies in what Secret in the kube-system namespace the certificates should be stored
 	KubeadmCertsSecret = "kubeadm-certs"
+
+	// KubernetesDir is the directory Kubernetes owns for storing various configuration files
+	// This constant MUST NOT be modified during runtime. It's a variable solely for use in unit testing.
+	KubernetesDir = "/etc/kubernetes"
 )
 
 var (


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

This changes KubernetesDir to a constant as per the issue [1531](https://github.com/kubernetes/kubeadm/issues/1531)

**Which issue(s) this PR fixes**:

Fixes [1531](https://github.com/kubernetes/kubeadm/issues/1531)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
