### PR TITLE
Update k8s.gcr.io/k8s-dns-node-cache image version

### DIFF
--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -111,7 +111,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: k8s.gcr.io/k8s-dns-node-cache:1.15.1
+        image: k8s.gcr.io/k8s-dns-node-cache:1.15.2
         resources:
           limits:
             memory: 30Mi


### PR DESCRIPTION
This revised image resolves kubernetes/dns#292 by updating the image from `k8s.gcr.io/k8s-dns-node-cache:1.15.1` to `k8s.gcr.io/k8s-dns-node-cache:1.15.2`