### PR TITLE
use new method to detect cgroup driver

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -66,23 +66,23 @@ func (f fakeExecer) LookPath(file string) (string, error) { return "", errors.Ne
 var (
 	systemdCgroupExecer = fakeExecer{
 		ioMap: map[string]fakeCmd{
-			"docker info": {
-				b: []byte(`Cgroup Driver: systemd`),
+			"docker info -f {{.CgroupDriver}}": {
+				b: []byte(`systemd`),
 			},
 		},
 	}
 
 	cgroupfsCgroupExecer = fakeExecer{
 		ioMap: map[string]fakeCmd{
-			"docker info": {
-				b: []byte(`Cgroup Driver: cgroupfs`),
+			"docker info -f {{.CgroupDriver}}": {
+				b: []byte(`cgroupfs`),
 			},
 		},
 	}
 
 	errCgroupExecer = fakeExecer{
 		ioMap: map[string]fakeCmd{
-			"docker info": {
+			"docker info -f {{.CgroupDriver}}": {
 				err: errors.New("no such binary: docker"),
 			},
 		},

--- a/cmd/kubeadm/app/util/cgroupdriver_test.go
+++ b/cmd/kubeadm/app/util/cgroupdriver_test.go
@@ -23,45 +23,36 @@ import (
 func TestGetCgroupDriverDocker(t *testing.T) {
 	testCases := []struct {
 		name          string
-		info          string
+		driver        string
 		expectedError bool
 	}{
 		{
 			name:          "valid: value is 'cgroupfs'",
-			info:          `Cgroup Driver: cgroupfs`,
+			driver:        `cgroupfs`,
 			expectedError: false,
 		},
 		{
 			name:          "valid: value is 'systemd'",
-			info:          `Cgroup Driver: systemd`,
+			driver:        `systemd`,
 			expectedError: false,
 		},
 		{
-			name:          "invalid: missing 'Cgroup Driver' key and value",
-			info:          "",
-			expectedError: true,
-		},
-		{
-			name:          "invalid: only a 'Cgroup Driver' key is present",
-			info:          `Cgroup Driver`,
-			expectedError: true,
-		},
-		{
 			name:          "invalid: empty 'Cgroup Driver' value",
-			info:          `Cgroup Driver: `,
+			driver:        ``,
 			expectedError: true,
 		},
 		{
 			name:          "invalid: unknown 'Cgroup Driver' value",
-			info:          `Cgroup Driver: invalid-value`,
+			driver:        `invalid-value`,
 			expectedError: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := getCgroupDriverFromDockerInfo(tc.info); (err != nil) != tc.expectedError {
-				t.Fatalf("expected error: %v, saw: %v, error: %v", tc.expectedError, (err != nil), err)
+			result := tc.driver != CgroupDriverCgroupfs && tc.driver != CgroupDriverSystemd
+			if result != tc.expectedError {
+				t.Fatalf("expected error: %v, saw: %v", tc.expectedError, result)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Use new easy method to detect cgroup driver

**Which issue(s) this PR fixes**:

Related to: https://github.com/kubernetes/kubernetes/pull/72831

**Special notes for your reviewer**:

/area kubeadm
sig/cluster-lifecycle

/assign @yagonobre
/assign @neolit123 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```