### PR TITLE
Remove golint failures from pkg/apis/admissionregistration

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -4,7 +4,6 @@ cmd/kube-controller-manager/app
 cmd/kubeadm/app/apis/kubeadm/v1beta1
 pkg/apis/abac/latest
 pkg/apis/admission
-pkg/apis/admissionregistration
 pkg/apis/admissionregistration/v1beta1
 pkg/apis/admissionregistration/validation
 pkg/apis/apps

--- a/pkg/apis/admissionregistration/register.go
+++ b/pkg/apis/admissionregistration/register.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// GroupName is the name used for this API group
 const GroupName = "admissionregistration.k8s.io"
 
 // SchemeGroupVersion is group version used to register these objects
@@ -37,8 +38,10 @@ func Resource(resource string) schema.GroupResource {
 }
 
 var (
+	// SchemeBuilder is the scheme builder with scheme init functions to run for this API package
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
+	// AddToScheme is a global function that registers this API group & version to a scheme
+	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 // Adds the list of known types to scheme.

--- a/pkg/apis/admissionregistration/types.go
+++ b/pkg/apis/admissionregistration/types.go
@@ -63,6 +63,7 @@ type Rule struct {
 	Scope *ScopeType
 }
 
+// ScopeType specifies the type of scope being used
 type ScopeType string
 
 const (
@@ -75,6 +76,7 @@ const (
 	AllScopes ScopeType = "*"
 )
 
+// FailurePolicyType specifies the type of failure policy
 type FailurePolicyType string
 
 const (
@@ -84,6 +86,7 @@ const (
 	Fail FailurePolicyType = "Fail"
 )
 
+// SideEffectClass denotes the type of side effects resulting from calling the webhook
 type SideEffectClass string
 
 const (
@@ -263,6 +266,7 @@ type RuleWithOperations struct {
 	Rule
 }
 
+// OperationType specifies what type of operation the admission hook cares about.
 type OperationType string
 
 // The constants should be kept in sync with those defined in k8s.io/kubernetes/pkg/admission/interface.go.


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Removes golint failures from pkg/apis/admissionregistration

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/kubernetes/issues/68026.

**Special notes for your reviewer**:
Also added `test/integration/apiserver/admissionwebhook` to golint_failures; it is failing on kubernetes/master currently. I'm happy to fix it later if that is off topic for this PR.

```release-note
NONE
```
