### PR TITLE
exclude .idea/ directory from boilerplate checking

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -149,7 +149,7 @@ def file_extension(filename):
 
 skipped_dirs = ['Godeps', 'third_party', '_gopath', '_output', '.git', 'cluster/env.sh',
                 "vendor", "test/e2e/generated/bindata.go", "hack/boilerplate/test",
-                "pkg/kubectl/generated/bindata.go"]
+                "pkg/kubectl/generated/bindata.go", ".idea"]
 
 # list all the files contain 'DO NOT EDIT', but are not generated
 skipped_ungenerated_files = ['hack/lib/swagger.sh', 'hack/boilerplate/boilerplate.py']


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Exclude .idea/ from boilerplate checking for obvious reasons. This script can be further refined to exclude boilerplate checking anything in .gitignore, since files in .gitignore will not be checked in. For now, let's explicitly just ignore this directory.

```release-note
NONE
```
