### PR TITLE
Update some OWNERS files

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -3,14 +3,13 @@
 reviewers:
   - castrojo
   - cblecker
-  - grodrigues3
   - nikhita
   - parispittman
   - Phillels
 approvers:
   - castrojo
   - cblecker
-  - grodrigues3
+  - nikhita
   - parispittman
   - Phillels
 labels:

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -13,5 +13,5 @@ approvers:
   - ixdy
   - jbeda
   - lavalamp
-  - zmerlynn
   - mikedanese
+  - zmerlynn

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -9,30 +9,26 @@ reviewers:
   - jbeda
   - juanvallejo
   - lavalamp
-  - zmerlynn
-  - sttts
-  - gmarek
-  - vishh
-  - spiffxp
   - SataQiu
+  - spiffxp
+  - sttts
+  - vishh
   - xichengliudui
+  - zmerlynn
 approvers:
   - bentheelder
   - cblecker
   - deads2k
+  - dims # for local-up-cluster related files
   - eparis
   - fejta
   - ixdy
   - jbeda
   - lavalamp
-  - madhusudancs
-  - pwittrock
-  - shashidharatd
-  - zmerlynn
-  - sttts
-  - gmarek
-  - vishh
   - liggitt
+  - pwittrock
   - soltysh # for sig-cli related stuff
-  - dims # for local-up-cluster related files
   - spiffxp
+  - sttts
+  - vishh
+  - zmerlynn


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This updates some OWNERS files.

Key changes:
- Swaps out @grodrigues3 for @nikhita in the GitHub issue templates
- Alpha sort the build/ OWNERS file
- Prune and alpha sort the hack/ OWNERS file

I looked at folks who hadn't done an approval in the last 6 months in the `hack/` directory, and pruned out the folks:
- @gmarek 
- @madhusudancs
- @shashidharatd

If any of you three are planning on getting active again and would like me to add you back to the file, please let me know. Will leave this open for a few days for comment.

cc other hack/ OWNERS: @bentheelder, @deads2k, @dims, @eparis, @fejta, @ixdy, @jbeda, @lavalamp, @pwittrock, @liggitt, @soltysh, @spiffxp, @sttts, @vishh, @zmerlynn

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
