### PR TITLE
Broadcast if at least one Pod is moved to active queue

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -623,6 +623,7 @@ func (p *PriorityQueue) AssignedPodUpdated(pod *v1.Pod) {
 func (p *PriorityQueue) MoveAllToActiveQueue() {
 	p.lock.Lock()
 	defer p.lock.Unlock()
+	moved := false
 	for _, pInfo := range p.unschedulableQ.podInfoMap {
 		pod := pInfo.pod
 		if p.isPodBackingOff(pod) {
@@ -632,12 +633,16 @@ func (p *PriorityQueue) MoveAllToActiveQueue() {
 		} else {
 			if err := p.activeQ.Add(pInfo); err != nil {
 				klog.Errorf("Error adding pod %v to the scheduling queue: %v", pod.Name, err)
+			} else {
+				moved = true
 			}
 		}
 	}
 	p.unschedulableQ.clear()
 	p.moveRequestCycle = p.schedulingCycle
-	p.cond.Broadcast()
+	if moved {
+		p.cond.Broadcast()
+	}
 }
 
 // NOTE: this function assumes lock has been acquired in caller


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In PriorityQueue#MoveAllToActiveQueue, p.cond.Broadcast is called unconditionally at the end.
However, if all Pods encounter error during addition to active queue, it seems there is no need to broadcast.

```release-note
NONE
```
