### PR TITLE
Run in privileged remote containers

### DIFF
--- a/build/root/BUILD.root
+++ b/build/root/BUILD.root
@@ -110,10 +110,15 @@ genrule(
 platform(
     name = "rbe_with_network",
     parents = ["@rbe_default//config:platform"],
+    # https://cloud.google.com/remote-build-execution/docs/remote-execution-environment#remote_execution_properties
     remote_execution_properties = """
       properties: {
         name: "dockerNetwork"
         value: "standard"
+      }
+      properties: {
+        name: "dockerPrivileged"
+        value: "true"
       }
       {PARENT_REMOTE_EXECUTION_PROPERTIES}
     """,


### PR DESCRIPTION
/assign @mikedanese @cblecker 

Fixes https://github.com/kubernetes/kubernetes/issues/77040
Fixes https://github.com/kubernetes/kubernetes/issues/77041

Note that the non-rbe job runs in a privileged container whereas the rbe job runs unprivileged.

https://github.com/fejta/test-infra/blob/26216e434963dd74dd1156d276a5aaf2b13b06b8/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml#L133-L191

Looks like the two jobs above must run in a privileged container, but we can limit this privilege to the remote execution and keep the prow container unprivileged.

ref https://github.com/kubernetes/test-infra/issues/12282
<!--
```release-note
NONE
```
-->