### PR TITLE
`kubectl top`: mention Metrics Server is required due to Heapster deperecation

### DIFF
--- a/pkg/kubectl/cmd/top/top.go
+++ b/pkg/kubectl/cmd/top/top.go
@@ -36,7 +36,7 @@ var (
 
 		The top command allows you to see the resource consumption for nodes or pods.
 
-		This command requires Metrics Server to be correctly configured and working on the server. `))
+		This command requires Heapster or its successor Metrics Server to be correctly configured and working on the server. `))
 )
 
 func NewCmdTop(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {

--- a/pkg/kubectl/cmd/top/top.go
+++ b/pkg/kubectl/cmd/top/top.go
@@ -36,7 +36,7 @@ var (
 
 		The top command allows you to see the resource consumption for nodes or pods.
 
-		This command requires Heapster to be correctly configured and working on the server. `))
+		This command requires Metrics Server to be correctly configured and working on the server. `))
 )
 
 func NewCmdTop(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Heapster is deprecated so users should know that Metrics Server is now required for `kubectl top`
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #77047

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubectl top now mentions that [Metrics Server](https://github.com/kubernetes-incubator/metrics-server) is required due to Heapster deprecation. 
```
