### PR TITLE
Bump minimum docker version to 1.13.1 in kubeadm

### DIFF
--- a/cmd/kubeadm/app/util/system/docker_validator_test.go
+++ b/cmd/kubeadm/app/util/system/docker_validator_test.go
@@ -28,7 +28,7 @@ func TestValidateDockerInfo(t *testing.T) {
 		Reporter: DefaultReporter,
 	}
 	spec := &DockerSpec{
-		Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`},
+		Version:     []string{`1\.13\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`},
 		GraphDriver: []string{"driver_1", "driver_2"},
 	}
 	for _, test := range []struct {
@@ -38,32 +38,20 @@ func TestValidateDockerInfo(t *testing.T) {
 		warn bool
 	}{
 		{
-			name: "unsupported Docker version 1.10.1",
-			info: types.Info{Driver: "driver_1", ServerVersion: "1.10.1"},
+			name: "unsupported Docker version 1.12.1",
+			info: types.Info{Driver: "driver_2", ServerVersion: "1.12.1"},
 			err:  true,
 			warn: false,
 		},
 		{
 			name: "unsupported driver",
-			info: types.Info{Driver: "bad_driver", ServerVersion: "1.11.1"},
+			info: types.Info{Driver: "bad_driver", ServerVersion: "1.13.1"},
 			err:  true,
 			warn: false,
 		},
 		{
-			name: "valid Docker version 1.11.1",
-			info: types.Info{Driver: "driver_1", ServerVersion: "1.11.1"},
-			err:  false,
-			warn: false,
-		},
-		{
-			name: "valid Docker version 1.12.1",
-			info: types.Info{Driver: "driver_2", ServerVersion: "1.12.1"},
-			err:  false,
-			warn: false,
-		},
-		{
 			name: "valid Docker version 1.13.1",
-			info: types.Info{Driver: "driver_2", ServerVersion: "1.13.1"},
+			info: types.Info{Driver: "driver_1", ServerVersion: "1.13.1"},
 			err:  false,
 			warn: false,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Bump minimum docker version to 1.13.1, as Kubernetes bumped in #72831

**Which issue(s) this PR fixes**:

Related to: https://github.com/kubernetes/kubernetes/pull/72831

**Special notes for your reviewer**:

/area kubeadm
sig/cluster-lifecycle

/assign @yagonobre
/assign @neolit123 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: bump the minimum supported Docker version to 1.13.1
```