### PR TITLE
Fix shellcheck failures of hack/verify-no-vendor-cycles.sh

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -33,7 +33,6 @@
 ./hack/test-integration.sh
 ./hack/update-vendor.sh
 ./hack/verify-golint.sh
-./hack/verify-no-vendor-cycles.sh
 ./hack/verify-test-featuregates.sh
 ./test/cmd/apply.sh
 ./test/cmd/apps.sh

--- a/hack/verify-no-vendor-cycles.sh
+++ b/hack/verify-no-vendor-cycles.sh
@@ -18,16 +18,20 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 export GO111MODULE=auto
 
-staging_repos=($(ls "${KUBE_ROOT}/staging/src/k8s.io/"))
+staging_repos=()
+while IFS= read -r repo; do
+  staging_repos+=( "${repo}" )
+done < <(ls "${KUBE_ROOT}/staging/src/k8s.io/")
+
 staging_repos_pattern=$(IFS="|"; echo "${staging_repos[*]}")
 
 failed=false
-for i in $(find vendor/ -type d); do
-  deps=$(go list -f '{{range .Deps}}{{.}}{{"\n"}}{{end}}' ./$i 2> /dev/null || echo "")
+while IFS= read -r -d '' i; do
+  deps=$(go list -f '{{range .Deps}}{{.}}{{"\n"}}{{end}}' ./"$i" 2> /dev/null || echo "")
   deps_on_main=$(echo "${deps}" | grep -v "k8s.io/kubernetes/vendor/" | grep "k8s.io/kubernetes" || echo "")
   if [ -n "${deps_on_main}" ]; then
     echo "Package ${i} has a cyclic dependency on the main repository."
@@ -38,7 +42,7 @@ for i in $(find vendor/ -type d); do
     echo "Package ${i} has a cyclic dependency on staging repository packages: ${deps_on_staging}"
     failed=true
   fi
-done
+done < <(find vendor/ -type d)
 
 if [[ "${failed}" == "true" ]]; then
   exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Fix shellcheck failures of hack/verify-no-vendor-cycles.sh

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #72956

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
