### PR TITLE
Follow on for Store parsed CIDRs at initialization of Proxier #76779

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -280,9 +280,11 @@ func parseExcludedCIDRs(excludeCIDRs []string) []*net.IPNet {
 	var cidrExclusions []*net.IPNet
 	for _, excludedCIDR := range excludeCIDRs {
 		_, n, err := net.ParseCIDR(excludedCIDR)
-		if err == nil {
-			cidrExclusions = append(cidrExclusions, n)
+		if err != nil {
+			klog.Errorf("Error parsing exclude CIDR %q,  err: %v", excludedCIDR, err)
+			continue
 		}
+		cidrExclusions = append(cidrExclusions, n)
 	}
 	return cidrExclusions
 }

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -274,11 +274,11 @@ func (r *realIPGetter) NodeIPs() (ips []net.IP, err error) {
 // Proxier implements ProxyProvider
 var _ proxy.ProxyProvider = &Proxier{}
 
-// ParseExcludedCIDRs parses the input strings and returns net.IPNet
+// parseExcludedCIDRs parses the input strings and returns net.IPNet
 // The validation has been done earlier so the error condition will never happen under normal conditions
-func ParseExcludedCIDRs(excludeCIDRStrs []string) []*net.IPNet {
+func parseExcludedCIDRs(excludeCIDRs []string) []*net.IPNet {
 	var cidrExclusions []*net.IPNet
-	for _, excludedCIDR := range excludeCIDRStrs {
+	for _, excludedCIDR := range excludeCIDRs {
 		_, n, err := net.ParseCIDR(excludedCIDR)
 		if err == nil {
 			cidrExclusions = append(cidrExclusions, n)
@@ -299,7 +299,7 @@ func NewProxier(ipt utiliptables.Interface,
 	exec utilexec.Interface,
 	syncPeriod time.Duration,
 	minSyncPeriod time.Duration,
-	excludeCIDRStrs []string,
+	excludeCIDRs []string,
 	strictARP bool,
 	masqueradeAll bool,
 	masqueradeBit int,
@@ -410,7 +410,7 @@ func NewProxier(ipt utiliptables.Interface,
 		endpointsChanges:      proxy.NewEndpointChangeTracker(hostname, nil, &isIPv6, recorder),
 		syncPeriod:            syncPeriod,
 		minSyncPeriod:         minSyncPeriod,
-		excludeCIDRs:          ParseExcludedCIDRs(excludeCIDRStrs),
+		excludeCIDRs:          parseExcludedCIDRs(excludeCIDRs),
 		iptables:              ipt,
 		masqueradeAll:         masqueradeAll,
 		masqueradeMark:        masqueradeMark,

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -2823,7 +2823,7 @@ func TestCleanLegacyService(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ipt, ipvs, ipset, nil, ParseExcludedCIDRs([]string{"3.3.3.0/24", "4.4.4.0/24"}))
+	fp := NewFakeProxier(ipt, ipvs, ipset, nil, parseExcludedCIDRs([]string{"3.3.3.0/24", "4.4.4.0/24"}))
 
 	// All ipvs services that were processed in the latest sync loop.
 	activeServices := map[string]bool{"ipvs0": true, "ipvs1": true}
@@ -2930,7 +2930,7 @@ func TestCleanLegacyRealServersExcludeCIDRs(t *testing.T) {
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
 	gtm := NewGracefulTerminationManager(ipvs)
-	fp := NewFakeProxier(ipt, ipvs, ipset, nil, ParseExcludedCIDRs([]string{"4.4.4.4/32"}))
+	fp := NewFakeProxier(ipt, ipvs, ipset, nil, parseExcludedCIDRs([]string{"4.4.4.4/32"}))
 	fp.gracefuldeleteManager = gtm
 
 	vs := &utilipvs.VirtualServer{
@@ -2984,7 +2984,7 @@ func TestCleanLegacyService6(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ipt, ipvs, ipset, nil, ParseExcludedCIDRs([]string{"3000::/64", "4000::/64"}))
+	fp := NewFakeProxier(ipt, ipvs, ipset, nil, parseExcludedCIDRs([]string{"3000::/64", "4000::/64"}))
 	fp.nodeIP = net.ParseIP("::1")
 
 	// All ipvs services that were processed in the latest sync loop.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR addresses review comments from #76779.

For err checking in parseExcludedCIDRs, I think the current form should be fine since it has 3 lines while the suggested alternative has 4 lines.

```release-note
NONE
```
