### PR TITLE
automatically assign cgroupDriver/resolverConfig in Kubelet config file

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/BUILD
+++ b/cmd/kubeadm/app/cmd/alpha/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//cmd/kubeadm/app/util/config:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
+        "//cmd/kubeadm/app/util/runtime:go_default_library",
         "//pkg/util/normalizer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/duration:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",

--- a/cmd/kubeadm/app/cmd/phases/init/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubelet.go
@@ -70,7 +70,7 @@ func runKubeletStart(c workflow.RunData) error {
 	}
 
 	// Write the kubelet configuration file to disk.
-	if err := kubeletphase.WriteConfigToDisk(data.Cfg().ComponentConfigs.Kubelet, data.KubeletDir()); err != nil {
+	if err := kubeletphase.WriteConfigToDisk(data.Cfg().ComponentConfigs.Kubelet, &data.Cfg().NodeRegistration, data.KubeletDir()); err != nil {
 		return errors.Wrap(err, "error writing kubelet configuration to disk")
 	}
 

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -131,7 +131,7 @@ func runKubeletStartJoinPhase(c workflow.RunData) error {
 	kubeletphase.TryStopKubelet()
 
 	// Write the configuration for the kubelet (using the bootstrap token credentials) to disk so the kubelet can start
-	if err := kubeletphase.DownloadConfig(bootstrapClient, kubeletVersion, kubeadmconstants.KubeletRunDirectory); err != nil {
+	if err := kubeletphase.DownloadConfig(bootstrapClient, kubeletVersion, &initCfg.NodeRegistration, kubeadmconstants.KubeletRunDirectory); err != nil {
 		return err
 	}
 

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
@@ -93,7 +93,7 @@ func runKubeletConfigPhase() func(c workflow.RunData) error {
 		}
 
 		// TODO: Checkpoint the current configuration first so that if something goes wrong it can be recovered
-		if err := kubeletphase.DownloadConfig(client, kubeletVersion, kubeletDir); err != nil {
+		if err := kubeletphase.DownloadAndMergeConfig(client, kubeletVersion, kubeletDir); err != nil {
 			return err
 		}
 

--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -4,6 +4,8 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
+        "config_unix.go",
+        "config_windows.go",
         "dynamic.go",
         "flags.go",
         "kubelet.go",
@@ -12,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/scheme:go_default_library",
         "//cmd/kubeadm/app/componentconfigs:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/images:go_default_library",
@@ -20,17 +23,57 @@ go_library(
         "//pkg/kubelet/apis/config:go_default_library",
         "//pkg/util/initsystem:go_default_library",
         "//pkg/util/node:go_default_library",
-        "//pkg/util/procfs:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
-        "//vendor/k8s.io/utils/exec:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//pkg/util/procfs:go_default_library",
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "//pkg/util/procfs:go_default_library",
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "//pkg/util/procfs:go_default_library",
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "//pkg/util/procfs:go_default_library",
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//pkg/util/procfs:go_default_library",
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "//pkg/util/procfs:go_default_library",
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "//pkg/util/procfs:go_default_library",
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "//pkg/util/procfs:go_default_library",
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "//pkg/util/procfs:go_default_library",
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "//pkg/util/procfs:go_default_library",
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_test(

--- a/cmd/kubeadm/app/phases/kubelet/config_unix.go
+++ b/cmd/kubeadm/app/phases/kubelet/config_unix.go
@@ -1,0 +1,51 @@
+// +build !windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"k8s.io/klog"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/pkg/util/procfs"
+	utilsexec "k8s.io/utils/exec"
+)
+
+// buildDynamicDefaults returns a Kubelet config file with corrected values according to different OS configuration
+func buildDynamicDefaults(kubeletConfig *kubeletconfig.KubeletConfiguration, nodeReg *kubeadmapi.NodeRegistrationOptions) *kubeletconfig.KubeletConfiguration {
+
+	if nodeReg.CRISocket == kubeadmconstants.DefaultDockerCRISocket {
+		driver, err := kubeadmutil.GetCgroupDriverDocker(utilsexec.New())
+		if err != nil {
+			klog.Warningf("cannot automatically assign a cgroupDriver value in the KubeletConfiguration file: %v\n", err)
+		} else {
+			kubeletConfig.CgroupDriver = driver
+		}
+	}
+
+	// TODO: Conditionally set `CgroupDriver` to either `systemd` or `cgroupfs` for CRI other than Docker
+
+	if pids, _ := procfs.PidOf("systemd-resolved"); len(pids) > 0 {
+		// procfs.PidOf only returns an error if the regex is empty or doesn't compile, so we can ignore it
+		kubeletConfig.ResolverConfig = "/run/systemd/resolve/resolv.conf"
+	}
+
+	return kubeletConfig
+}

--- a/cmd/kubeadm/app/phases/kubelet/config_windows.go
+++ b/cmd/kubeadm/app/phases/kubelet/config_windows.go
@@ -1,0 +1,30 @@
+// +build windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+)
+
+// buildDynamicDefaults returns a Kubelet config file with corrected values according to different OS configuration
+// This function is a no-op on Windows
+func buildDynamicDefaults(kubeletConfig *kubeletconfig.KubeletConfiguration, nodeReg *kubeadmapi.NodeRegistrationOptions) *kubeletconfig.KubeletConfiguration {
+	return kubeletConfig
+}

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -118,8 +118,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 						},
 					},
 				},
-				execer:          errCgroupExecer,
-				pidOfFunc:       binaryNotRunningPidOfFunc,
 				defaultHostname: "foo",
 			},
 			expected: map[string]string{
@@ -133,45 +131,11 @@ func TestBuildKubeletArgMap(t *testing.T) {
 					CRISocket: "/var/run/dockershim.sock",
 					Name:      "override-name",
 				},
-				execer:          errCgroupExecer,
-				pidOfFunc:       binaryNotRunningPidOfFunc,
 				defaultHostname: "default",
 			},
 			expected: map[string]string{
 				"network-plugin":    "cni",
 				"hostname-override": "override-name",
-			},
-		},
-		{
-			name: "systemd cgroup driver",
-			opts: kubeletFlagsOpts{
-				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
-					CRISocket: "/var/run/dockershim.sock",
-					Name:      "foo",
-				},
-				execer:          systemdCgroupExecer,
-				pidOfFunc:       binaryNotRunningPidOfFunc,
-				defaultHostname: "foo",
-			},
-			expected: map[string]string{
-				"network-plugin": "cni",
-				"cgroup-driver":  "systemd",
-			},
-		},
-		{
-			name: "cgroupfs cgroup driver",
-			opts: kubeletFlagsOpts{
-				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
-					CRISocket: "/var/run/dockershim.sock",
-					Name:      "foo",
-				},
-				execer:          cgroupfsCgroupExecer,
-				pidOfFunc:       binaryNotRunningPidOfFunc,
-				defaultHostname: "foo",
-			},
-			expected: map[string]string{
-				"network-plugin": "cni",
-				"cgroup-driver":  "cgroupfs",
 			},
 		},
 		{
@@ -181,8 +145,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 					CRISocket: "/var/run/containerd.sock",
 					Name:      "foo",
 				},
-				execer:          cgroupfsCgroupExecer,
-				pidOfFunc:       binaryNotRunningPidOfFunc,
 				defaultHostname: "foo",
 			},
 			expected: map[string]string{
@@ -210,31 +172,12 @@ func TestBuildKubeletArgMap(t *testing.T) {
 					},
 				},
 				registerTaintsUsingFlags: true,
-				execer:                   cgroupfsCgroupExecer,
-				pidOfFunc:                binaryNotRunningPidOfFunc,
 				defaultHostname:          "foo",
 			},
 			expected: map[string]string{
 				"container-runtime":          "remote",
 				"container-runtime-endpoint": "/var/run/containerd.sock",
 				"register-with-taints":       "foo=bar:baz,key=val:eff",
-			},
-		},
-		{
-			name: "systemd-resolved running",
-			opts: kubeletFlagsOpts{
-				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
-					CRISocket: "/var/run/containerd.sock",
-					Name:      "foo",
-				},
-				execer:          cgroupfsCgroupExecer,
-				pidOfFunc:       binaryRunningPidOfFunc,
-				defaultHostname: "foo",
-			},
-			expected: map[string]string{
-				"container-runtime":          "remote",
-				"container-runtime-endpoint": "/var/run/containerd.sock",
-				"resolv-conf":                "/run/systemd/resolve/resolv.conf",
 			},
 		},
 		{
@@ -245,13 +188,10 @@ func TestBuildKubeletArgMap(t *testing.T) {
 					Name:      "foo",
 				},
 				pauseImage:      "gcr.io/pause:3.1",
-				execer:          cgroupfsCgroupExecer,
-				pidOfFunc:       binaryNotRunningPidOfFunc,
 				defaultHostname: "foo",
 			},
 			expected: map[string]string{
 				"network-plugin":            "cni",
-				"cgroup-driver":             "cgroupfs",
 				"pod-infra-container-image": "gcr.io/pause:3.1",
 			},
 		},

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -148,7 +148,7 @@ func writeKubeletConfigFiles(client clientset.Interface, cfg *kubeadmapi.InitCon
 	}
 	errs := []error{}
 	// Write the configuration for the kubelet down to disk so the upgraded kubelet can start with fresh config
-	if err := kubeletphase.DownloadConfig(client, newK8sVer, kubeletDir); err != nil {
+	if err := kubeletphase.DownloadConfig(client, newK8sVer, &cfg.NodeRegistration, kubeletDir); err != nil {
 		// Tolerate the error being NotFound when dryrunning, as there is a pretty common scenario: the dryrun process
 		// *would* post the new kubelet-config-1.X configmap that doesn't exist now when we're trying to download it
 		// again.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

`--cgroup-driver` command line argument was deprecated and moved to kubelet config file, this PR is used to automatically assign cgroupDriver in Kubelet config file.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/874

**Special notes for your reviewer**:

/area kubeadm
sig/cluster-lifecycle

/assign @yagonobre
/assign @neolit123 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: apply the detected cgroup-driver and systemd-resolved as values in the KubeletConfiguration instead of flags to the kubelet binary.
```