### PR TITLE
Update Cluster Autoscaler to 1.13.4

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.13.2",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.13.4",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
```release-note
Update Cluster Autoscaler to 1.13.4
 - https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.13.4 
 - https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.13.3
```
