### PR TITLE
kubeadm: add etcdversion constant for v1.15

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -391,6 +391,7 @@ var (
 		12: "3.2.24",
 		13: "3.2.24",
 		14: "3.3.10",
+		15: "3.3.10",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
kubeadm chooses the etcd version using a map. This PR adds an entry for v1.15

**Special notes for your reviewer**:
This is required for testing upgrade from stable to master

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cluster-lifecycle
/area kubeadm
/priority important-soon
@kubernetes/sig-cluster-lifecycle-pr-reviews
/assign @neolit123 