### PR TITLE
Fix a bug in the gpu device plugin

### DIFF
--- a/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml
+++ b/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
         hostPath:
           path: /dev
       containers:
-      - image: "k8s.gcr.io/nvidia-gpu-device-plugin@sha256:d18b678437fedc4ec4211c20b3e5469a137a44f989da43dc275e4f2678170db4"
+      - image: "k8s.gcr.io/nvidia-gpu-device-plugin@sha256:08509a36233c5096bb273a492251a9a5ca28558ab36d74007ca2a9d3f0b61e1d"
         command: ["/usr/bin/nvidia-gpu-device-plugin", "-logtostderr"]
         name: nvidia-gpu-device-plugin
         resources:


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
The gpu device plugin was not registering any gpu devices that were installed after the plugin server started. This caused fewer gpus to be registered with the kubelet when the plugin server started before all gpu devices are finished installing. 

This PR uses the updated gpu device plugin that periodically checks for new gpu devices. 
Refer to https://github.com/GoogleCloudPlatform/container-engine-accelerators/pull/110

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
