### PR TITLE
Use framework.ExpectNoError() for e2e/auth

### DIFF
--- a/test/e2e/auth/metadata_concealment.go
+++ b/test/e2e/auth/metadata_concealment.go
@@ -24,7 +24,6 @@ import (
 	jobutil "k8s.io/kubernetes/test/e2e/framework/job"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	imageutil "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -56,10 +55,10 @@ var _ = SIGDescribe("Metadata Concealment", func() {
 			},
 		}
 		job, err := jobutil.CreateJob(f.ClientSet, f.Namespace.Name, job)
-		Expect(err).NotTo(HaveOccurred(), "failed to create job (%s:%s)", f.Namespace.Name, job.Name)
+		framework.ExpectNoError(err, "failed to create job (%s:%s)", f.Namespace.Name, job.Name)
 
 		By("Ensuring job reaches completions")
 		err = jobutil.WaitForJobComplete(f.ClientSet, f.Namespace.Name, job.Name, int32(1))
-		Expect(err).NotTo(HaveOccurred(), "failed to ensure job completion (%s:%s)", f.Namespace.Name, job.Name)
+		framework.ExpectNoError(err, "failed to ensure job completion (%s:%s)", f.Namespace.Name, job.Name)
 	})
 })

--- a/test/e2e/auth/node_authn.go
+++ b/test/e2e/auth/node_authn.go
@@ -38,7 +38,7 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 		ns = f.Namespace.Name
 
 		nodeList, err := f.ClientSet.CoreV1().Nodes().List(metav1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred(), "failed to list nodes in namespace: %s", ns)
+		framework.ExpectNoError(err, "failed to list nodes in namespace: %s", ns)
 		Expect(len(nodeList.Items)).NotTo(BeZero())
 
 		pickedNode := nodeList.Items[0]
@@ -49,7 +49,7 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 		// make sure ServiceAccount admission controller is enabled, so secret generation on SA creation works
 		saName := "default"
 		sa, err := f.ClientSet.CoreV1().ServiceAccounts(ns).Get(saName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred(), "failed to retrieve service account (%s:%s)", ns, saName)
+		framework.ExpectNoError(err, "failed to retrieve service account (%s:%s)", ns, saName)
 		Expect(len(sa.Secrets)).NotTo(BeZero())
 	})
 
@@ -73,7 +73,7 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 			AutomountServiceAccountToken: &trueValue,
 		}
 		_, err := f.ClientSet.CoreV1().ServiceAccounts(ns).Create(newSA)
-		Expect(err).NotTo(HaveOccurred(), "failed to create service account (%s:%s)", ns, newSA.Name)
+		framework.ExpectNoError(err, "failed to create service account (%s:%s)", ns, newSA.Name)
 
 		pod := createNodeAuthTestPod(f)
 

--- a/test/e2e/auth/node_authz.go
+++ b/test/e2e/auth/node_authz.go
@@ -51,24 +51,24 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		ns = f.Namespace.Name
 
 		nodeList, err := f.ClientSet.CoreV1().Nodes().List(metav1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred(), "failed to list nodes in namespace: %s", ns)
+		framework.ExpectNoError(err, "failed to list nodes in namespace: %s", ns)
 		Expect(len(nodeList.Items)).NotTo(Equal(0))
 		nodeName = nodeList.Items[0].Name
 		asUser = NodeNamePrefix + nodeName
 		saName := "default"
 		sa, err := f.ClientSet.CoreV1().ServiceAccounts(ns).Get(saName, metav1.GetOptions{})
 		Expect(len(sa.Secrets)).NotTo(Equal(0))
-		Expect(err).NotTo(HaveOccurred(), "failed to retrieve service account (%s:%s)", ns, saName)
+		framework.ExpectNoError(err, "failed to retrieve service account (%s:%s)", ns, saName)
 		defaultSaSecret = sa.Secrets[0].Name
 		By("Creating a kubernetes client that impersonates a node")
 		config, err := framework.LoadConfig()
-		Expect(err).NotTo(HaveOccurred(), "failed to load kubernetes client config")
+		framework.ExpectNoError(err, "failed to load kubernetes client config")
 		config.Impersonate = restclient.ImpersonationConfig{
 			UserName: asUser,
 			Groups:   []string{NodesGroup},
 		}
 		c, err = clientset.NewForConfig(config)
-		Expect(err).NotTo(HaveOccurred(), "failed to create Clientset for the given config: %+v", *config)
+		framework.ExpectNoError(err, "failed to create Clientset for the given config: %+v", *config)
 
 	})
 	It("Getting a non-existent secret should exit with the Forbidden error, not a NotFound error", func() {
@@ -98,7 +98,7 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 			},
 		}
 		_, err := f.ClientSet.CoreV1().ConfigMaps(ns).Create(configmap)
-		Expect(err).NotTo(HaveOccurred(), "failed to create configmap (%s:%s) %+v", ns, configmap.Name, *configmap)
+		framework.ExpectNoError(err, "failed to create configmap (%s:%s) %+v", ns, configmap.Name, *configmap)
 		_, err = c.CoreV1().ConfigMaps(ns).Get(configmap.Name, metav1.GetOptions{})
 		Expect(apierrors.IsForbidden(err)).Should(Equal(true))
 	})
@@ -115,7 +115,7 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 			},
 		}
 		_, err := f.ClientSet.CoreV1().Secrets(ns).Create(secret)
-		Expect(err).NotTo(HaveOccurred(), "failed to create secret (%s:%s)", ns, secret.Name)
+		framework.ExpectNoError(err, "failed to create secret (%s:%s)", ns, secret.Name)
 
 		By("Node should not get the secret")
 		_, err = c.CoreV1().Secrets(ns).Get(secret.Name, metav1.GetOptions{})
@@ -148,7 +148,7 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		}
 
 		_, err = f.ClientSet.CoreV1().Pods(ns).Create(pod)
-		Expect(err).NotTo(HaveOccurred(), "failed to create pod (%s:%s)", ns, pod.Name)
+		framework.ExpectNoError(err, "failed to create pod (%s:%s)", ns, pod.Name)
 
 		By("The node should able to access the secret")
 		itv := framework.Poll
@@ -161,7 +161,7 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 			}
 			return true, nil
 		})
-		Expect(err).NotTo(HaveOccurred(), "failed to get secret after trying every %v for %v (%s:%s)", itv, dur, ns, secret.Name)
+		framework.ExpectNoError(err, "failed to get secret after trying every %v for %v (%s:%s)", itv, dur, ns, secret.Name)
 	})
 
 	It("A node shouldn't be able to create another node", func() {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The e2e test framework has ExpectNoError() for readable test code.
This replaces Expect(err).NotTo(HaveOccurred()) with it for e2e/auth.

Ref: https://github.com/kubernetes/kubernetes/issues/77103

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
