### PR TITLE
Correct the appending of singular

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -203,7 +203,7 @@ func (m *DefaultRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]s
 		// fully qualified.  Find the exact match
 		for plural, singular := range m.pluralToSingular {
 			if singular == resource {
-				ret = append(ret, plural)
+				ret = append(ret, singular)
 				break
 			}
 			if plural == resource {
@@ -219,7 +219,7 @@ func (m *DefaultRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]s
 		for plural, singular := range m.pluralToSingular {
 			if singular.GroupResource() == requestedGroupResource {
 				foundExactMatch = true
-				ret = append(ret, plural)
+				ret = append(ret, singular)
 			}
 			if plural.GroupResource() == requestedGroupResource {
 				foundExactMatch = true
@@ -235,7 +235,7 @@ func (m *DefaultRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]s
 					continue
 				}
 				if singular.Resource == requestedGroupResource.Resource {
-					ret = append(ret, plural)
+					ret = append(ret, singular)
 				}
 				if plural.Resource == requestedGroupResource.Resource {
 					ret = append(ret, plural)
@@ -247,7 +247,7 @@ func (m *DefaultRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]s
 	case hasVersion:
 		for plural, singular := range m.pluralToSingular {
 			if singular.Version == resource.Version && singular.Resource == resource.Resource {
-				ret = append(ret, plural)
+				ret = append(ret, singular)
 			}
 			if plural.Version == resource.Version && plural.Resource == resource.Resource {
 				ret = append(ret, plural)
@@ -257,7 +257,7 @@ func (m *DefaultRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]s
 	default:
 		for plural, singular := range m.pluralToSingular {
 			if singular.Resource == resource.Resource {
-				ret = append(ret, plural)
+				ret = append(ret, singular)
 			}
 			if plural.Resource == resource.Resource {
 				ret = append(ret, plural)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In restmapper.go, there are multiple places where we compare whether singular is the matching resource and append plural if match is found.

I think singular should be appended for such match.

```release-note
NONE
```
