### PR TITLE
Emit the nvidia driver version in gpu e2e test

### DIFF
--- a/test/e2e/scheduling/nvidia-gpus.go
+++ b/test/e2e/scheduling/nvidia-gpus.go
@@ -179,6 +179,7 @@ func testNvidiaGPUs(f *framework.Framework) {
 	// Wait for all pods to succeed
 	for _, pod := range podList {
 		f.PodClient().WaitForSuccess(pod.Name, 5*time.Minute)
+		logContainers(f, pod)
 	}
 
 	e2elog.Logf("Stopping ResourceUsageGather")
@@ -187,6 +188,14 @@ func testNvidiaGPUs(f *framework.Framework) {
 	summary, err := rsgather.StopAndSummarize([]int{50, 90, 100}, constraints)
 	f.TestSummaries = append(f.TestSummaries, summary)
 	framework.ExpectNoError(err, "getting resource usage summary")
+}
+
+func logContainers(f *framework.Framework, pod *v1.Pod) {
+	for _, container := range pod.Spec.Containers {
+		logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, container.Name)
+		framework.ExpectNoError(err, "Should be able to get container logs for container: %s", container.Name)
+		e2elog.Logf("Got container logs for %s:\n%v", container.Name, logs)
+	}
 }
 
 var _ = SIGDescribe("[Feature:GPUDevicePlugin]", func() {

--- a/test/images/cuda-vector-add/Dockerfile
+++ b/test/images/cuda-vector-add/Dockerfile
@@ -23,4 +23,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /usr/local/cuda/samples/0_Simple/vectorAdd
 RUN make
 
-CMD ./vectorAdd
+CMD nvidia-smi && ./vectorAdd


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
This PR logs the nvidia gpu driver version so that the test logs can be used to more easily verify the driver version is mapped to the correct kubernetes version. `nvidia-smi` is used in order to display the driver information, which contains the driver version. https://developer.nvidia.com/nvidia-system-management-interface


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
