### PR TITLE
Automated cherry pick of #76773: Create the "internal" firewall rule for kubemark master.

### DIFF
--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -102,6 +102,13 @@ function create-master-instance-with-resources {
     --target-tags "${MASTER_TAG}" \
     --allow "tcp:443" &
 
+  run-gcloud-compute-with-retries firewall-rules create "${MASTER_NAME}-internal" \
+    --project "${PROJECT}" \
+    --network "${NETWORK}" \
+    --source-ranges "10.0.0.0/8" \
+    --target-tags "${MASTER_TAG}" \
+    --allow "tcp:1-2379,tcp:2382-65535,udp:1-65535,icmp" &
+
   wait
 }
 
@@ -136,6 +143,10 @@ function delete-master-instance-and-resources {
 	  --project "${PROJECT}" \
 	  --quiet || true
   
+  gcloud compute firewall-rules delete "${MASTER_NAME}-internal" \
+	  --project "${PROJECT}" \
+	  --quiet || true
+
   if [ "${SEPARATE_EVENT_MACHINE:-false}" == "true" ]; then
 	  gcloud compute instances delete "${EVENT_STORE_NAME}" \
     	  ${GCLOUD_COMMON_ARGS} || true


### PR DESCRIPTION
Cherry pick of #76773 on release-1.13.

#76773: Create the "internal" firewall rule for kubemark master.

```release-note
NONE
```