### PR TITLE
apiserver: store nodename while reconcile default k8s service endpoints

### DIFF
--- a/pkg/master/controller_test.go
+++ b/pkg/master/controller_test.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/kubernetes/pkg/master/reconcilers"
 )
 
+const testNodeName = "test-nodename"
+
 func TestReconcileEndpoints(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	om := func(name string) metav1.ObjectMeta {
@@ -53,7 +55,7 @@ func TestReconcileEndpoints(t *testing.T) {
 			expectCreate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
@@ -67,7 +69,7 @@ func TestReconcileEndpoints(t *testing.T) {
 				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
@@ -82,15 +84,18 @@ func TestReconcileEndpoints(t *testing.T) {
 				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}, {IP: "4.3.2.1"}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						Addresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)},
+							{IP: "4.3.2.1", NodeName: strToPtr(testNodeName)},
+						},
+						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
 			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
@@ -106,11 +111,11 @@ func TestReconcileEndpoints(t *testing.T) {
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
 						Addresses: []corev1.EndpointAddress{
-							{IP: "1.2.3.4"},
-							{IP: "4.3.2.1"},
-							{IP: "4.3.2.2"},
-							{IP: "4.3.2.3"},
-							{IP: "4.3.2.4"},
+							{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)},
+							{IP: "4.3.2.1", NodeName: strToPtr(testNodeName)},
+							{IP: "4.3.2.2", NodeName: strToPtr(testNodeName)},
+							{IP: "4.3.2.3", NodeName: strToPtr(testNodeName)},
+							{IP: "4.3.2.4", NodeName: strToPtr(testNodeName)},
 						},
 						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
@@ -120,10 +125,10 @@ func TestReconcileEndpoints(t *testing.T) {
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
 					Addresses: []corev1.EndpointAddress{
-						{IP: "1.2.3.4"},
-						{IP: "4.3.2.2"},
-						{IP: "4.3.2.3"},
-						{IP: "4.3.2.4"},
+						{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)},
+						{IP: "4.3.2.2", NodeName: strToPtr(testNodeName)},
+						{IP: "4.3.2.3", NodeName: strToPtr(testNodeName)},
+						{IP: "4.3.2.4", NodeName: strToPtr(testNodeName)},
 					},
 					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
@@ -140,11 +145,11 @@ func TestReconcileEndpoints(t *testing.T) {
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
 						Addresses: []corev1.EndpointAddress{
-							{IP: "1.2.3.4"},
-							{IP: "4.3.2.1"},
-							{IP: "4.3.2.2"},
-							{IP: "4.3.2.3"},
-							{IP: "4.3.2.4"},
+							{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)},
+							{IP: "4.3.2.1", NodeName: strToPtr(testNodeName)},
+							{IP: "4.3.2.2", NodeName: strToPtr(testNodeName)},
+							{IP: "4.3.2.3", NodeName: strToPtr(testNodeName)},
+							{IP: "4.3.2.4", NodeName: strToPtr(testNodeName)},
 						},
 						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
@@ -154,10 +159,10 @@ func TestReconcileEndpoints(t *testing.T) {
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
 					Addresses: []corev1.EndpointAddress{
-						{IP: "4.3.2.1"},
-						{IP: "4.3.2.2"},
-						{IP: "4.3.2.3"},
-						{IP: "4.3.2.4"},
+						{IP: "4.3.2.1", NodeName: strToPtr(testNodeName)},
+						{IP: "4.3.2.2", NodeName: strToPtr(testNodeName)},
+						{IP: "4.3.2.3", NodeName: strToPtr(testNodeName)},
+						{IP: "4.3.2.4", NodeName: strToPtr(testNodeName)},
 					},
 					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
@@ -174,8 +179,8 @@ func TestReconcileEndpoints(t *testing.T) {
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
 						Addresses: []corev1.EndpointAddress{
-							{IP: "4.3.2.1"},
-							{IP: "4.3.2.2"},
+							{IP: "4.3.2.1", NodeName: strToPtr(testNodeName)},
+							{IP: "4.3.2.2", NodeName: strToPtr(testNodeName)},
 						},
 						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
@@ -194,7 +199,7 @@ func TestReconcileEndpoints(t *testing.T) {
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
 						Addresses: []corev1.EndpointAddress{
-							{IP: "4.3.2.1"},
+							{IP: "4.3.2.1", NodeName: strToPtr(testNodeName)},
 						},
 						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
@@ -204,8 +209,8 @@ func TestReconcileEndpoints(t *testing.T) {
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
 					Addresses: []corev1.EndpointAddress{
-						{IP: "4.3.2.1"},
-						{IP: "4.3.2.2"},
+						{IP: "4.3.2.1", NodeName: strToPtr(testNodeName)},
+						{IP: "4.3.2.2", NodeName: strToPtr(testNodeName)},
 					},
 					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
@@ -220,7 +225,7 @@ func TestReconcileEndpoints(t *testing.T) {
 				Items: []corev1.Endpoints{{
 					ObjectMeta: om("bar"),
 					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
@@ -228,7 +233,7 @@ func TestReconcileEndpoints(t *testing.T) {
 			expectCreate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
@@ -242,7 +247,7 @@ func TestReconcileEndpoints(t *testing.T) {
 				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "4.3.2.1"}},
+						Addresses: []corev1.EndpointAddress{{IP: "4.3.2.1", NodeName: strToPtr(testNodeName)}},
 						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
@@ -250,7 +255,7 @@ func TestReconcileEndpoints(t *testing.T) {
 			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
@@ -264,7 +269,7 @@ func TestReconcileEndpoints(t *testing.T) {
 				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 9090, Protocol: "TCP"}},
 					}},
 				}},
@@ -272,7 +277,7 @@ func TestReconcileEndpoints(t *testing.T) {
 			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
@@ -286,7 +291,7 @@ func TestReconcileEndpoints(t *testing.T) {
 				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "UDP"}},
 					}},
 				}},
@@ -294,7 +299,7 @@ func TestReconcileEndpoints(t *testing.T) {
 			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
@@ -308,7 +313,7 @@ func TestReconcileEndpoints(t *testing.T) {
 				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
@@ -316,7 +321,7 @@ func TestReconcileEndpoints(t *testing.T) {
 			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 					Ports:     []corev1.EndpointPort{{Name: "baz", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
@@ -334,7 +339,7 @@ func TestReconcileEndpoints(t *testing.T) {
 				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 						Ports: []corev1.EndpointPort{
 							{Name: "foo", Port: 8080, Protocol: "TCP"},
 							{Name: "bar", Port: 1000, Protocol: "TCP"},
@@ -356,7 +361,7 @@ func TestReconcileEndpoints(t *testing.T) {
 				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
@@ -364,7 +369,7 @@ func TestReconcileEndpoints(t *testing.T) {
 			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 					Ports: []corev1.EndpointPort{
 						{Name: "foo", Port: 8080, Protocol: "TCP"},
 						{Name: "bar", Port: 1000, Protocol: "TCP"},
@@ -381,7 +386,7 @@ func TestReconcileEndpoints(t *testing.T) {
 			expectCreate: &corev1.Endpoints{
 				ObjectMeta: om("boo"),
 				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 					Ports:     []corev1.EndpointPort{{Name: "boo", Port: 7777, Protocol: "SCTP"}},
 				}},
 			},
@@ -392,7 +397,7 @@ func TestReconcileEndpoints(t *testing.T) {
 		if test.endpoints != nil {
 			fakeClient = fake.NewSimpleClientset(test.endpoints)
 		}
-		reconciler := reconcilers.NewMasterCountEndpointReconciler(test.additionalMasters+1, fakeClient.CoreV1())
+		reconciler := reconcilers.NewMasterCountEndpointReconciler(strToPtr(testNodeName), test.additionalMasters+1, fakeClient.CoreV1())
 		err := reconciler.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, true)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
@@ -458,7 +463,7 @@ func TestReconcileEndpoints(t *testing.T) {
 				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
@@ -477,7 +482,7 @@ func TestReconcileEndpoints(t *testing.T) {
 				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "4.3.2.1"}},
+						Addresses: []corev1.EndpointAddress{{IP: "4.3.2.1", NodeName: strToPtr(testNodeName)}},
 						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
@@ -485,7 +490,7 @@ func TestReconcileEndpoints(t *testing.T) {
 			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
@@ -499,7 +504,7 @@ func TestReconcileEndpoints(t *testing.T) {
 			expectCreate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
 					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
@@ -510,7 +515,7 @@ func TestReconcileEndpoints(t *testing.T) {
 		if test.endpoints != nil {
 			fakeClient = fake.NewSimpleClientset(test.endpoints)
 		}
-		reconciler := reconcilers.NewMasterCountEndpointReconciler(test.additionalMasters+1, fakeClient.CoreV1())
+		reconciler := reconcilers.NewMasterCountEndpointReconciler(strToPtr(testNodeName), test.additionalMasters+1, fakeClient.CoreV1())
 		err := reconciler.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, false)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
@@ -959,4 +964,8 @@ func TestCreateOrUpdateMasterService(t *testing.T) {
 			t.Errorf("case %q: no update expected, yet saw: %v", test.testName, updates)
 		}
 	}
+}
+
+func strToPtr(s string) *string {
+	return &s
 }

--- a/pkg/master/controller_test.go
+++ b/pkg/master/controller_test.go
@@ -422,16 +422,21 @@ func TestReconcileEndpoints(t *testing.T) {
 				Items: []corev1.Endpoints{{
 					ObjectMeta: om("foo"),
 					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr("stale-nodename")}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						Addresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4", NodeName: strToPtr("stale-nodename")},
+							{IP: "4.3.2.1"},
+						},
+						Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 					}},
 				}},
 			},
 			expectUpdate: &corev1.Endpoints{
 				ObjectMeta: om("foo"),
 				Subsets: []corev1.EndpointSubset{{
-					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
-					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					Addresses: []corev1.EndpointAddress{
+						{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)},
+					},
+					Ports: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 				}},
 			},
 		},

--- a/pkg/master/controller_test.go
+++ b/pkg/master/controller_test.go
@@ -391,6 +391,50 @@ func TestReconcileEndpoints(t *testing.T) {
 				}},
 			},
 		},
+		{
+			testName:      "existing endpoints empty nodename",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("foo"),
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					}},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("foo"),
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				}},
+			},
+		},
+		{
+			testName:      "existing endpoints stale nodename",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("foo"),
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr("stale-nodename")}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					}},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("foo"),
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodeName)}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				}},
+			},
+		},
 	}
 	for _, test := range reconcile_tests {
 		fakeClient := fake.NewSimpleClientset()

--- a/pkg/master/reconcilers/lease.go
+++ b/pkg/master/reconcilers/lease.go
@@ -73,7 +73,7 @@ func (s *storageLeases) ListLeases() ([]corev1.EndpointAddress, error) {
 		epaList[i] = ip.Subsets[0].Addresses[0]
 	}
 
-	klog.V(6).Infof("Current masters listed in storage are %v", formatEndpointAddresses(epaList))
+	klog.V(6).Infof("Current masters listed in storage are %v", prepareForDisplay(epaList))
 
 	return epaList, nil
 }
@@ -221,7 +221,7 @@ func (r *leaseEndpointReconciler) doReconcile(serviceName string, endpointPorts 
 		e.Subsets[0].Ports = endpointPorts
 	}
 
-	klog.Warningf("Resetting endpoints for master service %q to %v", serviceName, formatEndpointAddresses(masters))
+	klog.Warningf("Resetting endpoints for master service %q to %v", serviceName, prepareForDisplay(masters))
 	if shouldCreate {
 		if _, err = r.endpointClient.Endpoints(corev1.NamespaceDefault).Create(e); errors.IsAlreadyExists(err) {
 			err = nil
@@ -310,7 +310,7 @@ func (r *leaseEndpointReconciler) StopReconciling() {
 	r.stopReconcilingCalled = true
 }
 
-func formatEndpointAddresses(addrs []corev1.EndpointAddress) []string {
+func prepareForDisplay(addrs []corev1.EndpointAddress) []string {
 	items := make([]string, len(addrs))
 	for i, epa := range addrs {
 		items[i] = epa.IP

--- a/pkg/master/reconcilers/lease_test.go
+++ b/pkg/master/reconcilers/lease_test.go
@@ -427,6 +427,50 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 				}},
 			},
 		},
+		{
+			testName:      "existing endpoints empty nodename",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("foo"),
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					}},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("foo"),
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodename)}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				}},
+			},
+		},
+		{
+			testName:      "existing endpoints stale nodename",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("foo"),
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr("stale-nodename")}},
+						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					}},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("foo"),
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4", NodeName: strToPtr(testNodename)}},
+					Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				}},
+			},
+		},
 	}
 	for _, test := range reconcileTests {
 		fakeLeases := newFakeLeases(testNodename)

--- a/pkg/master/reconcilers/mastercount.go
+++ b/pkg/master/reconcilers/mastercount.go
@@ -201,13 +201,8 @@ func checkEndpointSubsetFormat(e *corev1.Endpoints, ip string, nodeName *string,
 		}
 	}
 	for _, addr := range sub.Addresses {
-		if addr.NodeName == nil {
-			formatCorrect = false
-			break
-		}
-
 		if addr.IP == ip {
-			if *addr.NodeName != *nodeName {
+			if addr.NodeName == nil || *addr.NodeName != *nodeName {
 				formatCorrect = false
 				break
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
Apiserver does not store nodename while reconciling endpoints for k8s default service. Endpoint's nodename is important when we want to determine whether the endpoint is local to the current node. see https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/endpoints.go#L260


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
