### PR TITLE
Validate k8s.io/hostname node label equals metadata.Name

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -10135,6 +10135,21 @@ func TestValidateNode(t *testing.T) {
 				},
 			},
 		},
+		"hostname-label-different-than-name": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "abc",
+				Labels: map[string]string{
+					"kubernetes.io/hostname": "different-hostname",
+				},
+			},
+			Status: core.NodeStatus{
+				Addresses: []core.NodeAddress{},
+				Capacity: core.ResourceList{
+					core.ResourceName(core.ResourceCPU):    resource.MustParse("10"),
+					core.ResourceName(core.ResourceMemory): resource.MustParse("10G"),
+				},
+			},
+		},
 		"invalid-labels": {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "abc-123",
@@ -10626,6 +10641,18 @@ func TestValidateNodeUpdate(t *testing.T) {
 							        }
 							    ]
 							}`,
+				},
+			},
+		}, false},
+		{core.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+		}, core.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				Labels: map[string]string{
+					"kubernetes.io/hostname": "invalid-new-name",
 				},
 			},
 		}, false},


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
If these values ever diverge, it can cause unexpected and unwanted behavior.
We use this validation as an extra source of protection against the
k8s.io/hostname label accidentally drifting.

**Which issue(s) this PR fixes**:
Fixes #77067 

**Special notes for your reviewer**:
cc @neolit123 @cofyc 

**Does this PR introduce a user-facing change?**:
```release-note
If `kubernetes.io/hostname` label exists on `Node`, it must have the same value as `metadata.Name`.
```
