### PR TITLE
Fixed a `make clean` regression

### DIFF
--- a/hack/make-rules/clean.sh
+++ b/hack/make-rules/clean.sh
@@ -29,7 +29,7 @@ CLEAN_PATTERNS=(
 )
 
 for pattern in "${CLEAN_PATTERNS[@]}"; do
-  while IFS=$'\n' read -r -d match; do
+  while IFS=$'\n' read -r match; do
     echo "Removing ${match#${KUBE_ROOT}\/} .."
     rm -rf "${match#${KUBE_ROOT}\/}"
   done <   <(find "${KUBE_ROOT}" -iregex "^${KUBE_ROOT}/${pattern}$")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/assign @BenTheElder

**What this PR does / why we need it**:

There is a regression introduced in #76840:

```console
root@k8s-bm:~/go/src/k8s.io/kubernetes# make clean
+++ [0426 13:51:42] Verifying Prerequisites....
hack/make-rules/clean.sh: line 33: match: unbound variable
Makefile:345: recipe for target 'clean' failed
make: *** [clean] Error 1
```

We shouldn't put "match" as a delimiter (followed by `-d`). IMO a delimiter other than newline (default) is unnecessary in this case.

With this PR, the bug can be fixed:

```console
root@k8s-bm:~/go/src/k8s.io/kubernetes# make clean
+++ [0426 13:52:09] Verifying Prerequisites....
Removing test/e2e/generated/bindata.go ..
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
