### PR TITLE
Addresses linter complaint in broken_webhook test file

### DIFF
--- a/test/integration/apiserver/admissionwebhook/broken_webhook_test.go
+++ b/test/integration/apiserver/admissionwebhook/broken_webhook_test.go
@@ -150,7 +150,7 @@ func exampleDeployment(name string) *appsv1.Deployment {
 
 func brokenWebhookConfig(name string) *admissionregistrationv1beta1.ValidatingWebhookConfiguration {
 	var path string
-	var failurePolicy admissionregistrationv1beta1.FailurePolicyType = admissionregistrationv1beta1.Fail
+	var failurePolicy = admissionregistrationv1beta1.Fail
 	return &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,


### PR DESCRIPTION
 /kind cleanup

**What this PR does / why we need it**:
This came up as part of https://github.com/kubernetes/kubernetes/issues/68026#issuecomment-487150255. It sidesteps the flaky linter issue by fixing the code as suggested.

/assign @dims
/assign @liggitt
/sig api-machinery

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
