### PR TITLE
runtimeclass: remove feature gate handling in core validation tests

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -6192,7 +6192,6 @@ func TestValidatePodSpec(t *testing.T) {
 	maxGroupID := int64(2147483647)
 
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodPriority, true)()
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RuntimeClass, true)()
 
 	successCases := []core.PodSpec{
 		{ // Populate basic fields, leave defaults for most.


### PR DESCRIPTION
RuntimeClass is at beta now, with a default of being enabled in the
feature gate. There is no longer a need to override the feature-gate in
tests.

Signed-off-by: Eric Ernst <eric.ernst@intel.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

RuntimeClass is at beta now, with a default of being enabled in the
feature gate. There is no longer a need to override the feature-gate in
tests. This PR removes the feature gate override which is a noop today.

I'm not sure if there's a general policy in place (ie, keep until GA).

**Which issue(s) this PR fixes**:

Cleanup core validation code 


```release-note
remove RuntimeClass feature-gate override from core validation_test.go
```
