### PR TITLE
Bundle the SyncResults under one lock in ReasonCache#Update

### DIFF
--- a/pkg/kubelet/reason_cache.go
+++ b/pkg/kubelet/reason_cache.go
@@ -83,7 +83,7 @@ func (c *ReasonCache) Update(uid types.UID, result kubecontainer.PodSyncResult) 
 			toRemove = append(toRemove, name)
 		}
 	}
-	if len(toAdd) + len(toRemove) > 0 {
+	if len(toAdd)+len(toRemove) > 0 {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		if len(toAdd) > 0 {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In ReasonCache#Update, we obtain and release lock for each SyncResult addition / removal.

This PR bundles all the SyncResult additions / removals under one lock.

```release-note
NONE
```
