### PR TITLE
tableprinter: simplifies default printer handler

### DIFF
--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/duration:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/github.com/liggitt/tabwriter:go_default_library",
     ],

--- a/pkg/printers/internalversion/BUILD
+++ b/pkg/printers/internalversion/BUILD
@@ -95,7 +95,6 @@ go_library(
         "//staging/src/k8s.io/api/rbac/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/scheduling/v1:go_default_library",
         "//staging/src/k8s.io/api/storage/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",


### PR DESCRIPTION
* Removes unused `DefaultTableHandler` functionality.
* `printObjectMeta` becomes the fixed default handler, since it is the only one used.

Helps fix:
https://github.com/kubernetes/kubectl/issues/80

```release-note
NONE
```

/kind cleanup
/sig cli
/assign
