### PR TITLE
Only create one pod per node with gpus in E2E test

### DIFF
--- a/test/e2e/scheduling/nvidia-gpus.go
+++ b/test/e2e/scheduling/nvidia-gpus.go
@@ -168,11 +168,23 @@ func SetupNVIDIAGPUNode(f *framework.Framework, setupResourceGatherer bool) *fra
 	return rsgather
 }
 
+func getGPUsPerPod() int64 {
+	var gpusPerPod int64
+	gpuPod := makeCudaAdditionDevicePluginTestPod()
+	for _, container := range gpuPod.Spec.Containers {
+		if val, ok := container.Resources.Limits[gpuResourceName]; ok {
+			gpusPerPod += (&val).Value()
+		}
+	}
+	return gpusPerPod
+}
+
 func testNvidiaGPUs(f *framework.Framework) {
 	rsgather := SetupNVIDIAGPUNode(f, true)
-	e2elog.Logf("Creating as many pods as there are Nvidia GPUs and have the pods run a CUDA app")
+	gpuPodNum := getGPUsAvailable(f) / getGPUsPerPod()
+	e2elog.Logf("Creating %d pods and have the pods run a CUDA app", gpuPodNum)
 	podList := []*v1.Pod{}
-	for i := int64(0); i < getGPUsAvailable(f); i++ {
+	for i := int64(0); i < gpuPodNum; i++ {
 		podList = append(podList, f.PodClient().Create(makeCudaAdditionDevicePluginTestPod()))
 	}
 	e2elog.Logf("Wait for all test pods to succeed")


### PR DESCRIPTION
**What type of PR is 
/kind cleanup

**What this PR does / why we need it**:
The GPU E2E test is scheduling more than one pod per node, where the pod contains two containers, each requesting 1 GPU and each node is configured with 2 GPUs. This is causing there to be pods waiting until the previous pods are finished to be scheduled.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
