### PR TITLE
Add OWNERS file for cmd/kube-proxy

### DIFF
--- a/cmd/kube-proxy/OWNERS
+++ b/cmd/kube-proxy/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- sig-network-reviewers
+approvers:
+- sig-network-approvers
+labels:
+- sig/network


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Ref https://github.com/kubernetes/kubernetes/pull/76320#issuecomment-487188482, adding OWNERS file for `cmd/kube-proxy` can help related folks approving fixes like #76320.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE 

**Special notes for your reviewer**:
/assign @thockin

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
