### PR TITLE
Stop serverCertificateManager if oomWatcher fails to start

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1324,6 +1324,9 @@ func (kl *Kubelet) initializeModules() error {
 
 	// Start out of memory watcher.
 	if err := kl.oomWatcher.Start(kl.nodeRef); err != nil {
+		if kl.serverCertificateManager != nil {
+			kl.serverCertificateManager.Stop()
+		}
 		return fmt.Errorf("Failed to start OOM watcher %v", err)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently in Kubelet#initializeModules, when oomWatcher fails to start we just return the error.

This PR stops serverCertificateManager before returning the error.

```release-note
NONE
```
