### PR TITLE
Fix named service port issue in port-forward

### DIFF
--- a/pkg/kubectl/cmd/portforward/portforward.go
+++ b/pkg/kubectl/cmd/portforward/portforward.go
@@ -184,10 +184,11 @@ func translateServicePortToTargetPort(ports []string, svc corev1.Service, pod co
 			return nil, err
 		}
 
-		if int32(portnum) != containerPort {
-			translated = append(translated, fmt.Sprintf("%s:%d", localPort, containerPort))
+		containerPortStr := strconv.Itoa(int(containerPort))
+		if localPort != containerPortStr {
+			translated = append(translated, fmt.Sprintf("%s:%s", localPort, containerPortStr))
 		} else {
-			translated = append(translated, port)
+			translated = append(translated, containerPortStr)
 		}
 	}
 	return translated, nil

--- a/pkg/kubectl/cmd/portforward/portforward_test.go
+++ b/pkg/kubectl/cmd/portforward/portforward_test.go
@@ -378,6 +378,42 @@ func TestTranslateServicePortToTargetPort(t *testing.T) {
 			err:        false,
 		},
 		{
+			name: "test success 4 (named service port with same target port)",
+			svc: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							Name:       "http",
+							TargetPort: intstr.FromInt(80),
+						},
+						{
+							Port:       443,
+							Name:       "https",
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: int32(80)},
+								{
+									ContainerPort: int32(443)},
+							},
+						},
+					},
+				},
+			},
+			ports:      []string{"http", "https"},
+			translated: []string{"80", "443"},
+			err:        false,
+		},
+		{
 			name: "test success 4 (named service port with random local port)",
 			svc: corev1.Service{
 				Spec: corev1.ServiceSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Named ports are supported in port-forward, but there would be errors if the service's `targetPort` is set to the same value as the `port` field. For example:
```
# cat nginx-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: nginx-svc
  labels:
    run: nginx
spec:
  ports:
  - port: 80
    name: http
    targetPort: 80
  selector:
    run: nginx

# kubectl port-forward svc/nginx-svc http
error: Error parsing local port 'http': strconv.ParseUint: parsing "http": invalid syntax
```
This is caused by a condition check that if service port is equal to container port, the user inputted string will be used as translated result, leading to parsing error in following steps.

The patch fixes the issue by checking if local port is equal to container port and only return a single port when they are equal.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #75093

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix named service port issue in port-forward
```