### PR TITLE
Check error return from buffer.Write

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -336,9 +336,18 @@ func nodeHostsFileContent(hostsFilePath string, hostAliases []v1.HostAlias) ([]b
 		return nil, err
 	}
 	var buffer bytes.Buffer
-	buffer.WriteString(managedHostsHeaderWithHostNetwork)
-	buffer.Write(hostsFileContent)
-	buffer.Write(hostsEntriesFromHostAliases(hostAliases))
+	_, err = buffer.WriteString(managedHostsHeaderWithHostNetwork)
+	if err != nil {
+		return nil, err
+	}
+	_, err = buffer.Write(hostsFileContent)
+	if err != nil {
+		return nil, err
+	}
+	_, err = buffer.Write(hostsEntriesFromHostAliases(hostAliases))
+	if err != nil {
+		return nil, err
+	}
 	return buffer.Bytes(), nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently the error return from buffer.Write calls is ignored in nodeHostsFileContent.

This PR adds checking of the error return.

```release-note
NONE
```
