### PR TITLE
Increase maxMsgSize for dockershim

### DIFF
--- a/pkg/kubelet/dockershim/remote/docker_server.go
+++ b/pkg/kubelet/dockershim/remote/docker_server.go
@@ -26,9 +26,9 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util"
 )
 
-// maxMsgSize use 8MB as the default message size limit.
+// maxMsgSize use 16MB as the default message size limit.
 // grpc library default is 4MB
-const maxMsgSize = 1024 * 1024 * 8
+const maxMsgSize = 1024 * 1024 * 16
 
 // DockerServer is the grpc server of dockershim.
 type DockerServer struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Increase the grpc max message size to be the same as the value defined
in `pkg/kubelet/remote/utils.go`.

Increase the limit because, `ListPodSandbox` (and possibly other) calls
are hitting the limit. Long term, the best solution to this issue is to
use pagination, but that is not currently available.

**Which issue(s) this PR fixes**:
Fixes #77138 

**Special notes for your reviewer**:
cc @dims 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
