### PR TITLE
Fix for kube-proxy to wait for some duration for the node to be defined.

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -143,6 +143,9 @@ func newProxyServer(
 	nodeIP := net.ParseIP(config.BindAddress)
 	if nodeIP.IsUnspecified() {
 		nodeIP = utilnode.GetNodeIP(client, hostname)
+		if nodeIP == nil {
+			return nil, fmt.Errorf("unable to get node IP for hostname %s", hostname)
+		}
 	}
 	if proxyMode == proxyModeIPTables {
 		klog.V(0).Info("Using iptables Proxier.")

--- a/pkg/util/node/BUILD
+++ b/pkg/util/node/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -106,17 +107,31 @@ func GetNodeHostIP(node *v1.Node) (net.IP, error) {
 }
 
 // GetNodeIP returns the ip of node with the provided hostname
+// If required, wait for the node to be defined.
 func GetNodeIP(client clientset.Interface, hostname string) net.IP {
 	var nodeIP net.IP
-	node, err := client.CoreV1().Nodes().Get(hostname, metav1.GetOptions{})
-	if err != nil {
-		klog.Warningf("Failed to retrieve node info: %v", err)
-		return nil
+	backoff := wait.Backoff {
+		Steps:    5,
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Jitter:   0.2,
 	}
-	nodeIP, err = GetNodeHostIP(node)
-	if err != nil {
-		klog.Warningf("Failed to retrieve node IP: %v", err)
-		return nil
+
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		node, err := client.CoreV1().Nodes().Get(hostname, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("Failed to retrieve node info: %v", err)
+			return false, nil
+		}
+		nodeIP, err = GetNodeHostIP(node)
+		if err != nil {
+			klog.Errorf("Failed to retrieve node IP: %v", err)
+			return false, err
+		}
+		return true, nil
+	})
+	if err == nil {
+		klog.Infof("Successfully retrieved node IP: %v", nodeIP)
 	}
 	return nodeIP
 }

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -110,7 +110,7 @@ func GetNodeHostIP(node *v1.Node) (net.IP, error) {
 // If required, wait for the node to be defined.
 func GetNodeIP(client clientset.Interface, hostname string) net.IP {
 	var nodeIP net.IP
-	backoff := wait.Backoff {
+	backoff := wait.Backoff{
 		Steps:    5,
 		Duration: 1 * time.Second,
 		Factor:   2.0,


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
Kube-proxy must atleast wait for some duration for the node to defined so that it can fetch the node IP. This node IP is currently used in ipvs proxier for the node-port services.

**Which issue(s) this PR fixes**:
Fixes #37414

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Improvement in Kube-proxy. Kube-proxy waits for some duration for the node to be defined.
```
