### PR TITLE
DelayingQueue.ShutDown() should be reentrant

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -18,6 +18,7 @@ package workqueue
 
 import (
 	"container/heap"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/clock"
@@ -66,6 +67,8 @@ type delayingType struct {
 
 	// stopCh lets us signal a shutdown to the waiting loop
 	stopCh chan struct{}
+	// stopOnce guarantees we only signal shutdown a single time
+	stopOnce sync.Once
 
 	// heartbeat ensures we wait no more than maxWait before firing
 	heartbeat clock.Ticker
@@ -133,11 +136,14 @@ func (pq waitForPriorityQueue) Peek() interface{} {
 	return pq[0]
 }
 
-// ShutDown gives a way to shut off this queue
+// ShutDown stops the queue. After the queue drains, the returned shutdown bool
+// on Get() will be true. This method may be invoked more than once.
 func (q *delayingType) ShutDown() {
-	q.Interface.ShutDown()
-	close(q.stopCh)
-	q.heartbeat.Stop()
+	q.stopOnce.Do(func() {
+		q.Interface.ShutDown()
+		close(q.stopCh)
+		q.heartbeat.Stop()
+	})
 }
 
 // AddAfter adds the given item to the work queue after the given delay


### PR DESCRIPTION
All queue ShutDown() calls should be able to be invoked multiple times.

```
goroutine 228 [running]:
github.com/openshift/cluster-version-operator/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/openshift/cluster-version-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x107
panic(0x12a5960, 0x1556450)
	/usr/local/go/src/runtime/panic.go:502 +0x229
github.com/openshift/cluster-version-operator/vendor/k8s.io/client-go/util/workqueue.(*delayingType).ShutDown(0xc4206899a0)
	/go/src/github.com/openshift/cluster-version-operator/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go:137 +0x45
```

Use sync.Once to guarantee a single close.

/kind bug

```release-note
DelayingQueue.ShutDown() is now able to be invoked multiple times without causing a closed channel panic.
```