### PR TITLE
feat: add logger package in test e2e framework

### DIFF
--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -154,6 +154,7 @@ filegroup(
         "//test/e2e/framework/gpu:all-srcs",
         "//test/e2e/framework/ingress:all-srcs",
         "//test/e2e/framework/job:all-srcs",
+        "//test/e2e/framework/log:all-srcs",
         "//test/e2e/framework/metrics:all-srcs",
         "//test/e2e/framework/podlogs:all-srcs",
         "//test/e2e/framework/providers/aws:all-srcs",

--- a/test/e2e/framework/job/BUILD
+++ b/test/e2e/framework/job/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
     ],
 )
 

--- a/test/e2e/framework/job/rest.go
+++ b/test/e2e/framework/job/rest.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 
 	batch "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
 // GetJob uses c to get the Job in namespace ns named name. If the returned error is nil, the returned Job is valid.
@@ -63,7 +64,7 @@ func UpdateJobWithRetries(c clientset.Interface, namespace, name string, applyUp
 		// Apply the update, then attempt to push it to the apiserver.
 		applyUpdate(job)
 		if job, err = jobs.Update(job); err == nil {
-			framework.Logf("Updating job %s", name)
+			e2elog.Logf("Updating job %s", name)
 			return true, nil
 		}
 		updateErr = err

--- a/test/e2e/framework/log/BUILD
+++ b/test/e2e/framework/log/BUILD
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["logger.go"],
+    importpath = "k8s.io/kubernetes/test/e2e/framework/log",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/framework/log/logger.go
+++ b/test/e2e/framework/log/logger.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+)
+
+func nowStamp() string {
+	return time.Now().Format(time.StampMilli)
+}
+
+func log(level string, format string, args ...interface{}) {
+	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
+}
+
+// Logf logs the info.
+func Logf(format string, args ...interface{}) {
+	log("INFO", format, args...)
+}


### PR DESCRIPTION
/kind cleanup
/priority backlog

**What this PR does / why we need it**:

Related to https://github.com/kubernetes/kubernetes/issues/77095

The `Logf` function is called in a huge number of files in the framework pkg, which is quite hard to refactor in one pull request. We could create log pkg first, and refactor upstream pkg piece by piece and delete the original function impletamtation in util.go

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/cc @WanLinghao 
/cc @andrewsykim 