### PR TITLE
fix azure disk list corruption issue

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_standard.go
@@ -41,7 +41,9 @@ func (as *availabilitySet) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 		return err
 	}
 
-	disks := *vm.StorageProfile.DataDisks
+	disks := make([]compute.DataDisk, len(*vm.StorageProfile.DataDisks))
+	copy(disks, *vm.StorageProfile.DataDisks)
+
 	if isManagedDisk {
 		disks = append(disks,
 			compute.DataDisk{
@@ -113,7 +115,9 @@ func (as *availabilitySet) DetachDisk(diskName, diskURI string, nodeName types.N
 		return nil, err
 	}
 
-	disks := *vm.StorageProfile.DataDisks
+	disks := make([]compute.DataDisk, len(*vm.StorageProfile.DataDisks))
+	copy(disks, *vm.StorageProfile.DataDisks)
+
 	bFoundDisk := false
 	for i, disk := range disks {
 		if disk.Lun != nil && (disk.Name != nil && diskName != "" && *disk.Name == diskName) ||

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_vmss.go
@@ -43,7 +43,8 @@ func (ss *scaleSet) AttachDisk(isManagedDisk bool, diskName, diskURI string, nod
 
 	disks := []compute.DataDisk{}
 	if vm.StorageProfile != nil && vm.StorageProfile.DataDisks != nil {
-		disks = *vm.StorageProfile.DataDisks
+		disks = make([]compute.DataDisk, len(*vm.StorageProfile.DataDisks))
+		copy(disks, *vm.StorageProfile.DataDisks)
 	}
 	if isManagedDisk {
 		disks = append(disks,
@@ -118,7 +119,8 @@ func (ss *scaleSet) DetachDisk(diskName, diskURI string, nodeName types.NodeName
 
 	disks := []compute.DataDisk{}
 	if vm.StorageProfile != nil && vm.StorageProfile.DataDisks != nil {
-		disks = *vm.StorageProfile.DataDisks
+		disks = make([]compute.DataDisk, len(*vm.StorageProfile.DataDisks))
+		copy(disks, *vm.StorageProfile.DataDisks)
 	}
 	bFoundDisk := false
 	for i, disk := range disks {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixed azure disk list corruption issue:
In Azure disk attach/detach function, it uses slice(`disks`) to store the disk list:
https://github.com/kubernetes/kubernetes/blob/f01c1401a9802cf650382983161dd587705d7444/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_standard.go#L44
And after `disks` changed, the original `vm.StorageProfile.DataDisks` would also be changed, so original azure data disk list is corrupted after attach/detach disk

example code as below:
```
func main() {
    var disks *[]string 
    disks = &[]string{"disk1", "disk2", "disk3", "disk4"}
    copy := *disks

    //detach a disk
    copy = append(copy[:1], copy[2:]...)

    
    fmt.Println("disks = ", *disks)
    fmt.Println("copy = ", copy)
}


# ./test
disks =  [disk1 disk3 disk4 disk4]
copy =  [disk1 disk3 disk4]
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #77186

**Special notes for your reviewer**:

**release-note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix azure disk list corruption issue
```

/kind bug
/assign @feiskyer @khenidak 
/priority important-soon
/sig azure

/test pull-kubernetes-e2e-aks-engine-azure