### PR TITLE
kubeadm: remove duplicated token.parsePEMCerts()

### DIFF
--- a/cmd/kubeadm/app/discovery/token/BUILD
+++ b/cmd/kubeadm/app/discovery/token/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
+        "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//staging/src/k8s.io/cluster-bootstrap/token/api:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/cmd/kubeadm/app/discovery/token/token.go
+++ b/cmd/kubeadm/app/discovery/token/token.go
@@ -18,8 +18,6 @@ package token
 
 import (
 	"bytes"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"sync"
 	"time"
@@ -31,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	"k8s.io/klog"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -119,7 +118,7 @@ func RetrieveValidatedConfigInfo(cfg *kubeadmapi.JoinConfiguration) (*clientcmda
 		for _, cluster := range insecureConfig.Clusters {
 			clusterCABytes = cluster.CertificateAuthorityData
 		}
-		clusterCAs, err := parsePEMCerts(clusterCABytes)
+		clusterCAs, err := certutil.ParseCertsPEM(clusterCABytes)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse cluster CA from the %s configmap", bootstrapapi.ConfigMapClusterInfo)
 
@@ -224,29 +223,4 @@ func fetchKubeConfigWithTimeout(apiEndpoint string, discoveryTimeout time.Durati
 		wg.Wait()
 		return resultingKubeConfig, nil
 	}
-}
-
-// parsePEMCerts decodes PEM-formatted certificates into a slice of x509.Certificates
-func parsePEMCerts(certData []byte) ([]*x509.Certificate, error) {
-	var certificates []*x509.Certificate
-	var pemBlock *pem.Block
-
-	for {
-		pemBlock, certData = pem.Decode(certData)
-		if pemBlock == nil {
-			return nil, errors.New("invalid PEM data")
-		}
-
-		cert, err := x509.ParseCertificate(pemBlock.Bytes)
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to parse certificate")
-		}
-		certificates = append(certificates, cert)
-
-		if len(certData) == 0 {
-			break
-		}
-	}
-
-	return certificates, nil
 }

--- a/cmd/kubeadm/app/discovery/token/token_test.go
+++ b/cmd/kubeadm/app/discovery/token/token_test.go
@@ -25,30 +25,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-// testCertPEM is a simple self-signed test certificate issued with the openssl CLI:
-// openssl req -new -newkey rsa:2048 -days 36500 -nodes -x509 -keyout /dev/null -out test.crt
-const testCertPEM = `
------BEGIN CERTIFICATE-----
-MIIDRDCCAiygAwIBAgIJAJgVaCXvC6HkMA0GCSqGSIb3DQEBBQUAMB8xHTAbBgNV
-BAMTFGt1YmVhZG0ta2V5cGlucy10ZXN0MCAXDTE3MDcwNTE3NDMxMFoYDzIxMTcw
-NjExMTc0MzEwWjAfMR0wGwYDVQQDExRrdWJlYWRtLWtleXBpbnMtdGVzdDCCASIw
-DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK0ba8mHU9UtYlzM1Own2Fk/XGjR
-J4uJQvSeGLtz1hID1IA0dLwruvgLCPadXEOw/f/IWIWcmT+ZmvIHZKa/woq2iHi5
-+HLhXs7aG4tjKGLYhag1hLjBI7icqV7ovkjdGAt9pWkxEzhIYClFMXDjKpMSynu+
-YX6nZ9tic1cOkHmx2yiZdMkuriRQnpTOa7bb03OC1VfGl7gHlOAIYaj4539WCOr8
-+ACTUMJUFEHcRZ2o8a/v6F9GMK+7SC8SJUI+GuroXqlMAdhEv4lX5Co52enYaClN
-+D9FJLRpBv2YfiCQdJRaiTvCBSxEFz6BN+PtP5l2Hs703ZWEkOqCByM6HV8CAwEA
-AaOBgDB+MB0GA1UdDgQWBBRQgUX8MhK2rWBWQiPHWcKzoWDH5DBPBgNVHSMESDBG
-gBRQgUX8MhK2rWBWQiPHWcKzoWDH5KEjpCEwHzEdMBsGA1UEAxMUa3ViZWFkbS1r
-ZXlwaW5zLXRlc3SCCQCYFWgl7wuh5DAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEB
-BQUAA4IBAQCaAUif7Pfx3X0F08cxhx8/Hdx4jcJw6MCq6iq6rsXM32ge43t8OHKC
-pJW08dk58a3O1YQSMMvD6GJDAiAfXzfwcwY6j258b1ZlI9Ag0VokvhMl/XfdCsdh
-AWImnL1t4hvU5jLaImUUMlYxMcSfHBGAm7WJIZ2LdEfg6YWfZh+WGbg1W7uxLxk6
-y4h5rWdNnzBHWAGf7zJ0oEDV6W6RSwNXtC0JNnLaeIUm/6xdSddJlQPwUv8YH4jX
-c1vuFqTnJBPcb7W//R/GI2Paicm1cmns9NLnPR35exHxFTy+D1yxmGokpoPMdife
-aH+sfuxT8xeTPb3kjzF9eJTlnEquUDLM
------END CERTIFICATE-----`
-
 func TestFetchKubeConfigWithTimeout(t *testing.T) {
 	const testAPIEndpoint = "sample-endpoint:1234"
 	tests := []struct {
@@ -92,36 +68,5 @@ func TestFetchKubeConfigWithTimeout(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func TestParsePEMCert(t *testing.T) {
-	for _, testCase := range []struct {
-		name        string
-		input       []byte
-		expectValid bool
-	}{
-		{"invalid certificate data", []byte{0}, false},
-		{"certificate with junk appended", []byte(testCertPEM + "\nABC"), false},
-		{"multiple certificates", []byte(testCertPEM + "\n" + testCertPEM), true},
-		{"valid", []byte(testCertPEM), true},
-		{"empty input", []byte{}, false},
-	} {
-		certs, err := parsePEMCerts(testCase.input)
-		if testCase.expectValid {
-			if err != nil {
-				t.Errorf("failed TestParsePEMCert(%s): unexpected error %v", testCase.name, err)
-			}
-			if certs == nil {
-				t.Errorf("failed TestParsePEMCert(%s): returned nil", testCase.name)
-			}
-		} else {
-			if err == nil {
-				t.Errorf("failed TestParsePEMCert(%s): expected an error", testCase.name)
-			}
-			if certs != nil {
-				t.Errorf("failed TestParsePEMCert(%s): expected not to get a certificate back, but got some", testCase.name)
-			}
-		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The function `parsePEMCerts()` duplicates `ParseCertsPEM()` from the `k8s.io/client-go/util/cert` package.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
