### PR TITLE
Remove proxy workaround fixed in go 1.12.4

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -230,34 +230,7 @@ func (h *UpgradeAwareHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 	proxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: h.Location.Scheme, Host: h.Location.Host})
 	proxy.Transport = h.Transport
 	proxy.FlushInterval = h.FlushInterval
-	proxy.ServeHTTP(maybeWrapFlushHeadersWriter(w), newReq)
-}
-
-// maybeWrapFlushHeadersWriter wraps the given writer to force flushing headers prior to writing the response body.
-// if the given writer does not support http.Flusher, http.Hijacker, and http.CloseNotifier, the original writer is returned.
-// TODO(liggitt): drop this once https://github.com/golang/go/issues/31125 is fixed
-func maybeWrapFlushHeadersWriter(w http.ResponseWriter) http.ResponseWriter {
-	flusher, isFlusher := w.(http.Flusher)
-	hijacker, isHijacker := w.(http.Hijacker)
-	closeNotifier, isCloseNotifier := w.(http.CloseNotifier)
-	// flusher, hijacker, and closeNotifier are all used by the ReverseProxy implementation.
-	// if the given writer can't support all three, return the original writer.
-	if !isFlusher || !isHijacker || !isCloseNotifier {
-		return w
-	}
-	return &flushHeadersWriter{w, flusher, hijacker, closeNotifier}
-}
-
-type flushHeadersWriter struct {
-	http.ResponseWriter
-	http.Flusher
-	http.Hijacker
-	http.CloseNotifier
-}
-
-func (w *flushHeadersWriter) WriteHeader(code int) {
-	w.ResponseWriter.WriteHeader(code)
-	w.Flusher.Flush()
+	proxy.ServeHTTP(w, newReq)
 }
 
 // tryUpgrade returns true if the request was handled.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/76154

Drops the proxy flush workaround, since we picked up the golang fix in 1.12.4

Leaves the unit test in place to make sure this doesn't regress

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @cheftako 