### PR TITLE
Return early when node expansion is determined

### DIFF
--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -681,17 +681,15 @@ func (c *csiDriverClient) NodeSupportsNodeExpand(ctx context.Context) (bool, err
 
 		capabilities := resp.GetCapabilities()
 
-		nodeExpandSet := false
 		if capabilities == nil {
 			return false, nil
 		}
 		for _, capability := range capabilities {
 			if capability.GetRpc().GetType() == csipbv1.NodeServiceCapability_RPC_EXPAND_VOLUME {
-				nodeExpandSet = true
 				return true, nil
 			}
 		}
-		return nodeExpandSet, nil
+		return false, nil
 	} else if c.nodeV0ClientCreator != nil {
 		return false, nil
 	}

--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -688,6 +688,7 @@ func (c *csiDriverClient) NodeSupportsNodeExpand(ctx context.Context) (bool, err
 		for _, capability := range capabilities {
 			if capability.GetRpc().GetType() == csipbv1.NodeServiceCapability_RPC_EXPAND_VOLUME {
 				nodeExpandSet = true
+				return true, nil
 			}
 		}
 		return nodeExpandSet, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In csiDriverClient#NodeSupportsNodeExpand, once we find csipbv1.NodeServiceCapability_RPC_EXPAND_VOLUME capability, we can return early.

```release-note
NONE
```
