### PR TITLE
Provide Stop func to ImageGCManager

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1324,6 +1324,7 @@ func (kl *Kubelet) initializeModules() error {
 
 	// Start out of memory watcher.
 	if err := kl.oomWatcher.Start(kl.nodeRef); err != nil {
+		kl.imageManager.Stop()
 		return fmt.Errorf("Failed to start OOM watcher %v", err)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

This fixes issue #77227

**What this PR does / why we need it**:
This PR adds Stop func to ImageGCManager so that the manager can be stopped at time of shutdown.

```release-note
NONE
```
