### PR TITLE
Fix verify godeps failure on 1.12

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1543,7 +1543,7 @@
 		},
 		{
 			"ImportPath": "github.com/evanphx/json-patch",
-			"Comment": "v4.1.0-19-g5858425",
+			"Comment": "v4.2.0",
 			"Rev": "5858425f75500d40c52783dce87d085a483ce135"
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
github.com/evanphx/json-patch added a new tag at the same sha this
morning: https://github.com/evanphx/json-patch/releases/tag/v4.2.0

This confused godeps. This PR updates our file to match godeps
expectation.

**Which issue(s) this PR fixes**:
Fixes: #77238

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/priority critical-urgent
/sig testing
/assign @liggitt
