### PR TITLE
Return the error from handleCreateEvent

### DIFF
--- a/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
@@ -211,7 +211,7 @@ func (w *Watcher) traversePluginDir(dir string) error {
 			}
 			//TODO: Handle errors by taking corrective measures
 			if err := w.handleCreateEvent(event); err != nil {
-				klog.Errorf("error %v when handling create event: %s", err, event)
+				return fmt.Errorf("error %v when handling create event: %s", err, event)
 			}
 		default:
 			klog.V(5).Infof("Ignoring file %s with mode %v", path, mode)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The error from w.handleCreateEvent call in Watcher#traversePluginDir should be returned to caller.

```release-note
NONE
```
