### PR TITLE
make all nodePorts jump to the firewall chain

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1081,7 +1081,12 @@ func (proxier *Proxier) syncProxyRules() {
 					// Jump to the service chain.
 					writeLine(proxier.natRules, append(args, "-j", string(svcChain))...)
 				} else {
-					// TODO: Make all nodePorts jump to the firewall chain.
+					for _, lp := range lps {
+						writeLine(proxier.natRules,
+							append(args, "-d", lp.IP,
+								"--dport", strconv.Itoa(svcInfo.NodePort),
+								"-j", string(fwChain))...)
+					}
 					// Currently we only create it for loadbalancers (#33586).
 
 					// Fix localhost martian source error

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1081,13 +1081,11 @@ func (proxier *Proxier) syncProxyRules() {
 					// Jump to the service chain.
 					writeLine(proxier.natRules, append(args, "-j", string(svcChain))...)
 				} else {
-					for _, lp := range lps {
-						writeLine(proxier.natRules,
-							append(args, "-d", lp.IP,
-								"--dport", strconv.Itoa(svcInfo.NodePort),
-								"-j", string(fwChain))...)
-					}
-					// Currently we only create it for loadbalancers (#33586).
+					// Make all nodePorts jump to the firewall chain.
+					writeLine(proxier.natRules,
+						append(args,
+							"-m", "addrtype", "--dst-type", "LOCAL",
+							"-j", string(fwChain))...)
 
 					// Fix localhost martian source error
 					loopback := "127.0.0.0/8"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind design
> /kind feature

**What this PR does / why we need it**:
Complete TODO: make all nodePorts jump to the firewall chain
https://github.com/kubernetes/kubernetes/blob/0f4b666469d9bb3d6cb0ef95d7ce9f7930301ec0/pkg/proxy/iptables/proxier.go#L1084
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
