### PR TITLE
Preserve existing namespace when using kubectl set --local

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -169,7 +169,12 @@ func (i *Info) String() string {
 
 // Namespaced returns true if the object belongs to a namespace
 func (i *Info) Namespaced() bool {
-	return i.Mapping != nil && i.Mapping.Scope.Name() == meta.RESTScopeNameNamespace
+	if i.Mapping != nil {
+		// if we have RESTMapper info, use it
+		return i.Mapping.Scope.Name() == meta.RESTScopeNameNamespace
+	}
+	// otherwise, use the presence of a namespace in the info as an indicator
+	return len(i.Namespace) > 0
 }
 
 // Watch returns server changes to this object after it was retrieved.

--- a/test/fixtures/pkg/kubectl/cmd/set/namespaced-resource.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/set/namespaced-resource.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: namespaced-rc
+  namespace: existing-ns
+spec:
+  replicas: 1
+  selector:
+    app: mock
+  template:
+    metadata:
+      labels:
+        app: mock
+    spec:
+      containers:
+      - name: mock-container
+        image: k8s.gcr.io/pause:3.1


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Uses existing namespace info in manifests to determine whether to preserve namespace info when running commands locally without RESTMapper info

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/639

**Does this PR introduce a user-facing change?**:
```release-note
Preserves existing namespace information in manifests when running `kubectl set ... --local` commands
```

/sig cli
/cc @seans3