### PR TITLE
Automated cherry pick of #75997: Bump debian-iptables versions to v11.0.2.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -89,8 +89,8 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
   local arch=$1
-  local debian_base_version=0.4.1
-  local debian_iptables_version=v11.0.1
+  local debian_base_version=v1.0.0
+  local debian_iptables_version=v11.0.2
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets
   local targets=(

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -18,7 +18,7 @@ REGISTRY ?= staging-k8s.gcr.io
 IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
-TAG ?= 0.4.1
+TAG ?= v1.0.0
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,12 +16,12 @@
 
 REGISTRY?="staging-k8s.gcr.io"
 IMAGE=$(REGISTRY)/debian-iptables
-TAG?=v11.0.1
+TAG?=v11.0.2
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 TEMP_DIR:=$(shell mktemp -d)
 
-BASEIMAGE?=k8s.gcr.io/debian-base-$(ARCH):0.4.1
+BASEIMAGE?=k8s.gcr.io/debian-base-$(ARCH):v1.0.0
 
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -45,8 +45,8 @@ _ETCD_TARBALL_ARCH_SHA256 = {
 # Note that these are digests for the manifest list. We resolve the manifest
 # list to each of its platform-specific images in
 # debian_image_dependencies().
-_DEBIAN_BASE_DIGEST = "sha256:6966a0aedd7592c18ff2dd803c08bd85780ee19f5e3a2e7cf908a4cd837afcde"  # 0.4.1
-_DEBIAN_IPTABLES_DIGEST = "sha256:656e45c00083359107b1d6ae0411ff3894ba23011a8533e229937a71be84e063"  # v11.0.1
+_DEBIAN_BASE_DIGEST = "sha256:3801f944c765dc1b54900826ca67b1380bb8c73b9caf4a2a27ce613b3ba3e742"  # v1.0.0
+_DEBIAN_IPTABLES_DIGEST = "sha256:b522b0035dba3ac2d5c0dbaaf8217bd66248e790332ccfdf653e0f943a280dcf"  # v11.0.2
 _DEBIAN_HYPERKUBE_BASE_DIGEST = "sha256:8cabe02be6e86685d8860b7ace7c7addc9591a339728703027a4854677f1c772"  # 0.12.1
 
 # Dependencies needed for a Kubernetes "release", e.g. building docker images,


### PR DESCRIPTION
Cherry pick of #75997 on release-1.14.

#75997: Bump debian-iptables versions to v11.0.2.