### PR TITLE
Automated cherry pick of #76732: os exit when option is true

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -92,6 +92,7 @@ const (
 // proxyRun defines the interface to run a specified ProxyServer
 type proxyRun interface {
 	Run() error
+	CleanupAndExit() error
 }
 
 // Options contains everything necessary to create and run a proxy server.
@@ -306,6 +307,11 @@ func (o *Options) Run() error {
 	if err != nil {
 		return err
 	}
+
+	if o.CleanupAndExit {
+		return proxyServer.CleanupAndExit()
+	}
+
 	o.proxyServer = proxyServer
 	return o.runLoop()
 }
@@ -499,7 +505,6 @@ type ProxyServer struct {
 	Conntracker            Conntracker // if nil, ignored
 	ProxyMode              string
 	NodeRef                *v1.ObjectReference
-	CleanupAndExit         bool
 	CleanupIPVS            bool
 	MetricsBindAddress     string
 	EnableProfiling        bool
@@ -551,19 +556,10 @@ func createClients(config componentbaseconfig.ClientConnectionConfiguration, mas
 }
 
 // Run runs the specified ProxyServer.  This should never exit (unless CleanupAndExit is set).
+// TODO: At the moment, Run() cannot return a nil error, otherwise it's caller will never exit. Update callers of Run to handle nil errors.
 func (s *ProxyServer) Run() error {
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", version.Get())
-	// remove iptables rules and exit
-	if s.CleanupAndExit {
-		encounteredError := userspace.CleanupLeftovers(s.IptInterface)
-		encounteredError = iptables.CleanupLeftovers(s.IptInterface) || encounteredError
-		encounteredError = ipvs.CleanupLeftovers(s.IpvsInterface, s.IptInterface, s.IpsetInterface, s.CleanupIPVS) || encounteredError
-		if encounteredError {
-			return errors.New("encountered an error while tearing down rules.")
-		}
-		return nil
-	}
 
 	// TODO(vmarmol): Use container config for this.
 	var oomAdjuster *oom.OOMAdjuster
@@ -708,4 +704,16 @@ func getConntrackMax(config kubeproxyconfig.KubeProxyConntrackConfiguration) (in
 		return floor, nil
 	}
 	return 0, nil
+}
+
+// CleanupAndExit remove iptables rules and exit if success return nil
+func (s *ProxyServer) CleanupAndExit() error {
+	encounteredError := userspace.CleanupLeftovers(s.IptInterface)
+	encounteredError = iptables.CleanupLeftovers(s.IptInterface) || encounteredError
+	encounteredError = ipvs.CleanupLeftovers(s.IpvsInterface, s.IptInterface, s.IpsetInterface, s.CleanupIPVS) || encounteredError
+	if encounteredError {
+		return errors.New("encountered an error while tearing down rules")
+	}
+
+	return nil
 }

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -103,7 +103,6 @@ func newProxyServer(
 			IptInterface:   iptInterface,
 			IpvsInterface:  ipvsInterface,
 			IpsetInterface: ipsetInterface,
-			CleanupAndExit: cleanupAndExit,
 		}, nil
 	}
 

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -108,7 +109,6 @@ func TestProxyServerWithCleanupAndExit(t *testing.T) {
 		assert.Nil(t, err, "unexpected error in NewProxyServer, addr: %s", addr)
 		assert.NotNil(t, proxyserver, "nil proxy server obj, addr: %s", addr)
 		assert.NotNil(t, proxyserver.IptInterface, "nil iptables intf, addr: %s", addr)
-		assert.True(t, proxyserver.CleanupAndExit, "false CleanupAndExit, addr: %s", addr)
 
 		// Clean up config for next test case
 		configz.Delete(kubeproxyconfig.GroupName)
@@ -540,6 +540,11 @@ func (s *fakeProxyServerLongRun) Run() error {
 	}
 }
 
+// CleanupAndExit runs in the specified ProxyServer.
+func (s *fakeProxyServerLongRun) CleanupAndExit() error {
+	return nil
+}
+
 type fakeProxyServerError struct{}
 
 // Run runs the specified ProxyServer.
@@ -548,4 +553,9 @@ func (s *fakeProxyServerError) Run() error {
 		time.Sleep(2 * time.Second)
 		return fmt.Errorf("mocking error from ProxyServer.Run()")
 	}
+}
+
+// CleanupAndExit runs in the specified ProxyServer.
+func (s *fakeProxyServerError) CleanupAndExit() error {
+	return errors.New("mocking error from ProxyServer.CleanupAndExit()")
 }

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -24,6 +24,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+
+	// Enable pprof HTTP handlers.
 	_ "net/http/pprof"
 
 	"k8s.io/api/core/v1"
@@ -63,7 +65,7 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 
 	// We omit creation of pretty much everything if we run in cleanup mode
 	if cleanupAndExit {
-		return &ProxyServer{CleanupAndExit: cleanupAndExit}, nil
+		return &ProxyServer{}, nil
 	}
 
 	client, eventClient, err := createClients(config.ClientConnection, master)


### PR DESCRIPTION
#76109 removed automatic rule cleanup in kube-proxy, and encourages users to use `kube-proxy --cleanup`. `--cleanup` has a longstanding bug where it does not exit after cleanup (#76727). This bug is a larger problem now that more users are using the flag.

Cherry pick of #76732 on release-1.14.

#76732: os exit when option is true