### PR TITLE
Enable API resource paging by default, by feature gate in sample-apiserver

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -150,6 +150,7 @@ func TestAddFlags(t *testing.T) {
 					CAFile:     "/var/run/kubernetes/etcdca.crt",
 					CertFile:   "/var/run/kubernetes/etcdce.crt",
 				},
+				Paging:                true,
 				Prefix:                "/registry",
 				CompactionInterval:    storagebackend.DefaultCompactInterval,
 				CountMetricPollPeriod: time.Minute,

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
@@ -74,6 +74,7 @@ type Config struct {
 
 func NewDefaultConfig(prefix string, codec runtime.Codec) *Config {
 	return &Config{
+		Paging:             true,
 		Prefix:             prefix,
 		Codec:              codec,
 		CompactionInterval: DefaultCompactInterval,

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/features"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -112,6 +113,8 @@ func (o *WardleServerOptions) Config() (*apiserver.Config, error) {
 	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
+
+	o.RecommendedOptions.Etcd.StorageConfig.Paging = utilfeature.DefaultFeatureGate.Enabled(features.APIListChunking)
 
 	o.RecommendedOptions.ExtraAdmissionInitializers = func(c *genericapiserver.RecommendedConfig) ([]admission.PluginInitializer, error) {
 		client, err := clientset.NewForConfig(c.LoopbackClientConfig)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Enable paging and quorum reads by default in etcd storage, and by feature gate in sample-apiserver

**Does this PR introduce a user-facing change?**:
```release-note
API paging is now enabled by default in k8s.io/apiserver recommended options, and in k8s.io/sample-apiserver
```

/cc MikeSpreitzer
/sig api-machinery