### PR TITLE
Log warning if there is error setting rlimit

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1047,7 +1047,7 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 	podCfg := kubeDeps.PodConfig
 
 	if err := rlimit.RlimitNumFiles(uint64(kubeServer.MaxOpenFiles)); err != nil {
-		klog.Warning("Warning: encountered %v when setting max open files", err)
+		klog.Warningf("Warning: encountered %v when setting max open files", err)
 	}
 
 	// process pods and exit.

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1046,7 +1046,9 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 	}
 	podCfg := kubeDeps.PodConfig
 
-	rlimit.RlimitNumFiles(uint64(kubeServer.MaxOpenFiles))
+	if err := rlimit.RlimitNumFiles(uint64(kubeServer.MaxOpenFiles)); err != nil {
+		klog.Warning("Warning: encountered %v when setting max open files", err)
+	}
 
 	// process pods and exit.
 	if runOnce {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently the error return from rlimit.RlimitNumFiles is ignored in RunKubelet.
This PR adds a warning log if the error is not nil.

```release-note
NONE
```
