### PR TITLE
Automated cherry pick of #76722: Pin GCE Windows node image to 1809 v20190312.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2020,7 +2020,9 @@ function create-node-template() {
   if [[ "${os}" == 'linux' ]]; then
       node_image_flags="--image-project ${NODE_IMAGE_PROJECT} --image ${NODE_IMAGE}"
   elif [[ "${os}" == 'windows' ]]; then
-      node_image_flags="--image-project ${WINDOWS_NODE_IMAGE_PROJECT} --image-family ${WINDOWS_NODE_IMAGE_FAMILY}"
+      # TODO(pjh): revert back to using WINDOWS_NODE_IMAGE_FAMILY instead of
+      # pinning to the v20190312 image once #76666 is resolved.
+      node_image_flags="--image-project ${WINDOWS_NODE_IMAGE_PROJECT} --image=windows-server-1809-dc-core-for-containers-v20190312"
   else
       echo "Unknown OS ${os}" >&2
       exit 1


### PR DESCRIPTION
Cherry pick of #76722 on release-1.14.

#76722: Pin GCE Windows node image to 1809 v20190312.