### PR TITLE
Use map to check for long-running request

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -824,15 +824,17 @@ func trimURLPath(path string) string {
 	return parts[0]
 }
 
+var longRunningRequestPathMap = map[string]bool{
+	"exec":        true,
+	"attach":      true,
+	"portforward": true,
+	"debug":       true,
+}
+
 // isLongRunningRequest determines whether the request is long-running or not.
 func isLongRunningRequest(path string) bool {
-	longRunningRequestPaths := []string{"exec", "attach", "portforward", "debug"}
-	for _, p := range longRunningRequestPaths {
-		if p == path {
-			return true
-		}
-	}
-	return false
+	_, ok := longRunningRequestPathMap[path]
+	return ok
 }
 
 // ServeHTTP responds to HTTP requests on the Kubelet.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In isLongRunningRequest, we check path against each candidate in serial fashion.

This PR uses map to expedite the check.

```release-note
NONE
```
