### PR TITLE
Automated cherry pick of #69631: use k8s.gcr.io/pause instead of kubernetes/pause

### DIFF
--- a/test/e2e/scheduling/taints_test.go
+++ b/test/e2e/scheduling/taints_test.go
@@ -61,7 +61,7 @@ func createPodForTaintsTest(hasToleration bool, tolerationSeconds int, podName, 
 				Containers: []v1.Container{
 					{
 						Name:  "pause",
-						Image: "kubernetes/pause",
+						Image: "k8s.gcr.io/pause:3.1",
 					},
 				},
 			},
@@ -80,7 +80,7 @@ func createPodForTaintsTest(hasToleration bool, tolerationSeconds int, podName, 
 					Containers: []v1.Container{
 						{
 							Name:  "pause",
-							Image: "kubernetes/pause",
+							Image: "k8s.gcr.io/pause:3.1",
 						},
 					},
 					Tolerations: []v1.Toleration{{Key: "kubernetes.io/e2e-evict-taint-key", Value: "evictTaintVal", Effect: v1.TaintEffectNoExecute}},
@@ -99,7 +99,7 @@ func createPodForTaintsTest(hasToleration bool, tolerationSeconds int, podName, 
 					Containers: []v1.Container{
 						{
 							Name:  "pause",
-							Image: "kubernetes/pause",
+							Image: "k8s.gcr.io/pause:3.1",
 						},
 					},
 					// default - tolerate forever

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -1026,7 +1026,7 @@ func MakePodSpec() v1.PodSpec {
 	return v1.PodSpec{
 		Containers: []v1.Container{{
 			Name:  "pause",
-			Image: "kubernetes/pause",
+			Image: "k8s.gcr.io/pause:3.1",
 			Ports: []v1.ContainerPort{{ContainerPort: 80}},
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
@@ -1253,7 +1253,7 @@ type DaemonConfig struct {
 
 func (config *DaemonConfig) Run() error {
 	if config.Image == "" {
-		config.Image = "kubernetes/pause"
+		config.Image = "k8s.gcr.io/pause:3.1"
 	}
 	nameLabel := map[string]string{
 		"name": config.Name + "-daemon",


### PR DESCRIPTION
Cherry pick of #69631 on release-1.12.

#69631: use k8s.gcr.io/pause instead of kubernetes/pause

```release-note
Use k8s.gcr.io/pause image instead of kubernetes/pause in test framework
```