### PR TITLE
Perform component wise comparison when comparands are computed

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -110,19 +110,23 @@ func (a *cpuAccumulator) freeCPUs() []int {
 			// as each core.
 			iSocketColoScore := a.topo.CPUDetails.CPUsInSocket(iSocket).Intersection(a.result).Size()
 			jSocketColoScore := a.topo.CPUDetails.CPUsInSocket(jSocket).Intersection(a.result).Size()
+			if iSocketColoScore > jSocketColoScore {
+				return true
+			}
 
 			// Compute the number of available CPUs available on the same socket
 			// as each core.
 			iSocketFreeScore := a.details.CPUsInSocket(iSocket).Size()
 			jSocketFreeScore := a.details.CPUsInSocket(jSocket).Size()
+			if iSocketFreeScore < jSocketFreeScore {
+				return true
+			}
 
 			// Compute the number of available CPUs on each core.
 			iCoreFreeScore := a.details.CPUsInCore(iCore).Size()
 			jCoreFreeScore := a.details.CPUsInCore(jCore).Size()
 
-			return iSocketColoScore > jSocketColoScore ||
-				iSocketFreeScore < jSocketFreeScore ||
-				iCoreFreeScore < jCoreFreeScore ||
+			return iCoreFreeScore < jCoreFreeScore ||
 				iSocket < jSocket ||
 				iCore < jCore
 		})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In cpuAccumulator#freeCPUs, we perform comparison at the end of the func.

This PR lifts comparison to where the underlying comparands are computed.

```release-note
NONE
```
