### PR TITLE
Clean up kube-proxy.

### DIFF
--- a/cmd/kube-proxy/app/BUILD
+++ b/cmd/kube-proxy/app/BUILD
@@ -163,7 +163,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/apis/core:go_default_library",
         "//pkg/proxy/apis/config:go_default_library",
         "//pkg/util/configz:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -332,11 +332,9 @@ func (o *Options) runLoop() error {
 	}()
 
 	for {
-		select {
-		case err := <-o.errCh:
-			if err != nil {
-				return err
-			}
+		err := <-o.errCh
+		if err != nil {
+			return err
 		}
 	}
 }

--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -29,8 +29,6 @@ import (
 func Test_getProxyMode(t *testing.T) {
 	var cases = []struct {
 		flag            string
-		annotationKey   string
-		annotationVal   string
 		iptablesVersion string
 		ipsetVersion    string
 		kmods           []string

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -33,19 +33,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	componentbaseconfig "k8s.io/component-base/config"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/util/configz"
 	utilpointer "k8s.io/utils/pointer"
 )
-
-type fakeNodeInterface struct {
-	node api.Node
-}
-
-func (fake *fakeNodeInterface) Get(hostname string, options metav1.GetOptions) (*api.Node, error) {
-	return &fake.node, nil
-}
 
 type fakeIPTablesVersioner struct {
 	version string // what to return


### PR DESCRIPTION
These are based on recommendation from
[staticcheck](http://staticcheck.io/).

- Removes dead type/function along with the import that the function
introduced.
- Removes unused struct fields.
- Removes select nested in a tight for loop, the select does not have a
default, so it will be blocking.

/kind cleanup

```release-note
None
```
