### PR TITLE
Clean up kubeadm.

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -117,7 +117,6 @@ type initData struct {
 	dryRunDir               string
 	externalCA              bool
 	client                  clientset.Interface
-	waiter                  apiclient.Waiter
 	outputWriter            io.Writer
 	uploadCerts             bool
 	certificateKey          string

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -138,7 +138,6 @@ var _ phases.JoinData = &joinData{}
 // this data is shared across all the phases that are included in the workflow.
 type joinData struct {
 	cfg                   *kubeadmapi.JoinConfiguration
-	skipTokenPrint        bool
 	initCfg               *kubeadmapi.InitConfiguration
 	tlsBootstrapCfg       *clientcmdapi.Config
 	clientSet             *clientset.Clientset
@@ -187,7 +186,7 @@ func NewCmdJoin(out io.Writer, joinOptions *joinOptions) *cobra.Command {
 			} else {
 				// otherwise, if the node joined as a worker node;
 				// outputs the join done message and exit
-				fmt.Fprintf(data.outputWriter, joinWorkerNodeDoneMsg)
+				fmt.Fprint(data.outputWriter, joinWorkerNodeDoneMsg)
 			}
 		},
 		// We accept the control-plane location as an optional positional argument

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
@@ -100,7 +100,6 @@ func TestCompileManifests(t *testing.T) {
 		name     string
 		manifest string
 		data     interface{}
-		expected bool
 	}{
 		{
 			name:     "KubeProxyConfigMap19",

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -376,7 +376,7 @@ func TestWriteKeyFilesIfNotExist(t *testing.T) {
 			t.Fatalf("Failed to marshal expected private key: %v", err)
 		}
 
-		if bytes.Compare(resultingKeyPEM, expectedKeyPEM) != 0 {
+		if !bytes.Equal(resultingKeyPEM, expectedKeyPEM) {
 			t.Error("created key does not match expected key")
 		}
 	}
@@ -736,7 +736,6 @@ func TestNewCSR(t *testing.T) {
 func TestCreateCertificateFilesMethods(t *testing.T) {
 
 	var tests = []struct {
-		setupFunc     func(cfg *kubeadmapi.InitConfiguration) error
 		createFunc    func(cfg *kubeadmapi.InitConfiguration) error
 		expectedFiles []string
 		externalEtcd  bool

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -521,12 +521,8 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 			mounts := getHostPathVolumesForTheControlPlane(rt.cfg)
 
 			// Avoid unit test errors when the flexvolume is mounted
-			if _, ok := mounts.volumes[kubeadmconstants.KubeControllerManager][flexvolumeDirVolumeName]; ok {
-				delete(mounts.volumes[kubeadmconstants.KubeControllerManager], flexvolumeDirVolumeName)
-			}
-			if _, ok := mounts.volumeMounts[kubeadmconstants.KubeControllerManager][flexvolumeDirVolumeName]; ok {
-				delete(mounts.volumeMounts[kubeadmconstants.KubeControllerManager], flexvolumeDirVolumeName)
-			}
+			delete(mounts.volumes[kubeadmconstants.KubeControllerManager], flexvolumeDirVolumeName)
+			delete(mounts.volumeMounts[kubeadmconstants.KubeControllerManager], flexvolumeDirVolumeName)
 			if !reflect.DeepEqual(mounts.volumes, rt.vol) {
 				t.Errorf(
 					"failed getHostPathVolumesForTheControlPlane:\n\texpected: %v\n\t  actual: %v",
@@ -632,7 +628,7 @@ func TestAddExtraHostPathMounts(t *testing.T) {
 			if *vol.HostPath.Type != v1.HostPathType(hostMount.PathType) {
 				t.Errorf("Expected to host path type %q", hostMount.PathType)
 			}
-			volMount, _ := mounts.volumeMounts["component"][volumeName]
+			volMount := mounts.volumeMounts["component"][volumeName]
 			if volMount.Name != volumeName {
 				t.Errorf("Expected volume mount name %q", volumeName)
 			}

--- a/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane.go
+++ b/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane.go
@@ -30,7 +30,7 @@ func MarkControlPlane(client clientset.Interface, controlPlaneName string, taint
 
 	fmt.Printf("[mark-control-plane] Marking the node %s as control-plane by adding the label \"%s=''\"\n", controlPlaneName, constants.LabelNodeRoleMaster)
 
-	if taints != nil && len(taints) > 0 {
+	if len(taints) > 0 {
 		taintStrs := []string{}
 		for _, taint := range taints {
 			taintStrs = append(taintStrs, taint.ToString())

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -19,7 +19,6 @@ package upgrade
 import (
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -40,8 +39,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
 )
-
-var expiry = 180 * 24 * time.Hour
 
 // PerformPostUpgradeTasks runs nearly the same functions as 'kubeadm init' would do
 // Note that the mark-control-plane phase is left out, not needed, and no token is created as that doesn't belong to the upgrade

--- a/cmd/kubeadm/app/util/cgroupdriver.go
+++ b/cmd/kubeadm/app/util/cgroupdriver.go
@@ -45,13 +45,6 @@ func GetCgroupDriverDocker(execer utilsexec.Interface) (string, error) {
 	return strings.TrimSuffix(driver, "\n"), nil
 }
 
-func validateCgroupDriver(driver string) error {
-	if driver != CgroupDriverCgroupfs && driver != CgroupDriverSystemd {
-		return errors.Errorf("unknown cgroup driver %q", driver)
-	}
-	return nil
-}
-
 func callDockerInfo(execer utilsexec.Interface) (string, error) {
 	out, err := execer.Command("docker", "info", "-f", "{{.CgroupDriver}}").Output()
 	if err != nil {

--- a/cmd/kubeadm/app/util/config/initconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration_test.go
@@ -29,17 +29,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
-const (
-	controlPlaneV1beta1YAML           = "testdata/conversion/controlplane/v1beta1.yaml"
-	controlPlaneV1beta1YAMLNonLinux   = "testdata/conversion/controlplane/v1beta1_non_linux.yaml"
-	controlPlaneInternalYAML          = "testdata/conversion/controlplane/internal.yaml"
-	controlPlaneInternalYAMLNonLinux  = "testdata/conversion/controlplane/internal_non_linux.yaml"
-	controlPlaneIncompleteYAML        = "testdata/defaulting/controlplane/incomplete.yaml"
-	controlPlaneDefaultedYAML         = "testdata/defaulting/controlplane/defaulted.yaml"
-	controlPlaneDefaultedYAMLNonLinux = "testdata/defaulting/controlplane/defaulted_non_linux.yaml"
-	controlPlaneInvalidYAML           = "testdata/validation/invalid_controlplanecfg.yaml"
-)
-
 func diff(expected, actual []byte) string {
 	// Write out the diff
 	var diffBytes bytes.Buffer

--- a/cmd/kubeadm/app/util/runtime/runtime.go
+++ b/cmd/kubeadm/app/util/runtime/runtime.go
@@ -109,9 +109,7 @@ func (runtime *CRIRuntime) ListKubeContainers() ([]string, error) {
 		return nil, errors.Wrapf(err, "output: %s, error", string(out))
 	}
 	pods := []string{}
-	for _, pod := range strings.Fields(string(out)) {
-		pods = append(pods, pod)
-	}
+	pods = append(pods, strings.Fields(string(out))...)
 	return pods, nil
 }
 

--- a/cmd/kubeadm/app/util/system/report.go
+++ b/cmd/kubeadm/app/util/system/report.go
@@ -18,9 +18,10 @@ package system
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"os"
+
+	"github.com/pkg/errors"
 )
 
 // ValidationResultType is type of the validation result. Different validation results
@@ -38,9 +39,9 @@ type color int32
 
 const (
 	red    color = 31
-	green        = 32
-	yellow       = 33
-	white        = 37
+	green  color = 32
+	yellow color = 33
+	white  color = 37
 )
 
 func colorize(s string, c color) string {


### PR DESCRIPTION
These are based on recommendation from
[staticcheck](http://staticcheck.io/).

- Remove unused struct fields
- Remove unused function
- Remove unused variables
- Remove unused constants.
- Miscellaneous cleanups

/kind cleanup
/priority backlog

```release-note
NONE
```
