### PR TITLE
Backward compatible access modes and removal of zone/zones parameters from GCE PD CSI Translation library

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/api/core/v1"
+)
+
+func TestBackwardCompatibleAccessModes(t *testing.T) {
+	testCases := []struct {
+		name           string
+		accessModes    []v1.PersistentVolumeAccessMode
+		expAccessModes []v1.PersistentVolumeAccessMode
+	}{
+		{
+			name: "multiple normals",
+			accessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadOnlyMany,
+				v1.ReadWriteOnce,
+			},
+			expAccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadOnlyMany,
+				v1.ReadWriteOnce,
+			},
+		},
+		{
+			name: "one normal",
+			accessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			expAccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+		},
+		{
+			name: "some readwritemany",
+			accessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+				v1.ReadWriteMany,
+			},
+			expAccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+				v1.ReadWriteOnce,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("running test: %v", tc.name)
+
+		got := backwardCompatibleAccessModes(tc.accessModes)
+
+		if !reflect.DeepEqual(tc.expAccessModes, got) {
+			t.Fatalf("Expected access modes: %v, instead got: %v", tc.expAccessModes, got)
+		}
+	}
+}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
For preprovisioned in-tree GCE PD we did not enforce access modes so a `ReadWriteMany` volume could have been created and used as a normal `ReadWriteOnce` volume. However, CSI now enforces access modes and will not allow you to attach volumes specified as `ReadWriteMany` so for backwards compatibility purposes we change all `ReadWriteMany` to `ReadWriteOnce` when translating volumes.

Additionally we remove the deprecated `zone` and `zones` parameters from the storage class parameters when translating from in-tree to CSI. A follow-up PR will incorporate `zone` and `zones` parameters into topology decisions on the external provisioner

Partially does the thing for #77235

/assign @saad-ali @msau42 
/cc @ddebroy @leakingtapan 

```release-note
NONE
```
