### PR TITLE
Bump the version of the ip-masq-agent addon to pick up CVE fixes

### DIFF
--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -32,7 +32,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: k8s.gcr.io/ip-masq-agent-amd64:v2.1.1
+        image: k8s.gcr.io/ip-masq-agent-amd64:v2.2.1
         args:
           - --masq-chain=IP-MASQ
         resources:


### PR DESCRIPTION
This is related to the same CVE fixes in PR #75845. We complete the loop by referencing the enw containers in the yaml.

The CVEs are in the dependencies of ip-masq-agent -
debian-base bump at: https://github.com/kubernetes-incubator/ip-masq-agent/pull/31
debian-iptables-amd64 bump at: https://github.com/kubernetes-incubator/ip-masq-agent/pull/30

/kind cleanup

/sig network
/sig release

```release-note
None
```

/assign @bowei @tallclair 