### PR TITLE
Return proper error from sync

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -223,7 +223,6 @@ func (c *AvailableConditionController) sync(key string) error {
 			apiregistration.SetAPIServiceCondition(apiService, availableCondition)
 			if _, err2 := updateAPIServiceStatus(c.apiServiceClient, originalAPIService, apiService); err2 != nil {
 				klog.Errorf("cannot update API service status: %v", err2)
-				return err
 			}
 			return err
 		} else if err != nil {
@@ -233,7 +232,6 @@ func (c *AvailableConditionController) sync(key string) error {
 			apiregistration.SetAPIServiceCondition(apiService, availableCondition)
 			if _, err2 := updateAPIServiceStatus(c.apiServiceClient, originalAPIService, apiService); err2 != nil {
 				klog.Errorf("cannot update API service status: %v", err2)
-				return err
 			}
 			return err
 		}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -223,7 +223,7 @@ func (c *AvailableConditionController) sync(key string) error {
 			apiregistration.SetAPIServiceCondition(apiService, availableCondition)
 			if _, err2 := updateAPIServiceStatus(c.apiServiceClient, originalAPIService, apiService); err2 != nil {
 				klog.Errorf("cannot update API service status: %v", err2)
-				return err2
+				return err
 			}
 			return err
 		} else if err != nil {
@@ -233,7 +233,7 @@ func (c *AvailableConditionController) sync(key string) error {
 			apiregistration.SetAPIServiceCondition(apiService, availableCondition)
 			if _, err2 := updateAPIServiceStatus(c.apiServiceClient, originalAPIService, apiService); err2 != nil {
 				klog.Errorf("cannot update API service status: %v", err2)
-				return err2
+				return err
 			}
 			return err
 		}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -223,8 +223,9 @@ func (c *AvailableConditionController) sync(key string) error {
 			apiregistration.SetAPIServiceCondition(apiService, availableCondition)
 			if _, err2 := updateAPIServiceStatus(c.apiServiceClient, originalAPIService, apiService); err2 != nil {
 				klog.Errorf("cannot update API service status: %v", err2)
+				return err2
 			}
-			return err2
+			return err
 		} else if err != nil {
 			availableCondition.Status = apiregistration.ConditionUnknown
 			availableCondition.Reason = "EndpointsAccessError"
@@ -232,8 +233,9 @@ func (c *AvailableConditionController) sync(key string) error {
 			apiregistration.SetAPIServiceCondition(apiService, availableCondition)
 			if _, err2 := updateAPIServiceStatus(c.apiServiceClient, originalAPIService, apiService); err2 != nil {
 				klog.Errorf("cannot update API service status: %v", err2)
+				return err2
 			}
-			return err2
+			return err
 		}
 		hasActiveEndpoints := false
 		for _, subset := range endpoints.Subsets {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
For AvailableConditionController#sync, when err is not nil we call updateAPIServiceStatus and return the error.
However, the err is assigned the return value from call to updateAPIServiceStatus before returning.
This means that though the call to updateAPIServiceStatus may be successful, its return value would be nonetheless returned to caller of sync.

```release-note
NONE
```
