### PR TITLE
GKE also requires SAR endpoints

### DIFF
--- a/test/e2e/framework/auth/BUILD
+++ b/test/e2e/framework/auth/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/authorization/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1beta1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/test/e2e/framework/auth/helpers.go
+++ b/test/e2e/framework/auth/helpers.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	authorizationv1beta1 "k8s.io/api/authorization/v1beta1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -68,15 +67,6 @@ func WaitForNamedAuthorizationUpdate(c v1beta1authorization.SubjectAccessReviews
 
 	err := wait.Poll(policyCachePollInterval, policyCachePollTimeout, func() (bool, error) {
 		response, err := c.SubjectAccessReviews().Create(review)
-		// GKE doesn't enable the SAR endpoint.  Without this endpoint, we cannot determine if the policy engine
-		// has adjusted as expected.  In this case, simply wait one second and hope it's up to date
-		// TODO: Should have a check for the provider here but that introduces too tight of
-		// coupling with the `framework` package. See: https://github.com/kubernetes/kubernetes/issues/76726
-		if apierrors.IsNotFound(err) {
-			logf("SubjectAccessReview endpoint is missing")
-			time.Sleep(1 * time.Second)
-			return true, nil
-		}
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There was a specific error flow that was commented as only applying
to GKE. This was never tested specifically for GKE (only commented
as such) but that seems to be out of date and can be removed. If
the SAR endpoint does not exist it should be considered an error.

**Which issue(s) this PR fixes**:
Fixes #76726

**Special notes for your reviewer**:
See https://cloud.google.com/kubernetes-engine/docs/reference/api-permissions and just search for `subjectaccessreview`. You'll see there are subjectaccessreview, selfsubjectaccessreview, and localsubjectaccessreview endpoints.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig testing
/area test
/area test-framework
