### PR TITLE
Clean up kubelet.

### DIFF
--- a/cmd/kubelet/app/options/options_test.go
+++ b/cmd/kubelet/app/options/options_test.go
@@ -49,7 +49,6 @@ func TestRoundTrip(t *testing.T) {
 		inputFlags    func() *KubeletServer
 		outputFlags   func() *KubeletServer
 		flagDefaulter func(*pflag.FlagSet)
-		skipDefault   bool
 		err           bool
 		expectArgs    bool
 	}{

--- a/pkg/kubelet/apis/stats/v1alpha1/types.go
+++ b/pkg/kubelet/apis/stats/v1alpha1/types.go
@@ -146,7 +146,7 @@ type ContainerStats struct {
 	// User defined metrics that are exposed by containers in the pod. Typically, we expect only one container in the pod to be exposing user defined metrics. In the event of multiple containers exposing metrics, they will be combined here.
 	// +patchMergeKey=name
 	// +patchStrategy=merge
-	UserDefinedMetrics []UserDefinedMetric `json:"userDefinedMetrics,omitmepty" patchStrategy:"merge" patchMergeKey:"name"`
+	UserDefinedMetrics []UserDefinedMetric `json:"userDefinedMetrics,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // PodReference contains enough information to locate the referenced pod.

--- a/pkg/kubelet/checkpoint/checkpoint.go
+++ b/pkg/kubelet/checkpoint/checkpoint.go
@@ -91,9 +91,7 @@ func getPodKey(pod *v1.Pod) string {
 func LoadPods(cpm checkpointmanager.CheckpointManager) ([]*v1.Pod, error) {
 	pods := make([]*v1.Pod, 0)
 
-	var err error
-	checkpointKeys := []string{}
-	checkpointKeys, err = cpm.ListCheckpoints()
+	checkpointKeys, err := cpm.ListCheckpoints()
 	if err != nil {
 		klog.Errorf("Failed to list checkpoints: %v", err)
 	}

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -114,7 +114,6 @@ type containerManagerImpl struct {
 	status Status
 	// External containers being managed.
 	systemContainers []*systemContainer
-	qosContainers    QOSContainersInfo
 	// Tasks that are run periodically
 	periodicTasks []func()
 	// Holds all the mounted cgroup subsystems

--- a/pkg/kubelet/cm/cpumanager/state/state_compatibility_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_compatibility_test.go
@@ -68,6 +68,9 @@ func TestCheckpointToFileCompatibility(t *testing.T) {
 	defer cpm.RemoveCheckpoint(compatibilityTestingCheckpoint)
 
 	checkpointState, err := NewCheckpointState(testingDir, compatibilityTestingCheckpoint, "none")
+	if err != nil {
+		t.Errorf("Failed to create checkpointState, %v", err)
+	}
 
 	checkpointState.SetDefaultCPUSet(state.defaultCPUSet)
 	checkpointState.SetCPUAssignments(state.assignments)

--- a/pkg/kubelet/cm/cpumanager/state/state_file.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_file.go
@@ -20,10 +20,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 	"os"
 	"sync"
+
+	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
 type stateFileData struct {
@@ -144,7 +145,6 @@ func (sf *stateFile) storeState() {
 	if err = ioutil.WriteFile(sf.stateFilePath, content, 0644); err != nil {
 		panic("[cpumanager] state file not written")
 	}
-	return
 }
 
 func (sf *stateFile) GetCPUSet(containerID string) (cpuset.CPUSet, bool) {

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -109,8 +109,8 @@ func TestDevicePluginReRegistration(t *testing.T) {
 			t.Fatalf("timeout while waiting for manager update")
 		}
 		capacity, allocatable, _ := m.GetCapacity()
-		resourceCapacity, _ := capacity[v1.ResourceName(testResourceName)]
-		resourceAllocatable, _ := allocatable[v1.ResourceName(testResourceName)]
+		resourceCapacity := capacity[v1.ResourceName(testResourceName)]
+		resourceAllocatable := allocatable[v1.ResourceName(testResourceName)]
 		require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
 		require.Equal(t, int64(2), resourceAllocatable.Value(), "Devices are not updated.")
 
@@ -125,8 +125,8 @@ func TestDevicePluginReRegistration(t *testing.T) {
 			t.Fatalf("timeout while waiting for manager update")
 		}
 		capacity, allocatable, _ = m.GetCapacity()
-		resourceCapacity, _ = capacity[v1.ResourceName(testResourceName)]
-		resourceAllocatable, _ = allocatable[v1.ResourceName(testResourceName)]
+		resourceCapacity = capacity[v1.ResourceName(testResourceName)]
+		resourceAllocatable = allocatable[v1.ResourceName(testResourceName)]
 		require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
 		require.Equal(t, int64(2), resourceAllocatable.Value(), "Devices shouldn't change.")
 
@@ -142,8 +142,8 @@ func TestDevicePluginReRegistration(t *testing.T) {
 			t.Fatalf("timeout while waiting for manager update")
 		}
 		capacity, allocatable, _ = m.GetCapacity()
-		resourceCapacity, _ = capacity[v1.ResourceName(testResourceName)]
-		resourceAllocatable, _ = allocatable[v1.ResourceName(testResourceName)]
+		resourceCapacity = capacity[v1.ResourceName(testResourceName)]
+		resourceAllocatable = allocatable[v1.ResourceName(testResourceName)]
 		require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
 		require.Equal(t, int64(1), resourceAllocatable.Value(), "Devices of plugin previously registered should be removed.")
 		p2.Stop()
@@ -178,8 +178,8 @@ func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
 		t.FailNow()
 	}
 	capacity, allocatable, _ := m.GetCapacity()
-	resourceCapacity, _ := capacity[v1.ResourceName(testResourceName)]
-	resourceAllocatable, _ := allocatable[v1.ResourceName(testResourceName)]
+	resourceCapacity := capacity[v1.ResourceName(testResourceName)]
+	resourceAllocatable := allocatable[v1.ResourceName(testResourceName)]
 	require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
 	require.Equal(t, int64(2), resourceAllocatable.Value(), "Devices are not updated.")
 
@@ -194,8 +194,8 @@ func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
 	}
 
 	capacity, allocatable, _ = m.GetCapacity()
-	resourceCapacity, _ = capacity[v1.ResourceName(testResourceName)]
-	resourceAllocatable, _ = allocatable[v1.ResourceName(testResourceName)]
+	resourceCapacity = capacity[v1.ResourceName(testResourceName)]
+	resourceAllocatable = allocatable[v1.ResourceName(testResourceName)]
 	require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
 	require.Equal(t, int64(2), resourceAllocatable.Value(), "Devices are not updated.")
 
@@ -211,8 +211,8 @@ func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
 	}
 
 	capacity, allocatable, _ = m.GetCapacity()
-	resourceCapacity, _ = capacity[v1.ResourceName(testResourceName)]
-	resourceAllocatable, _ = allocatable[v1.ResourceName(testResourceName)]
+	resourceCapacity = capacity[v1.ResourceName(testResourceName)]
+	resourceAllocatable = allocatable[v1.ResourceName(testResourceName)]
 	require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
 	require.Equal(t, int64(1), resourceAllocatable.Value(), "Devices of previous registered should be removed")
 	p2.Stop()
@@ -371,7 +371,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	// Expires resourceName1 endpoint. Verifies testManager.GetCapacity() reports that resourceName1
 	// is removed from capacity and it no longer exists in healthyDevices after the call.
 	e1.setStopTime(time.Now().Add(-1*endpointStopGracePeriod - time.Duration(10)*time.Second))
-	capacity, allocatable, removed := testManager.GetCapacity()
+	capacity, _, removed := testManager.GetCapacity()
 	as.Equal([]string{resourceName1}, removed)
 	_, ok = capacity[v1.ResourceName(resourceName1)]
 	as.False(ok)
@@ -419,7 +419,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	as.Equal(1, len(testManager.endpoints))
 	_, ok = testManager.endpoints[resourceName2]
 	as.True(ok)
-	capacity, allocatable, removed = testManager.GetCapacity()
+	capacity, _, removed = testManager.GetCapacity()
 	val, ok = capacity[v1.ResourceName(resourceName2)]
 	as.True(ok)
 	as.Equal(int64(0), val.Value())

--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -49,7 +49,6 @@ type QOSContainerManager interface {
 
 type qosContainerManagerImpl struct {
 	sync.Mutex
-	nodeInfo           *v1.Node
 	qosContainersInfo  QOSContainersInfo
 	subsystems         *CgroupSubsystems
 	cgroupManager      CgroupManager

--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -382,7 +382,7 @@ func TestPodUpdateAnnotations(t *testing.T) {
 	channel, ch, _ := createPodConfigTester(PodConfigNotificationIncremental)
 
 	pod := CreateValidPod("foo2", "new")
-	pod.Annotations = make(map[string]string, 0)
+	pod.Annotations = make(map[string]string)
 	pod.Annotations["kubernetes.io/blah"] = "blah"
 
 	clone := pod.DeepCopy()
@@ -411,7 +411,7 @@ func TestPodUpdateLabels(t *testing.T) {
 	channel, ch, _ := createPodConfigTester(PodConfigNotificationIncremental)
 
 	pod := CreateValidPod("foo2", "new")
-	pod.Labels = make(map[string]string, 0)
+	pod.Labels = make(map[string]string)
 	pod.Labels["key"] = "value"
 
 	clone := pod.DeepCopy()
@@ -432,7 +432,7 @@ func TestPodRestore(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	pod := CreateValidPod("api-server", "kube-default")
-	pod.Annotations = make(map[string]string, 0)
+	pod.Annotations = make(map[string]string)
 	pod.Annotations["kubernetes.io/config.source"] = kubetypes.ApiserverSource
 	pod.Annotations[core.BootstrapCheckpointAnnotationKey] = "true"
 

--- a/pkg/kubelet/config/file_linux_test.go
+++ b/pkg/kubelet/config/file_linux_test.go
@@ -130,11 +130,10 @@ func TestWatchFileChanged(t *testing.T) {
 }
 
 type testCase struct {
-	lock       *sync.Mutex
-	desc       string
-	linkedFile string
-	pod        runtime.Object
-	expected   kubetypes.PodUpdate
+	lock     *sync.Mutex
+	desc     string
+	pod      runtime.Object
+	expected kubetypes.PodUpdate
 }
 
 func getTestCases(hostname types.NodeName) []*testCase {

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -106,7 +106,7 @@ func (s *sourceURL) extractFromURL() error {
 		return fmt.Errorf("zero-length data received from %v", s.url)
 	}
 	// Short circuit if the data has not changed since the last time it was read.
-	if bytes.Compare(data, s.data) == 0 {
+	if bytes.Equal(data, s.data) {
 		return nil
 	}
 	s.data = data

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -272,13 +272,6 @@ func (f *FakeRuntime) KillContainerInPod(container v1.Container, pod *v1.Pod) er
 	f.CalledFunctions = append(f.CalledFunctions, "KillContainerInPod")
 	f.KilledContainers = append(f.KilledContainers, container.Name)
 
-	var containers []v1.Container
-	for _, c := range pod.Spec.Containers {
-		if c.Name == container.Name {
-			continue
-		}
-		containers = append(containers, c)
-	}
 	return f.Err
 }
 

--- a/pkg/kubelet/dockershim/helpers_test.go
+++ b/pkg/kubelet/dockershim/helpers_test.go
@@ -134,7 +134,6 @@ func TestEnsureSandboxImageExists(t *testing.T) {
 		injectErr    error
 		calls        []string
 		err          bool
-		configJSON   string
 	}{
 		"should not pull image when it already exists": {
 			injectImage: true,

--- a/pkg/kubelet/dockershim/network/cni/cni_test.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_test.go
@@ -71,6 +71,10 @@ func installPluginUnderTest(t *testing.T, testBinDir, testConfDir, testDataDir, 
 	pluginExec := path.Join(testBinDir, binName)
 	f, err = os.Create(pluginExec)
 
+	if err != nil {
+		t.Errorf("Failed creating exec plugin, %v", err)
+	}
+
 	const execScriptTempl = `#!/usr/bin/env bash
 cat > {{.InputFile}}
 env > {{.OutputEnv}}
@@ -323,6 +327,9 @@ func TestCNIPlugin(t *testing.T) {
 		t.Errorf("Expected nil: %v", err)
 	}
 	output, err = ioutil.ReadFile(outputFile)
+	if err != nil {
+		t.Errorf("Could not read file %s, due to: %v", outputFile, err)
+	}
 	expectedOutput = "DEL /proc/12345/ns/net podNamespace podName test_infra_container"
 	if string(output) != expectedOutput {
 		t.Errorf("Mismatch in expected output for setup hook. Expected '%s', got '%s'", expectedOutput, string(output))

--- a/pkg/kubelet/dockershim/network/hairpin/hairpin.go
+++ b/pkg/kubelet/dockershim/network/hairpin/hairpin.go
@@ -37,7 +37,7 @@ const (
 )
 
 var (
-	ethtoolOutputRegex = regexp.MustCompile("peer_ifindex: (\\d+)")
+	ethtoolOutputRegex = regexp.MustCompile(`peer_ifindex: (\d+)`)
 )
 
 func findPairInterfaceOfContainerInterface(e exec.Interface, containerInterfaceName, containerDesc string, nsenterArgs []string) (string, error) {

--- a/pkg/kubelet/dockershim/network/hostport/fake_iptables.go
+++ b/pkg/kubelet/dockershim/network/hostport/fake_iptables.go
@@ -43,7 +43,7 @@ type fakeIPTables struct {
 
 func NewFakeIPTables() *fakeIPTables {
 	return &fakeIPTables{
-		tables: make(map[string]*fakeTable, 0),
+		tables: make(map[string]*fakeTable),
 		builtinChains: map[string]sets.String{
 			string(utiliptables.TableFilter): sets.NewString("INPUT", "FORWARD", "OUTPUT"),
 			string(utiliptables.TableNAT):    sets.NewString("PREROUTING", "INPUT", "OUTPUT", "POSTROUTING"),
@@ -203,7 +203,7 @@ func (f *fakeIPTables) EnsureRule(position utiliptables.RulePosition, tableName 
 	ruleArgs := make([]string, 0)
 	for _, arg := range args {
 		// quote args with internal spaces (like comments)
-		if strings.Index(arg, " ") >= 0 {
+		if strings.Contains(arg, " ") {
 			arg = fmt.Sprintf("\"%s\"", arg)
 		}
 		ruleArgs = append(ruleArgs, arg)

--- a/pkg/kubelet/dockershim/network/hostport/hostport_manager.go
+++ b/pkg/kubelet/dockershim/network/hostport/hostport_manager.go
@@ -351,7 +351,7 @@ func getExistingHostportIPTablesRules(iptables utiliptables.Interface) (map[util
 		}
 	}
 
-	for _, line := range strings.Split(string(iptablesData.Bytes()), "\n") {
+	for _, line := range strings.Split(iptablesData.String(), "\n") {
 		if strings.HasPrefix(line, fmt.Sprintf("-A %s", kubeHostportChainPrefix)) ||
 			strings.HasPrefix(line, fmt.Sprintf("-A %s", string(kubeHostportsChain))) {
 			existingHostportRules = append(existingHostportRules, line)
@@ -382,8 +382,6 @@ func filterRules(rules []string, filters []utiliptables.Chain) []string {
 // filterChains deletes all entries of filter chains from chain map
 func filterChains(chains map[utiliptables.Chain]string, filterChains []utiliptables.Chain) {
 	for _, chain := range filterChains {
-		if _, ok := chains[chain]; ok {
-			delete(chains, chain)
-		}
+		delete(chains, chain)
 	}
 }

--- a/pkg/kubelet/dockershim/network/hostport/hostport_manager_test.go
+++ b/pkg/kubelet/dockershim/network/hostport/hostport_manager_test.go
@@ -284,7 +284,7 @@ func TestHostportManager(t *testing.T) {
 	err := iptables.SaveInto(utiliptables.TableNAT, raw)
 	assert.NoError(t, err)
 
-	lines := strings.Split(string(raw.Bytes()), "\n")
+	lines := strings.Split(raw.String(), "\n")
 	expectedLines := map[string]bool{
 		`*nat`:                              true,
 		`:KUBE-HOSTPORTS - [0:0]`:           true,
@@ -331,7 +331,7 @@ func TestHostportManager(t *testing.T) {
 	raw.Reset()
 	err = iptables.SaveInto(utiliptables.TableNAT, raw)
 	assert.NoError(t, err)
-	lines = strings.Split(string(raw.Bytes()), "\n")
+	lines = strings.Split(raw.String(), "\n")
 	remainingChains := make(map[string]bool)
 	for _, line := range lines {
 		if strings.HasPrefix(line, ":") {

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -499,7 +499,7 @@ func (m *managerImpl) podEphemeralStorageLimitEviction(podStats statsapi.PodStat
 	}
 
 	podEphemeralStorageTotalUsage := &resource.Quantity{}
-	fsStatsSet := []fsStatsType{}
+	var fsStatsSet []fsStatsType
 	if *m.dedicatedImageFs {
 		fsStatsSet = []fsStatsType{fsStatsLogs, fsStatsLocalVolumeSource}
 	} else {

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -546,6 +546,9 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 	kubelet := testKubelet.kubelet
 	kubelet.kubeClient = nil // ensure only the heartbeat client is used
 	kubelet.heartbeatClient, err = clientset.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to create ClientSet: %v", err)
+	}
 	kubelet.onRepeatedHeartbeatFailure = func() {
 		atomic.AddInt64(&failureCallbacks, 1)
 	}
@@ -987,7 +990,7 @@ func TestUpdateNodeStatusWithLease(t *testing.T) {
 
 	updatedNode, err = applyNodeStatusPatch(updatedNode, patchAction.GetPatch())
 	require.NoError(t, err)
-	memCapacity, _ := updatedNode.Status.Capacity[v1.ResourceMemory]
+	memCapacity := updatedNode.Status.Capacity[v1.ResourceMemory]
 	updatedMemoryCapacity, _ := (&memCapacity).AsInt64()
 	assert.Equal(t, newMemoryCapacity, updatedMemoryCapacity, "Memory capacity")
 
@@ -2006,8 +2009,6 @@ func TestRegisterWithApiServerWithTaint(t *testing.T) {
 			utilfeature.DefaultFeatureGate.Enabled(features.TaintNodesByCondition),
 			taintutil.TaintExists(got.Spec.Taints, unschedulableTaint),
 			"test unschedulable taint for TaintNodesByCondition")
-
-		return
 	})
 }
 

--- a/pkg/kubelet/kubeletconfig/checkpoint/configmap.go
+++ b/pkg/kubelet/kubeletconfig/checkpoint/configmap.go
@@ -22,8 +22,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 )
 
-const configMapConfigKey = "kubelet"
-
 // configMapPayload implements Payload, backed by a v1/ConfigMap config source object
 type configMapPayload struct {
 	cm *apiv1.ConfigMap

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -34,7 +34,7 @@ import (
 
 // TestRemoveContainer tests removing the container and its corresponding container logs.
 func TestRemoveContainer(t *testing.T) {
-	fakeRuntime, _, m, err := createTestRuntimeManager()
+	fakeRuntime, _, m, _ := createTestRuntimeManager()
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       "12345678",
@@ -58,7 +58,7 @@ func TestRemoveContainer(t *testing.T) {
 
 	containerID := fakeContainers[0].Id
 	fakeOS := m.osInterface.(*containertest.FakeOS)
-	err = m.removeContainer(containerID)
+	err := m.removeContainer(containerID)
 	assert.NoError(t, err)
 	// Verify container log is removed
 	expectedContainerLogPath := filepath.Join(podLogsRootDirectory, "new_bar_12345678", "foo", "0.log")

--- a/pkg/kubelet/kuberuntime/logs/logs.go
+++ b/pkg/kubelet/kuberuntime/logs/logs.go
@@ -49,8 +49,6 @@ import (
 const (
 	// timeFormat is the time format used in the log.
 	timeFormat = time.RFC3339Nano
-	// blockSize is the block size used in tail.
-	blockSize = 1024
 
 	// stateCheckPeriod is the period to check container state while following
 	// the container log. Kubelet should not keep following the log when the

--- a/pkg/kubelet/lifecycle/predicate_test.go
+++ b/pkg/kubelet/lifecycle/predicate_test.go
@@ -26,9 +26,7 @@ import (
 )
 
 var (
-	quantity              = *resource.NewQuantity(1, resource.DecimalSI)
-	extendedResourceName1 = "example.com/er1"
-	extendedResourceName2 = "example.com/er2"
+	quantity = *resource.NewQuantity(1, resource.DecimalSI)
 )
 
 func TestRemoveMissingExtendedResources(t *testing.T) {

--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -186,8 +186,6 @@ func (c *Configurer) CheckLimitsForResolvConf() {
 		klog.V(4).Infof("CheckLimitsForResolvConf: " + log)
 		return
 	}
-
-	return
 }
 
 // parseResolvConf reads a resolv.conf file from the given reader, and parses

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -253,7 +253,7 @@ func (g *GenericPLEG) relist() {
 				needsReinspection[pid] = pod
 
 				continue
-			} else if _, found := g.podsToReinspect[pid]; found {
+			} else {
 				// this pod was in the list to reinspect and we did so because it had events, so remove it
 				// from the list (we don't want the reinspection code below to inspect it a second time in
 				// this relist execution)

--- a/pkg/kubelet/pluginmanager/pluginwatcher/example_handler.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/example_handler.go
@@ -39,8 +39,7 @@ type exampleHandler struct {
 
 	eventChans map[string]chan examplePluginEvent // map[pluginName]eventChan
 
-	m     sync.Mutex
-	count int
+	m sync.Mutex
 
 	permitDeprecatedDir bool
 }

--- a/pkg/kubelet/pluginmanager/pluginwatcher/example_plugin.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/example_plugin.go
@@ -134,11 +134,9 @@ func (e *examplePlugin) Serve(services ...string) error {
 		case "v1beta1":
 			v1beta1 := &pluginServiceV1Beta1{server: e}
 			v1beta1.RegisterService()
-			break
 		case "v1beta2":
 			v1beta2 := &pluginServiceV1Beta2{server: e}
 			v1beta2.RegisterService()
-			break
 		default:
 			return fmt.Errorf("Unsupported service: '%s'", service)
 		}

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -240,9 +240,7 @@ func (p *podWorkers) removeWorker(uid types.UID) {
 		// If there is an undelivered work update for this pod we need to remove it
 		// since per-pod goroutine won't be able to put it to the already closed
 		// channel when it finishes processing the current work update.
-		if _, cached := p.lastUndeliveredWorkUpdate[uid]; cached {
-			delete(p.lastUndeliveredWorkUpdate, uid)
-		}
+		delete(p.lastUndeliveredWorkUpdate, uid)
 	}
 }
 func (p *podWorkers) ForgetWorker(uid types.UID) {

--- a/pkg/kubelet/prober/testing/fake_manager.go
+++ b/pkg/kubelet/prober/testing/fake_manager.go
@@ -24,12 +24,12 @@ import (
 type FakeManager struct{}
 
 // Unused methods.
-func (_ FakeManager) AddPod(_ *v1.Pod)        {}
-func (_ FakeManager) RemovePod(_ *v1.Pod)     {}
-func (_ FakeManager) CleanupPods(_ []*v1.Pod) {}
-func (_ FakeManager) Start()                  {}
+func (FakeManager) AddPod(_ *v1.Pod)        {}
+func (FakeManager) RemovePod(_ *v1.Pod)     {}
+func (FakeManager) CleanupPods(_ []*v1.Pod) {}
+func (FakeManager) Start()                  {}
 
-func (_ FakeManager) UpdatePodStatus(_ types.UID, podStatus *v1.PodStatus) {
+func (FakeManager) UpdatePodStatus(_ types.UID, podStatus *v1.PodStatus) {
 	for i := range podStatus.ContainerStatuses {
 		podStatus.ContainerStatuses[i].Ready = true
 	}

--- a/pkg/kubelet/remote/fake/fake_runtime.go
+++ b/pkg/kubelet/remote/fake/fake_runtime.go
@@ -200,14 +200,12 @@ func (f *RemoteRuntime) ContainerStatus(ctx context.Context, req *kubeapi.Contai
 
 // ExecSync runs a command in a container synchronously.
 func (f *RemoteRuntime) ExecSync(ctx context.Context, req *kubeapi.ExecSyncRequest) (*kubeapi.ExecSyncResponse, error) {
-	var exitCode int32
 	stdout, stderr, err := f.RuntimeService.ExecSync(req.ContainerId, req.Cmd, time.Duration(req.Timeout)*time.Second)
 	if err != nil {
-		exitError, ok := err.(utilexec.ExitError)
+		_, ok := err.(utilexec.ExitError)
 		if !ok {
 			return nil, err
 		}
-		exitCode = int32(exitError.ExitStatus())
 
 		return nil, err
 	}
@@ -215,7 +213,7 @@ func (f *RemoteRuntime) ExecSync(ctx context.Context, req *kubeapi.ExecSyncReque
 	return &kubeapi.ExecSyncResponse{
 		Stdout:   stdout,
 		Stderr:   stderr,
-		ExitCode: exitCode,
+		ExitCode: 0,
 	}, nil
 }
 

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -676,7 +676,6 @@ func getPortForwardRequestParams(req *restful.Request) portForwardRequestParams 
 }
 
 type responder struct {
-	errorMessage string
 }
 
 func (r *responder) Error(w http.ResponseWriter, req *http.Request, err error) {

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -289,13 +289,11 @@ func (f *fakeAuth) Authorize(a authorizer.Attributes) (authorized authorizer.Dec
 }
 
 type serverTestFramework struct {
-	serverUnderTest         *Server
-	fakeKubelet             *fakeKubelet
-	fakeAuth                *fakeAuth
-	testHTTPServer          *httptest.Server
-	fakeRuntime             *fakeRuntime
-	testStreamingHTTPServer *httptest.Server
-	criHandler              *utiltesting.FakeHandler
+	serverUnderTest *Server
+	fakeKubelet     *fakeKubelet
+	fakeAuth        *fakeAuth
+	testHTTPServer  *httptest.Server
+	criHandler      *utiltesting.FakeHandler
 }
 
 func newServerTest() *serverTestFramework {

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -92,9 +92,8 @@ func GetValidatedSources(sources []string) ([]string, error) {
 			return []string{FileSource, HTTPSource, ApiserverSource}, nil
 		case FileSource, HTTPSource, ApiserverSource:
 			validated = append(validated, source)
-			break
 		case "":
-			break
+			// noop
 		default:
 			return []string{}, fmt.Errorf("unknown pod source %q", source)
 		}
@@ -192,8 +191,5 @@ func IsCritical(ns string, annotations map[string]string) bool {
 
 // IsCriticalPodBasedOnPriority checks if the given pod is a critical pod based on priority resolved from pod Spec.
 func IsCriticalPodBasedOnPriority(priority int32) bool {
-	if priority >= scheduling.SystemCriticalPriority {
-		return true
-	}
-	return false
+	return priority >= scheduling.SystemCriticalPriority
 }

--- a/pkg/kubelet/types/pod_update_test.go
+++ b/pkg/kubelet/types/pod_update_test.go
@@ -45,7 +45,7 @@ func TestGetValidatedSources(t *testing.T) {
 	require.Len(t, sources, 3)
 
 	// Unknown source.
-	sources, err = GetValidatedSources([]string{"taco"})
+	_, err = GetValidatedSources([]string{"taco"})
 	require.Error(t, err)
 }
 

--- a/pkg/kubelet/util/format/pod.go
+++ b/pkg/kubelet/util/format/pod.go
@@ -68,5 +68,5 @@ func aggregatePods(pods []*v1.Pod, handler podHandler) string {
 	for _, pod := range pods {
 		podStrings = append(podStrings, handler(pod))
 	}
-	return fmt.Sprintf(strings.Join(podStrings, ", "))
+	return fmt.Sprint(strings.Join(podStrings, ", "))
 }

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
@@ -359,8 +359,14 @@ func Test_AddTwoPodsToVolume_Positive(t *testing.T) {
 	volumeSpec2 := &volume.Spec{Volume: &pod2.Spec.Volumes[0]}
 	generatedVolumeName1, err := util.GetUniqueVolumeNameFromSpec(
 		plugin, volumeSpec1)
+	if err != nil {
+		t.Errorf("Could not get unique name of volume1, due to: %v", err)
+	}
 	generatedVolumeName2, err := util.GetUniqueVolumeNameFromSpec(
 		plugin, volumeSpec2)
+	if err != nil {
+		t.Errorf("Could not get unique name of volume2, due to: %v", err)
+	}
 
 	if generatedVolumeName1 != generatedVolumeName2 {
 		t.Fatalf(
@@ -466,6 +472,9 @@ func Test_AddPodToVolume_Negative_VolumeDoesntExist(t *testing.T) {
 
 	volumeName, err := util.GetUniqueVolumeNameFromSpec(
 		plugin, volumeSpec)
+	if err != nil {
+		t.Errorf("Failed getting unique volume name, %v", err)
+	}
 
 	podName := util.GetUniquePodName(pod)
 

--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -122,7 +122,6 @@ type reconciler struct {
 	kubeClient                    clientset.Interface
 	controllerAttachDetachEnabled bool
 	loopSleepDuration             time.Duration
-	syncDuration                  time.Duration
 	waitForAttachTimeout          time.Duration
 	nodeName                      types.NodeName
 	desiredStateOfWorld           cache.DesiredStateOfWorld
@@ -351,7 +350,6 @@ type reconstructedVolume struct {
 	attachablePlugin    volumepkg.AttachableVolumePlugin
 	volumeGidValue      string
 	devicePath          string
-	reportedInUse       bool
 	mounter             volumepkg.Mounter
 	blockVolumeMapper   volumepkg.BlockVolumeMapper
 }

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -332,7 +332,6 @@ func delayClaimBecomesBound(
 		Phase: v1.ClaimBound,
 	}
 	kubeClient.CoreV1().PersistentVolumeClaims(namespace).Update(volumeClaim)
-	return
 }
 
 func runVolumeManager(manager VolumeManager) chan struct{} {


### PR DESCRIPTION
These are based on recommendation from
[staticcheck](http://staticcheck.io/).

- Remove unused struct fields
- Remove unused variables
- Remove unused constant
- Remove redundant return and break statements
- Fix typo `omitmepty`
- Miscellaneous cleanups

/kind cleanup

```release-note
NONE
```
/priority backlog
/sig node
