### PR TITLE
add metrics directory in component-base for shared metrics code across kubernetes binaries

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/OWNERS
+++ b/staging/src/k8s.io/component-base/metrics/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- piosz
+- brancz
+reviewers:
+- sig-instrumentation-pr-reviews
+labels:
+- sig/instrumentation


### PR DESCRIPTION
Adding a metrics directory in component-base for shared metrics code. Currently empty, but will be populated with instrumentation related work from [control plane metrics stability KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/draft-20190404-kubernetes-control-plane-metrics-stability.md). 

/kind feature

```release-note
NONE
```
/cc @brancz @sttts 