### PR TITLE
Don't use mapfile as it isn't bash 3 compatible

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -137,8 +137,8 @@ readonly KUBE_NODE_BINARIES_WIN=("${KUBE_NODE_BINARIES[@]/%/.exe}")
 # NOTE: All functions that return lists should use newlines.
 # bash functions can't return arrays, and spaces are tricky, so newline
 # separators are the preferred pattern.
-# To transform a string of newline-separated items to an array, use mapfile -t:
-# mapfile -t FOO <<< "$(kube::golang::dups a b c a)"
+# To transform a string of newline-separated items to an array, use kube::util::read-array:
+# kube::util::read-array FOO < <(kube::golang::dups a b c a)
 #
 # ALWAYS remember to quote your subshells. Not doing so will break in
 # bash 4.3, and potentially cause other issues.
@@ -172,33 +172,33 @@ kube::golang::setup_platforms() {
 
     # Deduplicate to ensure the intersection trick with kube::golang::dups
     # is not defeated by duplicates in user input.
-    mapfile -t platforms <<< "$(kube::golang::dedup "${platforms[@]}")"
+    kube::util::read-array platforms < <(kube::golang::dedup "${platforms[@]}")
 
     # Use kube::golang::dups to restrict the builds to the platforms in
     # KUBE_SUPPORTED_*_PLATFORMS. Items should only appear at most once in each
     # set, so if they appear twice after the merge they are in the intersection.
-    mapfile -t KUBE_SERVER_PLATFORMS <<< "$(kube::golang::dups \
+    kube::util::read-array KUBE_SERVER_PLATFORMS < <(kube::golang::dups \
         "${platforms[@]}" \
         "${KUBE_SUPPORTED_SERVER_PLATFORMS[@]}" \
-      )"
+      )
     readonly KUBE_SERVER_PLATFORMS
 
-    mapfile -t KUBE_NODE_PLATFORMS <<< "$(kube::golang::dups \
+    kube::util::read-array KUBE_NODE_PLATFORMS < <(kube::golang::dups \
         "${platforms[@]}" \
         "${KUBE_SUPPORTED_NODE_PLATFORMS[@]}" \
-      )"
+      )
     readonly KUBE_NODE_PLATFORMS
 
-    mapfile -t KUBE_TEST_PLATFORMS <<< "$(kube::golang::dups \
+    kube::util::read-array KUBE_TEST_PLATFORMS < <(kube::golang::dups \
         "${platforms[@]}" \
         "${KUBE_SUPPORTED_TEST_PLATFORMS[@]}" \
-      )"
+      )
     readonly KUBE_TEST_PLATFORMS
 
-    mapfile -t KUBE_CLIENT_PLATFORMS <<< "$(kube::golang::dups \
+    kube::util::read-array KUBE_CLIENT_PLATFORMS < <(kube::golang::dups \
         "${platforms[@]}" \
         "${KUBE_SUPPORTED_CLIENT_PLATFORMS[@]}" \
-      )"
+      )
     readonly KUBE_CLIENT_PLATFORMS
 
   elif [[ "${KUBE_FASTBUILD:-}" == "true" ]]; then

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -702,6 +702,23 @@ function kube::util::require-jq {
   fi
 }
 
+# kube::util::read-array
+# Reads in stdin and adds it line by line to the array provided. This can be
+# used instead of "mapfile -t", and is bash 3 compatible.
+#
+# Assumed vars:
+#   $1 (name of array to create/modify)
+#
+# Example usage:
+# kube::util::read-array files < <(ls -1)
+#
+function kube::util::read-array {
+  local i=0
+  unset -v "$1"
+  while IFS= read -r "$1[i++]"; do :; done
+  eval "[[ \${$1[--i]} ]]" || unset "$1[i]" # ensures last element isn't empty
+}
+
 # Some useful colors.
 if [[ -z "${color_start-}" ]]; then
   declare -r color_start="\033["


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Moves away from using mapfile in `hack/lib/golang.sh` so that users don't have to use bash 4+. This mainly fixes building on Darwin.

**Which issue(s) this PR fixes**:
Fixes #77349

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
