### PR TITLE
Move auth and network tests to use framework/log

### DIFF
--- a/test/e2e/auth/BUILD
+++ b/test/e2e/auth/BUILD
@@ -55,6 +55,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/auth:go_default_library",
         "//test/e2e/framework/job:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",

--- a/test/e2e/auth/audit.go
+++ b/test/e2e/auth/audit.go
@@ -36,6 +36,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/auth"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -738,9 +739,9 @@ func expectEvents(f *framework.Framework, expectedEvents []utils.AuditEvent) {
 		defer stream.Close()
 		missingReport, err := utils.CheckAuditLines(stream, expectedEvents, auditv1.SchemeGroupVersion)
 		if err != nil {
-			framework.Logf("Failed to observe audit events: %v", err)
+			e2elog.Logf("Failed to observe audit events: %v", err)
 		} else if len(missingReport.MissingEvents) > 0 {
-			framework.Logf(missingReport.String())
+			e2elog.Logf(missingReport.String())
 		}
 		return len(missingReport.MissingEvents) == 0, nil
 	})

--- a/test/e2e/auth/audit_dynamic.go
+++ b/test/e2e/auth/audit_dynamic.go
@@ -36,6 +36,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/auth"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -113,14 +114,14 @@ var _ = SIGDescribe("[Feature:DynamicAudit]", func() {
 		err = wait.Poll(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {
 			p, err := f.ClientSet.CoreV1().Pods(namespace).Get("audit-proxy", metav1.GetOptions{})
 			if errors.IsNotFound(err) {
-				framework.Logf("waiting for audit-proxy pod to be present")
+				e2elog.Logf("waiting for audit-proxy pod to be present")
 				return false, nil
 			} else if err != nil {
 				return false, err
 			}
 			podIP = p.Status.PodIP
 			if podIP == "" {
-				framework.Logf("waiting for audit-proxy pod IP to be ready")
+				e2elog.Logf("waiting for audit-proxy pod IP to be ready")
 				return false, nil
 			}
 			return true, nil
@@ -153,17 +154,17 @@ var _ = SIGDescribe("[Feature:DynamicAudit]", func() {
 
 		_, err = f.ClientSet.AuditregistrationV1alpha1().AuditSinks().Create(&sink)
 		framework.ExpectNoError(err, "failed to create audit sink")
-		framework.Logf("created audit sink")
+		e2elog.Logf("created audit sink")
 
 		// check that we are receiving logs in the proxy
 		err = wait.Poll(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {
 			logs, err := framework.GetPodLogs(f.ClientSet, namespace, "audit-proxy", "proxy")
 			if err != nil {
-				framework.Logf("waiting for audit-proxy pod logs to be available")
+				e2elog.Logf("waiting for audit-proxy pod logs to be available")
 				return false, nil
 			}
 			if logs == "" {
-				framework.Logf("waiting for audit-proxy pod logs to be non-empty")
+				e2elog.Logf("waiting for audit-proxy pod logs to be non-empty")
 				return false, nil
 			}
 			return true, nil
@@ -369,9 +370,9 @@ var _ = SIGDescribe("[Feature:DynamicAudit]", func() {
 			reader := strings.NewReader(logs)
 			missingReport, err := utils.CheckAuditLines(reader, expectedEvents, auditv1.SchemeGroupVersion)
 			if err != nil {
-				framework.Logf("Failed to observe audit events: %v", err)
+				e2elog.Logf("Failed to observe audit events: %v", err)
 			} else if len(missingReport.MissingEvents) > 0 {
-				framework.Logf(missingReport.String())
+				e2elog.Logf(missingReport.String())
 			}
 			return len(missingReport.MissingEvents) == 0, nil
 		})

--- a/test/e2e/auth/certificates.go
+++ b/test/e2e/auth/certificates.go
@@ -28,6 +28,7 @@ import (
 	v1beta1client "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/utils"
 
 	. "github.com/onsi/ginkgo"
@@ -66,13 +67,13 @@ var _ = SIGDescribe("Certificates API", func() {
 		}
 		csrs := f.ClientSet.CertificatesV1beta1().CertificateSigningRequests()
 
-		framework.Logf("creating CSR")
+		e2elog.Logf("creating CSR")
 		csr, err = csrs.Create(csr)
 		framework.ExpectNoError(err)
 
 		csrName := csr.Name
 
-		framework.Logf("approving CSR")
+		e2elog.Logf("approving CSR")
 		framework.ExpectNoError(wait.Poll(5*time.Second, time.Minute, func() (bool, error) {
 			csr.Status.Conditions = []v1beta1.CertificateSigningRequestCondition{
 				{
@@ -84,27 +85,27 @@ var _ = SIGDescribe("Certificates API", func() {
 			csr, err = csrs.UpdateApproval(csr)
 			if err != nil {
 				csr, _ = csrs.Get(csrName, metav1.GetOptions{})
-				framework.Logf("err updating approval: %v", err)
+				e2elog.Logf("err updating approval: %v", err)
 				return false, nil
 			}
 			return true, nil
 		}))
 
-		framework.Logf("waiting for CSR to be signed")
+		e2elog.Logf("waiting for CSR to be signed")
 		framework.ExpectNoError(wait.Poll(5*time.Second, time.Minute, func() (bool, error) {
 			csr, err = csrs.Get(csrName, metav1.GetOptions{})
 			if err != nil {
-				framework.Logf("error getting csr: %v", err)
+				e2elog.Logf("error getting csr: %v", err)
 				return false, nil
 			}
 			if len(csr.Status.Certificate) == 0 {
-				framework.Logf("csr not signed yet")
+				e2elog.Logf("csr not signed yet")
 				return false, nil
 			}
 			return true, nil
 		}))
 
-		framework.Logf("testing the client")
+		e2elog.Logf("testing the client")
 		rcfg, err := framework.LoadConfig()
 		framework.ExpectNoError(err)
 

--- a/test/e2e/auth/node_authz.go
+++ b/test/e2e/auth/node_authz.go
@@ -20,13 +20,14 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
@@ -156,7 +157,7 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		err = wait.Poll(itv, dur, func() (bool, error) {
 			_, err = c.CoreV1().Secrets(ns).Get(secret.Name, metav1.GetOptions{})
 			if err != nil {
-				framework.Logf("Failed to get secret %v, err: %v", secret.Name, err)
+				e2elog.Logf("Failed to get secret %v, err: %v", secret.Name, err)
 				return false, nil
 			}
 			return true, nil

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
@@ -48,19 +49,19 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			By("waiting for a single token reference")
 			sa, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Get("default", metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
-				framework.Logf("default service account was not found")
+				e2elog.Logf("default service account was not found")
 				return false, nil
 			}
 			if err != nil {
-				framework.Logf("error getting default service account: %v", err)
+				e2elog.Logf("error getting default service account: %v", err)
 				return false, err
 			}
 			switch len(sa.Secrets) {
 			case 0:
-				framework.Logf("default service account has no secret references")
+				e2elog.Logf("default service account has no secret references")
 				return false, nil
 			case 1:
-				framework.Logf("default service account has a single secret reference")
+				e2elog.Logf("default service account has a single secret reference")
 				secrets = sa.Secrets
 				return true, nil
 			default:
@@ -86,19 +87,19 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			By("waiting for a new token reference")
 			sa, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Get("default", metav1.GetOptions{})
 			if err != nil {
-				framework.Logf("error getting default service account: %v", err)
+				e2elog.Logf("error getting default service account: %v", err)
 				return false, err
 			}
 			switch len(sa.Secrets) {
 			case 0:
-				framework.Logf("default service account has no secret references")
+				e2elog.Logf("default service account has no secret references")
 				return false, nil
 			case 1:
 				if sa.Secrets[0] == secrets[0] {
-					framework.Logf("default service account still has the deleted secret reference")
+					e2elog.Logf("default service account still has the deleted secret reference")
 					return false, nil
 				}
-				framework.Logf("default service account has a new single secret reference")
+				e2elog.Logf("default service account has a new single secret reference")
 				secrets = sa.Secrets
 				return true, nil
 			default:
@@ -130,15 +131,15 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			By("waiting for a new token to be created and added")
 			sa, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Get("default", metav1.GetOptions{})
 			if err != nil {
-				framework.Logf("error getting default service account: %v", err)
+				e2elog.Logf("error getting default service account: %v", err)
 				return false, err
 			}
 			switch len(sa.Secrets) {
 			case 0:
-				framework.Logf("default service account has no secret references")
+				e2elog.Logf("default service account has no secret references")
 				return false, nil
 			case 1:
-				framework.Logf("default service account has a new single secret reference")
+				e2elog.Logf("default service account has a new single secret reference")
 				secrets = sa.Secrets
 				return true, nil
 			default:
@@ -176,21 +177,21 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			By("getting the auto-created API token")
 			sa, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Get("mount-test", metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
-				framework.Logf("mount-test service account was not found")
+				e2elog.Logf("mount-test service account was not found")
 				return false, nil
 			}
 			if err != nil {
-				framework.Logf("error getting mount-test service account: %v", err)
+				e2elog.Logf("error getting mount-test service account: %v", err)
 				return false, err
 			}
 			if len(sa.Secrets) == 0 {
-				framework.Logf("mount-test service account has no secret references")
+				e2elog.Logf("mount-test service account has no secret references")
 				return false, nil
 			}
 			for _, secretRef := range sa.Secrets {
 				secret, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Get(secretRef.Name, metav1.GetOptions{})
 				if err != nil {
-					framework.Logf("Error getting secret %s: %v", secretRef.Name, err)
+					e2elog.Logf("Error getting secret %s: %v", secretRef.Name, err)
 					continue
 				}
 				if secret.Type == v1.SecretTypeServiceAccountToken {
@@ -199,7 +200,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				}
 			}
 
-			framework.Logf("default service account has no secret references to valid service account tokens")
+			e2elog.Logf("default service account has no secret references to valid service account tokens")
 			return false, nil
 		}))
 
@@ -287,21 +288,21 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			By("getting the auto-created API token")
 			sa, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Get(mountSA.Name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
-				framework.Logf("mount service account was not found")
+				e2elog.Logf("mount service account was not found")
 				return false, nil
 			}
 			if err != nil {
-				framework.Logf("error getting mount service account: %v", err)
+				e2elog.Logf("error getting mount service account: %v", err)
 				return false, err
 			}
 			if len(sa.Secrets) == 0 {
-				framework.Logf("mount service account has no secret references")
+				e2elog.Logf("mount service account has no secret references")
 				return false, nil
 			}
 			for _, secretRef := range sa.Secrets {
 				secret, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Get(secretRef.Name, metav1.GetOptions{})
 				if err != nil {
-					framework.Logf("Error getting secret %s: %v", secretRef.Name, err)
+					e2elog.Logf("Error getting secret %s: %v", secretRef.Name, err)
 					continue
 				}
 				if secret.Type == v1.SecretTypeServiceAccountToken {
@@ -309,7 +310,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				}
 			}
 
-			framework.Logf("default service account has no secret references to valid service account tokens")
+			e2elog.Logf("default service account has no secret references to valid service account tokens")
 			return false, nil
 		}))
 
@@ -391,7 +392,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			}
 			createdPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
 			framework.ExpectNoError(err)
-			framework.Logf("created pod %s", tc.PodName)
+			e2elog.Logf("created pod %s", tc.PodName)
 
 			hasServiceAccountTokenVolume := false
 			for _, c := range createdPod.Spec.Containers {
@@ -405,7 +406,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			if hasServiceAccountTokenVolume != tc.ExpectTokenVolume {
 				framework.Failf("%s: expected volume=%v, got %v (%#v)", tc.PodName, tc.ExpectTokenVolume, hasServiceAccountTokenVolume, createdPod)
 			} else {
-				framework.Logf("pod %s service account token volume mount: %v", tc.PodName, hasServiceAccountTokenVolume)
+				e2elog.Logf("pod %s service account token volume mount: %v", tc.PodName, hasServiceAccountTokenVolume)
 			}
 		}
 	})

--- a/test/e2e/network/BUILD
+++ b/test/e2e/network/BUILD
@@ -61,6 +61,7 @@ go_library(
         "//test/e2e/framework/auth:go_default_library",
         "//test/e2e/framework/endpoints:go_default_library",
         "//test/e2e/framework/ingress:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/providers/gce:go_default_library",
         "//test/e2e/network/scale:go_default_library",
         "//test/images/net/nat:go_default_library",

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -21,10 +21,11 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -339,9 +340,9 @@ var _ = SIGDescribe("DNS", func() {
 		})
 		testServerPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(testServerPod)
 		Expect(err).NotTo(HaveOccurred(), "failed to create pod: %s", testServerPod.Name)
-		framework.Logf("Created pod %v", testServerPod)
+		e2elog.Logf("Created pod %v", testServerPod)
 		defer func() {
-			framework.Logf("Deleting pod %s...", testServerPod.Name)
+			e2elog.Logf("Deleting pod %s...", testServerPod.Name)
 			if err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(testServerPod.Name, metav1.NewDeleteOptions(0)); err != nil {
 				framework.Failf("Failed to delete pod %s: %v", testServerPod.Name, err)
 			}
@@ -352,7 +353,7 @@ var _ = SIGDescribe("DNS", func() {
 		testServerPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(testServerPod.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(), "failed to get pod %v", testServerPod.Name)
 		testServerIP := testServerPod.Status.PodIP
-		framework.Logf("testServerIP is %s", testServerIP)
+		e2elog.Logf("testServerIP is %s", testServerIP)
 
 		By("Creating a pod with dnsPolicy=None and customized dnsConfig...")
 		testUtilsPod := generateDNSUtilsPod()
@@ -370,9 +371,9 @@ var _ = SIGDescribe("DNS", func() {
 		}
 		testUtilsPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(testUtilsPod)
 		Expect(err).NotTo(HaveOccurred(), "failed to create pod: %s", testUtilsPod.Name)
-		framework.Logf("Created pod %v", testUtilsPod)
+		e2elog.Logf("Created pod %v", testUtilsPod)
 		defer func() {
-			framework.Logf("Deleting pod %s...", testUtilsPod.Name)
+			e2elog.Logf("Deleting pod %s...", testUtilsPod.Name)
 			if err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(testUtilsPod.Name, metav1.NewDeleteOptions(0)); err != nil {
 				framework.Failf("Failed to delete pod %s: %v", testUtilsPod.Name, err)
 			}
@@ -411,12 +412,12 @@ var _ = SIGDescribe("DNS", func() {
 				CaptureStderr: true,
 			})
 			if err != nil {
-				framework.Logf("Failed to execute dig command, stdout:%v, stderr: %v, err: %v", stdout, stderr, err)
+				e2elog.Logf("Failed to execute dig command, stdout:%v, stderr: %v, err: %v", stdout, stderr, err)
 				return false, nil
 			}
 			res := strings.Split(stdout, "\n")
 			if len(res) != 1 || res[0] != testInjectedIP {
-				framework.Logf("Expect command `%v` to return %s, got: %v", cmd, testInjectedIP, res)
+				e2elog.Logf("Expect command `%v` to return %s, got: %v", cmd, testInjectedIP, res)
 				return false, nil
 			}
 			return true, nil

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/fields"
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
@@ -71,7 +72,7 @@ func (t *dnsTestCommon) init() {
 	Expect(len(pods.Items)).Should(BeNumerically(">=", 1))
 
 	t.dnsPod = &pods.Items[0]
-	framework.Logf("Using DNS pod: %v", t.dnsPod.Name)
+	e2elog.Logf("Using DNS pod: %v", t.dnsPod.Name)
 
 	if strings.Contains(t.dnsPod.Name, "coredns") {
 		t.name = "coredns"
@@ -132,7 +133,7 @@ func (t *dnsTestCommon) runDig(dnsName, target string) []string {
 		CaptureStderr: true,
 	})
 
-	framework.Logf("Running dig: %v, stdout: %q, stderr: %q, err: %v",
+	e2elog.Logf("Running dig: %v, stdout: %q, stderr: %q, err: %v",
 		cmd, stdout, stderr, err)
 
 	if stdout == "" {
@@ -224,7 +225,7 @@ func (t *dnsTestCommon) createUtilPodLabel(baseName string) {
 	var err error
 	t.utilPod, err = t.c.CoreV1().Pods(t.f.Namespace.Name).Create(t.utilPod)
 	Expect(err).NotTo(HaveOccurred(), "failed to create pod: %v", t.utilPod)
-	framework.Logf("Created pod %v", t.utilPod)
+	e2elog.Logf("Created pod %v", t.utilPod)
 	Expect(t.f.WaitForPodRunning(t.utilPod.Name)).NotTo(HaveOccurred(), "pod failed to start running: %v", t.utilPod)
 
 	t.utilService = &v1.Service{
@@ -249,13 +250,13 @@ func (t *dnsTestCommon) createUtilPodLabel(baseName string) {
 
 	t.utilService, err = t.c.CoreV1().Services(t.f.Namespace.Name).Create(t.utilService)
 	Expect(err).NotTo(HaveOccurred(), "failed to create service: %s/%s", t.f.Namespace.Name, t.utilService.ObjectMeta.Name)
-	framework.Logf("Created service %v", t.utilService)
+	e2elog.Logf("Created service %v", t.utilService)
 }
 
 func (t *dnsTestCommon) deleteUtilPod() {
 	podClient := t.c.CoreV1().Pods(t.f.Namespace.Name)
 	if err := podClient.Delete(t.utilPod.Name, metav1.NewDeleteOptions(0)); err != nil {
-		framework.Logf("Delete of pod %v/%v failed: %v",
+		e2elog.Logf("Delete of pod %v/%v failed: %v",
 			t.utilPod.Namespace, t.utilPod.Name, err)
 	}
 }
@@ -315,7 +316,7 @@ func (t *dnsTestCommon) createDNSPodFromObj(pod *v1.Pod) {
 	var err error
 	t.dnsServerPod, err = t.c.CoreV1().Pods(t.f.Namespace.Name).Create(t.dnsServerPod)
 	Expect(err).NotTo(HaveOccurred(), "failed to create pod: %v", t.dnsServerPod)
-	framework.Logf("Created pod %v", t.dnsServerPod)
+	e2elog.Logf("Created pod %v", t.dnsServerPod)
 	Expect(t.f.WaitForPodRunning(t.dnsServerPod.Name)).NotTo(HaveOccurred(), "pod failed to start running: %v", t.dnsServerPod)
 
 	t.dnsServerPod, err = t.c.CoreV1().Pods(t.f.Namespace.Name).Get(
@@ -369,7 +370,7 @@ func (t *dnsTestCommon) createDNSServerWithPtrRecord(isIPv6 bool) {
 func (t *dnsTestCommon) deleteDNSServerPod() {
 	podClient := t.c.CoreV1().Pods(t.f.Namespace.Name)
 	if err := podClient.Delete(t.dnsServerPod.Name, metav1.NewDeleteOptions(0)); err != nil {
-		framework.Logf("Delete of pod %v/%v failed: %v",
+		e2elog.Logf("Delete of pod %v/%v failed: %v",
 			t.utilPod.Namespace, t.dnsServerPod.Name, err)
 	}
 }
@@ -524,18 +525,18 @@ func assertFilesContain(fileNames []string, fileDir string, pod *v1.Pod, client 
 				if ctx.Err() != nil {
 					framework.Failf("Unable to read %s from pod %s/%s: %v", fileName, pod.Namespace, pod.Name, err)
 				} else {
-					framework.Logf("Unable to read %s from pod %s/%s: %v", fileName, pod.Namespace, pod.Name, err)
+					e2elog.Logf("Unable to read %s from pod %s/%s: %v", fileName, pod.Namespace, pod.Name, err)
 				}
 				failed = append(failed, fileName)
 			} else if check && strings.TrimSpace(string(contents)) != expected {
-				framework.Logf("File %s from pod  %s/%s contains '%s' instead of '%s'", fileName, pod.Namespace, pod.Name, string(contents), expected)
+				e2elog.Logf("File %s from pod  %s/%s contains '%s' instead of '%s'", fileName, pod.Namespace, pod.Name, string(contents), expected)
 				failed = append(failed, fileName)
 			}
 		}
 		if len(failed) == 0 {
 			return true, nil
 		}
-		framework.Logf("Lookups using %s/%s failed for: %v\n", pod.Namespace, pod.Name, failed)
+		e2elog.Logf("Lookups using %s/%s failed for: %v\n", pod.Namespace, pod.Name, failed)
 		return false, nil
 	}))
 	Expect(len(failed)).To(Equal(0))
@@ -566,7 +567,7 @@ func validateDNSResults(f *framework.Framework, pod *v1.Pod, fileNames []string)
 
 	// TODO: probe from the host, too.
 
-	framework.Logf("DNS probes using %s/%s succeeded\n", pod.Namespace, pod.Name)
+	e2elog.Logf("DNS probes using %s/%s succeeded\n", pod.Namespace, pod.Name)
 }
 
 func validateTargetedProbeOutput(f *framework.Framework, pod *v1.Pod, fileNames []string, value string) {
@@ -592,7 +593,7 @@ func validateTargetedProbeOutput(f *framework.Framework, pod *v1.Pod, fileNames 
 	By("looking for the results for each expected name from probers")
 	assertFilesContain(fileNames, "results", pod, f.ClientSet, true, value)
 
-	framework.Logf("DNS probes using %s succeeded\n", pod.Name)
+	e2elog.Logf("DNS probes using %s succeeded\n", pod.Name)
 }
 
 func reverseArray(arr []string) []string {

--- a/test/e2e/network/dns_scale_records.go
+++ b/test/e2e/network/dns_scale_records.go
@@ -22,11 +22,12 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 
 	. "github.com/onsi/ginkgo"
@@ -66,7 +67,7 @@ var _ = SIGDescribe("[Feature:PerformanceDNS][Serial]", func() {
 			defer GinkgoRecover()
 			framework.ExpectNoError(testutils.CreateServiceWithRetries(f.ClientSet, services[i].Namespace, services[i]))
 		}
-		framework.Logf("Creating %v test services", maxServicesPerCluster)
+		e2elog.Logf("Creating %v test services", maxServicesPerCluster)
 		workqueue.ParallelizeUntil(context.TODO(), parallelCreateServiceWorkers, len(services), createService)
 		dnsTest := dnsTestCommon{
 			f:  f,
@@ -75,7 +76,7 @@ var _ = SIGDescribe("[Feature:PerformanceDNS][Serial]", func() {
 		}
 		dnsTest.createUtilPodLabel("e2e-dns-scale-records")
 		defer dnsTest.deleteUtilPod()
-		framework.Logf("Querying %v%% of service records", checkServicePercent*100)
+		e2elog.Logf("Querying %v%% of service records", checkServicePercent*100)
 		for i := 0; i < len(services); i++ {
 			if i%(1/checkServicePercent) != 0 {
 				continue
@@ -84,7 +85,7 @@ var _ = SIGDescribe("[Feature:PerformanceDNS][Serial]", func() {
 			svc, err := f.ClientSet.CoreV1().Services(s.Namespace).Get(s.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 			qname := fmt.Sprintf("%v.%v.svc.%v", s.Name, s.Namespace, framework.TestContext.ClusterDNSDomain)
-			framework.Logf("Querying %v expecting %v", qname, svc.Spec.ClusterIP)
+			e2elog.Logf("Querying %v expecting %v", qname, svc.Spec.ClusterIP)
 			dnsTest.checkDNSRecordFrom(
 				qname,
 				func(actual []string) bool {

--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -24,12 +24,13 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -108,7 +109,7 @@ var _ = SIGDescribe("ClusterDns [Feature:Example]", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to list pods in namespace: %s", ns.Name)
 			err = framework.PodsResponding(c, ns.Name, backendPodName, false, pods)
 			Expect(err).NotTo(HaveOccurred(), "waiting for all pods to respond")
-			framework.Logf("found %d backend pods responding in namespace %s", len(pods.Items), ns.Name)
+			e2elog.Logf("found %d backend pods responding in namespace %s", len(pods.Items), ns.Name)
 
 			err = framework.ServiceResponding(c, ns.Name, backendSvcName)
 			Expect(err).NotTo(HaveOccurred(), "waiting for the service to respond")

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -20,13 +20,14 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	cloudprovider "k8s.io/cloud-provider"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/master/ports"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/providers/gce"
 
 	. "github.com/onsi/ginkgo"
@@ -68,7 +69,7 @@ var _ = SIGDescribe("Firewall rule", func() {
 		By("Getting cluster ID")
 		clusterID, err := gce.GetClusterID(cs)
 		Expect(err).NotTo(HaveOccurred())
-		framework.Logf("Got cluster ID: %v", clusterID)
+		e2elog.Logf("Got cluster ID: %v", clusterID)
 
 		jig := framework.NewServiceTestJig(cs, serviceName)
 		nodeList := jig.GetNodes(framework.MaxNodesForEndpointsTests)
@@ -130,7 +131,7 @@ var _ = SIGDescribe("Firewall rule", func() {
 			podName := fmt.Sprintf("netexec%v", i)
 			jig.LaunchNetexecPodOnNode(f, nodeName, podName, firewallTestHTTPPort, firewallTestUDPPort, true)
 			defer func() {
-				framework.Logf("Cleaning up the netexec pod: %v", podName)
+				e2elog.Logf("Cleaning up the netexec pod: %v", podName)
 				Expect(cs.CoreV1().Pods(ns).Delete(podName, nil)).NotTo(HaveOccurred())
 			}()
 		}

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/images/net/nat"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -209,7 +210,7 @@ var _ = SIGDescribe("Network", func() {
 		const epsilonSeconds = 60
 		const expectedTimeoutSeconds = 60 * 60
 
-		framework.Logf("conntrack entry timeout was: %v, expected: %v",
+		e2elog.Logf("conntrack entry timeout was: %v, expected: %v",
 			timeoutSeconds, expectedTimeoutSeconds)
 
 		Expect(math.Abs(float64(timeoutSeconds - expectedTimeoutSeconds))).Should(

--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"fmt"
@@ -134,7 +135,7 @@ var _ = SIGDescribe("NetworkPolicy", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Create Server with Service in NS-B
-			framework.Logf("Waiting for server to come up.")
+			e2elog.Logf("Waiting for server to come up.")
 			err = framework.WaitForPodRunningInNamespace(f.ClientSet, podServer)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -365,11 +366,11 @@ func testCanConnect(f *framework.Framework, ns *v1.Namespace, podName string, se
 		}
 	}()
 
-	framework.Logf("Waiting for %s to complete.", podClient.Name)
+	e2elog.Logf("Waiting for %s to complete.", podClient.Name)
 	err := framework.WaitForPodNoLongerRunningInNamespace(f.ClientSet, podClient.Name, ns.Name)
 	Expect(err).NotTo(HaveOccurred(), "Pod did not finish as expected.")
 
-	framework.Logf("Waiting for %s to complete.", podClient.Name)
+	e2elog.Logf("Waiting for %s to complete.", podClient.Name)
 	err = framework.WaitForPodSuccessInNamespace(f.ClientSet, podClient.Name, ns.Name)
 	if err != nil {
 		// Collect pod logs when we see a failure.
@@ -381,13 +382,13 @@ func testCanConnect(f *framework.Framework, ns *v1.Namespace, podName string, se
 		// Collect current NetworkPolicies applied in the test namespace.
 		policies, err := f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).List(metav1.ListOptions{})
 		if err != nil {
-			framework.Logf("error getting current NetworkPolicies for %s namespace: %s", f.Namespace.Name, err)
+			e2elog.Logf("error getting current NetworkPolicies for %s namespace: %s", f.Namespace.Name, err)
 		}
 
 		// Collect the list of pods running in the test namespace.
 		podsInNS, err := framework.GetPodsInNamespace(f.ClientSet, f.Namespace.Name, map[string]string{})
 		if err != nil {
-			framework.Logf("error getting pods for %s namespace: %s", f.Namespace.Name, err)
+			e2elog.Logf("error getting pods for %s namespace: %s", f.Namespace.Name, err)
 		}
 
 		pods := []string{}
@@ -412,7 +413,7 @@ func testCannotConnect(f *framework.Framework, ns *v1.Namespace, podName string,
 		}
 	}()
 
-	framework.Logf("Waiting for %s to complete.", podClient.Name)
+	e2elog.Logf("Waiting for %s to complete.", podClient.Name)
 	err := framework.WaitForPodSuccessInNamespace(f.ClientSet, podClient.Name, ns.Name)
 
 	// We expect an error here since it's a cannot connect test.
@@ -427,13 +428,13 @@ func testCannotConnect(f *framework.Framework, ns *v1.Namespace, podName string,
 		// Collect current NetworkPolicies applied in the test namespace.
 		policies, err := f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).List(metav1.ListOptions{})
 		if err != nil {
-			framework.Logf("error getting current NetworkPolicies for %s namespace: %s", f.Namespace.Name, err)
+			e2elog.Logf("error getting current NetworkPolicies for %s namespace: %s", f.Namespace.Name, err)
 		}
 
 		// Collect the list of pods running in the test namespace.
 		podsInNS, err := framework.GetPodsInNamespace(f.ClientSet, f.Namespace.Name, map[string]string{})
 		if err != nil {
-			framework.Logf("error getting pods for %s namespace: %s", f.Namespace.Name, err)
+			e2elog.Logf("error getting pods for %s namespace: %s", f.Namespace.Name, err)
 		}
 
 		pods := []string{}
@@ -508,7 +509,7 @@ func createServerPodAndService(f *framework.Framework, namespace *v1.Namespace, 
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())
-	framework.Logf("Created pod %v", pod.ObjectMeta.Name)
+	e2elog.Logf("Created pod %v", pod.ObjectMeta.Name)
 
 	svcName := fmt.Sprintf("svc-%s", podName)
 	By(fmt.Sprintf("Creating a service %s for pod %s in namespace %s", svcName, podName, namespace.Name))
@@ -524,7 +525,7 @@ func createServerPodAndService(f *framework.Framework, namespace *v1.Namespace, 
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())
-	framework.Logf("Created service %s", svc.Name)
+	e2elog.Logf("Created service %s", svc.Name)
 
 	return pod, svc
 }

--- a/test/e2e/network/network_tiers.go
+++ b/test/e2e/network/network_tiers.go
@@ -30,6 +30,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/providers/gce"
 
 	. "github.com/onsi/ginkgo"
@@ -53,7 +54,7 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 			framework.DescribeSvc(f.Namespace.Name)
 		}
 		for _, lb := range serviceLBNames {
-			framework.Logf("cleaning gce resource for %s", lb)
+			e2elog.Logf("cleaning gce resource for %s", lb)
 			framework.TestContext.CloudConfig.Provider.CleanupServiceResources(cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
 		}
 		//reset serviceLBNames
@@ -111,12 +112,12 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 			if requestedAddrName != "" {
 				// Release GCE static address - this is not kube-managed and will not be automatically released.
 				if err := gceCloud.DeleteRegionAddress(requestedAddrName, gceCloud.Region()); err != nil {
-					framework.Logf("failed to release static IP address %q: %v", requestedAddrName, err)
+					e2elog.Logf("failed to release static IP address %q: %v", requestedAddrName, err)
 				}
 			}
 		}()
 		Expect(err).NotTo(HaveOccurred())
-		framework.Logf("Allocated static IP to be used by the load balancer: %q", requestedIP)
+		e2elog.Logf("Allocated static IP to be used by the load balancer: %q", requestedIP)
 
 		By("updating the Service to use the standard tier with a requested IP")
 		svc = jig.UpdateServiceOrFail(ns, svc.Name, func(svc *v1.Service) {

--- a/test/e2e/network/networking_perf.go
+++ b/test/e2e/network/networking_perf.go
@@ -24,8 +24,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -110,8 +111,8 @@ func networkingIPerfTest(isIPv6 bool) {
 			numClient,
 		)
 
-		framework.Logf("Reading all perf results to stdout.")
-		framework.Logf("date,cli,cliPort,server,serverPort,id,interval,transferBits,bandwidthBits")
+		e2elog.Logf("Reading all perf results to stdout.")
+		e2elog.Logf("date,cli,cliPort,server,serverPort,id,interval,transferBits,bandwidthBits")
 
 		// Calculate expected number of clients based on total nodes.
 		expectedCli := func() int {
@@ -142,7 +143,7 @@ func networkingIPerfTest(isIPv6 bool) {
 				func(p v1.Pod) {
 					resultS, err := framework.LookForStringInLog(f.Namespace.Name, p.Name, "iperf-client", "0-", 1*time.Second)
 					if err == nil {
-						framework.Logf(resultS)
+						e2elog.Logf(resultS)
 						iperfResults.Add(NewIPerf(resultS))
 					} else {
 						framework.Failf("Unexpected error, %v when running forEach on the pods.", err)
@@ -154,7 +155,7 @@ func networkingIPerfTest(isIPv6 bool) {
 		fmt.Println("[end] Node,Bandwidth CSV")
 
 		for ipClient, bandwidth := range iperfResults.BandwidthMap {
-			framework.Logf("%v had bandwidth %v.  Ratio to expected (%v) was %f", ipClient, bandwidth, expectedBandwidth, float64(bandwidth)/float64(expectedBandwidth))
+			e2elog.Logf("%v had bandwidth %v.  Ratio to expected (%v) was %f", ipClient, bandwidth, expectedBandwidth, float64(bandwidth)/float64(expectedBandwidth))
 		}
 	})
 }

--- a/test/e2e/network/service_latency.go
+++ b/test/e2e/network/service_latency.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -103,14 +104,14 @@ var _ = SIGDescribe("Service endpoints latency", func() {
 			}
 			return dSorted[est]
 		}
-		framework.Logf("Latencies: %v", dSorted)
+		e2elog.Logf("Latencies: %v", dSorted)
 		p50 := percentile(50)
 		p90 := percentile(90)
 		p99 := percentile(99)
-		framework.Logf("50 %%ile: %v", p50)
-		framework.Logf("90 %%ile: %v", p90)
-		framework.Logf("99 %%ile: %v", p99)
-		framework.Logf("Total sample count: %v", len(dSorted))
+		e2elog.Logf("50 %%ile: %v", p50)
+		e2elog.Logf("90 %%ile: %v", p90)
+		e2elog.Logf("99 %%ile: %v", p99)
+		e2elog.Logf("Total sample count: %v", len(dSorted))
 
 		if p50 > limitMedian {
 			failing.Insert("Median latency should be less than " + limitMedian.String())
@@ -175,14 +176,14 @@ func runServiceLatencies(f *framework.Framework, inParallel, total int, acceptab
 	for i := 0; i < total; i++ {
 		select {
 		case e := <-errs:
-			framework.Logf("Got error: %v", e)
+			e2elog.Logf("Got error: %v", e)
 			errCount += 1
 		case d := <-durations:
 			output = append(output, d)
 		}
 	}
 	if errCount != 0 {
-		framework.Logf("Got %d errors out of %d tries", errCount, total)
+		e2elog.Logf("Got %d errors out of %d tries", errCount, total)
 		errRatio := float32(errCount) / float32(total)
 		if errRatio > acceptableFailureRatio {
 			return output, fmt.Errorf("error ratio %g is higher than the acceptable ratio %g", errRatio, acceptableFailureRatio)
@@ -345,13 +346,13 @@ func singleServiceLatency(f *framework.Framework, name string, q *endpointQuerie
 	if err != nil {
 		return 0, err
 	}
-	framework.Logf("Created: %v", gotSvc.Name)
+	e2elog.Logf("Created: %v", gotSvc.Name)
 
 	if e := q.request(gotSvc.Name); e == nil {
 		return 0, fmt.Errorf("Never got a result for endpoint %v", gotSvc.Name)
 	}
 	stopTime := time.Now()
 	d := stopTime.Sub(startTime)
-	framework.Logf("Got endpoints: %v [%v]", gotSvc.Name, d)
+	e2elog.Logf("Got endpoints: %v [%v]", gotSvc.Name, d)
 	return d, nil
 }

--- a/test/e2e/network/util_iperf.go
+++ b/test/e2e/network/util_iperf.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
 type IPerfResults struct {
@@ -56,7 +57,7 @@ func (i *IPerfResults) Add(ipr *IPerfResult) {
 // ToTSV exports an easily readable tab delimited format of all IPerfResults.
 func (i *IPerfResults) ToTSV() string {
 	if len(i.BandwidthMap) < 1 {
-		framework.Logf("Warning: no data in bandwidth map")
+		e2elog.Logf("Warning: no data in bandwidth map")
 	}
 
 	var buffer bytes.Buffer


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is part of the transition to using framework/log instead
of the Logf inside the framework package. This will help with
import size/cycles when importing the framework or subpackages.

**Which issue(s) this PR fixes**:
Ref #77359 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig testing
/area test
/area test-framework
