### PR TITLE
create new SCTP ipsets for IPVS proxier

### DIFF
--- a/pkg/proxy/ipvs/ipset.go
+++ b/pkg/proxy/ipvs/ipset.go
@@ -65,11 +65,21 @@ const (
 	kubeNodePortLocalSetUDPComment = "Kubernetes nodeport UDP port with externalTrafficPolicy=local"
 	kubeNodePortLocalSetUDP        = "KUBE-NODE-PORT-LOCAL-UDP"
 
-	kubeNodePortSetSCTPComment = "Kubernetes nodeport SCTP port for masquerade purpose"
-	kubeNodePortSetSCTP        = "KUBE-NODE-PORT-SCTP"
+	// This ipset is no longer active but still used in previous versions.
+	// DO NOT create an ipset using this name
+	legacyKubeNodePortSetSCTPComment = "Kubernetes nodeport SCTP port for masquerade purpose"
+	legacyKubeNodePortSetSCTP        = "KUBE-NODE-PORT-SCTP"
 
-	kubeNodePortLocalSetSCTPComment = "Kubernetes nodeport SCTP port with externalTrafficPolicy=local"
-	kubeNodePortLocalSetSCTP        = "KUBE-NODE-PORT-LOCAL-SCTP"
+	// This ipset is no longer active but still used in previous versions.
+	// DO NOT create an ipset using this name
+	legacyKubeNodePortLocalSetSCTPComment = "Kubernetes nodeport SCTP port with externalTrafficPolicy=local"
+	legacyKubeNodePortLocalSetSCTP        = "KUBE-NODE-PORT-LOCAL-SCTP"
+
+	kubeNodePortSetSCTPComment = "Kubernetes nodeport SCTP port for masquerade purpose with type 'hash ip:port'"
+	kubeNodePortSetSCTP        = "KUBE-NODE-PORT-SCTP-HASH"
+
+	kubeNodePortLocalSetSCTPComment = "Kubernetes nodeport SCTP port with externalTrafficPolicy=local with type 'hash ip:port'"
+	kubeNodePortLocalSetSCTP        = "KUBE-NODE-PORT-LOCAL-SCTP-HASH"
 )
 
 // IPSetVersioner can query the current ipset version.


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In https://github.com/kubernetes/kubernetes/pull/74341 we updated the `KUBE-NODE-PORT-SCTP` and `KUBE-NODE-PORT-LOCAL-SCTP` ipset to use type `hash ip:port` instead of `bitmap:port` since bitmap does not support sctp. This ended up being a breaking change because `ipset create <set> -exists` actually returns error unless the existing set and the proposed set are identical. With the type updated, ipset returns an error regardless of -exists (and rightly so).

This PR adds a new ipset `KUBE-NODE-PORT-SCTP-HASH` and `KUBE-NODE-PORT-LOCAL-SCTP-HASH` so that the IPVS proxier does not error if an ipset from a previous version exists. 

Shout out to @lbernail for finding the bug :) 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/77265

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug where kube-proxy returns error due to existing ipset rules using a different hash type.
```
