### PR TITLE
[WIP] feat: add un-reserve extension point to scheduler

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -113,6 +113,17 @@ type PrebindPlugin interface {
 	Prebind(pc *PluginContext, p *v1.Pod, nodeName string) *Status
 }
 
+// UnreservePlugin is an interface for Unreserve plugins. This is an informational
+// extension point. If a pod was reserved and then rejected in a later phase, then
+// un-reserve plugins will be notified. Un-reserve plugins should clean up state
+// associated with the reserved Pod.
+type UnreservePlugin interface {
+	Plugin
+	// Unreserve is called by the scheduling framework when a reserved pod was rejected
+	// in a later phase.
+	Unreserve(pc *PluginContext, p *v1.Pod, nodeName string) *Status
+}
+
 // Framework manages the set of plugins in use by the scheduling framework.
 // Configured plugins are called at specified points in a scheduling context.
 type Framework interface {
@@ -128,6 +139,11 @@ type Framework interface {
 	// plugins returns an error, it does not continue running the remaining ones and
 	// returns the error. In such case, pod will not be scheduled.
 	RunReservePlugins(pc *PluginContext, pod *v1.Pod, nodeName string) *Status
+
+	// RunUnreservePlugins runs the set of configured unreserve plugins. If any of these
+	// plugins returns an error, it does not continue running the remaining ones and
+	// returns the error.
+	RunUnreservePlugins(pc *PluginContext, pod *v1.Pod, nodeName string) *Status
 }
 
 // FrameworkHandle provides data and some tools that plugins can use. It is

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -515,6 +515,10 @@ func (sched *Scheduler) scheduleOne() {
 	if err != nil {
 		klog.Errorf("error assuming pod: %v", err)
 		metrics.PodScheduleErrors.Inc()
+
+		if err := fwk.RunUnreservePlugins(pluginContext, assumedPod, scheduleResult.SuggestedHost).AsError(); err != nil {
+			klog.Errorf("error run unreserve plugins: %v", err)
+		}
 		return
 	}
 	// bind the pod to its host asynchronously (we can do this b/c of the assumption step above).
@@ -525,6 +529,10 @@ func (sched *Scheduler) scheduleOne() {
 			if err != nil {
 				klog.Errorf("error binding volumes: %v", err)
 				metrics.PodScheduleErrors.Inc()
+
+				if err := fwk.RunUnreservePlugins(pluginContext, assumedPod, scheduleResult.SuggestedHost).AsError(); err != nil {
+					klog.Errorf("error run unreserve plugins: %v", err)
+				}
 				return
 			}
 		}
@@ -543,6 +551,10 @@ func (sched *Scheduler) scheduleOne() {
 				klog.Errorf("scheduler cache ForgetPod failed: %v", forgetErr)
 			}
 			sched.recordSchedulingFailure(assumedPod, prebindStatus.AsError(), reason, prebindStatus.Message())
+
+			if err := fwk.RunUnreservePlugins(pluginContext, assumedPod, scheduleResult.SuggestedHost).AsError(); err != nil {
+				klog.Errorf("error run unreserve plugins: %v", err)
+			}
 			return
 		}
 
@@ -558,6 +570,10 @@ func (sched *Scheduler) scheduleOne() {
 		if err != nil {
 			klog.Errorf("error binding pod: %v", err)
 			metrics.PodScheduleErrors.Inc()
+
+			if err := fwk.RunUnreservePlugins(pluginContext, assumedPod, scheduleResult.SuggestedHost).AsError(); err != nil {
+				klog.Errorf("error run unreserve plugins: %v", err)
+			}
 		} else {
 			klog.V(2).Infof("pod %v/%v is bound successfully on node %v, %d nodes evaluated, %d nodes were found feasible", assumedPod.Namespace, assumedPod.Name, scheduleResult.SuggestedHost, scheduleResult.EvaluatedNodes, scheduleResult.FeasibleNodes)
 			metrics.PodScheduleSuccesses.Inc()


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

Add un-reserve extension point to the scheduler.

Related to https://github.com/kubernetes/kubernetes/issues/77365 https://github.com/kubernetes/kubernetes/pull/75848 with schedule framework [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/20180409-scheduling-framework.md)

**Does this PR introduce a user-facing change?**:

```release-note
Implement un-reserve extension point for the scheduling framework.
```
