### PR TITLE
Move storage tests to use the framework/log package

### DIFF
--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -66,6 +66,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/auth:go_default_library",
         "//test/e2e/framework/deployment:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/metrics:go_default_library",
         "//test/e2e/framework/providers/gce:go_default_library",
         "//test/e2e/framework/testfiles:go_default_library",

--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -37,6 +37,7 @@ import (
 
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/drivers"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
@@ -715,7 +716,7 @@ func checkPodInfo(cs clientset.Interface, namespace, driverPodName, driverContai
 	if err != nil {
 		return fmt.Errorf("could not load CSI driver logs: %s", err)
 	}
-	framework.Logf("CSI driver logs:\n%s", log)
+	e2elog.Logf("CSI driver logs:\n%s", log)
 	// Find NodePublish in the logs
 	foundAttributes := sets.NewString()
 	logLines := strings.Split(log, "\n")
@@ -734,7 +735,7 @@ func checkPodInfo(cs clientset.Interface, namespace, driverPodName, driverContai
 		var call MockCSICall
 		err := json.Unmarshal([]byte(line), &call)
 		if err != nil {
-			framework.Logf("Could not parse CSI driver log line %q: %s", line, err)
+			e2elog.Logf("Could not parse CSI driver log line %q: %s", line, err)
 			continue
 		}
 		if call.Method != "/csi.v1.Node/NodePublishVolume" {
@@ -745,7 +746,7 @@ func checkPodInfo(cs clientset.Interface, namespace, driverPodName, driverContai
 			vv, found := call.Request.VolumeContext[k]
 			if found && v == vv {
 				foundAttributes.Insert(k)
-				framework.Logf("Found volume attribute %s: %s", k, v)
+				e2elog.Logf("Found volume attribute %s: %s", k, v)
 			}
 		}
 		// Process just the first NodePublish, the rest of the log is useless.
@@ -767,7 +768,7 @@ func checkPodInfo(cs clientset.Interface, namespace, driverPodName, driverContai
 func waitForCSIDriver(cs clientset.Interface, driverName string) error {
 	timeout := 4 * time.Minute
 
-	framework.Logf("waiting up to %v for CSIDriver %q", timeout, driverName)
+	e2elog.Logf("waiting up to %v for CSIDriver %q", timeout, driverName)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(framework.Poll) {
 		_, err := cs.StorageV1beta1().CSIDrivers().Get(driverName, metav1.GetOptions{})
 		if !errors.IsNotFound(err) {
@@ -780,9 +781,9 @@ func waitForCSIDriver(cs clientset.Interface, driverName string) error {
 func destroyCSIDriver(cs clientset.Interface, driverName string) {
 	driverGet, err := cs.StorageV1beta1().CSIDrivers().Get(driverName, metav1.GetOptions{})
 	if err == nil {
-		framework.Logf("deleting %s.%s: %s", driverGet.TypeMeta.APIVersion, driverGet.TypeMeta.Kind, driverGet.ObjectMeta.Name)
+		e2elog.Logf("deleting %s.%s: %s", driverGet.TypeMeta.APIVersion, driverGet.TypeMeta.Kind, driverGet.ObjectMeta.Name)
 		// Uncomment the following line to get full dump of CSIDriver object
-		// framework.Logf("%s", framework.PrettyPrint(driverGet))
+		// e2elog.Logf("%s", framework.PrettyPrint(driverGet))
 		cs.StorageV1beta1().CSIDrivers().Delete(driverName, nil)
 	}
 }

--- a/test/e2e/storage/drivers/BUILD
+++ b/test/e2e/storage/drivers/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/auth:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/volume:go_default_library",
         "//test/e2e/storage/testpatterns:go_default_library",
         "//test/e2e/storage/testsuites:go_default_library",

--- a/test/e2e/storage/drivers/csi_objects.go
+++ b/test/e2e/storage/drivers/csi_objects.go
@@ -27,13 +27,14 @@ import (
 	"path"
 	"path/filepath"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
 var (
@@ -49,16 +50,16 @@ var (
 
 func shredFile(filePath string) {
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		framework.Logf("File %v was not found, skipping shredding", filePath)
+		e2elog.Logf("File %v was not found, skipping shredding", filePath)
 		return
 	}
-	framework.Logf("Shredding file %v", filePath)
+	e2elog.Logf("Shredding file %v", filePath)
 	_, _, err := framework.RunCmd("shred", "--remove", filePath)
 	if err != nil {
-		framework.Logf("Failed to shred file %v: %v", filePath, err)
+		e2elog.Logf("Failed to shred file %v: %v", filePath, err)
 	}
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		framework.Logf("File %v successfully shredded", filePath)
+		e2elog.Logf("File %v successfully shredded", filePath)
 		return
 	}
 	// Shred failed Try to remove the file for good meausure
@@ -78,13 +79,13 @@ func createGCESecrets(client clientset.Interface, ns string) {
 
 	premadeSAFile, ok := os.LookupEnv(saEnv)
 	if !ok {
-		framework.Logf("Could not find env var %v, please either create cloud-sa"+
+		e2elog.Logf("Could not find env var %v, please either create cloud-sa"+
 			" secret manually or rerun test after setting %v to the filepath of"+
 			" the GCP Service Account to give to the GCE Persistent Disk CSI Driver", saEnv, saEnv)
 		return
 	}
 
-	framework.Logf("Found CI service account key at %v", premadeSAFile)
+	e2elog.Logf("Found CI service account key at %v", premadeSAFile)
 	// Need to copy it saFile
 	stdout, stderr, err := framework.RunCmd("cp", premadeSAFile, saFile)
 	framework.ExpectNoError(err, "error copying service account key: %s\nstdout: %s\nstderr: %s", err, stdout, stderr)

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -55,6 +55,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/auth"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/volume"
 	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
@@ -311,15 +312,15 @@ func (v *glusterVolume) DeleteVolume() {
 
 	name := v.prefix + "-server"
 
-	framework.Logf("Deleting Gluster endpoints %q...", name)
+	e2elog.Logf("Deleting Gluster endpoints %q...", name)
 	err := cs.CoreV1().Endpoints(ns.Name).Delete(name, nil)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			framework.Failf("Gluster delete endpoints failed: %v", err)
 		}
-		framework.Logf("Gluster endpoints %q not found, assuming deleted", name)
+		e2elog.Logf("Gluster endpoints %q not found, assuming deleted", name)
 	}
-	framework.Logf("Deleting Gluster server pod %q...", v.serverPod.Name)
+	e2elog.Logf("Deleting Gluster server pod %q...", v.serverPod.Name)
 	err = framework.DeletePodWithWait(f, cs, v.serverPod)
 	if err != nil {
 		framework.Failf("Gluster server pod delete failed: %v", err)
@@ -1057,7 +1058,7 @@ func (c *cinderDriver) CreateVolume(config *testsuites.PerTestConfig, volType te
 	By("creating a test Cinder volume")
 	output, err := exec.Command("cinder", "create", "--display-name="+volumeName, "1").CombinedOutput()
 	outputString := string(output[:])
-	framework.Logf("cinder output:\n%s", outputString)
+	e2elog.Logf("cinder output:\n%s", outputString)
 	framework.ExpectNoError(err)
 
 	// Parse 'id'' from stdout. Expected format:
@@ -1077,7 +1078,7 @@ func (c *cinderDriver) CreateVolume(config *testsuites.PerTestConfig, volType te
 		volumeID = fields[3]
 		break
 	}
-	framework.Logf("Volume ID: %s", volumeID)
+	e2elog.Logf("Volume ID: %s", volumeID)
 	Expect(volumeID).NotTo(Equal(""))
 	return &cinderVolume{
 		volumeName: volumeName,
@@ -1094,16 +1095,16 @@ func (v *cinderVolume) DeleteVolume() {
 	var err error
 	timeout := time.Second * 120
 
-	framework.Logf("Waiting up to %v for removal of cinder volume %s", timeout, name)
+	e2elog.Logf("Waiting up to %v for removal of cinder volume %s", timeout, name)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(5 * time.Second) {
 		output, err = exec.Command("cinder", "delete", name).CombinedOutput()
 		if err == nil {
-			framework.Logf("Cinder volume %s deleted", name)
+			e2elog.Logf("Cinder volume %s deleted", name)
 			return
 		}
-		framework.Logf("Failed to delete volume %s: %v", name, err)
+		e2elog.Logf("Failed to delete volume %s: %v", name, err)
 	}
-	framework.Logf("Giving up deleting volume %s: %v\n%s", name, err, string(output[:]))
+	e2elog.Logf("Giving up deleting volume %s: %v\n%s", name, err, string(output[:]))
 }
 
 // GCE

--- a/test/e2e/storage/ephemeral_volume.go
+++ b/test/e2e/storage/ephemeral_volume.go
@@ -21,11 +21,12 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -58,7 +59,7 @@ var _ = utils.SIGDescribe("Ephemeralstorage", func() {
 
 				// Allow it to sleep for 30 seconds
 				time.Sleep(30 * time.Second)
-				framework.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
+				e2elog.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
 				framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod))
 			})
 		}

--- a/test/e2e/storage/flexvolume_mounted_volume_resize.go
+++ b/test/e2e/storage/flexvolume_mounted_volume_resize.go
@@ -22,7 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +30,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edeploy "k8s.io/kubernetes/test/e2e/framework/deployment"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
@@ -102,7 +103,7 @@ var _ = utils.SIGDescribe("Mounted flexvolume expand[Slow]", func() {
 	})
 
 	AfterEach(func() {
-		framework.Logf("AfterEach: Cleaning up resources for mounted volume resize")
+		e2elog.Logf("AfterEach: Cleaning up resources for mounted volume resize")
 
 		if c != nil {
 			if errs := framework.PVPVCCleanup(c, ns, nil, pvc); len(errs) > 0 {

--- a/test/e2e/storage/flexvolume_online_resize.go
+++ b/test/e2e/storage/flexvolume_online_resize.go
@@ -22,12 +22,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
@@ -101,7 +102,7 @@ var _ = utils.SIGDescribe("Mounted flexvolume volume expand [Slow] [Feature:Expa
 	})
 
 	AfterEach(func() {
-		framework.Logf("AfterEach: Cleaning up resources for mounted volume resize")
+		e2elog.Logf("AfterEach: Cleaning up resources for mounted volume resize")
 
 		if c != nil {
 			if errs := framework.PVPVCCleanup(c, ns, nil, pvc); len(errs) > 0 {

--- a/test/e2e/storage/generic_persistent_volume-disruptive.go
+++ b/test/e2e/storage/generic_persistent_volume-disruptive.go
@@ -20,9 +20,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
@@ -65,7 +66,7 @@ var _ = utils.SIGDescribe("GenericPersistentVolume[Disruptive]", func() {
 			pv        *v1.PersistentVolume
 		)
 		BeforeEach(func() {
-			framework.Logf("Initializing pod and pvcs for test")
+			e2elog.Logf("Initializing pod and pvcs for test")
 			clientPod, pvc, pv = createPodPVCFromSC(f, c, ns)
 		})
 		for _, test := range disruptiveTestTable {
@@ -77,7 +78,7 @@ var _ = utils.SIGDescribe("GenericPersistentVolume[Disruptive]", func() {
 			}(test)
 		}
 		AfterEach(func() {
-			framework.Logf("Tearing down test spec")
+			e2elog.Logf("Tearing down test spec")
 			tearDownTestCase(c, f, ns, clientPod, pvc, pv, false)
 			pvc, clientPod = nil, nil
 		})

--- a/test/e2e/storage/mounted_volume_resize.go
+++ b/test/e2e/storage/mounted_volume_resize.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/conditions"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edeploy "k8s.io/kubernetes/test/e2e/framework/deployment"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
@@ -97,7 +98,7 @@ var _ = utils.SIGDescribe("Mounted volume expand", func() {
 	})
 
 	AfterEach(func() {
-		framework.Logf("AfterEach: Cleaning up resources for mounted volume resize")
+		e2elog.Logf("AfterEach: Cleaning up resources for mounted volume resize")
 
 		if c != nil {
 			if errs := framework.PVPVCCleanup(c, ns, nil, pvc); len(errs) > 0 {

--- a/test/e2e/storage/nfs_persistent_volume-disruptive.go
+++ b/test/e2e/storage/nfs_persistent_volume-disruptive.go
@@ -22,12 +22,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/volume"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
@@ -87,7 +88,7 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 		// Get the first ready node IP that is not hosting the NFS pod.
 		var err error
 		if clientNodeIP == "" {
-			framework.Logf("Designating test node")
+			e2elog.Logf("Designating test node")
 			nodes := framework.GetReadySchedulableNodesOrDie(c)
 			for _, node := range nodes.Items {
 				if node.Name != nfsServerPod.Spec.NodeName {
@@ -185,7 +186,7 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 			framework.ExpectNoError(err)
 			err = framework.WaitForControllerManagerUp()
 			framework.ExpectNoError(err)
-			framework.Logf("kube-controller-manager restarted")
+			e2elog.Logf("kube-controller-manager restarted")
 
 			By("Observing the kube-controller-manager healthy for at least 2 minutes")
 			// Continue checking for 2 minutes to make sure kube-controller-manager is healthy
@@ -203,12 +204,12 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 		)
 
 		BeforeEach(func() {
-			framework.Logf("Initializing test spec")
+			e2elog.Logf("Initializing test spec")
 			clientPod, pv, pvc = initTestCase(f, c, nfsPVconfig, pvcConfig, ns, clientNode.Name)
 		})
 
 		AfterEach(func() {
-			framework.Logf("Tearing down test spec")
+			e2elog.Logf("Tearing down test spec")
 			tearDownTestCase(c, f, ns, clientPod, pvc, pv, true /* force PV delete */)
 			pv, pvc, clientPod = nil, nil, nil
 		})
@@ -256,9 +257,9 @@ func initTestCase(f *framework.Framework, c clientset.Interface, pvConfig framew
 	framework.ExpectNoError(err)
 	pod := framework.MakePod(ns, nil, []*v1.PersistentVolumeClaim{pvc}, true, "")
 	pod.Spec.NodeName = nodeName
-	framework.Logf("Creating NFS client pod.")
+	e2elog.Logf("Creating NFS client pod.")
 	pod, err = c.CoreV1().Pods(ns).Create(pod)
-	framework.Logf("NFS client Pod %q created on Node %q", pod.Name, nodeName)
+	e2elog.Logf("NFS client Pod %q created on Node %q", pod.Name, nodeName)
 	framework.ExpectNoError(err)
 	defer func() {
 		if err != nil {

--- a/test/e2e/storage/persistent_volumes-gce.go
+++ b/test/e2e/storage/persistent_volumes-gce.go
@@ -19,13 +19,14 @@ package storage
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/providers/gce"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
@@ -104,7 +105,7 @@ var _ = utils.SIGDescribe("PersistentVolumes GCEPD", func() {
 	})
 
 	AfterEach(func() {
-		framework.Logf("AfterEach: Cleaning up test resources")
+		e2elog.Logf("AfterEach: Cleaning up test resources")
 		if c != nil {
 			framework.ExpectNoError(framework.DeletePodWithWait(f, c, clientPod))
 			if errs := framework.PVPVCCleanup(c, ns, pv, pvc); len(errs) > 0 {

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -567,7 +568,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 
 				for _, pod := range pods {
 					if err := deletePodAndPVCs(config, pod); err != nil {
-						framework.Logf("Deleting pod %v failed: %v", pod.Name, err)
+						e2elog.Logf("Deleting pod %v failed: %v", pod.Name, err)
 					}
 				}
 			}()
@@ -591,7 +592,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 						}
 						delete(pods, pod.Name)
 						numFinished++
-						framework.Logf("%v/%v pods finished", numFinished, totalPods)
+						e2elog.Logf("%v/%v pods finished", numFinished, totalPods)
 					case v1.PodFailed:
 					case v1.PodUnknown:
 						return false, fmt.Errorf("pod %v is in %v phase", pod.Name, pod.Status.Phase)
@@ -671,7 +672,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 })
 
 func deletePodAndPVCs(config *localTestConfig, pod *v1.Pod) error {
-	framework.Logf("Deleting pod %v", pod.Name)
+	e2elog.Logf("Deleting pod %v", pod.Name)
 	if err := config.client.CoreV1().Pods(config.ns).Delete(pod.Name, nil); err != nil {
 		return err
 	}
@@ -845,7 +846,7 @@ func verifyLocalVolume(config *localTestConfig, volume *localTestVolume) {
 func verifyLocalPod(config *localTestConfig, volume *localTestVolume, pod *v1.Pod, expectedNodeName string) {
 	podNodeName, err := podNodeName(config, pod)
 	framework.ExpectNoError(err)
-	framework.Logf("pod %q created on Node %q", pod.Name, podNodeName)
+	e2elog.Logf("pod %q created on Node %q", pod.Name, podNodeName)
 	Expect(podNodeName).To(Equal(expectedNodeName))
 }
 
@@ -1030,7 +1031,7 @@ func testReadFileContent(testFileDir string, testFile string, testFileContent st
 // Fail on error
 func podRWCmdExec(pod *v1.Pod, cmd string) string {
 	out, err := utils.PodExec(pod, cmd)
-	framework.Logf("podRWCmdExec out: %q err: %v", out, err)
+	e2elog.Logf("podRWCmdExec out: %q err: %v", out, err)
 	framework.ExpectNoError(err)
 	return out
 }

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -23,12 +23,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/volume"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -150,7 +151,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 		Context("with Single PV - PVC pairs", func() {
 			// Note: this is the only code where the pv is deleted.
 			AfterEach(func() {
-				framework.Logf("AfterEach: Cleaning up test resources.")
+				e2elog.Logf("AfterEach: Cleaning up test resources.")
 				if errs := framework.PVPVCCleanup(c, ns, pv, pvc); len(errs) > 0 {
 					framework.Failf("AfterEach: Failed to delete PVC and/or PV. Errors: %v", utilerrors.NewAggregate(errs))
 				}
@@ -212,7 +213,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 			var claims framework.PVCMap
 
 			AfterEach(func() {
-				framework.Logf("AfterEach: deleting %v PVCs and %v PVs...", len(claims), len(pvols))
+				e2elog.Logf("AfterEach: deleting %v PVCs and %v PVs...", len(claims), len(pvols))
 				errs := framework.PVPVCMapCleanup(c, ns, pvols, claims)
 				if len(errs) > 0 {
 					errmsg := []string{}
@@ -266,7 +267,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 			})
 
 			AfterEach(func() {
-				framework.Logf("AfterEach: Cleaning up test resources.")
+				e2elog.Logf("AfterEach: Cleaning up test resources.")
 				if errs := framework.PVPVCCleanup(c, ns, pv, pvc); len(errs) > 0 {
 					framework.Failf("AfterEach: Failed to delete PVC and/or PV. Errors: %v", utilerrors.NewAggregate(errs))
 				}
@@ -300,7 +301,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 				framework.ExpectNoError(err)
 				framework.ExpectNoError(framework.WaitForPodSuccessInNamespace(c, pod.Name, ns))
 				framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod))
-				framework.Logf("Pod exited without failure; the volume has been recycled.")
+				e2elog.Logf("Pod exited without failure; the volume has been recycled.")
 			})
 		})
 	})

--- a/test/e2e/storage/pv_protection.go
+++ b/test/e2e/storage/pv_protection.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/slice"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -89,7 +90,7 @@ var _ = utils.SIGDescribe("PV Protection", func() {
 	})
 
 	AfterEach(func() {
-		framework.Logf("AfterEach: Cleaning up test resources.")
+		e2elog.Logf("AfterEach: Cleaning up test resources.")
 		if errs := framework.PVPVCCleanup(client, nameSpace, pv, pvc); len(errs) > 0 {
 			framework.Failf("AfterEach: Failed to delete PVC and/or PV. Errors: %v", utilerrors.NewAggregate(errs))
 		}

--- a/test/e2e/storage/testsuites/BUILD
+++ b/test/e2e/storage/testsuites/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/csi-translation-lib:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/metrics:go_default_library",
         "//test/e2e/framework/podlogs:go_default_library",
         "//test/e2e/framework/volume:go_default_library",

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/volume"
 	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
 )
@@ -131,7 +132,7 @@ func (p *provisioningTestSuite) defineTests(driver TestDriver, pattern testpatte
 		}
 		l.pvc = getClaim(claimSize, l.config.Framework.Namespace.Name)
 		l.pvc.Spec.StorageClassName = &l.sc.Name
-		framework.Logf("In creating storage class object and pvc object for driver - sc: %v, pvc: %v", l.sc, l.pvc)
+		e2elog.Logf("In creating storage class object and pvc object for driver - sc: %v, pvc: %v", l.sc, l.pvc)
 		l.testCase = &StorageClassTest{
 			Client:       l.config.Framework.ClientSet,
 			Claim:        l.pvc,
@@ -245,7 +246,7 @@ func (t StorageClassTest) TestDynamicProvisioning() *v1.PersistentVolume {
 		class, err = client.StorageV1().StorageClasses().Get(class.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		defer func() {
-			framework.Logf("deleting storage class %s", class.Name)
+			e2elog.Logf("deleting storage class %s", class.Name)
 			framework.ExpectNoError(client.StorageV1().StorageClasses().Delete(class.Name, nil))
 		}()
 	}
@@ -254,7 +255,7 @@ func (t StorageClassTest) TestDynamicProvisioning() *v1.PersistentVolume {
 	claim, err = client.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(claim)
 	framework.ExpectNoError(err)
 	defer func() {
-		framework.Logf("deleting claim %q/%q", claim.Namespace, claim.Name)
+		e2elog.Logf("deleting claim %q/%q", claim.Namespace, claim.Name)
 		// typically this claim has already been deleted
 		err = client.CoreV1().PersistentVolumeClaims(claim.Namespace).Delete(claim.Name, nil)
 		if err != nil && !apierrs.IsNotFound(err) {
@@ -475,7 +476,7 @@ func (t StorageClassTest) TestBindingWaitForFirstConsumerMultiPVC(claims []*v1.P
 		}
 		if len(errors) > 0 {
 			for claimName, err := range errors {
-				framework.Logf("Failed to delete PVC: %s due to error: %v", claimName, err)
+				e2elog.Logf("Failed to delete PVC: %s due to error: %v", claimName, err)
 			}
 		}
 	}()
@@ -593,9 +594,9 @@ func StopPod(c clientset.Interface, pod *v1.Pod) {
 	}
 	body, err := c.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &v1.PodLogOptions{}).Do().Raw()
 	if err != nil {
-		framework.Logf("Error getting logs for pod %s: %v", pod.Name, err)
+		e2elog.Logf("Error getting logs for pod %s: %v", pod.Name, err)
 	} else {
-		framework.Logf("Pod %s has the following logs: %s", pod.Name, body)
+		e2elog.Logf("Pod %s has the following logs: %s", pod.Name, body)
 	}
 	framework.DeletePodOrFail(c, pod.Namespace, pod.Name)
 }
@@ -663,19 +664,19 @@ func prepareDataSourceForProvisioning(
 	}
 
 	cleanupFunc := func() {
-		framework.Logf("deleting snapshot %q/%q", snapshot.GetNamespace(), snapshot.GetName())
+		e2elog.Logf("deleting snapshot %q/%q", snapshot.GetNamespace(), snapshot.GetName())
 		err = dynamicClient.Resource(snapshotGVR).Namespace(updatedClaim.Namespace).Delete(snapshot.GetName(), nil)
 		if err != nil && !apierrs.IsNotFound(err) {
 			framework.Failf("Error deleting snapshot %q. Error: %v", snapshot.GetName(), err)
 		}
 
-		framework.Logf("deleting initClaim %q/%q", updatedClaim.Namespace, updatedClaim.Name)
+		e2elog.Logf("deleting initClaim %q/%q", updatedClaim.Namespace, updatedClaim.Name)
 		err = client.CoreV1().PersistentVolumeClaims(updatedClaim.Namespace).Delete(updatedClaim.Name, nil)
 		if err != nil && !apierrs.IsNotFound(err) {
 			framework.Failf("Error deleting initClaim %q. Error: %v", updatedClaim.Name, err)
 		}
 
-		framework.Logf("deleting SnapshotClass %s", snapshotClass.GetName())
+		e2elog.Logf("deleting SnapshotClass %s", snapshotClass.GetName())
 		framework.ExpectNoError(dynamicClient.Resource(snapshotClassGVR).Delete(snapshotClass.GetName(), nil))
 	}
 

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -797,7 +798,7 @@ func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
 
 	By("Failing liveness probe")
 	out, err := podContainerExec(pod, 1, fmt.Sprintf("rm %v", probeFilePath))
-	framework.Logf("Pod exec output: %v", out)
+	e2elog.Logf("Pod exec output: %v", out)
 	Expect(err).ToNot(HaveOccurred(), "while failing liveness probe")
 
 	// Check that container has restarted
@@ -810,10 +811,10 @@ func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
 		}
 		for _, status := range pod.Status.ContainerStatuses {
 			if status.Name == pod.Spec.Containers[0].Name {
-				framework.Logf("Container %v, restarts: %v", status.Name, status.RestartCount)
+				e2elog.Logf("Container %v, restarts: %v", status.Name, status.RestartCount)
 				restarts = status.RestartCount
 				if restarts > 0 {
-					framework.Logf("Container has restart count: %v", restarts)
+					e2elog.Logf("Container has restart count: %v", restarts)
 					return true, nil
 				}
 			}
@@ -826,7 +827,7 @@ func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
 	By("Rewriting the file")
 	writeCmd := fmt.Sprintf("echo test-after > %v", probeFilePath)
 	out, err = podContainerExec(pod, 1, writeCmd)
-	framework.Logf("Pod exec output: %v", out)
+	e2elog.Logf("Pod exec output: %v", out)
 	Expect(err).ToNot(HaveOccurred(), "while rewriting the probe file")
 
 	// Wait for container restarts to stabilize
@@ -843,13 +844,13 @@ func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
 				if status.RestartCount == restarts {
 					stableCount++
 					if stableCount > stableThreshold {
-						framework.Logf("Container restart has stabilized")
+						e2elog.Logf("Container restart has stabilized")
 						return true, nil
 					}
 				} else {
 					restarts = status.RestartCount
 					stableCount = 0
-					framework.Logf("Container has restart count: %v", restarts)
+					e2elog.Logf("Container has restart count: %v", restarts)
 				}
 				break
 			}

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -30,10 +30,11 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/volume"
 	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
@@ -277,7 +278,7 @@ func deleteFile(pod *v1.Pod, fpath string) {
 	_, err := utils.PodExec(pod, fmt.Sprintf("rm -f %s", fpath))
 	if err != nil {
 		// keep going, the test dir will be deleted when the volume is unmounted
-		framework.Logf("unable to delete test file %s: %v\nerror ignored, continuing test", fpath, err)
+		e2elog.Logf("unable to delete test file %s: %v\nerror ignored, continuing test", fpath, err)
 	}
 }
 
@@ -309,12 +310,12 @@ func testVolumeIO(f *framework.Framework, cs clientset.Interface, config volume.
 		By(fmt.Sprintf("deleting client pod %q...", clientPod.Name))
 		e := framework.DeletePodWithWait(f, cs, clientPod)
 		if e != nil {
-			framework.Logf("client pod failed to delete: %v", e)
+			e2elog.Logf("client pod failed to delete: %v", e)
 			if err == nil { // delete err is returned if err is not set
 				err = e
 			}
 		} else {
-			framework.Logf("sleeping a bit so kubelet can unmount and detach the volume")
+			e2elog.Logf("sleeping a bit so kubelet can unmount and detach the volume")
 			time.Sleep(volume.PodCleanupTimeout)
 		}
 	}()

--- a/test/e2e/storage/utils/BUILD
+++ b/test/e2e/storage/utils/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/test/e2e/storage/volume_expand.go
+++ b/test/e2e/storage/volume_expand.go
@@ -23,13 +23,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
@@ -221,7 +222,7 @@ func expandPVCSize(origPVC *v1.PersistentVolumeClaim, size resource.Quantity, c 
 		if err == nil {
 			return true, nil
 		}
-		framework.Logf("Error updating pvc %s with %v", pvcName, err)
+		e2elog.Logf("Error updating pvc %s with %v", pvcName, err)
 		return false, nil
 	})
 	return updatedPVC, waitErr

--- a/test/e2e/storage/vsphere/BUILD
+++ b/test/e2e/storage/vsphere/BUILD
@@ -53,6 +53,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/deployment:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/storage/utils:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/test/e2e/storage/vsphere/config.go
+++ b/test/e2e/storage/vsphere/config.go
@@ -23,7 +23,7 @@ import (
 	"os"
 
 	"gopkg.in/gcfg.v1"
-	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
 const (
@@ -130,13 +130,13 @@ func populateInstanceMap(cfg *ConfigFile) (map[string]*VSphere, error) {
 	if cfg.Workspace.VCenterIP == "" || cfg.Workspace.DefaultDatastore == "" || cfg.Workspace.Folder == "" || cfg.Workspace.Datacenter == "" {
 		msg := fmt.Sprintf("All fields in workspace are mandatory."+
 			" vsphere.conf does not have the workspace specified correctly. cfg.Workspace: %+v", cfg.Workspace)
-		framework.Logf(msg)
+		e2elog.Logf(msg)
 		return nil, errors.New(msg)
 	}
 	for vcServer, vcConfig := range cfg.VirtualCenter {
-		framework.Logf("Initializing vc server %s", vcServer)
+		e2elog.Logf("Initializing vc server %s", vcServer)
 		if vcServer == "" {
-			framework.Logf("vsphere.conf does not have the VirtualCenter IP address specified")
+			e2elog.Logf("vsphere.conf does not have the VirtualCenter IP address specified")
 			return nil, errors.New("vsphere.conf does not have the VirtualCenter IP address specified")
 		}
 		vcConfig.Hostname = vcServer
@@ -149,12 +149,12 @@ func populateInstanceMap(cfg *ConfigFile) (map[string]*VSphere, error) {
 		}
 		if vcConfig.Username == "" {
 			msg := fmt.Sprintf("vcConfig.Username is empty for vc %s!", vcServer)
-			framework.Logf(msg)
+			e2elog.Logf(msg)
 			return nil, errors.New(msg)
 		}
 		if vcConfig.Password == "" {
 			msg := fmt.Sprintf("vcConfig.Password is empty for vc %s!", vcServer)
-			framework.Logf(msg)
+			e2elog.Logf(msg)
 			return nil, errors.New(msg)
 		}
 		if vcConfig.Port == "" {
@@ -176,6 +176,6 @@ func populateInstanceMap(cfg *ConfigFile) (map[string]*VSphere, error) {
 		vsphereInstances[vcServer] = &vsphereIns
 	}
 
-	framework.Logf("ConfigFile %v \n vSphere instances %v", cfg, vsphereInstances)
+	e2elog.Logf("ConfigFile %v \n vSphere instances %v", cfg, vsphereInstances)
 	return vsphereInstances, nil
 }

--- a/test/e2e/storage/vsphere/nodemapper.go
+++ b/test/e2e/storage/vsphere/nodemapper.go
@@ -27,8 +27,8 @@ import (
 	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"k8s.io/api/core/v1"
-	"k8s.io/kubernetes/test/e2e/framework"
+	v1 "k8s.io/api/core/v1"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	neturl "net/url"
 )
@@ -77,7 +77,7 @@ func (nm *NodeMapper) GenerateNodeMap(vSphereInstances map[string]*VSphere, node
 		if vs.Config.Datacenters == "" {
 			datacenters, err = vs.GetAllDatacenter(ctx)
 			if err != nil {
-				framework.Logf("NodeMapper error: %v", err)
+				e2elog.Logf("NodeMapper error: %v", err)
 				continue
 			}
 		} else {
@@ -89,7 +89,7 @@ func (nm *NodeMapper) GenerateNodeMap(vSphereInstances map[string]*VSphere, node
 				}
 				datacenter, err := vs.GetDatacenter(ctx, dc)
 				if err != nil {
-					framework.Logf("NodeMapper error dc: %s \n err: %v", dc, err)
+					e2elog.Logf("NodeMapper error dc: %s \n err: %v", dc, err)
 
 					continue
 				}
@@ -98,7 +98,7 @@ func (nm *NodeMapper) GenerateNodeMap(vSphereInstances map[string]*VSphere, node
 		}
 
 		for _, dc := range datacenters {
-			framework.Logf("Search candidates vc=%s and datacenter=%s", vs.Config.Hostname, dc.Name())
+			e2elog.Logf("Search candidates vc=%s and datacenter=%s", vs.Config.Hostname, dc.Name())
 			queueChannel = append(queueChannel, &VmSearch{vs: vs, datacenter: dc})
 		}
 	}
@@ -107,20 +107,20 @@ func (nm *NodeMapper) GenerateNodeMap(vSphereInstances map[string]*VSphere, node
 		n := node
 		go func() {
 			nodeUUID := getUUIDFromProviderID(n.Spec.ProviderID)
-			framework.Logf("Searching for node with UUID: %s", nodeUUID)
+			e2elog.Logf("Searching for node with UUID: %s", nodeUUID)
 			for _, res := range queueChannel {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				vm, err := res.vs.GetVMByUUID(ctx, nodeUUID, res.datacenter)
 				if err != nil {
-					framework.Logf("Error %v while looking for node=%s in vc=%s and datacenter=%s",
+					e2elog.Logf("Error %v while looking for node=%s in vc=%s and datacenter=%s",
 						err, n.Name, res.vs.Config.Hostname, res.datacenter.Name())
 					continue
 				}
 				if vm != nil {
 					hostSystemRef := res.vs.GetHostFromVMReference(ctx, vm.Reference())
 					zones := retrieveZoneInformationForNode(n.Name, res.vs, hostSystemRef)
-					framework.Logf("Found node %s as vm=%+v placed on host=%+v under zones %s in vc=%s and datacenter=%s",
+					e2elog.Logf("Found node %s as vm=%+v placed on host=%+v under zones %s in vc=%s and datacenter=%s",
 						n.Name, vm, hostSystemRef, zones, res.vs.Config.Hostname, res.datacenter.Name())
 					nodeInfo := &NodeInfo{Name: n.Name, DataCenterRef: res.datacenter.Reference(), VirtualMachineRef: vm.Reference(), HostSystemRef: hostSystemRef, VSphere: res.vs, Zones: zones}
 					nm.SetNodeInfo(n.Name, nodeInfo)
@@ -192,10 +192,10 @@ func retrieveZoneInformationForNode(nodeName string, connection *VSphere, hostSy
 				}
 				switch {
 				case category.Name == "k8s-zone":
-					framework.Logf("Found %s associated with %s for %s", tag.Name, ancestor.Name, nodeName)
+					e2elog.Logf("Found %s associated with %s for %s", tag.Name, ancestor.Name, nodeName)
 					zonesAttachedToObject = append(zonesAttachedToObject, tag.Name)
 				case category.Name == "k8s-region":
-					framework.Logf("Found %s associated with %s for %s", tag.Name, ancestor.Name, nodeName)
+					e2elog.Logf("Found %s associated with %s for %s", tag.Name, ancestor.Name, nodeName)
 				}
 			}
 			// Overwrite zone information if it exists for this object
@@ -250,7 +250,7 @@ func (nm *NodeMapper) GenerateZoneToDatastoreMap() error {
 			vcToZoneDatastoresMap[vc][zone] = commonDatastores
 		}
 	}
-	framework.Logf("Zone to datastores map : %+v", vcToZoneDatastoresMap)
+	e2elog.Logf("Zone to datastores map : %+v", vcToZoneDatastoresMap)
 	return nil
 }
 

--- a/test/e2e/storage/vsphere/persistent_volumes-vsphere.go
+++ b/test/e2e/storage/vsphere/persistent_volumes-vsphere.go
@@ -21,11 +21,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -111,7 +112,7 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere", func() {
 	})
 
 	AfterEach(func() {
-		framework.Logf("AfterEach: Cleaning up test resources")
+		e2elog.Logf("AfterEach: Cleaning up test resources")
 		if c != nil {
 			framework.ExpectNoError(framework.DeletePodWithWait(f, c, clientPod), "AfterEach: failed to delete pod ", clientPod.Name)
 

--- a/test/e2e/storage/vsphere/pv_reclaimpolicy.go
+++ b/test/e2e/storage/vsphere/pv_reclaimpolicy.go
@@ -22,11 +22,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -129,7 +130,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
 
 			By("Verify the volume is accessible and available in the pod")
 			verifyVSphereVolumesAccessible(c, pod, []*v1.PersistentVolume{pv})
-			framework.Logf("Verified that Volume is accessible in the POD after deleting PV claim")
+			e2elog.Logf("Verified that Volume is accessible in the POD after deleting PV claim")
 
 			By("Deleting the Pod")
 			framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod), "Failed to delete pod ", pod.Name)
@@ -175,7 +176,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
 			pvc = nil
 
 			By("Verify PV is retained")
-			framework.Logf("Waiting for PV %v to become Released", pv.Name)
+			e2elog.Logf("Waiting for PV %v to become Released", pv.Name)
 			err = framework.WaitForPersistentVolumePhase(v1.VolumeReleased, c, pv.Name, 3*time.Second, 300*time.Second)
 			framework.ExpectNoError(err)
 			framework.ExpectNoError(framework.DeletePersistentVolume(c, pv.Name), "Failed to delete PV ", pv.Name)

--- a/test/e2e/storage/vsphere/vsphere.go
+++ b/test/e2e/storage/vsphere/vsphere.go
@@ -30,7 +30,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
 const (
@@ -121,7 +121,7 @@ func (vs *VSphere) GetFolderByPath(ctx context.Context, dc object.Reference, fol
 	finder.SetDatacenter(datacenter)
 	vmFolder, err := finder.Folder(ctx, folderPath)
 	if err != nil {
-		framework.Logf("Failed to get the folder reference for %s. err: %+v", folderPath, err)
+		e2elog.Logf("Failed to get the folder reference for %s. err: %+v", folderPath, err)
 		return vmFolderMor, err
 	}
 	return vmFolder.Reference(), nil
@@ -156,15 +156,15 @@ func (vs *VSphere) CreateVolume(volumeOptions *VolumeOptions, dataCenterRef type
 			soapFault := soap.ToSoapFault(err)
 			if _, ok := soapFault.VimFault().(types.FileAlreadyExists); ok {
 				directoryAlreadyPresent = true
-				framework.Logf("Directory with the path %+q is already present", directoryPath)
+				e2elog.Logf("Directory with the path %+q is already present", directoryPath)
 			}
 		}
 		if !directoryAlreadyPresent {
-			framework.Logf("Cannot create dir %#v. err %s", directoryPath, err)
+			e2elog.Logf("Cannot create dir %#v. err %s", directoryPath, err)
 			return "", err
 		}
 	}
-	framework.Logf("Created dir with path as %+q", directoryPath)
+	e2elog.Logf("Created dir with path as %+q", directoryPath)
 	vmdkPath := directoryPath + volumeOptions.Name + ".vmdk"
 
 	// Create a virtual disk manager
@@ -180,12 +180,12 @@ func (vs *VSphere) CreateVolume(volumeOptions *VolumeOptions, dataCenterRef type
 	// Create virtual disk
 	task, err := vdm.CreateVirtualDisk(ctx, vmdkPath, datacenter, vmDiskSpec)
 	if err != nil {
-		framework.Logf("Failed to create virtual disk: %s. err: %+v", vmdkPath, err)
+		e2elog.Logf("Failed to create virtual disk: %s. err: %+v", vmdkPath, err)
 		return "", err
 	}
 	taskInfo, err := task.WaitForResult(ctx, nil)
 	if err != nil {
-		framework.Logf("Failed to complete virtual disk creation: %s. err: %+v", vmdkPath, err)
+		e2elog.Logf("Failed to complete virtual disk creation: %s. err: %+v", vmdkPath, err)
 		return "", err
 	}
 	volumePath := taskInfo.Result.(string)
@@ -209,12 +209,12 @@ func (vs *VSphere) DeleteVolume(volumePath string, dataCenterRef types.ManagedOb
 	// Delete virtual disk
 	task, err := virtualDiskManager.DeleteVirtualDisk(ctx, diskPath, datacenter)
 	if err != nil {
-		framework.Logf("Failed to delete virtual disk. err: %v", err)
+		e2elog.Logf("Failed to delete virtual disk. err: %v", err)
 		return err
 	}
 	err = task.Wait(ctx)
 	if err != nil {
-		framework.Logf("Failed to delete virtual disk. err: %v", err)
+		e2elog.Logf("Failed to delete virtual disk. err: %v", err)
 		return err
 	}
 	return nil
@@ -233,7 +233,7 @@ func (vs *VSphere) IsVMPresent(vmName string, dataCenterRef types.ManagedObjectR
 	vmFolder := object.NewFolder(vs.Client.Client, folderMor)
 	vmFoldersChildren, err := vmFolder.Children(ctx)
 	if err != nil {
-		framework.Logf("Failed to get children from Folder: %s. err: %+v", vmFolder.InventoryPath, err)
+		e2elog.Logf("Failed to get children from Folder: %s. err: %+v", vmFolder.InventoryPath, err)
 		return
 	}
 	for _, vmFoldersChild := range vmFoldersChildren {

--- a/test/e2e/storage/vsphere/vsphere_statefulsets.go
+++ b/test/e2e/storage/vsphere/vsphere_statefulsets.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -63,7 +64,7 @@ var _ = utils.SIGDescribe("vsphere statefulset", func() {
 		Bootstrap(f)
 	})
 	AfterEach(func() {
-		framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+		e2elog.Logf("Deleting all statefulset in namespace: %v", namespace)
 		framework.DeleteAllStatefulSets(client, namespace)
 	})
 
@@ -114,7 +115,7 @@ var _ = utils.SIGDescribe("vsphere statefulset", func() {
 				for _, volumespec := range sspod.Spec.Volumes {
 					if volumespec.PersistentVolumeClaim != nil {
 						vSpherediskPath := getvSphereVolumePathFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
-						framework.Logf("Waiting for Volume: %q to detach from Node: %q", vSpherediskPath, sspod.Spec.NodeName)
+						e2elog.Logf("Waiting for Volume: %q to detach from Node: %q", vSpherediskPath, sspod.Spec.NodeName)
 						framework.ExpectNoError(waitForVSphereDiskToDetach(vSpherediskPath, sspod.Spec.NodeName))
 					}
 				}
@@ -141,7 +142,7 @@ var _ = utils.SIGDescribe("vsphere statefulset", func() {
 			for _, volumespec := range pod.Spec.Volumes {
 				if volumespec.PersistentVolumeClaim != nil {
 					vSpherediskPath := getvSphereVolumePathFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
-					framework.Logf("Verify Volume: %q is attached to the Node: %q", vSpherediskPath, sspod.Spec.NodeName)
+					e2elog.Logf("Verify Volume: %q is attached to the Node: %q", vSpherediskPath, sspod.Spec.NodeName)
 					// Verify scale up has re-attached the same volumes and not introduced new volume
 					Expect(volumesBeforeScaleDown[vSpherediskPath] == "").To(BeFalse())
 					isVolumeAttached, verifyDiskAttachedError := diskIsAttached(vSpherediskPath, sspod.Spec.NodeName)

--- a/test/e2e/storage/vsphere/vsphere_volume_diskformat.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_diskformat.go
@@ -25,11 +25,12 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -101,7 +102,7 @@ var _ = utils.SIGDescribe("Volume Disk Format [Feature:vsphere]", func() {
 
 func invokeTest(f *framework.Framework, client clientset.Interface, namespace string, nodeName string, nodeKeyValueLabel map[string]string, diskFormat string) {
 
-	framework.Logf("Invoking Test for DiskFomat: %s", diskFormat)
+	e2elog.Logf("Invoking Test for DiskFomat: %s", diskFormat)
 	scParameters := make(map[string]string)
 	scParameters["diskformat"] = diskFormat
 

--- a/test/e2e/storage/vsphere/vsphere_volume_fstype.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_fstype.go
@@ -22,10 +22,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -93,7 +94,7 @@ var _ = utils.SIGDescribe("Volume FStype [Feature:vsphere]", func() {
 })
 
 func invokeTestForFstype(f *framework.Framework, client clientset.Interface, namespace string, fstype string, expectedContent string) {
-	framework.Logf("Invoking Test for fstype: %s", fstype)
+	e2elog.Logf("Invoking Test for fstype: %s", fstype)
 	scParameters := make(map[string]string)
 	scParameters["fstype"] = fstype
 

--- a/test/e2e/storage/vsphere/vsphere_volume_node_poweroff.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_node_poweroff.go
@@ -27,12 +27,13 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edeploy "k8s.io/kubernetes/test/e2e/framework/deployment"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -158,19 +159,19 @@ func waitForPodToFailover(client clientset.Interface, deployment *apps.Deploymen
 		}
 
 		if newNode != oldNode {
-			framework.Logf("The pod has been failed over from %q to %q", oldNode, newNode)
+			e2elog.Logf("The pod has been failed over from %q to %q", oldNode, newNode)
 			return true, nil
 		}
 
-		framework.Logf("Waiting for pod to be failed over from %q", oldNode)
+		e2elog.Logf("Waiting for pod to be failed over from %q", oldNode)
 		return false, nil
 	})
 
 	if err != nil {
 		if err == wait.ErrWaitTimeout {
-			framework.Logf("Time out after waiting for %v", timeout)
+			e2elog.Logf("Time out after waiting for %v", timeout)
 		}
-		framework.Logf("Pod did not fail over from %q with error: %v", oldNode, err)
+		e2elog.Logf("Pod did not fail over from %q with error: %v", oldNode, err)
 		return "", err
 	}
 

--- a/test/e2e/storage/vsphere/vsphere_volume_perf.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_perf.go
@@ -22,10 +22,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storageV1 "k8s.io/api/storage/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -103,11 +104,11 @@ var _ = utils.SIGDescribe("vcp-performance [Feature:vsphere]", func() {
 		}
 
 		iterations64 := float64(iterations)
-		framework.Logf("Average latency for below operations")
-		framework.Logf("Creating %d PVCs and waiting for bound phase: %v seconds", volumeCount, sumLatency[CreateOp]/iterations64)
-		framework.Logf("Creating %v Pod: %v seconds", volumeCount/volumesPerPod, sumLatency[AttachOp]/iterations64)
-		framework.Logf("Deleting %v Pod and waiting for disk to be detached: %v seconds", volumeCount/volumesPerPod, sumLatency[DetachOp]/iterations64)
-		framework.Logf("Deleting %v PVCs: %v seconds", volumeCount, sumLatency[DeleteOp]/iterations64)
+		e2elog.Logf("Average latency for below operations")
+		e2elog.Logf("Creating %d PVCs and waiting for bound phase: %v seconds", volumeCount, sumLatency[CreateOp]/iterations64)
+		e2elog.Logf("Creating %v Pod: %v seconds", volumeCount/volumesPerPod, sumLatency[AttachOp]/iterations64)
+		e2elog.Logf("Deleting %v Pod and waiting for disk to be detached: %v seconds", volumeCount/volumesPerPod, sumLatency[DetachOp]/iterations64)
+		e2elog.Logf("Deleting %v PVCs: %v seconds", volumeCount, sumLatency[DeleteOp]/iterations64)
 
 	})
 })

--- a/test/e2e/storage/vsphere/vsphere_volume_vpxd_restart.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_vpxd_restart.go
@@ -24,11 +24,12 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -105,7 +106,7 @@ var _ = utils.SIGDescribe("Verify Volume Attach Through vpxd Restart [Feature:vs
 				pods         []*v1.Pod
 			)
 
-			framework.Logf("Testing for nodes on vCenter host: %s", vcHost)
+			e2elog.Logf("Testing for nodes on vCenter host: %s", vcHost)
 
 			for i, node := range nodes {
 				By(fmt.Sprintf("Creating test vsphere volume %d", i))

--- a/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go
@@ -25,10 +25,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -103,7 +104,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		namespace = f.Namespace.Name
 		policyName = GetAndExpectStringEnvVar(SPBMPolicyName)
 		tagPolicy = GetAndExpectStringEnvVar(SPBMTagPolicy)
-		framework.Logf("framework: %+v", f)
+		e2elog.Logf("framework: %+v", f)
 		scParameters = make(map[string]string)
 		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 		if !(len(nodeList.Items) > 0) {
@@ -119,7 +120,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		By(fmt.Sprintf("Invoking test for VSAN policy hostFailuresToTolerate: %s, cacheReservation: %s", HostFailuresToTolerateCapabilityVal, CacheReservationCapabilityVal))
 		scParameters[Policy_HostFailuresToTolerate] = HostFailuresToTolerateCapabilityVal
 		scParameters[Policy_CacheReservation] = CacheReservationCapabilityVal
-		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
+		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		invokeValidPolicyTest(f, client, namespace, scParameters)
 	})
 
@@ -128,7 +129,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		By(fmt.Sprintf("Invoking test for VSAN policy diskStripes: %s, objectSpaceReservation: %s", DiskStripesCapabilityVal, ObjectSpaceReservationCapabilityVal))
 		scParameters[Policy_DiskStripes] = "1"
 		scParameters[Policy_ObjectSpaceReservation] = "30"
-		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
+		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		invokeValidPolicyTest(f, client, namespace, scParameters)
 	})
 
@@ -138,7 +139,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[Policy_DiskStripes] = DiskStripesCapabilityVal
 		scParameters[Policy_ObjectSpaceReservation] = ObjectSpaceReservationCapabilityVal
 		scParameters[Datastore] = VsanDatastore
-		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
+		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		invokeValidPolicyTest(f, client, namespace, scParameters)
 	})
 
@@ -147,7 +148,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		By(fmt.Sprintf("Invoking test for VSAN policy objectSpaceReservation: %s, iopsLimit: %s", ObjectSpaceReservationCapabilityVal, IopsLimitCapabilityVal))
 		scParameters[Policy_ObjectSpaceReservation] = ObjectSpaceReservationCapabilityVal
 		scParameters[Policy_IopsLimit] = IopsLimitCapabilityVal
-		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
+		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		invokeValidPolicyTest(f, client, namespace, scParameters)
 	})
 
@@ -156,7 +157,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		By(fmt.Sprintf("Invoking test for VSAN policy objectSpaceReserve: %s, stripeWidth: %s", ObjectSpaceReservationCapabilityVal, StripeWidthCapabilityVal))
 		scParameters["objectSpaceReserve"] = ObjectSpaceReservationCapabilityVal
 		scParameters[Policy_DiskStripes] = StripeWidthCapabilityVal
-		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
+		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
 		Expect(err).To(HaveOccurred())
 		errorMsg := "invalid option \\\"objectSpaceReserve\\\" for volume plugin kubernetes.io/vsphere-volume"
@@ -171,7 +172,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		By(fmt.Sprintf("Invoking test for VSAN policy diskStripes: %s, cacheReservation: %s", DiskStripesCapabilityInvalidVal, CacheReservationCapabilityVal))
 		scParameters[Policy_DiskStripes] = DiskStripesCapabilityInvalidVal
 		scParameters[Policy_CacheReservation] = CacheReservationCapabilityVal
-		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
+		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
 		Expect(err).To(HaveOccurred())
 		errorMsg := "Invalid value for " + Policy_DiskStripes + "."
@@ -185,7 +186,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 	It("verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass", func() {
 		By(fmt.Sprintf("Invoking test for VSAN policy hostFailuresToTolerate: %s", HostFailuresToTolerateCapabilityInvalidVal))
 		scParameters[Policy_HostFailuresToTolerate] = HostFailuresToTolerateCapabilityInvalidVal
-		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
+		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
 		Expect(err).To(HaveOccurred())
 		errorMsg := "Invalid value for " + Policy_HostFailuresToTolerate + "."
@@ -201,7 +202,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[Policy_DiskStripes] = DiskStripesCapabilityVal
 		scParameters[Policy_ObjectSpaceReservation] = ObjectSpaceReservationCapabilityVal
 		scParameters[Datastore] = VmfsDatastore
-		framework.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
+		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
 		Expect(err).To(HaveOccurred())
 		errorMsg := "The specified datastore: \\\"" + VmfsDatastore + "\\\" is not a VSAN datastore. " +
@@ -215,7 +216,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		By(fmt.Sprintf("Invoking test for SPBM policy: %s", policyName))
 		scParameters[SpbmStoragePolicy] = policyName
 		scParameters[DiskFormat] = ThinDisk
-		framework.Logf("Invoking test for SPBM storage policy: %+v", scParameters)
+		e2elog.Logf("Invoking test for SPBM storage policy: %+v", scParameters)
 		invokeValidPolicyTest(f, client, namespace, scParameters)
 	})
 
@@ -223,7 +224,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[Policy_DiskStripes] = DiskStripesCapabilityMaxVal
 		scParameters[Policy_ObjectSpaceReservation] = ObjectSpaceReservationCapabilityVal
 		scParameters[Datastore] = VsanDatastore
-		framework.Logf("Invoking test for SPBM storage policy: %+v", scParameters)
+		e2elog.Logf("Invoking test for SPBM storage policy: %+v", scParameters)
 		kubernetesClusterName := GetAndExpectStringEnvVar(KubernetesClusterName)
 		invokeStaleDummyVMTestWithStoragePolicy(client, masterNode, namespace, kubernetesClusterName, scParameters)
 	})
@@ -233,7 +234,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[SpbmStoragePolicy] = tagPolicy
 		scParameters[Datastore] = VsanDatastore
 		scParameters[DiskFormat] = ThinDisk
-		framework.Logf("Invoking test for SPBM storage policy on a non-compatible datastore: %+v", scParameters)
+		e2elog.Logf("Invoking test for SPBM storage policy on a non-compatible datastore: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
 		Expect(err).To(HaveOccurred())
 		errorMsg := "User specified datastore is not compatible with the storagePolicy: \\\"" + tagPolicy + "\\\""
@@ -246,7 +247,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		By(fmt.Sprintf("Invoking test for SPBM policy: %s", BronzeStoragePolicy))
 		scParameters[SpbmStoragePolicy] = BronzeStoragePolicy
 		scParameters[DiskFormat] = ThinDisk
-		framework.Logf("Invoking test for non-existing SPBM storage policy: %+v", scParameters)
+		e2elog.Logf("Invoking test for non-existing SPBM storage policy: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
 		Expect(err).To(HaveOccurred())
 		errorMsg := "no pbm profile found with name: \\\"" + BronzeStoragePolicy + "\\"
@@ -261,7 +262,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		Expect(scParameters[SpbmStoragePolicy]).NotTo(BeEmpty())
 		scParameters[Policy_DiskStripes] = DiskStripesCapabilityVal
 		scParameters[DiskFormat] = ThinDisk
-		framework.Logf("Invoking test for SPBM storage policy and VSAN capabilities together: %+v", scParameters)
+		e2elog.Logf("Invoking test for SPBM storage policy and VSAN capabilities together: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
 		Expect(err).To(HaveOccurred())
 		errorMsg := "Cannot specify storage policy capabilities along with storage policy name. Please specify only one"

--- a/test/e2e/storage/vsphere/vsphere_zone_support.go
+++ b/test/e2e/storage/vsphere/vsphere_zone_support.go
@@ -24,10 +24,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
@@ -352,7 +353,7 @@ func verifyPVCCreationFails(client clientset.Interface, namespace string, scPara
 	Expect(err).To(HaveOccurred())
 
 	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(metav1.ListOptions{})
-	framework.Logf("Failure message : %+q", eventList.Items[0].Message)
+	e2elog.Logf("Failure message : %+q", eventList.Items[0].Message)
 	return fmt.Errorf("Failure message: %+q", eventList.Items[0].Message)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is part of the transition to using framework/log instead
of the Logf inside the framework package. This will help with
import size/cycles when importing the framework or subpackages.

**Which issue(s) this PR fixes**:
Ref #77359

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig testing
/area test
/area test-framework
