### PR TITLE
Move scalability, upgrade, and common packages to framework/log

### DIFF
--- a/test/e2e/common/BUILD
+++ b/test/e2e/common/BUILD
@@ -78,6 +78,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/deployment:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/replicaset:go_default_library",
         "//test/e2e/framework/volume:go_default_library",
         "//test/utils:go_default_library",

--- a/test/e2e/common/autoscaling_utils.go
+++ b/test/e2e/common/autoscaling_utils.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -33,6 +33,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edeploy "k8s.io/kubernetes/test/e2e/framework/deployment"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/replicaset"
 	testutils "k8s.io/kubernetes/test/utils"
 
@@ -170,19 +171,19 @@ func newResourceConsumer(name, nsName string, kind schema.GroupVersionKind, repl
 
 // ConsumeCPU consumes given number of CPU
 func (rc *ResourceConsumer) ConsumeCPU(millicores int) {
-	framework.Logf("RC %s: consume %v millicores in total", rc.name, millicores)
+	e2elog.Logf("RC %s: consume %v millicores in total", rc.name, millicores)
 	rc.cpu <- millicores
 }
 
 // ConsumeMem consumes given number of Mem
 func (rc *ResourceConsumer) ConsumeMem(megabytes int) {
-	framework.Logf("RC %s: consume %v MB in total", rc.name, megabytes)
+	e2elog.Logf("RC %s: consume %v MB in total", rc.name, megabytes)
 	rc.mem <- megabytes
 }
 
 // ConsumeMem consumes given number of custom metric
 func (rc *ResourceConsumer) ConsumeCustomMetric(amount int) {
-	framework.Logf("RC %s: consume custom metric %v in total", rc.name, amount)
+	e2elog.Logf("RC %s: consume custom metric %v in total", rc.name, amount)
 	rc.customMetric <- amount
 }
 
@@ -195,13 +196,13 @@ func (rc *ResourceConsumer) makeConsumeCPURequests() {
 	for {
 		select {
 		case millicores = <-rc.cpu:
-			framework.Logf("RC %s: setting consumption to %v millicores in total", rc.name, millicores)
+			e2elog.Logf("RC %s: setting consumption to %v millicores in total", rc.name, millicores)
 		case <-time.After(sleepTime):
-			framework.Logf("RC %s: sending request to consume %d millicores", rc.name, millicores)
+			e2elog.Logf("RC %s: sending request to consume %d millicores", rc.name, millicores)
 			rc.sendConsumeCPURequest(millicores)
 			sleepTime = rc.sleepTime
 		case <-rc.stopCPU:
-			framework.Logf("RC %s: stopping CPU consumer", rc.name)
+			e2elog.Logf("RC %s: stopping CPU consumer", rc.name)
 			return
 		}
 	}
@@ -216,13 +217,13 @@ func (rc *ResourceConsumer) makeConsumeMemRequests() {
 	for {
 		select {
 		case megabytes = <-rc.mem:
-			framework.Logf("RC %s: setting consumption to %v MB in total", rc.name, megabytes)
+			e2elog.Logf("RC %s: setting consumption to %v MB in total", rc.name, megabytes)
 		case <-time.After(sleepTime):
-			framework.Logf("RC %s: sending request to consume %d MB", rc.name, megabytes)
+			e2elog.Logf("RC %s: sending request to consume %d MB", rc.name, megabytes)
 			rc.sendConsumeMemRequest(megabytes)
 			sleepTime = rc.sleepTime
 		case <-rc.stopMem:
-			framework.Logf("RC %s: stopping mem consumer", rc.name)
+			e2elog.Logf("RC %s: stopping mem consumer", rc.name)
 			return
 		}
 	}
@@ -237,13 +238,13 @@ func (rc *ResourceConsumer) makeConsumeCustomMetric() {
 	for {
 		select {
 		case delta = <-rc.customMetric:
-			framework.Logf("RC %s: setting bump of metric %s to %d in total", rc.name, customMetricName, delta)
+			e2elog.Logf("RC %s: setting bump of metric %s to %d in total", rc.name, customMetricName, delta)
 		case <-time.After(sleepTime):
-			framework.Logf("RC %s: sending request to consume %d of custom metric %s", rc.name, delta, customMetricName)
+			e2elog.Logf("RC %s: sending request to consume %d of custom metric %s", rc.name, delta, customMetricName)
 			rc.sendConsumeCustomMetric(delta)
 			sleepTime = rc.sleepTime
 		case <-rc.stopCustomMetric:
-			framework.Logf("RC %s: stopping metric consumer", rc.name)
+			e2elog.Logf("RC %s: stopping metric consumer", rc.name)
 			return
 		}
 	}
@@ -263,10 +264,10 @@ func (rc *ResourceConsumer) sendConsumeCPURequest(millicores int) {
 			Param("millicores", strconv.Itoa(millicores)).
 			Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
 			Param("requestSizeMillicores", strconv.Itoa(rc.requestSizeInMillicores))
-		framework.Logf("ConsumeCPU URL: %v", *req.URL())
+		e2elog.Logf("ConsumeCPU URL: %v", *req.URL())
 		_, err = req.DoRaw()
 		if err != nil {
-			framework.Logf("ConsumeCPU failure: %v", err)
+			e2elog.Logf("ConsumeCPU failure: %v", err)
 			return false, nil
 		}
 		return true, nil
@@ -290,10 +291,10 @@ func (rc *ResourceConsumer) sendConsumeMemRequest(megabytes int) {
 			Param("megabytes", strconv.Itoa(megabytes)).
 			Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
 			Param("requestSizeMegabytes", strconv.Itoa(rc.requestSizeInMegabytes))
-		framework.Logf("ConsumeMem URL: %v", *req.URL())
+		e2elog.Logf("ConsumeMem URL: %v", *req.URL())
 		_, err = req.DoRaw()
 		if err != nil {
-			framework.Logf("ConsumeMem failure: %v", err)
+			e2elog.Logf("ConsumeMem failure: %v", err)
 			return false, nil
 		}
 		return true, nil
@@ -318,10 +319,10 @@ func (rc *ResourceConsumer) sendConsumeCustomMetric(delta int) {
 			Param("delta", strconv.Itoa(delta)).
 			Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
 			Param("requestSizeMetrics", strconv.Itoa(rc.requestSizeCustomMetric))
-		framework.Logf("ConsumeCustomMetric URL: %v", *req.URL())
+		e2elog.Logf("ConsumeCustomMetric URL: %v", *req.URL())
 		_, err = req.DoRaw()
 		if err != nil {
-			framework.Logf("ConsumeCustomMetric failure: %v", err)
+			e2elog.Logf("ConsumeCustomMetric failure: %v", err)
 			return false, nil
 		}
 		return true, nil
@@ -366,7 +367,7 @@ func (rc *ResourceConsumer) WaitForReplicas(desiredReplicas int, duration time.D
 	interval := 20 * time.Second
 	err := wait.PollImmediate(interval, duration, func() (bool, error) {
 		replicas := rc.GetReplicas()
-		framework.Logf("waiting for %d replicas (current: %d)", desiredReplicas, replicas)
+		e2elog.Logf("waiting for %d replicas (current: %d)", desiredReplicas, replicas)
 		return replicas == desiredReplicas, nil // Expected number of replicas found. Exit.
 	})
 	framework.ExpectNoErrorWithOffset(1, err, "timeout waiting %v for %d replicas", duration, desiredReplicas)
@@ -380,12 +381,12 @@ func (rc *ResourceConsumer) EnsureDesiredReplicasInRange(minDesiredReplicas, max
 	interval := 10 * time.Second
 	err := wait.PollImmediate(interval, duration, func() (bool, error) {
 		replicas := rc.GetReplicas()
-		framework.Logf("expecting there to be in [%d, %d] replicas (are: %d)", minDesiredReplicas, maxDesiredReplicas, replicas)
+		e2elog.Logf("expecting there to be in [%d, %d] replicas (are: %d)", minDesiredReplicas, maxDesiredReplicas, replicas)
 		as, err := rc.GetHpa(hpaName)
 		if err != nil {
-			framework.Logf("Error getting HPA: %s", err)
+			e2elog.Logf("Error getting HPA: %s", err)
 		} else {
-			framework.Logf("HPA status: %+v", as.Status)
+			e2elog.Logf("HPA status: %+v", as.Status)
 		}
 		if replicas < minDesiredReplicas {
 			return false, fmt.Errorf("number of replicas below target")
@@ -397,7 +398,7 @@ func (rc *ResourceConsumer) EnsureDesiredReplicasInRange(minDesiredReplicas, max
 	})
 	// The call above always returns an error, but if it is timeout, it's OK (condition satisfied all the time).
 	if err == wait.ErrWaitTimeout {
-		framework.Logf("Number of replicas was stable over %v", duration)
+		e2elog.Logf("Number of replicas was stable over %v", duration)
 		return
 	}
 	framework.ExpectNoErrorWithOffset(1, err)

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -29,6 +29,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 
 	. "github.com/onsi/ginkgo"
@@ -74,7 +75,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		startedTime, err := getContainerStartedTime(p, probTestContainerName)
 		framework.ExpectNoError(err)
 
-		framework.Logf("Container started at %v, pod became ready at %v", startedTime, readyTime)
+		e2elog.Logf("Container started at %v, pod became ready at %v", startedTime, readyTime)
 		initialDelay := probTestInitialDelaySeconds * time.Second
 		if readyTime.Sub(startedTime) < initialDelay {
 			framework.Failf("Pod became ready before it's %v initial delay", initialDelay)
@@ -484,14 +485,14 @@ func runLivenessTest(f *framework.Framework, pod *v1.Pod, expectNumRestarts int,
 	// 'Terminated' which can cause indefinite blocking.)
 	framework.ExpectNoError(framework.WaitForPodNotPending(f.ClientSet, ns, pod.Name),
 		fmt.Sprintf("starting pod %s in namespace %s", pod.Name, ns))
-	framework.Logf("Started pod %s in namespace %s", pod.Name, ns)
+	e2elog.Logf("Started pod %s in namespace %s", pod.Name, ns)
 
 	// Check the pod's current state and verify that restartCount is present.
 	By("checking the pod's current state and verifying that restartCount is present")
 	pod, err := podClient.Get(pod.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err, fmt.Sprintf("getting pod %s in namespace %s", pod.Name, ns))
 	initialRestartCount := podutil.GetExistingContainerStatus(pod.Status.ContainerStatuses, containerName).RestartCount
-	framework.Logf("Initial restart count of pod %s is %d", pod.Name, initialRestartCount)
+	e2elog.Logf("Initial restart count of pod %s is %d", pod.Name, initialRestartCount)
 
 	// Wait for the restart state to be as desired.
 	deadline := time.Now().Add(timeout)
@@ -502,7 +503,7 @@ func runLivenessTest(f *framework.Framework, pod *v1.Pod, expectNumRestarts int,
 		framework.ExpectNoError(err, fmt.Sprintf("getting pod %s", pod.Name))
 		restartCount := podutil.GetExistingContainerStatus(pod.Status.ContainerStatuses, containerName).RestartCount
 		if restartCount != lastRestartCount {
-			framework.Logf("Restart count of pod %s/%s is now %d (%v elapsed)",
+			e2elog.Logf("Restart count of pod %s/%s is now %d (%v elapsed)",
 				ns, pod.Name, restartCount, time.Since(start))
 			if restartCount < lastRestartCount {
 				framework.Failf("Restart count should increment monotonically: restart cont of pod %s/%s changed from %d to %d",

--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -18,13 +18,15 @@ package common
 
 import (
 	"fmt"
-	"k8s.io/api/core/v1"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -658,7 +660,7 @@ func waitForPodContainerRestart(f *framework.Framework, pod *v1.Pod, volumeMount
 	By("Failing liveness probe")
 	stdout, stderr, err := f.ExecShellInPodWithFullOutput(pod.Name, fmt.Sprintf("rm %v", volumeMount))
 
-	framework.Logf("Pod exec output: %v / %v", stdout, stderr)
+	e2elog.Logf("Pod exec output: %v / %v", stdout, stderr)
 	Expect(err).ToNot(HaveOccurred(), "while failing liveness probe")
 
 	// Check that container has restarted
@@ -671,10 +673,10 @@ func waitForPodContainerRestart(f *framework.Framework, pod *v1.Pod, volumeMount
 		}
 		for _, status := range pod.Status.ContainerStatuses {
 			if status.Name == pod.Spec.Containers[0].Name {
-				framework.Logf("Container %v, restarts: %v", status.Name, status.RestartCount)
+				e2elog.Logf("Container %v, restarts: %v", status.Name, status.RestartCount)
 				restarts = status.RestartCount
 				if restarts > 0 {
-					framework.Logf("Container has restart count: %v", restarts)
+					e2elog.Logf("Container has restart count: %v", restarts)
 					return true, nil
 				}
 			}
@@ -686,7 +688,7 @@ func waitForPodContainerRestart(f *framework.Framework, pod *v1.Pod, volumeMount
 	// Fix liveness probe
 	By("Rewriting the file")
 	stdout, _, err = f.ExecShellInPodWithFullOutput(pod.Name, fmt.Sprintf("echo test-after > %v", volumeMount))
-	framework.Logf("Pod exec output: %v", stdout)
+	e2elog.Logf("Pod exec output: %v", stdout)
 	Expect(err).ToNot(HaveOccurred(), "while rewriting the probe file")
 
 	// Wait for container restarts to stabilize
@@ -703,13 +705,13 @@ func waitForPodContainerRestart(f *framework.Framework, pod *v1.Pod, volumeMount
 				if status.RestartCount == restarts {
 					stableCount++
 					if stableCount > stableThreshold {
-						framework.Logf("Container restart has stabilized")
+						e2elog.Logf("Container restart has stabilized")
 						return true, nil
 					}
 				} else {
 					restarts = status.RestartCount
 					stableCount = 0
-					framework.Logf("Container has restart count: %v", restarts)
+					e2elog.Logf("Container has restart count: %v", restarts)
 				}
 				break
 			}

--- a/test/e2e/common/init_container.go
+++ b/test/e2e/common/init_container.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -31,6 +31,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/client/conditions"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
@@ -87,7 +88,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 				},
 			},
 		}
-		framework.Logf("PodSpec: initContainers in spec.initContainers")
+		e2elog.Logf("PodSpec: initContainers in spec.initContainers")
 		startedPod := podClient.Create(pod)
 		w, err := podClient.Watch(metav1.SingleObject(startedPod.ObjectMeta))
 		Expect(err).NotTo(HaveOccurred(), "error watching a pod")
@@ -158,7 +159,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 				},
 			},
 		}
-		framework.Logf("PodSpec: initContainers in spec.initContainers")
+		e2elog.Logf("PodSpec: initContainers in spec.initContainers")
 		startedPod := podClient.Create(pod)
 		w, err := podClient.Watch(metav1.SingleObject(startedPod.ObjectMeta))
 		Expect(err).NotTo(HaveOccurred(), "error watching a pod")
@@ -230,7 +231,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 				},
 			},
 		}
-		framework.Logf("PodSpec: initContainers in spec.initContainers")
+		e2elog.Logf("PodSpec: initContainers in spec.initContainers")
 		startedPod := podClient.Create(pod)
 		w, err := podClient.Watch(metav1.SingleObject(startedPod.ObjectMeta))
 		Expect(err).NotTo(HaveOccurred(), "error watching a pod")
@@ -280,7 +281,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 					if status.RestartCount < 3 {
 						return false, nil
 					}
-					framework.Logf("init container has failed twice: %#v", t)
+					e2elog.Logf("init container has failed twice: %#v", t)
 					// TODO: more conditions
 					return true, nil
 				default:
@@ -347,7 +348,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 				},
 			},
 		}
-		framework.Logf("PodSpec: initContainers in spec.initContainers")
+		e2elog.Logf("PodSpec: initContainers in spec.initContainers")
 		startedPod := podClient.Create(pod)
 
 		w, err := podClient.Watch(metav1.SingleObject(startedPod.ObjectMeta))

--- a/test/e2e/common/node_lease.go
+++ b/test/e2e/common/node_lease.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 
 	. "github.com/onsi/ginkgo"
@@ -115,23 +116,23 @@ var _ = framework.KubeDescribe("NodeLease", func() {
 				if currentHeartbeatTime == lastHeartbeatTime {
 					if currentObserved.Sub(lastObserved) > 2*leaseDuration {
 						// heartbeat hasn't changed while watching for at least 2*leaseDuration, success!
-						framework.Logf("node status heartbeat is unchanged for %s, was waiting for at least %s, success!", currentObserved.Sub(lastObserved), 2*leaseDuration)
+						e2elog.Logf("node status heartbeat is unchanged for %s, was waiting for at least %s, success!", currentObserved.Sub(lastObserved), 2*leaseDuration)
 						return true, nil
 					}
-					framework.Logf("node status heartbeat is unchanged for %s, waiting for %s", currentObserved.Sub(lastObserved), 2*leaseDuration)
+					e2elog.Logf("node status heartbeat is unchanged for %s, waiting for %s", currentObserved.Sub(lastObserved), 2*leaseDuration)
 					return false, nil
 				}
 
 				if currentHeartbeatTime.Sub(lastHeartbeatTime) >= leaseDuration {
 					// heartbeat time changed, but the diff was greater than leaseDuration, success!
-					framework.Logf("node status heartbeat changed in %s, was waiting for at least %s, success!", currentHeartbeatTime.Sub(lastHeartbeatTime), leaseDuration)
+					e2elog.Logf("node status heartbeat changed in %s, was waiting for at least %s, success!", currentHeartbeatTime.Sub(lastHeartbeatTime), leaseDuration)
 					return true, nil
 				}
 
 				if !apiequality.Semantic.DeepEqual(lastStatus, currentStatus) {
 					// heartbeat time changed, but there were relevant changes in the status, keep waiting
-					framework.Logf("node status heartbeat changed in %s (with other status changes), waiting for %s", currentHeartbeatTime.Sub(lastHeartbeatTime), leaseDuration)
-					framework.Logf("%s", diff.ObjectReflectDiff(lastStatus, currentStatus))
+					e2elog.Logf("node status heartbeat changed in %s (with other status changes), waiting for %s", currentHeartbeatTime.Sub(lastHeartbeatTime), leaseDuration)
+					e2elog.Logf("%s", diff.ObjectReflectDiff(lastStatus, currentStatus))
 					lastHeartbeatTime = currentHeartbeatTime
 					lastObserved = currentObserved
 					lastStatus = currentStatus

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -21,10 +21,11 @@ import (
 	"path"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/kubelet/images"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -153,7 +154,7 @@ while true; do sleep 1; done
 				Expect(GetContainerState(status.State)).To(Equal(ContainerStateTerminated))
 
 				By("the termination message should be set")
-				framework.Logf("Expected: %v to match Container's Termination Message: %v --", expectedMsg, status.State.Terminated.Message)
+				e2elog.Logf("Expected: %v to match Container's Termination Message: %v --", expectedMsg, status.State.Terminated.Message)
 				Expect(status.State.Terminated.Message).Should(expectedMsg)
 
 				By("delete the container")
@@ -344,7 +345,7 @@ while true; do sleep 1; done
 						break
 					}
 					if i < flakeRetry {
-						framework.Logf("No.%d attempt failed: %v, retrying...", i, err)
+						e2elog.Logf("No.%d attempt failed: %v, retrying...", i, err)
 					} else {
 						framework.Failf("All %d attempts failed: %v", flakeRetry, err)
 					}

--- a/test/e2e/common/security_context.go
+++ b/test/e2e/common/security_context.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
@@ -189,7 +190,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 				framework.Failf("GetPodLogs for pod %q failed: %v", podName, err)
 			}
 
-			framework.Logf("Got logs for pod %q: %q", podName, logs)
+			e2elog.Logf("Got logs for pod %q: %q", podName, logs)
 			if !strings.Contains(logs, "Operation not permitted") {
 				framework.Failf("unprivileged container shouldn't be able to create dummy device")
 			}

--- a/test/e2e/scalability/BUILD
+++ b/test/e2e/scalability/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//staging/src/k8s.io/client-go/transport:go_default_library",
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/timer:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",

--- a/test/e2e/upgrades/BUILD
+++ b/test/e2e/upgrades/BUILD
@@ -39,6 +39,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/gpu:go_default_library",
         "//test/e2e/framework/job:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/testfiles:go_default_library",
         "//test/e2e/scheduling:go_default_library",
         "//test/utils/image:go_default_library",

--- a/test/e2e/upgrades/apparmor.go
+++ b/test/e2e/upgrades/apparmor.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -79,7 +80,7 @@ func (t *AppArmorUpgradeTest) Test(f *framework.Framework, done <-chan struct{},
 func (t *AppArmorUpgradeTest) Teardown(f *framework.Framework) {
 	// rely on the namespace deletion to clean up everything
 	ginkgo.By("Logging container failures")
-	framework.LogFailedContainers(f.ClientSet, f.Namespace.Name, framework.Logf)
+	framework.LogFailedContainers(f.ClientSet, f.Namespace.Name, e2elog.Logf)
 }
 
 func (t *AppArmorUpgradeTest) verifyPodStillUp(f *framework.Framework) {

--- a/test/e2e/upgrades/apps/BUILD
+++ b/test/e2e/upgrades/apps/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/deployment:go_default_library",
         "//test/e2e/framework/job:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/replicaset:go_default_library",
         "//test/e2e/upgrades:go_default_library",
         "//test/utils/image:go_default_library",

--- a/test/e2e/upgrades/apps/daemonsets.go
+++ b/test/e2e/upgrades/apps/daemonsets.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 )
 
@@ -132,7 +133,7 @@ func checkRunningOnAllNodes(f *framework.Framework, namespace string, selector m
 	nodeNames := make([]string, 0)
 	for _, node := range nodeList.Items {
 		if len(node.Spec.Taints) != 0 {
-			framework.Logf("Ignore taints %v on Node %v for DaemonSet Pod.", node.Spec.Taints, node.Name)
+			e2elog.Logf("Ignore taints %v on Node %v for DaemonSet Pod.", node.Spec.Taints, node.Name)
 		}
 		// DaemonSet Pods are expected to run on all the nodes in e2e.
 		nodeNames = append(nodeNames, node.Name)
@@ -153,11 +154,11 @@ func checkDaemonPodOnNodes(f *framework.Framework, namespace string, labelSet ma
 	nodesToPodCount := make(map[string]int)
 	for _, pod := range pods {
 		if controller.IsPodActive(&pod) {
-			framework.Logf("Pod name: %v\t Node Name: %v", pod.Name, pod.Spec.NodeName)
+			e2elog.Logf("Pod name: %v\t Node Name: %v", pod.Name, pod.Spec.NodeName)
 			nodesToPodCount[pod.Spec.NodeName]++
 		}
 	}
-	framework.Logf("nodesToPodCount: %v", nodesToPodCount)
+	e2elog.Logf("nodesToPodCount: %v", nodesToPodCount)
 
 	// Ensure that exactly 1 pod is running on all nodes in nodeNames.
 	for _, nodeName := range nodeNames {

--- a/test/e2e/upgrades/cassandra.go
+++ b/test/e2e/upgrades/cassandra.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 )
 
@@ -90,13 +91,13 @@ func (t *CassandraUpgradeTest) Setup(f *framework.Framework) {
 			return false, nil
 		}
 		if _, err := t.listUsers(); err != nil {
-			framework.Logf("Service endpoint is up but isn't responding")
+			e2elog.Logf("Service endpoint is up but isn't responding")
 			return false, nil
 		}
 		return true, nil
 	})
 	framework.ExpectNoError(err)
-	framework.Logf("Service endpoint is up")
+	e2elog.Logf("Service endpoint is up")
 
 	ginkgo.By("Adding 2 dummy users")
 	gomega.Expect(t.addUser("Alice")).NotTo(gomega.HaveOccurred())
@@ -175,7 +176,7 @@ func (t *CassandraUpgradeTest) Test(f *framework.Framework, done <-chan struct{}
 	go wait.Until(func() {
 		writeAttempts++
 		if err := t.addUser(fmt.Sprintf("user-%d", writeAttempts)); err != nil {
-			framework.Logf("Unable to add user: %v", err)
+			e2elog.Logf("Unable to add user: %v", err)
 			mu.Lock()
 			errors[err.Error()]++
 			mu.Unlock()
@@ -187,7 +188,7 @@ func (t *CassandraUpgradeTest) Test(f *framework.Framework, done <-chan struct{}
 	wait.Until(func() {
 		users, err := t.listUsers()
 		if err != nil {
-			framework.Logf("Could not retrieve users: %v", err)
+			e2elog.Logf("Could not retrieve users: %v", err)
 			failures++
 			mu.Lock()
 			errors[err.Error()]++
@@ -197,14 +198,14 @@ func (t *CassandraUpgradeTest) Test(f *framework.Framework, done <-chan struct{}
 		success++
 		lastUserCount = len(users)
 	}, 10*time.Millisecond, done)
-	framework.Logf("got %d users; want >=%d", lastUserCount, t.successfulWrites)
+	e2elog.Logf("got %d users; want >=%d", lastUserCount, t.successfulWrites)
 
 	gomega.Expect(lastUserCount >= t.successfulWrites).To(gomega.BeTrue())
 	ratio := float64(success) / float64(success+failures)
-	framework.Logf("Successful gets %d/%d=%v", success, success+failures, ratio)
+	e2elog.Logf("Successful gets %d/%d=%v", success, success+failures, ratio)
 	ratio = float64(t.successfulWrites) / float64(writeAttempts)
-	framework.Logf("Successful writes %d/%d=%v", t.successfulWrites, writeAttempts, ratio)
-	framework.Logf("Errors: %v", errors)
+	e2elog.Logf("Successful writes %d/%d=%v", t.successfulWrites, writeAttempts, ratio)
+	e2elog.Logf("Errors: %v", errors)
 	// TODO(maisem): tweak this value once we have a few test runs.
 	gomega.Expect(ratio > 0.75).To(gomega.BeTrue())
 }

--- a/test/e2e/upgrades/etcd.go
+++ b/test/e2e/upgrades/etcd.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 )
 
@@ -85,13 +86,13 @@ func (t *EtcdUpgradeTest) Setup(f *framework.Framework) {
 			return false, nil
 		}
 		if _, err := t.listUsers(); err != nil {
-			framework.Logf("Service endpoint is up but isn't responding")
+			e2elog.Logf("Service endpoint is up but isn't responding")
 			return false, nil
 		}
 		return true, nil
 	})
 	framework.ExpectNoError(err)
-	framework.Logf("Service endpoint is up")
+	e2elog.Logf("Service endpoint is up")
 
 	ginkgo.By("Adding 2 dummy users")
 	gomega.Expect(t.addUser("Alice")).NotTo(gomega.HaveOccurred())
@@ -163,7 +164,7 @@ func (t *EtcdUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upg
 	go wait.Until(func() {
 		writeAttempts++
 		if err := t.addUser(fmt.Sprintf("user-%d", writeAttempts)); err != nil {
-			framework.Logf("Unable to add user: %v", err)
+			e2elog.Logf("Unable to add user: %v", err)
 			mu.Lock()
 			errors[err.Error()]++
 			mu.Unlock()
@@ -175,7 +176,7 @@ func (t *EtcdUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upg
 	wait.Until(func() {
 		users, err := t.listUsers()
 		if err != nil {
-			framework.Logf("Could not retrieve users: %v", err)
+			e2elog.Logf("Could not retrieve users: %v", err)
 			failures++
 			mu.Lock()
 			errors[err.Error()]++
@@ -185,14 +186,14 @@ func (t *EtcdUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upg
 		success++
 		lastUserCount = len(users)
 	}, 10*time.Millisecond, done)
-	framework.Logf("got %d users; want >=%d", lastUserCount, t.successfulWrites)
+	e2elog.Logf("got %d users; want >=%d", lastUserCount, t.successfulWrites)
 
 	gomega.Expect(lastUserCount >= t.successfulWrites).To(gomega.BeTrue())
 	ratio := float64(success) / float64(success+failures)
-	framework.Logf("Successful gets %d/%d=%v", success, success+failures, ratio)
+	e2elog.Logf("Successful gets %d/%d=%v", success, success+failures, ratio)
 	ratio = float64(t.successfulWrites) / float64(writeAttempts)
-	framework.Logf("Successful writes %d/%d=%v", t.successfulWrites, writeAttempts, ratio)
-	framework.Logf("Errors: %v", errors)
+	e2elog.Logf("Successful writes %d/%d=%v", t.successfulWrites, writeAttempts, ratio)
+	e2elog.Logf("Errors: %v", errors)
 	// TODO(maisem): tweak this value once we have a few test runs.
 	gomega.Expect(ratio > 0.75).To(gomega.BeTrue())
 }

--- a/test/e2e/upgrades/kube_proxy_migration.go
+++ b/test/e2e/upgrades/kube_proxy_migration.go
@@ -21,12 +21,13 @@ import (
 	"time"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -104,12 +105,12 @@ func (t *KubeProxyDowngradeTest) Teardown(f *framework.Framework) {
 }
 
 func waitForKubeProxyStaticPodsRunning(c clientset.Interface) error {
-	framework.Logf("Waiting up to %v for kube-proxy static pods running", defaultTestTimeout)
+	e2elog.Logf("Waiting up to %v for kube-proxy static pods running", defaultTestTimeout)
 
 	condition := func() (bool, error) {
 		pods, err := getKubeProxyStaticPods(c)
 		if err != nil {
-			framework.Logf("Failed to get kube-proxy static pods: %v", err)
+			e2elog.Logf("Failed to get kube-proxy static pods: %v", err)
 			return false, nil
 		}
 
@@ -121,7 +122,7 @@ func waitForKubeProxyStaticPodsRunning(c clientset.Interface) error {
 			}
 		}
 		if numberkubeProxyPods != numberSchedulableNodes {
-			framework.Logf("Expect %v kube-proxy static pods running, got %v running, %v in total", numberSchedulableNodes, numberkubeProxyPods, len(pods.Items))
+			e2elog.Logf("Expect %v kube-proxy static pods running, got %v running, %v in total", numberSchedulableNodes, numberkubeProxyPods, len(pods.Items))
 			return false, nil
 		}
 		return true, nil
@@ -134,17 +135,17 @@ func waitForKubeProxyStaticPodsRunning(c clientset.Interface) error {
 }
 
 func waitForKubeProxyStaticPodsDisappear(c clientset.Interface) error {
-	framework.Logf("Waiting up to %v for kube-proxy static pods disappear", defaultTestTimeout)
+	e2elog.Logf("Waiting up to %v for kube-proxy static pods disappear", defaultTestTimeout)
 
 	condition := func() (bool, error) {
 		pods, err := getKubeProxyStaticPods(c)
 		if err != nil {
-			framework.Logf("Failed to get kube-proxy static pods: %v", err)
+			e2elog.Logf("Failed to get kube-proxy static pods: %v", err)
 			return false, nil
 		}
 
 		if len(pods.Items) != 0 {
-			framework.Logf("Expect kube-proxy static pods to disappear, got %v pods", len(pods.Items))
+			e2elog.Logf("Expect kube-proxy static pods to disappear, got %v pods", len(pods.Items))
 			return false, nil
 		}
 		return true, nil
@@ -157,24 +158,24 @@ func waitForKubeProxyStaticPodsDisappear(c clientset.Interface) error {
 }
 
 func waitForKubeProxyDaemonSetRunning(c clientset.Interface) error {
-	framework.Logf("Waiting up to %v for kube-proxy DaemonSet running", defaultTestTimeout)
+	e2elog.Logf("Waiting up to %v for kube-proxy DaemonSet running", defaultTestTimeout)
 
 	condition := func() (bool, error) {
 		daemonSets, err := getKubeProxyDaemonSet(c)
 		if err != nil {
-			framework.Logf("Failed to get kube-proxy DaemonSet: %v", err)
+			e2elog.Logf("Failed to get kube-proxy DaemonSet: %v", err)
 			return false, nil
 		}
 
 		if len(daemonSets.Items) != 1 {
-			framework.Logf("Expect only one kube-proxy DaemonSet, got %v", len(daemonSets.Items))
+			e2elog.Logf("Expect only one kube-proxy DaemonSet, got %v", len(daemonSets.Items))
 			return false, nil
 		}
 
 		numberSchedulableNodes := len(framework.GetReadySchedulableNodesOrDie(c).Items)
 		numberkubeProxyPods := int(daemonSets.Items[0].Status.NumberAvailable)
 		if numberkubeProxyPods != numberSchedulableNodes {
-			framework.Logf("Expect %v kube-proxy DaemonSet pods running, got %v", numberSchedulableNodes, numberkubeProxyPods)
+			e2elog.Logf("Expect %v kube-proxy DaemonSet pods running, got %v", numberSchedulableNodes, numberkubeProxyPods)
 			return false, nil
 		}
 		return true, nil
@@ -187,17 +188,17 @@ func waitForKubeProxyDaemonSetRunning(c clientset.Interface) error {
 }
 
 func waitForKubeProxyDaemonSetDisappear(c clientset.Interface) error {
-	framework.Logf("Waiting up to %v for kube-proxy DaemonSet disappear", defaultTestTimeout)
+	e2elog.Logf("Waiting up to %v for kube-proxy DaemonSet disappear", defaultTestTimeout)
 
 	condition := func() (bool, error) {
 		daemonSets, err := getKubeProxyDaemonSet(c)
 		if err != nil {
-			framework.Logf("Failed to get kube-proxy DaemonSet: %v", err)
+			e2elog.Logf("Failed to get kube-proxy DaemonSet: %v", err)
 			return false, nil
 		}
 
 		if len(daemonSets.Items) != 0 {
-			framework.Logf("Expect kube-proxy DaemonSet to disappear, got %v DaemonSet", len(daemonSets.Items))
+			e2elog.Logf("Expect kube-proxy DaemonSet to disappear, got %v DaemonSet", len(daemonSets.Items))
 			return false, nil
 		}
 		return true, nil

--- a/test/e2e/upgrades/mysql.go
+++ b/test/e2e/upgrades/mysql.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 )
 
@@ -100,13 +101,13 @@ func (t *MySQLUpgradeTest) Setup(f *framework.Framework) {
 			return false, nil
 		}
 		if _, err := t.countNames(); err != nil {
-			framework.Logf("Service endpoint is up but isn't responding")
+			e2elog.Logf("Service endpoint is up but isn't responding")
 			return false, nil
 		}
 		return true, nil
 	})
 	framework.ExpectNoError(err)
-	framework.Logf("Service endpoint is up")
+	e2elog.Logf("Service endpoint is up")
 
 	ginkgo.By("Adding 2 names to the database")
 	gomega.Expect(t.addName(strconv.Itoa(t.nextWrite))).NotTo(gomega.HaveOccurred())
@@ -126,7 +127,7 @@ func (t *MySQLUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, up
 	go wait.Until(func() {
 		_, err := t.countNames()
 		if err != nil {
-			framework.Logf("Error while trying to read data: %v", err)
+			e2elog.Logf("Error while trying to read data: %v", err)
 			readFailure++
 		} else {
 			readSuccess++
@@ -136,7 +137,7 @@ func (t *MySQLUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, up
 	wait.Until(func() {
 		err := t.addName(strconv.Itoa(t.nextWrite))
 		if err != nil {
-			framework.Logf("Error while trying to write data: %v", err)
+			e2elog.Logf("Error while trying to write data: %v", err)
 			writeFailure++
 		} else {
 			writeSuccess++
@@ -144,10 +145,10 @@ func (t *MySQLUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, up
 	}, framework.Poll, done)
 
 	t.successfulWrites = writeSuccess
-	framework.Logf("Successful reads: %d", readSuccess)
-	framework.Logf("Successful writes: %d", writeSuccess)
-	framework.Logf("Failed reads: %d", readFailure)
-	framework.Logf("Failed writes: %d", writeFailure)
+	e2elog.Logf("Successful reads: %d", readSuccess)
+	e2elog.Logf("Successful writes: %d", writeSuccess)
+	e2elog.Logf("Failed reads: %d", readFailure)
+	e2elog.Logf("Failed writes: %d", writeFailure)
 
 	// TODO: Not sure what the ratio defining a successful test run should be. At time of writing the
 	// test, failures only seem to happen when a race condition occurs (read/write starts, doesn't

--- a/test/e2e/upgrades/nvidia-gpu.go
+++ b/test/e2e/upgrades/nvidia-gpu.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/gpu"
 	jobutil "k8s.io/kubernetes/test/e2e/framework/job"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/scheduling"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -89,7 +90,7 @@ func (t *NvidiaGPUUpgradeTest) startJob(f *framework.Framework) {
 	ns := f.Namespace.Name
 	_, err := jobutil.CreateJob(f.ClientSet, ns, testJob)
 	framework.ExpectNoError(err)
-	framework.Logf("Created job %v", testJob)
+	e2elog.Logf("Created job %v", testJob)
 	ginkgo.By("Waiting for gpu job pod start")
 	err = jobutil.WaitForAllJobPodsRunning(f.ClientSet, ns, testJob.Name, 1)
 	framework.ExpectNoError(err)
@@ -105,11 +106,11 @@ func (t *NvidiaGPUUpgradeTest) verifyJobPodSuccess(f *framework.Framework) {
 	pods, err := jobutil.GetJobPods(f.ClientSet, f.Namespace.Name, "cuda-add")
 	framework.ExpectNoError(err)
 	createdPod := pods.Items[0].Name
-	framework.Logf("Created pod %v", createdPod)
+	e2elog.Logf("Created pod %v", createdPod)
 	f.PodClient().WaitForSuccess(createdPod, 5*time.Minute)
 	logs, err := framework.GetPodLogs(f.ClientSet, ns, createdPod, "vector-addition")
 	framework.ExpectNoError(err, "Should be able to get pod logs")
-	framework.Logf("Got pod logs: %v", logs)
+	e2elog.Logf("Got pod logs: %v", logs)
 	regex := regexp.MustCompile("PASSED")
 	gomega.Expect(regex.MatchString(logs)).To(gomega.BeTrue())
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is part of the transition to using framework/log instead
of the Logf inside the framework package. This will help with
import size/cycles when importing the framework or subpackages.

**Which issue(s) this PR fixes**:
Ref #77359

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig testing
/area test
/area test-framework
