### PR TITLE
Use container type to guide search among container status

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -195,6 +195,7 @@ const (
 	container     = iota
 	initContainer = iota
 )
+
 func (m *manager) SetContainerReadiness(podUID types.UID, containerID kubecontainer.ContainerID, ready bool) {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -191,8 +191,8 @@ func (m *manager) SetPodStatus(pod *v1.Pod, status v1.PodStatus) {
 }
 
 const (
-	unknown = iota
-	container = iota
+	unknown       = iota
+	container     = iota
 	initContainer = iota
 )
 func (m *manager) SetContainerReadiness(podUID types.UID, containerID kubecontainer.ContainerID, ready bool) {
@@ -254,7 +254,7 @@ func (m *manager) SetContainerReadiness(podUID types.UID, containerID kubecontai
 
 func findContainerStatus(status *v1.PodStatus, containerID string, containerType int) (containerStatus *v1.ContainerStatus, init bool, ok bool, theType int) {
 	// Find the container to update.
-	if (containerType != initContainer) {
+	if containerType != initContainer {
 		for i, c := range status.ContainerStatuses {
 			if c.ContainerID == containerID {
 				return &status.ContainerStatuses[i], false, true, container
@@ -262,7 +262,7 @@ func findContainerStatus(status *v1.PodStatus, containerID string, containerType
 		}
 	}
 
-	if (containerType != container) {
+	if containerType != container {
 		for i, c := range status.InitContainerStatuses {
 			if c.ContainerID == containerID {
 				return &status.InitContainerStatuses[i], true, true, initContainer


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In manager#SetContainerReadiness, we call findContainerStatus twice where containers / init containers are iterated.

This PR introduces an enum representing whether the container Id is for container or init container so that in the second call we search the correct type of containers.

```release-note
NONE
```
