### PR TITLE
Expect the correct object type to be removed

### DIFF
--- a/test/cmd/generic-resources.sh
+++ b/test/cmd/generic-resources.sh
@@ -378,7 +378,7 @@ run_recursive_resources_tests() {
   # Command
   output_message=$(! kubectl delete -f hack/testdata/recursive/rc --recursive --grace-period=0 --force 2>&1 "${kube_flags[@]}")
   # Post-condition: busybox0 & busybox1 replication controllers are deleted, and since busybox2 is malformed, it should error
-  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" ''
   kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
 
   ### Rollout on multiple deployments recursively


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Makes the integration test check the correct object is removed.

Currently it is deleting replication controllers, then immediately checking if the child pods are removed.

Garbage collection deletes those pods asynchronously, which is leading to flakes. It should be checking replicationcontrollers, per the comment.

```release-note
NONE
```

/sig cli
/priority important-soon