### PR TITLE
Allow to define kubeconfig file for OpenStack cloud provider

### DIFF
--- a/pkg/volume/cinder/cinder_test.go
+++ b/pkg/volume/cinder/cinder_test.go
@@ -317,6 +317,7 @@ func getOpenstackConfig() openstack.Config {
 			CAFile          string `gcfg:"ca-file"`
 			SecretName      string `gcfg:"secret-name"`
 			SecretNamespace string `gcfg:"secret-namespace"`
+			KubeconfigPath  string `gcfg:"kubeconfig-path"`
 		}{
 			Username:   "user",
 			Password:   "pass",


### PR DESCRIPTION
Now, to build a kubernetes client, provider uses only in-cluster config,
but if kubelet is not running as a pod, then it doesn't work.

This commit adds an ability to specify a path to the kubeconfig file if
necessary. If no value was provided, then the provider falls back to
in-cluster config.

/kind feature

```release-note
Allow to define kubeconfig file for OpenStack cloud provider.
```