### PR TITLE
Implement UpdateContainerResources in FakeRuntimeService

### DIFF
--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
@@ -407,6 +407,10 @@ func (r *FakeRuntimeService) ContainerStatus(containerID string) (*runtimeapi.Co
 }
 
 func (r *FakeRuntimeService) UpdateContainerResources(string, *runtimeapi.LinuxContainerResources) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "UpdateContainerResources")
 	return nil
 }
 


### PR DESCRIPTION
/kind bug

Adds UpdateContainerResources to the stored calls.

```release-note
NONE
```
