### PR TITLE
ipvs: setup correct ipset unit test fixtures

### DIFF
--- a/pkg/proxy/ipvs/ipset_test.go
+++ b/pkg/proxy/ipvs/ipset_test.go
@@ -207,7 +207,7 @@ func TestSyncIPSetEntries(t *testing.T) {
 		if err := set.handle.CreateSet(&set.IPSet, true); err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
-		for _, entry := range testCases[i].expectedEntries {
+		for _, entry := range testCases[i].currentEntries {
 			set.handle.AddEntry(entry, testCases[i].set, true)
 		}
 


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The test case struct in TestSyncIPSetEntries has a `currentEntries` field but it's not used anywhere in the test. Before `syncIPSetEntries`, we do add entries to `expectedEntries`, this seems like a bug. Luckily after switching to `currentEntries` all the ipset tests still pass, but it seems like the unit test is not testing some potential edge cases without this change. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig network
/assign @m1093782566 