### PR TITLE
Obtain unsorted slice in cpuAccumulator#freeCores

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -69,7 +69,7 @@ func (a *cpuAccumulator) freeSockets() []int {
 // - socket ID, ascending
 // - core ID, ascending
 func (a *cpuAccumulator) freeCores() []int {
-	socketIDs := a.details.Sockets().ToSlice()
+	socketIDs := a.details.Sockets().ToSliceNoSort()
 	sort.Slice(socketIDs,
 		func(i, j int) bool {
 			iCores := a.details.CoresInSocket(socketIDs[i]).Filter(a.isCoreFree)

--- a/pkg/kubelet/cm/cpuset/cpuset.go
+++ b/pkg/kubelet/cm/cpuset/cpuset.go
@@ -172,6 +172,16 @@ func (s CPUSet) ToSlice() []int {
 	return result
 }
 
+// ToSliceNoSort returns a slice of integers that contains all elements from
+// this set.
+func (s CPUSet) ToSliceNoSort() []int {
+	result := []int{}
+	for cpu := range s.elems {
+		result = append(result, cpu)
+	}
+	return result
+}
+
 // String returns a new string representation of the elements in this CPU set
 // in canonical linux CPU list format.
 //


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In cpuAccumulator#freeCores, we call a.details.Sockets().ToSlice() to get sorted slice.

The slice would be sorted again next.

This PR adds ToSliceNoSort which returns unsorted slice. The slice would be sorted subsequently.

```release-note
NONE
```
