### PR TITLE
Union all CPUSets in one round

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -154,9 +154,11 @@ func (p *staticPolicy) validateState(s state.State) error {
 	// topology that was received during CPU manager startup matches with
 	// the set of CPUs stored in the state.
 	totalKnownCPUs := tmpDefaultCPUset.Clone()
+	tmpCPUSets := []cpuset.CPUSet{}
 	for _, cset := range tmpAssignments {
-		totalKnownCPUs = totalKnownCPUs.Union(cset)
+		tmpCPUSets = append(tmpCPUSets, cset)
 	}
+	totalKnownCPUs = totalKnownCPUs.UnionAll(tmpCPUSets)
 	if !totalKnownCPUs.Equals(p.topology.CPUDetails.CPUs()) {
 		return fmt.Errorf("current set of available CPUs \"%s\" doesn't match with CPUs in state \"%s\"",
 			p.topology.CPUDetails.CPUs().String(), totalKnownCPUs.String())

--- a/pkg/kubelet/cm/cpuset/cpuset.go
+++ b/pkg/kubelet/cm/cpuset/cpuset.go
@@ -147,6 +147,22 @@ func (s CPUSet) Union(s2 CPUSet) CPUSet {
 	return b.Result()
 }
 
+// UnionAll returns a new CPU set that contains all of the elements from this
+// set and all of the elements from the supplied sets, without mutating
+// either source set.
+func (s CPUSet) UnionAll(s2 []CPUSet) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		b.Add(cpu)
+	}
+	for _, cs := range s2 {
+		for cpu := range cs.elems {
+			b.Add(cpu)
+		}
+	}
+	return b.Result()
+}
+
 // Intersection returns a new CPU set that contains all of the elements
 // that are present in both this set and the supplied set, without mutating
 // either source set.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In staticPolicy#validateState, we call totalKnownCPUs.Union repeatedly. In each Union call, the elements of former CPUSet would be duplicated.

This PR introduces UnionAll which performs the union in one round, reducing duplication.

```release-note
NONE
```
