### PR TITLE
Implement rollout restart for statefulset and daemonset

### DIFF
--- a/pkg/kubectl/cmd/rollout/rollout_restart.go
+++ b/pkg/kubectl/cmd/rollout/rollout_restart.go
@@ -54,11 +54,14 @@ var (
 	restartLong = templates.LongDesc(`
 		Restart a resource.
 
-	        A deployment with the "RolloutStrategy" will be rolling restarted.`)
+	        Resource will be rollout restarted.`)
 
 	restartExample = templates.Examples(`
 		# Restart a deployment
-		kubectl rollout restart deployment/nginx`)
+		kubectl rollout restart deployment/nginx
+
+		# Restart a daemonset
+		kubectl rollout restart daemonset/abc`)
 )
 
 // NewRolloutRestartOptions returns an initialized RestartOptions instance
@@ -73,7 +76,7 @@ func NewRolloutRestartOptions(streams genericclioptions.IOStreams) *RestartOptio
 func NewCmdRolloutRestart(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewRolloutRestartOptions(streams)
 
-	validArgs := []string{"deployment"}
+	validArgs := []string{"deployment", "daemonset", "statefulset"}
 
 	cmd := &cobra.Command{
 		Use:                   "restart RESOURCE",

--- a/pkg/kubectl/polymorphichelpers/objectrestarter.go
+++ b/pkg/kubectl/polymorphichelpers/objectrestarter.go
@@ -71,6 +71,48 @@ func defaultObjectRestarter(obj runtime.Object) ([]byte, error) {
 		obj.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 		return runtime.Encode(scheme.Codecs.LegacyCodec(appsv1beta1.SchemeGroupVersion), obj)
 
+	case *extensionsv1beta1.DaemonSet:
+		if obj.Spec.Template.ObjectMeta.Annotations == nil {
+			obj.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		obj.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		return runtime.Encode(scheme.Codecs.LegacyCodec(extensionsv1beta1.SchemeGroupVersion), obj)
+
+	case *appsv1.DaemonSet:
+		if obj.Spec.Template.ObjectMeta.Annotations == nil {
+			obj.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		obj.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		return runtime.Encode(scheme.Codecs.LegacyCodec(appsv1.SchemeGroupVersion), obj)
+
+	case *appsv1beta2.DaemonSet:
+		if obj.Spec.Template.ObjectMeta.Annotations == nil {
+			obj.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		obj.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		return runtime.Encode(scheme.Codecs.LegacyCodec(appsv1beta2.SchemeGroupVersion), obj)
+
+	case *appsv1.StatefulSet:
+		if obj.Spec.Template.ObjectMeta.Annotations == nil {
+			obj.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		obj.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		return runtime.Encode(scheme.Codecs.LegacyCodec(appsv1.SchemeGroupVersion), obj)
+
+	case *appsv1beta1.StatefulSet:
+		if obj.Spec.Template.ObjectMeta.Annotations == nil {
+			obj.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		obj.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		return runtime.Encode(scheme.Codecs.LegacyCodec(appsv1beta1.SchemeGroupVersion), obj)
+
+	case *appsv1beta2.StatefulSet:
+		if obj.Spec.Template.ObjectMeta.Annotations == nil {
+			obj.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		obj.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		return runtime.Encode(scheme.Codecs.LegacyCodec(appsv1beta2.SchemeGroupVersion), obj)
+
 	default:
 		return nil, fmt.Errorf("restarting is not supported")
 	}

--- a/test/cmd/apps.sh
+++ b/test/cmd/apps.sh
@@ -43,6 +43,10 @@ run_daemonset_tests() {
   kubectl set resources daemonsets/bind "${kube_flags[@]}" --limits=cpu=200m,memory=512Mi
   kube::test::get_object_assert 'daemonsets bind' "{{${template_generation_field}}}" '4'
 
+  # Rollout restart should change generation
+  kubectl rollout restart daemonset/bind "${kube_flags[@]}"
+  kube::test::get_object_assert 'daemonsets bind' "{{${template_generation_field}}}" '5'
+
   # Clean up
   kubectl delete -f hack/testdata/rollingupdate-daemonset.yaml "${kube_flags[@]}"
 
@@ -487,6 +491,10 @@ run_stateful_set_tests() {
   # doesn't start  the scheduler, so pet-0 will block all others.
   # TODO: test robust scaling in an e2e.
   wait-for-pods-with-label "app=nginx-statefulset" "nginx-0"
+
+  # Rollout restart should change generation
+  kubectl rollout restart statefulset nginx "${kube_flags[@]}"
+  kube::test::get_object_assert 'statefulset nginx' "{{$statefulset_observed_generation}}" '3'
 
   ### Clean up
   kubectl delete -f hack/testdata/rollingupdate-statefulset.yaml "${kube_flags[@]}"


### PR DESCRIPTION
Specifically, DaemonSet and Statefulset

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #13488

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`kubectl rollout restart` now works for daemonsets and statefulsets.
```
