### PR TITLE
Add OWNERS file for gce/manifests

### DIFF
--- a/cluster/gce/manifests/OWNERS
+++ b/cluster/gce/manifests/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- tallclair
+- MrHohn
+approvers:
+- tallclair
+- MrHohn
+labels:
+- sig/gcp


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adding an OWNERS file (that includes myself) to gce/manifest so I can help reviewing/approving changes like https://github.com/kubernetes/kubernetes/pull/77282.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
