### PR TITLE
refactor: use e2elog.Logf instead of framework.Logf

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -66,6 +66,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/auth:go_default_library",
         "//test/e2e/framework/ginkgowrapper:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/metrics:go_default_library",
         "//test/e2e/framework/providers/aws:go_default_library",
         "//test/e2e/framework/providers/azure:go_default_library",

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -31,6 +31,7 @@ import (
 	commonutils "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/auth"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 
 	. "github.com/onsi/ginkgo"
@@ -82,14 +83,14 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 					pod, err := c.CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
 					framework.ExpectNoError(err, fmt.Sprintf("getting pod %s", podName))
 					stat := podutil.GetExistingContainerStatus(pod.Status.ContainerStatuses, podName)
-					framework.Logf("Pod: %s, restart count:%d", stat.Name, stat.RestartCount)
+					e2elog.Logf("Pod: %s, restart count:%d", stat.Name, stat.RestartCount)
 					if stat.RestartCount > 0 {
-						framework.Logf("Saw %v restart, succeeded...", podName)
+						e2elog.Logf("Saw %v restart, succeeded...", podName)
 						wg.Done()
 						return
 					}
 				}
-				framework.Logf("Failed waiting for %v restart! ", podName)
+				e2elog.Logf("Failed waiting for %v restart! ", podName)
 				passed = false
 				wg.Done()
 			}

--- a/test/e2e/gke_local_ssd.go
+++ b/test/e2e/gke_local_ssd.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -37,14 +38,14 @@ var _ = framework.KubeDescribe("GKE local SSD [Feature:GKELocalSSD]", func() {
 	})
 
 	It("should write and read from node local SSD [Feature:GKELocalSSD]", func() {
-		framework.Logf("Start local SSD test")
+		e2elog.Logf("Start local SSD test")
 		createNodePoolWithLocalSsds("np-ssd")
 		doTestWriteAndReadToLocalSsd(f)
 	})
 })
 
 func createNodePoolWithLocalSsds(nodePoolName string) {
-	framework.Logf("Create node pool: %s with local SSDs in cluster: %s ",
+	e2elog.Logf("Create node pool: %s with local SSDs in cluster: %s ",
 		nodePoolName, framework.TestContext.CloudConfig.Cluster)
 	out, err := exec.Command("gcloud", "alpha", "container", "node-pools", "create",
 		nodePoolName,
@@ -53,7 +54,7 @@ func createNodePoolWithLocalSsds(nodePoolName string) {
 	if err != nil {
 		framework.Failf("Failed to create node pool %s: Err: %v\n%v", nodePoolName, err, string(out))
 	}
-	framework.Logf("Successfully created node pool %s:\n%v", nodePoolName, string(out))
+	e2elog.Logf("Successfully created node pool %s:\n%v", nodePoolName, string(out))
 }
 
 func doTestWriteAndReadToLocalSsd(f *framework.Framework) {

--- a/test/e2e/gke_node_pools.go
+++ b/test/e2e/gke_node_pools.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -34,13 +35,13 @@ var _ = framework.KubeDescribe("GKE node pools [Feature:GKENodePool]", func() {
 	})
 
 	It("should create a cluster with multiple node pools [Feature:GKENodePool]", func() {
-		framework.Logf("Start create node pool test")
+		e2elog.Logf("Start create node pool test")
 		testCreateDeleteNodePool(f, "test-pool")
 	})
 })
 
 func testCreateDeleteNodePool(f *framework.Framework, poolName string) {
-	framework.Logf("Create node pool: %q in cluster: %q", poolName, framework.TestContext.CloudConfig.Cluster)
+	e2elog.Logf("Create node pool: %q in cluster: %q", poolName, framework.TestContext.CloudConfig.Cluster)
 
 	clusterStr := fmt.Sprintf("--cluster=%s", framework.TestContext.CloudConfig.Cluster)
 
@@ -48,50 +49,50 @@ func testCreateDeleteNodePool(f *framework.Framework, poolName string) {
 		poolName,
 		clusterStr,
 		"--num-nodes=2").CombinedOutput()
-	framework.Logf("\n%s", string(out))
+	e2elog.Logf("\n%s", string(out))
 	if err != nil {
 		framework.Failf("Failed to create node pool %q. Err: %v\n%v", poolName, err, string(out))
 	}
-	framework.Logf("Successfully created node pool %q.", poolName)
+	e2elog.Logf("Successfully created node pool %q.", poolName)
 
 	out, err = exec.Command("gcloud", "container", "node-pools", "list",
 		clusterStr).CombinedOutput()
 	if err != nil {
 		framework.Failf("Failed to list node pools from cluster %q. Err: %v\n%v", framework.TestContext.CloudConfig.Cluster, err, string(out))
 	}
-	framework.Logf("Node pools:\n%s", string(out))
+	e2elog.Logf("Node pools:\n%s", string(out))
 
-	framework.Logf("Checking that 2 nodes have the correct node pool label.")
+	e2elog.Logf("Checking that 2 nodes have the correct node pool label.")
 	nodeCount := nodesWithPoolLabel(f, poolName)
 	if nodeCount != 2 {
 		framework.Failf("Wanted 2 nodes with node pool label, got: %v", nodeCount)
 	}
-	framework.Logf("Success, found 2 nodes with correct node pool labels.")
+	e2elog.Logf("Success, found 2 nodes with correct node pool labels.")
 
-	framework.Logf("Deleting node pool: %q in cluster: %q", poolName, framework.TestContext.CloudConfig.Cluster)
+	e2elog.Logf("Deleting node pool: %q in cluster: %q", poolName, framework.TestContext.CloudConfig.Cluster)
 	out, err = exec.Command("gcloud", "container", "node-pools", "delete",
 		poolName,
 		clusterStr,
 		"-q").CombinedOutput()
-	framework.Logf("\n%s", string(out))
+	e2elog.Logf("\n%s", string(out))
 	if err != nil {
 		framework.Failf("Failed to delete node pool %q. Err: %v\n%v", poolName, err, string(out))
 	}
-	framework.Logf("Successfully deleted node pool %q.", poolName)
+	e2elog.Logf("Successfully deleted node pool %q.", poolName)
 
 	out, err = exec.Command("gcloud", "container", "node-pools", "list",
 		clusterStr).CombinedOutput()
 	if err != nil {
 		framework.Failf("\nFailed to list node pools from cluster %q. Err: %v\n%v", framework.TestContext.CloudConfig.Cluster, err, string(out))
 	}
-	framework.Logf("\nNode pools:\n%s", string(out))
+	e2elog.Logf("\nNode pools:\n%s", string(out))
 
-	framework.Logf("Checking that no nodes have the deleted node pool's label.")
+	e2elog.Logf("Checking that no nodes have the deleted node pool's label.")
 	nodeCount = nodesWithPoolLabel(f, poolName)
 	if nodeCount != 0 {
 		framework.Failf("Wanted 0 nodes with node pool label, got: %v", nodeCount)
 	}
-	framework.Logf("Success, found no nodes with the deleted node pool's label.")
+	e2elog.Logf("Success, found no nodes with the deleted node pool's label.")
 }
 
 // nodesWithPoolLabel returns the number of nodes that have the "gke-nodepool"

--- a/test/e2e/scheduling/BUILD
+++ b/test/e2e/scheduling/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/gpu:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/providers/gce:go_default_library",
         "//test/e2e/framework/replicaset:go_default_library",
         "//test/utils:go_default_library",

--- a/test/e2e/scheduling/equivalence_cache_predicates.go
+++ b/test/e2e/scheduling/equivalence_cache_predicates.go
@@ -27,6 +27,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -72,7 +73,7 @@ var _ = framework.KubeDescribe("EquivalenceCache [Serial]", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		for _, node := range nodeList.Items {
-			framework.Logf("\nLogging pods the kubelet thinks is on node %v before test", node.Name)
+			e2elog.Logf("\nLogging pods the kubelet thinks is on node %v before test", node.Name)
 			framework.PrintAllKubeletPods(cs, node.Name)
 		}
 

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -100,7 +101,7 @@ var _ = SIGDescribe("LimitRange", func() {
 			err = equalResourceRequirement(expected, pod.Spec.Containers[i].Resources)
 			if err != nil {
 				// Print the pod to help in debugging.
-				framework.Logf("Pod %+v does not have the expected requirements", pod)
+				e2elog.Logf("Pod %+v does not have the expected requirements", pod)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		}
@@ -121,7 +122,7 @@ var _ = SIGDescribe("LimitRange", func() {
 			err = equalResourceRequirement(expected, pod.Spec.Containers[i].Resources)
 			if err != nil {
 				// Print the pod to help in debugging.
-				framework.Logf("Pod %+v does not have the expected requirements", pod)
+				e2elog.Logf("Pod %+v does not have the expected requirements", pod)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		}
@@ -170,18 +171,18 @@ var _ = SIGDescribe("LimitRange", func() {
 			limitRanges, err := f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).List(options)
 
 			if err != nil {
-				framework.Logf("Unable to retrieve LimitRanges: %v", err)
+				e2elog.Logf("Unable to retrieve LimitRanges: %v", err)
 				return false, nil
 			}
 
 			if len(limitRanges.Items) == 0 {
-				framework.Logf("limitRange is already deleted")
+				e2elog.Logf("limitRange is already deleted")
 				return true, nil
 			}
 
 			if len(limitRanges.Items) > 0 {
 				if limitRanges.Items[0].ObjectMeta.DeletionTimestamp == nil {
-					framework.Logf("deletion has not yet been observed")
+					e2elog.Logf("deletion has not yet been observed")
 					return false, nil
 				}
 				return true, nil
@@ -200,12 +201,12 @@ var _ = SIGDescribe("LimitRange", func() {
 })
 
 func equalResourceRequirement(expected v1.ResourceRequirements, actual v1.ResourceRequirements) error {
-	framework.Logf("Verifying requests: expected %v with actual %v", expected.Requests, actual.Requests)
+	e2elog.Logf("Verifying requests: expected %v with actual %v", expected.Requests, actual.Requests)
 	err := equalResourceList(expected.Requests, actual.Requests)
 	if err != nil {
 		return err
 	}
-	framework.Logf("Verifying limits: expected %v with actual %v", expected.Limits, actual.Limits)
+	e2elog.Logf("Verifying limits: expected %v with actual %v", expected.Limits, actual.Limits)
 	err = equalResourceList(expected.Limits, actual.Limits)
 	return err
 }

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -30,6 +30,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -88,7 +89,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		framework.ExpectNoError(err)
 
 		for _, node := range nodeList.Items {
-			framework.Logf("\nLogging pods the kubelet thinks is on node %v before test", node.Name)
+			e2elog.Logf("\nLogging pods the kubelet thinks is on node %v before test", node.Name)
 			framework.PrintAllKubeletPods(cs, node.Name)
 		}
 
@@ -103,7 +104,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		totalPodCapacity = 0
 
 		for _, node := range nodeList.Items {
-			framework.Logf("Node: %v", node)
+			e2elog.Logf("Node: %v", node)
 			podCapacity, found := node.Status.Capacity[v1.ResourcePods]
 			Expect(found).To(Equal(true))
 			totalPodCapacity += podCapacity.Value()
@@ -123,7 +124,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 				*initPausePod(f, pausePodConfig{
 					Name:   "",
 					Labels: map[string]string{"name": ""},
-				}), true, framework.Logf))
+				}), true, e2elog.Logf))
 		}
 		podName := "additional-pod"
 		WaitForSchedulerAfterAction(f, createPausePodAction(f, pausePodConfig{
@@ -158,7 +159,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		for _, pod := range pods.Items {
 			_, found := nodeToAllocatableMap[pod.Spec.NodeName]
 			if found && pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
-				framework.Logf("Pod %v requesting local ephemeral resource =%vm on Node %v", pod.Name, getRequestedStorageEphemeralStorage(pod), pod.Spec.NodeName)
+				e2elog.Logf("Pod %v requesting local ephemeral resource =%vm on Node %v", pod.Name, getRequestedStorageEphemeralStorage(pod), pod.Spec.NodeName)
 				nodeToAllocatableMap[pod.Spec.NodeName] -= getRequestedStorageEphemeralStorage(pod)
 			}
 		}
@@ -167,9 +168,9 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 
 		milliEphemeralStoragePerPod := nodeMaxAllocatable / maxNumberOfPods
 
-		framework.Logf("Using pod capacity: %vm", milliEphemeralStoragePerPod)
+		e2elog.Logf("Using pod capacity: %vm", milliEphemeralStoragePerPod)
 		for name, leftAllocatable := range nodeToAllocatableMap {
-			framework.Logf("Node: %v has local ephemeral resource allocatable: %vm", name, leftAllocatable)
+			e2elog.Logf("Node: %v has local ephemeral resource allocatable: %vm", name, leftAllocatable)
 			podsNeededForSaturation += (int)(leftAllocatable / milliEphemeralStoragePerPod)
 		}
 
@@ -192,7 +193,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 							v1.ResourceEphemeralStorage: *resource.NewMilliQuantity(milliEphemeralStoragePerPod, "DecimalSI"),
 						},
 					},
-				}), true, framework.Logf))
+				}), true, e2elog.Logf))
 		}
 		podName := "additional-pod"
 		conf := pausePodConfig{
@@ -262,7 +263,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		for _, pod := range pods.Items {
 			_, found := nodeToAllocatableMap[pod.Spec.NodeName]
 			if found && pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
-				framework.Logf("Pod %v requesting resource cpu=%vm on Node %v", pod.Name, getRequestedCPU(pod), pod.Spec.NodeName)
+				e2elog.Logf("Pod %v requesting resource cpu=%vm on Node %v", pod.Name, getRequestedCPU(pod), pod.Spec.NodeName)
 				nodeToAllocatableMap[pod.Spec.NodeName] -= getRequestedCPU(pod)
 			}
 		}

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -34,6 +34,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/replicaset"
 
 	. "github.com/onsi/ginkgo"
@@ -115,7 +116,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 					Requests: podRes,
 				},
 			})
-			framework.Logf("Created pod: %v", pods[i].Name)
+			e2elog.Logf("Created pod: %v", pods[i].Name)
 		}
 		By("Wait for pods to be scheduled.")
 		for _, pod := range pods {
@@ -175,7 +176,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 					Requests: podRes,
 				},
 			})
-			framework.Logf("Created pod: %v", pods[i].Name)
+			e2elog.Logf("Created pod: %v", pods[i].Name)
 		}
 		By("Wait for pods to be scheduled.")
 		for _, pod := range pods {
@@ -285,7 +286,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 					},
 				},
 			})
-			framework.Logf("Created pod: %v", pods[i].Name)
+			e2elog.Logf("Created pod: %v", pods[i].Name)
 		}
 		defer func() { // Remove added labels
 			for i := 0; i < numPods; i++ {
@@ -368,7 +369,7 @@ var _ = SIGDescribe("PodPriorityResolution [Serial]", func() {
 				framework.ExpectNoError(err)
 			}()
 			Expect(pod.Spec.Priority).NotTo(BeNil())
-			framework.Logf("Created pod: %v", pod.Name)
+			e2elog.Logf("Created pod: %v", pod.Name)
 		}
 	})
 })
@@ -391,11 +392,11 @@ var _ = SIGDescribe("PreemptionExecutionPath", func() {
 			// list existing priorities
 			priorityList, err := cs.SchedulingV1().PriorityClasses().List(metav1.ListOptions{})
 			if err != nil {
-				framework.Logf("Unable to list priorities: %v", err)
+				e2elog.Logf("Unable to list priorities: %v", err)
 			} else {
-				framework.Logf("List existing priorities:")
+				e2elog.Logf("List existing priorities:")
 				for _, p := range priorityList.Items {
-					framework.Logf("%v/%v created at %v", p.Name, p.Value, p.CreationTimestamp)
+					e2elog.Logf("%v/%v created at %v", p.Name, p.Value, p.CreationTimestamp)
 				}
 			}
 		}
@@ -420,7 +421,7 @@ var _ = SIGDescribe("PreemptionExecutionPath", func() {
 		// find an available node
 		By("Finding an available node")
 		nodeName := GetNodeThatCanRunPod(f)
-		framework.Logf("found a healthy node: %s", nodeName)
+		e2elog.Logf("found a healthy node: %s", nodeName)
 
 		// get the node API object
 		var err error
@@ -449,8 +450,8 @@ var _ = SIGDescribe("PreemptionExecutionPath", func() {
 			priorityPairs = append(priorityPairs, priorityPair{name: priorityName, value: priorityVal})
 			_, err := cs.SchedulingV1().PriorityClasses().Create(&schedulerapi.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: priorityName}, Value: priorityVal})
 			if err != nil {
-				framework.Logf("Failed to create priority '%v/%v': %v", priorityName, priorityVal, err)
-				framework.Logf("Reason: %v. Msg: %v", errors.ReasonForError(err), err)
+				e2elog.Logf("Failed to create priority '%v/%v': %v", priorityName, priorityVal, err)
+				e2elog.Logf("Reason: %v. Msg: %v", errors.ReasonForError(err), err)
 			}
 			Expect(err == nil || errors.IsAlreadyExists(err)).To(Equal(true))
 		}
@@ -549,16 +550,16 @@ var _ = SIGDescribe("PreemptionExecutionPath", func() {
 			runPauseRS(f, rsConfs[i])
 		}
 
-		framework.Logf("pods created so far: %v", podNamesSeen)
-		framework.Logf("length of pods created so far: %v", len(podNamesSeen))
+		e2elog.Logf("pods created so far: %v", podNamesSeen)
+		e2elog.Logf("length of pods created so far: %v", len(podNamesSeen))
 
 		// create ReplicaSet4
 		// if runPauseRS failed, it means ReplicaSet4 cannot be scheduled even after 1 minute
 		// which is unacceptable
 		runPauseRS(f, rsConfs[rsNum-1])
 
-		framework.Logf("pods created so far: %v", podNamesSeen)
-		framework.Logf("length of pods created so far: %v", len(podNamesSeen))
+		e2elog.Logf("pods created so far: %v", podNamesSeen)
+		e2elog.Logf("length of pods created so far: %v", len(podNamesSeen))
 
 		// count pods number of ReplicaSet{1,2,3}, if it's more than expected replicas
 		// then it denotes its pods have been over-preempted

--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -35,6 +35,7 @@ import (
 	priorityutil "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util"
 	"k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -154,7 +155,7 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 		defer func() {
 			// Resize the replication controller to zero to get rid of pods.
 			if err := framework.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, rc.Name); err != nil {
-				framework.Logf("Failed to cleanup replication controller %v: %v.", rc.Name, err)
+				e2elog.Logf("Failed to cleanup replication controller %v: %v.", rc.Name, err)
 			}
 		}()
 
@@ -301,7 +302,7 @@ func createBalancedPodForNodes(f *framework.Framework, cs clientset.Interface, n
 					Requests: needCreateResource,
 				},
 				NodeName: node.Name,
-			}), true, framework.Logf)
+			}), true, e2elog.Logf)
 
 		if err != nil {
 			return err
@@ -317,7 +318,7 @@ func createBalancedPodForNodes(f *framework.Framework, cs clientset.Interface, n
 }
 
 func computeCpuMemFraction(cs clientset.Interface, node v1.Node, resource *v1.ResourceRequirements) (float64, float64) {
-	framework.Logf("ComputeCpuMemFraction for node: %v", node.Name)
+	e2elog.Logf("ComputeCpuMemFraction for node: %v", node.Name)
 	totalRequestedCpuResource := resource.Requests.Cpu().MilliValue()
 	totalRequestedMemResource := resource.Requests.Memory().Value()
 	allpods, err := cs.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{})
@@ -326,7 +327,7 @@ func computeCpuMemFraction(cs clientset.Interface, node v1.Node, resource *v1.Re
 	}
 	for _, pod := range allpods.Items {
 		if pod.Spec.NodeName == node.Name {
-			framework.Logf("Pod for on the node: %v, Cpu: %v, Mem: %v", pod.Name, getNonZeroRequests(&pod).MilliCPU, getNonZeroRequests(&pod).Memory)
+			e2elog.Logf("Pod for on the node: %v, Cpu: %v, Mem: %v", pod.Name, getNonZeroRequests(&pod).MilliCPU, getNonZeroRequests(&pod).Memory)
 			// Ignore best effort pods while computing fractions as they won't be taken in account by scheduler.
 			if v1qos.GetPodQOS(&pod) == v1.PodQOSBestEffort {
 				continue
@@ -352,8 +353,8 @@ func computeCpuMemFraction(cs clientset.Interface, node v1.Node, resource *v1.Re
 		memFraction = floatOne
 	}
 
-	framework.Logf("Node: %v, totalRequestedCpuResource: %v, cpuAllocatableMil: %v, cpuFraction: %v", node.Name, totalRequestedCpuResource, cpuAllocatableMil, cpuFraction)
-	framework.Logf("Node: %v, totalRequestedMemResource: %v, memAllocatableVal: %v, memFraction: %v", node.Name, totalRequestedMemResource, memAllocatableVal, memFraction)
+	e2elog.Logf("Node: %v, totalRequestedCpuResource: %v, cpuAllocatableMil: %v, cpuFraction: %v", node.Name, totalRequestedCpuResource, cpuAllocatableMil, cpuFraction)
+	e2elog.Logf("Node: %v, totalRequestedMemResource: %v, memAllocatableVal: %v, memFraction: %v", node.Name, totalRequestedMemResource, memAllocatableVal, memFraction)
 
 	return cpuFraction, memFraction
 }

--- a/test/e2e/scheduling/taints.go
+++ b/test/e2e/scheduling/taints.go
@@ -19,20 +19,19 @@ package scheduling
 import (
 	"time"
 
+	. "github.com/onsi/ginkgo"
+	_ "github.com/stretchr/testify/assert"
+
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-
-	"k8s.io/client-go/tools/cache"
-
-	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
-
-	. "github.com/onsi/ginkgo"
-	_ "github.com/stretchr/testify/assert"
 )
 
 func getTestTaint() v1.Taint {
@@ -137,7 +136,7 @@ func createTestController(cs clientset.Interface, observedDeletions chan string,
 			},
 		},
 	)
-	framework.Logf("Starting informer...")
+	e2elog.Logf("Starting informer...")
 	go controller.Run(stopCh)
 }
 
@@ -179,7 +178,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		By("Starting pod...")
 		nodeName, err := testutils.RunPodAndGetNodeName(cs, pod, 2*time.Minute)
 		framework.ExpectNoError(err)
-		framework.Logf("Pod is running on %v. Tainting Node", nodeName)
+		e2elog.Logf("Pod is running on %v. Tainting Node", nodeName)
 
 		By("Trying to apply a taint on the Node")
 		testTaint := getTestTaint()
@@ -194,7 +193,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		case <-timeoutChannel:
 			framework.Failf("Failed to evict Pod")
 		case <-observedDeletions:
-			framework.Logf("Noticed Pod eviction. Test successful")
+			e2elog.Logf("Noticed Pod eviction. Test successful")
 		}
 	})
 
@@ -211,7 +210,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		By("Starting pod...")
 		nodeName, err := testutils.RunPodAndGetNodeName(cs, pod, 2*time.Minute)
 		framework.ExpectNoError(err)
-		framework.Logf("Pod is running on %v. Tainting Node", nodeName)
+		e2elog.Logf("Pod is running on %v. Tainting Node", nodeName)
 
 		By("Trying to apply a taint on the Node")
 		testTaint := getTestTaint()
@@ -224,7 +223,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		timeoutChannel := time.NewTimer(time.Duration(KubeletPodDeletionDelaySeconds+AdditionalWaitPerDeleteSeconds) * time.Second).C
 		select {
 		case <-timeoutChannel:
-			framework.Logf("Pod wasn't evicted. Test successful")
+			e2elog.Logf("Pod wasn't evicted. Test successful")
 		case <-observedDeletions:
 			framework.Failf("Pod was evicted despite toleration")
 		}
@@ -244,7 +243,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		By("Starting pod...")
 		nodeName, err := testutils.RunPodAndGetNodeName(cs, pod, 2*time.Minute)
 		framework.ExpectNoError(err)
-		framework.Logf("Pod is running on %v. Tainting Node", nodeName)
+		e2elog.Logf("Pod is running on %v. Tainting Node", nodeName)
 
 		By("Trying to apply a taint on the Node")
 		testTaint := getTestTaint()
@@ -257,7 +256,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		timeoutChannel := time.NewTimer(time.Duration(KubeletPodDeletionDelaySeconds+AdditionalWaitPerDeleteSeconds) * time.Second).C
 		select {
 		case <-timeoutChannel:
-			framework.Logf("Pod wasn't evicted")
+			e2elog.Logf("Pod wasn't evicted")
 		case <-observedDeletions:
 			framework.Failf("Pod was evicted despite toleration")
 			return
@@ -268,7 +267,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		case <-timeoutChannel:
 			framework.Failf("Pod wasn't evicted")
 		case <-observedDeletions:
-			framework.Logf("Pod was evicted after toleration time run out. Test successful")
+			e2elog.Logf("Pod was evicted after toleration time run out. Test successful")
 			return
 		}
 	})
@@ -288,7 +287,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		By("Starting pod...")
 		nodeName, err := testutils.RunPodAndGetNodeName(cs, pod, 2*time.Minute)
 		framework.ExpectNoError(err)
-		framework.Logf("Pod is running on %v. Tainting Node", nodeName)
+		e2elog.Logf("Pod is running on %v. Tainting Node", nodeName)
 
 		By("Trying to apply a taint on the Node")
 		testTaint := getTestTaint()
@@ -306,19 +305,19 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		timeoutChannel := time.NewTimer(AdditionalWaitPerDeleteSeconds).C
 		select {
 		case <-timeoutChannel:
-			framework.Logf("Pod wasn't evicted. Proceeding")
+			e2elog.Logf("Pod wasn't evicted. Proceeding")
 		case <-observedDeletions:
 			framework.Failf("Pod was evicted despite toleration")
 			return
 		}
-		framework.Logf("Removing taint from Node")
+		e2elog.Logf("Removing taint from Node")
 		framework.RemoveTaintOffNode(cs, nodeName, testTaint)
 		taintRemoved = true
 		By("Waiting some time to make sure that toleration time passed.")
 		timeoutChannel = time.NewTimer(time.Duration(KubeletPodDeletionDelaySeconds+3*AdditionalWaitPerDeleteSeconds) * time.Second).C
 		select {
 		case <-timeoutChannel:
-			framework.Logf("Pod wasn't evicted. Test successful")
+			e2elog.Logf("Pod wasn't evicted. Test successful")
 		case <-observedDeletions:
 			framework.Failf("Pod was evicted despite toleration")
 		}
@@ -355,10 +354,10 @@ var _ = SIGDescribe("NoExecuteTaintManager Multiple Pods [Serial]", func() {
 		By("Starting pods...")
 		nodeName1, err := testutils.RunPodAndGetNodeName(cs, pod1, 2*time.Minute)
 		framework.ExpectNoError(err)
-		framework.Logf("Pod1 is running on %v. Tainting Node", nodeName1)
+		e2elog.Logf("Pod1 is running on %v. Tainting Node", nodeName1)
 		nodeName2, err := testutils.RunPodAndGetNodeName(cs, pod2, 2*time.Minute)
 		framework.ExpectNoError(err)
-		framework.Logf("Pod2 is running on %v. Tainting Node", nodeName2)
+		e2elog.Logf("Pod2 is running on %v. Tainting Node", nodeName2)
 
 		By("Trying to apply a taint on the Nodes")
 		testTaint := getTestTaint()
@@ -387,7 +386,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Multiple Pods [Serial]", func() {
 			case podName := <-observedDeletions:
 				evicted++
 				if podName == podGroup+"1" {
-					framework.Logf("Noticed Pod %q gets evicted.", podName)
+					e2elog.Logf("Noticed Pod %q gets evicted.", podName)
 				} else if podName == podGroup+"2" {
 					framework.Failf("Unexepected Pod %q gets evicted.", podName)
 					return
@@ -417,12 +416,12 @@ var _ = SIGDescribe("NoExecuteTaintManager Multiple Pods [Serial]", func() {
 			framework.Failf("error getting kubernetes.io/hostname label on node %s", nodeName)
 		}
 		framework.ExpectNoError(err)
-		framework.Logf("Pod1 is running on %v. Tainting Node", nodeName)
+		e2elog.Logf("Pod1 is running on %v. Tainting Node", nodeName)
 		// ensure pod2 lands on the same node as pod1
 		pod2.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeHostNameLabel}
 		_, err = testutils.RunPodAndGetNodeName(cs, pod2, 2*time.Minute)
 		framework.ExpectNoError(err)
-		framework.Logf("Pod2 is running on %v. Tainting Node", nodeName)
+		e2elog.Logf("Pod2 is running on %v. Tainting Node", nodeName)
 
 		By("Trying to apply a taint on the Node")
 		testTaint := getTestTaint()
@@ -440,7 +439,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Multiple Pods [Serial]", func() {
 				framework.Failf("Failed to evict all Pods. %d pod(s) is not evicted.", 2-evicted)
 				return
 			case podName := <-observedDeletions:
-				framework.Logf("Noticed Pod %q gets evicted.", podName)
+				e2elog.Logf("Noticed Pod %q gets evicted.", podName)
 				evicted++
 			}
 		}

--- a/test/e2e/scheduling/ubernetes_lite.go
+++ b/test/e2e/scheduling/ubernetes_lite.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -100,7 +101,7 @@ func SpreadServiceOrFail(f *framework.Framework, replicaCount int, image string)
 	// Based on the callers, replicas is always positive number: zoneCount >= 0 implies (2*zoneCount)+1 > 0.
 	// Thus, no need to test for it. Once the precondition changes to zero number of replicas,
 	// test for replicaCount > 0. Otherwise, StartPods panics.
-	framework.ExpectNoError(testutils.StartPods(f.ClientSet, replicaCount, f.Namespace.Name, serviceName, *podSpec, false, framework.Logf))
+	framework.ExpectNoError(testutils.StartPods(f.ClientSet, replicaCount, f.Namespace.Name, serviceName, *podSpec, false, e2elog.Logf))
 
 	// Wait for all of them to be scheduled
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"service": serviceName}))
@@ -207,7 +208,7 @@ func SpreadRCOrFail(f *framework.Framework, replicaCount int32, image string) {
 	defer func() {
 		// Resize the replication controller to zero to get rid of pods.
 		if err := framework.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, controller.Name); err != nil {
-			framework.Logf("Failed to cleanup replication controller %v: %v.", controller.Name, err)
+			e2elog.Logf("Failed to cleanup replication controller %v: %v.", controller.Name, err)
 		}
 	}()
 	// List the pods, making sure we observe all the replicas.

--- a/test/e2e/scheduling/ubernetes_lite_volumes.go
+++ b/test/e2e/scheduling/ubernetes_lite_volumes.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/providers/gce"
 )
 
@@ -65,7 +66,7 @@ func OnlyAllowNodeZones(f *framework.Framework, zoneCount int, image string) {
 	// Get all the zones that the nodes are in
 	expectedZones, err := gceCloud.GetAllZonesFromCloudProvider()
 	Expect(err).NotTo(HaveOccurred())
-	framework.Logf("Expected zones: %v", expectedZones)
+	e2elog.Logf("Expected zones: %v", expectedZones)
 
 	// Get all the zones in this current region
 	region := gceCloud.Region()
@@ -120,7 +121,7 @@ func OnlyAllowNodeZones(f *framework.Framework, zoneCount int, image string) {
 
 	defer func() {
 		// Teardown of the compute instance
-		framework.Logf("Deleting compute resource: %v", name)
+		e2elog.Logf("Deleting compute resource: %v", name)
 		err := gceCloud.DeleteInstance(project, zone, name)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -140,7 +141,7 @@ func OnlyAllowNodeZones(f *framework.Framework, zoneCount int, image string) {
 
 		// Defer the cleanup
 		defer func() {
-			framework.Logf("deleting claim %q/%q", pvc.Namespace, pvc.Name)
+			e2elog.Logf("deleting claim %q/%q", pvc.Namespace, pvc.Name)
 			err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, nil)
 			if err != nil {
 				framework.Failf("Error deleting claim %q. Error: %v", pvc.Name, err)

--- a/test/e2e/ui/BUILD
+++ b/test/e2e/ui/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/utils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
     ],

--- a/test/e2e/ui/dashboard.go
+++ b/test/e2e/ui/dashboard.go
@@ -26,6 +26,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 
 	"github.com/onsi/ginkgo"
@@ -63,7 +64,7 @@ var _ = SIGDescribe("Kubernetes Dashboard", func() {
 			var status int
 			proxyRequest, errProxy := framework.GetServicesProxyRequest(f.ClientSet, f.ClientSet.CoreV1().RESTClient().Get())
 			if errProxy != nil {
-				framework.Logf("Get services proxy request failed: %v", errProxy)
+				e2elog.Logf("Get services proxy request failed: %v", errProxy)
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
@@ -82,9 +83,9 @@ var _ = SIGDescribe("Kubernetes Dashboard", func() {
 					framework.Failf("Request to kubernetes-dashboard failed: %v", err)
 					return true, err
 				}
-				framework.Logf("Request to kubernetes-dashboard failed: %v", err)
+				e2elog.Logf("Request to kubernetes-dashboard failed: %v", err)
 			} else if status != http.StatusOK {
-				framework.Logf("Unexpected status from kubernetes-dashboard: %v", status)
+				e2elog.Logf("Unexpected status from kubernetes-dashboard: %v", status)
 			}
 			// Don't return err here as it aborts polling.
 			return status == http.StatusOK, nil


### PR DESCRIPTION
/kind cleanup
/priority backlog

**What this PR does / why we need it**:

Move `e2e` `e2e/ui` and `e2e/scheduling` test to use `e2e.Logf` 

Ref #77359

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
