### PR TITLE
Check error return from os.Stat

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -508,6 +508,9 @@ func (m *cgroupManagerImpl) Pids(name CgroupName) []int {
 			// do nothing, continue
 			continue
 		}
+		if err != nil {
+			continue
+		}
 		// Get a list of pids that are still charged to the pod's cgroup
 		pids, err = getCgroupProcs(dir)
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In cgroupManagerImpl#Pids, we call os.Stat but don't check error return beyond NotExist error.

This PR adds check for error return.

```release-note
NONE
```
