### PR TITLE
Impose length limit when concatenating revisions

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -267,8 +267,12 @@ func SetNewReplicaSetAnnotations(deployment *apps.Deployment, newRS *apps.Replic
 		if len(oldRevisions[0]) == 0 {
 			newRS.Annotations[RevisionHistoryAnnotation] = oldRevision
 		} else {
-			oldRevisions = append(oldRevisions, oldRevision)
-			newRS.Annotations[RevisionHistoryAnnotation] = strings.Join(oldRevisions, ",")
+			if len(revisionHistoryAnnotation) + len(oldRevision) < 262144 {
+				oldRevisions = append(oldRevisions, oldRevision)
+				newRS.Annotations[RevisionHistoryAnnotation] = strings.Join(oldRevisions, ",")
+			} else {
+				klog.Warningf("Not appending revision due to length limit of 262144 reached")
+			}
 		}
 	}
 	// If the new replica set is about to be created, we need to add replica annotations to it.

--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -267,7 +267,7 @@ func SetNewReplicaSetAnnotations(deployment *apps.Deployment, newRS *apps.Replic
 		if len(oldRevisions[0]) == 0 {
 			newRS.Annotations[RevisionHistoryAnnotation] = oldRevision
 		} else {
-			if len(revisionHistoryAnnotation) + len(oldRevision) < 262144 {
+			if len(revisionHistoryAnnotation)+len(oldRevision) < 262144 {
 				oldRevisions = append(oldRevisions, oldRevision)
 				newRS.Annotations[RevisionHistoryAnnotation] = strings.Join(oldRevisions, ",")
 			} else {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As Paul reported, we should impose length limit when concatenating revisions.

Otherwise, we may see the following error:
```
I0502 01:39:20.871854       6 deployment_controller.go:485] Error syncing deployment yarn-crm/crm-qa-nm: ReplicaSet.apps "crm-qa-nm-7bf7b57dff" is invalid: metadata.annotations: Too long: must have at most 262144 characters
```

**Which issue(s) this PR fixes**:
Fixes #77387

```release-note
NONE
```
