### PR TITLE
add a barrier to smplify ds controller

### DIFF
--- a/pkg/controller/BUILD
+++ b/pkg/controller/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = [
+        "barrier_test.go",
         "controller_ref_manager_test.go",
         "controller_utils_test.go",
     ],
@@ -29,6 +30,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
@@ -42,6 +44,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = [
+        "barrier.go",
         "client_builder.go",
         "client_builder_dynamic.go",
         "controller_ref_manager.go",

--- a/pkg/controller/barrier.go
+++ b/pkg/controller/barrier.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Limiter is used by an task barrier to limit the rate that it spawns tasks.
+// Calls to limiter are synchonized by the taskBarrier.
+type Limiter interface {
+	// reserve attempts reserve a new slot for the task. It returns true if the
+	// slot was successfully reserved.
+	reserve() bool
+
+	// release is called to inform to the limiter that a single task has
+	// completed. The limiter is expected to call Signal or Broadcast on the
+	// condition to wake goroutines that may be waiting for a reservation slot.
+	release(*sync.Cond)
+}
+
+// TaskBarrier is an incremental barrier that makes it easy to create multiple
+// async operations and wait for them as a group. It allows creation to be rate
+// limited by a Limiter. It reports errors to Policy, which aggregates the
+// errors and decides whether the barrier should continue or bail out early. It
+// takes care of error prone requirements, such as remembering to count the
+// start tasks with a waitgroup and synchronizing completion reporting out of
+// the task loop.
+type TaskBarrier struct {
+	// cond guards all state including the policy.
+	cond *sync.Cond
+	// Policy is used to propagate errors from tasks started by a barrier, and
+	// also to signal to the barrier that it should terminate early (i.e. refuse
+	// to create more tasks). It receives a (possibly nil) error on each
+	// completion of a task. It returns a bool indicating whether the barrier
+	// should continue creating tasks.
+	//
+	// The barrier will synchronize calls to Policy and make no more calls once
+	// Wait returns. If state modified by Policy needs to be accessed outside of
+	// Policy but before Wait returns, it's Policy's responsibility to
+	// synchronize access to this state.
+	Policy func(error) bool
+	// Limiter is the limiter that the task barrier will use to limit the
+	// creation of tasks.
+	Limiter Limiter
+	// the barrier becomes done when:
+	// * a call to policy returns false, indicating that the barrier should not
+	//   continue creating tasks.
+	// * on the first return of Wait
+	done bool
+	// each active task places a hold on the task barrier. Wait will not return
+	// until all holds are removed.
+	holds int
+}
+
+// NewTaskBarrier creates a task barrier with a limiter that never blocks and
+// ignores all errors. The Policy and Limiter can be replace before the task
+// barrier is used.
+func NewTaskBarrier() *TaskBarrier {
+	return &TaskBarrier{
+		cond: sync.NewCond(&sync.Mutex{}),
+		// ignore all errors by default
+		Policy:  func(error) bool { return true },
+		Limiter: NewNoLimiter(),
+	}
+}
+
+// Go requests that the barrier start a new task. The barrier will ignore
+// requests to Go if the barrier is already done (e.g. if a call to Wait has
+// returned).
+func (tb *TaskBarrier) Go(task func() error) {
+	tb.cond.L.Lock()
+	defer tb.cond.L.Unlock()
+
+	// Wait for the limiter to give the goahead or the task barrier to
+	// transition to done.
+	for !tb.Limiter.reserve() && !tb.done {
+		tb.cond.Wait()
+	}
+
+	// bail if the barrier is done
+	if tb.done {
+		return
+	}
+
+	// add a hold and start the task.
+	tb.holds++
+
+	go func() {
+		// Run the task, then under lock:
+		// * release the task's hold on the barrier
+		// * release the task's reservation back to the limiter
+		// * report the task's return to Policy. If the Policy indicates
+		//   that we shouldn't continue, set the barrier to done.
+		// * if holds drop to zero or the barrier is done, wake everyone up.
+		err := task()
+
+		tb.cond.L.Lock()
+		defer tb.cond.L.Unlock()
+
+		tb.holds--
+		tb.Limiter.release(tb.cond)
+
+		if ok := tb.Policy(err); !ok {
+			tb.done = true
+		}
+		if tb.holds == 0 || tb.done {
+			tb.cond.Broadcast()
+		}
+	}()
+}
+
+// Wait waits for all holds tasks to complete. Once Wait has returned, the
+// barrier is done and all calls to Go() will be ignored.
+func (tb *TaskBarrier) Wait() {
+	tb.cond.L.Lock()
+	defer tb.cond.L.Unlock()
+
+	for tb.holds > 0 {
+		tb.cond.Wait()
+	}
+	tb.done = true
+}
+
+// NewSlowStarter returns a Limiter that rate limits a barrier to allow loops
+// with parallelism to start slowly and speed up. It uses a token bucket that
+// is refilled with two tokens for every token returned allowing a loop to
+// incrementally double.
+//
+// For example, this can be used to gracefully handle attempts to start large
+// numbers of pods that would likely all fail with the same error. If a
+// DaemonSet in namespace with no quota attempts to create a large number of
+// pods, TaskBarrier will prevent the DaemonSet controller from spamming the
+// API service with the pod create requests after one of its pods fails.
+// Conveniently, this also prevents the event spam that those failures would
+// generate.
+func NewSlowStarter() Limiter {
+	return &slowStartLimiter{
+		tokens: 1,
+	}
+}
+
+type slowStartLimiter struct {
+	tokens int
+}
+
+// calls to reserve must be guarded by the task barrier's condition.
+func (s *slowStartLimiter) reserve() bool {
+	// Negative available tokens will happen if more tokens are returned to
+	// TaskBarrier than it hands out. This can't happen through misuse, so we
+	// made a mistake somewhere around here. We can either:
+	//
+	// * Panic proactively
+	// * Continue to wait for the tokens reach positive again, potentially
+	//   deadlocking the consumer
+	// * Protect against this condition with a sync.Once that escapes the stack
+	//   and is captured by a release callback. This doesn't prevent bugs.
+	if s.tokens < 0 {
+		panic(fmt.Errorf("slowStartLimiter reached negative available tokens: %v", s.tokens))
+	}
+
+	if s.tokens == 0 {
+		return false
+	}
+
+	s.tokens--
+	return true
+}
+
+// calls to release must be guarded by the task barrier's condition.
+func (s *slowStartLimiter) release(cond *sync.Cond) {
+	// slow starter doubles its rate over usage. for every slot released, make
+	// two slots available, and signal two waiters.
+	s.tokens += 2
+	cond.Signal()
+	cond.Signal()
+}
+
+// NewNoLimiter returns a barrier that never blocks a limiter from starting a
+// new task.
+func NewNoLimiter() Limiter {
+	return noLimiter{}
+}
+
+type noLimiter struct{}
+
+func (noLimiter) reserve() bool {
+	return true
+}
+
+func (noLimiter) release(cond *sync.Cond) {
+	// no need to signal because nothing should ever be blocked on us.
+}

--- a/pkg/controller/barrier_test.go
+++ b/pkg/controller/barrier_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestTaskBarrier(t *testing.T) {
+	noOp := func() error {
+		return nil
+	}
+	noOpJitter := func() error {
+		time.Sleep(wait.Jitter(10*time.Millisecond, 0.5))
+		return nil
+	}
+	noOpErr := func() error {
+		return errors.New("err")
+	}
+
+	tests := []struct {
+		prepare  func(*TaskBarrier)
+		complete int
+		errCount int
+	}{
+		{
+			prepare: func(s *TaskBarrier) {
+				s.Go(noOp)
+			},
+			complete: 1,
+		},
+		{
+			prepare: func(s *TaskBarrier) {
+				s.Go(noOp)
+				s.Go(noOpJitter)
+				s.Go(noOpJitter)
+				s.Go(noOpJitter)
+			},
+			complete: 4,
+		},
+		{
+			prepare: func(s *TaskBarrier) {
+				s.Go(noOpErr)
+				s.Go(noOp)
+				s.Go(noOp)
+				s.Go(noOp)
+				s.Go(noOp)
+			},
+			complete: 1,
+			errCount: 1,
+		},
+		{
+			prepare: func(s *TaskBarrier) {
+				s.Go(noOp)
+				s.Go(noOp)
+				s.Go(noOp)
+				s.Go(noOp)
+				s.Go(noOpErr)
+			},
+			complete: 5,
+			errCount: 1,
+		},
+		{
+			prepare: func(s *TaskBarrier) {
+				for i := 0; i < 1000; i++ {
+					s.Go(noOpJitter)
+					s.Go(noOpJitter)
+					s.Go(noOpJitter)
+				}
+				s.Go(noOpErr)
+			},
+			complete: 3001,
+			errCount: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			var (
+				errs     []error
+				complete int
+			)
+			s := NewTaskBarrier()
+			s.Limiter = NewSlowStarter()
+			s.Policy = func(err error) bool {
+				complete++
+				if err != nil {
+					errs = append(errs, err)
+					return false
+				}
+				return true
+			}
+
+			test.prepare(s)
+			s.Wait()
+
+			if s.holds != 0 {
+				t.Errorf("unexpected holds on the barrier: %v", s.holds)
+			}
+			if got, want := len(errs), test.errCount; got != want {
+				t.Errorf("unexpected error count: got=%v want=%v", got, want)
+			}
+			if got, want := complete, test.complete; got != want {
+				t.Errorf("unexpected completions: got=%v want=%v", got, want)
+			}
+		})
+	}
+}

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -44,14 +44,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	clientretry "k8s.io/client-go/util/retry"
+	"k8s.io/klog"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
 	"k8s.io/utils/integer"
-
-	"k8s.io/klog"
 )
 
 const (
@@ -66,20 +65,7 @@ const (
 	// 500 pods. Just creation is limited to 20qps, and watching happens with ~10-30s
 	// latency/pod at the scale of 3000 pods over 100 nodes.
 	ExpectationsTimeout = 5 * time.Minute
-	// When batching pod creates, SlowStartInitialBatchSize is the size of the
-	// initial batch.  The size of each successive batch is twice the size of
-	// the previous batch.  For example, for a value of 1, batch sizes would be
-	// 1, 2, 4, 8, ...  and for a value of 10, batch sizes would be
-	// 10, 20, 40, 80, ...  Setting the value higher means that quota denials
-	// will result in more doomed API calls and associated event spam.  Setting
-	// the value lower will result in more API call round trip periods for
-	// large batches.
-	//
-	// Given a number of pods to start "N":
-	// The number of doomed calls per sync once quota is exceeded is given by:
-	//      min(N,SlowStartInitialBatchSize)
-	// The number of batches is given by:
-	//      1+floor(log_2(ceil(N/SlowStartInitialBatchSize)))
+	// SlowStartInitialBatchSize is deprecated. Use the TaskBarrier.
 	SlowStartInitialBatchSize = 1
 )
 

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -27,8 +27,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,8 +47,6 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/controller/testutil"
 	"k8s.io/kubernetes/pkg/securitycontext"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // NewFakeControllerExpectationsLookup creates a fake store for PodExpectations.

--- a/pkg/controller/daemon/BUILD
+++ b/pkg/controller/daemon/BUILD
@@ -51,7 +51,6 @@ go_library(
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
-        "//vendor/k8s.io/utils/integer:go_default_library",
     ],
 )
 


### PR DESCRIPTION
The slow start throttling is basically untested and really difficult to reason about:

https://github.com/kubernetes/kubernetes/blob/e871241268c4aed15cd7d55692289297513bec87/pkg/controller/daemon/daemon_controller.go#L1023-L1028

All of the parallelism in the pod diff can be decluttered with a barrier.

Initial part of https://github.com/kubernetes/kubernetes/issues/77436

```release-note
NONE
```
