### PR TITLE
Fix go lint failures in volume scheduling packages

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -107,8 +107,6 @@ pkg/controller/volume/expand
 pkg/controller/volume/persistentvolume
 pkg/controller/volume/persistentvolume/config/v1alpha1
 pkg/controller/volume/persistentvolume/options
-pkg/controller/volume/persistentvolume/testing
-pkg/controller/volume/scheduling
 pkg/credentialprovider
 pkg/credentialprovider/gcp
 pkg/features

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -687,7 +687,7 @@ func runMultisyncTests(t *testing.T, tests []controllerTest, storageClasses []*s
 			obj := reactor.PopChange()
 			if obj == nil {
 				// Nothing was changed, should we exit?
-				if firstSync || reactor.ChangedSinceLastSync() > 0 {
+				if firstSync || reactor.GetChangeCount() > 0 {
 					// There were some changes after the last "periodic sync".
 					// Simulate "periodic sync" of everything (until it produces
 					// no changes).
@@ -711,7 +711,7 @@ func runMultisyncTests(t *testing.T, tests []controllerTest, storageClasses []*s
 				ctrl.claims.Update(claim)
 				err = ctrl.syncClaim(claim)
 				if err != nil {
-					if err == pvtesting.VersionConflictError {
+					if err == pvtesting.ErrVersionConflict {
 						// Ignore version errors
 						klog.V(4).Infof("test intentionaly ignores version error.")
 					} else {
@@ -728,7 +728,7 @@ func runMultisyncTests(t *testing.T, tests []controllerTest, storageClasses []*s
 				ctrl.volumes.store.Update(volume)
 				err = ctrl.syncVolume(volume)
 				if err != nil {
-					if err == pvtesting.VersionConflictError {
+					if err == pvtesting.ErrVersionConflict {
 						// Ignore version errors
 						klog.V(4).Infof("test intentionaly ignores version error.")
 					} else {

--- a/pkg/controller/volume/scheduling/scheduler_assume_cache.go
+++ b/pkg/controller/volume/scheduling/scheduler_assume_cache.go
@@ -127,7 +127,8 @@ func (c *assumeCache) objInfoIndexFunc(obj interface{}) ([]string, error) {
 	return c.indexFunc(objInfo.latestObj)
 }
 
-func NewAssumeCache(informer cache.SharedIndexInformer, description, indexName string, indexFunc cache.IndexFunc) *assumeCache {
+// NewAssumeCache creates an assume cache for genernal objects.
+func NewAssumeCache(informer cache.SharedIndexInformer, description, indexName string, indexFunc cache.IndexFunc) AssumeCache {
 	c := &assumeCache{
 		description: description,
 		indexFunc:   indexFunc,
@@ -354,8 +355,9 @@ func pvStorageClassIndexFunc(obj interface{}) ([]string, error) {
 	return []string{""}, fmt.Errorf("object is not a v1.PersistentVolume: %v", obj)
 }
 
+// NewPVAssumeCache creates a PV assume cache.
 func NewPVAssumeCache(informer cache.SharedIndexInformer) PVAssumeCache {
-	return &pvAssumeCache{assumeCache: NewAssumeCache(informer, "v1.PersistentVolume", "storageclass", pvStorageClassIndexFunc)}
+	return &pvAssumeCache{NewAssumeCache(informer, "v1.PersistentVolume", "storageclass", pvStorageClassIndexFunc).(*assumeCache)}
 }
 
 func (c *pvAssumeCache) GetPV(pvName string) (*v1.PersistentVolume, error) {
@@ -414,8 +416,9 @@ type pvcAssumeCache struct {
 	*assumeCache
 }
 
+// NewPVCAssumeCache creates a PVC assume cache.
 func NewPVCAssumeCache(informer cache.SharedIndexInformer) PVCAssumeCache {
-	return &pvcAssumeCache{assumeCache: NewAssumeCache(informer, "v1.PersistentVolumeClaim", "namespace", cache.MetaNamespaceIndexFunc)}
+	return &pvcAssumeCache{NewAssumeCache(informer, "v1.PersistentVolumeClaim", "namespace", cache.MetaNamespaceIndexFunc).(*assumeCache)}
 }
 
 func (c *pvcAssumeCache) GetPVC(pvcKey string) (*v1.PersistentVolumeClaim, error) {

--- a/pkg/controller/volume/scheduling/scheduler_assume_cache.go
+++ b/pkg/controller/volume/scheduling/scheduler_assume_cache.go
@@ -345,7 +345,7 @@ type PVAssumeCache interface {
 }
 
 type pvAssumeCache struct {
-	*assumeCache
+	AssumeCache
 }
 
 func pvStorageClassIndexFunc(obj interface{}) ([]string, error) {
@@ -357,7 +357,7 @@ func pvStorageClassIndexFunc(obj interface{}) ([]string, error) {
 
 // NewPVAssumeCache creates a PV assume cache.
 func NewPVAssumeCache(informer cache.SharedIndexInformer) PVAssumeCache {
-	return &pvAssumeCache{NewAssumeCache(informer, "v1.PersistentVolume", "storageclass", pvStorageClassIndexFunc).(*assumeCache)}
+	return &pvAssumeCache{NewAssumeCache(informer, "v1.PersistentVolume", "storageclass", pvStorageClassIndexFunc)}
 }
 
 func (c *pvAssumeCache) GetPV(pvName string) (*v1.PersistentVolume, error) {
@@ -413,12 +413,12 @@ type PVCAssumeCache interface {
 }
 
 type pvcAssumeCache struct {
-	*assumeCache
+	AssumeCache
 }
 
 // NewPVCAssumeCache creates a PVC assume cache.
 func NewPVCAssumeCache(informer cache.SharedIndexInformer) PVCAssumeCache {
-	return &pvcAssumeCache{NewAssumeCache(informer, "v1.PersistentVolumeClaim", "namespace", cache.MetaNamespaceIndexFunc).(*assumeCache)}
+	return &pvcAssumeCache{NewAssumeCache(informer, "v1.PersistentVolumeClaim", "namespace", cache.MetaNamespaceIndexFunc)}
 }
 
 func (c *pvcAssumeCache) GetPVC(pvcKey string) (*v1.PersistentVolumeClaim, error) {

--- a/pkg/controller/volume/scheduling/scheduler_assume_cache_test.go
+++ b/pkg/controller/volume/scheduling/scheduler_assume_cache_test.go
@@ -109,13 +109,13 @@ func TestAssumePV(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		cache := NewPVAssumeCache(nil)
-		internal_cache, ok := cache.(*pvAssumeCache)
+		internalCache, ok := cache.(*pvAssumeCache)
 		if !ok {
 			t.Fatalf("Failed to get internal cache")
 		}
 
 		// Add oldPV to cache
-		internal_cache.add(scenario.oldPV)
+		internalCache.add(scenario.oldPV)
 		if err := verifyPV(cache, scenario.oldPV.Name, scenario.oldPV); err != nil {
 			t.Errorf("Failed to GetPV() after initial update: %v", err)
 			continue
@@ -143,7 +143,7 @@ func TestAssumePV(t *testing.T) {
 
 func TestRestorePV(t *testing.T) {
 	cache := NewPVAssumeCache(nil)
-	internal_cache, ok := cache.(*pvAssumeCache)
+	internalCache, ok := cache.(*pvAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -155,7 +155,7 @@ func TestRestorePV(t *testing.T) {
 	cache.Restore("nothing")
 
 	// Add oldPV to cache
-	internal_cache.add(oldPV)
+	internalCache.add(oldPV)
 	if err := verifyPV(cache, oldPV.Name, oldPV); err != nil {
 		t.Fatalf("Failed to GetPV() after initial update: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestRestorePV(t *testing.T) {
 
 func TestBasicPVCache(t *testing.T) {
 	cache := NewPVAssumeCache(nil)
-	internal_cache, ok := cache.(*pvAssumeCache)
+	internalCache, ok := cache.(*pvAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -202,7 +202,7 @@ func TestBasicPVCache(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		pv := makePV(fmt.Sprintf("test-pv%v", i), "1", "")
 		pvs[pv.Name] = pv
-		internal_cache.add(pv)
+		internalCache.add(pv)
 	}
 
 	// List them
@@ -211,7 +211,7 @@ func TestBasicPVCache(t *testing.T) {
 	// Update a PV
 	updatedPV := makePV("test-pv3", "2", "")
 	pvs[updatedPV.Name] = updatedPV
-	internal_cache.update(nil, updatedPV)
+	internalCache.update(nil, updatedPV)
 
 	// List them
 	verifyListPVs(t, cache, pvs, "")
@@ -219,7 +219,7 @@ func TestBasicPVCache(t *testing.T) {
 	// Delete a PV
 	deletedPV := pvs["test-pv7"]
 	delete(pvs, deletedPV.Name)
-	internal_cache.delete(deletedPV)
+	internalCache.delete(deletedPV)
 
 	// List them
 	verifyListPVs(t, cache, pvs, "")
@@ -227,7 +227,7 @@ func TestBasicPVCache(t *testing.T) {
 
 func TestPVCacheWithStorageClasses(t *testing.T) {
 	cache := NewPVAssumeCache(nil)
-	internal_cache, ok := cache.(*pvAssumeCache)
+	internalCache, ok := cache.(*pvAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -237,7 +237,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		pv := makePV(fmt.Sprintf("test-pv%v", i), "1", "class1")
 		pvs1[pv.Name] = pv
-		internal_cache.add(pv)
+		internalCache.add(pv)
 	}
 
 	// Add a bunch of PVs
@@ -245,7 +245,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		pv := makePV(fmt.Sprintf("test2-pv%v", i), "1", "class2")
 		pvs2[pv.Name] = pv
-		internal_cache.add(pv)
+		internalCache.add(pv)
 	}
 
 	// List them
@@ -255,7 +255,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 	// Update a PV
 	updatedPV := makePV("test-pv3", "2", "class1")
 	pvs1[updatedPV.Name] = updatedPV
-	internal_cache.update(nil, updatedPV)
+	internalCache.update(nil, updatedPV)
 
 	// List them
 	verifyListPVs(t, cache, pvs1, "class1")
@@ -264,7 +264,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 	// Delete a PV
 	deletedPV := pvs1["test-pv7"]
 	delete(pvs1, deletedPV.Name)
-	internal_cache.delete(deletedPV)
+	internalCache.delete(deletedPV)
 
 	// List them
 	verifyListPVs(t, cache, pvs1, "class1")
@@ -273,7 +273,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 
 func TestAssumeUpdatePVCache(t *testing.T) {
 	cache := NewPVAssumeCache(nil)
-	internal_cache, ok := cache.(*pvAssumeCache)
+	internalCache, ok := cache.(*pvAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -282,7 +282,7 @@ func TestAssumeUpdatePVCache(t *testing.T) {
 
 	// Add a PV
 	pv := makePV(pvName, "1", "")
-	internal_cache.add(pv)
+	internalCache.add(pv)
 	if err := verifyPV(cache, pvName, pv); err != nil {
 		t.Fatalf("failed to get PV: %v", err)
 	}
@@ -298,7 +298,7 @@ func TestAssumeUpdatePVCache(t *testing.T) {
 	}
 
 	// Add old PV
-	internal_cache.add(pv)
+	internalCache.add(pv)
 	if err := verifyPV(cache, pvName, newPV); err != nil {
 		t.Fatalf("failed to get PV after old PV added: %v", err)
 	}
@@ -366,13 +366,13 @@ func TestAssumePVC(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		cache := NewPVCAssumeCache(nil)
-		internal_cache, ok := cache.(*pvcAssumeCache)
+		internalCache, ok := cache.(*pvcAssumeCache)
 		if !ok {
 			t.Fatalf("Failed to get internal cache")
 		}
 
 		// Add oldPVC to cache
-		internal_cache.add(scenario.oldPVC)
+		internalCache.add(scenario.oldPVC)
 		if err := verifyPVC(cache, getPVCName(scenario.oldPVC), scenario.oldPVC); err != nil {
 			t.Errorf("Failed to GetPVC() after initial update: %v", err)
 			continue
@@ -400,7 +400,7 @@ func TestAssumePVC(t *testing.T) {
 
 func TestRestorePVC(t *testing.T) {
 	cache := NewPVCAssumeCache(nil)
-	internal_cache, ok := cache.(*pvcAssumeCache)
+	internalCache, ok := cache.(*pvcAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -412,7 +412,7 @@ func TestRestorePVC(t *testing.T) {
 	cache.Restore("nothing")
 
 	// Add oldPVC to cache
-	internal_cache.add(oldPVC)
+	internalCache.add(oldPVC)
 	if err := verifyPVC(cache, getPVCName(oldPVC), oldPVC); err != nil {
 		t.Fatalf("Failed to GetPVC() after initial update: %v", err)
 	}
@@ -440,7 +440,7 @@ func TestRestorePVC(t *testing.T) {
 
 func TestAssumeUpdatePVCCache(t *testing.T) {
 	cache := NewPVCAssumeCache(nil)
-	internal_cache, ok := cache.(*pvcAssumeCache)
+	internalCache, ok := cache.(*pvcAssumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -450,7 +450,7 @@ func TestAssumeUpdatePVCCache(t *testing.T) {
 
 	// Add a PVC
 	pvc := makeClaim(pvcName, "1", pvcNamespace)
-	internal_cache.add(pvc)
+	internalCache.add(pvc)
 	if err := verifyPVC(cache, getPVCName(pvc), pvc); err != nil {
 		t.Fatalf("failed to get PVC: %v", err)
 	}
@@ -466,7 +466,7 @@ func TestAssumeUpdatePVCCache(t *testing.T) {
 	}
 
 	// Add old PVC
-	internal_cache.add(pvc)
+	internalCache.add(pvc)
 	if err := verifyPVC(cache, getPVCName(pvc), newPVC); err != nil {
 		t.Fatalf("failed to get PVC after old PVC added: %v", err)
 	}

--- a/pkg/controller/volume/scheduling/scheduler_assume_cache_test.go
+++ b/pkg/controller/volume/scheduling/scheduler_assume_cache_test.go
@@ -109,7 +109,7 @@ func TestAssumePV(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		cache := NewPVAssumeCache(nil)
-		internalCache, ok := cache.(*pvAssumeCache)
+		internalCache, ok := cache.(*pvAssumeCache).AssumeCache.(*assumeCache)
 		if !ok {
 			t.Fatalf("Failed to get internal cache")
 		}
@@ -143,7 +143,7 @@ func TestAssumePV(t *testing.T) {
 
 func TestRestorePV(t *testing.T) {
 	cache := NewPVAssumeCache(nil)
-	internalCache, ok := cache.(*pvAssumeCache)
+	internalCache, ok := cache.(*pvAssumeCache).AssumeCache.(*assumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -183,7 +183,7 @@ func TestRestorePV(t *testing.T) {
 
 func TestBasicPVCache(t *testing.T) {
 	cache := NewPVAssumeCache(nil)
-	internalCache, ok := cache.(*pvAssumeCache)
+	internalCache, ok := cache.(*pvAssumeCache).AssumeCache.(*assumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -227,7 +227,7 @@ func TestBasicPVCache(t *testing.T) {
 
 func TestPVCacheWithStorageClasses(t *testing.T) {
 	cache := NewPVAssumeCache(nil)
-	internalCache, ok := cache.(*pvAssumeCache)
+	internalCache, ok := cache.(*pvAssumeCache).AssumeCache.(*assumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -273,7 +273,7 @@ func TestPVCacheWithStorageClasses(t *testing.T) {
 
 func TestAssumeUpdatePVCache(t *testing.T) {
 	cache := NewPVAssumeCache(nil)
-	internalCache, ok := cache.(*pvAssumeCache)
+	internalCache, ok := cache.(*pvAssumeCache).AssumeCache.(*assumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -366,7 +366,7 @@ func TestAssumePVC(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		cache := NewPVCAssumeCache(nil)
-		internalCache, ok := cache.(*pvcAssumeCache)
+		internalCache, ok := cache.(*pvcAssumeCache).AssumeCache.(*assumeCache)
 		if !ok {
 			t.Fatalf("Failed to get internal cache")
 		}
@@ -400,7 +400,7 @@ func TestAssumePVC(t *testing.T) {
 
 func TestRestorePVC(t *testing.T) {
 	cache := NewPVCAssumeCache(nil)
-	internalCache, ok := cache.(*pvcAssumeCache)
+	internalCache, ok := cache.(*pvcAssumeCache).AssumeCache.(*assumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}
@@ -440,7 +440,7 @@ func TestRestorePVC(t *testing.T) {
 
 func TestAssumeUpdatePVCCache(t *testing.T) {
 	cache := NewPVCAssumeCache(nil)
-	internalCache, ok := cache.(*pvcAssumeCache)
+	internalCache, ok := cache.(*pvcAssumeCache).AssumeCache.(*assumeCache)
 	if !ok {
 		t.Fatalf("Failed to get internal cache")
 	}

--- a/pkg/controller/volume/scheduling/scheduler_bind_cache_metrics.go
+++ b/pkg/controller/volume/scheduling/scheduler_bind_cache_metrics.go
@@ -24,6 +24,7 @@ import (
 const VolumeSchedulerSubsystem = "scheduler_volume"
 
 var (
+	// VolumeBindingRequestSchedulerBinderCache tracks the number of volume binder cache operations.
 	VolumeBindingRequestSchedulerBinderCache = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: VolumeSchedulerSubsystem,
@@ -32,6 +33,7 @@ var (
 		},
 		[]string{"operation"},
 	)
+	// VolumeSchedulingStageLatency tracks the latency of volume scheduling operations.
 	VolumeSchedulingStageLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: VolumeSchedulerSubsystem,
@@ -41,6 +43,7 @@ var (
 		},
 		[]string{"operation"},
 	)
+	// VolumeSchedulingStageFailed tracks the number of failed volume scheduling operations.
 	VolumeSchedulingStageFailed = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: VolumeSchedulerSubsystem,

--- a/pkg/controller/volume/scheduling/scheduler_binder_cache.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder_cache.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-// podBindingCache stores PV binding decisions per pod per node.
+// PodBindingCache stores PV binding decisions per pod per node.
 // Pod entries are removed when the Pod is deleted or updated to
 // no longer be schedulable.
 type PodBindingCache interface {
@@ -69,6 +69,7 @@ type nodeDecision struct {
 	provisionings []*v1.PersistentVolumeClaim
 }
 
+// NewPodBindingCache creates a pod binding cache.
 func NewPodBindingCache() PodBindingCache {
 	return &podBindingCache{bindingDecisions: map[string]nodeDecisions{}}
 }

--- a/pkg/controller/volume/scheduling/scheduler_binder_fake.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder_fake.go
@@ -18,6 +18,7 @@ package scheduling
 
 import "k8s.io/api/core/v1"
 
+// FakeVolumeBinderConfig holds configurations for fake volume binder.
 type FakeVolumeBinderConfig struct {
 	AllBound             bool
 	FindUnboundSatsified bool
@@ -27,7 +28,7 @@ type FakeVolumeBinderConfig struct {
 	BindErr              error
 }
 
-// NewVolumeBinder sets up all the caches needed for the scheduler to make
+// NewFakeVolumeBinder sets up all the caches needed for the scheduler to make
 // topology-aware volume binding decisions.
 func NewFakeVolumeBinder(config *FakeVolumeBinderConfig) *FakeVolumeBinder {
 	return &FakeVolumeBinder{
@@ -35,26 +36,31 @@ func NewFakeVolumeBinder(config *FakeVolumeBinderConfig) *FakeVolumeBinder {
 	}
 }
 
+// FakeVolumeBinder represents a fake volume binder for testing.
 type FakeVolumeBinder struct {
 	config       *FakeVolumeBinderConfig
 	AssumeCalled bool
 	BindCalled   bool
 }
 
+// FindPodVolumes implements SchedulerVolumeBinder.FindPodVolumes.
 func (b *FakeVolumeBinder) FindPodVolumes(pod *v1.Pod, node *v1.Node) (unboundVolumesSatisfied, boundVolumesSatsified bool, err error) {
 	return b.config.FindUnboundSatsified, b.config.FindBoundSatsified, b.config.FindErr
 }
 
+// AssumePodVolumes implements SchedulerVolumeBinder.AssumePodVolumes.
 func (b *FakeVolumeBinder) AssumePodVolumes(assumedPod *v1.Pod, nodeName string) (bool, error) {
 	b.AssumeCalled = true
 	return b.config.AllBound, b.config.AssumeErr
 }
 
+// BindPodVolumes implements SchedulerVolumeBinder.BindPodVolumes.
 func (b *FakeVolumeBinder) BindPodVolumes(assumedPod *v1.Pod) error {
 	b.BindCalled = true
 	return b.config.BindErr
 }
 
+// GetBindingsCache implements SchedulerVolumeBinder.GetBindingsCache.
 func (b *FakeVolumeBinder) GetBindingsCache() PodBindingCache {
 	return nil
 }

--- a/pkg/controller/volume/scheduling/scheduler_binder_test.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder_test.go
@@ -103,8 +103,8 @@ type testEnv struct {
 	binder               SchedulerVolumeBinder
 	internalBinder       *volumeBinder
 	internalNodeInformer coreinformers.NodeInformer
-	internalPVCache      *pvAssumeCache
-	internalPVCCache     *pvcAssumeCache
+	internalPVCache      *assumeCache
+	internalPVCCache     *assumeCache
 }
 
 func newTestBinder(t *testing.T, stopCh <-chan struct{}) *testEnv {
@@ -206,13 +206,13 @@ func newTestBinder(t *testing.T, stopCh <-chan struct{}) *testEnv {
 	}
 
 	pvCache := internalBinder.pvCache
-	internalPVCache, ok := pvCache.(*pvAssumeCache)
+	internalPVCache, ok := pvCache.(*pvAssumeCache).AssumeCache.(*assumeCache)
 	if !ok {
 		t.Fatalf("Failed to convert to internal PV cache")
 	}
 
 	pvcCache := internalBinder.pvcCache
-	internalPVCCache, ok := pvcCache.(*pvcAssumeCache)
+	internalPVCCache, ok := pvcCache.(*pvcAssumeCache).AssumeCache.(*assumeCache)
 	if !ok {
 		t.Fatalf("Failed to convert to internal PVC cache")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

- pkg/controller/volume/persistentvolume/testing
- pkg/controller/volume/scheduling

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #77084 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
