### PR TITLE
DO NOT MERGE: Use an alternate implementation for gzip compression handling

### DIFF
--- a/staging/src/k8s.io/apiserver/BUILD
+++ b/staging/src/k8s.io/apiserver/BUILD
@@ -50,6 +50,7 @@ filegroup(
         "//staging/src/k8s.io/apiserver/plugin/pkg/audit:all-srcs",
         "//staging/src/k8s.io/apiserver/plugin/pkg/authenticator:all-srcs",
         "//staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook:all-srcs",
+        "//staging/src/k8s.io/apiserver/third_party/gorilla-handlers:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/BUILD
@@ -55,6 +55,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/endpoints/metrics:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/httplog:go_default_library",
+        "//staging/src/k8s.io/apiserver/third_party/gorilla-handlers:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/compression.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/compression.go
@@ -17,161 +17,23 @@ limitations under the License.
 package filters
 
 import (
-	"compress/gzip"
-	"compress/zlib"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"strings"
 
-	"github.com/emicklei/go-restful"
-
-	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apiserver/pkg/endpoints/request"
-)
-
-// Compressor is an interface to compression writers
-type Compressor interface {
-	io.WriteCloser
-	Flush() error
-}
-
-const (
-	headerAcceptEncoding  = "Accept-Encoding"
-	headerContentEncoding = "Content-Encoding"
-
-	encodingGzip    = "gzip"
-	encodingDeflate = "deflate"
+	restful "github.com/emicklei/go-restful"
 )
 
 // WithCompression wraps an http.Handler with the Compression Handler
 func WithCompression(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		wantsCompression, encoding := wantsCompressedResponse(req)
-		w.Header().Set("Vary", "Accept-Encoding")
-		if wantsCompression {
-			compressionWriter, err := NewCompressionResponseWriter(w, encoding)
-			if err != nil {
-				handleError(w, req, err)
-				runtime.HandleError(fmt.Errorf("failed to compress HTTP response: %v", err))
-				return
-			}
-			compressionWriter.Header().Set("Content-Encoding", encoding)
-			handler.ServeHTTP(compressionWriter, req)
-			compressionWriter.(*compressionResponseWriter).Close()
-		} else {
-			handler.ServeHTTP(w, req)
-		}
-	})
-}
-
-// wantsCompressedResponse reads the Accept-Encoding header to see if and which encoding is requested.
-func wantsCompressedResponse(req *http.Request) (bool, string) {
-	// don't compress watches
-	ctx := req.Context()
-	info, ok := request.RequestInfoFrom(ctx)
-	if !ok {
-		return false, ""
-	}
-	if !info.IsResourceRequest {
-		return false, ""
-	}
-	if info.Verb == "watch" {
-		return false, ""
-	}
-	header := req.Header.Get(headerAcceptEncoding)
-	gi := strings.Index(header, encodingGzip)
-	zi := strings.Index(header, encodingDeflate)
-	// use in order of appearance
-	switch {
-	case gi == -1:
-		return zi != -1, encodingDeflate
-	case zi == -1:
-		return gi != -1, encodingGzip
-	case gi < zi:
-		return true, encodingGzip
-	default:
-		return true, encodingDeflate
-	}
-}
-
-type compressionResponseWriter struct {
-	writer     http.ResponseWriter
-	compressor Compressor
-	encoding   string
-}
-
-// NewCompressionResponseWriter returns wraps w with a compression ResponseWriter, using the given encoding
-func NewCompressionResponseWriter(w http.ResponseWriter, encoding string) (http.ResponseWriter, error) {
-	var compressor Compressor
-	switch encoding {
-	case encodingGzip:
-		compressor = gzip.NewWriter(w)
-	case encodingDeflate:
-		compressor = zlib.NewWriter(w)
-	default:
-		return nil, fmt.Errorf("%s is not a supported encoding type", encoding)
-	}
-	return &compressionResponseWriter{
-		writer:     w,
-		compressor: compressor,
-		encoding:   encoding,
-	}, nil
-}
-
-// compressionResponseWriter implements http.Responsewriter Interface
-var _ http.ResponseWriter = &compressionResponseWriter{}
-
-func (c *compressionResponseWriter) Header() http.Header {
-	return c.writer.Header()
-}
-
-// compress data according to compression method
-func (c *compressionResponseWriter) Write(p []byte) (int, error) {
-	if c.compressorClosed() {
-		return -1, errors.New("compressing error: tried to write data using closed compressor")
-	}
-	c.Header().Set(headerContentEncoding, c.encoding)
-	defer c.compressor.Flush()
-	return c.compressor.Write(p)
-}
-
-func (c *compressionResponseWriter) WriteHeader(status int) {
-	c.writer.WriteHeader(status)
-}
-
-// CloseNotify is part of http.CloseNotifier interface
-func (c *compressionResponseWriter) CloseNotify() <-chan bool {
-	return c.writer.(http.CloseNotifier).CloseNotify()
-}
-
-// Close the underlying compressor
-func (c *compressionResponseWriter) Close() error {
-	if c.compressorClosed() {
-		return errors.New("Compressing error: tried to close already closed compressor")
-	}
-
-	c.compressor.Close()
-	c.compressor = nil
-	return nil
-}
-
-func (c *compressionResponseWriter) Flush() {
-	if c.compressorClosed() {
-		return
-	}
-	c.compressor.Flush()
-}
-
-func (c *compressionResponseWriter) compressorClosed() bool {
-	return nil == c.compressor
+	// TODO: handler has to do the following:
+	// * handle watch flushes by closing and reopening (gzip(a) +  gzip(b) == gzip(a+b))
+	// * verify no unanticipated behavional change
+	return CompressHandler(handler)
 }
 
 // RestfulWithCompression wraps WithCompression to be compatible with go-restful
 func RestfulWithCompression(function restful.RouteFunction) restful.RouteFunction {
 	return restful.RouteFunction(func(request *restful.Request, response *restful.Response) {
-		handler := WithCompression(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		handler := CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			response.ResponseWriter = w
 			request.Request = req
 			function(request, response)

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/compression_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/compression_test.go
@@ -76,7 +76,7 @@ func TestCompression(t *testing.T) {
 			if response.StatusCode != 200 {
 				t.Fatalf("unexpected response: %#v", response)
 			}
-			if test.encoding == "gzip" { //&& !test.watch {
+			if test.encoding == "gzip" && !test.watch {
 				if response.Header.Get("Content-Encoding") != "gzip" {
 					t.Errorf("expected response header Content-Encoding to be set to \"gzip\": %#v", response)
 				}

--- a/staging/src/k8s.io/apiserver/third_party/gorilla-handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/third_party/gorilla-handlers/BUILD
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["compress.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/third_party/gorilla-handlers",
+    importpath = "k8s.io/apiserver/third_party/gorilla-handlers",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["compress_test.go"],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiserver/third_party/gorilla-handlers/LICENSE
+++ b/staging/src/k8s.io/apiserver/third_party/gorilla-handlers/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2013 The Gorilla Handlers Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/staging/src/k8s.io/apiserver/third_party/gorilla-handlers/README.kubernetes
+++ b/staging/src/k8s.io/apiserver/third_party/gorilla-handlers/README.kubernetes
@@ -1,0 +1,8 @@
+This package is forked from gorilla/handlers to add detection of double gzip encoding from
+https://github.com/gorilla/handlers/pull/157.
+
+Original source is located at:
+
+https://github.com/gorilla/handlers/blob/e1b2144f2167de0e1042d1d35e5cba5119d4fb5d/LICENSE
+https://github.com/gorilla/handlers/blob/e1b2144f2167de0e1042d1d35e5cba5119d4fb5d/compress.go
+https://github.com/gorilla/handlers/blob/e1b2144f2167de0e1042d1d35e5cba5119d4fb5d/compress_test.go

--- a/staging/src/k8s.io/apiserver/third_party/gorilla-handlers/compress.go
+++ b/staging/src/k8s.io/apiserver/third_party/gorilla-handlers/compress.go
@@ -1,0 +1,150 @@
+// Copyright 2013 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package handlers
+
+import (
+	"compress/flate"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type compressResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+	http.Hijacker
+	http.Flusher
+	http.CloseNotifier
+}
+
+func (w *compressResponseWriter) WriteHeader(c int) {
+	w.ResponseWriter.Header().Del("Content-Length")
+	w.ResponseWriter.WriteHeader(c)
+}
+
+func (w *compressResponseWriter) Header() http.Header {
+	return w.ResponseWriter.Header()
+}
+
+func (w *compressResponseWriter) Write(b []byte) (int, error) {
+	h := w.ResponseWriter.Header()
+	if h.Get("Content-Type") == "" {
+		h.Set("Content-Type", http.DetectContentType(b))
+	}
+	h.Del("Content-Length")
+
+	return w.Writer.Write(b)
+}
+
+type flusher interface {
+	Flush() error
+}
+
+func (w *compressResponseWriter) Flush() {
+	// Flush compressed data if compressor supports it.
+	if f, ok := w.Writer.(flusher); ok {
+		f.Flush()
+	}
+	// Flush HTTP response.
+	if w.Flusher != nil {
+		w.Flusher.Flush()
+	}
+}
+
+// CompressHandler gzip compresses HTTP responses for clients that support it
+// via the 'Accept-Encoding' header.
+//
+// Compressing TLS traffic may leak the page contents to an attacker if the
+// page contains user input: http://security.stackexchange.com/a/102015/12208
+func CompressHandler(h http.Handler) http.Handler {
+	return CompressHandlerLevel(h, gzip.DefaultCompression)
+}
+
+// CompressHandlerLevel gzip compresses HTTP responses with specified compression level
+// for clients that support it via the 'Accept-Encoding' header.
+//
+// The compression level should be gzip.DefaultCompression, gzip.NoCompression,
+// or any integer value between gzip.BestSpeed and gzip.BestCompression inclusive.
+// gzip.DefaultCompression is used in case of invalid compression level.
+func CompressHandlerLevel(h http.Handler, level int) http.Handler {
+	if level < gzip.DefaultCompression || level > gzip.BestCompression {
+		level = gzip.DefaultCompression
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	L:
+		for _, enc := range strings.Split(r.Header.Get("Accept-Encoding"), ",") {
+			switch strings.TrimSpace(enc) {
+			case "gzip":
+				w.Header().Set("Content-Encoding", "gzip")
+				r.Header.Del("Accept-Encoding")
+				w.Header().Add("Vary", "Accept-Encoding")
+
+				gw, _ := gzip.NewWriterLevel(w, level)
+				defer gw.Close()
+
+				h, hok := w.(http.Hijacker)
+				if !hok { /* w is not Hijacker... oh well... */
+					h = nil
+				}
+
+				f, fok := w.(http.Flusher)
+				if !fok {
+					f = nil
+				}
+
+				cn, cnok := w.(http.CloseNotifier)
+				if !cnok {
+					cn = nil
+				}
+
+				w = &compressResponseWriter{
+					Writer:         gw,
+					ResponseWriter: w,
+					Hijacker:       h,
+					Flusher:        f,
+					CloseNotifier:  cn,
+				}
+
+				break L
+			case "deflate":
+				w.Header().Set("Content-Encoding", "deflate")
+				r.Header.Del("Accept-Encoding")
+				w.Header().Add("Vary", "Accept-Encoding")
+
+				fw, _ := flate.NewWriter(w, level)
+				defer fw.Close()
+
+				h, hok := w.(http.Hijacker)
+				if !hok { /* w is not Hijacker... oh well... */
+					h = nil
+				}
+
+				f, fok := w.(http.Flusher)
+				if !fok {
+					f = nil
+				}
+
+				cn, cnok := w.(http.CloseNotifier)
+				if !cnok {
+					cn = nil
+				}
+
+				w = &compressResponseWriter{
+					Writer:         fw,
+					ResponseWriter: w,
+					Hijacker:       h,
+					Flusher:        f,
+					CloseNotifier:  cn,
+				}
+
+				break L
+			}
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/staging/src/k8s.io/apiserver/third_party/gorilla-handlers/compress_test.go
+++ b/staging/src/k8s.io/apiserver/third_party/gorilla-handlers/compress_test.go
@@ -1,0 +1,219 @@
+// Copyright 2013 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package handlers
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+)
+
+var contentType = "text/plain; charset=utf-8"
+
+func compressedRequest(w *httptest.ResponseRecorder, compression string) {
+	CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(9*1024))
+		w.Header().Set("Content-Type", contentType)
+		for i := 0; i < 1024; i++ {
+			io.WriteString(w, "Gorilla!\n")
+		}
+	})).ServeHTTP(w, &http.Request{
+		Method: "GET",
+		Header: http.Header{
+			"Accept-Encoding": []string{compression},
+		},
+	})
+
+}
+
+func TestCompressHandlerNoCompression(t *testing.T) {
+	w := httptest.NewRecorder()
+	compressedRequest(w, "")
+	if enc := w.HeaderMap.Get("Content-Encoding"); enc != "" {
+		t.Errorf("wrong content encoding, got %q want %q", enc, "")
+	}
+	if ct := w.HeaderMap.Get("Content-Type"); ct != contentType {
+		t.Errorf("wrong content type, got %q want %q", ct, contentType)
+	}
+	if w.Body.Len() != 1024*9 {
+		t.Errorf("wrong len, got %d want %d", w.Body.Len(), 1024*9)
+	}
+	if l := w.HeaderMap.Get("Content-Length"); l != "9216" {
+		t.Errorf("wrong content-length. got %q expected %d", l, 1024*9)
+	}
+}
+
+func TestAcceptEncodingIsDropped(t *testing.T) {
+	tCases := []struct {
+		name,
+		compression,
+		expect string
+		isPresent bool
+	}{
+		{
+			"accept-encoding-gzip",
+			"gzip",
+			"",
+			false,
+		},
+		{
+			"accept-encoding-deflate",
+			"deflate",
+			"",
+			false,
+		},
+		{
+			"accept-encoding-gzip,deflate",
+			"gzip,deflate",
+			"",
+			false,
+		},
+		{
+			"accept-encoding-gzip,deflate,something",
+			"gzip,deflate,something",
+			"",
+			false,
+		},
+		{
+			"accept-encoding-unknown",
+			"unknown",
+			"unknown",
+			true,
+		},
+	}
+
+	for _, tCase := range tCases {
+		ch := CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			acceptEnc := r.Header.Get("Accept-Encoding")
+			if acceptEnc == "" && tCase.isPresent {
+				t.Fatalf("%s: expected 'Accept-Encoding' header to be present but was not", tCase.name)
+			}
+			if acceptEnc != "" {
+				if !tCase.isPresent {
+					t.Fatalf("%s: expected 'Accept-Encoding' header to be dropped but was still present having value %q", tCase.name, acceptEnc)
+				}
+				if acceptEnc != tCase.expect {
+					t.Fatalf("%s: expected 'Accept-Encoding' to be %q but was %q", tCase.name, tCase.expect, acceptEnc)
+				}
+			}
+		}))
+
+		w := httptest.NewRecorder()
+		ch.ServeHTTP(w, &http.Request{
+			Method: "GET",
+			Header: http.Header{
+				"Accept-Encoding": []string{tCase.compression},
+			},
+		})
+	}
+}
+
+func TestCompressHandlerGzip(t *testing.T) {
+	w := httptest.NewRecorder()
+	compressedRequest(w, "gzip")
+	if w.HeaderMap.Get("Content-Encoding") != "gzip" {
+		t.Errorf("wrong content encoding, got %q want %q", w.HeaderMap.Get("Content-Encoding"), "gzip")
+	}
+	if w.HeaderMap.Get("Content-Type") != "text/plain; charset=utf-8" {
+		t.Errorf("wrong content type, got %s want %s", w.HeaderMap.Get("Content-Type"), "text/plain; charset=utf-8")
+	}
+	if w.Body.Len() != 72 {
+		t.Errorf("wrong len, got %d want %d", w.Body.Len(), 72)
+	}
+	if l := w.HeaderMap.Get("Content-Length"); l != "" {
+		t.Errorf("wrong content-length. got %q expected %q", l, "")
+	}
+}
+
+func TestCompressHandlerDeflate(t *testing.T) {
+	w := httptest.NewRecorder()
+	compressedRequest(w, "deflate")
+	if w.HeaderMap.Get("Content-Encoding") != "deflate" {
+		t.Fatalf("wrong content encoding, got %q want %q", w.HeaderMap.Get("Content-Encoding"), "deflate")
+	}
+	if w.HeaderMap.Get("Content-Type") != "text/plain; charset=utf-8" {
+		t.Fatalf("wrong content type, got %s want %s", w.HeaderMap.Get("Content-Type"), "text/plain; charset=utf-8")
+	}
+	if w.Body.Len() != 54 {
+		t.Fatalf("wrong len, got %d want %d", w.Body.Len(), 54)
+	}
+}
+
+func TestCompressHandlerGzipDeflate(t *testing.T) {
+	w := httptest.NewRecorder()
+	compressedRequest(w, "gzip, deflate ")
+	if w.HeaderMap.Get("Content-Encoding") != "gzip" {
+		t.Fatalf("wrong content encoding, got %q want %q", w.HeaderMap.Get("Content-Encoding"), "gzip")
+	}
+	if w.HeaderMap.Get("Content-Type") != "text/plain; charset=utf-8" {
+		t.Fatalf("wrong content type, got %s want %s", w.HeaderMap.Get("Content-Type"), "text/plain; charset=utf-8")
+	}
+}
+
+type fullyFeaturedResponseWriter struct{}
+
+// Header/Write/WriteHeader implement the http.ResponseWriter interface.
+func (fullyFeaturedResponseWriter) Header() http.Header {
+	return http.Header{}
+}
+func (fullyFeaturedResponseWriter) Write([]byte) (int, error) {
+	return 0, nil
+}
+func (fullyFeaturedResponseWriter) WriteHeader(int) {}
+
+// Flush implements the http.Flusher interface.
+func (fullyFeaturedResponseWriter) Flush() {}
+
+// Hijack implements the http.Hijacker interface.
+func (fullyFeaturedResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, nil
+}
+
+// CloseNotify implements the http.CloseNotifier interface.
+func (fullyFeaturedResponseWriter) CloseNotify() <-chan bool {
+	return nil
+}
+
+func TestCompressHandlerPreserveInterfaces(t *testing.T) {
+	// Compile time validation fullyFeaturedResponseWriter implements all the
+	// interfaces we're asserting in the test case below.
+	var (
+		_ http.Flusher       = fullyFeaturedResponseWriter{}
+		_ http.CloseNotifier = fullyFeaturedResponseWriter{}
+		_ http.Hijacker      = fullyFeaturedResponseWriter{}
+	)
+	var h http.Handler = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		comp := r.Header.Get("Accept-Encoding")
+		if _, ok := rw.(*compressResponseWriter); !ok {
+			t.Fatalf("ResponseWriter wasn't wrapped by compressResponseWriter, got %T type", rw)
+		}
+		if _, ok := rw.(http.Flusher); !ok {
+			t.Errorf("ResponseWriter lost http.Flusher interface for %q", comp)
+		}
+		if _, ok := rw.(http.CloseNotifier); !ok {
+			t.Errorf("ResponseWriter lost http.CloseNotifier interface for %q", comp)
+		}
+		if _, ok := rw.(http.Hijacker); !ok {
+			t.Errorf("ResponseWriter lost http.Hijacker interface for %q", comp)
+		}
+	})
+	h = CompressHandler(h)
+	var (
+		rw fullyFeaturedResponseWriter
+	)
+	r, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("Failed to create test request: %v", err)
+	}
+	r.Header.Set("Accept-Encoding", "gzip")
+	h.ServeHTTP(rw, r)
+
+	r.Header.Set("Accept-Encoding", "deflate")
+	h.ServeHTTP(rw, r)
+}


### PR DESCRIPTION
The apiserver compression feature has never made it past alpha since 1.7 due to incompatibilities with ecosystem tools. After reviewing the code the current server filter implementation has a number of issues that could impact correct behavior

1. not thread safe
2. incorrect double encoding behavior if a handler also handles accept-encoding
3. incorrect closure of the response writer during panics

Rather than roll our own code, take the upstream gorilla/handlers (i have this as third_party for now, but we could easily fork the repo under k8s.io and add the necessary patch) and integrate it.

With these changes the more extensive aggregated API usage in OpenShift test suites passes while before it failed (https://github.com/openshift/origin/pull/22770)

Since the go client exercises this code automatically, passage of this code here and in OpenShift represents a reasonably large subset of the apiserver variants that we could encounter. 

TODO:

* [ ] review ecosystem aggregated apis for implications
* [ ] decide how to manage the dependency (third_party vs fork into k8s.io/*)
* [ ] compare gorilla/handlers to other variants to ensure we aren't missing anything obvious
* [ ] add a better e2e test
* [ ] promote to beta in 1.16 if we get sufficient soak
* [ ] decided whether we want to default to a lower quality level for better CPU tradeoff


/kind bug
/assign @liggitt

```release-note
Replace the custom gzip server filter with a more correct implementation.
```