### PR TITLE
Continue with next finder if there is error with one finder

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -270,6 +270,7 @@ func (dc *DisruptionController) getPodReplicationController(pod *v1.Pod) (*contr
 	}
 	rc, err := dc.rcLister.ReplicationControllers(pod.Namespace).Get(controllerRef.Name)
 	if err != nil {
+		klog.Warningf("error retrieving ReplicationController %v", err)
 		// The only possible error is NotFound, which is ok here.
 		return nil, nil
 	}
@@ -588,7 +589,7 @@ func (dc *DisruptionController) getExpectedScale(pdb *policy.PodDisruptionBudget
 			var controllerNScale *controllerAndScale
 			controllerNScale, err = finder(pod)
 			if err != nil {
-				return
+				continue
 			}
 			if controllerNScale != nil {
 				controllerScale[controllerNScale.UID] = controllerNScale.scale


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In DisruptionController#getExpectedScale, when one finder returns error, we can continue with next finder.
The check following the inner loop would make sure there is controller per pod.

```release-note
NONE
```
