### PR TITLE
Avoid crashing kubelet when trying to use the RuntimeClassManager wit…

### DIFF
--- a/pkg/kubelet/runtimeclass/runtimeclass_manager.go
+++ b/pkg/kubelet/runtimeclass/runtimeclass_manager.go
@@ -35,6 +35,10 @@ type Manager struct {
 func NewManager(client clientset.Interface) *Manager {
 	const resyncPeriod = 0
 
+	if client == nil {
+	    return nil
+	}
+
 	factory := informers.NewSharedInformerFactory(client, resyncPeriod)
 	lister := factory.Node().V1beta1().RuntimeClasses().Lister()
 


### PR DESCRIPTION
…hout an api-server

Crashing kubelet makes it unnecessarily hard to find the real problem.

E.g. in my case it was the case that the default system unit file for
kubelet on Gentoo ignores the config provided by kubeadm. Therefore calling
kubeadm join ended up with starting kubelet without a config which then
resulted in a crash when the RuntimeClassManager tried to access the
non-existent kubeconfig.

Avoid that.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
