### PR TITLE
Do not log and record the event when we can not find the plugin and the StorageClassName is not set

### DIFF
--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -216,6 +216,13 @@ func (expc *expandController) pvcUpdate(oldObj, newObj interface{}) {
 			eventType := v1.EventTypeNormal
 			if err != nil {
 				eventType = v1.EventTypeWarning
+			} else {
+				// Do not log and record the event when we can not found the plugin
+				// and the StorageClassName is not set at the same time.
+				// See https://github.com/kubernetes/kubernetes/issues/77404
+				if len(pv.Spec.StorageClassName) == 0 {
+					return
+				}
 			}
 			expc.recorder.Event(newPVC, eventType, events.ExternalExpanding,
 				fmt.Sprintf("Ignoring the PVC: %v.", err))

--- a/pkg/controller/volume/expand/pvc_populator.go
+++ b/pkg/controller/volume/expand/pvc_populator.go
@@ -107,6 +107,13 @@ func (populator *pvcPopulator) Sync() {
 			eventType := v1.EventTypeNormal
 			if err != nil {
 				eventType = v1.EventTypeWarning
+			} else {
+				// Do not log and record the event when we can not found the plugin
+				// and the StorageClassName is not set at the same time.
+				// See https://github.com/kubernetes/kubernetes/issues/77404
+				if len(pv.Spec.StorageClassName) == 0 {
+					return
+				}
 			}
 			populator.recorder.Event(pvc, eventType, events.ExternalExpanding,
 				fmt.Sprintf("Ignoring the PVC: %v.", err))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug

**What this PR does / why we need it**:

Do not log and record the event when can not find the plugin and the StorageClassName is not set. Because when this happens, external-expander would also can not found the storage driver to expand the volume.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #77404 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Do not log and record the event when can not find the plugin and the StorageClassName is not set.
```
