### PR TITLE
feat: remove klog in AddUnschedulableIfNotPresent

### DIFF
--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -682,7 +682,9 @@ func MakeDefaultErrorFunc(client clientset.Interface, podQueue internalqueue.Sch
 				pod, err := client.CoreV1().Pods(podID.Namespace).Get(podID.Name, metav1.GetOptions{})
 				if err == nil {
 					if len(pod.Spec.NodeName) == 0 {
-						podQueue.AddUnschedulableIfNotPresent(pod, podSchedulingCycle)
+						if err := podQueue.AddUnschedulableIfNotPresent(pod, podSchedulingCycle); err != nil {
+							klog.Error(err)
+						}
 					}
 					break
 				}

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -313,10 +313,7 @@ func (p *PriorityQueue) AddUnschedulableIfNotPresent(pod *v1.Pod, podSchedulingC
 	// it to unschedulableQ.
 	if p.moveRequestCycle >= podSchedulingCycle {
 		if err := p.podBackoffQ.Add(pInfo); err != nil {
-			// TODO: Delete this klog call and log returned errors at the call site.
-			err = fmt.Errorf("error adding pod %v to the backoff queue: %v", pod.Name, err)
-			klog.Error(err)
-			return err
+			return fmt.Errorf("error adding pod %v to the backoff queue: %v", pod.Name, err)
 		}
 	} else {
 		p.unschedulableQ.addOrUpdate(pInfo)


### PR DESCRIPTION
/kind cleanup
/priority backlog

**What this PR does / why we need it**:

move `klog` from `AddUnschedulableIfNotPresent` and to the call site.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
