### PR TITLE
fix increment-decrement lint error

### DIFF
--- a/pkg/credentialprovider/keyring_test.go
+++ b/pkg/credentialprovider/keyring_test.go
@@ -470,7 +470,7 @@ func (d *testProvider) LazyProvide(image string) *DockerConfigEntry {
 
 // Provide implements dockerConfigProvider
 func (d *testProvider) Provide(image string) DockerConfig {
-	d.Count += 1
+	d.Count++
 	return DockerConfig{}
 }
 

--- a/pkg/registry/apps/replicaset/storage/storage_test.go
+++ b/pkg/registry/apps/replicaset/storage/storage_test.go
@@ -173,7 +173,7 @@ func TestGenerationNumber(t *testing.T) {
 	}
 
 	// Updates to spec should increment the generation number
-	storedRS.Spec.Replicas += 1
+	storedRS.Spec.Replicas++
 	if _, _, err := storage.ReplicaSet.Update(ctx, storedRS.Name, rest.DefaultUpdatedObjectInfo(storedRS), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestGenerationNumber(t *testing.T) {
 	}
 
 	// Updates to status should not increment either spec or status generation numbers
-	storedRS.Status.Replicas += 1
+	storedRS.Status.Replicas++
 	if _, _, err := storage.ReplicaSet.Update(ctx, storedRS.Name, rest.DefaultUpdatedObjectInfo(storedRS), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/registry/core/replicationcontroller/storage/storage_test.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage_test.go
@@ -176,7 +176,7 @@ func TestGenerationNumber(t *testing.T) {
 	}
 
 	// Updates to spec should increment the generation number
-	controller.Spec.Replicas += 1
+	controller.Spec.Replicas++
 	if _, _, err := storage.Controller.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestGenerationNumber(t *testing.T) {
 	}
 
 	// Updates to status should not increment either spec or status generation numbers
-	controller.Status.Replicas += 1
+	controller.Status.Replicas++
 	if _, _, err := storage.Controller.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
@@ -196,7 +196,7 @@ func negativeScaleInt64(base int64, scale Scale) (result int64, exact bool) {
 		if base > 0 {
 			value++
 		} else {
-			value += -1
+			value--
 		}
 	}
 	return value, !fraction

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
@@ -194,7 +194,7 @@ func negativeScaleInt64(base int64, scale Scale) (result int64, exact bool) {
 	}
 	if fraction {
 		if base > 0 {
-			value += 1
+			value++
 		} else {
 			value += -1
 		}

--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -93,17 +93,17 @@ func (j *JSONPath) FindResults(data interface{}) ([][]reflect.Value, error) {
 
 		// encounter an end node, break the current block
 		if j.endRange > 0 && j.endRange <= j.inRange {
-			j.endRange -= 1
+			j.endRange--
 			break
 		}
 		// encounter a range node, start a range loop
 		if j.beginRange > 0 {
-			j.beginRange -= 1
-			j.inRange += 1
+			j.beginRange--
+			j.inRange++
 			for k, value := range results {
 				j.parser.Root.Nodes = nodes[i+1:]
 				if k == len(results)-1 {
-					j.inRange -= 1
+					j.inRange--
 				}
 				nextResults, err := j.FindResults(value.Interface())
 				if err != nil {
@@ -213,11 +213,11 @@ func (j *JSONPath) evalIdentifier(input []reflect.Value, node *IdentifierNode) (
 	switch node.Name {
 	case "range":
 		j.stack = append(j.stack, j.cur)
-		j.beginRange += 1
+		j.beginRange++
 		results = input
 	case "end":
 		if j.endRange < j.inRange { // inside a loop, break the current block
-			j.endRange += 1
+			j.endRange++
 			break
 		}
 		// the loop is about to end, pop value and continue the following execution

--- a/test/e2e/network/service_latency.go
+++ b/test/e2e/network/service_latency.go
@@ -177,7 +177,7 @@ func runServiceLatencies(f *framework.Framework, inParallel, total int, acceptab
 		select {
 		case e := <-errs:
 			e2elog.Logf("Got error: %v", e)
-			errCount += 1
+			errCount++
 		case d := <-durations:
 			output = append(output, d)
 		}

--- a/test/e2e_node/garbage_collector_test.go
+++ b/test/e2e_node/garbage_collector_test.go
@@ -200,7 +200,7 @@ func containerGCTest(f *framework.Framework, test testRun) {
 						containerCount := 0
 						for _, containerName := range containerNames {
 							if containerName == pod.getContainerName(i) {
-								containerCount += 1
+								containerCount++
 							}
 						}
 						if containerCount > maxPerPodContainer+1 {
@@ -228,7 +228,7 @@ func containerGCTest(f *framework.Framework, test testRun) {
 							containerCount := 0
 							for _, containerName := range containerNames {
 								if containerName == pod.getContainerName(i) {
-									containerCount += 1
+									containerCount++
 								}
 							}
 							if pod.restartCount > 0 && containerCount < maxPerPodContainer+1 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

fix increment-decrement lint error:
1. replace `+=1` with `++`
2. replace `-=1` with `--`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
