### PR TITLE
remove VM API call dependency in azure disk WaitForAttach

### DIFF
--- a/pkg/volume/azure_dd/BUILD
+++ b/pkg/volume/azure_dd/BUILD
@@ -60,6 +60,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "attacher_test.go",
         "azure_common_test.go",
         "azure_dd_block_test.go",
         "azure_dd_test.go",

--- a/pkg/volume/azure_dd/attacher_test.go
+++ b/pkg/volume/azure_dd/attacher_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure_dd
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/volume"
+)
+
+func createVolSpec(name string, readOnly bool) *volume.Spec {
+	return &volume.Spec{
+		Volume: &v1.Volume{
+			VolumeSource: v1.VolumeSource{
+				AzureDisk: &v1.AzureDiskVolumeSource{
+					DiskName: name,
+					ReadOnly: &readOnly,
+				},
+			},
+		},
+	}
+}
+func TestWaitForAttach(t *testing.T) {
+	tests := []struct {
+		devicePath  string
+		expected    string
+		expectError bool
+	}{
+		{
+			devicePath:  "/dev/disk/azure/scsi1/lun0",
+			expected:    "/dev/disk/azure/scsi1/lun0",
+			expectError: false,
+		},
+		{
+			devicePath:  "/dev/sdc",
+			expected:    "/dev/sdc",
+			expectError: false,
+		},
+		{
+			devicePath:  "/dev/disk0",
+			expected:    "/dev/disk0",
+			expectError: false,
+		},
+	}
+
+	attacher := azureDiskAttacher{}
+	spec := createVolSpec("fakedisk", false)
+
+	for _, test := range tests {
+		result, err := attacher.WaitForAttach(spec, test.devicePath, nil, 3000*time.Millisecond)
+		assert.Equal(t, result, test.expected)
+		assert.Equal(t, err != nil, test.expectError, fmt.Sprintf("error msg: %v", err))
+	}
+}

--- a/pkg/volume/azure_dd/azure_common_test.go
+++ b/pkg/volume/azure_dd/azure_common_test.go
@@ -183,57 +183,42 @@ func TestNormalizeStorageAccountType(t *testing.T) {
 	}
 }
 
-func TestGetDiskLUN(t *testing.T) {
+func TestGetDiskNum(t *testing.T) {
 	tests := []struct {
 		deviceInfo  string
-		expectedLUN int32
+		expectedNum string
 		expectError bool
 	}{
 		{
-			deviceInfo:  "0",
-			expectedLUN: 0,
+			deviceInfo:  "/dev/disk0",
+			expectedNum: "0",
 			expectError: false,
 		},
 		{
-			deviceInfo:  "10",
-			expectedLUN: 10,
+			deviceInfo:  "/dev/disk99",
+			expectedNum: "99",
 			expectError: false,
 		},
 		{
-			deviceInfo:  "11d",
-			expectedLUN: -1,
+			deviceInfo:  "",
+			expectedNum: "",
+			expectError: true,
+		},
+		{
+			deviceInfo:  "/dev/disk",
+			expectedNum: "",
 			expectError: true,
 		},
 		{
 			deviceInfo:  "999",
-			expectedLUN: -1,
-			expectError: true,
-		},
-		{
-			deviceInfo:  "",
-			expectedLUN: -1,
-			expectError: true,
-		},
-		{
-			deviceInfo:  "/dev/disk/azure/scsi1/lun2",
-			expectedLUN: 2,
-			expectError: false,
-		},
-		{
-			deviceInfo:  "/dev/disk/azure/scsi0/lun12",
-			expectedLUN: 12,
-			expectError: false,
-		},
-		{
-			deviceInfo:  "/dev/disk/by-id/scsi1/lun2",
-			expectedLUN: -1,
+			expectedNum: "",
 			expectError: true,
 		},
 	}
 
 	for _, test := range tests {
-		result, err := getDiskLUN(test.deviceInfo)
-		assert.Equal(t, result, test.expectedLUN)
+		result, err := getDiskNum(test.deviceInfo)
+		assert.Equal(t, result, test.expectedNum)
 		assert.Equal(t, err != nil, test.expectError, fmt.Sprintf("error msg: %v", err))
 	}
 }

--- a/pkg/volume/azure_dd/azure_common_windows.go
+++ b/pkg/volume/azure_dd/azure_common_windows.go
@@ -84,7 +84,7 @@ func findDiskByLun(lun int, iohandler ioHandler, exec mount.Exec) (string, error
 					if d, ok := v["number"]; ok {
 						if diskNum, ok := d.(float64); ok {
 							klog.V(2).Infof("azureDisk Mount: got disk number(%d) by LUN(%d)", int(diskNum), lun)
-							return strconv.Itoa(int(diskNum)), nil
+							return fmt.Sprintf(winDiskNumFormat, int(diskNum)), nil
 						}
 						klog.Warningf("LUN(%d) found, but could not get disk number(%q), location: %q", lun, d, location)
 					}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR removes the VM API call dep in azure disk `WaitForAttach` func, originally `devicePath` is a disk LUN num, and then it could be a real device path due to the volume status update(you could find more details in this PR: https://github.com/kubernetes/kubernetes/pull/62612), in that condition, return the `devicePath` immediately, get disk lun num by VM API call is actually not necessary.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #77462

**Special notes for your reviewer**:

**release-note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
remove VM API call dep in azure disk WaitForAttach
```

/assign @feiskyer @khenidak
/priority important-soon
/sig azure