### PR TITLE
add operation name for vm/vmss update operations in prometheus metrics

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
@@ -550,25 +550,13 @@ func (az *Cloud) deleteRouteWithRetry(routeName string) error {
 	})
 }
 
-// CreateOrUpdateVMWithRetry invokes az.VirtualMachinesClient.CreateOrUpdate with exponential backoff retry
-func (az *Cloud) CreateOrUpdateVMWithRetry(resourceGroup, vmName string, newVM compute.VirtualMachine) error {
-	return wait.ExponentialBackoff(az.requestBackoff(), func() (bool, error) {
-		ctx, cancel := getContextWithCancel()
-		defer cancel()
-
-		resp, err := az.VirtualMachinesClient.CreateOrUpdate(ctx, resourceGroup, vmName, newVM)
-		klog.V(10).Infof("VirtualMachinesClient.CreateOrUpdate(%s): end", vmName)
-		return az.processHTTPRetryResponse(nil, "", resp, err)
-	})
-}
-
 // UpdateVmssVMWithRetry invokes az.VirtualMachineScaleSetVMsClient.Update with exponential backoff retry
-func (az *Cloud) UpdateVmssVMWithRetry(resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.VirtualMachineScaleSetVM) error {
+func (az *Cloud) UpdateVmssVMWithRetry(resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.VirtualMachineScaleSetVM, source string) error {
 	return wait.ExponentialBackoff(az.requestBackoff(), func() (bool, error) {
 		ctx, cancel := getContextWithCancel()
 		defer cancel()
 
-		resp, err := az.VirtualMachineScaleSetVMsClient.Update(ctx, resourceGroupName, VMScaleSetName, instanceID, parameters)
+		resp, err := az.VirtualMachineScaleSetVMsClient.Update(ctx, resourceGroupName, VMScaleSetName, instanceID, parameters, source)
 		klog.V(10).Infof("VirtualMachinesClient.CreateOrUpdate(%s,%s): end", VMScaleSetName, instanceID)
 		return az.processHTTPRetryResponse(nil, "", resp, err)
 	})

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_client.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_client.go
@@ -48,7 +48,7 @@ func createRateLimitErr(isWrite bool, opName string) error {
 
 // VirtualMachinesClient defines needed functions for azure compute.VirtualMachinesClient
 type VirtualMachinesClient interface {
-	CreateOrUpdate(ctx context.Context, resourceGroupName string, VMName string, parameters compute.VirtualMachine) (resp *http.Response, err error)
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, VMName string, parameters compute.VirtualMachine, source string) (resp *http.Response, err error)
 	Get(ctx context.Context, resourceGroupName string, VMName string, expand compute.InstanceViewTypes) (result compute.VirtualMachine, err error)
 	List(ctx context.Context, resourceGroupName string) (result []compute.VirtualMachine, err error)
 }
@@ -103,7 +103,7 @@ type VirtualMachineScaleSetVMsClient interface {
 	Get(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string) (result compute.VirtualMachineScaleSetVM, err error)
 	GetInstanceView(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string) (result compute.VirtualMachineScaleSetVMInstanceView, err error)
 	List(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, filter string, selectParameter string, expand string) (result []compute.VirtualMachineScaleSetVM, err error)
-	Update(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.VirtualMachineScaleSetVM) (resp *http.Response, err error)
+	Update(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.VirtualMachineScaleSetVM, source string) (resp *http.Response, err error)
 }
 
 // RoutesClient defines needed functions for azure network.RoutesClient
@@ -183,7 +183,7 @@ func newAzVirtualMachinesClient(config *azClientConfig) *azVirtualMachinesClient
 	}
 }
 
-func (az *azVirtualMachinesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, VMName string, parameters compute.VirtualMachine) (resp *http.Response, err error) {
+func (az *azVirtualMachinesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, VMName string, parameters compute.VirtualMachine, source string) (resp *http.Response, err error) {
 	// /* Write rate limiting */
 	if !az.rateLimiterWriter.TryAccept() {
 		err = createRateLimitErr(true, "VMCreateOrUpdate")
@@ -195,7 +195,7 @@ func (az *azVirtualMachinesClient) CreateOrUpdate(ctx context.Context, resourceG
 		klog.V(10).Infof("azVirtualMachinesClient.CreateOrUpdate(%q, %q): end", resourceGroupName, VMName)
 	}()
 
-	mc := newMetricContext("vm", "create_or_update", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("vm", "create_or_update", resourceGroupName, az.client.SubscriptionID, source)
 	future, err := az.client.CreateOrUpdate(ctx, resourceGroupName, VMName, parameters)
 	if err != nil {
 		return future.Response(), err
@@ -217,7 +217,7 @@ func (az *azVirtualMachinesClient) Get(ctx context.Context, resourceGroupName st
 		klog.V(10).Infof("azVirtualMachinesClient.Get(%q, %q): end", resourceGroupName, VMName)
 	}()
 
-	mc := newMetricContext("vm", "get", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("vm", "get", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.Get(ctx, resourceGroupName, VMName, expand)
 	mc.Observe(err)
 	return
@@ -234,7 +234,7 @@ func (az *azVirtualMachinesClient) List(ctx context.Context, resourceGroupName s
 		klog.V(10).Infof("azVirtualMachinesClient.List(%q): end", resourceGroupName)
 	}()
 
-	mc := newMetricContext("vm", "list", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("vm", "list", resourceGroupName, az.client.SubscriptionID, "")
 	iterator, err := az.client.ListComplete(ctx, resourceGroupName)
 	mc.Observe(err)
 	if err != nil {
@@ -290,7 +290,7 @@ func (az *azInterfacesClient) CreateOrUpdate(ctx context.Context, resourceGroupN
 		klog.V(10).Infof("azInterfacesClient.CreateOrUpdate(%q,%q): end", resourceGroupName, networkInterfaceName)
 	}()
 
-	mc := newMetricContext("interfaces", "create_or_update", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("interfaces", "create_or_update", resourceGroupName, az.client.SubscriptionID, "")
 	future, err := az.client.CreateOrUpdate(ctx, resourceGroupName, networkInterfaceName, parameters)
 	if err != nil {
 		mc.Observe(err)
@@ -313,7 +313,7 @@ func (az *azInterfacesClient) Get(ctx context.Context, resourceGroupName string,
 		klog.V(10).Infof("azInterfacesClient.Get(%q,%q): end", resourceGroupName, networkInterfaceName)
 	}()
 
-	mc := newMetricContext("interfaces", "get", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("interfaces", "get", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.Get(ctx, resourceGroupName, networkInterfaceName, expand)
 	mc.Observe(err)
 	return
@@ -330,7 +330,7 @@ func (az *azInterfacesClient) GetVirtualMachineScaleSetNetworkInterface(ctx cont
 		klog.V(10).Infof("azInterfacesClient.GetVirtualMachineScaleSetNetworkInterface(%q,%q,%q,%q): end", resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName)
 	}()
 
-	mc := newMetricContext("interfaces", "get_vmss_ni", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("interfaces", "get_vmss_ni", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.GetVirtualMachineScaleSetNetworkInterface(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, expand)
 	mc.Observe(err)
 	return
@@ -373,7 +373,7 @@ func (az *azLoadBalancersClient) CreateOrUpdate(ctx context.Context, resourceGro
 		klog.V(10).Infof("azLoadBalancersClient.CreateOrUpdate(%q,%q): end", resourceGroupName, loadBalancerName)
 	}()
 
-	mc := newMetricContext("load_balancers", "create_or_update", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("load_balancers", "create_or_update", resourceGroupName, az.client.SubscriptionID, "")
 	req, err := az.createOrUpdatePreparer(ctx, resourceGroupName, loadBalancerName, parameters, etag)
 	if err != nil {
 		mc.Observe(err)
@@ -430,7 +430,7 @@ func (az *azLoadBalancersClient) Delete(ctx context.Context, resourceGroupName s
 		klog.V(10).Infof("azLoadBalancersClient.Delete(%q,%q): end", resourceGroupName, loadBalancerName)
 	}()
 
-	mc := newMetricContext("load_balancers", "delete", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("load_balancers", "delete", resourceGroupName, az.client.SubscriptionID, "")
 	future, err := az.client.Delete(ctx, resourceGroupName, loadBalancerName)
 	mc.Observe(err)
 	if err != nil {
@@ -453,7 +453,7 @@ func (az *azLoadBalancersClient) Get(ctx context.Context, resourceGroupName stri
 		klog.V(10).Infof("azLoadBalancersClient.Get(%q,%q): end", resourceGroupName, loadBalancerName)
 	}()
 
-	mc := newMetricContext("load_balancers", "get", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("load_balancers", "get", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.Get(ctx, resourceGroupName, loadBalancerName, expand)
 	mc.Observe(err)
 	return
@@ -470,7 +470,7 @@ func (az *azLoadBalancersClient) List(ctx context.Context, resourceGroupName str
 		klog.V(10).Infof("azLoadBalancersClient.List(%q): end", resourceGroupName)
 	}()
 
-	mc := newMetricContext("load_balancers", "list", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("load_balancers", "list", resourceGroupName, az.client.SubscriptionID, "")
 	iterator, err := az.client.ListComplete(ctx, resourceGroupName)
 	mc.Observe(err)
 	if err != nil {
@@ -526,7 +526,7 @@ func (az *azPublicIPAddressesClient) CreateOrUpdate(ctx context.Context, resourc
 		klog.V(10).Infof("azPublicIPAddressesClient.CreateOrUpdate(%q,%q): end", resourceGroupName, publicIPAddressName)
 	}()
 
-	mc := newMetricContext("public_ip_addresses", "create_or_update", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("public_ip_addresses", "create_or_update", resourceGroupName, az.client.SubscriptionID, "")
 	future, err := az.client.CreateOrUpdate(ctx, resourceGroupName, publicIPAddressName, parameters)
 	mc.Observe(err)
 	if err != nil {
@@ -550,7 +550,7 @@ func (az *azPublicIPAddressesClient) Delete(ctx context.Context, resourceGroupNa
 		klog.V(10).Infof("azPublicIPAddressesClient.Delete(%q,%q): end", resourceGroupName, publicIPAddressName)
 	}()
 
-	mc := newMetricContext("public_ip_addresses", "delete", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("public_ip_addresses", "delete", resourceGroupName, az.client.SubscriptionID, "")
 	future, err := az.client.Delete(ctx, resourceGroupName, publicIPAddressName)
 	mc.Observe(err)
 	if err != nil {
@@ -573,7 +573,7 @@ func (az *azPublicIPAddressesClient) Get(ctx context.Context, resourceGroupName 
 		klog.V(10).Infof("azPublicIPAddressesClient.Get(%q,%q): end", resourceGroupName, publicIPAddressName)
 	}()
 
-	mc := newMetricContext("public_ip_addresses", "get", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("public_ip_addresses", "get", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.Get(ctx, resourceGroupName, publicIPAddressName, expand)
 	mc.Observe(err)
 	return
@@ -589,7 +589,7 @@ func (az *azPublicIPAddressesClient) List(ctx context.Context, resourceGroupName
 		klog.V(10).Infof("azPublicIPAddressesClient.List(%q): end", resourceGroupName)
 	}()
 
-	mc := newMetricContext("public_ip_addresses", "list", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("public_ip_addresses", "list", resourceGroupName, az.client.SubscriptionID, "")
 	iterator, err := az.client.ListComplete(ctx, resourceGroupName)
 	mc.Observe(err)
 	if err != nil {
@@ -645,7 +645,7 @@ func (az *azSubnetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName
 		klog.V(10).Infof("azSubnetsClient.CreateOrUpdate(%q,%q,%q): end", resourceGroupName, virtualNetworkName, subnetName)
 	}()
 
-	mc := newMetricContext("subnets", "create_or_update", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("subnets", "create_or_update", resourceGroupName, az.client.SubscriptionID, "")
 	future, err := az.client.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkName, subnetName, subnetParameters)
 	if err != nil {
 		mc.Observe(err)
@@ -669,7 +669,7 @@ func (az *azSubnetsClient) Delete(ctx context.Context, resourceGroupName string,
 		klog.V(10).Infof("azSubnetsClient.Delete(%q,%q,%q): end", resourceGroupName, virtualNetworkName, subnetName)
 	}()
 
-	mc := newMetricContext("subnets", "delete", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("subnets", "delete", resourceGroupName, az.client.SubscriptionID, "")
 	future, err := az.client.Delete(ctx, resourceGroupName, virtualNetworkName, subnetName)
 	if err != nil {
 		mc.Observe(err)
@@ -692,7 +692,7 @@ func (az *azSubnetsClient) Get(ctx context.Context, resourceGroupName string, vi
 		klog.V(10).Infof("azSubnetsClient.Get(%q,%q,%q): end", resourceGroupName, virtualNetworkName, subnetName)
 	}()
 
-	mc := newMetricContext("subnets", "get", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("subnets", "get", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.Get(ctx, resourceGroupName, virtualNetworkName, subnetName, expand)
 	mc.Observe(err)
 	return
@@ -708,7 +708,7 @@ func (az *azSubnetsClient) List(ctx context.Context, resourceGroupName string, v
 		klog.V(10).Infof("azSubnetsClient.List(%q,%q): end", resourceGroupName, virtualNetworkName)
 	}()
 
-	mc := newMetricContext("subnets", "list", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("subnets", "list", resourceGroupName, az.client.SubscriptionID, "")
 	iterator, err := az.client.ListComplete(ctx, resourceGroupName, virtualNetworkName)
 	if err != nil {
 		mc.Observe(err)
@@ -764,7 +764,7 @@ func (az *azSecurityGroupsClient) CreateOrUpdate(ctx context.Context, resourceGr
 		klog.V(10).Infof("azSecurityGroupsClient.CreateOrUpdate(%q,%q): end", resourceGroupName, networkSecurityGroupName)
 	}()
 
-	mc := newMetricContext("security_groups", "create_or_update", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("security_groups", "create_or_update", resourceGroupName, az.client.SubscriptionID, "")
 	req, err := az.createOrUpdatePreparer(ctx, resourceGroupName, networkSecurityGroupName, parameters, etag)
 	if err != nil {
 		mc.Observe(err)
@@ -821,7 +821,7 @@ func (az *azSecurityGroupsClient) Delete(ctx context.Context, resourceGroupName 
 		klog.V(10).Infof("azSecurityGroupsClient.Delete(%q,%q): end", resourceGroupName, networkSecurityGroupName)
 	}()
 
-	mc := newMetricContext("security_groups", "delete", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("security_groups", "delete", resourceGroupName, az.client.SubscriptionID, "")
 	future, err := az.client.Delete(ctx, resourceGroupName, networkSecurityGroupName)
 	if err != nil {
 		mc.Observe(err)
@@ -844,7 +844,7 @@ func (az *azSecurityGroupsClient) Get(ctx context.Context, resourceGroupName str
 		klog.V(10).Infof("azSecurityGroupsClient.Get(%q,%q): end", resourceGroupName, networkSecurityGroupName)
 	}()
 
-	mc := newMetricContext("security_groups", "get", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("security_groups", "get", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.Get(ctx, resourceGroupName, networkSecurityGroupName, expand)
 	mc.Observe(err)
 	return
@@ -860,7 +860,7 @@ func (az *azSecurityGroupsClient) List(ctx context.Context, resourceGroupName st
 		klog.V(10).Infof("azSecurityGroupsClient.List(%q): end", resourceGroupName)
 	}()
 
-	mc := newMetricContext("security_groups", "list", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("security_groups", "list", resourceGroupName, az.client.SubscriptionID, "")
 	iterator, err := az.client.ListComplete(ctx, resourceGroupName)
 	mc.Observe(err)
 	if err != nil {
@@ -915,7 +915,7 @@ func (az *azVirtualMachineScaleSetsClient) Get(ctx context.Context, resourceGrou
 		klog.V(10).Infof("azVirtualMachineScaleSetsClient.Get(%q,%q): end", resourceGroupName, VMScaleSetName)
 	}()
 
-	mc := newMetricContext("vmss", "get", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("vmss", "get", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.Get(ctx, resourceGroupName, VMScaleSetName)
 	mc.Observe(err)
 	return
@@ -932,7 +932,7 @@ func (az *azVirtualMachineScaleSetsClient) List(ctx context.Context, resourceGro
 		klog.V(10).Infof("azVirtualMachineScaleSetsClient.List(%q): end", resourceGroupName)
 	}()
 
-	mc := newMetricContext("vmss", "list", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("vmss", "list", resourceGroupName, az.client.SubscriptionID, "")
 	iterator, err := az.client.ListComplete(ctx, resourceGroupName)
 	mc.Observe(err)
 	if err != nil {
@@ -987,7 +987,7 @@ func (az *azVirtualMachineScaleSetVMsClient) Get(ctx context.Context, resourceGr
 		klog.V(10).Infof("azVirtualMachineScaleSetVMsClient.Get(%q,%q,%q): end", resourceGroupName, VMScaleSetName, instanceID)
 	}()
 
-	mc := newMetricContext("vmssvm", "get", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("vmssvm", "get", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.Get(ctx, resourceGroupName, VMScaleSetName, instanceID)
 	mc.Observe(err)
 	return
@@ -1004,7 +1004,7 @@ func (az *azVirtualMachineScaleSetVMsClient) GetInstanceView(ctx context.Context
 		klog.V(10).Infof("azVirtualMachineScaleSetVMsClient.GetInstanceView(%q,%q,%q): end", resourceGroupName, VMScaleSetName, instanceID)
 	}()
 
-	mc := newMetricContext("vmssvm", "get_instance_view", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("vmssvm", "get_instance_view", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.GetInstanceView(ctx, resourceGroupName, VMScaleSetName, instanceID)
 	mc.Observe(err)
 	return
@@ -1021,7 +1021,7 @@ func (az *azVirtualMachineScaleSetVMsClient) List(ctx context.Context, resourceG
 		klog.V(10).Infof("azVirtualMachineScaleSetVMsClient.List(%q,%q,%q): end", resourceGroupName, virtualMachineScaleSetName, filter)
 	}()
 
-	mc := newMetricContext("vmssvm", "list", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("vmssvm", "list", resourceGroupName, az.client.SubscriptionID, "")
 	iterator, err := az.client.ListComplete(ctx, resourceGroupName, virtualMachineScaleSetName, filter, selectParameter, expand)
 	mc.Observe(err)
 	if err != nil {
@@ -1040,7 +1040,7 @@ func (az *azVirtualMachineScaleSetVMsClient) List(ctx context.Context, resourceG
 	return result, nil
 }
 
-func (az *azVirtualMachineScaleSetVMsClient) Update(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.VirtualMachineScaleSetVM) (resp *http.Response, err error) {
+func (az *azVirtualMachineScaleSetVMsClient) Update(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.VirtualMachineScaleSetVM, source string) (resp *http.Response, err error) {
 	if !az.rateLimiterWriter.TryAccept() {
 		err = createRateLimitErr(true, "VMSSUpdate")
 		return
@@ -1051,7 +1051,7 @@ func (az *azVirtualMachineScaleSetVMsClient) Update(ctx context.Context, resourc
 		klog.V(10).Infof("azVirtualMachineScaleSetVMsClient.Update(%q,%q,%q): end", resourceGroupName, VMScaleSetName, instanceID)
 	}()
 
-	mc := newMetricContext("vmssvm", "update", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("vmssvm", "create_or_update", resourceGroupName, az.client.SubscriptionID, source)
 	future, err := az.client.Update(ctx, resourceGroupName, VMScaleSetName, instanceID, parameters)
 	mc.Observe(err)
 	if err != nil {
@@ -1100,7 +1100,7 @@ func (az *azRoutesClient) CreateOrUpdate(ctx context.Context, resourceGroupName 
 		klog.V(10).Infof("azRoutesClient.CreateOrUpdate(%q,%q,%q): end", resourceGroupName, routeTableName, routeName)
 	}()
 
-	mc := newMetricContext("routes", "create_or_update", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("routes", "create_or_update", resourceGroupName, az.client.SubscriptionID, "")
 	req, err := az.createOrUpdatePreparer(ctx, resourceGroupName, routeTableName, routeName, routeParameters, etag)
 	if err != nil {
 		mc.Observe(err)
@@ -1159,7 +1159,7 @@ func (az *azRoutesClient) Delete(ctx context.Context, resourceGroupName string, 
 		klog.V(10).Infof("azRoutesClient.Delete(%q,%q,%q): end", resourceGroupName, routeTableName, routeName)
 	}()
 
-	mc := newMetricContext("routes", "delete", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("routes", "delete", resourceGroupName, az.client.SubscriptionID, "")
 	future, err := az.client.Delete(ctx, resourceGroupName, routeTableName, routeName)
 	if err != nil {
 		mc.Observe(err)
@@ -1208,7 +1208,7 @@ func (az *azRouteTablesClient) CreateOrUpdate(ctx context.Context, resourceGroup
 		klog.V(10).Infof("azRouteTablesClient.CreateOrUpdate(%q,%q): end", resourceGroupName, routeTableName)
 	}()
 
-	mc := newMetricContext("route_tables", "create_or_update", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("route_tables", "create_or_update", resourceGroupName, az.client.SubscriptionID, "")
 	req, err := az.createOrUpdatePreparer(ctx, resourceGroupName, routeTableName, parameters, etag)
 	if err != nil {
 		mc.Observe(err)
@@ -1264,7 +1264,7 @@ func (az *azRouteTablesClient) Get(ctx context.Context, resourceGroupName string
 		klog.V(10).Infof("azRouteTablesClient.Get(%q,%q): end", resourceGroupName, routeTableName)
 	}()
 
-	mc := newMetricContext("route_tables", "get", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("route_tables", "get", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.Get(ctx, resourceGroupName, routeTableName, expand)
 	mc.Observe(err)
 	return
@@ -1306,7 +1306,7 @@ func (az *azStorageAccountClient) Create(ctx context.Context, resourceGroupName 
 		klog.V(10).Infof("azStorageAccountClient.Create(%q,%q): end", resourceGroupName, accountName)
 	}()
 
-	mc := newMetricContext("storage_account", "create", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("storage_account", "create", resourceGroupName, az.client.SubscriptionID, "")
 	future, err := az.client.Create(ctx, resourceGroupName, accountName, parameters)
 	if err != nil {
 		return future.Response(), err
@@ -1328,7 +1328,7 @@ func (az *azStorageAccountClient) Delete(ctx context.Context, resourceGroupName 
 		klog.V(10).Infof("azStorageAccountClient.Delete(%q,%q): end", resourceGroupName, accountName)
 	}()
 
-	mc := newMetricContext("storage_account", "delete", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("storage_account", "delete", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.Delete(ctx, resourceGroupName, accountName)
 	mc.Observe(err)
 	return
@@ -1345,7 +1345,7 @@ func (az *azStorageAccountClient) ListKeys(ctx context.Context, resourceGroupNam
 		klog.V(10).Infof("azStorageAccountClient.ListKeys(%q,%q): end", resourceGroupName, accountName)
 	}()
 
-	mc := newMetricContext("storage_account", "list_keys", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("storage_account", "list_keys", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.ListKeys(ctx, resourceGroupName, accountName)
 	mc.Observe(err)
 	return
@@ -1362,7 +1362,7 @@ func (az *azStorageAccountClient) ListByResourceGroup(ctx context.Context, resou
 		klog.V(10).Infof("azStorageAccountClient.ListByResourceGroup(%q): end", resourceGroupName)
 	}()
 
-	mc := newMetricContext("storage_account", "list_by_resource_group", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("storage_account", "list_by_resource_group", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.ListByResourceGroup(ctx, resourceGroupName)
 	mc.Observe(err)
 	return
@@ -1379,7 +1379,7 @@ func (az *azStorageAccountClient) GetProperties(ctx context.Context, resourceGro
 		klog.V(10).Infof("azStorageAccountClient.GetProperties(%q,%q): end", resourceGroupName, accountName)
 	}()
 
-	mc := newMetricContext("storage_account", "get_properties", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("storage_account", "get_properties", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.GetProperties(ctx, resourceGroupName, accountName)
 	mc.Observe(err)
 	return
@@ -1421,7 +1421,7 @@ func (az *azDisksClient) CreateOrUpdate(ctx context.Context, resourceGroupName s
 		klog.V(10).Infof("azDisksClient.CreateOrUpdate(%q,%q): end", resourceGroupName, diskName)
 	}()
 
-	mc := newMetricContext("disks", "create_or_update", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("disks", "create_or_update", resourceGroupName, az.client.SubscriptionID, "")
 	future, err := az.client.CreateOrUpdate(ctx, resourceGroupName, diskName, diskParameter)
 	mc.Observe(err)
 	if err != nil {
@@ -1445,7 +1445,7 @@ func (az *azDisksClient) Delete(ctx context.Context, resourceGroupName string, d
 		klog.V(10).Infof("azDisksClient.Delete(%q,%q): end", resourceGroupName, diskName)
 	}()
 
-	mc := newMetricContext("disks", "delete", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("disks", "delete", resourceGroupName, az.client.SubscriptionID, "")
 	future, err := az.client.Delete(ctx, resourceGroupName, diskName)
 	mc.Observe(err)
 	if err != nil {
@@ -1468,7 +1468,7 @@ func (az *azDisksClient) Get(ctx context.Context, resourceGroupName string, disk
 		klog.V(10).Infof("azDisksClient.Get(%q,%q): end", resourceGroupName, diskName)
 	}()
 
-	mc := newMetricContext("disks", "get", resourceGroupName, az.client.SubscriptionID)
+	mc := newMetricContext("disks", "get", resourceGroupName, az.client.SubscriptionID, "")
 	result, err = az.client.Get(ctx, resourceGroupName, diskName)
 	mc.Observe(err)
 	return
@@ -1522,7 +1522,7 @@ func (az *azVirtualMachineSizesClient) List(ctx context.Context, location string
 		klog.V(10).Infof("azVirtualMachineSizesClient.List(%q): end", location)
 	}()
 
-	mc := newMetricContext("vmsizes", "list", "", az.client.SubscriptionID)
+	mc := newMetricContext("vmsizes", "list", "", az.client.SubscriptionID, "")
 	result, err = az.client.List(ctx, location)
 	mc.Observe(err)
 	return

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_standard.go
@@ -84,7 +84,7 @@ func (as *availabilitySet) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 	// Invalidate the cache right after updating
 	defer as.cloud.vmCache.Delete(vmName)
 
-	_, err = as.VirtualMachinesClient.CreateOrUpdate(ctx, nodeResourceGroup, vmName, newVM)
+	_, err = as.VirtualMachinesClient.CreateOrUpdate(ctx, nodeResourceGroup, vmName, newVM, "attach_disk")
 	if err != nil {
 		klog.Errorf("azureDisk - attach disk(%s, %s) failed, err: %v", diskName, diskURI, err)
 		detail := err.Error()
@@ -151,7 +151,7 @@ func (as *availabilitySet) DetachDisk(diskName, diskURI string, nodeName types.N
 	// Invalidate the cache right after updating
 	defer as.cloud.vmCache.Delete(vmName)
 
-	return as.VirtualMachinesClient.CreateOrUpdate(ctx, nodeResourceGroup, vmName, newVM)
+	return as.VirtualMachinesClient.CreateOrUpdate(ctx, nodeResourceGroup, vmName, newVM, "detach_disk")
 }
 
 // GetDataDisks gets a list of data disks attached to the node.

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_vmss.go
@@ -89,7 +89,7 @@ func (ss *scaleSet) AttachDisk(isManagedDisk bool, diskName, diskURI string, nod
 	defer ss.vmssVMCache.Delete(key)
 
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - attach disk(%s, %s)", nodeResourceGroup, nodeName, diskName, diskURI)
-	_, err = ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM)
+	_, err = ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM, "attach_disk")
 	if err != nil {
 		detail := err.Error()
 		if strings.Contains(detail, errLeaseFailed) || strings.Contains(detail, errDiskBlobNotFound) {
@@ -159,7 +159,7 @@ func (ss *scaleSet) DetachDisk(diskName, diskURI string, nodeName types.NodeName
 	defer ss.vmssVMCache.Delete(key)
 
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - detach disk(%s, %s)", nodeResourceGroup, nodeName, diskName, diskURI)
-	return ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM)
+	return ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM, "detach_disk")
 }
 
 // GetDataDisks gets a list of data disks attached to the node.

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_fakes.go
@@ -290,7 +290,7 @@ func newFakeAzureVirtualMachinesClient() *fakeAzureVirtualMachinesClient {
 	return fVMC
 }
 
-func (fVMC *fakeAzureVirtualMachinesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, VMName string, parameters compute.VirtualMachine) (resp *http.Response, err error) {
+func (fVMC *fakeAzureVirtualMachinesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, VMName string, parameters compute.VirtualMachine, source string) (resp *http.Response, err error) {
 	fVMC.mutex.Lock()
 	defer fVMC.mutex.Unlock()
 
@@ -550,7 +550,7 @@ func (fVMC *fakeVirtualMachineScaleSetVMsClient) GetInstanceView(ctx context.Con
 	return result, nil
 }
 
-func (fVMC *fakeVirtualMachineScaleSetVMsClient) Update(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.VirtualMachineScaleSetVM) (resp *http.Response, err error) {
+func (fVMC *fakeVirtualMachineScaleSetVMsClient) Update(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.VirtualMachineScaleSetVM, source string) (resp *http.Response, err error) {
 	fVMC.mutex.Lock()
 	defer fVMC.mutex.Unlock()
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_metrics.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_metrics.go
@@ -33,6 +33,7 @@ var (
 		"request",         // API function that is being invoked
 		"resource_group",  // Resource group of the resource being monitored
 		"subscription_id", // Subscription ID of the resource being monitored
+		"source",          // Oeration source(optional)
 	}
 
 	apiMetrics = registerAPIMetrics(metricLabels...)
@@ -43,10 +44,10 @@ type metricContext struct {
 	attributes []string
 }
 
-func newMetricContext(prefix, request, resourceGroup, subscriptionID string) *metricContext {
+func newMetricContext(prefix, request, resourceGroup, subscriptionID, source string) *metricContext {
 	return &metricContext{
 		start:      time.Now(),
-		attributes: []string{prefix + "_" + request, strings.ToLower(resourceGroup), subscriptionID},
+		attributes: []string{prefix + "_" + request, strings.ToLower(resourceGroup), subscriptionID, source},
 	}
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_metrics_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_metrics_test.go
@@ -23,12 +23,12 @@ import (
 )
 
 func TestAzureMetricLabelCardinality(t *testing.T) {
-	mc := newMetricContext("test", "create", "resource_group", "subscription_id")
+	mc := newMetricContext("test", "create", "resource_group", "subscription_id", "source")
 	assert.Len(t, mc.attributes, len(metricLabels), "cardinalities of labels and values must match")
 }
 
 func TestAzureMetricLabelPrefix(t *testing.T) {
-	mc := newMetricContext("prefix", "request", "resource_group", "subscription_id")
+	mc := newMetricContext("prefix", "request", "resource_group", "subscription_id", "source")
 	found := false
 	for _, attribute := range mc.attributes {
 		if attribute == "prefix_request" {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -1108,7 +1108,7 @@ func getClusterResources(az *Cloud, vmCount int, availabilitySetCount int) (clus
 
 		vmCtx, vmCancel := getContextWithCancel()
 		defer vmCancel()
-		_, err := az.VirtualMachinesClient.CreateOrUpdate(vmCtx, az.Config.ResourceGroup, vmName, newVM)
+		_, err := az.VirtualMachinesClient.CreateOrUpdate(vmCtx, az.Config.ResourceGroup, vmName, newVM, "")
 		if err != nil {
 		}
 		// add to kubernetes

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -712,10 +712,10 @@ func (ss *scaleSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeNam
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 	klog.V(2).Infof("EnsureHostInPool begins to update vmssVM(%s) with new backendPoolID %s", vmName, backendPoolID)
-	resp, err := ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM)
+	resp, err := ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM, "network_update")
 	if ss.CloudProviderBackoff && shouldRetryHTTPRequest(resp, err) {
 		klog.V(2).Infof("EnsureHostInPool update backing off vmssVM(%s) with new backendPoolID %s, err: %v", vmName, backendPoolID, err)
-		retryErr := ss.UpdateVmssVMWithRetry(nodeResourceGroup, ssName, instanceID, newVM)
+		retryErr := ss.UpdateVmssVMWithRetry(nodeResourceGroup, ssName, instanceID, newVM, "network_update")
 		if retryErr != nil {
 			err = retryErr
 			klog.Errorf("EnsureHostInPool update abort backoff vmssVM(%s) with new backendPoolID %s, err: %v", vmName, backendPoolID, err)
@@ -841,10 +841,10 @@ func (ss *scaleSet) ensureBackendPoolDeletedFromNode(service *v1.Service, nodeNa
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 	klog.V(2).Infof("ensureBackendPoolDeletedFromNode begins to update vmssVM(%s) with backendPoolID %s", nodeName, backendPoolID)
-	resp, err := ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM)
+	resp, err := ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM, "network_update")
 	if ss.CloudProviderBackoff && shouldRetryHTTPRequest(resp, err) {
 		klog.V(2).Infof("ensureBackendPoolDeletedFromNode update backing off vmssVM(%s) with backendPoolID %s, err: %v", nodeName, backendPoolID, err)
-		retryErr := ss.UpdateVmssVMWithRetry(nodeResourceGroup, ssName, instanceID, newVM)
+		retryErr := ss.UpdateVmssVMWithRetry(nodeResourceGroup, ssName, instanceID, newVM, "network_update")
 		if retryErr != nil {
 			err = retryErr
 			klog.Errorf("ensureBackendPoolDeletedFromNode update abort backoff vmssVM(%s) with backendPoolID %s, err: %v", nodeName, backendPoolID, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Current we cannot know whether it's attach/detach disk in prometheous metric, and even in vmss update, it also contains network update, this PR add a new parameter(`operation`) to get rid of this
```
# curl http://localhost:10252/metrics | grep cloudprovider_azure_api_request | grep -e sum -e count | grep disk
 
cloudprovider_azure_api_request_duration_seconds_sum{request="vmssvm_create_or_update",resource_group="andy-vmss1141",source="attach_disk",subscription_id="b9d2281e-dcd5-4dfd-9a97-xxx"} 1335.532763361
cloudprovider_azure_api_request_duration_seconds_count{request="vmssvm_create_or_update",resource_group="andy-vmss1141",source="attach_disk",subscription_id="b9d2281e-dcd5-4dfd-9a97-xxx"} 6
cloudprovider_azure_api_request_duration_seconds_sum{request="vmssvm_create_or_update",resource_group="andy-vmss1141",source="detach_disk",subscription_id="b9d2281e-dcd5-4dfd-9a97-xxx"} 1577.4697504959997
cloudprovider_azure_api_request_duration_seconds_count{request="vmssvm_create_or_update",resource_group="andy-vmss1141",source="detach_disk",subscription_id="b9d2281e-dcd5-4dfd-9a97-xxx"} 7
```
This PR also removes a useless function: `CreateOrUpdateVMWithRetry`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
add operation name for vm/vmss update operations in prometheus metrics
```

/assign @feiskyer 
/priority important-soon
/sig azure
