### PR TITLE
Fix kubectl proxy not accepting requests against [::1]

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server.go
+++ b/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// DefaultHostAcceptRE is the default value for which hosts to accept.
-	DefaultHostAcceptRE = "^localhost$,^127\\.0\\.0\\.1$,^\\[::1\\]$"
+	DefaultHostAcceptRE = "^localhost$,^127\\.0\\.0\\.1$,^::1$"
 	// DefaultPathAcceptRE is the default path to accept.
 	DefaultPathAcceptRE = "^.*"
 	// DefaultPathRejectRE is the default set of paths to reject.
@@ -117,7 +117,11 @@ func (f *FilterServer) HandlerFor(delegate http.Handler) *FilterServer {
 func extractHost(header string) (host string) {
 	host, _, err := net.SplitHostPort(header)
 	if err != nil {
-		host = header
+		if i := strings.IndexByte(header, ']'); i != -1 {
+			host = strings.TrimPrefix(header[:i], "[")
+		} else {
+			host = header
+		}
 	}
 	return host
 }

--- a/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server_test.go
@@ -275,6 +275,17 @@ func TestAccept(t *testing.T) {
 			method:        "PUT",
 			expectAccept:  false,
 		},
+		{
+			name:          "test23",
+			acceptPaths:   DefaultPathAcceptRE,
+			rejectPaths:   DefaultPathRejectRE,
+			acceptHosts:   DefaultHostAcceptRE,
+			rejectMethods: "POST,PUT,PATCH",
+			path:          "/api/v1/namespaces/default/pods/somepod",
+			host:          "::1",
+			method:        "GET",
+			expectAccept:  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -479,6 +490,8 @@ func TestExtractHost(t *testing.T) {
 	fixtures := map[string]string{
 		"localhost:8085": "localhost",
 		"marmalade":      "marmalade",
+		"[::1]:8001":     "::1",
+		"[::1]":          "::1",
 	}
 	for header, expected := range fixtures {
 		host := extractHost(header)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Although DefaultHostAcceptRE includes [::1], the requests against [::1] are rejected by FilterServer when serving on 0.0.0.0 or [::1].

It's because the function extractHost strips square brackets of IPv6 address if port is specified but keeps square brackets if port isn't specified, for example:

- `extractHost("[::1]:8001")` would get `"::1"`
- `extractHost("[::1]")` would get `"[::1]"`

This patch ensures extractHost always strips square brackets, and uses `"::1"` as the default accepted IPv6 loopback address.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #77496

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix kubectl proxy not accepting requests against [::1]
```
