### PR TITLE
kubeadm: upload the `ClusterConfiguration` during the upgrade

### DIFF
--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
@@ -101,6 +101,10 @@ func UploadConfiguration(cfg *kubeadmapi.InitConfiguration, client clientset.Int
 			kubeadmconstants.ClusterStatusConfigMapKey:        string(clusterStatusYaml),
 		},
 	}, func(cm *v1.ConfigMap) error {
+		// Upgrade will call to UploadConfiguration with a modified KubernetesVersion reflecting the new
+		// Kubernetes version. In that case, the mutation path will take place.
+		cm.Data[kubeadmconstants.ClusterConfigurationConfigMapKey] = string(clusterConfigurationYaml)
+		// Mutate the ClusterStatus now
 		return mutateClusterStatus(cm, func(cs *kubeadmapi.ClusterStatus) error {
 			// Handle a nil APIEndpoints map. Should only happen if someone manually
 			// interacted with the ConfigMap.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
During the upgrade process, `kubeadm` will take the current
`ClusterConfiguration`, update the `KubernetesVersion` to the latest
version, and call to `UploadConfig`.

This change makes sure that when the mutation happens, not only the
`ClusterStatus` is mutated, but the `ClusterConfiguration` object
inside the `kubeadm-config` ConfigMap as well; it will contain the
new `KubernetesVersion`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/1556

**Special notes for your reviewer**:
This is the straightforward fix with the least intrusive changes. However, I think the upgrade path could instead of calling to `UploadConfig` make explicit what it needs to mutate inside the `kubeadm-config` ConfigMap (I think it's only the `KubernetesVersion` inside the `ClusterConfiguration` object).

This can be refactored later if desired, I think it would be better for the upgrade path to be explicit about what it mutates instead of blindly calling to `UploadConfig`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @fabriziopandini 
/assign @rosti 
/assign @neolit123 