### PR TITLE
organize sig-net-api-{reviewers,approvers} in OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -289,6 +289,12 @@ aliases:
     - smarterclayton
     - thockin
 
+  sig-network-api-reviewers:
+    - caseydavenport
+    - cmluciano
+    - danwinship
+    - thockin
+
   sig-node-api-approvers:
     - smarterclayton
     - thockin
@@ -371,11 +377,7 @@ aliases:
   
   # sig-cluster-lifecycle-api-reviewers:
   #   - 
-  #   - 
-  
-  # sig-network-api-reviewers:
-  #   - 
-  #   - 
+  #   -
   
   # sig-node-api-reviewers:
   #   - 

--- a/pkg/apis/networking/OWNERS
+++ b/pkg/apis/networking/OWNERS
@@ -1,9 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+- sig-network-api-approvers
 reviewers:
-- caseydavenport
-- cmluciano
-- danwinship
-- thockin
+- sig-network-api-reviewers
 labels:
 - sig/network


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Moves sig-net-api-reviewers into the OWNERS_ALIASES from pkg/apis/net/OWNERS 

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
