### PR TITLE
[WIP] add -o templatefile/go-template-file support read from stdin

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
@@ -19,6 +19,7 @@ package genericclioptions
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -88,14 +89,21 @@ func (f *GoTemplatePrintFlags) ToPrinter(templateFormat string) (printers.Resour
 	}
 
 	if templateFormat == "templatefile" || templateFormat == "go-template-file" {
-		data, err := ioutil.ReadFile(templateValue)
-		if err != nil {
-			return nil, fmt.Errorf("error reading --template %s, %v\n", templateValue, err)
+		if strings.HasPrefix(templateValue, "-") {
+			data, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return nil, fmt.Errorf("error reading from stdin, %v\n", templateValue, err)
+			}
+			templateValue = string(data)
+		} else {
+			data, err := ioutil.ReadFile(templateValue)
+			if err != nil {
+				return nil, fmt.Errorf("error reading --template %s, %v\n", templateValue, err)
+			}
+
+			templateValue = string(data)
 		}
-
-		templateValue = string(data)
 	}
-
 	p, err := printers.NewGoTemplatePrinter([]byte(templateValue))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing template %s, %v\n", templateValue, err)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

> /kind feature

**What this PR does / why we need it**:
```
➜  ~ oc get secret mysecret  -o yaml
apiVersion: v1
data:
  password: MWYyZDFlMmU2N2Rm
  username: YWRtaW4=
kind: Secret
metadata:
  creationTimestamp: "2019-05-06T16:36:17Z"
  name: mysecret
  namespace: ci
  resourceVersion: "269418"
  selfLink: /api/v1/namespaces/ci/secrets/mysecret
  uid: 120aefb3-701d-11e9-86fb-5254006af7c8
type: Opaque
➜  ~ kubectl get secret mysecret -o go-template-file=- << EOF > ./test-out
export DB_USER={{ .data.username }}
EOF
➜  ~ cat ./test-out 
export DB_USER=YWRtaW4=
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/581

**Special notes for your reviewer**:
just a simple tweak to prove it works. PR hasn't finished yet, will add more once @kubernetes/sig-cli-maintainers approve adding this feature.
@jamielennox @juanvallejo @soltysh 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
make templatefile/go-template-file support reading from stdin by -o templatefile=-`
```
