### PR TITLE
tests: Combine Linux / Windows image pulling tests

### DIFF
--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -363,27 +363,25 @@ while true; do sleep 1; done
 				imagePullTest(image, false, v1.PodPending, true, false)
 			})
 
-			ginkgo.It("should be able to pull image from gcr.io [LinuxOnly] [NodeConformance]", func() {
-				image := imageutils.GetE2EImage(imageutils.DebianBase)
-				imagePullTest(image, false, v1.PodRunning, false, false)
-			})
-
 			ginkgo.It("should be able to pull image from gcr.io [NodeConformance]", func() {
-				framework.SkipUnlessNodeOSDistroIs("windows")
-				image := imageutils.GetE2EImage(imageutils.WindowsNanoServer)
-				imagePullTest(image, false, v1.PodRunning, false, true)
-			})
-
-			ginkgo.It("should be able to pull image from docker hub [LinuxOnly] [NodeConformance]", func() {
-				image := imageutils.GetE2EImage(imageutils.Alpine)
-				imagePullTest(image, false, v1.PodRunning, false, false)
+				image := imageutils.GetE2EImage(imageutils.DebianBase)
+				isWindows := false
+				if framework.NodeOSDistroIs("windows") {
+					image = imageutils.GetE2EImage(imageutils.WindowsNanoServer)
+					isWindows = true
+				}
+				imagePullTest(image, false, v1.PodRunning, false, isWindows)
 			})
 
 			ginkgo.It("should be able to pull image from docker hub [NodeConformance]", func() {
-				framework.SkipUnlessNodeOSDistroIs("windows")
-				// TODO(claudiub): Switch to nanoserver image manifest list.
-				image := "e2eteam/busybox:1.29"
-				imagePullTest(image, false, v1.PodRunning, false, true)
+				image := imageutils.GetE2EImage(imageutils.Alpine)
+				isWindows := false
+				if framework.NodeOSDistroIs("windows") {
+					// TODO(claudiub): Switch to nanoserver image manifest list.
+					image = "e2eteam/busybox:1.29"
+					isWindows = true
+				}
+				imagePullTest(image, false, v1.PodRunning, false, isWindows)
 			})
 
 			ginkgo.It("should not be able to pull from private registry without secret [NodeConformance]", func() {
@@ -391,15 +389,14 @@ while true; do sleep 1; done
 				imagePullTest(image, false, v1.PodPending, true, false)
 			})
 
-			ginkgo.It("should be able to pull from private registry with secret [LinuxOnly] [NodeConformance]", func() {
-				image := imageutils.GetE2EImage(imageutils.AuthenticatedAlpine)
-				imagePullTest(image, true, v1.PodRunning, false, false)
-			})
-
 			ginkgo.It("should be able to pull from private registry with secret [NodeConformance]", func() {
-				framework.SkipUnlessNodeOSDistroIs("windows")
-				image := imageutils.GetE2EImage(imageutils.AuthenticatedWindowsNanoServer)
-				imagePullTest(image, true, v1.PodRunning, false, true)
+				image := imageutils.GetE2EImage(imageutils.AuthenticatedAlpine)
+				isWindows := false
+				if framework.NodeOSDistroIs("windows") {
+					image = imageutils.GetE2EImage(imageutils.AuthenticatedWindowsNanoServer)
+					isWindows = true
+				}
+				imagePullTest(image, true, v1.PodRunning, false, isWindows)
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

/sig testing
/sig windows

/area conformance

**What this PR does / why we need it**:

Because Linux images cannot run on Windows and vice-versa, separate tests were added for both OSes, only separated by a ``[LinuxOnly]`` tag in their names. Ideally, we could have the same test names for both OSes.

Based on the given ``--node-os-distro``, we can select which image to use when spawning the pod.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related: #69871

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
