### PR TITLE
Handle conversion errors from ObjectToTyped correctly

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/versionconverter.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/versionconverter.go
@@ -97,5 +97,5 @@ func (v *versionConverter) Convert(object typed.TypedValue, version fieldpath.AP
 
 // IsMissingVersionError
 func (v *versionConverter) IsMissingVersionError(err error) bool {
-	return runtime.IsNotRegisteredError(err)
+	return runtime.IsNotRegisteredError(err) || isNoCorrespondingTypeError(err)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/assign @apelisse 
/cc @liggitt 
/sig api-machinery
/wg apply

**What this PR does / why we need it**:
Fixes an issue with server-side apply where disabling a version is be unsafe if the converters are still registered.

**Which issue(s) this PR fixes**:
Fixes #77519

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```