### PR TITLE
iptables proxier: route local traffic to LB IPs to service chain

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1202,6 +1202,16 @@ func (proxier *Proxier) syncProxyRules() {
 			continue
 		}
 
+		// For LBs with externalTrafficPolicy=Local, we need to re-route any local traffic to the service chain masqueraded.
+		// Masqueraded traffic in this scenario is okay since source IP preservation only applies to external traffic anyways.
+		args = append(args[:0], "-A", string(svcXlbChain))
+		writeLine(proxier.natRules, append(args,
+			"-m", "comment", "--comment", fmt.Sprintf(`"masquerade LOCAL traffic for %s LB IP"`, svcNameString),
+			"-m", "addrtype", "--src-type", "LOCAL", "-j", string(KubeMarkMasqChain))...)
+		writeLine(proxier.natRules, append(args,
+			"-m", "comment", "--comment", fmt.Sprintf(`"route LOCAL traffic for %s LB IP to service chain"`, svcNameString),
+			"-m", "addrtype", "--src-type", "LOCAL", "-j", string(svcChain))...)
+
 		// First rule in the chain redirects all pod -> external VIP traffic to the
 		// Service's ClusterIP instead. This happens whether or not we have local
 		// endpoints; only if clusterCIDR is specified

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -942,7 +942,10 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 }
 
 func onlyLocalNodePorts(t *testing.T, fp *Proxier, ipt *iptablestest.FakeIPTables) {
-	shouldLBTOSVCRuleExist := len(fp.clusterCIDR) > 0
+	// LB to SVC rule should always exist for local only since
+	// any traffic with `--src-type LOCAL` now routes to service chain
+	shouldLBTOSVCRuleExist := true
+
 	svcIP := "10.20.30.41"
 	svcPort := 80
 	svcNodePort := 3001

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -424,6 +424,18 @@ func hasJump(rules []iptablestest.Rule, destChain, destIP string, destPort int) 
 	return match
 }
 
+func hasSrcType(rules []iptablestest.Rule, srcType string) bool {
+	for _, r := range rules {
+		if r[iptablestest.SrcType] != srcType {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}
+
 func TestHasJump(t *testing.T) {
 	testCases := map[string]struct {
 		rules     []iptablestest.Rule
@@ -942,10 +954,6 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 }
 
 func onlyLocalNodePorts(t *testing.T, fp *Proxier, ipt *iptablestest.FakeIPTables) {
-	// LB to SVC rule should always exist for local only since
-	// any traffic with `--src-type LOCAL` now routes to service chain
-	shouldLBTOSVCRuleExist := true
-
 	svcIP := "10.20.30.41"
 	svcPort := 80
 	svcNodePort := 3001
@@ -1021,12 +1029,8 @@ func onlyLocalNodePorts(t *testing.T, fp *Proxier, ipt *iptablestest.FakeIPTable
 	if hasJump(lbRules, nonLocalEpChain, "", 0) {
 		errorf(fmt.Sprintf("Found jump from lb chain %v to non-local ep %v", lbChain, epStrLocal), lbRules, t)
 	}
-	if hasJump(lbRules, svcChain, "", 0) != shouldLBTOSVCRuleExist {
-		prefix := "Did not find "
-		if !shouldLBTOSVCRuleExist {
-			prefix = "Found "
-		}
-		errorf(fmt.Sprintf("%s jump from lb chain %v to svc %v", prefix, lbChain, svcChain), lbRules, t)
+	if !hasJump(lbRules, svcChain, "", 0) || !hasSrcType(lbRules, "LOCAL") {
+		errorf(fmt.Sprintf("Did not find jump from lb chain %v to svc %v with src-type LOCAL", lbChain, svcChain), lbRules, t)
 	}
 	if !hasJump(lbRules, localEpChain, "", 0) {
 		errorf(fmt.Sprintf("Didn't find jump from lb chain %v to local ep %v", lbChain, epStrLocal), lbRules, t)

--- a/pkg/util/iptables/testing/fake.go
+++ b/pkg/util/iptables/testing/fake.go
@@ -34,6 +34,7 @@ const (
 	ToDest      = "--to-destination "
 	Recent      = "recent "
 	MatchSet    = "--match-set "
+	SrcType     = "--src-type "
 )
 
 type Rule map[string]string
@@ -113,7 +114,7 @@ func (f *FakeIPTables) GetRules(chainName string) (rules []Rule) {
 	for _, l := range strings.Split(string(f.Lines), "\n") {
 		if strings.Contains(l, fmt.Sprintf("-A %v", chainName)) {
 			newRule := Rule(map[string]string{})
-			for _, arg := range []string{Destination, Source, DPort, Protocol, Jump, ToDest, Recent, MatchSet} {
+			for _, arg := range []string{Destination, Source, DPort, Protocol, Jump, ToDest, Recent, MatchSet, SrcType} {
 				tok := getToken(l, arg)
 				if tok != "" {
 					newRule[arg] = tok


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
For any traffic to an LB IP that originates from the local node, re-route that traffic to the Kubernetes service chain. This allows traffic to an external LB from inside a cluster reachable. The implication of this is that internal traffic to an LB IP will need to go through SNAT. This is likely okay since source IP preservation with externalTrafficPolicy=Local only applies for external traffic anyways. The fix was spelled out in more detail by Tim here https://github.com/kubernetes/kubernetes/issues/65387. 

I think the correct behavior is to actually route the traffic to the LB instead of intercepting it with iptables but with the current set of rules I'm not sure this is possible. We also already have rules that route pods in the cluster cidr that want to reach LB IPs to the service chain:
```
-A KUBE-XLB-ECF5TUORC5E2ZCRD -s 10.8.0.0/14 -m comment --comment "Redirect pods trying to reach external loadbalancer VIP to clusterIP" -j KUBE-SVC-ECF5TUORC5E2ZCRD
```
Allowing traffic with `--src-type LOCAL` to do the same makes sense to me

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/65387 https://github.com/kubernetes/kubernetes/issues/66607

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
iptables proxier: route local traffic to LB IPs to service chain
```
