### PR TITLE
Modify e2e/lifecycle tests to import e2elog.Logf

### DIFF
--- a/test/e2e/lifecycle/BUILD
+++ b/test/e2e/lifecycle/BUILD
@@ -35,6 +35,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/ginkgowrapper:go_default_library",
         "//test/e2e/framework/lifecycle:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/upgrades:go_default_library",
         "//test/e2e/upgrades/apps:go_default_library",
         "//test/e2e/upgrades/storage:go_default_library",

--- a/test/e2e/lifecycle/addon_update.go
+++ b/test/e2e/lifecycle/addon_update.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -297,7 +298,7 @@ var _ = SIGDescribe("Addon update", func() {
 		sshExecAndVerify(sshClient, fmt.Sprintf("sudo cp %s/%s %s/%s", temporaryRemotePath, svcAddonEnsureExists, destinationDir, svcAddonEnsureExists))
 		// Delete the "ensure exist class" addon at the end.
 		defer func() {
-			framework.Logf("Cleaning up ensure exist class addon.")
+			e2elog.Logf("Cleaning up ensure exist class addon.")
 			gomega.Expect(f.ClientSet.CoreV1().Services(addonNsName).Delete("addon-ensure-exists-test", nil)).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -389,7 +390,7 @@ func sshExecAndVerify(client *ssh.Client, cmd string) {
 }
 
 func sshExec(client *ssh.Client, cmd string) (string, string, int, error) {
-	framework.Logf("Executing '%s' on %v", cmd, client.RemoteAddr())
+	e2elog.Logf("Executing '%s' on %v", cmd, client.RemoteAddr())
 	session, err := client.NewSession()
 	if err != nil {
 		return "", "", 0, fmt.Errorf("error creating session to host %s: '%v'", client.RemoteAddr(), err)
@@ -421,7 +422,7 @@ func sshExec(client *ssh.Client, cmd string) (string, string, int, error) {
 }
 
 func writeRemoteFile(sshClient *ssh.Client, data, dir, fileName string, mode os.FileMode) error {
-	framework.Logf(fmt.Sprintf("Writing remote file '%s/%s' on %v", dir, fileName, sshClient.RemoteAddr()))
+	e2elog.Logf(fmt.Sprintf("Writing remote file '%s/%s' on %v", dir, fileName, sshClient.RemoteAddr()))
 	session, err := sshClient.NewSession()
 	if err != nil {
 		return fmt.Errorf("error creating session to host %s: '%v'", sshClient.RemoteAddr(), err)

--- a/test/e2e/lifecycle/ha_master.go
+++ b/test/e2e/lifecycle/ha_master.go
@@ -28,10 +28,11 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
 func addMasterReplica(zone string) error {
-	framework.Logf(fmt.Sprintf("Adding a new master replica, zone: %s", zone))
+	e2elog.Logf(fmt.Sprintf("Adding a new master replica, zone: %s", zone))
 	_, _, err := framework.RunCmd(path.Join(framework.TestContext.RepoRoot, "hack/e2e-internal/e2e-grow-cluster.sh"), zone, "true", "true", "false")
 	if err != nil {
 		return err
@@ -40,7 +41,7 @@ func addMasterReplica(zone string) error {
 }
 
 func removeMasterReplica(zone string) error {
-	framework.Logf(fmt.Sprintf("Removing an existing master replica, zone: %s", zone))
+	e2elog.Logf(fmt.Sprintf("Removing an existing master replica, zone: %s", zone))
 	_, _, err := framework.RunCmd(path.Join(framework.TestContext.RepoRoot, "hack/e2e-internal/e2e-shrink-cluster.sh"), zone, "true", "false", "false")
 	if err != nil {
 		return err
@@ -49,7 +50,7 @@ func removeMasterReplica(zone string) error {
 }
 
 func addWorkerNodes(zone string) error {
-	framework.Logf(fmt.Sprintf("Adding worker nodes, zone: %s", zone))
+	e2elog.Logf(fmt.Sprintf("Adding worker nodes, zone: %s", zone))
 	_, _, err := framework.RunCmd(path.Join(framework.TestContext.RepoRoot, "hack/e2e-internal/e2e-grow-cluster.sh"), zone, "true", "false", "true")
 	if err != nil {
 		return err
@@ -58,7 +59,7 @@ func addWorkerNodes(zone string) error {
 }
 
 func removeWorkerNodes(zone string) error {
-	framework.Logf(fmt.Sprintf("Removing worker nodes, zone: %s", zone))
+	e2elog.Logf(fmt.Sprintf("Removing worker nodes, zone: %s", zone))
 	_, _, err := framework.RunCmd(path.Join(framework.TestContext.RepoRoot, "hack/e2e-internal/e2e-shrink-cluster.sh"), zone, "true", "true", "true")
 	if err != nil {
 		return err

--- a/test/e2e/lifecycle/node_lease.go
+++ b/test/e2e/lifecycle/node_lease.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -108,7 +109,7 @@ var _ = SIGDescribe("[Disruptive]NodeLease", func() {
 				pass := true
 				for _, node := range originalNodes.Items {
 					if _, err := leaseClient.Get(node.ObjectMeta.Name, metav1.GetOptions{}); err != nil {
-						framework.Logf("Try to get lease of node %s, but got error: %v", node.ObjectMeta.Name, err)
+						e2elog.Logf("Try to get lease of node %s, but got error: %v", node.ObjectMeta.Name, err)
 						pass = false
 					}
 				}

--- a/test/e2e/lifecycle/restart.go
+++ b/test/e2e/lifecycle/restart.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 
 	"github.com/onsi/ginkgo"
@@ -61,7 +62,7 @@ var _ = SIGDescribe("Restart [Disruptive]", func() {
 		ginkgo.By("ensuring all nodes are ready")
 		originalNodes, err = framework.CheckNodesReady(f.ClientSet, numNodes, framework.NodeReadyInitialTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		framework.Logf("Got the following nodes before restart: %v", nodeNames(originalNodes))
+		e2elog.Logf("Got the following nodes before restart: %v", nodeNames(originalNodes))
 
 		ginkgo.By("ensuring all pods are running and ready")
 		allPods := ps.List()
@@ -91,7 +92,7 @@ var _ = SIGDescribe("Restart [Disruptive]", func() {
 		ginkgo.By("ensuring all nodes are ready after the restart")
 		nodesAfter, err := framework.CheckNodesReady(f.ClientSet, numNodes, framework.RestartNodeReadyAgainTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		framework.Logf("Got the following nodes after restart: %v", nodeNames(nodesAfter))
+		e2elog.Logf("Got the following nodes after restart: %v", nodeNames(nodesAfter))
 
 		// Make sure that we have the same number of nodes. We're not checking
 		// that the names match because that's implementation specific.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/priority important-longterm
/area e2e-test-framework

**What this PR does / why we need it**:

Modify test/e2e/lifecycle tests to import e2elog.Logf instead of framework.Logf to address issue #77359

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
