### PR TITLE
Replace 'wget -T' with 'curl -m' to add support on Windows

### DIFF
--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -1550,7 +1550,7 @@ func checkAffinityFailed(tracker affinityTracker, err string) {
 // return false only in case of unexpected errors.
 func CheckAffinity(jig *ServiceTestJig, execPod *v1.Pod, targetIP string, targetPort int, shouldHold bool) bool {
 	targetIPPort := net.JoinHostPort(targetIP, strconv.Itoa(targetPort))
-	cmd := fmt.Sprintf(`wget -qO- http://%s/ -T 2`, targetIPPort)
+	cmd := fmt.Sprintf(`curl -s http://%s/ -m 3`, targetIPPort)
 	timeout := ServiceTestTimeout
 	if execPod == nil {
 		timeout = LoadBalancerPollTimeout


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Based in discussion with @bclau, Windows doesn't support `-T` flag in wget. So as an alternative, `curl` is used. [[Ref](https://github.com/kubernetes/kubernetes/pull/76443#issuecomment-483891944)]

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This e2e is failing to reach service's ip with an error : `Connection to 10.105.224.22:80 timed out or not enough responses.`

Few Error lines from kubelet.log:
```
May 07 09:53:30 kind-worker kubelet[721]: I0507 09:53:30.317254     721 reconciler.go:203] operationExecutor.VerifyControllerAttachedVolume started for volume "default-token-zt52v" (UniqueName: "kubernetes.io/secret/26601ae7-012d-49a1-a684-7ae4a6cd954b-default-token-zt52v") pod "execpod-affinity79dpt" (UID: "26601ae7-012d-49a1-a684-7ae4a6cd954b")
May 07 10:02:04 kind-worker kubelet[721]: I0507 10:02:04.561250     721 reconciler.go:203] operationExecutor.VerifyControllerAttachedVolume started for volume "default-token-spmjh" (UniqueName: "kubernetes.io/secret/e9aee952-999d-42c5-bd38-b0fe336effce-default-token-spmjh") pod "execpod-affinityxvghm" (UID: "e9aee952-999d-42c5-bd38-b0fe336effce")
May 07 10:03:10 kind-worker kubelet[721]: E0507 10:03:10.662356     721 kuberuntime_container.go:71] Can't make a ref to pod "execpod-affinityxvghm_services-1295(e9aee952-999d-42c5-bd38-b0fe336effce)", container exec: selfLink was empty, can't make reference
May 07 10:16:04 kind-worker kubelet[721]: I0507 10:16:04.940091     721 reconciler.go:203] operationExecutor.VerifyControllerAttachedVolume started for volume "default-token-kb7df" (UniqueName: "kubernetes.io/secret/fdc0679c-9d5f-458c-b3e3-b949dc342112-default-token-kb7df") pod "execpod-affinitycp7xw" (UID: "fdc0679c-9d5f-458c-b3e3-b949dc342112")
May 07 10:16:05 kind-worker kubelet[721]: E0507 10:16:05.299752     721 kuberuntime_manager.go:883] PodSandboxStatus of sandbox "227aa5eb825225b41768353242c5b9d9dec3b38057b1275c38146c9c5f189673" for pod "execpod-affinitycp7xw_services-2652(fdc0679c-9d5f-458c-b3e3-b949dc342112)" error: rpc error: code = Unknown desc = Error: No such container: 227aa5eb825225b41768353242c5b9d9dec3b38057b1275c38146c9c5f189673
May 07 10:16:38 kind-worker kubelet[721]: W0507 10:16:38.287958     721 status_manager.go:501] Failed to update status for pod "execpod-affinitycp7xw_services-2652(fdc0679c-9d5f-458c-b3e3-b949dc342112)": failed to patch status "{}" for pod "services-2652"/"execpod-affinitycp7xw": pods "execpod-affinitycp7xw" not found
May 07 10:16:41 kind-worker kubelet[721]: weave-cni: error removing interface "eth0": no such file or directory
May 07 10:16:41 kind-worker kubelet[721]: weave-cni: unable to release IP address: 400 Bad Request: Delete: no addresses for 227aa5eb825225b41768353242c5b9d9dec3b38057b1275c38146c9c5f189673
May 07 10:16:41 kind-worker kubelet[721]: W0507 10:16:41.916283     721 docker_sandbox.go:384] failed to read pod IP from plugin/docker: NetworkPlugin cni failed on the status hook for pod "execpod-affinitycp7xw_services-2652": CNI failed to retrieve network namespace path: cannot find network namespace for the terminated container "227aa5eb825225b41768353242c5b9d9dec3b38057b1275c38146c9c5f189673"
May 07 10:16:42 kind-worker kubelet[721]: W0507 10:16:42.970535     721 pod_container_deletor.go:75] Container "227aa5eb825225b41768353242c5b9d9dec3b38057b1275c38146c9c5f189673" not found in pod's containers
May 07 10:54:40 kind-worker kubelet[721]: I0507 10:54:40.724799     721 reconciler.go:203] operationExecutor.VerifyControllerAttachedVolume started for volume "default-token-dqcjb" (UniqueName: "kubernetes.io/secret/4d994634-f33a-453b-90f0-8d6fa10f684c-default-token-dqcjb") pod "execpod-affinityn5z57" (UID: "4d994634-f33a-453b-90f0-8d6fa10f684c")
May 07 10:58:46 kind-worker kubelet[721]: I0507 10:58:46.326710     721 reconciler.go:203] operationExecutor.VerifyControllerAttachedVolume started for volume "default-token-h894n" (UniqueName: "kubernetes.io/secret/31207bc0-d024-49a3-95ff-e4b46d751c60-default-token-h894n") pod "execpod-affinitynwbhz" (UID: "31207bc0-d024-49a3-95ff-e4b46d751c60")
May 07 11:01:11 kind-worker kubelet[721]: I0507 11:01:11.219226     721 reconciler.go:203] operationExecutor.VerifyControllerAttachedVolume started for volume "default-token-fj89h" (UniqueName: "kubernetes.io/secret/530d6079-38e1-4f17-b4b1-0d09ce0932f6-default-token-fj89h") pod "execpod-affinity7vp5d" (UID: "530d6079-38e1-4f17-b4b1-0d09ce0932f6")
May 07 11:01:12 kind-worker kubelet[721]: E0507 11:01:12.330353     721 kuberuntime_manager.go:898] getPodContainerStatuses for pod "execpod-affinity7vp5d_services-8123(530d6079-38e1-4f17-b4b1-0d09ce0932f6)" failed: rpc error: code = Unknown desc = Error: No such container: c46866ced944f93e7072a49672e13479723358239cfca5c6b9365c8b57630692
May 07 11:02:16 kind-worker kubelet[721]: W0507 11:02:16.067079     721 status_manager.go:501] Failed to update status for pod "execpod-affinity7vp5d_services-8123(530d6079-38e1-4f17-b4b1-0d09ce0932f6)": failed to patch status "{}" for pod "services-8123"/"execpod-affinity7vp5d": pods "execpod-affinity7vp5d" not found
May 07 11:15:50 kind-worker kubelet[721]: W0507 11:15:50.311006     721 docker_sandbox.go:384] failed to read pod IP from plugin/docker: NetworkPlugin cni failed on the status hook for pod "execpod-affinity44hbl_services-3991": Unexpected command output nsenter: cannot open /proc/41614/ns/net: No such file or directory
```

https://github.com/kubernetes/kubernetes/issues/77192 is tracking following observed error.
```
May 07 10:03:10 kind-worker kubelet[721]: E0507 10:03:10.662356     721 kuberuntime_container.go:71] Can't make a ref to pod "execpod-affinityxvghm_services-1295(e9aee952-999d-42c5-bd38-b0fe336effce)", container exec: selfLink was empty, can't make reference
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/sig testing
cc @bclau 
/area conformance