### PR TITLE
remove check version when destroy container

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -378,13 +378,9 @@ function kube::build::short_hash() {
 # a workaround for bug https://github.com/docker/docker/issues/3968.
 function kube::build::destroy_container() {
   "${DOCKER[@]}" kill "$1" >/dev/null 2>&1 || true
-  if [[ $("${DOCKER[@]}" version --format '{{.Server.Version}}') = 17.06.0* ]]; then
-    # Workaround https://github.com/moby/moby/issues/33948.
-    # TODO: remove when 17.06.0 is not relevant anymore
-    DOCKER_API_VERSION=v1.29 "${DOCKER[@]}" wait "$1" >/dev/null 2>&1 || true
-  else
-    "${DOCKER[@]}" wait "$1" >/dev/null 2>&1 || true
-  fi
+
+  "${DOCKER[@]}" wait "$1" >/dev/null 2>&1 || true
+  
   "${DOCKER[@]}" rm -f -v "$1" >/dev/null 2>&1 || true
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Fix TODO: remove when 17.06.0 is not relevant anymore
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Ref. https://github.com/moby/moby/issues/33948
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
