### PR TITLE
Create dynamic fake client-go with initial nil object list

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/fake/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple.go
@@ -39,9 +39,11 @@ func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *
 
 	codecs := serializer.NewCodecFactory(scheme)
 	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
-	for _, obj := range objects {
-		if err := o.Add(obj); err != nil {
-			panic(err)
+	if objects != nil {
+		for _, obj := range objects {
+			if err := o.Add(obj); err != nil {
+				panic(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When using the client-go dynamic/fake client package, it requires to pass an empty slice of object.  This issue adds code (and test) to support creating dynamic fake client without any object (nil).

**Which issue(s) this PR fixes**:
Fixes #77547

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery
