### PR TITLE
apiextensions: publish (only) structural OpenAPI schemas

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-openapi/strfmt v0.17.0
 	github.com/go-openapi/validate v0.18.0
 	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415
+	github.com/google/go-cmp v0.3.0
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf
 	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/BUILD
@@ -7,6 +7,7 @@ go_library(
         "convert.go",
         "goopenapi.go",
         "structural.go",
+        "unfold.go",
         "validation.go",
         "visitor.go",
         "zz_generated.deepcopy.go",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/unfold.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/unfold.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schema
+
+// Unfold expands vendor extensions of a structural schema.
+// It mutates the receiver.
+func (s *Structural) Unfold() *Structural {
+	if s == nil {
+		return nil
+	}
+
+	mapper := Visitor{
+		Structural: func(s *Structural) bool {
+			if !s.XIntOrString {
+				return false
+			}
+
+			skipAnyOf := isIntOrStringAnyOfPattern(s)
+			skipFirstAllOfAnyOf := isIntOrStringAllOfPattern(s)
+			if skipAnyOf || skipFirstAllOfAnyOf {
+				return false
+			}
+
+			if s.AnyOf == nil {
+				s.AnyOf = []NestedValueValidation{
+					{ForbiddenGenerics: Generic{Type: "integer"}},
+					{ForbiddenGenerics: Generic{Type: "string"}},
+				}
+			} else {
+				s.AllOf = append([]NestedValueValidation{
+					{
+						ValueValidation: ValueValidation{
+							AnyOf: []NestedValueValidation{
+								{ForbiddenGenerics: Generic{Type: "integer"}},
+								{ForbiddenGenerics: Generic{Type: "string"}},
+							},
+						},
+					},
+				}, s.AllOf...)
+			}
+
+			return true
+		},
+		NestedValueValidation: nil, // x-kubernetes-int-or-string cannot be set in nested value validation
+	}
+	mapper.Visit(s)
+
+	return s
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
@@ -97,15 +97,8 @@ func validateStructuralInvariants(s *Structural, lvl level, fldPath *field.Path)
 	//      - type: integer
 	//      - type: string
 	//    - ... zero or more
-	skipAnyOf := false
-	skipFirstAllOfAnyOf := false
-	if s.XIntOrString && s.ValueValidation != nil {
-		if len(s.ValueValidation.AnyOf) == 2 && reflect.DeepEqual(s.ValueValidation.AnyOf, intOrStringAnyOf) {
-			skipAnyOf = true
-		} else if len(s.ValueValidation.AllOf) >= 1 && len(s.ValueValidation.AllOf[0].AnyOf) == 2 && reflect.DeepEqual(s.ValueValidation.AllOf[0].AnyOf, intOrStringAnyOf) {
-			skipFirstAllOfAnyOf = true
-		}
-	}
+	skipAnyOf := isIntOrStringAnyOfPattern(s)
+	skipFirstAllOfAnyOf := isIntOrStringAllOfPattern(s)
 
 	allErrs = append(allErrs, validateValueValidation(s.ValueValidation, skipAnyOf, skipFirstAllOfAnyOf, lvl, fldPath)...)
 
@@ -155,6 +148,20 @@ func validateStructuralInvariants(s *Structural, lvl level, fldPath *field.Path)
 	}
 
 	return allErrs
+}
+
+func isIntOrStringAnyOfPattern(s *Structural) bool {
+	if s == nil || s.ValueValidation == nil {
+		return false
+	}
+	return len(s.ValueValidation.AnyOf) == 2 && reflect.DeepEqual(s.ValueValidation.AnyOf, intOrStringAnyOf)
+}
+
+func isIntOrStringAllOfPattern(s *Structural) bool {
+	if s == nil || s.ValueValidation == nil {
+		return false
+	}
+	return len(s.ValueValidation.AllOf) >= 1 && len(s.ValueValidation.AllOf[0].AnyOf) == 2 && reflect.DeepEqual(s.ValueValidation.AllOf[0].AnyOf, intOrStringAnyOf)
 }
 
 // validateGeneric checks the generic fields of a structural schema.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/BUILD
@@ -14,7 +14,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
-        "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation:go_default_library",
+        "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi:go_default_library",
@@ -49,10 +49,12 @@ go_test(
     deps = [
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
+        "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/github.com/googleapis/gnostic/OpenAPIv2:go_default_library",
         "//vendor/github.com/googleapis/gnostic/compiler:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder_test.go
@@ -22,14 +22,14 @@ import (
 
 	"github.com/go-openapi/spec"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestNewBuilder(t *testing.T) {
-	type args struct {
-	}
 	tests := []struct {
 		name string
 
@@ -37,41 +37,302 @@ func TestNewBuilder(t *testing.T) {
 
 		wantedSchema      string
 		wantedItemsSchema string
+
+		v2 bool // produce OpenAPIv2
 	}{
 		{
 			"nil",
 			"",
 			`{"type":"object","x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`, `{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
+			true,
 		},
-		{"empty",
-			"{}",
-			`{"properties":{"apiVersion":{},"kind":{},"metadata":{}},"x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
+		{"with properties",
+			`{"type":"object","properties":{"spec":{"type":"object"},"status":{"type":"object"}}}`,
+			`{"type":"object","properties":{"apiVersion":{"type":"string"},"kind":{"type":"string"},"metadata":{"$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},"spec":{"type":"object"},"status":{"type":"object"}},"x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
 			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
+			true,
 		},
-		{"empty properties",
-			`{"properties":{"spec":{},"status":{}}}`,
-			`{"properties":{"apiVersion":{},"kind":{},"metadata":{},"spec":{},"status":{}},"x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
-			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
-		},
-		{"filled properties",
-			`{"properties":{"spec":{"type":"object"},"status":{"type":"object"}}}`,
-			`{"properties":{"apiVersion":{},"kind":{},"metadata":{},"spec":{"type":"object"},"status":{"type":"object"}},"x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
-			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
-		},
-		{"type",
+		{"type only",
 			`{"type":"object"}`,
-			`{"properties":{"apiVersion":{},"kind":{},"metadata":{}},"type":"object","x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
+			`{"type":"object","properties":{"apiVersion":{"type":"string"},"kind":{"type":"string"},"metadata":{"$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"}},"x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
 			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
+			true,
+		},
+		{"with extensions",
+			`
+{
+  "type":"object", 
+  "properties": {
+    "int-or-string-1": {
+      "x-kubernetes-int-or-string": true,
+      "anyOf": [
+        {"type":"integer"},
+        {"type":"string"}
+      ]
+    },
+    "int-or-string-2": {
+      "x-kubernetes-int-or-string": true,
+      "allOf": [{
+        "anyOf": [
+          {"type":"integer"},
+          {"type":"string"}
+        ]
+      }, {
+        "anyOf": [
+          {"minimum": 42.0}
+        ]
+      }]
+    },
+    "int-or-string-3": {
+      "x-kubernetes-int-or-string": true,
+      "anyOf": [
+        {"type":"integer"},
+        {"type":"string"}
+      ],
+      "allOf": [{
+        "anyOf": [
+          {"minimum": 42.0}
+        ]
+      }]
+    },
+    "int-or-string-4": {
+      "x-kubernetes-int-or-string": true,
+      "anyOf": [
+        {"minimum": 42.0}
+      ]
+    },
+    "int-or-string-5": {
+      "x-kubernetes-int-or-string": true,
+      "anyOf": [
+        {"minimum": 42.0}
+      ],
+      "allOf": [
+        {"minimum": 42.0}
+      ]
+    },
+    "int-or-string-6": {
+      "x-kubernetes-int-or-string": true
+    },
+    "preserve-unknown-fields": {
+      "x-kubernetes-preserve-unknown-fields": true
+    },
+    "embedded-object": {
+      "x-kubernetes-embedded-resource": true,
+      "x-kubernetes-preserve-unknown-fields": true,
+      "type": "object"
+    }
+  }
+}`,
+			`
+{
+  "type":"object",
+  "properties": {
+    "apiVersion": {"type":"string"},
+    "kind": {"type":"string"},
+    "metadata": {"$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
+    "int-or-string-1": {
+      "x-kubernetes-int-or-string": true
+    },
+    "int-or-string-2": {
+      "x-kubernetes-int-or-string": true
+    },
+    "int-or-string-3": {
+      "x-kubernetes-int-or-string": true
+    },
+    "int-or-string-4": {
+      "x-kubernetes-int-or-string": true
+    },
+    "int-or-string-5": {
+      "x-kubernetes-int-or-string": true
+    },
+    "int-or-string-6": {
+      "x-kubernetes-int-or-string": true
+    },
+    "preserve-unknown-fields": {
+      "x-kubernetes-preserve-unknown-fields": true
+    },
+    "embedded-object": {
+      "x-kubernetes-embedded-resource": true,
+      "x-kubernetes-preserve-unknown-fields": true,
+      "type": "object"
+    }
+  },
+  "x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]
+}`,
+			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
+			true,
+		},
+		{"with extensions as v3 schema",
+			`
+{
+  "type":"object", 
+  "properties": {
+    "int-or-string-1": {
+      "x-kubernetes-int-or-string": true,
+      "anyOf": [
+        {"type":"integer"},
+        {"type":"string"}
+      ]
+    },
+    "int-or-string-2": {
+      "x-kubernetes-int-or-string": true,
+      "allOf": [{
+        "anyOf": [
+          {"type":"integer"},
+          {"type":"string"}
+        ]
+      }, {
+        "anyOf": [
+          {"minimum": 42.0}
+        ]
+      }]
+    },
+    "int-or-string-3": {
+      "x-kubernetes-int-or-string": true,
+      "anyOf": [
+        {"type":"integer"},
+        {"type":"string"}
+      ],
+      "allOf": [{
+        "anyOf": [
+          {"minimum": 42.0}
+        ]
+      }]
+    },
+    "int-or-string-4": {
+      "x-kubernetes-int-or-string": true,
+      "anyOf": [
+        {"minimum": 42.0}
+      ]
+    },
+    "int-or-string-5": {
+      "x-kubernetes-int-or-string": true,
+      "anyOf": [
+        {"minimum": 42.0}
+      ],
+      "allOf": [
+        {"minimum": 42.0}
+      ]
+    },
+    "int-or-string-6": {
+      "x-kubernetes-int-or-string": true
+    },
+    "preserve-unknown-fields": {
+      "x-kubernetes-preserve-unknown-fields": true
+    },
+    "embedded-object": {
+      "x-kubernetes-embedded-resource": true,
+      "x-kubernetes-preserve-unknown-fields": true,
+      "type": "object"
+    }
+  }
+}`,
+			`
+{
+  "type":"object",
+  "properties": {
+    "apiVersion": {"type":"string"},
+    "kind": {"type":"string"},
+    "metadata": {"$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
+    "int-or-string-1": {
+      "x-kubernetes-int-or-string": true,
+      "anyOf": [
+        {"type":"integer"},
+        {"type":"string"}
+      ]
+    },
+    "int-or-string-2": {
+      "x-kubernetes-int-or-string": true,
+      "allOf": [{
+        "anyOf": [
+          {"type":"integer"},
+          {"type":"string"}
+        ]
+      }, {
+        "anyOf": [
+          {"minimum": 42.0}
+        ]
+      }]
+    },
+    "int-or-string-3": {
+      "x-kubernetes-int-or-string": true,
+      "anyOf": [
+        {"type":"integer"},
+        {"type":"string"}
+      ],
+      "allOf": [{
+        "anyOf": [
+          {"minimum": 42.0}
+        ]
+      }]
+    },
+    "int-or-string-4": {
+      "x-kubernetes-int-or-string": true,
+      "allOf": [{
+        "anyOf": [
+          {"type":"integer"},
+          {"type":"string"}
+        ]
+      }],
+      "anyOf": [
+        {"minimum": 42.0}
+      ]
+    },
+    "int-or-string-5": {
+      "x-kubernetes-int-or-string": true,
+      "anyOf": [
+        {"minimum": 42.0}
+      ],
+      "allOf": [{
+        "anyOf": [
+          {"type":"integer"},
+          {"type":"string"}
+        ]
+      }, {
+        "minimum": 42.0
+      }]
+    },
+    "int-or-string-6": {
+      "x-kubernetes-int-or-string": true,
+      "anyOf": [
+        {"type":"integer"},
+        {"type":"string"}
+      ]
+    },
+    "preserve-unknown-fields": {
+      "x-kubernetes-preserve-unknown-fields": true
+    },
+    "embedded-object": {
+      "x-kubernetes-embedded-resource": true,
+      "x-kubernetes-preserve-unknown-fields": true,
+      "type": "object"
+    }
+  },
+  "x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]
+}`,
+			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
+			false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var schema *spec.Schema
+			var schema *structuralschema.Structural
 			if len(tt.schema) > 0 {
-				schema = &spec.Schema{}
-				if err := json.Unmarshal([]byte(tt.schema), schema); err != nil {
+				v1beta1Schema := &v1beta1.JSONSchemaProps{}
+				if err := json.Unmarshal([]byte(tt.schema), &v1beta1Schema); err != nil {
 					t.Fatal(err)
 				}
+				internalSchema := &apiextensions.JSONSchemaProps{}
+				v1beta1.Convert_v1beta1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(v1beta1Schema, internalSchema, nil)
+				var err error
+				schema, err = structuralschema.NewStructural(internalSchema)
+				if err != nil {
+					t.Fatalf("structural schema error: %v", err)
+				}
+				if errs := structuralschema.ValidateStructural(schema, nil); len(errs) > 0 {
+					t.Fatalf("structural schema validation error: %v", errs.ToAggregate())
+				}
+				schema = schema.Unfold()
 			}
 
 			got := newBuilder(&apiextensions.CustomResourceDefinition{
@@ -86,7 +347,7 @@ func TestNewBuilder(t *testing.T) {
 					},
 					Scope: apiextensions.NamespaceScoped,
 				},
-			}, "v1", schema)
+			}, "v1", schema, tt.v2)
 
 			var wantedSchema, wantedItemsSchema spec.Schema
 			if err := json.Unmarshal([]byte(tt.wantedSchema), &wantedSchema); err != nil {
@@ -103,14 +364,12 @@ func TestNewBuilder(t *testing.T) {
 			}
 
 			// wipe out TypeMeta/ObjectMeta content, with those many lines of descriptions. We trust that they match here.
-			if _, found := got.schema.Properties["kind"]; found {
-				got.schema.Properties["kind"] = spec.Schema{}
-			}
-			if _, found := got.schema.Properties["apiVersion"]; found {
-				got.schema.Properties["apiVersion"] = spec.Schema{}
-			}
-			if _, found := got.schema.Properties["metadata"]; found {
-				got.schema.Properties["metadata"] = spec.Schema{}
+			for _, metaField := range []string{"kind", "apiVersion", "metadata"} {
+				if _, found := got.schema.Properties["kind"]; found {
+					prop := got.schema.Properties[metaField]
+					prop.Description = ""
+					got.schema.Properties[metaField] = prop
+				}
 			}
 
 			if !reflect.DeepEqual(&wantedSchema, got.schema) {

--- a/test/integration/master/crd_test.go
+++ b/test/integration/master/crd_test.go
@@ -160,6 +160,7 @@ func TestCRDOpenAPI(t *testing.T) {
 			},
 			Validation: &apiextensionsv1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+					Type: "object",
 					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 						"foo": {Type: "string"},
 					},


### PR DESCRIPTION
This switch OpenAPI publishing over to structural schemas:

1) only structural schemas published
2) the go-openapi schema generation and OpenAPI v2 conversion goes through structural schema in order to simplify the logic and to remove go-openapi dependencies.

This is based on https://github.com/kubernetes/kubernetes/pull/77333. I.e. only the last commits are relevant here.

```
Publishing of CustomResourceDefinition validation schemas as part of /openapi/v2 (alpha feature, behind the CustomResourcePublishOpenAPI feature gate) is restricted to structural schemas only. CRDs with schemas which are not structural have the NonStructuralSchema condition set with the violations.
```