### PR TITLE
Promote spiffxp to approver, add oomichi as reviewer

### DIFF
--- a/test/conformance/OWNERS
+++ b/test/conformance/OWNERS
@@ -4,10 +4,11 @@
 reviewers:
   - mml
   - cheftako
-  - spiffxp
+  - oomichi
 approvers:
   - mml
   - cheftako
+  - spiffxp
 labels:
   - area/conformance
   - sig/architecture


### PR DESCRIPTION
I'd like to remove the approver bottleneck for the code responsible for
walking / linting conformance tests. I've reviewed a number of PR's
related to this code since adding myself as a reviewer in October.

This doesn't give me approval rights for conformance test list,
just the code responsible for generating the list

I'd like to propose @oomichi as a reviewer given the work he's doing on
conformance-related linting in hack/