### PR TITLE
Implement the permit extension point in scheduler.

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/BUILD
+++ b/pkg/scheduler/framework/v1alpha1/BUILD
@@ -7,6 +7,7 @@ go_library(
         "framework.go",
         "interface.go",
         "registry.go",
+        "waiting_pods_map.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1",
     visibility = ["//visibility:public"],
@@ -14,6 +15,7 @@ go_library(
         "//pkg/scheduler/internal/cache:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/scheduler/framework/v1alpha1/waiting_pods_map.go
+++ b/pkg/scheduler/framework/v1alpha1/waiting_pods_map.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"sync"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// waitingPodsMap a thread-safe map used to maintain pods waiting in the permit phase.
+type waitingPodsMap struct {
+	pods map[types.UID]WaitingPod
+	mu   sync.RWMutex
+}
+
+// newWaitingPodsMap returns a new waitingPodsMap.
+func newWaitingPodsMap() *waitingPodsMap {
+	return &waitingPodsMap{
+		pods: make(map[types.UID]WaitingPod),
+	}
+}
+
+// add a new WaitingPod to the map.
+func (m *waitingPodsMap) add(wp WaitingPod) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pods[wp.GetPod().UID] = wp
+}
+
+// remove a WaitingPod from the map.
+func (m *waitingPodsMap) remove(uid types.UID) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.pods, uid)
+}
+
+// get a WaitingPod from the map.
+func (m *waitingPodsMap) get(uid types.UID) WaitingPod {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.pods[uid]
+
+}
+
+// iterate acquires a read lock and iterates over the WaitingPods map.
+func (m *waitingPodsMap) iterate(callback func(WaitingPod)) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, v := range m.pods {
+		callback(v)
+	}
+}
+
+// waitingPod represents a pod waiting in the permit phase.
+type waitingPod struct {
+	pod *v1.Pod
+	s   chan *Status
+}
+
+// newWaitingPod returns a new waitingPod instance.
+func newWaitingPod(pod *v1.Pod) *waitingPod {
+	return &waitingPod{
+		pod: pod,
+		s:   make(chan *Status),
+	}
+}
+
+// GetPod returns a reference to the waiting pod.
+func (w *waitingPod) GetPod() *v1.Pod {
+	return w.pod
+}
+
+// Allow the waiting pod to be scheduled. Returns true if the allow signal was
+// successfully delivered, false otherwise.
+func (w *waitingPod) Allow() bool {
+	select {
+	case w.s <- NewStatus(Success, ""):
+		return true
+	default:
+		return false
+	}
+}
+
+// Reject declares the waiting pod unschedulable. Returns true if the allow signal
+// was successfully delivered, false otherwise.
+func (w *waitingPod) Reject(msg string) bool {
+	select {
+	case w.s <- NewStatus(Unschedulable, msg):
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Ref #77372

Looking for early feedback, tests and example plugins to be added.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind feature


**What this PR does / why we need it**:
Implements the permit extension point of the new scheduler framework

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #77372

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Implement Permit extension point of the scheduling framework.
```
