### PR TITLE
pkg/proxy: add sig-network-approvers/sig-network-reviewers to OWNERS files

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -226,6 +226,7 @@ aliases:
     - thockin
     - rramkumar1
     - cmluciano
+    - m1093782566
   sig-apps-approvers:
     - kow3ns
     - janetkuo

--- a/pkg/proxy/OWNERS
+++ b/pkg/proxy/OWNERS
@@ -1,18 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- thockin
-- matchstick
+- sig-network-approvers
 reviewers:
-- thockin
-- lavalamp
-- smarterclayton
-- brendandburns
-- vishh
-- justinsb
-- freehan
-- dcbw
-- m1093782566
-- danwinship
+- sig-network-reviewers
 labels:
 - sig/network

--- a/pkg/proxy/config/OWNERS
+++ b/pkg/proxy/config/OWNERS
@@ -1,10 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- thockin
+- sig-network-reviewers
 - lavalamp
 - smarterclayton
 - brendandburns
-- freehan
 labels:
 - sig/network

--- a/pkg/proxy/healthcheck/OWNERS
+++ b/pkg/proxy/healthcheck/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-reviewers:
-- m1093782566

--- a/pkg/proxy/iptables/OWNERS
+++ b/pkg/proxy/iptables/OWNERS
@@ -1,11 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- thockin
+- sig-network-reviewers
 - smarterclayton
 - justinsb
-- freehan
-- dcbw
-- danwinship
 labels:
 - sig/network

--- a/pkg/proxy/ipvs/OWNERS
+++ b/pkg/proxy/ipvs/OWNERS
@@ -1,12 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- thockin
+- sig-network-reviewers
 - brendandburns
-- m1093782566
 - Lion-Wei
 approvers:
-- thockin
+- sig-network-approvers
 - brendandburns
 - m1093782566
 labels:

--- a/pkg/proxy/userspace/OWNERS
+++ b/pkg/proxy/userspace/OWNERS
@@ -1,15 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- thockin
-- dcbw
-- danwinship
+- sig-network-approvers
 reviewers:
-- thockin
+- sig-network-reviewers
 - lavalamp
 - smarterclayton
-- freehan
-- dcbw
-- danwinship
 labels:
 - sig/network


### PR DESCRIPTION
Use sig-network-[approvers | reviewers] in most of the proxy OWNERS files. Leave pkg/proxy/api with Tim though.

/kind cleanup
```release-note
NONE
```
@thockin 
