### PR TITLE
Fix addKlogFlags in global flag libs

### DIFF
--- a/cmd/kubelet/app/options/BUILD
+++ b/cmd/kubelet/app/options/BUILD
@@ -70,7 +70,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["options_test.go"],
+    srcs = [
+        "globalflags_test.go",
+        "options_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",

--- a/cmd/kubelet/app/options/globalflags.go
+++ b/cmd/kubelet/app/options/globalflags.go
@@ -26,7 +26,6 @@ import (
 
 	// libs that provide registration functions
 	"k8s.io/component-base/logs"
-	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/version/verflag"
 
 	// ensure libs have a chance to globally register their flags
@@ -93,7 +92,25 @@ func addCredentialProviderFlags(fs *pflag.FlagSet) {
 
 // addKlogFlags adds flags from k8s.io/klog
 func addKlogFlags(fs *pflag.FlagSet) {
-	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	klog.InitFlags(local)
-	fs.AddGoFlagSet(local)
+	// lookup flags in global flag set and re-register the values with our flagset
+	global := flag.CommandLine
+	local := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+	// DO NOT call klog.InitFlags. It has the side-effect of resetting
+	// flag values to their defaults, which can break previously-loaded
+	// config at runtime.
+
+	register(global, local, "log_dir")
+	register(global, local, "log_file")
+	register(global, local, "log_file_max_size")
+	register(global, local, "logtostderr")
+	register(global, local, "alsologtostderr")
+	register(global, local, "v")
+	register(global, local, "skip_headers")
+	register(global, local, "skip_log_headers")
+	register(global, local, "stderrthreshold")
+	register(global, local, "vmodule")
+	register(global, local, "log_backtrace_at")
+
+	fs.AddFlagSet(local)
 }

--- a/cmd/kubelet/app/options/globalflags_test.go
+++ b/cmd/kubelet/app/options/globalflags_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,82 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package globalflag
+package options
 
 import (
-	"flag"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
 	"github.com/spf13/pflag"
-
 	"k8s.io/apimachinery/pkg/util/diff"
-	cliflag "k8s.io/component-base/cli/flag"
 )
-
-func TestAddGlobalFlags(t *testing.T) {
-	namedFlagSets := &cliflag.NamedFlagSets{}
-	nfs := namedFlagSets.FlagSet("global")
-	AddGlobalFlags(nfs, "test-cmd")
-
-	actualFlag := []string{}
-	nfs.VisitAll(func(flag *pflag.Flag) {
-		actualFlag = append(actualFlag, flag.Name)
-	})
-
-	// Get all flags from flags.CommandLine, except flag `test.*`.
-	wantedFlag := []string{"help"}
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	pflag.VisitAll(func(flag *pflag.Flag) {
-		if !strings.Contains(flag.Name, "test.") {
-			wantedFlag = append(wantedFlag, normalize(flag.Name))
-		}
-	})
-	sort.Strings(wantedFlag)
-
-	if !reflect.DeepEqual(wantedFlag, actualFlag) {
-		t.Errorf("[Default]: expected %+v, got %+v", wantedFlag, actualFlag)
-	}
-
-	tests := []struct {
-		expectedFlag  []string
-		matchExpected bool
-	}{
-		{
-			// Happy case
-			expectedFlag:  []string{"alsologtostderr", "help", "log-backtrace-at", "log-dir", "log-file", "log-file-max-size", "log-flush-frequency", "logtostderr", "skip-headers", "skip-log-headers", "stderrthreshold", "v", "vmodule"},
-			matchExpected: false,
-		},
-		{
-			// Missing flag
-			expectedFlag:  []string{"logtostderr", "log-dir"},
-			matchExpected: true,
-		},
-		{
-			// Empty flag
-			expectedFlag:  []string{},
-			matchExpected: true,
-		},
-		{
-			// Invalid flag
-			expectedFlag:  []string{"foo"},
-			matchExpected: true,
-		},
-	}
-
-	for i, test := range tests {
-		if reflect.DeepEqual(test.expectedFlag, actualFlag) == test.matchExpected {
-			t.Errorf("[%d]: expected %+v, got %+v", i, test.expectedFlag, actualFlag)
-		}
-	}
-}
 
 func TestSideEffect(t *testing.T) {
 	// construct an initial flagset
 	fs := pflag.NewFlagSet("", pflag.ExitOnError)
-	AddGlobalFlags(fs, "")
+	AddGlobalFlags(fs)
 
 	// change some of the values from their defaults and record the new values
 	want := map[string]string{}
@@ -121,7 +60,7 @@ func TestSideEffect(t *testing.T) {
 
 	// construct another flagset
 	fs2 := pflag.NewFlagSet("", pflag.ExitOnError)
-	AddGlobalFlags(fs2, "")
+	AddGlobalFlags(fs2)
 
 	// check if the values in the original flagset still match what we recorded
 	got := map[string]string{}

--- a/staging/src/k8s.io/component-base/cli/globalflag/BUILD
+++ b/staging/src/k8s.io/component-base/cli/globalflag/BUILD
@@ -9,7 +9,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/component-base/logs:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 
@@ -18,6 +17,7 @@ go_test(
     srcs = ["globalflags_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
     ],


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig node
/priority critical-urgent
/assign @liggitt @dims @sttts 

**What this PR does / why we need it**:

klog.InitFlags has the side-effect of resetting defaults. It should be possible to construct a FlagSet with global flags registered, without invoking side-effects. The new behavior was introduced in https://github.com/kubernetes/kubernetes/pull/76474.
    
In this case, the reset broke Kubelet logging config: https://github.com/kubernetes/kubernetes/issues/77416

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
