### PR TITLE
prevent `predicatesOrdering` from escaping from UT

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -173,11 +173,6 @@ func Ordering() []string {
 	return predicatesOrdering
 }
 
-// SetPredicatesOrdering sets the ordering of predicates.
-func SetPredicatesOrdering(names []string) {
-	predicatesOrdering = names
-}
-
 // GetPersistentVolumeInfo returns a persistent volume object by PV ID.
 func (c *CachedPersistentVolumeInfo) GetPersistentVolumeInfo(pvID string) (*v1.PersistentVolume, error) {
 	return c.Get(pvID)

--- a/pkg/scheduler/algorithm/predicates/utils.go
+++ b/pkg/scheduler/algorithm/predicates/utils.go
@@ -77,3 +77,13 @@ func portsConflict(existingPorts schedulernodeinfo.HostPortInfo, wantPorts []*v1
 
 	return false
 }
+
+// SetPredicatesOrderingDuringTest sets the predicatesOrdering to the specified
+// value, and returns a function that restores the original value.
+func SetPredicatesOrderingDuringTest(value []string) func() {
+	origVal := predicatesOrdering
+	predicatesOrdering = value
+	return func() {
+		predicatesOrdering = origVal
+	}
+}

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -217,7 +217,7 @@ func TestSelectHost(t *testing.T) {
 }
 
 func TestGenericScheduler(t *testing.T) {
-	algorithmpredicates.SetPredicatesOrdering(order)
+	defer algorithmpredicates.SetPredicatesOrderingDuringTest(order)()
 	tests := []struct {
 		name                     string
 		predicates               map[string]algorithmpredicates.FitPredicate
@@ -479,7 +479,6 @@ func TestGenericScheduler(t *testing.T) {
 
 // makeScheduler makes a simple genericScheduler for testing.
 func makeScheduler(predicates map[string]algorithmpredicates.FitPredicate, nodes []*v1.Node) *genericScheduler {
-	algorithmpredicates.SetPredicatesOrdering(order)
 	cache := internalcache.New(time.Duration(0), wait.NeverStop)
 	fwk, _ := framework.NewFramework(EmptyPluginRegistry, nil)
 	for _, n := range nodes {
@@ -503,6 +502,7 @@ func makeScheduler(predicates map[string]algorithmpredicates.FitPredicate, nodes
 }
 
 func TestFindFitAllError(t *testing.T) {
+	defer algorithmpredicates.SetPredicatesOrderingDuringTest(order)()
 	predicates := map[string]algorithmpredicates.FitPredicate{"true": truePredicate, "matches": matchesPredicate}
 	nodes := makeNodeList([]string{"3", "2", "1"})
 	scheduler := makeScheduler(predicates, nodes)
@@ -531,6 +531,7 @@ func TestFindFitAllError(t *testing.T) {
 }
 
 func TestFindFitSomeError(t *testing.T) {
+	defer algorithmpredicates.SetPredicatesOrderingDuringTest(order)()
 	predicates := map[string]algorithmpredicates.FitPredicate{"true": truePredicate, "matches": matchesPredicate}
 	nodes := makeNodeList([]string{"3", "2", "1"})
 	scheduler := makeScheduler(predicates, nodes)
@@ -846,7 +847,7 @@ var startTime20190107 = metav1.Date(2019, 1, 7, 1, 1, 1, 0, time.UTC)
 // TestSelectNodesForPreemption tests selectNodesForPreemption. This test assumes
 // that podsFitsOnNode works correctly and is tested separately.
 func TestSelectNodesForPreemption(t *testing.T) {
-	algorithmpredicates.SetPredicatesOrdering(order)
+	defer algorithmpredicates.SetPredicatesOrderingDuringTest(order)()
 	tests := []struct {
 		name                 string
 		predicates           map[string]algorithmpredicates.FitPredicate
@@ -1005,7 +1006,7 @@ func TestSelectNodesForPreemption(t *testing.T) {
 
 // TestPickOneNodeForPreemption tests pickOneNodeForPreemption.
 func TestPickOneNodeForPreemption(t *testing.T) {
-	algorithmpredicates.SetPredicatesOrdering(order)
+	defer algorithmpredicates.SetPredicatesOrderingDuringTest(order)()
 	tests := []struct {
 		name       string
 		predicates map[string]algorithmpredicates.FitPredicate
@@ -1321,6 +1322,7 @@ func TestNodesWherePreemptionMightHelp(t *testing.T) {
 }
 
 func TestPreempt(t *testing.T) {
+	defer algorithmpredicates.SetPredicatesOrderingDuringTest(order)()
 	failedPredMap := FailedPredicateMap{
 		"machine1": []algorithmpredicates.PredicateFailureReason{algorithmpredicates.NewInsufficientResourceError(v1.ResourceMemory, 1000, 500, 300)},
 		"machine2": []algorithmpredicates.PredicateFailureReason{algorithmpredicates.ErrDiskConflict},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind failing-test
/sig scheduling
/priority important-soon

**What this PR does / why we need it**:

`generic_scheduler_test.go` modifies "predicatesOrdering" in UT without setting it back. This causes modified "predicatesOrdering" to be effective in the entire unit test lifecycle, hence could lead to flaky tests and unexpected behavior. For example, it fails when running `TestPreempt` only:

```
$ go test k8s.io/kubernetes/pkg/scheduler/core -run "^TestPreempt$"
-- FAIL: TestPreempt (0.00s)
    --- FAIL: TestPreempt/basic_preemption_logic (0.00s)
        generic_scheduler_test.go:1467: ===== Running test TestPreempt/basic_preemption_logic
        generic_scheduler_test.go:1512: expected node: machine1, got: machine2
        generic_scheduler_test.go:1518: expected 2 pods, got 0.
    --- FAIL: TestPreempt/One_node_doesn't_need_any_preemption (0.00s)
        generic_scheduler_test.go:1467: ===== Running test TestPreempt/One_node_doesn't_need_any_preemption
        generic_scheduler_test.go:1512: expected node: machine3, got: machine1
    --- FAIL: TestPreempt/Scheduler_extenders_allow_only_machine1,_otherwise_machine3_would_have_been_chosen (0.00s)
        generic_scheduler_test.go:1467: ===== Running test TestPreempt/Scheduler_extenders_allow_only_machine1,_otherwise_machine3_would_have_been_chosen
        generic_scheduler_test.go:1518: expected 2 pods, got 0.
    --- FAIL: TestPreempt/One_scheduler_extender_allows_only_machine1,_the_other_returns_error_but_ignorable._Only_machine1_would_be_chosen (0.00s)
        generic_scheduler_test.go:1467: ===== Running test TestPreempt/One_scheduler_extender_allows_only_machine1,_the_other_returns_error_but_ignorable._Only_machine1_would_be_chosen
        generic_scheduler_test.go:1518: expected 2 pods, got 0.
    --- FAIL: TestPreempt/One_scheduler_extender_allows_only_machine1,_but_it_is_not_interested_in_given_pod,_otherwise_machine1_would_have_been_chosen (0.00s)
        generic_scheduler_test.go:1467: ===== Running test TestPreempt/One_scheduler_extender_allows_only_machine1,_but_it_is_not_interested_in_given_pod,_otherwise_machine1_would_have_been_chosen
        generic_scheduler_test.go:1512: expected node: machine3, got: machine2
FAIL
FAIL    k8s.io/kubernetes/pkg/scheduler/core    0.011s
```

**Special notes for your reviewer**:

If appropriate, we can remove function `SetPredicatesOrdering()` - there is no usage inside k8s codebase.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/assign @k82cn @bsalamat 
