### PR TITLE
Fix unstructured list interface compatibility, fix kubectl paging

### DIFF
--- a/pkg/printers/tablegenerator.go
+++ b/pkg/printers/tablegenerator.go
@@ -112,6 +112,7 @@ func (h *HumanReadablePrinter) GenerateTable(obj runtime.Object, options PrintOp
 		table.ResourceVersion = m.GetResourceVersion()
 		table.SelfLink = m.GetSelfLink()
 		table.Continue = m.GetContinue()
+		table.RemainingItemCount = m.GetRemainingItemCount()
 	} else {
 		if m, err := meta.CommonAccessor(obj); err == nil {
 			table.ResourceVersion = m.GetResourceVersion()

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor/tableconvertor.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor/tableconvertor.go
@@ -87,6 +87,7 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 		table.ResourceVersion = m.GetResourceVersion()
 		table.SelfLink = m.GetSelfLink()
 		table.Continue = m.GetContinue()
+		table.RemainingItemCount = m.GetRemainingItemCount()
 	} else {
 		if m, err := meta.CommonAccessor(obj); err == nil {
 			table.ResourceVersion = m.GetResourceVersion()

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go
@@ -107,6 +107,8 @@ type Type interface {
 	SetKind(kind string)
 }
 
+var _ ListInterface = &ListMeta{}
+
 func (meta *ListMeta) GetResourceVersion() string        { return meta.ResourceVersion }
 func (meta *ListMeta) SetResourceVersion(version string) { meta.ResourceVersion = version }
 func (meta *ListMeta) GetSelfLink() string               { return meta.SelfLink }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -47,6 +47,7 @@ type Unstructured struct {
 
 var _ metav1.Object = &Unstructured{}
 var _ runtime.Unstructured = &Unstructured{}
+var _ metav1.ListInterface = &Unstructured{}
 
 func (obj *Unstructured) GetObjectKind() schema.ObjectKind { return obj }
 
@@ -317,6 +318,14 @@ func (u *Unstructured) SetContinue(c string) {
 		return
 	}
 	u.setNestedField(c, "metadata", "continue")
+}
+
+func (u *Unstructured) GetRemainingItemCount() int64 {
+	return getNestedInt64(u.Object, "metadata", "remainingItemCount")
+}
+
+func (u *Unstructured) SetRemainingItemCount(c int64) {
+	u.setNestedField(c, "metadata", "remainingItemCount")
 }
 
 func (u *Unstructured) GetCreationTimestamp() metav1.Time {

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/table.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/table.go
@@ -67,6 +67,7 @@ func (c defaultTableConvertor) ConvertToTable(ctx context.Context, object runtim
 		table.ResourceVersion = m.GetResourceVersion()
 		table.SelfLink = m.GetSelfLink()
 		table.Continue = m.GetContinue()
+		table.RemainingItemCount = m.GetRemainingItemCount()
 	} else {
 		if m, err := meta.CommonAccessor(object); err == nil {
 			table.ResourceVersion = m.GetResourceVersion()

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
@@ -73,6 +73,7 @@ func (c *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOpti
 		table.ResourceVersion = m.GetResourceVersion()
 		table.SelfLink = m.GetSelfLink()
 		table.Continue = m.GetContinue()
+		table.RemainingItemCount = m.GetRemainingItemCount()
 	} else {
 		if m, err := meta.CommonAccessor(obj); err == nil {
 			table.ResourceVersion = m.GetResourceVersion()

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -129,6 +129,13 @@ run_kubectl_get_tests() {
   # Post-condition: Check if we get a limit and continue
   kube::test::if_has_string "${output_message}" "/clusterroles?limit=500 200 OK"
 
+  ### Test kubectl get accumulates pages
+  output_message=$(kubectl get namespaces --chunk-size=1 --no-headers "${kube_flags[@]}")
+  # Post-condition: Check we got multiple pages worth of namespaces
+  kube::test::if_has_string "${output_message}" "default"
+  kube::test::if_has_string "${output_message}" "kube-public"
+  kube::test::if_has_string "${output_message}" "kube-system"
+
   ### Test kubectl get chunk size does not result in a --watch error when resource list is served in multiple chunks
   # Pre-condition: ConfigMap one two tree does not exist
   kube::test::get_object_assert 'configmaps' '{{range.items}}{{ if eq $id_field \"one\" }}found{{end}}{{end}}:' ':'


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
* Fixes ListInterface compatibility of the unstructured object broken in https://github.com/kubernetes/kubernetes/pull/75993 (and adds a type assertion)
* Fixes kubectl chunk paging (and adds a test)
* Propagates remaining item counts to returned tables

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @caesarxuchao @wojtek-t