### PR TITLE
Update kubectl exec use to put flags in the right place

### DIFF
--- a/pkg/kubectl/cmd/exec/exec.go
+++ b/pkg/kubectl/cmd/exec/exec.go
@@ -82,7 +82,7 @@ func NewCmdExec(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		Executor: &DefaultRemoteExecutor{},
 	}
 	cmd := &cobra.Command{
-		Use:                   "exec (POD | TYPE/NAME) [-c CONTAINER] -- COMMAND [args...]",
+		Use:                   "exec (POD | TYPE/NAME) [-c CONTAINER] [flags] -- COMMAND [args...]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Execute a command in a container"),
 		Long:                  "Execute a command in a container.",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig cli
/priority important-longterm

**What this PR does / why we need it**:
Cobra automatically adds `[flags]` when they are present at the end of usage string. In `kubectl exec` they end up after `COMMAND` which is wrong. 

**Special notes for your reviewer**:
/assign @juanvallejo 

**Does this PR introduce a user-facing change?**:
```release-note
Fix kubectl exec usage string
```
