### PR TITLE
Make e2e/framework consistently use the corev1 alias

### DIFF
--- a/test/e2e/framework/create.go
+++ b/test/e2e/framework/create.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pkg/errors"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	storage "k8s.io/api/storage/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -326,9 +326,9 @@ func (f *Framework) patchItemRecursively(item interface{}) error {
 		f.PatchName(&item.Name)
 	case *storage.StorageClass:
 		f.PatchName(&item.Name)
-	case *v1.ServiceAccount:
+	case *corev1.ServiceAccount:
 		f.PatchNamespace(&item.ObjectMeta.Namespace)
-	case *v1.Secret:
+	case *corev1.Secret:
 		f.PatchNamespace(&item.ObjectMeta.Namespace)
 	case *rbac.ClusterRoleBinding:
 		f.PatchName(&item.Name)
@@ -350,7 +350,7 @@ func (f *Framework) patchItemRecursively(item interface{}) error {
 		if err := f.patchItemRecursively(&item.RoleRef); err != nil {
 			return errors.Wrapf(err, "%T", f)
 		}
-	case *v1.Service:
+	case *corev1.Service:
 		f.PatchNamespace(&item.ObjectMeta.Namespace)
 	case *apps.StatefulSet:
 		f.PatchNamespace(&item.ObjectMeta.Namespace)
@@ -370,11 +370,11 @@ func (f *Framework) patchItemRecursively(item interface{}) error {
 type serviceAccountFactory struct{}
 
 func (f *serviceAccountFactory) New() runtime.Object {
-	return &v1.ServiceAccount{}
+	return &corev1.ServiceAccount{}
 }
 
 func (*serviceAccountFactory) Create(f *Framework, i interface{}) (func() error, error) {
-	item, ok := i.(*v1.ServiceAccount)
+	item, ok := i.(*corev1.ServiceAccount)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
@@ -475,11 +475,11 @@ func (*roleBindingFactory) Create(f *Framework, i interface{}) (func() error, er
 type serviceFactory struct{}
 
 func (f *serviceFactory) New() runtime.Object {
-	return &v1.Service{}
+	return &corev1.Service{}
 }
 
 func (*serviceFactory) Create(f *Framework, i interface{}) (func() error, error) {
-	item, ok := i.(*v1.Service)
+	item, ok := i.(*corev1.Service)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
@@ -559,11 +559,11 @@ func (*storageClassFactory) Create(f *Framework, i interface{}) (func() error, e
 type secretFactory struct{}
 
 func (f *secretFactory) New() runtime.Object {
-	return &v1.Secret{}
+	return &corev1.Secret{}
 }
 
 func (*secretFactory) Create(f *Framework, i interface{}) (func() error, error) {
-	item, ok := i.(*v1.Secret)
+	item, ok := i.(*corev1.Secret)
 	if !ok {
 		return nil, errorItemNotSupported
 	}

--- a/test/e2e/framework/exec_util.go
+++ b/test/e2e/framework/exec_util.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
@@ -61,7 +61,7 @@ func (f *Framework) ExecWithOptions(options ExecOptions) (string, string, error)
 		Namespace(options.Namespace).
 		SubResource("exec").
 		Param("container", options.ContainerName)
-	req.VersionedParams(&v1.PodExecOptions{
+	req.VersionedParams(&corev1.PodExecOptions{
 		Container: options.ContainerName,
 		Command:   options.Command,
 		Stdin:     options.Stdin != nil,

--- a/test/e2e/framework/gpu/gpu_util.go
+++ b/test/e2e/framework/gpu/gpu_util.go
@@ -17,7 +17,7 @@ limitations under the License.
 package gpu
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/klog"
@@ -39,7 +39,7 @@ const (
 // This is based on the Device Plugin system and expected to run on a COS based node
 // After the NVIDIA drivers were installed
 // TODO make this generic and not linked to COS only
-func NumberOfNVIDIAGPUs(node *v1.Node) int64 {
+func NumberOfNVIDIAGPUs(node *corev1.Node) int64 {
 	val, ok := node.Status.Capacity[NVIDIAGPUResourceName]
 	if !ok {
 		return 0
@@ -48,10 +48,10 @@ func NumberOfNVIDIAGPUs(node *v1.Node) int64 {
 }
 
 // NVIDIADevicePlugin returns the official Google Device Plugin pod for NVIDIA GPU in GKE
-func NVIDIADevicePlugin() *v1.Pod {
+func NVIDIADevicePlugin() *corev1.Pod {
 	ds, err := framework.DsFromManifest(GPUDevicePluginDSYAML)
 	framework.ExpectNoError(err)
-	p := &v1.Pod{
+	p := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "device-plugin-nvidia-gpu-" + string(uuid.NewUUID()),
 			Namespace: metav1.NamespaceSystem,

--- a/test/e2e/framework/job/fixtures.go
+++ b/test/e2e/framework/job/fixtures.go
@@ -18,7 +18,7 @@ package job
 
 import (
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -29,7 +29,7 @@ import (
 // first time it is run and succeeds subsequently. name is the Name of the Job. RestartPolicy indicates the restart
 // policy of the containers in which the Pod is running. Parallelism is the Job's parallelism, and completions is the
 // Job's required number of completions.
-func NewTestJob(behavior, name string, rPol v1.RestartPolicy, parallelism, completions int32, activeDeadlineSeconds *int64, backoffLimit int32) *batchv1.Job {
+func NewTestJob(behavior, name string, rPol corev1.RestartPolicy, parallelism, completions int32, activeDeadlineSeconds *int64, backoffLimit int32) *batchv1.Job {
 	manualSelector := false
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -44,26 +44,26 @@ func NewTestJob(behavior, name string, rPol v1.RestartPolicy, parallelism, compl
 			Completions:           &completions,
 			BackoffLimit:          &backoffLimit,
 			ManualSelector:        &manualSelector,
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{JobSelectorKey: name},
 				},
-				Spec: v1.PodSpec{
+				Spec: corev1.PodSpec{
 					RestartPolicy: rPol,
-					Volumes: []v1.Volume{
+					Volumes: []corev1.Volume{
 						{
 							Name: "data",
-							VolumeSource: v1.VolumeSource{
-								EmptyDir: &v1.EmptyDirVolumeSource{},
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},
-					Containers: []v1.Container{
+					Containers: []corev1.Container{
 						{
 							Name:    "c",
 							Image:   framework.BusyBoxImage,
 							Command: []string{},
-							VolumeMounts: []v1.VolumeMount{
+							VolumeMounts: []corev1.VolumeMount{
 								{
 									MountPath: "/data",
 									Name:      "data",
@@ -101,7 +101,7 @@ func NewTestJob(behavior, name string, rPol v1.RestartPolicy, parallelism, compl
 func FinishTime(finishedJob *batchv1.Job) metav1.Time {
 	var finishTime metav1.Time
 	for _, c := range finishedJob.Status.Conditions {
-		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == v1.ConditionTrue {
+		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == corev1.ConditionTrue {
 			return c.LastTransitionTime
 		}
 	}

--- a/test/e2e/framework/job/rest.go
+++ b/test/e2e/framework/job/rest.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	batch "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -35,7 +35,7 @@ func GetJob(c clientset.Interface, ns, name string) (*batch.Job, error) {
 }
 
 // GetJobPods returns a list of Pods belonging to a Job.
-func GetJobPods(c clientset.Interface, ns, jobName string) (*v1.PodList, error) {
+func GetJobPods(c clientset.Interface, ns, jobName string) (*corev1.PodList, error) {
 	label := labels.SelectorFromSet(labels.Set(map[string]string{JobSelectorKey: jobName}))
 	options := metav1.ListOptions{LabelSelector: label.String()}
 	return c.CoreV1().Pods(ns).List(options)

--- a/test/e2e/framework/job/wait.go
+++ b/test/e2e/framework/job/wait.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -40,7 +40,7 @@ func WaitForAllJobPodsRunning(c clientset.Interface, ns, jobName string, paralle
 		}
 		count := int32(0)
 		for _, p := range pods.Items {
-			if p.Status.Phase == v1.PodRunning {
+			if p.Status.Phase == corev1.PodRunning {
 				count++
 			}
 		}
@@ -78,7 +78,7 @@ func WaitForJobFailure(c clientset.Interface, ns, jobName string, timeout time.D
 			return false, err
 		}
 		for _, c := range curr.Status.Conditions {
-			if c.Type == batchv1.JobFailed && c.Status == v1.ConditionTrue {
+			if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
 				if reason == "" || reason == c.Reason {
 					return true, nil
 				}
@@ -110,7 +110,7 @@ func CheckForAllJobPodsRunning(c clientset.Interface, ns, jobName string, parall
 	}
 	count := int32(0)
 	for _, p := range pods.Items {
-		if p.Status.Phase == v1.PodRunning {
+		if p.Status.Phase == corev1.PodRunning {
 			count++
 		}
 	}

--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
@@ -333,7 +333,7 @@ func (k *NodeKiller) Run(stopCh <-chan struct{}) {
 	}, k.config.Interval, k.config.JitterFactor, true, stopCh)
 }
 
-func (k *NodeKiller) pickNodes() []v1.Node {
+func (k *NodeKiller) pickNodes() []corev1.Node {
 	nodes := GetReadySchedulableNodesOrDie(k.client)
 	numNodes := int(k.config.FailureRatio * float64(len(nodes.Items)))
 	shuffledNodes := shuffleNodes(nodes.Items)
@@ -343,7 +343,7 @@ func (k *NodeKiller) pickNodes() []v1.Node {
 	return shuffledNodes
 }
 
-func (k *NodeKiller) kill(nodes []v1.Node) {
+func (k *NodeKiller) kill(nodes []corev1.Node) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(nodes))
 	for _, node := range nodes {
@@ -372,6 +372,6 @@ func (k *NodeKiller) kill(nodes []v1.Node) {
 }
 
 // DeleteNodeOnCloudProvider deletes the specified node.
-func DeleteNodeOnCloudProvider(node *v1.Node) error {
+func DeleteNodeOnCloudProvider(node *corev1.Node) error {
 	return TestContext.CloudConfig.Provider.DeleteNode(node)
 }

--- a/test/e2e/framework/podlogs/podlogs.go
+++ b/test/e2e/framework/podlogs/podlogs.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 )
@@ -46,7 +46,7 @@ import (
 // The stream includes formatted error messages and ends with
 //    rpc error: code = Unknown desc = Error: No such container: 41a...
 // when the pod gets deleted while streaming.
-func LogsForPod(ctx context.Context, cs clientset.Interface, ns, pod string, opts *v1.PodLogOptions) (io.ReadCloser, error) {
+func LogsForPod(ctx context.Context, cs clientset.Interface, ns, pod string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
 	req := cs.CoreV1().Pods(ns).GetLogs(pod, opts)
 	return req.Context(ctx).Stream()
 }
@@ -112,7 +112,7 @@ func CopyAllLogs(ctx context.Context, cs clientset.Interface, ns string, to LogO
 						continue
 					}
 					readCloser, err := LogsForPod(ctx, cs, ns, pod.ObjectMeta.Name,
-						&v1.PodLogOptions{
+						&corev1.PodLogOptions{
 							Container: c.Name,
 							Follow:    true,
 						})
@@ -228,7 +228,7 @@ func WatchPods(ctx context.Context, cs clientset.Interface, ns string, to io.Wri
 					continue
 				}
 
-				pod, ok := e.Object.(*v1.Pod)
+				pod, ok := e.Object.(*corev1.Pod)
 				if !ok {
 					continue
 				}

--- a/test/e2e/framework/provider.go
+++ b/test/e2e/framework/provider.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 )
 
@@ -95,18 +95,18 @@ type ProviderInterface interface {
 	GetGroupNodes(group string) ([]string, error)
 	GroupSize(group string) (int, error)
 
-	DeleteNode(node *v1.Node) error
+	DeleteNode(node *corev1.Node) error
 
 	CreatePD(zone string) (string, error)
 	DeletePD(pdName string) error
-	CreatePVSource(zone, diskName string) (*v1.PersistentVolumeSource, error)
-	DeletePVSource(pvSource *v1.PersistentVolumeSource) error
+	CreatePVSource(zone, diskName string) (*corev1.PersistentVolumeSource, error)
+	DeletePVSource(pvSource *corev1.PersistentVolumeSource) error
 
 	CleanupServiceResources(c clientset.Interface, loadBalancerName, region, zone string)
 
 	EnsureLoadBalancerResourcesDeleted(ip, portRange string) error
 	LoadBalancerSrcRanges() []string
-	EnableAndDisableInternalLB() (enable, disable func(svc *v1.Service))
+	EnableAndDisableInternalLB() (enable, disable func(svc *corev1.Service))
 }
 
 // NullProvider is the default implementation of the ProviderInterface
@@ -135,7 +135,7 @@ func (n NullProvider) GroupSize(group string) (int, error) {
 }
 
 // DeleteNode is a base implementation which deletes a node.
-func (n NullProvider) DeleteNode(node *v1.Node) error {
+func (n NullProvider) DeleteNode(node *corev1.Node) error {
 	return fmt.Errorf("provider does not support DeleteNode")
 }
 
@@ -150,12 +150,12 @@ func (n NullProvider) DeletePD(pdName string) error {
 }
 
 // CreatePVSource is a base implementation which creates PV source.
-func (n NullProvider) CreatePVSource(zone, diskName string) (*v1.PersistentVolumeSource, error) {
+func (n NullProvider) CreatePVSource(zone, diskName string) (*corev1.PersistentVolumeSource, error) {
 	return nil, fmt.Errorf("Provider not supported")
 }
 
 // DeletePVSource is a base implementation which deletes PV source.
-func (n NullProvider) DeletePVSource(pvSource *v1.PersistentVolumeSource) error {
+func (n NullProvider) DeletePVSource(pvSource *corev1.PersistentVolumeSource) error {
 	return fmt.Errorf("Provider not supported")
 }
 
@@ -174,8 +174,8 @@ func (n NullProvider) LoadBalancerSrcRanges() []string {
 }
 
 // EnableAndDisableInternalLB is a base implementation which returns functions for enabling/disabling an internal LB.
-func (n NullProvider) EnableAndDisableInternalLB() (enable, disable func(svc *v1.Service)) {
-	nop := func(svc *v1.Service) {}
+func (n NullProvider) EnableAndDisableInternalLB() (enable, disable func(svc *corev1.Service)) {
+	nop := func(svc *corev1.Service) {}
 	return nop, nop
 }
 

--- a/test/e2e/framework/providers/aws/aws.go
+++ b/test/e2e/framework/providers/aws/aws.go
@@ -26,7 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	awscloud "k8s.io/legacy-cloud-providers/aws"
 )
@@ -67,7 +67,7 @@ func (p *Provider) GroupSize(group string) (int, error) {
 }
 
 // DeleteNode deletes a node which is specified as the argument
-func (p *Provider) DeleteNode(node *v1.Node) error {
+func (p *Provider) DeleteNode(node *corev1.Node) error {
 	client := newAWSClient("")
 
 	instanceID, err := awscloud.KubernetesInstanceID(node.Spec.ProviderID).MapToAWSInstanceID()
@@ -123,9 +123,9 @@ func (p *Provider) DeletePD(pdName string) error {
 }
 
 // CreatePVSource creates a persistent volume source
-func (p *Provider) CreatePVSource(zone, diskName string) (*v1.PersistentVolumeSource, error) {
-	return &v1.PersistentVolumeSource{
-		AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
+func (p *Provider) CreatePVSource(zone, diskName string) (*corev1.PersistentVolumeSource, error) {
+	return &corev1.PersistentVolumeSource{
+		AWSElasticBlockStore: &corev1.AWSElasticBlockStoreVolumeSource{
 			VolumeID: diskName,
 			FSType:   "ext3",
 		},
@@ -133,7 +133,7 @@ func (p *Provider) CreatePVSource(zone, diskName string) (*v1.PersistentVolumeSo
 }
 
 // DeletePVSource deletes a persistent volume source
-func (p *Provider) DeletePVSource(pvSource *v1.PersistentVolumeSource) error {
+func (p *Provider) DeletePVSource(pvSource *corev1.PersistentVolumeSource) error {
 	return framework.DeletePDWithRetry(pvSource.AWSElasticBlockStore.VolumeID)
 }
 

--- a/test/e2e/framework/providers/azure/azure.go
+++ b/test/e2e/framework/providers/azure/azure.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/legacy-cloud-providers/azure"
@@ -55,7 +55,7 @@ type Provider struct {
 }
 
 // DeleteNode deletes a node which is specified as the argument
-func (p *Provider) DeleteNode(node *v1.Node) error {
+func (p *Provider) DeleteNode(node *corev1.Node) error {
 	return errors.New("not implemented yet")
 }
 
@@ -79,11 +79,11 @@ func (p *Provider) DeletePD(pdName string) error {
 }
 
 // EnableAndDisableInternalLB returns functions for both enabling and disabling internal Load Balancer
-func (p *Provider) EnableAndDisableInternalLB() (enable, disable func(svc *v1.Service)) {
-	enable = func(svc *v1.Service) {
+func (p *Provider) EnableAndDisableInternalLB() (enable, disable func(svc *corev1.Service)) {
+	enable = func(svc *corev1.Service) {
 		svc.ObjectMeta.Annotations = map[string]string{azure.ServiceAnnotationLoadBalancerInternal: "true"}
 	}
-	disable = func(svc *v1.Service) {
+	disable = func(svc *corev1.Service) {
 		svc.ObjectMeta.Annotations = map[string]string{azure.ServiceAnnotationLoadBalancerInternal: "false"}
 	}
 	return

--- a/test/e2e/framework/providers/gce/firewall.go
+++ b/test/e2e/framework/providers/gce/firewall.go
@@ -25,7 +25,7 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
@@ -40,8 +40,8 @@ func MakeFirewallNameForLBService(name string) string {
 }
 
 // ConstructFirewallForLBService returns the expected GCE firewall rule for a loadbalancer type service
-func ConstructFirewallForLBService(svc *v1.Service, nodeTag string) *compute.Firewall {
-	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+func ConstructFirewallForLBService(svc *corev1.Service, nodeTag string) *compute.Firewall {
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 		framework.Failf("can not construct firewall rule for non-loadbalancer type service")
 	}
 	fw := compute.Firewall{}
@@ -68,8 +68,8 @@ func MakeHealthCheckFirewallNameForLBService(clusterID, name string, isNodesHeal
 }
 
 // ConstructHealthCheckFirewallForLBService returns the expected GCE firewall rule for a loadbalancer type service
-func ConstructHealthCheckFirewallForLBService(clusterID string, svc *v1.Service, nodeTag string, isNodesHealthCheck bool) *compute.Firewall {
-	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+func ConstructHealthCheckFirewallForLBService(clusterID string, svc *corev1.Service, nodeTag string, isNodesHealthCheck bool) *compute.Firewall {
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 		framework.Failf("can not construct firewall rule for non-loadbalancer type service")
 	}
 	fw := compute.Firewall{}

--- a/test/e2e/framework/providers/gce/gce.go
+++ b/test/e2e/framework/providers/gce/gce.go
@@ -26,7 +26,7 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -193,7 +193,7 @@ func getGCEZoneForGroup(group string) (string, error) {
 }
 
 // DeleteNode deletes a node which is specified as the argument
-func (p *Provider) DeleteNode(node *v1.Node) error {
+func (p *Provider) DeleteNode(node *corev1.Node) error {
 	zone := framework.TestContext.CloudConfig.Zone
 	project := framework.TestContext.CloudConfig.ProjectID
 
@@ -235,9 +235,9 @@ func (p *Provider) DeletePD(pdName string) error {
 }
 
 // CreatePVSource creates a persistent volume source
-func (p *Provider) CreatePVSource(zone, diskName string) (*v1.PersistentVolumeSource, error) {
-	return &v1.PersistentVolumeSource{
-		GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+func (p *Provider) CreatePVSource(zone, diskName string) (*corev1.PersistentVolumeSource, error) {
+	return &corev1.PersistentVolumeSource{
+		GCEPersistentDisk: &corev1.GCEPersistentDiskVolumeSource{
 			PDName:   diskName,
 			FSType:   "ext3",
 			ReadOnly: false,
@@ -246,7 +246,7 @@ func (p *Provider) CreatePVSource(zone, diskName string) (*v1.PersistentVolumeSo
 }
 
 // DeletePVSource deletes a persistent volume source
-func (p *Provider) DeletePVSource(pvSource *v1.PersistentVolumeSource) error {
+func (p *Provider) DeletePVSource(pvSource *corev1.PersistentVolumeSource) error {
 	return framework.DeletePDWithRetry(pvSource.GCEPersistentDisk.PDName)
 }
 
@@ -301,7 +301,7 @@ func (p *Provider) cleanupGCEResources(c clientset.Interface, loadBalancerName, 
 	if hc != nil {
 		hcNames = append(hcNames, hc.Name)
 	}
-	if err := p.gceCloud.DeleteExternalTargetPoolAndChecks(&v1.Service{}, loadBalancerName, region, clusterID, hcNames...); err != nil &&
+	if err := p.gceCloud.DeleteExternalTargetPoolAndChecks(&corev1.Service{}, loadBalancerName, region, clusterID, hcNames...); err != nil &&
 		!IsGoogleAPIHTTPErrorCode(err, http.StatusNotFound) {
 		retErr = fmt.Errorf("%v\n%v", retErr, err)
 	}
@@ -315,11 +315,11 @@ func (p *Provider) LoadBalancerSrcRanges() []string {
 }
 
 // EnableAndDisableInternalLB returns functions for both enabling and disabling internal Load Balancer
-func (p *Provider) EnableAndDisableInternalLB() (enable, disable func(svc *v1.Service)) {
-	enable = func(svc *v1.Service) {
+func (p *Provider) EnableAndDisableInternalLB() (enable, disable func(svc *corev1.Service)) {
+	enable = func(svc *corev1.Service) {
 		svc.ObjectMeta.Annotations = map[string]string{gcecloud.ServiceAnnotationLoadBalancerType: string(gcecloud.LBTypeInternal)}
 	}
-	disable = func(svc *v1.Service) {
+	disable = func(svc *corev1.Service) {
 		delete(svc.ObjectMeta.Annotations, gcecloud.ServiceAnnotationLoadBalancerType)
 	}
 	return

--- a/test/e2e/framework/providers/gce/ingress.go
+++ b/test/e2e/framework/providers/gce/ingress.go
@@ -29,7 +29,7 @@ import (
 	"github.com/onsi/ginkgo"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
@@ -71,8 +71,8 @@ type IngressController struct {
 	rcPath       string
 	UID          string
 	staticIPName string
-	rc           *v1.ReplicationController
-	svc          *v1.Service
+	rc           *corev1.ReplicationController
+	svc          *corev1.Service
 	Client       clientset.Interface
 	Cloud        framework.CloudConfig
 }
@@ -616,7 +616,7 @@ func (cont *IngressController) isHTTPErrorCode(err error, code int) bool {
 }
 
 // WaitForNegBackendService waits for the expected backend service to become
-func (cont *IngressController) WaitForNegBackendService(svcPorts map[string]v1.ServicePort) error {
+func (cont *IngressController) WaitForNegBackendService(svcPorts map[string]corev1.ServicePort) error {
 	return wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
 		err := cont.verifyBackendMode(svcPorts, negBackend)
 		if err != nil {
@@ -628,7 +628,7 @@ func (cont *IngressController) WaitForNegBackendService(svcPorts map[string]v1.S
 }
 
 // WaitForIgBackendService returns true only if all global backend service with matching svcPorts pointing to IG as backend
-func (cont *IngressController) WaitForIgBackendService(svcPorts map[string]v1.ServicePort) error {
+func (cont *IngressController) WaitForIgBackendService(svcPorts map[string]corev1.ServicePort) error {
 	return wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
 		err := cont.verifyBackendMode(svcPorts, igBackend)
 		if err != nil {
@@ -640,16 +640,16 @@ func (cont *IngressController) WaitForIgBackendService(svcPorts map[string]v1.Se
 }
 
 // BackendServiceUsingNEG returns true only if all global backend service with matching svcPorts pointing to NEG as backend
-func (cont *IngressController) BackendServiceUsingNEG(svcPorts map[string]v1.ServicePort) error {
+func (cont *IngressController) BackendServiceUsingNEG(svcPorts map[string]corev1.ServicePort) error {
 	return cont.verifyBackendMode(svcPorts, negBackend)
 }
 
 // BackendServiceUsingIG returns true only if all global backend service with matching svcPorts pointing to IG as backend
-func (cont *IngressController) BackendServiceUsingIG(svcPorts map[string]v1.ServicePort) error {
+func (cont *IngressController) BackendServiceUsingIG(svcPorts map[string]corev1.ServicePort) error {
 	return cont.verifyBackendMode(svcPorts, igBackend)
 }
 
-func (cont *IngressController) verifyBackendMode(svcPorts map[string]v1.ServicePort, backendType backendType) error {
+func (cont *IngressController) verifyBackendMode(svcPorts map[string]corev1.ServicePort, backendType backendType) error {
 	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
 	beList, err := gceCloud.ListGlobalBackendServices()
 	if err != nil {

--- a/test/e2e/framework/providers/gce/recreate_node.go
+++ b/test/e2e/framework/providers/gce/recreate_node.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -30,7 +30,7 @@ import (
 	testutils "k8s.io/kubernetes/test/utils"
 )
 
-func nodeNames(nodes []v1.Node) []string {
+func nodeNames(nodes []corev1.Node) []string {
 	result := make([]string, 0, len(nodes))
 	for i := range nodes {
 		result = append(result, nodes[i].Name)
@@ -40,7 +40,7 @@ func nodeNames(nodes []v1.Node) []string {
 
 var _ = ginkgo.Describe("Recreate [Feature:Recreate]", func() {
 	f := framework.NewDefaultFramework("recreate")
-	var originalNodes []v1.Node
+	var originalNodes []corev1.Node
 	var originalPodNames []string
 	var ps *testutils.PodStore
 	systemNamespace := metav1.NamespaceSystem
@@ -91,7 +91,7 @@ var _ = ginkgo.Describe("Recreate [Feature:Recreate]", func() {
 })
 
 // Recreate all the nodes in the test instance group
-func testRecreate(c clientset.Interface, ps *testutils.PodStore, systemNamespace string, nodes []v1.Node, podNames []string) {
+func testRecreate(c clientset.Interface, ps *testutils.PodStore, systemNamespace string, nodes []corev1.Node, podNames []string) {
 	err := recreateNodes(c, nodes)
 	if err != nil {
 		framework.Failf("Test failed; failed to start the restart instance group command.")

--- a/test/e2e/framework/providers/gce/util.go
+++ b/test/e2e/framework/providers/gce/util.go
@@ -21,20 +21,20 @@ import (
 	"strings"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-func recreateNodes(c clientset.Interface, nodes []v1.Node) error {
+func recreateNodes(c clientset.Interface, nodes []corev1.Node) error {
 	// Build mapping from zone to nodes in that zone.
 	nodeNamesByZone := make(map[string][]string)
 	for i := range nodes {
 		node := &nodes[i]
 		zone := framework.TestContext.CloudConfig.Zone
-		if z, ok := node.Labels[v1.LabelZoneFailureDomain]; ok {
+		if z, ok := node.Labels[corev1.LabelZoneFailureDomain]; ok {
 			zone = z
 		}
 		nodeNamesByZone[zone] = append(nodeNamesByZone[zone], node.Name)
@@ -69,7 +69,7 @@ func recreateNodes(c clientset.Interface, nodes []v1.Node) error {
 	return nil
 }
 
-func waitForNodeBootIdsToChange(c clientset.Interface, nodes []v1.Node, timeout time.Duration) error {
+func waitForNodeBootIdsToChange(c clientset.Interface, nodes []corev1.Node, timeout time.Duration) error {
 	errMsg := []string{}
 	for i := range nodes {
 		node := &nodes[i]

--- a/test/e2e/framework/rc_util.go
+++ b/test/e2e/framework/rc_util.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -34,19 +34,19 @@ import (
 )
 
 // RcByNamePort returns a ReplicationController with specified name and port
-func RcByNamePort(name string, replicas int32, image string, port int, protocol v1.Protocol,
-	labels map[string]string, gracePeriod *int64) *v1.ReplicationController {
+func RcByNamePort(name string, replicas int32, image string, port int, protocol corev1.Protocol,
+	labels map[string]string, gracePeriod *int64) *corev1.ReplicationController {
 
-	return RcByNameContainer(name, replicas, image, labels, v1.Container{
+	return RcByNameContainer(name, replicas, image, labels, corev1.Container{
 		Name:  name,
 		Image: image,
-		Ports: []v1.ContainerPort{{ContainerPort: int32(port), Protocol: protocol}},
+		Ports: []corev1.ContainerPort{{ContainerPort: int32(port), Protocol: protocol}},
 	}, gracePeriod)
 }
 
 // RcByNameContainer returns a ReplicationController with specified name and container
-func RcByNameContainer(name string, replicas int32, image string, labels map[string]string, c v1.Container,
-	gracePeriod *int64) *v1.ReplicationController {
+func RcByNameContainer(name string, replicas int32, image string, labels map[string]string, c corev1.Container,
+	gracePeriod *int64) *corev1.ReplicationController {
 
 	zeroGracePeriod := int64(0)
 
@@ -55,7 +55,7 @@ func RcByNameContainer(name string, replicas int32, image string, labels map[str
 	if gracePeriod == nil {
 		gracePeriod = &zeroGracePeriod
 	}
-	return &v1.ReplicationController{
+	return &corev1.ReplicationController{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ReplicationController",
 			APIVersion: "v1",
@@ -63,17 +63,17 @@ func RcByNameContainer(name string, replicas int32, image string, labels map[str
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: v1.ReplicationControllerSpec{
+		Spec: corev1.ReplicationControllerSpec{
 			Replicas: func(i int32) *int32 { return &i }(replicas),
 			Selector: map[string]string{
 				"name": name,
 			},
-			Template: &v1.PodTemplateSpec{
+			Template: &corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
 				},
-				Spec: v1.PodSpec{
-					Containers:                    []v1.Container{c},
+				Spec: corev1.PodSpec{
+					Containers:                    []corev1.Container{c},
 					TerminationGracePeriodSeconds: gracePeriod,
 				},
 			},
@@ -81,14 +81,14 @@ func RcByNameContainer(name string, replicas int32, image string, labels map[str
 	}
 }
 
-type updateRcFunc func(d *v1.ReplicationController)
+type updateRcFunc func(d *corev1.ReplicationController)
 
 // UpdateReplicationControllerWithRetries retries updating the given rc on conflict with the following steps:
 // 1. Get latest resource
 // 2. applyUpdate
 // 3. Update the resource
-func UpdateReplicationControllerWithRetries(c clientset.Interface, namespace, name string, applyUpdate updateRcFunc) (*v1.ReplicationController, error) {
-	var rc *v1.ReplicationController
+func UpdateReplicationControllerWithRetries(c clientset.Interface, namespace, name string, applyUpdate updateRcFunc) (*corev1.ReplicationController, error) {
+	var rc *corev1.ReplicationController
 	var updateErr error
 	pollErr := wait.PollImmediate(10*time.Millisecond, 1*time.Minute, func() (bool, error) {
 		var err error

--- a/test/e2e/framework/replicaset/fixtures.go
+++ b/test/e2e/framework/replicaset/fixtures.go
@@ -18,7 +18,7 @@ package replicaset
 
 import (
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,12 +38,12 @@ func NewReplicaSet(name, namespace string, replicas int32, podLabels map[string]
 				MatchLabels: podLabels,
 			},
 			Replicas: &replicas,
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: podLabels,
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
 							Name:  imageName,
 							Image: image,

--- a/test/e2e/framework/resource_usage_gatherer.go
+++ b/test/e2e/framework/resource_usage_gatherer.go
@@ -27,7 +27,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientset "k8s.io/client-go/kubernetes"
@@ -232,7 +232,7 @@ const (
 )
 
 // NewResourceUsageGatherer returns a new ContainerResourceGatherer.
-func NewResourceUsageGatherer(c clientset.Interface, options ResourceGathererOptions, pods *v1.PodList) (*ContainerResourceGatherer, error) {
+func NewResourceUsageGatherer(c clientset.Interface, options ResourceGathererOptions, pods *corev1.PodList) (*ContainerResourceGatherer, error) {
 	g := ContainerResourceGatherer{
 		client:       c,
 		stopCh:       make(chan struct{}),

--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -129,19 +129,19 @@ func NewServiceTestJig(client clientset.Interface, name string) *ServiceTestJig 
 	return j
 }
 
-// newServiceTemplate returns the default v1.Service template for this jig, but
+// newServiceTemplate returns the default corev1.Service template for this jig, but
 // does not actually create the Service.  The default Service has the same name
 // as the jig and exposes the given port.
-func (j *ServiceTestJig) newServiceTemplate(namespace string, proto v1.Protocol, port int32) *v1.Service {
-	service := &v1.Service{
+func (j *ServiceTestJig) newServiceTemplate(namespace string, proto corev1.Protocol, port int32) *corev1.Service {
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      j.Name,
 			Labels:    j.Labels,
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Selector: j.Labels,
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Protocol: proto,
 					Port:     port,
@@ -155,8 +155,8 @@ func (j *ServiceTestJig) newServiceTemplate(namespace string, proto v1.Protocol,
 // CreateTCPServiceWithPort creates a new TCP Service with given port based on the
 // jig's defaults. Callers can provide a function to tweak the Service object before
 // it is created.
-func (j *ServiceTestJig) CreateTCPServiceWithPort(namespace string, tweak func(svc *v1.Service), port int32) *v1.Service {
-	svc := j.newServiceTemplate(namespace, v1.ProtocolTCP, port)
+func (j *ServiceTestJig) CreateTCPServiceWithPort(namespace string, tweak func(svc *corev1.Service), port int32) *corev1.Service {
+	svc := j.newServiceTemplate(namespace, corev1.ProtocolTCP, port)
 	if tweak != nil {
 		tweak(svc)
 	}
@@ -170,8 +170,8 @@ func (j *ServiceTestJig) CreateTCPServiceWithPort(namespace string, tweak func(s
 // CreateTCPServiceOrFail creates a new TCP Service based on the jig's
 // defaults.  Callers can provide a function to tweak the Service object before
 // it is created.
-func (j *ServiceTestJig) CreateTCPServiceOrFail(namespace string, tweak func(svc *v1.Service)) *v1.Service {
-	svc := j.newServiceTemplate(namespace, v1.ProtocolTCP, 80)
+func (j *ServiceTestJig) CreateTCPServiceOrFail(namespace string, tweak func(svc *corev1.Service)) *corev1.Service {
+	svc := j.newServiceTemplate(namespace, corev1.ProtocolTCP, 80)
 	if tweak != nil {
 		tweak(svc)
 	}
@@ -185,8 +185,8 @@ func (j *ServiceTestJig) CreateTCPServiceOrFail(namespace string, tweak func(svc
 // CreateUDPServiceOrFail creates a new UDP Service based on the jig's
 // defaults.  Callers can provide a function to tweak the Service object before
 // it is created.
-func (j *ServiceTestJig) CreateUDPServiceOrFail(namespace string, tweak func(svc *v1.Service)) *v1.Service {
-	svc := j.newServiceTemplate(namespace, v1.ProtocolUDP, 80)
+func (j *ServiceTestJig) CreateUDPServiceOrFail(namespace string, tweak func(svc *corev1.Service)) *corev1.Service {
+	svc := j.newServiceTemplate(namespace, corev1.ProtocolUDP, 80)
 	if tweak != nil {
 		tweak(svc)
 	}
@@ -199,17 +199,17 @@ func (j *ServiceTestJig) CreateUDPServiceOrFail(namespace string, tweak func(svc
 
 // CreateExternalNameServiceOrFail creates a new ExternalName type Service based on the jig's defaults.
 // Callers can provide a function to tweak the Service object before it is created.
-func (j *ServiceTestJig) CreateExternalNameServiceOrFail(namespace string, tweak func(svc *v1.Service)) *v1.Service {
-	svc := &v1.Service{
+func (j *ServiceTestJig) CreateExternalNameServiceOrFail(namespace string, tweak func(svc *corev1.Service)) *corev1.Service {
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      j.Name,
 			Labels:    j.Labels,
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Selector:     j.Labels,
 			ExternalName: "foo.example.com",
-			Type:         v1.ServiceTypeExternalName,
+			Type:         corev1.ServiceTypeExternalName,
 		},
 	}
 	if tweak != nil {
@@ -223,12 +223,12 @@ func (j *ServiceTestJig) CreateExternalNameServiceOrFail(namespace string, tweak
 }
 
 // CreateServiceWithServicePort creates a new Service with ServicePort.
-func (j *ServiceTestJig) CreateServiceWithServicePort(labels map[string]string, namespace string, ports []v1.ServicePort) (*v1.Service, error) {
-	service := &v1.Service{
+func (j *ServiceTestJig) CreateServiceWithServicePort(labels map[string]string, namespace string, ports []corev1.ServicePort) (*corev1.Service, error) {
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: j.Name,
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Selector: labels,
 			Ports:    ports,
 		},
@@ -236,9 +236,9 @@ func (j *ServiceTestJig) CreateServiceWithServicePort(labels map[string]string, 
 	return j.Client.CoreV1().Services(namespace).Create(service)
 }
 
-func (j *ServiceTestJig) ChangeServiceType(namespace, name string, newType v1.ServiceType, timeout time.Duration) {
+func (j *ServiceTestJig) ChangeServiceType(namespace, name string, newType corev1.ServiceType, timeout time.Duration) {
 	ingressIP := ""
-	svc := j.UpdateServiceOrFail(namespace, name, func(s *v1.Service) {
+	svc := j.UpdateServiceOrFail(namespace, name, func(s *corev1.Service) {
 		for _, ing := range s.Status.LoadBalancer.Ingress {
 			if ing.IP != "" {
 				ingressIP = ing.IP
@@ -256,19 +256,19 @@ func (j *ServiceTestJig) ChangeServiceType(namespace, name string, newType v1.Se
 // ExternalTrafficPolicy set to Local and sanity checks its nodePort.
 // If createPod is true, it also creates an RC with 1 replica of
 // the standard netexec container used everywhere in this test.
-func (j *ServiceTestJig) CreateOnlyLocalNodePortService(namespace, serviceName string, createPod bool) *v1.Service {
+func (j *ServiceTestJig) CreateOnlyLocalNodePortService(namespace, serviceName string, createPod bool) *corev1.Service {
 	ginkgo.By("creating a service " + namespace + "/" + serviceName + " with type=NodePort and ExternalTrafficPolicy=Local")
-	svc := j.CreateTCPServiceOrFail(namespace, func(svc *v1.Service) {
-		svc.Spec.Type = v1.ServiceTypeNodePort
-		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
-		svc.Spec.Ports = []v1.ServicePort{{Protocol: v1.ProtocolTCP, Port: 80}}
+	svc := j.CreateTCPServiceOrFail(namespace, func(svc *corev1.Service) {
+		svc.Spec.Type = corev1.ServiceTypeNodePort
+		svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+		svc.Spec.Ports = []corev1.ServicePort{{Protocol: corev1.ProtocolTCP, Port: 80}}
 	})
 
 	if createPod {
 		ginkgo.By("creating a pod to be part of the service " + serviceName)
 		j.RunOrFail(namespace, nil)
 	}
-	j.SanityCheckService(svc, v1.ServiceTypeNodePort)
+	j.SanityCheckService(svc, corev1.ServiceTypeNodePort)
 	return svc
 }
 
@@ -277,13 +277,13 @@ func (j *ServiceTestJig) CreateOnlyLocalNodePortService(namespace, serviceName s
 // If createPod is true, it also creates an RC with 1 replica of
 // the standard netexec container used everywhere in this test.
 func (j *ServiceTestJig) CreateOnlyLocalLoadBalancerService(namespace, serviceName string, timeout time.Duration, createPod bool,
-	tweak func(svc *v1.Service)) *v1.Service {
+	tweak func(svc *corev1.Service)) *corev1.Service {
 	ginkgo.By("creating a service " + namespace + "/" + serviceName + " with type=LoadBalancer and ExternalTrafficPolicy=Local")
-	svc := j.CreateTCPServiceOrFail(namespace, func(svc *v1.Service) {
-		svc.Spec.Type = v1.ServiceTypeLoadBalancer
+	svc := j.CreateTCPServiceOrFail(namespace, func(svc *corev1.Service) {
+		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 		// We need to turn affinity off for our LB distribution tests
-		svc.Spec.SessionAffinity = v1.ServiceAffinityNone
-		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+		svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
+		svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
 		if tweak != nil {
 			tweak(svc)
 		}
@@ -295,18 +295,18 @@ func (j *ServiceTestJig) CreateOnlyLocalLoadBalancerService(namespace, serviceNa
 	}
 	ginkgo.By("waiting for loadbalancer for service " + namespace + "/" + serviceName)
 	svc = j.WaitForLoadBalancerOrFail(namespace, serviceName, timeout)
-	j.SanityCheckService(svc, v1.ServiceTypeLoadBalancer)
+	j.SanityCheckService(svc, corev1.ServiceTypeLoadBalancer)
 	return svc
 }
 
 // CreateLoadBalancerService creates a loadbalancer service and waits
 // for it to acquire an ingress IP.
-func (j *ServiceTestJig) CreateLoadBalancerService(namespace, serviceName string, timeout time.Duration, tweak func(svc *v1.Service)) *v1.Service {
+func (j *ServiceTestJig) CreateLoadBalancerService(namespace, serviceName string, timeout time.Duration, tweak func(svc *corev1.Service)) *corev1.Service {
 	ginkgo.By("creating a service " + namespace + "/" + serviceName + " with type=LoadBalancer")
-	svc := j.CreateTCPServiceOrFail(namespace, func(svc *v1.Service) {
-		svc.Spec.Type = v1.ServiceTypeLoadBalancer
+	svc := j.CreateTCPServiceOrFail(namespace, func(svc *corev1.Service) {
+		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 		// We need to turn affinity off for our LB distribution tests
-		svc.Spec.SessionAffinity = v1.ServiceAffinityNone
+		svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
 		if tweak != nil {
 			tweak(svc)
 		}
@@ -314,11 +314,11 @@ func (j *ServiceTestJig) CreateLoadBalancerService(namespace, serviceName string
 
 	ginkgo.By("waiting for loadbalancer for service " + namespace + "/" + serviceName)
 	svc = j.WaitForLoadBalancerOrFail(namespace, serviceName, timeout)
-	j.SanityCheckService(svc, v1.ServiceTypeLoadBalancer)
+	j.SanityCheckService(svc, corev1.ServiceTypeLoadBalancer)
 	return svc
 }
 
-func GetNodeAddresses(node *v1.Node, addressType v1.NodeAddressType) (ips []string) {
+func GetNodeAddresses(node *corev1.Node, addressType corev1.NodeAddressType) (ips []string) {
 	for j := range node.Status.Addresses {
 		nodeAddress := &node.Status.Addresses[j]
 		if nodeAddress.Type == addressType && nodeAddress.Address != "" {
@@ -328,7 +328,7 @@ func GetNodeAddresses(node *v1.Node, addressType v1.NodeAddressType) (ips []stri
 	return
 }
 
-func CollectAddresses(nodes *v1.NodeList, addressType v1.NodeAddressType) []string {
+func CollectAddresses(nodes *corev1.NodeList, addressType corev1.NodeAddressType) []string {
 	ips := []string{}
 	for i := range nodes.Items {
 		ips = append(ips, GetNodeAddresses(&nodes.Items[i], addressType)...)
@@ -339,10 +339,10 @@ func CollectAddresses(nodes *v1.NodeList, addressType v1.NodeAddressType) []stri
 func GetNodePublicIps(c clientset.Interface) ([]string, error) {
 	nodes := GetReadySchedulableNodesOrDie(c)
 
-	ips := CollectAddresses(nodes, v1.NodeExternalIP)
+	ips := CollectAddresses(nodes, corev1.NodeExternalIP)
 	if len(ips) == 0 {
 		// If ExternalIP isn't set, assume the test programs can reach the InternalIP
-		ips = CollectAddresses(nodes, v1.NodeInternalIP)
+		ips = CollectAddresses(nodes, corev1.NodeInternalIP)
 	}
 	return ips, nil
 }
@@ -378,7 +378,7 @@ func PodNodePairs(c clientset.Interface, ns string) ([]PodNode, error) {
 
 // GetEndpointNodes returns a map of nodenames:external-ip on which the
 // endpoints of the given Service are running.
-func (j *ServiceTestJig) GetEndpointNodes(svc *v1.Service) map[string][]string {
+func (j *ServiceTestJig) GetEndpointNodes(svc *corev1.Service) map[string][]string {
 	nodes := j.GetNodes(MaxNodesForEndpointsTests)
 	endpoints, err := j.Client.CoreV1().Endpoints(svc.Namespace).Get(svc.Name, metav1.GetOptions{})
 	if err != nil {
@@ -398,7 +398,7 @@ func (j *ServiceTestJig) GetEndpointNodes(svc *v1.Service) map[string][]string {
 	nodeMap := map[string][]string{}
 	for _, n := range nodes.Items {
 		if epNodes.Has(n.Name) {
-			nodeMap[n.Name] = GetNodeAddresses(&n, v1.NodeExternalIP)
+			nodeMap[n.Name] = GetNodeAddresses(&n, corev1.NodeExternalIP)
 		}
 	}
 	return nodeMap
@@ -406,7 +406,7 @@ func (j *ServiceTestJig) GetEndpointNodes(svc *v1.Service) map[string][]string {
 
 // GetNodes returns the first maxNodesForTest nodes. Useful in large clusters
 // where we don't eg: want to create an endpoint per node.
-func (j *ServiceTestJig) GetNodes(maxNodesForTest int) (nodes *v1.NodeList) {
+func (j *ServiceTestJig) GetNodes(maxNodesForTest int) (nodes *corev1.NodeList) {
 	nodes = GetReadySchedulableNodesOrDie(j.Client)
 	if len(nodes.Items) <= maxNodesForTest {
 		maxNodesForTest = len(nodes.Items)
@@ -451,12 +451,12 @@ func (j *ServiceTestJig) WaitForEndpointOnNode(namespace, serviceName, nodeName 
 	ExpectNoError(err)
 }
 
-func (j *ServiceTestJig) SanityCheckService(svc *v1.Service, svcType v1.ServiceType) {
+func (j *ServiceTestJig) SanityCheckService(svc *corev1.Service, svcType corev1.ServiceType) {
 	if svc.Spec.Type != svcType {
 		Failf("unexpected Spec.Type (%s) for service, expected %s", svc.Spec.Type, svcType)
 	}
 
-	if svcType != v1.ServiceTypeExternalName {
+	if svcType != corev1.ServiceTypeExternalName {
 		if svc.Spec.ExternalName != "" {
 			Failf("unexpected Spec.ExternalName (%s) for service, expected empty", svc.Spec.ExternalName)
 		}
@@ -470,7 +470,7 @@ func (j *ServiceTestJig) SanityCheckService(svc *v1.Service, svcType v1.ServiceT
 	}
 
 	expectNodePorts := false
-	if svcType != v1.ServiceTypeClusterIP && svcType != v1.ServiceTypeExternalName {
+	if svcType != corev1.ServiceTypeClusterIP && svcType != corev1.ServiceTypeExternalName {
 		expectNodePorts = true
 	}
 	for i, port := range svc.Spec.Ports {
@@ -485,7 +485,7 @@ func (j *ServiceTestJig) SanityCheckService(svc *v1.Service, svcType v1.ServiceT
 		}
 	}
 	expectIngress := false
-	if svcType == v1.ServiceTypeLoadBalancer {
+	if svcType == corev1.ServiceTypeLoadBalancer {
 		expectIngress = true
 	}
 	hasIngress := len(svc.Status.LoadBalancer.Ingress) != 0
@@ -504,7 +504,7 @@ func (j *ServiceTestJig) SanityCheckService(svc *v1.Service, svcType v1.ServiceT
 // UpdateService fetches a service, calls the update function on it, and
 // then attempts to send the updated service. It tries up to 3 times in the
 // face of timeouts and conflicts.
-func (j *ServiceTestJig) UpdateService(namespace, name string, update func(*v1.Service)) (*v1.Service, error) {
+func (j *ServiceTestJig) UpdateService(namespace, name string, update func(*corev1.Service)) (*corev1.Service, error) {
 	for i := 0; i < 3; i++ {
 		service, err := j.Client.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
@@ -525,7 +525,7 @@ func (j *ServiceTestJig) UpdateService(namespace, name string, update func(*v1.S
 // UpdateServiceOrFail fetches a service, calls the update function on it, and
 // then attempts to send the updated service. It tries up to 3 times in the
 // face of timeouts and conflicts.
-func (j *ServiceTestJig) UpdateServiceOrFail(namespace, name string, update func(*v1.Service)) *v1.Service {
+func (j *ServiceTestJig) UpdateServiceOrFail(namespace, name string, update func(*corev1.Service)) *corev1.Service {
 	svc, err := j.UpdateService(namespace, name, update)
 	if err != nil {
 		Failf(err.Error())
@@ -533,9 +533,9 @@ func (j *ServiceTestJig) UpdateServiceOrFail(namespace, name string, update func
 	return svc
 }
 
-func (j *ServiceTestJig) WaitForNewIngressIPOrFail(namespace, name, existingIP string, timeout time.Duration) *v1.Service {
+func (j *ServiceTestJig) WaitForNewIngressIPOrFail(namespace, name, existingIP string, timeout time.Duration) *corev1.Service {
 	Logf("Waiting up to %v for service %q to get a new ingress IP", timeout, name)
-	service := j.waitForConditionOrFail(namespace, name, timeout, "have a new ingress IP", func(svc *v1.Service) bool {
+	service := j.waitForConditionOrFail(namespace, name, timeout, "have a new ingress IP", func(svc *corev1.Service) bool {
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
 			return false
 		}
@@ -548,14 +548,14 @@ func (j *ServiceTestJig) WaitForNewIngressIPOrFail(namespace, name, existingIP s
 	return service
 }
 
-func (j *ServiceTestJig) ChangeServiceNodePortOrFail(namespace, name string, initial int) *v1.Service {
+func (j *ServiceTestJig) ChangeServiceNodePortOrFail(namespace, name string, initial int) *corev1.Service {
 	var err error
-	var service *v1.Service
+	var service *corev1.Service
 	for i := 1; i < ServiceNodePortRange.Size; i++ {
 		offs1 := initial - ServiceNodePortRange.Base
 		offs2 := (offs1 + i) % ServiceNodePortRange.Size
 		newPort := ServiceNodePortRange.Base + offs2
-		service, err = j.UpdateService(namespace, name, func(s *v1.Service) {
+		service, err = j.UpdateService(namespace, name, func(s *corev1.Service) {
 			s.Spec.Ports[0].NodePort = int32(newPort)
 		})
 		if err != nil && strings.Contains(err.Error(), portallocator.ErrAllocated.Error()) {
@@ -571,15 +571,15 @@ func (j *ServiceTestJig) ChangeServiceNodePortOrFail(namespace, name string, ini
 	return service
 }
 
-func (j *ServiceTestJig) WaitForLoadBalancerOrFail(namespace, name string, timeout time.Duration) *v1.Service {
+func (j *ServiceTestJig) WaitForLoadBalancerOrFail(namespace, name string, timeout time.Duration) *corev1.Service {
 	Logf("Waiting up to %v for service %q to have a LoadBalancer", timeout, name)
-	service := j.waitForConditionOrFail(namespace, name, timeout, "have a load balancer", func(svc *v1.Service) bool {
+	service := j.waitForConditionOrFail(namespace, name, timeout, "have a load balancer", func(svc *corev1.Service) bool {
 		return len(svc.Status.LoadBalancer.Ingress) > 0
 	})
 	return service
 }
 
-func (j *ServiceTestJig) WaitForLoadBalancerDestroyOrFail(namespace, name string, ip string, port int, timeout time.Duration) *v1.Service {
+func (j *ServiceTestJig) WaitForLoadBalancerDestroyOrFail(namespace, name string, ip string, port int, timeout time.Duration) *corev1.Service {
 	// TODO: once support ticket 21807001 is resolved, reduce this timeout back to something reasonable
 	defer func() {
 		if err := EnsureLoadBalancerResourcesDeleted(ip, strconv.Itoa(port)); err != nil {
@@ -588,14 +588,14 @@ func (j *ServiceTestJig) WaitForLoadBalancerDestroyOrFail(namespace, name string
 	}()
 
 	Logf("Waiting up to %v for service %q to have no LoadBalancer", timeout, name)
-	service := j.waitForConditionOrFail(namespace, name, timeout, "have no load balancer", func(svc *v1.Service) bool {
+	service := j.waitForConditionOrFail(namespace, name, timeout, "have no load balancer", func(svc *corev1.Service) bool {
 		return len(svc.Status.LoadBalancer.Ingress) == 0
 	})
 	return service
 }
 
-func (j *ServiceTestJig) waitForConditionOrFail(namespace, name string, timeout time.Duration, message string, conditionFn func(*v1.Service) bool) *v1.Service {
-	var service *v1.Service
+func (j *ServiceTestJig) waitForConditionOrFail(namespace, name string, timeout time.Duration, message string, conditionFn func(*corev1.Service) bool) *corev1.Service {
+	var service *corev1.Service
 	pollFunc := func() (bool, error) {
 		svc, err := j.Client.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
@@ -613,36 +613,36 @@ func (j *ServiceTestJig) waitForConditionOrFail(namespace, name string, timeout 
 	return service
 }
 
-// newRCTemplate returns the default v1.ReplicationController object for
+// newRCTemplate returns the default corev1.ReplicationController object for
 // this jig, but does not actually create the RC.  The default RC has the same
 // name as the jig and runs the "netexec" container.
-func (j *ServiceTestJig) newRCTemplate(namespace string) *v1.ReplicationController {
+func (j *ServiceTestJig) newRCTemplate(namespace string) *corev1.ReplicationController {
 	var replicas int32 = 1
 	var grace int64 = 3 // so we don't race with kube-proxy when scaling up/down
 
-	rc := &v1.ReplicationController{
+	rc := &corev1.ReplicationController{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      j.Name,
 			Labels:    j.Labels,
 		},
-		Spec: v1.ReplicationControllerSpec{
+		Spec: corev1.ReplicationControllerSpec{
 			Replicas: &replicas,
 			Selector: j.Labels,
-			Template: &v1.PodTemplateSpec{
+			Template: &corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: j.Labels,
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
 							Name:  "netexec",
 							Image: imageutils.GetE2EImage(imageutils.Netexec),
 							Args:  []string{"--http-port=80", "--udp-port=80"},
-							ReadinessProbe: &v1.Probe{
+							ReadinessProbe: &corev1.Probe{
 								PeriodSeconds: 3,
-								Handler: v1.Handler{
-									HTTPGet: &v1.HTTPGetAction{
+								Handler: corev1.Handler{
+									HTTPGet: &corev1.HTTPGetAction{
 										Port: intstr.FromInt(80),
 										Path: "/hostName",
 									},
@@ -658,26 +658,26 @@ func (j *ServiceTestJig) newRCTemplate(namespace string) *v1.ReplicationControll
 	return rc
 }
 
-func (j *ServiceTestJig) AddRCAntiAffinity(rc *v1.ReplicationController) {
+func (j *ServiceTestJig) AddRCAntiAffinity(rc *corev1.ReplicationController) {
 	var replicas int32 = 2
 
 	rc.Spec.Replicas = &replicas
 	if rc.Spec.Template.Spec.Affinity == nil {
-		rc.Spec.Template.Spec.Affinity = &v1.Affinity{}
+		rc.Spec.Template.Spec.Affinity = &corev1.Affinity{}
 	}
 	if rc.Spec.Template.Spec.Affinity.PodAntiAffinity == nil {
-		rc.Spec.Template.Spec.Affinity.PodAntiAffinity = &v1.PodAntiAffinity{}
+		rc.Spec.Template.Spec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
 	}
 	rc.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
 		rc.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
-		v1.PodAffinityTerm{
+		corev1.PodAffinityTerm{
 			LabelSelector: &metav1.LabelSelector{MatchLabels: j.Labels},
 			Namespaces:    nil,
 			TopologyKey:   "kubernetes.io/hostname",
 		})
 }
 
-func (j *ServiceTestJig) CreatePDBOrFail(namespace string, rc *v1.ReplicationController) *policyv1beta1.PodDisruptionBudget {
+func (j *ServiceTestJig) CreatePDBOrFail(namespace string, rc *corev1.ReplicationController) *policyv1beta1.PodDisruptionBudget {
 	pdb := j.newPDBTemplate(namespace, rc)
 	newPdb, err := j.Client.PolicyV1beta1().PodDisruptionBudgets(namespace).Create(pdb)
 	if err != nil {
@@ -693,7 +693,7 @@ func (j *ServiceTestJig) CreatePDBOrFail(namespace string, rc *v1.ReplicationCon
 // newPDBTemplate returns the default policyv1beta1.PodDisruptionBudget object for
 // this jig, but does not actually create the PDB.  The default PDB specifies a
 // MinAvailable of N-1 and matches the pods created by the RC.
-func (j *ServiceTestJig) newPDBTemplate(namespace string, rc *v1.ReplicationController) *policyv1beta1.PodDisruptionBudget {
+func (j *ServiceTestJig) newPDBTemplate(namespace string, rc *corev1.ReplicationController) *policyv1beta1.PodDisruptionBudget {
 	minAvailable := intstr.FromInt(int(*rc.Spec.Replicas) - 1)
 
 	pdb := &policyv1beta1.PodDisruptionBudget{
@@ -714,7 +714,7 @@ func (j *ServiceTestJig) newPDBTemplate(namespace string, rc *v1.ReplicationCont
 // RunOrFail creates a ReplicationController and Pod(s) and waits for the
 // Pod(s) to be running. Callers can provide a function to tweak the RC object
 // before it is created.
-func (j *ServiceTestJig) RunOrFail(namespace string, tweak func(rc *v1.ReplicationController)) *v1.ReplicationController {
+func (j *ServiceTestJig) RunOrFail(namespace string, tweak func(rc *corev1.ReplicationController)) *corev1.ReplicationController {
 	rc := j.newRCTemplate(namespace)
 	if tweak != nil {
 		tweak(rc)
@@ -806,13 +806,13 @@ func (j *ServiceTestJig) waitForPodsReady(namespace string, pods []string) error
 }
 
 // newNetexecPodSpec returns the pod spec of netexec pod
-func newNetexecPodSpec(podName string, httpPort, udpPort int32, hostNetwork bool) *v1.Pod {
-	pod := &v1.Pod{
+func newNetexecPodSpec(podName string, httpPort, udpPort int32, hostNetwork bool) *corev1.Pod {
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: podName,
 		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name:  "netexec",
 					Image: netexecImageName,
@@ -821,7 +821,7 @@ func newNetexecPodSpec(podName string, httpPort, udpPort int32, hostNetwork bool
 						fmt.Sprintf("--http-port=%d", httpPort),
 						fmt.Sprintf("--udp-port=%d", udpPort),
 					},
-					Ports: []v1.ContainerPort{
+					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",
 							ContainerPort: httpPort,
@@ -852,21 +852,21 @@ func (j *ServiceTestJig) LaunchNetexecPodOnNode(f *Framework, nodeName, podName 
 }
 
 // newEchoServerPodSpec returns the pod spec of echo server pod
-func newEchoServerPodSpec(podName string) *v1.Pod {
+func newEchoServerPodSpec(podName string) *corev1.Pod {
 	port := 8080
-	pod := &v1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: podName,
 		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name:  "echoserver",
 					Image: imageutils.GetE2EImage(imageutils.EchoServer),
-					Ports: []v1.ContainerPort{{ContainerPort: int32(port)}},
+					Ports: []corev1.ContainerPort{{ContainerPort: int32(port)}},
 				},
 			},
-			RestartPolicy: v1.RestartPolicyNever,
+			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
 	return pod
@@ -1083,15 +1083,15 @@ func NewServerTest(client clientset.Interface, namespace string, serviceName str
 }
 
 // BuildServiceSpec builds default config for a service (which can then be changed)
-func (t *ServiceTestFixture) BuildServiceSpec() *v1.Service {
-	service := &v1.Service{
+func (t *ServiceTestFixture) BuildServiceSpec() *corev1.Service {
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      t.ServiceName,
 			Namespace: t.Namespace,
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Selector: t.Labels,
-			Ports: []v1.ServicePort{{
+			Ports: []corev1.ServicePort{{
 				Port:       80,
 				TargetPort: intstr.FromInt(80),
 			}},
@@ -1101,7 +1101,7 @@ func (t *ServiceTestFixture) BuildServiceSpec() *v1.Service {
 }
 
 // CreateRC creates a replication controller and records it for cleanup.
-func (t *ServiceTestFixture) CreateRC(rc *v1.ReplicationController) (*v1.ReplicationController, error) {
+func (t *ServiceTestFixture) CreateRC(rc *corev1.ReplicationController) (*corev1.ReplicationController, error) {
 	rc, err := t.Client.CoreV1().ReplicationControllers(t.Namespace).Create(rc)
 	if err == nil {
 		t.rcs[rc.Name] = true
@@ -1110,7 +1110,7 @@ func (t *ServiceTestFixture) CreateRC(rc *v1.ReplicationController) (*v1.Replica
 }
 
 // CreateService creates a service, and record it for cleanup
-func (t *ServiceTestFixture) CreateService(service *v1.Service) (*v1.Service, error) {
+func (t *ServiceTestFixture) CreateService(service *corev1.Service) (*corev1.Service, error) {
 	result, err := t.Client.CoreV1().Services(t.Namespace).Create(service)
 	if err == nil {
 		t.services[service.Name] = true
@@ -1175,7 +1175,7 @@ func (t *ServiceTestFixture) Cleanup() []error {
 	return errs
 }
 
-func GetIngressPoint(ing *v1.LoadBalancerIngress) string {
+func GetIngressPoint(ing *corev1.LoadBalancerIngress) string {
 	host := ing.IP
 	if host == "" {
 		host = ing.Hostname
@@ -1186,8 +1186,8 @@ func GetIngressPoint(ing *v1.LoadBalancerIngress) string {
 // UpdateService fetches a service, calls the update function on it,
 // and then attempts to send the updated service. It retries up to 2
 // times in the face of timeouts and conflicts.
-func UpdateService(c clientset.Interface, namespace, serviceName string, update func(*v1.Service)) (*v1.Service, error) {
-	var service *v1.Service
+func UpdateService(c clientset.Interface, namespace, serviceName string, update func(*corev1.Service)) (*corev1.Service, error) {
+	var service *corev1.Service
 	var err error
 	for i := 0; i < 3; i++ {
 		service, err = c.CoreV1().Services(namespace).Get(serviceName, metav1.GetOptions{})
@@ -1206,7 +1206,7 @@ func UpdateService(c clientset.Interface, namespace, serviceName string, update 
 	return service, err
 }
 
-func GetContainerPortsByPodUID(endpoints *v1.Endpoints) PortsByPodUID {
+func GetContainerPortsByPodUID(endpoints *corev1.Endpoints) PortsByPodUID {
 	m := PortsByPodUID{}
 	for _, ss := range endpoints.Subsets {
 		for _, port := range ss.Ports {
@@ -1301,7 +1301,7 @@ func ValidateEndpointsOrFail(c clientset.Interface, namespace, serviceName strin
 
 // StartServeHostnameService creates a replication controller that serves its
 // hostname and a service on top of it.
-func StartServeHostnameService(c clientset.Interface, svc *v1.Service, ns string, replicas int) ([]string, string, error) {
+func StartServeHostnameService(c clientset.Interface, svc *corev1.Service, ns string, replicas int) ([]string, string, error) {
 	podNames := make([]string, replicas)
 	name := svc.ObjectMeta.Name
 	ginkgo.By("creating service " + name + " in namespace " + ns)
@@ -1310,7 +1310,7 @@ func StartServeHostnameService(c clientset.Interface, svc *v1.Service, ns string
 		return podNames, "", err
 	}
 
-	var createdPods []*v1.Pod
+	var createdPods []*corev1.Pod
 	maxContainerFailures := 0
 	config := testutils.RCConfig{
 		Client:               c,
@@ -1473,21 +1473,21 @@ func DescribeSvc(ns string) {
 	Logf(desc)
 }
 
-func CreateServiceSpec(serviceName, externalName string, isHeadless bool, selector map[string]string) *v1.Service {
-	headlessService := &v1.Service{
+func CreateServiceSpec(serviceName, externalName string, isHeadless bool, selector map[string]string) *corev1.Service {
+	headlessService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: serviceName,
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Selector: selector,
 		},
 	}
 	if externalName != "" {
-		headlessService.Spec.Type = v1.ServiceTypeExternalName
+		headlessService.Spec.Type = corev1.ServiceTypeExternalName
 		headlessService.Spec.ExternalName = externalName
 	} else {
-		headlessService.Spec.Ports = []v1.ServicePort{
-			{Port: 80, Name: "http", Protocol: v1.ProtocolTCP},
+		headlessService.Spec.Ports = []corev1.ServicePort{
+			{Port: 80, Name: "http", Protocol: corev1.ProtocolTCP},
 		}
 	}
 	if isHeadless {
@@ -1498,7 +1498,7 @@ func CreateServiceSpec(serviceName, externalName string, isHeadless bool, select
 
 // EnableAndDisableInternalLB returns two functions for enabling and disabling the internal load balancer
 // setting for the supported cloud providers (currently GCE/GKE and Azure) and empty functions for others.
-func EnableAndDisableInternalLB() (enable func(svc *v1.Service), disable func(svc *v1.Service)) {
+func EnableAndDisableInternalLB() (enable func(svc *corev1.Service), disable func(svc *corev1.Service)) {
 	return TestContext.CloudConfig.Provider.EnableAndDisableInternalLB()
 }
 
@@ -1549,7 +1549,7 @@ func checkAffinityFailed(tracker affinityTracker, err string) {
 // number of same response observed in a row. If affinity is not expected, the
 // test will keep observe until different responses observed. The function will
 // return false only in case of unexpected errors.
-func CheckAffinity(jig *ServiceTestJig, execPod *v1.Pod, targetIP string, targetPort int, shouldHold bool) bool {
+func CheckAffinity(jig *ServiceTestJig, execPod *corev1.Pod, targetIP string, targetPort int, shouldHold bool) bool {
 	targetIPPort := net.JoinHostPort(targetIP, strconv.Itoa(targetPort))
 	cmd := fmt.Sprintf(`wget -qO- http://%s/ -T 2`, targetIPPort)
 	timeout := ServiceTestTimeout


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There is inconsistent aliasing of the k8s.io/api/core/v1
package. As part of a refactor of the framework code we
would like to increasing consistency on things like that.

Used the alias corev1 throughout.

**Which issue(s) this PR fixes**:
Ref #77045

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig testing
/area test
/area test-framework
/priority important-longterm
