### PR TITLE
ingress: migrate extensions.Ingress to networking.Ingress

### DIFF
--- a/pkg/kubectl/describe/versioned/describe.go
+++ b/pkg/kubectl/describe/versioned/describe.go
@@ -2291,7 +2291,7 @@ type IngressDescriber struct {
 }
 
 func (i *IngressDescriber) Describe(namespace, name string, describerSettings describe.DescriberSettings) (string, error) {
-	c := i.ExtensionsV1beta1().Ingresses(namespace)
+	c := i.NetworkingV1beta1().Ingresses(namespace)
 	ing, err := c.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return "", err
@@ -2299,7 +2299,7 @@ func (i *IngressDescriber) Describe(namespace, name string, describerSettings de
 	return i.describeIngress(ing, describerSettings)
 }
 
-func (i *IngressDescriber) describeBackend(ns string, backend *extensionsv1beta1.IngressBackend) string {
+func (i *IngressDescriber) describeBackend(ns string, backend *networkingv1beta1.IngressBackend) string {
 	endpoints, _ := i.CoreV1().Endpoints(ns).Get(backend.ServiceName, metav1.GetOptions{})
 	service, _ := i.CoreV1().Services(ns).Get(backend.ServiceName, metav1.GetOptions{})
 	spName := ""
@@ -2319,7 +2319,7 @@ func (i *IngressDescriber) describeBackend(ns string, backend *extensionsv1beta1
 	return formatEndpoints(endpoints, sets.NewString(spName))
 }
 
-func (i *IngressDescriber) describeIngress(ing *extensionsv1beta1.Ingress, describerSettings describe.DescriberSettings) (string, error) {
+func (i *IngressDescriber) describeIngress(ing *networkingv1beta1.Ingress, describerSettings describe.DescriberSettings) (string, error) {
 	return tabbedString(func(out io.Writer) error {
 		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%v\n", ing.Name)
@@ -2330,7 +2330,7 @@ func (i *IngressDescriber) describeIngress(ing *extensionsv1beta1.Ingress, descr
 		if def == nil {
 			// Ingresses that don't specify a default backend inherit the
 			// default backend in the kube-system namespace.
-			def = &extensionsv1beta1.IngressBackend{
+			def = &networkingv1beta1.IngressBackend{
 				ServiceName: "default-http-backend",
 				ServicePort: intstr.IntOrString{Type: intstr.Int, IntVal: 80},
 			}
@@ -2372,7 +2372,7 @@ func (i *IngressDescriber) describeIngress(ing *extensionsv1beta1.Ingress, descr
 	})
 }
 
-func describeIngressTLS(w PrefixWriter, ingTLS []extensionsv1beta1.IngressTLS) {
+func describeIngressTLS(w PrefixWriter, ingTLS []networkingv1beta1.IngressTLS) {
 	w.Write(LEVEL_0, "TLS:\n")
 	for _, t := range ingTLS {
 		if t.SecretName == "" {
@@ -4494,7 +4494,7 @@ func extractCSRStatus(csr *certificatesv1beta1.CertificateSigningRequest) (strin
 }
 
 // backendStringer behaves just like a string interface and converts the given backend to a string.
-func backendStringer(backend *extensionsv1beta1.IngressBackend) string {
+func backendStringer(backend *networkingv1beta1.IngressBackend) string {
 	if backend == nil {
 		return ""
 	}

--- a/test/e2e/framework/ingress/BUILD
+++ b/test/e2e/framework/ingress/BUILD
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/networking/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",

--- a/test/e2e/manifest/BUILD
+++ b/test/e2e/manifest/BUILD
@@ -13,7 +13,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/networking/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
@@ -41,5 +41,5 @@ go_test(
     name = "go_default_test",
     srcs = ["manifest_test.go"],
     embed = [":go_default_library"],
-    deps = ["//staging/src/k8s.io/api/extensions/v1beta1:go_default_library"],
+    deps = ["//staging/src/k8s.io/api/networking/v1beta1:go_default_library"],
 )

--- a/test/e2e/manifest/manifest.go
+++ b/test/e2e/manifest/manifest.go
@@ -22,7 +22,7 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -87,8 +87,8 @@ func SvcFromManifest(fileName string) (*v1.Service, error) {
 }
 
 // IngressFromManifest reads a .json/yaml file and returns the ingress in it.
-func IngressFromManifest(fileName string) (*extensions.Ingress, error) {
-	var ing extensions.Ingress
+func IngressFromManifest(fileName string) (*networkingv1beta1.Ingress, error) {
+	var ing networkingv1beta1.Ingress
 	data, err := testfiles.Read(fileName)
 	if err != nil {
 		return nil, err
@@ -106,8 +106,8 @@ func IngressFromManifest(fileName string) (*extensions.Ingress, error) {
 
 // IngressToManifest generates a yaml file in the given path with the given ingress.
 // Assumes that a directory exists at the given path.
-func IngressToManifest(ing *extensions.Ingress, path string) error {
-	serialized, err := marshalToYaml(ing, extensions.SchemeGroupVersion)
+func IngressToManifest(ing *networkingv1beta1.Ingress, path string) error {
+	serialized, err := marshalToYaml(ing, networkingv1beta1.SchemeGroupVersion)
 	if err != nil {
 		return fmt.Errorf("failed to marshal ingress %v to YAML: %v", ing, err)
 	}

--- a/test/e2e/manifest/manifest_test.go
+++ b/test/e2e/manifest/manifest_test.go
@@ -22,11 +22,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 )
 
 func TestIngressToManifest(t *testing.T) {
-	ing := &extensions.Ingress{}
+	ing := &networkingv1beta1.Ingress{}
 	// Create a temp dir.
 	tmpDir, err := ioutil.TempDir("", "kubemci")
 	if err != nil {

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -170,7 +170,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 
 			By(fmt.Sprintf("waiting for Ingress %s to get instance group annotation", name))
 			pollErr := wait.Poll(2*time.Second, framework.LoadBalancerPollTimeout, func() (bool, error) {
-				ing, err := f.ClientSet.ExtensionsV1beta1().Ingresses(ns).Get(name, metav1.GetOptions{})
+				ing, err := f.ClientSet.NetworkingV1beta1().Ingresses(ns).Get(name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
 				annotations := ing.Annotations
 				if annotations == nil || annotations[instanceGroupAnnotation] == "" {
@@ -193,7 +193,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			scKey := ingress.StatusPrefix + "/ssl-cert"
 			beKey := ingress.StatusPrefix + "/backends"
 			wait.Poll(2*time.Second, time.Minute, func() (bool, error) {
-				ing, err := f.ClientSet.ExtensionsV1beta1().Ingresses(ns).Get(name, metav1.GetOptions{})
+				ing, err := f.ClientSet.NetworkingV1beta1().Ingresses(ns).Get(name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
 				annotations := ing.Annotations
 				if annotations != nil && (annotations[umKey] != "" || annotations[fwKey] != "" ||

--- a/test/e2e/network/scale/BUILD
+++ b/test/e2e/network/scale/BUILD
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/networking/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/test/e2e/network/scale/ingress.go
+++ b/test/e2e/network/scale/ingress.go
@@ -24,7 +24,7 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientset "k8s.io/client-go/kubernetes"
@@ -74,7 +74,7 @@ type IngressScaleFramework struct {
 
 	ScaleTestDeploy *apps.Deployment
 	ScaleTestSvcs   []*v1.Service
-	ScaleTestIngs   []*extensions.Ingress
+	ScaleTestIngs   []*networkingv1beta1.Ingress
 
 	// BatchCreateLatencies stores all ingress creation latencies, in different
 	// batches.
@@ -121,7 +121,7 @@ func (f *IngressScaleFramework) PrepareScaleTest() error {
 	}
 
 	f.ScaleTestSvcs = []*v1.Service{}
-	f.ScaleTestIngs = []*extensions.Ingress{}
+	f.ScaleTestIngs = []*networkingv1beta1.Ingress{}
 
 	return nil
 }
@@ -133,7 +133,7 @@ func (f *IngressScaleFramework) CleanupScaleTest() []error {
 	f.Logger.Infof("Cleaning up ingresses...")
 	for _, ing := range f.ScaleTestIngs {
 		if ing != nil {
-			if err := f.Clientset.ExtensionsV1beta1().Ingresses(ing.Namespace).Delete(ing.Name, nil); err != nil {
+			if err := f.Clientset.NetworkingV1beta1().Ingresses(ing.Namespace).Delete(ing.Name, nil); err != nil {
 				errs = append(errs, fmt.Errorf("Error while deleting ingress %s/%s: %v", ing.Namespace, ing.Name, err))
 			}
 		}
@@ -190,7 +190,7 @@ func (f *IngressScaleFramework) RunScaleTest() []error {
 		numIngsToCreate := numIngsNeeded - numIngsCreated
 		ingWg.Add(numIngsToCreate)
 		svcQueue := make(chan *v1.Service, numIngsToCreate)
-		ingQueue := make(chan *extensions.Ingress, numIngsToCreate)
+		ingQueue := make(chan *networkingv1beta1.Ingress, numIngsToCreate)
 		errQueue := make(chan error, numIngsToCreate)
 		latencyQueue := make(chan time.Duration, numIngsToCreate)
 		start := time.Now()
@@ -270,14 +270,14 @@ func (f *IngressScaleFramework) RunScaleTest() []error {
 		f.StepCreateLatencies = append(f.StepCreateLatencies, elapsed)
 
 		f.Logger.Infof("Updating ingress and wait for change to take effect")
-		ingToUpdate, err := f.Clientset.ExtensionsV1beta1().Ingresses(f.Namespace).Get(ingCreated.Name, metav1.GetOptions{})
+		ingToUpdate, err := f.Clientset.NetworkingV1beta1().Ingresses(f.Namespace).Get(ingCreated.Name, metav1.GetOptions{})
 		if err != nil {
 			errs = append(errs, err)
 			return
 		}
 		addTestPathToIngress(ingToUpdate)
 		start = time.Now()
-		ingToUpdate, err = f.Clientset.ExtensionsV1beta1().Ingresses(f.Namespace).Update(ingToUpdate)
+		ingToUpdate, err = f.Clientset.NetworkingV1beta1().Ingresses(f.Namespace).Update(ingToUpdate)
 		if err != nil {
 			errs = append(errs, err)
 			return
@@ -357,45 +357,45 @@ func (f *IngressScaleFramework) GetFormattedLatencies() string {
 	return res
 }
 
-func addTestPathToIngress(ing *extensions.Ingress) {
+func addTestPathToIngress(ing *networkingv1beta1.Ingress) {
 	ing.Spec.Rules[0].IngressRuleValue.HTTP.Paths = append(
 		ing.Spec.Rules[0].IngressRuleValue.HTTP.Paths,
-		extensions.HTTPIngressPath{
+		networkingv1beta1.HTTPIngressPath{
 			Path:    "/test",
 			Backend: ing.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
 		})
 }
 
-func (f *IngressScaleFramework) createScaleTestServiceIngress(suffix string, enableTLS bool) (*v1.Service, *extensions.Ingress, error) {
+func (f *IngressScaleFramework) createScaleTestServiceIngress(suffix string, enableTLS bool) (*v1.Service, *networkingv1beta1.Ingress, error) {
 	svcCreated, err := f.Clientset.CoreV1().Services(f.Namespace).Create(generateScaleTestServiceSpec(suffix))
 	if err != nil {
 		return nil, nil, err
 	}
-	ingCreated, err := f.Clientset.ExtensionsV1beta1().Ingresses(f.Namespace).Create(generateScaleTestIngressSpec(suffix, enableTLS))
+	ingCreated, err := f.Clientset.NetworkingV1beta1().Ingresses(f.Namespace).Create(generateScaleTestIngressSpec(suffix, enableTLS))
 	if err != nil {
 		return nil, nil, err
 	}
 	return svcCreated, ingCreated, nil
 }
 
-func generateScaleTestIngressSpec(suffix string, enableTLS bool) *extensions.Ingress {
-	ing := &extensions.Ingress{
+func generateScaleTestIngressSpec(suffix string, enableTLS bool) *networkingv1beta1.Ingress {
+	ing := &networkingv1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s-%s", scaleTestIngressNamePrefix, suffix),
 		},
-		Spec: extensions.IngressSpec{
-			TLS: []extensions.IngressTLS{
+		Spec: networkingv1beta1.IngressSpec{
+			TLS: []networkingv1beta1.IngressTLS{
 				{SecretName: scaleTestSecretName},
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networkingv1beta1.IngressRule{
 				{
 					Host: scaleTestHostname,
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networkingv1beta1.IngressRuleValue{
+						HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+							Paths: []networkingv1beta1.HTTPIngressPath{
 								{
 									Path: "/scale",
-									Backend: extensions.IngressBackend{
+									Backend: networkingv1beta1.IngressBackend{
 										ServiceName: fmt.Sprintf("%s-%s", scaleTestBackendName, suffix),
 										ServicePort: intstr.IntOrString{
 											Type:   intstr.Int,
@@ -411,7 +411,7 @@ func generateScaleTestIngressSpec(suffix string, enableTLS bool) *extensions.Ing
 		},
 	}
 	if enableTLS {
-		ing.Spec.TLS = []extensions.IngressTLS{
+		ing.Spec.TLS = []networkingv1beta1.IngressTLS{
 			{SecretName: scaleTestSecretName},
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is a find/replace within my editor. I made the import
networkingv1beta1 so that it will be easier to replace for
the future v1 migration.

**Which issue(s) this PR fixes**:
Related: kubernetes/enhancements#758

**Special notes for your reviewer**:
- I'm hoping that I hit all of the variations, but it's possible that something got missed.

**Does this PR introduce a user-facing change?**:
-->
```release-note
ingress:  Update in-tree Ingress controllers, examples, and clients to target networking.k8s.io/v1beta1
```
