### PR TITLE
add sig-instrumentation to owners in component-base/metrics

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/OWNERS
+++ b/staging/src/k8s.io/component-base/metrics/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- piosz
+- brancz
+reviewers:
+- sig-instrumentation-pr-reviews
+labels:
+- sig/instrumentation


### PR DESCRIPTION
Adding sig-instrumentation owners file in component-base/metrics.

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adding owners to component-base/metrics

```release-note
NONE
```
/sig instrumentation
/assign @sttts @brancz 