### PR TITLE
[1.13] Bump addon-manager to v8.9.1

### DIFF
--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -14,7 +14,7 @@ spec:
   - name: kube-addon-manager
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: k8s.gcr.io/kube-addon-manager:v8.9
+    image: k8s.gcr.io/kube-addon-manager:v8.9.1
     command:
     - /bin/bash
     - -c

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v8.9
+    image: {{kube_docker_registry}}/kube-addon-manager:v8.9.1
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
Bumping addon-manager version in manifests to pick up the latest base image `debian-base:v1.0.0`.

Ref https://github.com/kubernetes/kubernetes/pull/76405.

```release-note
Bump addon-manager to v8.9.1
- Rebase image on debian-base:v1.0.0
```