### PR TITLE
Fix public IPs issues when multiple clusters are sharing the same resource group

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -1367,14 +1367,23 @@ func validatePublicIP(t *testing.T, publicIP *network.PublicIPAddress, service *
 		t.Errorf("Expected publicIP resource exists, when it is not an internal service")
 	}
 
-	if publicIP.Tags == nil || publicIP.Tags["service"] == nil {
-		t.Errorf("Expected publicIP resource has tags[service]")
+	if publicIP.Tags == nil || publicIP.Tags[serviceTagKey] == nil {
+		t.Errorf("Expected publicIP resource has tags[%s]", serviceTagKey)
 	}
 
 	serviceName := getServiceName(service)
-	if serviceName != *(publicIP.Tags["service"]) {
-		t.Errorf("Expected publicIP resource has matching tags[service]")
+	if serviceName != *(publicIP.Tags[serviceTagKey]) {
+		t.Errorf("Expected publicIP resource has matching tags[%s]", serviceTagKey)
 	}
+
+	if publicIP.Tags[clusterNameKey] == nil {
+		t.Errorf("Expected publicIP resource has tags[%s]", clusterNameKey)
+	}
+
+	if *(publicIP.Tags[clusterNameKey]) != testClusterName {
+		t.Errorf("Expected publicIP resource has matching tags[%s]", clusterNameKey)
+	}
+
 	// We cannot use service.Spec.LoadBalancerIP to compare with
 	// Public IP's IPAddress
 	// Because service properties are updated outside of cloudprovider code


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug
/sig azure
/priority important-soon

**What this PR does / why we need it**:

Fix public IPs issues when multiple clusters are sharing the same resource group.

To support this, a new tag "kubernetes-cluster-name" is added to public IP which indicates the kubernetes cluster name (set by kube-controller-manager ----cluster-name='cluster-name').

And for backward compatibility, the public IPs provisioned by old releases would still be supported.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #77511

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix public IPs issues when multiple clusters are sharing the same resource group.

action required: 

* If the cluster is upgraded from old releases and the same resource group would be shared by multiple clusters, please recreate those LoadBalancer services or add a new tag 'kubernetes-cluster-name: <cluster-name>' manually for existing public IPs.
* For multiple clusters sharing the same resource group, they should be configured with different cluster name by `kube-controller-manager --cluster-name=<cluster-name>`
```

/assign @andyzhangx 