### PR TITLE
Revert #77552 now the actual fix #77580 got merged

### DIFF
--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -104,7 +104,7 @@ while true; do
   # which are important for line counting.
   # Use trick from https://unix.stackexchange.com/a/383411 to avoid
   # newline truncation.
-  node=$(kubectl_retry get nodes --chunk-size=0 --no-headers; ret=$?; echo .; exit "$ret") && res="$?" || res="$?"
+  node=$(kubectl_retry get nodes --no-headers; ret=$?; echo .; exit "$ret") && res="$?" || res="$?"
   node="${node%.}"
   if [ "${res}" -ne "0" ]; then
     if [[ "${attempt}" -gt "${last_run:-$MAX_ATTEMPTS}" ]]; then


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
It reverts https://github.com/kubernetes/kubernetes/pull/77552 which was a temporary workaround that is no longer needed now as https://github.com/kubernetes/kubernetes/pull/77580 got in.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/77551

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
