### PR TITLE
Kubelet status manager sync the status of local Pods

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -162,7 +162,15 @@ func (kl *Kubelet) getPodResourcesDir() string {
 // GetPods returns all pods bound to the kubelet and their spec, and the mirror
 // pods.
 func (kl *Kubelet) GetPods() []*v1.Pod {
-	return kl.podManager.GetPods()
+	pods := kl.podManager.GetPods()
+	// a kubelet running without apiserver requires an additional
+	// update of the static pod status. See #57106
+	for _, p := range pods {
+		if status, ok := kl.statusManager.GetPodStatus(p.UID); ok {
+			p.Status = status
+		}
+	}
+	return pods
 }
 
 // GetRunningPods returns all pods running on kubelet from looking at the


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Re-introducing the change made in #57106

This enables the kubelet pod list to have correctly updated statuses for static pods.

Example of the static `kube-proxy` pod without the fix:

```json
    "status": {
        "phase": "Pending"
    }
```

And with the fix:

```json
    "status": {
        "phase": "Running",
        "conditions": [
            ...
        ],
        "hostIP": "10.132.0.5",
        "podIP": "10.132.0.5",
        "startTime": "2019-05-07T13:41:40Z",
        "containerStatuses": [
            {
                "name": "kube-proxy",
                "state": {
                    "running": {
                        "startedAt": "2019-05-09T12:18:49Z"
                    }
                },
                "lastState": {
                    "terminated": {
                        "exitCode": 255,
                        "reason": "Error",
                        "startedAt": "2019-05-09T12:16:42Z",
                        "finishedAt": "2019-05-09T12:18:12Z",
                        "containerID": "docker://505208a6ed12d2ba0ef80533554d156616805946ceeb52c929c06d48a245410a"
                    }
                },
                "ready": true,
                "restartCount": 3,
                "image": "k8s.gcr.io/kube-proxy:v1.15.0-alpha.0.669_fa86a27d02b784-dirty",
                "imageID": "docker://sha256:a38ce2de08f1da8ab989f29209e3f44f542e8b0811e31c72dc983d0827ef6d8b",
                "containerID": "docker://4f0806183f7492e3095512461c4179603988429daa88008d57c56c104a6c8d0e"
            }
        ],
        "qosClass": "Burstable"
    }
```


The mentioned PR #57106 was reverted because e2e reboot tests were failing see #59889

But I tested the change locally and ran the e2e `Feature:Reboot` tests (using `kubetest` with `gce` provider) and it seems to run fine:

```
Ran 6 of 3261 Specs in 1033.409 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 3255 Skipped PASS

Ginkgo ran 1 suite in 17m14.755647878s
Test Suite Passed
2019/05/09 14:21:55 process.go:155: Step './hack/ginkgo-e2e.sh --ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8' finished in 17m15.873100718s
```


**Which issue(s) this PR fixes**:
Fixes #61717

**Special notes for your reviewer**:
As per https://github.com/kubernetes/kubernetes/issues/61717#issuecomment-463413114 reboot tests seems to be OK now.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```