### PR TITLE
Fix handling empty result when invoking kubectl get

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -750,8 +750,8 @@ func (o *GetOptions) printGeneric(r *resource.Result) error {
 	}
 
 	var obj runtime.Object
-	if !singleItemImplied || len(infos) > 1 {
-		// we have more than one item, so coerce all items into a list.
+	if !singleItemImplied || len(infos) != 1 {
+		// we have zero or multple items, so coerce all items into a list.
 		// we don't want an *unstructured.Unstructured list yet, as we
 		// may be dealing with non-unstructured objects. Compose all items
 		// into an corev1.List, and then decode using an unstructured scheme.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig cli
/priority important-longterm

**What this PR does / why we need it**:
We were wrongly checking `IgnoreNotFound` error when printing results which might lead to panic when an empty file was passed through `kubectl get -f empty_file -o name`

**Special notes for your reviewer**:
/assign @juanvallejo

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
