### PR TITLE
Break out of inner loop when newQuantity is negative in admissionRequirementList#subtract

### DIFF
--- a/pkg/kubelet/preemption/preemption.go
+++ b/pkg/kubelet/preemption/preemption.go
@@ -189,10 +189,9 @@ func (a admissionRequirementList) distance(pod *v1.Pod) float64 {
 	dist := float64(0)
 	for _, req := range a {
 		remainingRequest := float64(req.quantity - resource.GetResourceRequest(pod, req.resourceName))
-		if remainingRequest < 0 {
-			remainingRequest = 0
+		if remainingRequest > 0 {
+			dist += math.Pow(remainingRequest/float64(req.quantity), 2)
 		}
-		dist += math.Pow(remainingRequest/float64(req.quantity), 2)
 	}
 	return dist
 }
@@ -205,6 +204,9 @@ func (a admissionRequirementList) subtract(pods ...*v1.Pod) admissionRequirement
 		newQuantity := req.quantity
 		for _, pod := range pods {
 			newQuantity -= resource.GetResourceRequest(pod, req.resourceName)
+			if newQuantity <= 0 {
+				break
+			}
 		}
 		if newQuantity > 0 {
 			newList = append(newList, &admissionRequirement{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In admissionRequirementList#subtract, when newQuantity becomes negative in the inner loop, we don't need to continue subtracting resource request(s).

In GetResourceRequest, unfold the first loop according to resource type.

```release-note
NONE
```
