### PR TITLE
Bump cluster-proportional-autoscaler to 1.6.0

### DIFF
--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         supplementalGroups: [ 65534 ]
         fsGroup: 65534
       containers:
-      - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2-r2
+      - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.6.0
         name: autoscaler
         command:
           - /cluster-proportional-autoscaler

--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -85,7 +85,7 @@ spec:
         fsGroup: 65534
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.4.0
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.6.0
         resources:
             requests:
                 cpu: "20m"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
[cluster-proportional-autoscaler 1.6.0](https://github.com/kubernetes-incubator/cluster-proportional-autoscaler/releases/tag/1.6.0) is rebased on distroless.

Ref https://github.com/kubernetes/enhancements/blob/master/keps/sig-release/20190316-rebase-images-to-distroless.md.

/assign @yuwenma @caseydavenport 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
