### PR TITLE
Bump cluster-proportional-vertical-autoscaler to 0.7.1

### DIFF
--- a/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/cpvpa-amd64:v0.6.0
+        - image: k8s.gcr.io/cpvpa-amd64:v0.7.1
           name: autoscaler
           command:
             - /cpvpa

--- a/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/cpvpa-amd64:v0.6.0
+        - image: k8s.gcr.io/cpvpa-amd64:v0.7.1
           name: autoscaler
           command:
             - /cpvpa


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
[cluster-proportional-vertical-autoscaler 0.7.1](https://github.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/releases/tag/v0.7.1) is rebased on distroless.

Ref https://github.com/kubernetes/enhancements/blob/master/keps/sig-release/20190316-rebase-images-to-distroless.md.

/assign @yuwenma @caseydavenport

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
