### PR TITLE
Use framework.ExpectNoError() for e2e/

### DIFF
--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 const (
@@ -77,7 +76,7 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 			passed := true
 			checkRestart := func(podName string, timeout time.Duration) {
 				err := framework.WaitForPodNameRunningInNamespace(c, podName, ns)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 				for t := time.Now(); time.Since(t) < timeout; time.Sleep(framework.Poll) {
 					pod, err := c.CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
 					framework.ExpectNoError(err, fmt.Sprintf("getting pod %s", podName))
@@ -123,11 +122,11 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 			framework.RunKubectlOrDieInput(secretYaml, "create", "-f", "-", nsFlag)
 			framework.RunKubectlOrDieInput(podYaml, "create", "-f", "-", nsFlag)
 			err := framework.WaitForPodNoLongerRunningInNamespace(c, podName, ns)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 
 			By("checking if secret was read correctly")
 			_, err = framework.LookForStringInLog(ns, "secret-test-pod", "test-container", "value-1", serverStartTimeout)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		})
 	})
 
@@ -141,13 +140,13 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 			By("creating the pod")
 			framework.RunKubectlOrDieInput(podYaml, "create", "-f", "-", nsFlag)
 			err := framework.WaitForPodNoLongerRunningInNamespace(c, podName, ns)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 
 			By("checking if name and namespace were passed correctly")
 			_, err = framework.LookForStringInLog(ns, podName, "test-container", fmt.Sprintf("MY_POD_NAMESPACE=%v", ns), serverStartTimeout)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			_, err = framework.LookForStringInLog(ns, podName, "test-container", fmt.Sprintf("MY_POD_NAME=%v", podName), serverStartTimeout)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		})
 	})
 })


### PR DESCRIPTION


**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The e2e test framework has ExpectNoError() for readable test code.
This replaces Expect(err).NotTo(HaveOccurred()) with it.

ref: https://github.com/kubernetes/kubernetes/issues/77103

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
