### PR TITLE
Promote oomichi to approver for test/

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -6,30 +6,20 @@ reviewers:
   - MrHohn
   - deads2k
   - enisoc
-  - enj # for test/integration/etcd/etcd_storage_path_test.go
-  - erictune
-  - foxish # for test/e2e/network-partition.go
-  - gmarek
   - janetkuo
-  - kow3ns # for test/e2e/statefulset.go
-  - krousey
   - liggitt
-  - madhusudancs
-  - marun
   - mikedanese
-  - msau42 # for test/e2e/commmon/{*volume,empty_dir}.go and test/e2e/framework/{pv|volume}_util.go
+  - msau42
   - ncdc
   - pwittrock # for test/e2e/kubectl.go
   - saad-ali
   - shyamjvs
   - smarterclayton
-  - soltysh
   - sig-testing-reviewers
   - sttts
   - timothysc
   - zmerlynn
   - vishh
-  - MaciekPytel # for test/e2e/common/autoscaling_utils.go
   - xichengliudui
   - andrewsykim
   - neolit123
@@ -43,19 +33,10 @@ approvers:
   - MrHohn
   - deads2k
   - enisoc
-  - enj # for test/integration/etcd/etcd_storage_path_test.go
-  - eparis
-  - erictune
-  - foxish # for test/e2e/network-partition.go
-  - gmarek
   - janetkuo
-  - kow3ns # for test/e2e/statefulset.go
-  - krousey
   - liggitt
-  - madhusudancs
-  - marun
   - mikedanese
-  - msau42 # for test/e2e/commmon/{*volume,empty_dir}.go and test/e2e/framework/{pv|volume}_util.go
+  - msau42
   - ncdc
   - oomichi
   - pwittrock # for test/e2e/kubectl.go
@@ -63,12 +44,23 @@ approvers:
   - shyamjvs
   - sig-testing-approvers
   - smarterclayton
-  - soltysh
   - sttts
   - timothysc
-  - zmerlynn
   - vishh
-  - MaciekPytel # for test/e2e/common/autoscaling_utils.go
+emeritus_approvers:
+  - enj
+  - eparis
+  - erictune
+  - foxish
+  - gmarek
+  - krousey
+  - kow3ns
+  - madhusudancs
+  - marun
+  - soltysh
+  - zmerlynn
+  - MaciekPytel
+
 labels:
 - area/test
 - sig/testing

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -30,7 +30,6 @@ reviewers:
   - zmerlynn
   - vishh
   - MaciekPytel # for test/e2e/common/autoscaling_utils.go
-  - oomichi
   - xichengliudui
   - andrewsykim
   - neolit123
@@ -58,6 +57,7 @@ approvers:
   - mikedanese
   - msau42 # for test/e2e/commmon/{*volume,empty_dir}.go and test/e2e/framework/{pv|volume}_util.go
   - ncdc
+  - oomichi
   - pwittrock # for test/e2e/kubectl.go
   - saad-ali
   - shyamjvs


### PR DESCRIPTION
I've been helping @oomichi out as a reviewer. I think he's ready to be
an approver for test/

I'm trying to bring more data to this process. I recognize it's not
perfect, and it can be gamed, so take this with the grain of salt that
I've been observing his reviews over the last few months and can tell
these aren't just rubber stamps.

Out of 100 most recently merged PRs involving 'oomichi', there are 41 PRs
touching file prefix 'test/' where 'oomichi' commented '/lgtm'

```
2019-01-14T22:24:02Z: https://github.com/kubernetes/kubernetes/pull/70923
2019-02-13T04:01:58Z: https://github.com/kubernetes/kubernetes/pull/73900
2019-02-26T09:55:21Z: https://github.com/kubernetes/kubernetes/pull/73508
2019-02-27T09:04:08Z: https://github.com/kubernetes/kubernetes/pull/74570
2019-03-01T04:36:18Z: https://github.com/kubernetes/kubernetes/pull/74538
2019-03-01T04:36:28Z: https://github.com/kubernetes/kubernetes/pull/74666
2019-03-01T22:08:34Z: https://github.com/kubernetes/kubernetes/pull/71022
2019-03-05T03:27:26Z: https://github.com/kubernetes/kubernetes/pull/74500
2019-03-07T01:58:59Z: https://github.com/kubernetes/kubernetes/pull/70036
2019-03-13T17:39:36Z: https://github.com/kubernetes/kubernetes/pull/72092
2019-03-15T19:40:58Z: https://github.com/kubernetes/kubernetes/pull/74646
2019-03-22T00:32:18Z: https://github.com/kubernetes/kubernetes/pull/75280
2019-03-22T00:32:32Z: https://github.com/kubernetes/kubernetes/pull/75347
2019-03-22T22:46:09Z: https://github.com/kubernetes/kubernetes/pull/74746
2019-03-22T22:46:48Z: https://github.com/kubernetes/kubernetes/pull/75611
2019-04-01T22:48:36Z: https://github.com/kubernetes/kubernetes/pull/75616
2019-04-05T04:07:30Z: https://github.com/kubernetes/kubernetes/pull/76057
2019-04-05T18:51:33Z: https://github.com/kubernetes/kubernetes/pull/75797
2019-04-05T18:52:10Z: https://github.com/kubernetes/kubernetes/pull/76006
2019-04-05T20:13:47Z: https://github.com/kubernetes/kubernetes/pull/76052
2019-04-12T19:56:48Z: https://github.com/kubernetes/kubernetes/pull/73739
2019-04-12T21:30:09Z: https://github.com/kubernetes/kubernetes/pull/74892
2019-04-13T04:38:04Z: https://github.com/kubernetes/kubernetes/pull/74702
2019-04-14T02:18:01Z: https://github.com/kubernetes/kubernetes/pull/75713
2019-04-15T17:26:08Z: https://github.com/kubernetes/kubernetes/pull/76368
2019-04-16T23:19:54Z: https://github.com/kubernetes/kubernetes/pull/75066
2019-04-16T23:20:11Z: https://github.com/kubernetes/kubernetes/pull/75989
2019-04-23T21:02:01Z: https://github.com/kubernetes/kubernetes/pull/76348
2019-04-24T02:08:00Z: https://github.com/kubernetes/kubernetes/pull/76705
2019-04-25T20:36:43Z: https://github.com/kubernetes/kubernetes/pull/75237
2019-04-27T01:30:35Z: https://github.com/kubernetes/kubernetes/pull/76218
2019-05-01T20:14:34Z: https://github.com/kubernetes/kubernetes/pull/76750
2019-05-03T19:35:39Z: https://github.com/kubernetes/kubernetes/pull/77123
2019-05-03T22:12:30Z: https://github.com/kubernetes/kubernetes/pull/77411
2019-05-04T01:26:04Z: https://github.com/kubernetes/kubernetes/pull/77054
2019-05-07T00:07:42Z: https://github.com/kubernetes/kubernetes/pull/77016
2019-05-07T02:17:41Z: https://github.com/kubernetes/kubernetes/pull/77034
2019-05-07T21:30:37Z: https://github.com/kubernetes/kubernetes/pull/70626
2019-05-08T05:14:46Z: https://github.com/kubernetes/kubernetes/pull/77479
2019-05-08T21:32:46Z: https://github.com/kubernetes/kubernetes/pull/77486
2019-05-09T04:48:48Z: https://github.com/kubernetes/kubernetes/pull/77425
```

/release-note-none