### PR TITLE
Cache resource requests per Pod per resource name in getPodsToPreempt

### DIFF
--- a/pkg/kubelet/preemption/preemption_test.go
+++ b/pkg/kubelet/preemption/preemption_test.go
@@ -363,7 +363,7 @@ func TestAdmissionRequirementsSubtract(t *testing.T) {
 		},
 	}
 	for _, run := range runs {
-		output := run.initial.subtract(run.inputPod)
+		output := run.initial.subtract(nil, run.inputPod)
 		if !admissionRequirementListEqual(output, run.expectedOutput) {
 			t.Errorf("expected: %s, got: %s for %s test", run.expectedOutput.toString(), output.toString(), run.testName)
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In requirements.subtract(), we iterate over all containers of the Pod to calculate new quantity.
Such iteration is repeated at the scope of getPodsToPreempt.

Cache resource requests per Pod per resource name (using a map) and pass it to calls of requirements.subtract() in getPodsToPreempt of preemption

**Which issue(s) this PR fixes**:
Fixes #77697

```release-note
NONE
```
