### PR TITLE
add legacy cloud providers unit tests to `make test`

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -98,6 +98,10 @@ kube::test::find_dirs() {
 
     find ./staging/src/k8s.io/cli-runtime -name '*_test.go' \
       -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
+
+    # add legacy cloud providers tests 
+    find ./staging/src/k8s.io/legacy-cloud-providers -name '*_test.go' \
+      -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
   )
 }
 


### PR DESCRIPTION

**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
the PR adds `./staging/src/k8s/legacy-cloud-providers` to list of directories discovered by unit tests/

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Once merged, `legacy cloud providers` unit tests will run as part of ci, just as they were before they move from `./pkg/cloudproviders/providers` 
```

@kubernetes/sig-cloud-provider 

@andrewsykim FYI