### PR TITLE
kubelet: use drive letters for the default paths on Windows

### DIFF
--- a/cmd/kubelet/app/options/BUILD
+++ b/cmd/kubelet/app/options/BUILD
@@ -14,6 +14,8 @@ go_library(
         "globalflags_linux.go",
         "globalflags_other.go",
         "options.go",
+        "options_other.go",
+        "options_windows.go",
         "osflags_others.go",
         "osflags_windows.go",
     ],

--- a/cmd/kubelet/app/options/options_other.go
+++ b/cmd/kubelet/app/options/options_other.go
@@ -1,0 +1,29 @@
+// +build !windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+const (
+	defaultRemoteRuntimeEndpoint = "unix:///var/run/dockershim.sock"
+	defaultRootDir               = "/var/lib/kubelet"
+	defaultCertDir               = "/var/lib/kubelet/pki"
+	defaultVolumePluginDir       = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
+)
+
+// initOptions is a no-op on non-Windows
+func initOptions() {}

--- a/cmd/kubelet/app/options/options_windows.go
+++ b/cmd/kubelet/app/options/options_windows.go
@@ -1,0 +1,47 @@
+// +build windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"os"
+	"path/filepath"
+
+	"k8s.io/klog"
+)
+
+const defaultRemoteRuntimeEndpoint = `npipe:////./pipe/dockershim`
+
+var defaultRootDir, defaultCertDir, defaultVolumePluginDir string
+
+// initOptions defaults the kubelet root, certificates and volume plugin directories
+// using the SystemDrive environment variable.
+func initOptions() {
+	const (
+		sysDrive        = "SystemDrive"
+		defaultSysDrive = "c:"
+	)
+	drive := os.Getenv(defaultSysDrive)
+	if drive == "" {
+		klog.Warningf("the environment variable %q is not set. Defaulting to %q", sysDrive, defaultSysDrive)
+		drive = defaultSysDrive
+	}
+	defaultRootDir = filepath.Join(drive, `var\lib\kubelet`)
+	defaultCertDir = filepath.Join(drive, `var\lib\kubelet\pki`)
+	defaultVolumePluginDir = filepath.Join(drive, `usr\libexec\kubernetes\kubelet-plugins\volume\exec\`)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The defaults paths for Windows not including a drive letter
can cause problems with the bootstrap process.

During bootstrap (with client cert rotation enabled) the kubelet client
store (PEM) path would be written as following in the kubeconfig file
`/etc/kubernetes/kubelet.conf`:

```
  client-certificate: \var\lib\kubelet\pki\kubelet-client-current.pem
  client-key: \var\lib\kubelet\pki\kubelet-client-current.pem
```

These paths come from the `cmd/kubelet/app/options.go` defaults.

When such a kubeconfig is loaded by client-go on Windows, the `client-*`
paths will be detected as relative paths because they do not include
a drive letter (artifact of `filepath.IsAbs()`).

Relative paths resolve is enabled by default in client-go's
`ClientConfigLoadingRules` and these paths will be expanded to
something like:
`c:\etc\kuberentes\var\lib\kubelet\pki\kubelet-client-current.pem`

At this point the validation of this kubeconfig will fail as the
cert files do not exist.

To avoid this problem, include separate `option_*.go` for Windows / Other
and default the Windows paths using `SystemDrive` (usually `C:`).

Potential breaking change:
- This can break existing k8s installations on Windows nodes
that don't use the same drive as the system drive. The chances
of that are minimal as the current documentation and setup scripts
use `c:\k`.

Alternative PR:
- Disable the path resolve by passing `DoNotResolvePaths` to
`ClientConfigLoadingRules` when `cmd/kubelet/app/server.go`
is building the kubeconfig for Windows only. This can break users relying
on relative paths on Windows.

A known workaround is to always pass an explicit `--cert-dir`
on Windows, which is not ideal.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/1393

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubelet: use drive letters for the default paths on Windows
```

/kind bug
/priority important-longterm
/sig node
/sig windows
/sig api-machinery
/sig cluster-lifecycle

/assign @feiskyer @yujuhong @PatrickLang 
