### PR TITLE
cleanup dot imports and make test error checking more readable in test/e2e/storage

### DIFF
--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -42,8 +42,8 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 )
 
 type cleanupFuncs func()
@@ -132,7 +132,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 	}
 
 	createPod := func() (*storagev1.StorageClass, *v1.PersistentVolumeClaim, *v1.Pod) {
-		By("Creating pod")
+		ginkgo.By("Creating pod")
 		var sc *storagev1.StorageClass
 		if dDriver, ok := m.driver.(testsuites.DynamicPVTestDriver); ok {
 			sc = dDriver.GetDynamicProvisionStorageClass(m.config, "")
@@ -197,12 +197,12 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 		var errs []error
 
 		for _, pod := range m.pods {
-			By(fmt.Sprintf("Deleting pod %s", pod.Name))
+			ginkgo.By(fmt.Sprintf("Deleting pod %s", pod.Name))
 			errs = append(errs, framework.DeletePodWithWait(f, cs, pod))
 		}
 
 		for _, claim := range m.pvcs {
-			By(fmt.Sprintf("Deleting claim %s", claim.Name))
+			ginkgo.By(fmt.Sprintf("Deleting claim %s", claim.Name))
 			claim, err := cs.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(claim.Name, metav1.GetOptions{})
 			if err == nil {
 				cs.CoreV1().PersistentVolumeClaims(claim.Namespace).Delete(claim.Name, nil)
@@ -212,11 +212,11 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 		}
 
 		for _, sc := range m.sc {
-			By(fmt.Sprintf("Deleting storageclass %s", sc.Name))
+			ginkgo.By(fmt.Sprintf("Deleting storageclass %s", sc.Name))
 			cs.StorageV1().StorageClasses().Delete(sc.Name, nil)
 		}
 
-		By("Cleaning up resources")
+		ginkgo.By("Cleaning up resources")
 		for _, cleanupFunc := range m.testCleanups {
 			cleanupFunc()
 		}
@@ -230,7 +230,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 	}
 
 	// The CSIDriverRegistry feature gate is needed for this test in Kubernetes 1.12.
-	Context("CSI attach test using mock driver", func() {
+	ginkgo.Context("CSI attach test using mock driver", func() {
 		tests := []struct {
 			name                   string
 			disableAttach          bool
@@ -252,7 +252,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 		}
 		for _, t := range tests {
 			test := t
-			It(t.name, func() {
+			ginkgo.It(t.name, func() {
 				var err error
 				init(testParameters{registerDriver: test.deployClusterRegistrar, disableAttach: test.disableAttach})
 				defer cleanup()
@@ -264,7 +264,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				err = framework.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "Failed to start pod: %v", err)
 
-				By("Checking if VolumeAttachment was created for the pod")
+				ginkgo.By("Checking if VolumeAttachment was created for the pod")
 				handle := getVolumeHandle(m.cs, claim)
 				attachmentHash := sha256.Sum256([]byte(fmt.Sprintf("%s%s%s", handle, m.provisioner, m.config.ClientNodeName)))
 				attachmentName := fmt.Sprintf("csi-%x", attachmentHash)
@@ -279,14 +279,14 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 					}
 				}
 				if test.disableAttach {
-					Expect(err).To(HaveOccurred(), "Unexpected VolumeAttachment found")
+					gomega.Expect(err).To(gomega.HaveOccurred(), "Unexpected VolumeAttachment found")
 				}
 			})
 
 		}
 	})
 
-	Context("CSI workload information using mock driver", func() {
+	ginkgo.Context("CSI workload information using mock driver", func() {
 		var (
 			err          error
 			podInfoTrue  = true
@@ -324,7 +324,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 		}
 		for _, t := range tests {
 			test := t
-			It(t.name, func() {
+			ginkgo.It(t.name, func() {
 				init(testParameters{
 					registerDriver: test.deployClusterRegistrar,
 					scName:         "csi-mock-sc-" + f.UniqueName,
@@ -338,7 +338,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				}
 				err = framework.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "Failed to start pod: %v", err)
-				By("Checking CSI driver logs")
+				ginkgo.By("Checking CSI driver logs")
 
 				// The driver is deployed as a statefulset with stable pod names
 				driverPodName := "csi-mockplugin-0"
@@ -348,8 +348,8 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 		}
 	})
 
-	Context("CSI volume limit information using mock driver", func() {
-		It("should report attach limit when limit is bigger than 0 [Slow]", func() {
+	ginkgo.Context("CSI volume limit information using mock driver", func() {
+		ginkgo.It("should report attach limit when limit is bigger than 0 [Slow]", func() {
 			// define volume limit to be 2 for this test
 
 			var err error
@@ -362,28 +362,28 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 			nodeAttachLimit, err := checkNodeForLimits(nodeName, attachKey, m.cs)
 			framework.ExpectNoError(err, "while fetching node %v", err)
 
-			Expect(nodeAttachLimit).To(Equal(2))
+			gomega.Expect(nodeAttachLimit).To(gomega.Equal(2))
 
 			_, _, pod1 := createPod()
-			Expect(pod1).NotTo(BeNil(), "while creating first pod")
+			gomega.Expect(pod1).NotTo(gomega.BeNil(), "while creating first pod")
 
 			err = framework.WaitForPodNameRunningInNamespace(m.cs, pod1.Name, pod1.Namespace)
 			framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
 			_, _, pod2 := createPod()
-			Expect(pod2).NotTo(BeNil(), "while creating second pod")
+			gomega.Expect(pod2).NotTo(gomega.BeNil(), "while creating second pod")
 
 			err = framework.WaitForPodNameRunningInNamespace(m.cs, pod2.Name, pod2.Namespace)
 			framework.ExpectNoError(err, "Failed to start pod2: %v", err)
 
 			_, _, pod3 := createPod()
-			Expect(pod3).NotTo(BeNil(), "while creating third pod")
+			gomega.Expect(pod3).NotTo(gomega.BeNil(), "while creating third pod")
 			err = waitForMaxVolumeCondition(pod3, m.cs)
 			framework.ExpectNoError(err, "while waiting for max volume condition on pod : %+v", pod3)
 		})
 	})
 
-	Context("CSI Volume expansion [Feature:ExpandCSIVolumes]", func() {
+	ginkgo.Context("CSI Volume expansion [Feature:ExpandCSIVolumes]", func() {
 		tests := []struct {
 			name                    string
 			nodeExpansionRequired   bool
@@ -412,7 +412,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 		}
 		for _, t := range tests {
 			test := t
-			It(t.name, func() {
+			ginkgo.It(t.name, func() {
 				var err error
 				tp := testParameters{
 					enableResizing:          true,
@@ -430,18 +430,18 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 
 				ns := f.Namespace.Name
 				sc, pvc, pod := createPod()
-				Expect(pod).NotTo(BeNil(), "while creating pod for resizing")
+				gomega.Expect(pod).NotTo(gomega.BeNil(), "while creating pod for resizing")
 
-				Expect(*sc.AllowVolumeExpansion).To(BeTrue(), "failed creating sc with allowed expansion")
+				gomega.Expect(*sc.AllowVolumeExpansion).To(gomega.BeTrue(), "failed creating sc with allowed expansion")
 
 				err = framework.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
-				By("Expanding current pvc")
+				ginkgo.By("Expanding current pvc")
 				newSize := resource.MustParse("6Gi")
 				pvc, err = expandPVCSize(pvc, newSize, m.cs)
 				framework.ExpectNoError(err, "While updating pvc for more size")
-				Expect(pvc).NotTo(BeNil())
+				gomega.Expect(pvc).NotTo(gomega.BeNil())
 
 				pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
 				if pvcSize.Cmp(newSize) != 0 {
@@ -449,43 +449,43 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				}
 				if test.expectFailure {
 					err = waitForResizingCondition(pvc, m.cs, csiResizingConditionWait)
-					Expect(err).To(HaveOccurred(), "unexpected resizing condition on PVC")
+					gomega.Expect(err).To(gomega.HaveOccurred(), "unexpected resizing condition on PVC")
 					return
 				}
 
-				By("Waiting for persistent volume resize to finish")
+				ginkgo.By("Waiting for persistent volume resize to finish")
 				err = waitForControllerVolumeResize(pvc, m.cs, csiResizeWaitPeriod)
 				framework.ExpectNoError(err, "While waiting for CSI PV resize to finish")
 
 				checkPVCSize := func() {
-					By("Waiting for PVC resize to finish")
+					ginkgo.By("Waiting for PVC resize to finish")
 					pvc, err = waitForFSResize(pvc, m.cs)
 					framework.ExpectNoError(err, "while waiting for PVC resize to finish")
 
 					pvcConditions := pvc.Status.Conditions
-					Expect(len(pvcConditions)).To(Equal(0), "pvc should not have conditions")
+					gomega.Expect(len(pvcConditions)).To(gomega.Equal(0), "pvc should not have conditions")
 				}
 
 				// if node expansion is not required PVC should be resized as well
 				if !test.nodeExpansionRequired {
 					checkPVCSize()
 				} else {
-					By("Checking for conditions on pvc")
+					ginkgo.By("Checking for conditions on pvc")
 					pvc, err = m.cs.CoreV1().PersistentVolumeClaims(ns).Get(pvc.Name, metav1.GetOptions{})
 					framework.ExpectNoError(err, "While fetching pvc after controller resize")
 
 					inProgressConditions := pvc.Status.Conditions
 					if len(inProgressConditions) > 0 {
-						Expect(inProgressConditions[0].Type).To(Equal(v1.PersistentVolumeClaimFileSystemResizePending), "pvc must have fs resizing condition")
+						gomega.Expect(inProgressConditions[0].Type).To(gomega.Equal(v1.PersistentVolumeClaimFileSystemResizePending), "pvc must have fs resizing condition")
 					}
 
-					By("Deleting the previously created pod")
+					ginkgo.By("Deleting the previously created pod")
 					err = framework.DeletePodWithWait(f, m.cs, pod)
 					framework.ExpectNoError(err, "while deleting pod for resizing")
 
-					By("Creating a new pod with same volume")
+					ginkgo.By("Creating a new pod with same volume")
 					pod2, err := createPodWithPVC(pvc)
-					Expect(pod2).NotTo(BeNil(), "while creating pod for csi resizing")
+					gomega.Expect(pod2).NotTo(gomega.BeNil(), "while creating pod for csi resizing")
 					framework.ExpectNoError(err, "while recreating pod for resizing")
 
 					checkPVCSize()
@@ -493,7 +493,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 			})
 		}
 	})
-	Context("CSI online volume expansion [Feature:ExpandCSIVolumes][Feature:ExpandInUseVolumes]", func() {
+	ginkgo.Context("CSI online volume expansion [Feature:ExpandCSIVolumes][Feature:ExpandInUseVolumes]", func() {
 		tests := []struct {
 			name          string
 			disableAttach bool
@@ -508,7 +508,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 		}
 		for _, t := range tests {
 			test := t
-			It(test.name, func() {
+			ginkgo.It(test.name, func() {
 				var err error
 				params := testParameters{enableResizing: true, enableNodeExpansion: true}
 				if test.disableAttach {
@@ -521,34 +521,34 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				defer cleanup()
 
 				sc, pvc, pod := createPod()
-				Expect(pod).NotTo(BeNil(), "while creating pod for resizing")
+				gomega.Expect(pod).NotTo(gomega.BeNil(), "while creating pod for resizing")
 
-				Expect(*sc.AllowVolumeExpansion).To(BeTrue(), "failed creating sc with allowed expansion")
+				gomega.Expect(*sc.AllowVolumeExpansion).To(gomega.BeTrue(), "failed creating sc with allowed expansion")
 
 				err = framework.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
-				By("Expanding current pvc")
+				ginkgo.By("Expanding current pvc")
 				newSize := resource.MustParse("6Gi")
 				pvc, err = expandPVCSize(pvc, newSize, m.cs)
 				framework.ExpectNoError(err, "While updating pvc for more size")
-				Expect(pvc).NotTo(BeNil())
+				gomega.Expect(pvc).NotTo(gomega.BeNil())
 
 				pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
 				if pvcSize.Cmp(newSize) != 0 {
 					framework.Failf("error updating pvc size %q", pvc.Name)
 				}
 
-				By("Waiting for persistent volume resize to finish")
+				ginkgo.By("Waiting for persistent volume resize to finish")
 				err = waitForControllerVolumeResize(pvc, m.cs, csiResizeWaitPeriod)
 				framework.ExpectNoError(err, "While waiting for PV resize to finish")
 
-				By("Waiting for PVC resize to finish")
+				ginkgo.By("Waiting for PVC resize to finish")
 				pvc, err = waitForFSResize(pvc, m.cs)
 				framework.ExpectNoError(err, "while waiting for PVC to finish")
 
 				pvcConditions := pvc.Status.Conditions
-				Expect(len(pvcConditions)).To(Equal(0), "pvc should not have conditions")
+				gomega.Expect(len(pvcConditions)).To(gomega.Equal(0), "pvc should not have conditions")
 
 			})
 		}
@@ -801,7 +801,7 @@ func getVolumeHandle(cs clientset.Interface, claim *v1.PersistentVolumeClaim) st
 		return ""
 	}
 	if pv.Spec.CSI == nil {
-		Expect(pv.Spec.CSI).NotTo(BeNil())
+		gomega.Expect(pv.Spec.CSI).NotTo(gomega.BeNil())
 		return ""
 	}
 	return pv.Spec.CSI.VolumeHandle

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
@@ -55,52 +55,52 @@ var _ = utils.SIGDescribe("CSI Volumes", func() {
 	for _, initDriver := range csiTestDrivers {
 		curDriver := initDriver()
 
-		Context(testsuites.GetDriverNameWithFeatureTags(curDriver), func() {
+		ginkgo.Context(testsuites.GetDriverNameWithFeatureTags(curDriver), func() {
 			testsuites.DefineTestSuite(curDriver, csiTestSuites)
 		})
 	}
 
 	// TODO: PD CSI driver needs to be serial because it uses a fixed name. Address as part of #71289
-	Context("CSI Topology test using GCE PD driver [Serial]", func() {
+	ginkgo.Context("CSI Topology test using GCE PD driver [Serial]", func() {
 		f := framework.NewDefaultFramework("csitopology")
 		driver := drivers.InitGcePDCSIDriver().(testsuites.DynamicPVTestDriver) // TODO (#71289) eliminate by moving this test to common test suite.
 		var (
 			config      *testsuites.PerTestConfig
 			testCleanup func()
 		)
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			driver.SkipUnsupportedTest(testpatterns.TestPattern{})
 			config, testCleanup = driver.PrepareTest(f)
 		})
 
-		AfterEach(func() {
+		ginkgo.AfterEach(func() {
 			if testCleanup != nil {
 				testCleanup()
 			}
 		})
 
-		It("should provision zonal PD with immediate volume binding and AllowedTopologies set and mount the volume to a pod", func() {
+		ginkgo.It("should provision zonal PD with immediate volume binding and AllowedTopologies set and mount the volume to a pod", func() {
 			suffix := "topology-positive"
 			testTopologyPositive(config.Framework.ClientSet, suffix, config.Framework.Namespace.GetName(), false /* delayBinding */, true /* allowedTopologies */)
 		})
 
-		It("should provision zonal PD with delayed volume binding and mount the volume to a pod", func() {
+		ginkgo.It("should provision zonal PD with delayed volume binding and mount the volume to a pod", func() {
 			suffix := "delayed"
 			testTopologyPositive(config.Framework.ClientSet, suffix, config.Framework.Namespace.GetName(), true /* delayBinding */, false /* allowedTopologies */)
 		})
 
-		It("should provision zonal PD with delayed volume binding and AllowedTopologies set and mount the volume to a pod", func() {
+		ginkgo.It("should provision zonal PD with delayed volume binding and AllowedTopologies set and mount the volume to a pod", func() {
 			suffix := "delayed-topology-positive"
 			testTopologyPositive(config.Framework.ClientSet, suffix, config.Framework.Namespace.GetName(), true /* delayBinding */, true /* allowedTopologies */)
 		})
 
-		It("should fail to schedule a pod with a zone missing from AllowedTopologies; PD is provisioned with immediate volume binding", func() {
+		ginkgo.It("should fail to schedule a pod with a zone missing from AllowedTopologies; PD is provisioned with immediate volume binding", func() {
 			framework.SkipUnlessMultizone(config.Framework.ClientSet)
 			suffix := "topology-negative"
 			testTopologyNegative(config.Framework.ClientSet, suffix, config.Framework.Namespace.GetName(), false /* delayBinding */)
 		})
 
-		It("should fail to schedule a pod with a zone missing from AllowedTopologies; PD is provisioned with delayed volume binding", func() {
+		ginkgo.It("should fail to schedule a pod with a zone missing from AllowedTopologies; PD is provisioned with delayed volume binding", func() {
 			framework.SkipUnlessMultizone(config.Framework.ClientSet)
 			suffix := "delayed-topology-negative"
 			testTopologyNegative(config.Framework.ClientSet, suffix, config.Framework.Namespace.GetName(), true /* delayBinding */)
@@ -124,7 +124,7 @@ func testTopologyPositive(cs clientset.Interface, suffix, namespace string, dela
 
 	if delayBinding {
 		_, node := test.TestBindingWaitForFirstConsumer(nil /* node selector */, false /* expect unschedulable */)
-		Expect(node).ToNot(BeNil(), "Unexpected nil node found")
+		gomega.Expect(node).ToNot(gomega.BeNil(), "Unexpected nil node found")
 	} else {
 		test.TestDynamicProvisioning()
 	}
@@ -136,7 +136,7 @@ func testTopologyNegative(cs clientset.Interface, suffix, namespace string, dela
 	// Use different zones for pod and PV
 	zones, err := framework.GetClusterZones(cs)
 	framework.ExpectNoError(err)
-	Expect(zones.Len()).To(BeNumerically(">=", 2))
+	gomega.Expect(zones.Len()).To(gomega.BeNumerically(">=", 2))
 	zonesList := zones.UnsortedList()
 	podZoneIndex := rand.Intn(zones.Len())
 	podZone := zonesList[podZoneIndex]

--- a/test/e2e/storage/detach_mounted.go
+++ b/test/e2e/storage/detach_mounted.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 )
 
 var (
@@ -49,7 +49,7 @@ var _ = utils.SIGDescribe("Detaching volumes", func() {
 	var node v1.Node
 	var suffix string
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("gce", "local")
 		framework.SkipUnlessMasterOSDistroIs("debian", "ubuntu", "gci", "custom")
 		framework.SkipUnlessNodeOSDistroIs("debian", "ubuntu", "gci", "custom")
@@ -62,13 +62,13 @@ var _ = utils.SIGDescribe("Detaching volumes", func() {
 		suffix = ns.Name
 	})
 
-	It("should not work when mount is in progress [Slow]", func() {
+	ginkgo.It("should not work when mount is in progress [Slow]", func() {
 		driver := "attachable-with-long-mount"
 		driverInstallAs := driver + "-" + suffix
 
-		By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
 		installFlex(cs, &node, "k8s", driverInstallAs, path.Join(driverDir, driver))
-		By(fmt.Sprintf("installing flexvolume %s on master as %s", path.Join(driverDir, driver), driverInstallAs))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on master as %s", path.Join(driverDir, driver), driverInstallAs))
 		installFlex(cs, nil, "k8s", driverInstallAs, path.Join(driverDir, driver))
 		volumeSource := v1.VolumeSource{
 			FlexVolume: &v1.FlexVolumeSource{
@@ -77,31 +77,31 @@ var _ = utils.SIGDescribe("Detaching volumes", func() {
 		}
 
 		clientPod := getFlexVolumePod(volumeSource, node.Name)
-		By("Creating pod that uses slow format volume")
+		ginkgo.By("Creating pod that uses slow format volume")
 		pod, err := cs.CoreV1().Pods(ns.Name).Create(clientPod)
 		framework.ExpectNoError(err)
 
 		uniqueVolumeName := getUniqueVolumeName(pod, driverInstallAs)
 
-		By("waiting for volumes to be attached to node")
+		ginkgo.By("waiting for volumes to be attached to node")
 		err = waitForVolumesAttached(cs, node.Name, uniqueVolumeName)
 		framework.ExpectNoError(err, "while waiting for volume to attach to %s node", node.Name)
 
-		By("waiting for volume-in-use on the node after pod creation")
+		ginkgo.By("waiting for volume-in-use on the node after pod creation")
 		err = waitForVolumesInUse(cs, node.Name, uniqueVolumeName)
 		framework.ExpectNoError(err, "while waiting for volume in use")
 
-		By("waiting for kubelet to start mounting the volume")
+		ginkgo.By("waiting for kubelet to start mounting the volume")
 		time.Sleep(20 * time.Second)
 
-		By("Deleting the flexvolume pod")
+		ginkgo.By("Deleting the flexvolume pod")
 		err = framework.DeletePodWithWait(f, cs, pod)
 		framework.ExpectNoError(err, "in deleting the pod")
 
 		// Wait a bit for node to sync the volume status
 		time.Sleep(30 * time.Second)
 
-		By("waiting for volume-in-use on the node after pod deletion")
+		ginkgo.By("waiting for volume-in-use on the node after pod deletion")
 		err = waitForVolumesInUse(cs, node.Name, uniqueVolumeName)
 		framework.ExpectNoError(err, "while waiting for volume in use")
 
@@ -109,13 +109,13 @@ var _ = utils.SIGDescribe("Detaching volumes", func() {
 		// we previously already waited for 30s.
 		time.Sleep(durationForStuckMount)
 
-		By("waiting for volume to disappear from node in-use")
+		ginkgo.By("waiting for volume to disappear from node in-use")
 		err = waitForVolumesNotInUse(cs, node.Name, uniqueVolumeName)
 		framework.ExpectNoError(err, "while waiting for volume to be removed from in-use")
 
-		By(fmt.Sprintf("uninstalling flexvolume %s from node %s", driverInstallAs, node.Name))
+		ginkgo.By(fmt.Sprintf("uninstalling flexvolume %s from node %s", driverInstallAs, node.Name))
 		uninstallFlex(cs, &node, "k8s", driverInstallAs)
-		By(fmt.Sprintf("uninstalling flexvolume %s from master", driverInstallAs))
+		ginkgo.By(fmt.Sprintf("uninstalling flexvolume %s from master", driverInstallAs))
 		uninstallFlex(cs, nil, "k8s", driverInstallAs)
 	})
 })

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -40,7 +40,7 @@ import (
 	"math/rand"
 	"strconv"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -127,7 +127,7 @@ func (h *hostpathCSIDriver) GetClaimSize() string {
 }
 
 func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
-	By(fmt.Sprintf("deploying %s driver", h.driverInfo.Name))
+	ginkgo.By(fmt.Sprintf("deploying %s driver", h.driverInfo.Name))
 	cancelLogging := testsuites.StartPodLogs(f)
 	cs := f.ClientSet
 
@@ -161,7 +161,7 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.Per
 	}
 
 	return config, func() {
-		By(fmt.Sprintf("uninstalling %s driver", h.driverInfo.Name))
+		ginkgo.By(fmt.Sprintf("uninstalling %s driver", h.driverInfo.Name))
 		cleanup()
 		cancelLogging()
 	}
@@ -258,7 +258,7 @@ func (m *mockCSIDriver) GetClaimSize() string {
 }
 
 func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
-	By("deploying csi mock driver")
+	ginkgo.By("deploying csi mock driver")
 	cancelLogging := testsuites.StartPodLogs(f)
 	cs := f.ClientSet
 
@@ -306,7 +306,7 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTest
 	}
 
 	return config, func() {
-		By("uninstalling csi mock driver")
+		ginkgo.By("uninstalling csi mock driver")
 		cleanup()
 		cancelLogging()
 	}
@@ -391,7 +391,7 @@ func (g *gcePDCSIDriver) GetClaimSize() string {
 }
 
 func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
-	By("deploying csi gce-pd driver")
+	ginkgo.By("deploying csi gce-pd driver")
 	cancelLogging := testsuites.StartPodLogs(f)
 	// It would be safer to rename the gcePD driver, but that
 	// hasn't been done before either and attempts to do so now led to
@@ -426,7 +426,7 @@ func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTes
 			Prefix:    "gcepd",
 			Framework: f,
 		}, func() {
-			By("uninstalling gce-pd driver")
+			ginkgo.By("uninstalling gce-pd driver")
 			cleanup()
 			cancelLogging()
 		}

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -43,8 +43,8 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -114,7 +114,7 @@ func (n *nfsDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 
 func (n *nfsDriver) GetVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) *v1.VolumeSource {
 	nv, ok := volume.(*nfsVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to NFS test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to NFS test volume")
 	return &v1.VolumeSource{
 		NFS: &v1.NFSVolumeSource{
 			Server:   nv.serverIP,
@@ -126,7 +126,7 @@ func (n *nfsDriver) GetVolumeSource(readOnly bool, fsType string, volume testsui
 
 func (n *nfsDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
 	nv, ok := volume.(*nfsVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to NFS test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to NFS test volume")
 	return &v1.PersistentVolumeSource{
 		NFS: &v1.NFSVolumeSource{
 			Server:   nv.serverIP,
@@ -165,7 +165,7 @@ func (n *nfsDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConf
 		"", "get", schema.GroupResource{Group: "storage.k8s.io", Resource: "storageclasses"}, true)
 	framework.ExpectNoError(err, "Failed to update authorization: %v", err)
 
-	By("creating an external dynamic provisioner pod")
+	ginkgo.By("creating an external dynamic provisioner pod")
 	n.externalProvisionerPod = utils.StartExternalProvisioner(cs, ns.Name, n.externalPluginName)
 
 	return &testsuites.PerTestConfig{
@@ -255,7 +255,7 @@ func (g *glusterFSDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) 
 
 func (g *glusterFSDriver) GetVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) *v1.VolumeSource {
 	gv, ok := volume.(*glusterVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to Gluster test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to Gluster test volume")
 
 	name := gv.prefix + "-server"
 	return &v1.VolumeSource{
@@ -270,7 +270,7 @@ func (g *glusterFSDriver) GetVolumeSource(readOnly bool, fsType string, volume t
 
 func (g *glusterFSDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
 	gv, ok := volume.(*glusterVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to Gluster test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to Gluster test volume")
 
 	name := gv.prefix + "-server"
 	return &v1.PersistentVolumeSource{
@@ -378,7 +378,7 @@ func (i *iSCSIDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 
 func (i *iSCSIDriver) GetVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) *v1.VolumeSource {
 	iv, ok := volume.(*iSCSIVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to iSCSI test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to iSCSI test volume")
 
 	volSource := v1.VolumeSource{
 		ISCSI: &v1.ISCSIVolumeSource{
@@ -396,7 +396,7 @@ func (i *iSCSIDriver) GetVolumeSource(readOnly bool, fsType string, volume tests
 
 func (i *iSCSIDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
 	iv, ok := volume.(*iSCSIVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to iSCSI test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to iSCSI test volume")
 
 	pvSource := v1.PersistentVolumeSource{
 		ISCSI: &v1.ISCSIPersistentVolumeSource{
@@ -491,7 +491,7 @@ func (r *rbdDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 
 func (r *rbdDriver) GetVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) *v1.VolumeSource {
 	rv, ok := volume.(*rbdVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to RBD test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to RBD test volume")
 
 	volSource := v1.VolumeSource{
 		RBD: &v1.RBDVolumeSource{
@@ -513,7 +513,7 @@ func (r *rbdDriver) GetVolumeSource(readOnly bool, fsType string, volume testsui
 
 func (r *rbdDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
 	rv, ok := volume.(*rbdVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to RBD test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to RBD test volume")
 
 	f := rv.f
 	ns := f.Namespace
@@ -614,7 +614,7 @@ func (c *cephFSDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 
 func (c *cephFSDriver) GetVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) *v1.VolumeSource {
 	cv, ok := volume.(*cephVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to Ceph test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to Ceph test volume")
 
 	return &v1.VolumeSource{
 		CephFS: &v1.CephFSVolumeSource{
@@ -630,7 +630,7 @@ func (c *cephFSDriver) GetVolumeSource(readOnly bool, fsType string, volume test
 
 func (c *cephFSDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
 	cv, ok := volume.(*cephVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to Ceph test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to Ceph test volume")
 
 	ns := cv.f.Namespace
 
@@ -784,7 +784,7 @@ func (h *hostPathSymlinkDriver) SkipUnsupportedTest(pattern testpatterns.TestPat
 
 func (h *hostPathSymlinkDriver) GetVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) *v1.VolumeSource {
 	hv, ok := volume.(*hostPathSymlinkVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to Hostpath Symlink test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to Hostpath Symlink test volume")
 
 	// hostPathSymlink doesn't support readOnly volume
 	if readOnly {
@@ -859,13 +859,13 @@ func (h *hostPathSymlinkDriver) CreateVolume(config *testsuites.PerTestConfig, v
 	}
 	// h.prepPod will be reused in cleanupDriver.
 	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(prepPod)
-	Expect(err).ToNot(HaveOccurred(), "while creating hostPath init pod")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while creating hostPath init pod")
 
 	err = framework.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, pod.Namespace)
-	Expect(err).ToNot(HaveOccurred(), "while waiting for hostPath init pod to succeed")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while waiting for hostPath init pod to succeed")
 
 	err = framework.DeletePodWithWait(f, f.ClientSet, pod)
-	Expect(err).ToNot(HaveOccurred(), "while deleting hostPath init pod")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while deleting hostPath init pod")
 	return &hostPathSymlinkVolume{
 		sourcePath: sourcePath,
 		targetPath: targetPath,
@@ -881,13 +881,13 @@ func (v *hostPathSymlinkVolume) DeleteVolume() {
 	v.prepPod.Spec.Containers[0].Command = []string{"/bin/sh", "-ec", cmd}
 
 	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(v.prepPod)
-	Expect(err).ToNot(HaveOccurred(), "while creating hostPath teardown pod")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while creating hostPath teardown pod")
 
 	err = framework.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, pod.Namespace)
-	Expect(err).ToNot(HaveOccurred(), "while waiting for hostPath teardown pod to succeed")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while waiting for hostPath teardown pod to succeed")
 
 	err = framework.DeletePodWithWait(f, f.ClientSet, pod)
-	Expect(err).ToNot(HaveOccurred(), "while deleting hostPath teardown pod")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while deleting hostPath teardown pod")
 }
 
 // emptydir
@@ -995,7 +995,7 @@ func (c *cinderDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 
 func (c *cinderDriver) GetVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) *v1.VolumeSource {
 	cv, ok := volume.(*cinderVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to Cinder test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to Cinder test volume")
 
 	volSource := v1.VolumeSource{
 		Cinder: &v1.CinderVolumeSource{
@@ -1011,7 +1011,7 @@ func (c *cinderDriver) GetVolumeSource(readOnly bool, fsType string, volume test
 
 func (c *cinderDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
 	cv, ok := volume.(*cinderVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to Cinder test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to Cinder test volume")
 
 	pvSource := v1.PersistentVolumeSource{
 		Cinder: &v1.CinderPersistentVolumeSource{
@@ -1055,7 +1055,7 @@ func (c *cinderDriver) CreateVolume(config *testsuites.PerTestConfig, volType te
 
 	// We assume that namespace.Name is a random string
 	volumeName := ns.Name
-	By("creating a test Cinder volume")
+	ginkgo.By("creating a test Cinder volume")
 	output, err := exec.Command("cinder", "create", "--display-name="+volumeName, "1").CombinedOutput()
 	outputString := string(output[:])
 	e2elog.Logf("cinder output:\n%s", outputString)
@@ -1079,7 +1079,7 @@ func (c *cinderDriver) CreateVolume(config *testsuites.PerTestConfig, volType te
 		break
 	}
 	e2elog.Logf("Volume ID: %s", volumeID)
-	Expect(volumeID).NotTo(Equal(""))
+	gomega.Expect(volumeID).NotTo(gomega.Equal(""))
 	return &cinderVolume{
 		volumeName: volumeName,
 		volumeID:   volumeID,
@@ -1166,7 +1166,7 @@ func (g *gcePdDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 
 func (g *gcePdDriver) GetVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) *v1.VolumeSource {
 	gv, ok := volume.(*gcePdVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to GCE PD test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to GCE PD test volume")
 	volSource := v1.VolumeSource{
 		GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
 			PDName:   gv.volumeName,
@@ -1181,7 +1181,7 @@ func (g *gcePdDriver) GetVolumeSource(readOnly bool, fsType string, volume tests
 
 func (g *gcePdDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
 	gv, ok := volume.(*gcePdVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to GCE PD test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to GCE PD test volume")
 	pvSource := v1.PersistentVolumeSource{
 		GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
 			PDName:   gv.volumeName,
@@ -1234,7 +1234,7 @@ func (g *gcePdDriver) CreateVolume(config *testsuites.PerTestConfig, volType tes
 			v1.LabelZoneFailureDomain: framework.TestContext.CloudConfig.Zone,
 		}
 	}
-	By("creating a test gce pd volume")
+	ginkgo.By("creating a test gce pd volume")
 	vname, err := framework.CreatePDWithRetry()
 	framework.ExpectNoError(err)
 	return &gcePdVolume{
@@ -1291,7 +1291,7 @@ func (v *vSphereDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 
 func (v *vSphereDriver) GetVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) *v1.VolumeSource {
 	vsv, ok := volume.(*vSphereVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to vSphere test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to vSphere test volume")
 
 	// vSphere driver doesn't seem to support readOnly volume
 	// TODO: check if it is correct
@@ -1311,7 +1311,7 @@ func (v *vSphereDriver) GetVolumeSource(readOnly bool, fsType string, volume tes
 
 func (v *vSphereDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
 	vsv, ok := volume.(*vSphereVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to vSphere test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to vSphere test volume")
 
 	// vSphere driver doesn't seem to support readOnly volume
 	// TODO: check if it is correct
@@ -1415,7 +1415,7 @@ func (a *azureDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
 
 func (a *azureDriver) GetVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) *v1.VolumeSource {
 	av, ok := volume.(*azureVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to Azure test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to Azure test volume")
 
 	diskName := av.volumeName[(strings.LastIndex(av.volumeName, "/") + 1):]
 
@@ -1434,7 +1434,7 @@ func (a *azureDriver) GetVolumeSource(readOnly bool, fsType string, volume tests
 
 func (a *azureDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
 	av, ok := volume.(*azureVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to Azure test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to Azure test volume")
 
 	diskName := av.volumeName[(strings.LastIndex(av.volumeName, "/") + 1):]
 
@@ -1476,7 +1476,7 @@ func (a *azureDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestCo
 }
 
 func (a *azureDriver) CreateVolume(config *testsuites.PerTestConfig, volType testpatterns.TestVolType) testsuites.TestVolume {
-	By("creating a test azure disk volume")
+	ginkgo.By("creating a test azure disk volume")
 	volumeName, err := framework.CreatePDWithRetry()
 	framework.ExpectNoError(err)
 	return &azureVolume{
@@ -1589,7 +1589,7 @@ func (a *awsDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConf
 // TODO: Fix authorization error in attach operation and uncomment below
 /*
 func (a *awsDriver) CreateVolume(config *testsuites.PerTestConfig, volType testpatterns.TestVolType) testsuites.TestVolume {
-	By("creating a test aws volume")
+	ginkgo.By("creating a test aws volume")
 	var err error
 	a.volumeName, err = framework.CreatePDWithRetry()
 	framework.ExpectNoError(err))
@@ -1773,7 +1773,7 @@ func (l *localDriver) nodeAffinityForNode(node *v1.Node) *v1.VolumeNodeAffinity 
 
 func (l *localDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
 	lv, ok := volume.(*localVolume)
-	Expect(ok).To(BeTrue(), "Failed to cast test volume to local test volume")
+	gomega.Expect(ok).To(gomega.BeTrue(), "Failed to cast test volume to local test volume")
 	return &v1.PersistentVolumeSource{
 		Local: &v1.LocalVolumeSource{
 			Path:   lv.ltr.Path,

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -29,8 +29,8 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 )
 
 const (
@@ -144,15 +144,15 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 		pod = f.PodClient().CreateSync(pod)
 
 		defer func() {
-			By("Cleaning up the secret")
+			ginkgo.By("Cleaning up the secret")
 			if err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(secret.Name, nil); err != nil {
 				framework.Failf("unable to delete secret %v: %v", secret.Name, err)
 			}
-			By("Cleaning up the configmap")
+			ginkgo.By("Cleaning up the configmap")
 			if err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(configMap.Name, nil); err != nil {
 				framework.Failf("unable to delete configmap %v: %v", configMap.Name, err)
 			}
-			By("Cleaning up the pod")
+			ginkgo.By("Cleaning up the pod")
 			if err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(pod.Name, metav1.NewDeleteOptions(0)); err != nil {
 				framework.Failf("unable to delete pod %v: %v", pod.Name, err)
 			}
@@ -194,7 +194,7 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 	// This test uses deprecated GitRepo VolumeSource so it MUST not be promoted to Conformance.
 	// To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod’s container.
 	// This projected volume maps approach can also be tested with secrets and downwardapi VolumeSource but are less prone to the race problem.
-	It("should not cause race condition when used for git_repo [Serial] [Slow]", func() {
+	ginkgo.It("should not cause race condition when used for git_repo [Serial] [Slow]", func() {
 		gitURL, gitRepo, cleanup := createGitServer(f)
 		defer cleanup()
 		volumes, volumeMounts := makeGitRepoVolumes(gitURL, gitRepo)
@@ -255,11 +255,11 @@ func createGitServer(f *framework.Framework) (gitURL string, gitRepo string, cle
 	}
 
 	return "http://" + gitServerSvc.Spec.ClusterIP + ":" + strconv.Itoa(httpPort), "test", func() {
-		By("Cleaning up the git server pod")
+		ginkgo.By("Cleaning up the git server pod")
 		if err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(gitServerPod.Name, metav1.NewDeleteOptions(0)); err != nil {
 			framework.Failf("unable to delete git server pod %v: %v", gitServerPod.Name, err)
 		}
-		By("Cleaning up the git server svc")
+		ginkgo.By("Cleaning up the git server svc")
 		if err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete(gitServerSvc.Name, nil); err != nil {
 			framework.Failf("unable to delete git server svc %v: %v", gitServerSvc.Name, err)
 		}
@@ -287,7 +287,7 @@ func makeGitRepoVolumes(gitURL, gitRepo string) (volumes []v1.Volume, volumeMoun
 }
 
 func createConfigmapsForRace(f *framework.Framework) (configMapNames []string) {
-	By(fmt.Sprintf("Creating %d configmaps", wrappedVolumeRaceConfigMapVolumeCount))
+	ginkgo.By(fmt.Sprintf("Creating %d configmaps", wrappedVolumeRaceConfigMapVolumeCount))
 	for i := 0; i < wrappedVolumeRaceConfigMapVolumeCount; i++ {
 		configMapName := fmt.Sprintf("racey-configmap-%d", i)
 		configMapNames = append(configMapNames, configMapName)
@@ -307,7 +307,7 @@ func createConfigmapsForRace(f *framework.Framework) (configMapNames []string) {
 }
 
 func deleteConfigMaps(f *framework.Framework, configMapNames []string) {
-	By("Cleaning up the configMaps")
+	ginkgo.By("Cleaning up the configMaps")
 	for _, configMapName := range configMapNames {
 		err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(configMapName, nil)
 		framework.ExpectNoError(err, "unable to delete configMap %v", configMapName)
@@ -346,10 +346,10 @@ func testNoWrappedVolumeRace(f *framework.Framework, volumes []v1.Volume, volume
 
 	rcName := wrappedVolumeRaceRCNamePrefix + string(uuid.NewUUID())
 	nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-	Expect(len(nodeList.Items)).To(BeNumerically(">", 0))
+	gomega.Expect(len(nodeList.Items)).To(gomega.BeNumerically(">", 0))
 	targetNode := nodeList.Items[0]
 
-	By("Creating RC which spawns configmap-volume pods")
+	ginkgo.By("Creating RC which spawns configmap-volume pods")
 	affinity := &v1.Affinity{
 		NodeAffinity: &v1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
@@ -412,7 +412,7 @@ func testNoWrappedVolumeRace(f *framework.Framework, volumes []v1.Volume, volume
 
 	pods, err := framework.PodsCreated(f.ClientSet, f.Namespace.Name, rcName, podCount)
 
-	By("Ensuring each pod is running")
+	ginkgo.By("Ensuring each pod is running")
 
 	// Wait for the pods to enter the running state. Waiting loops until the pods
 	// are running so non-running pods cause a timeout for this test.

--- a/test/e2e/storage/ephemeral_volume.go
+++ b/test/e2e/storage/ephemeral_volume.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 )
 
 var (
@@ -46,13 +46,13 @@ var _ = utils.SIGDescribe("Ephemeralstorage", func() {
 
 	f := framework.NewDefaultFramework("pv")
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		c = f.ClientSet
 	})
 
-	Describe("When pod refers to non-existent ephemeral storage", func() {
+	ginkgo.Describe("When pod refers to non-existent ephemeral storage", func() {
 		for _, testSource := range invalidEphemeralSource("pod-ephm-test") {
-			It(fmt.Sprintf("should allow deletion of pod with invalid volume : %s", testSource.volumeType), func() {
+			ginkgo.It(fmt.Sprintf("should allow deletion of pod with invalid volume : %s", testSource.volumeType), func() {
 				pod := testEphemeralVolumePod(f, testSource.volumeType, testSource.source)
 				pod, err := c.CoreV1().Pods(f.Namespace.Name).Create(pod)
 				framework.ExpectNoError(err)

--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -24,7 +24,7 @@ import (
 
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	clientset "k8s.io/client-go/kubernetes"
@@ -92,7 +92,7 @@ func installFlex(c clientset.Interface, node *v1.Node, vendor, driver, filePath 
 	cmd := fmt.Sprintf("sudo mkdir -p %s", flexDir)
 	sshAndLog(cmd, host, true /*failOnError*/)
 
-	data := testfiles.ReadOrDie(filePath, Fail)
+	data := testfiles.ReadOrDie(filePath, ginkgo.Fail)
 	cmd = fmt.Sprintf("sudo tee <<'EOF' %s\n%s\nEOF", flexFile, string(data))
 	sshAndLog(cmd, host, true /*failOnError*/)
 
@@ -164,7 +164,7 @@ var _ = utils.SIGDescribe("Flexvolumes", func() {
 	var config volume.TestConfig
 	var suffix string
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("gce", "local")
 		framework.SkipUnlessMasterOSDistroIs("debian", "ubuntu", "gci", "custom")
 		framework.SkipUnlessNodeOSDistroIs("debian", "ubuntu", "gci", "custom")
@@ -182,36 +182,36 @@ var _ = utils.SIGDescribe("Flexvolumes", func() {
 		suffix = ns.Name
 	})
 
-	It("should be mountable when non-attachable", func() {
+	ginkgo.It("should be mountable when non-attachable", func() {
 		driver := "dummy"
 		driverInstallAs := driver + "-" + suffix
 
-		By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
 		installFlex(cs, &node, "k8s", driverInstallAs, path.Join(driverDir, driver))
 
 		testFlexVolume(driverInstallAs, cs, config, f)
 
-		By("waiting for flex client pod to terminate")
+		ginkgo.By("waiting for flex client pod to terminate")
 		if err := f.WaitForPodTerminated(config.Prefix+"-client", ""); !apierrs.IsNotFound(err) {
 			framework.ExpectNoError(err, "Failed to wait client pod terminated: %v", err)
 		}
 
-		By(fmt.Sprintf("uninstalling flexvolume %s from node %s", driverInstallAs, node.Name))
+		ginkgo.By(fmt.Sprintf("uninstalling flexvolume %s from node %s", driverInstallAs, node.Name))
 		uninstallFlex(cs, &node, "k8s", driverInstallAs)
 	})
 
-	It("should be mountable when attachable", func() {
+	ginkgo.It("should be mountable when attachable", func() {
 		driver := "dummy-attachable"
 		driverInstallAs := driver + "-" + suffix
 
-		By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
 		installFlex(cs, &node, "k8s", driverInstallAs, path.Join(driverDir, driver))
-		By(fmt.Sprintf("installing flexvolume %s on master as %s", path.Join(driverDir, driver), driverInstallAs))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on master as %s", path.Join(driverDir, driver), driverInstallAs))
 		installFlex(cs, nil, "k8s", driverInstallAs, path.Join(driverDir, driver))
 
 		testFlexVolume(driverInstallAs, cs, config, f)
 
-		By("waiting for flex client pod to terminate")
+		ginkgo.By("waiting for flex client pod to terminate")
 		if err := f.WaitForPodTerminated(config.Prefix+"-client", ""); !apierrs.IsNotFound(err) {
 			framework.ExpectNoError(err, "Failed to wait client pod terminated: %v", err)
 		}
@@ -219,9 +219,9 @@ var _ = utils.SIGDescribe("Flexvolumes", func() {
 		// Detach might occur after pod deletion. Wait before deleting driver.
 		time.Sleep(detachTimeout)
 
-		By(fmt.Sprintf("uninstalling flexvolume %s from node %s", driverInstallAs, node.Name))
+		ginkgo.By(fmt.Sprintf("uninstalling flexvolume %s from node %s", driverInstallAs, node.Name))
 		uninstallFlex(cs, &node, "k8s", driverInstallAs)
-		By(fmt.Sprintf("uninstalling flexvolume %s from master", driverInstallAs))
+		ginkgo.By(fmt.Sprintf("uninstalling flexvolume %s from master", driverInstallAs))
 		uninstallFlex(cs, nil, "k8s", driverInstallAs)
 	})
 })

--- a/test/e2e/storage/flexvolume_online_resize.go
+++ b/test/e2e/storage/flexvolume_online_resize.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"path"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -49,7 +49,7 @@ var _ = utils.SIGDescribe("Mounted flexvolume volume expand [Slow] [Feature:Expa
 	)
 
 	f := framework.NewDefaultFramework("mounted-flexvolume-expand")
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("aws", "gce", "local")
 		framework.SkipUnlessMasterOSDistroIs("debian", "ubuntu", "gci", "custom")
 		framework.SkipUnlessNodeOSDistroIs("debian", "ubuntu", "gci", "custom")
@@ -86,7 +86,7 @@ var _ = utils.SIGDescribe("Mounted flexvolume volume expand [Slow] [Feature:Expa
 			fmt.Printf("storage class creation error: %v\n", err)
 		}
 		framework.ExpectNoError(err, "Error creating resizable storage class: %v", err)
-		Expect(*resizableSc.AllowVolumeExpansion).To(BeTrue())
+		gomega.Expect(*resizableSc.AllowVolumeExpansion).To(gomega.BeTrue())
 
 		pvc = getClaim("2Gi", ns)
 		pvc.Spec.StorageClassName = &resizableSc.Name
@@ -101,7 +101,7 @@ var _ = utils.SIGDescribe("Mounted flexvolume volume expand [Slow] [Feature:Expa
 		}
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		e2elog.Logf("AfterEach: Cleaning up resources for mounted volume resize")
 
 		if c != nil {
@@ -113,13 +113,13 @@ var _ = utils.SIGDescribe("Mounted flexvolume volume expand [Slow] [Feature:Expa
 		}
 	})
 
-	It("should be resizable when mounted", func() {
+	ginkgo.It("should be resizable when mounted", func() {
 		driver := "dummy-attachable"
 
 		node := nodeList.Items[0]
-		By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driver))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driver))
 		installFlex(c, &node, "k8s", driver, path.Join(driverDir, driver))
-		By(fmt.Sprintf("installing flexvolume %s on (master) node %s as %s", path.Join(driverDir, driver), node.Name, driver))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on (master) node %s as %s", path.Join(driverDir, driver), node.Name, driver))
 		installFlex(c, nil, "k8s", driver, path.Join(driverDir, driver))
 
 		pv := framework.MakePersistentVolume(framework.PersistentVolumeConfig{
@@ -135,44 +135,44 @@ var _ = utils.SIGDescribe("Mounted flexvolume volume expand [Slow] [Feature:Expa
 		pv, err = framework.CreatePV(c, pv)
 		framework.ExpectNoError(err, "Error creating pv %v", err)
 
-		By("Waiting for PVC to be in bound phase")
+		ginkgo.By("Waiting for PVC to be in bound phase")
 		pvcClaims := []*v1.PersistentVolumeClaim{pvc}
 		var pvs []*v1.PersistentVolume
 
 		pvs, err = framework.WaitForPVClaimBoundPhase(c, pvcClaims, framework.ClaimProvisionTimeout)
 		framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
-		Expect(len(pvs)).To(Equal(1))
+		gomega.Expect(len(pvs)).To(gomega.Equal(1))
 
 		var pod *v1.Pod
-		By("Creating pod")
+		ginkgo.By("Creating pod")
 		pod, err = framework.CreateNginxPod(c, ns, nodeKeyValueLabel, pvcClaims)
 		framework.ExpectNoError(err, "Failed to create pod %v", err)
 		defer framework.DeletePodWithWait(f, c, pod)
 
-		By("Waiting for pod to go to 'running' state")
+		ginkgo.By("Waiting for pod to go to 'running' state")
 		err = f.WaitForPodRunning(pod.ObjectMeta.Name)
 		framework.ExpectNoError(err, "Pod didn't go to 'running' state %v", err)
 
-		By("Expanding current pvc")
+		ginkgo.By("Expanding current pvc")
 		newSize := resource.MustParse("6Gi")
 		pvc, err = expandPVCSize(pvc, newSize, c)
 		framework.ExpectNoError(err, "While updating pvc for more size")
-		Expect(pvc).NotTo(BeNil())
+		gomega.Expect(pvc).NotTo(gomega.BeNil())
 
 		pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
 		if pvcSize.Cmp(newSize) != 0 {
 			framework.Failf("error updating pvc size %q", pvc.Name)
 		}
 
-		By("Waiting for cloudprovider resize to finish")
+		ginkgo.By("Waiting for cloudprovider resize to finish")
 		err = waitForControllerVolumeResize(pvc, c, totalResizeWaitPeriod)
 		framework.ExpectNoError(err, "While waiting for pvc resize to finish")
 
-		By("Waiting for file system resize to finish")
+		ginkgo.By("Waiting for file system resize to finish")
 		pvc, err = waitForFSResize(pvc, c)
 		framework.ExpectNoError(err, "while waiting for fs resize to finish")
 
 		pvcConditions := pvc.Status.Conditions
-		Expect(len(pvcConditions)).To(Equal(0), "pvc should not have conditions")
+		gomega.Expect(len(pvcConditions)).To(gomega.Equal(0), "pvc should not have conditions")
 	})
 })

--- a/test/e2e/storage/generic_persistent_volume-disruptive.go
+++ b/test/e2e/storage/generic_persistent_volume-disruptive.go
@@ -17,8 +17,8 @@ limitations under the License.
 package storage
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -35,7 +35,7 @@ var _ = utils.SIGDescribe("GenericPersistentVolume[Disruptive]", func() {
 		ns string
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		// Skip tests unless number of nodes is 2
 		framework.SkipUnlessNodeCountIsAtLeast(2)
 		framework.SkipIfProviderIs("local")
@@ -56,8 +56,8 @@ var _ = utils.SIGDescribe("GenericPersistentVolume[Disruptive]", func() {
 			runTest:    utils.TestVolumeUnmountsFromForceDeletedPod,
 		},
 	}
-	Context("When kubelet restarts", func() {
-		// Test table housing the It() title string and test spec.  runTest is type testBody, defined at
+	ginkgo.Context("When kubelet restarts", func() {
+		// Test table housing the ginkgo.It() title string and test spec.  runTest is type testBody, defined at
 		// the start of this file.  To add tests, define a function mirroring the testBody signature and assign
 		// to runTest.
 		var (
@@ -65,19 +65,19 @@ var _ = utils.SIGDescribe("GenericPersistentVolume[Disruptive]", func() {
 			pvc       *v1.PersistentVolumeClaim
 			pv        *v1.PersistentVolume
 		)
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			e2elog.Logf("Initializing pod and pvcs for test")
 			clientPod, pvc, pv = createPodPVCFromSC(f, c, ns)
 		})
 		for _, test := range disruptiveTestTable {
 			func(t disruptiveTest) {
-				It(t.testItStmt, func() {
-					By("Executing Spec")
+				ginkgo.It(t.testItStmt, func() {
+					ginkgo.By("Executing Spec")
 					t.runTest(c, f, clientPod)
 				})
 			}(test)
 		}
-		AfterEach(func() {
+		ginkgo.AfterEach(func() {
 			e2elog.Logf("Tearing down test spec")
 			tearDownTestCase(c, f, ns, clientPod, pvc, pv, false)
 			pvc, clientPod = nil, nil
@@ -97,9 +97,9 @@ func createPodPVCFromSC(f *framework.Framework, c clientset.Interface, ns string
 	pvcClaims := []*v1.PersistentVolumeClaim{pvc}
 	pvs, err := framework.WaitForPVClaimBoundPhase(c, pvcClaims, framework.ClaimProvisionTimeout)
 	framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
-	Expect(len(pvs)).To(Equal(1))
+	gomega.Expect(len(pvs)).To(gomega.Equal(1))
 
-	By("Creating a pod with dynamically provisioned volume")
+	ginkgo.By("Creating a pod with dynamically provisioned volume")
 	pod, err := framework.CreateNginxPod(c, ns, nil, pvcClaims)
 	framework.ExpectNoError(err, "While creating pods for kubelet restart test")
 	return pod, pvc, pvs[0]

--- a/test/e2e/storage/in_tree_volumes.go
+++ b/test/e2e/storage/in_tree_volumes.go
@@ -17,7 +17,7 @@ limitations under the License.
 package storage
 
 import (
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 	"k8s.io/kubernetes/test/e2e/storage/drivers"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
@@ -63,7 +63,7 @@ var _ = utils.SIGDescribe("In-tree Volumes", func() {
 	for _, initDriver := range testDrivers {
 		curDriver := initDriver()
 
-		Context(testsuites.GetDriverNameWithFeatureTags(curDriver), func() {
+		ginkgo.Context(testsuites.GetDriverNameWithFeatureTags(curDriver), func() {
 			testsuites.DefineTestSuite(curDriver, testSuites)
 		})
 	}

--- a/test/e2e/storage/nfs_persistent_volume-disruptive.go
+++ b/test/e2e/storage/nfs_persistent_volume-disruptive.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -58,7 +58,7 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 		selector                  *metav1.LabelSelector
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		// To protect the NFS volume pod from the kubelet restart, we isolate it on its own node.
 		framework.SkipUnlessNodeCountIsAtLeast(MinNodes)
 		framework.SkipIfProviderIs("local")
@@ -98,15 +98,15 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 					break
 				}
 			}
-			Expect(clientNodeIP).NotTo(BeEmpty())
+			gomega.Expect(clientNodeIP).NotTo(gomega.BeEmpty())
 		}
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		framework.DeletePodWithWait(f, c, nfsServerPod)
 	})
 
-	Context("when kube-controller-manager restarts", func() {
+	ginkgo.Context("when kube-controller-manager restarts", func() {
 		var (
 			diskName1, diskName2 string
 			err                  error
@@ -117,11 +117,11 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 			clientPod            *v1.Pod
 		)
 
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			framework.SkipUnlessProviderIs("gce")
 			framework.SkipUnlessSSHKeyPresent()
 
-			By("Initializing first PD with PVPVC binding")
+			ginkgo.By("Initializing first PD with PVPVC binding")
 			pvSource1, diskName1 = volume.CreateGCEVolume()
 			framework.ExpectNoError(err)
 			pvConfig1 = framework.PersistentVolumeConfig{
@@ -134,7 +134,7 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 			framework.ExpectNoError(err)
 			framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv1, pvc1))
 
-			By("Initializing second PD with PVPVC binding")
+			ginkgo.By("Initializing second PD with PVPVC binding")
 			pvSource2, diskName2 = volume.CreateGCEVolume()
 			framework.ExpectNoError(err)
 			pvConfig2 = framework.PersistentVolumeConfig{
@@ -147,12 +147,12 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 			framework.ExpectNoError(err)
 			framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv2, pvc2))
 
-			By("Attaching both PVC's to a single pod")
+			ginkgo.By("Attaching both PVC's to a single pod")
 			clientPod, err = framework.CreatePod(c, ns, nil, []*v1.PersistentVolumeClaim{pvc1, pvc2}, true, "")
 			framework.ExpectNoError(err)
 		})
 
-		AfterEach(func() {
+		ginkgo.AfterEach(func() {
 			// Delete client/user pod first
 			framework.ExpectNoError(framework.DeletePodWithWait(f, c, clientPod))
 
@@ -175,20 +175,20 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 			}
 		})
 
-		It("should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash", func() {
-			By("Deleting PVC for volume 2")
+		ginkgo.It("should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash", func() {
+			ginkgo.By("Deleting PVC for volume 2")
 			err = framework.DeletePersistentVolumeClaim(c, pvc2.Name, ns)
 			framework.ExpectNoError(err)
 			pvc2 = nil
 
-			By("Restarting the kube-controller-manager")
+			ginkgo.By("Restarting the kube-controller-manager")
 			err = framework.RestartControllerManager()
 			framework.ExpectNoError(err)
 			err = framework.WaitForControllerManagerUp()
 			framework.ExpectNoError(err)
 			e2elog.Logf("kube-controller-manager restarted")
 
-			By("Observing the kube-controller-manager healthy for at least 2 minutes")
+			ginkgo.By("Observing the kube-controller-manager healthy for at least 2 minutes")
 			// Continue checking for 2 minutes to make sure kube-controller-manager is healthy
 			err = framework.CheckForControllerManagerHealthy(2 * time.Minute)
 			framework.ExpectNoError(err)
@@ -196,25 +196,25 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 
 	})
 
-	Context("when kubelet restarts", func() {
+	ginkgo.Context("when kubelet restarts", func() {
 		var (
 			clientPod *v1.Pod
 			pv        *v1.PersistentVolume
 			pvc       *v1.PersistentVolumeClaim
 		)
 
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			e2elog.Logf("Initializing test spec")
 			clientPod, pv, pvc = initTestCase(f, c, nfsPVconfig, pvcConfig, ns, clientNode.Name)
 		})
 
-		AfterEach(func() {
+		ginkgo.AfterEach(func() {
 			e2elog.Logf("Tearing down test spec")
 			tearDownTestCase(c, f, ns, clientPod, pvc, pv, true /* force PV delete */)
 			pv, pvc, clientPod = nil, nil, nil
 		})
 
-		// Test table housing the It() title string and test spec.  runTest is type testBody, defined at
+		// Test table housing the ginkgo.It() title string and test spec.  runTest is type testBody, defined at
 		// the start of this file.  To add tests, define a function mirroring the testBody signature and assign
 		// to runTest.
 		disruptiveTestTable := []disruptiveTest{
@@ -235,8 +235,8 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 		// Test loop executes each disruptiveTest iteratively.
 		for _, test := range disruptiveTestTable {
 			func(t disruptiveTest) {
-				It(t.testItStmt, func() {
-					By("Executing Spec")
+				ginkgo.It(t.testItStmt, func() {
+					ginkgo.By("Executing Spec")
 					t.runTest(c, f, clientPod)
 				})
 			}(test)

--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -27,8 +27,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -67,7 +67,7 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 	)
 	f := framework.NewDefaultFramework("pod-disks")
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessNodeCountIsAtLeast(minNodes)
 		cs = f.ClientSet
 		ns = f.Namespace.Name
@@ -77,14 +77,14 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 		podClient = cs.CoreV1().Pods(ns)
 		nodeClient = cs.CoreV1().Nodes()
 		nodes = framework.GetReadySchedulableNodesOrDie(cs)
-		Expect(len(nodes.Items)).To(BeNumerically(">=", minNodes), fmt.Sprintf("Requires at least %d nodes", minNodes))
+		gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">=", minNodes), fmt.Sprintf("Requires at least %d nodes", minNodes))
 		host0Name = types.NodeName(nodes.Items[0].ObjectMeta.Name)
 		host1Name = types.NodeName(nodes.Items[1].ObjectMeta.Name)
 
 		mathrand.Seed(time.Now().UnixNano())
 	})
 
-	Context("schedule pods each with a PD, delete pod and verify detach [Slow]", func() {
+	ginkgo.Context("schedule pods each with a PD, delete pod and verify detach [Slow]", func() {
 		const (
 			podDefaultGrace   = "default (30s)"
 			podImmediateGrace = "immediate (0s)"
@@ -126,29 +126,29 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 			readOnly := t.readOnly
 			readOnlyTxt := readOnlyMap[readOnly]
 
-			It(fmt.Sprintf("for %s PD with pod delete grace period of %q", readOnlyTxt, t.descr), func() {
+			ginkgo.It(fmt.Sprintf("for %s PD with pod delete grace period of %q", readOnlyTxt, t.descr), func() {
 				framework.SkipUnlessProviderIs("gce", "gke", "aws")
 				if readOnly {
 					framework.SkipIfProviderIs("aws")
 				}
 
-				By("creating PD")
+				ginkgo.By("creating PD")
 				diskName, err := framework.CreatePDWithRetry()
 				framework.ExpectNoError(err, "Error creating PD")
 
 				var fmtPod *v1.Pod
 				if readOnly {
 					// if all test pods are RO then need a RW pod to format pd
-					By("creating RW fmt Pod to ensure PD is formatted")
+					ginkgo.By("creating RW fmt Pod to ensure PD is formatted")
 					fmtPod = testPDPod([]string{diskName}, host0Name, false, 1)
 					_, err = podClient.Create(fmtPod)
 					framework.ExpectNoError(err, "Failed to create fmtPod")
 					framework.ExpectNoError(f.WaitForPodRunningSlow(fmtPod.Name))
 
-					By("deleting the fmtPod")
+					ginkgo.By("deleting the fmtPod")
 					framework.ExpectNoError(podClient.Delete(fmtPod.Name, metav1.NewDeleteOptions(0)), "Failed to delete fmtPod")
 					e2elog.Logf("deleted fmtPod %q", fmtPod.Name)
-					By("waiting for PD to detach")
+					ginkgo.By("waiting for PD to detach")
 					framework.ExpectNoError(waitForPDDetach(diskName, host0Name))
 				}
 
@@ -158,7 +158,7 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 
 				defer func() {
 					// Teardown should do nothing unless test failed
-					By("defer: cleaning up PD-RW test environment")
+					ginkgo.By("defer: cleaning up PD-RW test environment")
 					e2elog.Logf("defer cleanup errors can usually be ignored")
 					if fmtPod != nil {
 						podClient.Delete(fmtPod.Name, podDelOpt)
@@ -168,7 +168,7 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 					detachAndDeletePDs(diskName, []types.NodeName{host0Name, host1Name})
 				}()
 
-				By("creating host0Pod on node0")
+				ginkgo.By("creating host0Pod on node0")
 				_, err = podClient.Create(host0Pod)
 				framework.ExpectNoError(err, fmt.Sprintf("Failed to create host0Pod: %v", err))
 				framework.ExpectNoError(f.WaitForPodRunningSlow(host0Pod.Name))
@@ -176,50 +176,50 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 
 				var containerName, testFile, testFileContents string
 				if !readOnly {
-					By("writing content to host0Pod on node0")
+					ginkgo.By("writing content to host0Pod on node0")
 					containerName = "mycontainer"
 					testFile = "/testpd1/tracker"
 					testFileContents = fmt.Sprintf("%v", mathrand.Int())
 					framework.ExpectNoError(f.WriteFileViaContainer(host0Pod.Name, containerName, testFile, testFileContents))
 					e2elog.Logf("wrote %q to file %q in pod %q on node %q", testFileContents, testFile, host0Pod.Name, host0Name)
-					By("verifying PD is present in node0's VolumeInUse list")
+					ginkgo.By("verifying PD is present in node0's VolumeInUse list")
 					framework.ExpectNoError(waitForPDInVolumesInUse(nodeClient, diskName, host0Name, nodeStatusTimeout, true /* shouldExist */))
-					By("deleting host0Pod") // delete this pod before creating next pod
+					ginkgo.By("deleting host0Pod") // delete this pod before creating next pod
 					framework.ExpectNoError(podClient.Delete(host0Pod.Name, podDelOpt), "Failed to delete host0Pod")
 					e2elog.Logf("deleted host0Pod %q", host0Pod.Name)
 				}
 
-				By("creating host1Pod on node1")
+				ginkgo.By("creating host1Pod on node1")
 				_, err = podClient.Create(host1Pod)
 				framework.ExpectNoError(err, "Failed to create host1Pod")
 				framework.ExpectNoError(f.WaitForPodRunningSlow(host1Pod.Name))
 				e2elog.Logf("host1Pod: %q, node1: %q", host1Pod.Name, host1Name)
 
 				if readOnly {
-					By("deleting host0Pod")
+					ginkgo.By("deleting host0Pod")
 					framework.ExpectNoError(podClient.Delete(host0Pod.Name, podDelOpt), "Failed to delete host0Pod")
 					e2elog.Logf("deleted host0Pod %q", host0Pod.Name)
 				} else {
-					By("verifying PD contents in host1Pod")
+					ginkgo.By("verifying PD contents in host1Pod")
 					verifyPDContentsViaContainer(f, host1Pod.Name, containerName, map[string]string{testFile: testFileContents})
 					e2elog.Logf("verified PD contents in pod %q", host1Pod.Name)
-					By("verifying PD is removed from node0")
+					ginkgo.By("verifying PD is removed from node0")
 					framework.ExpectNoError(waitForPDInVolumesInUse(nodeClient, diskName, host0Name, nodeStatusTimeout, false /* shouldExist */))
 					e2elog.Logf("PD %q removed from node %q's VolumeInUse list", diskName, host1Pod.Name)
 				}
 
-				By("deleting host1Pod")
+				ginkgo.By("deleting host1Pod")
 				framework.ExpectNoError(podClient.Delete(host1Pod.Name, podDelOpt), "Failed to delete host1Pod")
 				e2elog.Logf("deleted host1Pod %q", host1Pod.Name)
 
-				By("Test completed successfully, waiting for PD to detach from both nodes")
+				ginkgo.By("Test completed successfully, waiting for PD to detach from both nodes")
 				waitForPDDetach(diskName, host0Name)
 				waitForPDDetach(diskName, host1Name)
 			})
 		}
 	})
 
-	Context("schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow]", func() {
+	ginkgo.Context("schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow]", func() {
 		type testT struct {
 			numContainers int
 			numPDs        int
@@ -242,14 +242,14 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 			numPDs := t.numPDs
 			numContainers := t.numContainers
 
-			It(fmt.Sprintf("using %d containers and %d PDs", numContainers, numPDs), func() {
+			ginkgo.It(fmt.Sprintf("using %d containers and %d PDs", numContainers, numPDs), func() {
 				framework.SkipUnlessProviderIs("gce", "gke", "aws")
 				var host0Pod *v1.Pod
 				var err error
 				fileAndContentToVerify := make(map[string]string)
 				diskNames := make([]string, 0, numPDs)
 
-				By(fmt.Sprintf("creating %d PD(s)", numPDs))
+				ginkgo.By(fmt.Sprintf("creating %d PD(s)", numPDs))
 				for i := 0; i < numPDs; i++ {
 					name, err := framework.CreatePDWithRetry()
 					framework.ExpectNoError(err, fmt.Sprintf("Error creating PD %d", i))
@@ -258,7 +258,7 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 
 				defer func() {
 					// Teardown should do nothing unless test failed.
-					By("defer: cleaning up PD-RW test environment")
+					ginkgo.By("defer: cleaning up PD-RW test environment")
 					e2elog.Logf("defer cleanup errors can usually be ignored")
 					if host0Pod != nil {
 						podClient.Delete(host0Pod.Name, metav1.NewDeleteOptions(0))
@@ -270,13 +270,13 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 
 				for i := 0; i < t.repeatCnt; i++ { // "rapid" repeat loop
 					e2elog.Logf("PD Read/Writer Iteration #%v", i)
-					By(fmt.Sprintf("creating host0Pod with %d containers on node0", numContainers))
+					ginkgo.By(fmt.Sprintf("creating host0Pod with %d containers on node0", numContainers))
 					host0Pod = testPDPod(diskNames, host0Name, false /* readOnly */, numContainers)
 					_, err = podClient.Create(host0Pod)
 					framework.ExpectNoError(err, fmt.Sprintf("Failed to create host0Pod: %v", err))
 					framework.ExpectNoError(f.WaitForPodRunningSlow(host0Pod.Name))
 
-					By(fmt.Sprintf("writing %d file(s) via a container", numPDs))
+					ginkgo.By(fmt.Sprintf("writing %d file(s) via a container", numPDs))
 					containerName := "mycontainer"
 					if numContainers > 1 {
 						containerName = fmt.Sprintf("mycontainer%v", mathrand.Intn(numContainers)+1)
@@ -289,16 +289,16 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 						e2elog.Logf("wrote %q to file %q in pod %q (container %q) on node %q", testFileContents, testFile, host0Pod.Name, containerName, host0Name)
 					}
 
-					By("verifying PD contents via a container")
+					ginkgo.By("verifying PD contents via a container")
 					if numContainers > 1 {
 						containerName = fmt.Sprintf("mycontainer%v", mathrand.Intn(numContainers)+1)
 					}
 					verifyPDContentsViaContainer(f, host0Pod.Name, containerName, fileAndContentToVerify)
 
-					By("deleting host0Pod")
+					ginkgo.By("deleting host0Pod")
 					framework.ExpectNoError(podClient.Delete(host0Pod.Name, metav1.NewDeleteOptions(0)), "Failed to delete host0Pod")
 				}
-				By(fmt.Sprintf("Test completed successfully, waiting for %d PD(s) to detach from node0", numPDs))
+				ginkgo.By(fmt.Sprintf("Test completed successfully, waiting for %d PD(s) to detach from node0", numPDs))
 				for _, diskName := range diskNames {
 					waitForPDDetach(diskName, host0Name)
 				}
@@ -306,7 +306,7 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 		}
 	})
 
-	Context("detach in a disrupted environment [Slow] [Disruptive]", func() {
+	ginkgo.Context("detach in a disrupted environment [Slow] [Disruptive]", func() {
 		const (
 			deleteNode    = 1 // delete physical node
 			deleteNodeObj = 2 // delete node's api object only
@@ -333,11 +333,11 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 
 		for _, t := range tests {
 			disruptOp := t.disruptOp
-			It(fmt.Sprintf("when %s", t.descr), func() {
+			ginkgo.It(fmt.Sprintf("when %s", t.descr), func() {
 				framework.SkipUnlessProviderIs("gce")
 				origNodeCnt := len(nodes.Items) // healhy nodes running kubelet
 
-				By("creating a pd")
+				ginkgo.By("creating a pd")
 				diskName, err := framework.CreatePDWithRetry()
 				framework.ExpectNoError(err, "Error creating a pd")
 
@@ -346,21 +346,21 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 				containerName := "mycontainer"
 
 				defer func() {
-					By("defer: cleaning up PD-RW test env")
+					ginkgo.By("defer: cleaning up PD-RW test env")
 					e2elog.Logf("defer cleanup errors can usually be ignored")
-					By("defer: delete host0Pod")
+					ginkgo.By("defer: delete host0Pod")
 					podClient.Delete(host0Pod.Name, metav1.NewDeleteOptions(0))
-					By("defer: detach and delete PDs")
+					ginkgo.By("defer: detach and delete PDs")
 					detachAndDeletePDs(diskName, []types.NodeName{host0Name})
 					if disruptOp == deleteNode || disruptOp == deleteNodeObj {
 						if disruptOp == deleteNodeObj {
 							targetNode.ObjectMeta.SetResourceVersion("0")
 							// need to set the resource version or else the Create() fails
-							By("defer: re-create host0 node object")
+							ginkgo.By("defer: re-create host0 node object")
 							_, err := nodeClient.Create(targetNode)
 							framework.ExpectNoError(err, fmt.Sprintf("defer: Unable to re-create the deleted node object %q", targetNode.Name))
 						}
-						By("defer: verify the number of ready nodes")
+						ginkgo.By("defer: verify the number of ready nodes")
 						numNodes := countReadyNodes(cs, host0Name)
 						// if this defer is reached due to an Expect then nested
 						// Expects are lost, so use Failf here
@@ -370,43 +370,43 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 					}
 				}()
 
-				By("creating host0Pod on node0")
+				ginkgo.By("creating host0Pod on node0")
 				_, err = podClient.Create(host0Pod)
 				framework.ExpectNoError(err, fmt.Sprintf("Failed to create host0Pod: %v", err))
-				By("waiting for host0Pod to be running")
+				ginkgo.By("waiting for host0Pod to be running")
 				framework.ExpectNoError(f.WaitForPodRunningSlow(host0Pod.Name))
 
-				By("writing content to host0Pod")
+				ginkgo.By("writing content to host0Pod")
 				testFile := "/testpd1/tracker"
 				testFileContents := fmt.Sprintf("%v", mathrand.Int())
 				framework.ExpectNoError(f.WriteFileViaContainer(host0Pod.Name, containerName, testFile, testFileContents))
 				e2elog.Logf("wrote %q to file %q in pod %q on node %q", testFileContents, testFile, host0Pod.Name, host0Name)
 
-				By("verifying PD is present in node0's VolumeInUse list")
+				ginkgo.By("verifying PD is present in node0's VolumeInUse list")
 				framework.ExpectNoError(waitForPDInVolumesInUse(nodeClient, diskName, host0Name, nodeStatusTimeout, true /* should exist*/))
 
 				if disruptOp == deleteNode {
-					By("getting gce instances")
+					ginkgo.By("getting gce instances")
 					gceCloud, err := gce.GetGCECloud()
 					framework.ExpectNoError(err, fmt.Sprintf("Unable to create gcloud client err=%v", err))
 					output, err := gceCloud.ListInstanceNames(framework.TestContext.CloudConfig.ProjectID, framework.TestContext.CloudConfig.Zone)
 					framework.ExpectNoError(err, fmt.Sprintf("Unable to get list of node instances err=%v output=%s", err, output))
-					Expect(true, strings.Contains(string(output), string(host0Name)))
+					gomega.Expect(true, strings.Contains(string(output), string(host0Name)))
 
-					By("deleting host0")
+					ginkgo.By("deleting host0")
 					err = gceCloud.DeleteInstance(framework.TestContext.CloudConfig.ProjectID, framework.TestContext.CloudConfig.Zone, string(host0Name))
 					framework.ExpectNoError(err, fmt.Sprintf("Failed to delete host0Pod: err=%v", err))
-					By("expecting host0 node to be re-created")
+					ginkgo.By("expecting host0 node to be re-created")
 					numNodes := countReadyNodes(cs, host0Name)
-					Expect(numNodes).To(Equal(origNodeCnt), fmt.Sprintf("Requires current node count (%d) to return to original node count (%d)", numNodes, origNodeCnt))
+					gomega.Expect(numNodes).To(gomega.Equal(origNodeCnt), fmt.Sprintf("Requires current node count (%d) to return to original node count (%d)", numNodes, origNodeCnt))
 					output, err = gceCloud.ListInstanceNames(framework.TestContext.CloudConfig.ProjectID, framework.TestContext.CloudConfig.Zone)
 					framework.ExpectNoError(err, fmt.Sprintf("Unable to get list of node instances err=%v output=%s", err, output))
-					Expect(false, strings.Contains(string(output), string(host0Name)))
+					gomega.Expect(false, strings.Contains(string(output), string(host0Name)))
 
 				} else if disruptOp == deleteNodeObj {
-					By("deleting host0's node api object")
+					ginkgo.By("deleting host0's node api object")
 					framework.ExpectNoError(nodeClient.Delete(string(host0Name), metav1.NewDeleteOptions(0)), "Unable to delete host0's node object")
-					By("deleting host0Pod")
+					ginkgo.By("deleting host0Pod")
 					framework.ExpectNoError(podClient.Delete(host0Pod.Name, metav1.NewDeleteOptions(0)), "Unable to delete host0Pod")
 
 				} else if disruptOp == evictPod {
@@ -416,7 +416,7 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 							Namespace: ns,
 						},
 					}
-					By("evicting host0Pod")
+					ginkgo.By("evicting host0Pod")
 					err = wait.PollImmediate(framework.Poll, podEvictTimeout, func() (bool, error) {
 						err = cs.CoreV1().Pods(ns).Evict(evictTarget)
 						if err != nil {
@@ -428,16 +428,16 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 					framework.ExpectNoError(err, fmt.Sprintf("failed to evict host0Pod after %v", podEvictTimeout))
 				}
 
-				By("waiting for pd to detach from host0")
+				ginkgo.By("waiting for pd to detach from host0")
 				waitForPDDetach(diskName, host0Name)
 			})
 		}
 	})
 
-	It("should be able to delete a non-existent PD without error", func() {
+	ginkgo.It("should be able to delete a non-existent PD without error", func() {
 		framework.SkipUnlessProviderIs("gce")
 
-		By("delete a PD")
+		ginkgo.By("delete a PD")
 		framework.ExpectNoError(framework.DeletePDWithRetry("non-exist"))
 	})
 })
@@ -472,7 +472,7 @@ func verifyPDContentsViaContainer(f *framework.Framework, podName, containerName
 				break
 			}
 		}
-		Expect(strings.TrimSpace(value)).To(Equal(strings.TrimSpace(expectedContents)))
+		gomega.Expect(strings.TrimSpace(value)).To(gomega.Equal(strings.TrimSpace(expectedContents)))
 	}
 }
 
@@ -608,10 +608,10 @@ func detachAndDeletePDs(diskName string, hosts []types.NodeName) {
 	for _, host := range hosts {
 		e2elog.Logf("Detaching GCE PD %q from node %q.", diskName, host)
 		detachPD(host, diskName)
-		By(fmt.Sprintf("Waiting for PD %q to detach from %q", diskName, host))
+		ginkgo.By(fmt.Sprintf("Waiting for PD %q to detach from %q", diskName, host))
 		waitForPDDetach(diskName, host)
 	}
-	By(fmt.Sprintf("Deleting PD %q", diskName))
+	ginkgo.By(fmt.Sprintf("Deleting PD %q", diskName))
 	framework.ExpectNoError(framework.DeletePDWithRetry(diskName))
 }
 

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -313,9 +313,9 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			ginkgo.By("Creating local PVC and PV")
 			createLocalPVCsPVs(config, []*localTestVolume{testVol}, immediateMode)
 			pod, err := createLocalPod(config, testVol, nil)
-			gomega.Expect(err).To(gomega.HaveOccurred())
+			framework.ExpectError(err)
 			err = framework.WaitTimeoutForPodRunningInNamespace(config.client, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
-			gomega.Expect(err).To(gomega.HaveOccurred())
+			framework.ExpectError(err)
 			cleanupLocalPVCsPVs(config, []*localTestVolume{testVol})
 		})
 
@@ -332,7 +332,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			framework.ExpectNoError(err)
 
 			err = framework.WaitTimeoutForPodRunningInNamespace(config.client, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
-			gomega.Expect(err).To(gomega.HaveOccurred())
+			framework.ExpectError(err)
 
 			cleanupLocalVolumes(config, []*localTestVolume{testVol})
 		})
@@ -932,7 +932,7 @@ func createLocalPVCsPVs(config *localTestConfig, volumes []*localTestVolume, mod
 			}
 			return false, nil
 		})
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		framework.ExpectError(err)
 	}
 }
 

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -24,8 +24,8 @@ import (
 	"sync"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -145,10 +145,10 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 		scName string
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		// Get all the schedulable nodes
 		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		Expect(len(nodes.Items)).NotTo(BeZero(), "No available nodes for scheduling")
+		gomega.Expect(len(nodes.Items)).NotTo(gomega.BeZero(), "No available nodes for scheduling")
 
 		// Cap max number of nodes
 		maxLen := len(nodes.Items)
@@ -187,10 +187,10 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 		ctxString := fmt.Sprintf("[Volume type: %s]%v", testVolType, serialStr)
 		testMode := immediateMode
 
-		Context(ctxString, func() {
+		ginkgo.Context(ctxString, func() {
 			var testVol *localTestVolume
 
-			BeforeEach(func() {
+			ginkgo.BeforeEach(func() {
 				if testVolType == GCELocalSSDVolumeType {
 					SkipUnlessLocalSSDExists(config, "scsi", "fs", config.node0)
 				}
@@ -199,99 +199,99 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 				testVol = testVols[0]
 			})
 
-			AfterEach(func() {
+			ginkgo.AfterEach(func() {
 				cleanupLocalVolumes(config, []*localTestVolume{testVol})
 				cleanupStorageClass(config)
 			})
 
-			Context("One pod requesting one prebound PVC", func() {
+			ginkgo.Context("One pod requesting one prebound PVC", func() {
 				var (
 					pod1    *v1.Pod
 					pod1Err error
 				)
 
-				BeforeEach(func() {
-					By("Creating pod1")
+				ginkgo.BeforeEach(func() {
+					ginkgo.By("Creating pod1")
 					pod1, pod1Err = createLocalPod(config, testVol, nil)
 					framework.ExpectNoError(pod1Err)
 					verifyLocalPod(config, testVol, pod1, config.node0.Name)
 
 					writeCmd := createWriteCmd(volumeDir, testFile, testFileContent, testVol.localVolumeType)
 
-					By("Writing in pod1")
+					ginkgo.By("Writing in pod1")
 					podRWCmdExec(pod1, writeCmd)
 				})
 
-				AfterEach(func() {
-					By("Deleting pod1")
+				ginkgo.AfterEach(func() {
+					ginkgo.By("Deleting pod1")
 					framework.DeletePodOrFail(config.client, config.ns, pod1.Name)
 				})
 
-				It("should be able to mount volume and read from pod1", func() {
-					By("Reading in pod1")
+				ginkgo.It("should be able to mount volume and read from pod1", func() {
+					ginkgo.By("Reading in pod1")
 					// testFileContent was written in BeforeEach
 					testReadFileContent(volumeDir, testFile, testFileContent, pod1, testVolType)
 				})
 
-				It("should be able to mount volume and write from pod1", func() {
+				ginkgo.It("should be able to mount volume and write from pod1", func() {
 					// testFileContent was written in BeforeEach
 					testReadFileContent(volumeDir, testFile, testFileContent, pod1, testVolType)
 
-					By("Writing in pod1")
+					ginkgo.By("Writing in pod1")
 					writeCmd := createWriteCmd(volumeDir, testFile, testVol.ltr.Path /*writeTestFileContent*/, testVolType)
 					podRWCmdExec(pod1, writeCmd)
 				})
 			})
 
-			Context("Two pods mounting a local volume at the same time", func() {
-				It("should be able to write from pod1 and read from pod2", func() {
+			ginkgo.Context("Two pods mounting a local volume at the same time", func() {
+				ginkgo.It("should be able to write from pod1 and read from pod2", func() {
 					twoPodsReadWriteTest(config, testVol)
 				})
 			})
 
-			Context("Two pods mounting a local volume one after the other", func() {
-				It("should be able to write from pod1 and read from pod2", func() {
+			ginkgo.Context("Two pods mounting a local volume one after the other", func() {
+				ginkgo.It("should be able to write from pod1 and read from pod2", func() {
 					twoPodsReadWriteSerialTest(config, testVol)
 				})
 			})
 
-			Context("Set fsGroup for local volume", func() {
-				BeforeEach(func() {
+			ginkgo.Context("Set fsGroup for local volume", func() {
+				ginkgo.BeforeEach(func() {
 					if testVolType == BlockLocalVolumeType {
 						framework.Skipf("We don't set fsGroup on block device, skipped.")
 					}
 				})
 
-				It("should set fsGroup for one pod [Slow]", func() {
-					By("Checking fsGroup is set")
+				ginkgo.It("should set fsGroup for one pod [Slow]", func() {
+					ginkgo.By("Checking fsGroup is set")
 					pod := createPodWithFsGroupTest(config, testVol, 1234, 1234)
-					By("Deleting pod")
+					ginkgo.By("Deleting pod")
 					framework.DeletePodOrFail(config.client, config.ns, pod.Name)
 				})
 
-				It("should set same fsGroup for two pods simultaneously [Slow]", func() {
+				ginkgo.It("should set same fsGroup for two pods simultaneously [Slow]", func() {
 					fsGroup := int64(1234)
-					By("Create first pod and check fsGroup is set")
+					ginkgo.By("Create first pod and check fsGroup is set")
 					pod1 := createPodWithFsGroupTest(config, testVol, fsGroup, fsGroup)
-					By("Create second pod with same fsGroup and check fsGroup is correct")
+					ginkgo.By("Create second pod with same fsGroup and check fsGroup is correct")
 					pod2 := createPodWithFsGroupTest(config, testVol, fsGroup, fsGroup)
-					By("Deleting first pod")
+					ginkgo.By("Deleting first pod")
 					framework.DeletePodOrFail(config.client, config.ns, pod1.Name)
-					By("Deleting second pod")
+					ginkgo.By("Deleting second pod")
 					framework.DeletePodOrFail(config.client, config.ns, pod2.Name)
 				})
 
-				It("should set different fsGroup for second pod if first pod is deleted", func() {
+				ginkgo.It("should set different fsGroup for second pod if first pod is deleted", func() {
 					framework.Skipf("Disabled temporarily, reopen after #73168 is fixed")
 					fsGroup1, fsGroup2 := int64(1234), int64(4321)
-					By("Create first pod and check fsGroup is set")
+					ginkgo.By("Create first pod and check fsGroup is set")
 					pod1 := createPodWithFsGroupTest(config, testVol, fsGroup1, fsGroup1)
-					By("Deleting first pod")
+					ginkgo.By("Deleting first pod")
 					err := framework.DeletePodWithWait(f, config.client, pod1)
 					framework.ExpectNoError(err, "while deleting first pod")
-					By("Create second pod and check fsGroup is the new one")
+					ginkgo.By("Create second pod and check fsGroup is the new one")
 					pod2 := createPodWithFsGroupTest(config, testVol, fsGroup2, fsGroup2)
-					By("Deleting second pod")
+					ginkgo.By("Deleting second pod")
 					framework.DeletePodOrFail(config.client, config.ns, pod2.Name)
 				})
 			})
@@ -299,10 +299,10 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 		})
 	}
 
-	Context("Local volume that cannot be mounted [Slow]", func() {
+	ginkgo.Context("Local volume that cannot be mounted [Slow]", func() {
 		// TODO:
 		// - check for these errors in unit tests instead
-		It("should fail due to non-existent path", func() {
+		ginkgo.It("should fail due to non-existent path", func() {
 			testVol := &localTestVolume{
 				ltr: &utils.LocalTestResource{
 					Node: config.node0,
@@ -310,16 +310,16 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 				},
 				localVolumeType: DirectoryLocalVolumeType,
 			}
-			By("Creating local PVC and PV")
+			ginkgo.By("Creating local PVC and PV")
 			createLocalPVCsPVs(config, []*localTestVolume{testVol}, immediateMode)
 			pod, err := createLocalPod(config, testVol, nil)
-			Expect(err).To(HaveOccurred())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 			err = framework.WaitTimeoutForPodRunningInNamespace(config.client, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
-			Expect(err).To(HaveOccurred())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 			cleanupLocalPVCsPVs(config, []*localTestVolume{testVol})
 		})
 
-		It("should fail due to wrong node", func() {
+		ginkgo.It("should fail due to wrong node", func() {
 			if len(config.nodes) < 2 {
 				framework.Skipf("Runs only when number of nodes >= 2")
 			}
@@ -332,19 +332,19 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			framework.ExpectNoError(err)
 
 			err = framework.WaitTimeoutForPodRunningInNamespace(config.client, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
-			Expect(err).To(HaveOccurred())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 
 			cleanupLocalVolumes(config, []*localTestVolume{testVol})
 		})
 	})
 
-	Context("Pod with node different from PV's NodeAffinity", func() {
+	ginkgo.Context("Pod with node different from PV's NodeAffinity", func() {
 		var (
 			testVol    *localTestVolume
 			volumeType localVolumeType
 		)
 
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			if len(config.nodes) < 2 {
 				framework.Skipf("Runs only when number of nodes >= 2")
 			}
@@ -355,78 +355,78 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			testVol = testVols[0]
 		})
 
-		AfterEach(func() {
+		ginkgo.AfterEach(func() {
 			cleanupLocalVolumes(config, []*localTestVolume{testVol})
 			cleanupStorageClass(config)
 		})
 
-		It("should fail scheduling due to different NodeAffinity", func() {
+		ginkgo.It("should fail scheduling due to different NodeAffinity", func() {
 			testPodWithNodeConflict(config, volumeType, config.nodes[1].Name, makeLocalPodWithNodeAffinity, immediateMode)
 		})
 
-		It("should fail scheduling due to different NodeSelector", func() {
+		ginkgo.It("should fail scheduling due to different NodeSelector", func() {
 			testPodWithNodeConflict(config, volumeType, config.nodes[1].Name, makeLocalPodWithNodeSelector, immediateMode)
 		})
 	})
 
-	Context("StatefulSet with pod affinity [Slow]", func() {
+	ginkgo.Context("StatefulSet with pod affinity [Slow]", func() {
 		var testVols map[string][]*localTestVolume
 		const (
 			ssReplicas  = 3
 			volsPerNode = 6
 		)
 
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			setupStorageClass(config, &waitMode)
 
 			testVols = map[string][]*localTestVolume{}
 			for i, node := range config.nodes {
 				// The PVCs created here won't be used
-				By(fmt.Sprintf("Setting up local volumes on node %q", node.Name))
+				ginkgo.By(fmt.Sprintf("Setting up local volumes on node %q", node.Name))
 				vols := setupLocalVolumesPVCsPVs(config, DirectoryLocalVolumeType, &config.nodes[i], volsPerNode, waitMode)
 				testVols[node.Name] = vols
 			}
 		})
 
-		AfterEach(func() {
+		ginkgo.AfterEach(func() {
 			for _, vols := range testVols {
 				cleanupLocalVolumes(config, vols)
 			}
 			cleanupStorageClass(config)
 		})
 
-		It("should use volumes spread across nodes when pod has anti-affinity", func() {
+		ginkgo.It("should use volumes spread across nodes when pod has anti-affinity", func() {
 			if len(config.nodes) < ssReplicas {
 				framework.Skipf("Runs only when number of nodes >= %v", ssReplicas)
 			}
-			By("Creating a StatefulSet with pod anti-affinity on nodes")
+			ginkgo.By("Creating a StatefulSet with pod anti-affinity on nodes")
 			ss := createStatefulSet(config, ssReplicas, volsPerNode, true, false)
 			validateStatefulSet(config, ss, true)
 		})
 
-		It("should use volumes on one node when pod has affinity", func() {
-			By("Creating a StatefulSet with pod affinity on nodes")
+		ginkgo.It("should use volumes on one node when pod has affinity", func() {
+			ginkgo.By("Creating a StatefulSet with pod affinity on nodes")
 			ss := createStatefulSet(config, ssReplicas, volsPerNode/ssReplicas, false, false)
 			validateStatefulSet(config, ss, false)
 		})
 
-		It("should use volumes spread across nodes when pod management is parallel and pod has anti-affinity", func() {
+		ginkgo.It("should use volumes spread across nodes when pod management is parallel and pod has anti-affinity", func() {
 			if len(config.nodes) < ssReplicas {
 				framework.Skipf("Runs only when number of nodes >= %v", ssReplicas)
 			}
-			By("Creating a StatefulSet with pod anti-affinity on nodes")
+			ginkgo.By("Creating a StatefulSet with pod anti-affinity on nodes")
 			ss := createStatefulSet(config, ssReplicas, 1, true, true)
 			validateStatefulSet(config, ss, true)
 		})
 
-		It("should use volumes on one node when pod management is parallel and pod has affinity", func() {
-			By("Creating a StatefulSet with pod affinity on nodes")
+		ginkgo.It("should use volumes on one node when pod management is parallel and pod has affinity", func() {
+			ginkgo.By("Creating a StatefulSet with pod affinity on nodes")
 			ss := createStatefulSet(config, ssReplicas, 1, false, true)
 			validateStatefulSet(config, ss, false)
 		})
 	})
 
-	Context("Stress with local volumes [Serial]", func() {
+	ginkgo.Context("Stress with local volumes [Serial]", func() {
 		var (
 			allLocalVolumes = make(map[string][]*localTestVolume)
 			volType         = TmpfsLocalVolumeType
@@ -440,13 +440,13 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			podsFactor  = 4
 		)
 
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			setupStorageClass(config, &waitMode)
 			for i, node := range config.nodes {
-				By(fmt.Sprintf("Setting up %d local volumes on node %q", volsPerNode, node.Name))
+				ginkgo.By(fmt.Sprintf("Setting up %d local volumes on node %q", volsPerNode, node.Name))
 				allLocalVolumes[node.Name] = setupLocalVolumes(config, volType, &config.nodes[i], volsPerNode)
 			}
-			By(fmt.Sprintf("Create %d PVs", volsPerNode*len(config.nodes)))
+			ginkgo.By(fmt.Sprintf("Create %d PVs", volsPerNode*len(config.nodes)))
 			var err error
 			for _, localVolumes := range allLocalVolumes {
 				for _, localVolume := range localVolumes {
@@ -455,7 +455,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 					framework.ExpectNoError(err)
 				}
 			}
-			By("Start a goroutine to recycle unbound PVs")
+			ginkgo.By("Start a goroutine to recycle unbound PVs")
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -483,7 +483,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 							continue
 						}
 						// Delete and create a new PV for same local volume storage
-						By(fmt.Sprintf("Delete %q and create a new PV for same local volume storage", pv.Name))
+						ginkgo.By(fmt.Sprintf("Delete %q and create a new PV for same local volume storage", pv.Name))
 						for _, localVolumes := range allLocalVolumes {
 							for _, localVolume := range localVolumes {
 								if localVolume.pv.Name != pv.Name {
@@ -503,19 +503,19 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			}()
 		})
 
-		AfterEach(func() {
-			By("Stop and wait for recycle goroutine to finish")
+		ginkgo.AfterEach(func() {
+			ginkgo.By("Stop and wait for recycle goroutine to finish")
 			close(stopCh)
 			wg.Wait()
-			By("Clean all PVs")
+			ginkgo.By("Clean all PVs")
 			for nodeName, localVolumes := range allLocalVolumes {
-				By(fmt.Sprintf("Cleaning up %d local volumes on node %q", len(localVolumes), nodeName))
+				ginkgo.By(fmt.Sprintf("Cleaning up %d local volumes on node %q", len(localVolumes), nodeName))
 				cleanupLocalVolumes(config, localVolumes)
 			}
 			cleanupStorageClass(config)
 		})
 
-		It("should be able to process many pods and reuse local volumes", func() {
+		ginkgo.It("should be able to process many pods and reuse local volumes", func() {
 			var (
 				podsLock sync.Mutex
 				// Have one extra pod pending
@@ -528,7 +528,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 
 			// Create pods gradually instead of all at once because scheduler has
 			// exponential backoff
-			By(fmt.Sprintf("Creating %v pods periodically", numConcurrentPods))
+			ginkgo.By(fmt.Sprintf("Creating %v pods periodically", numConcurrentPods))
 			stop := make(chan struct{})
 			go wait.Until(func() {
 				podsLock.Lock()
@@ -573,7 +573,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 				}
 			}()
 
-			By("Waiting for all pods to complete successfully")
+			ginkgo.By("Waiting for all pods to complete successfully")
 			err := wait.PollImmediate(time.Second, 5*time.Minute, func() (done bool, err error) {
 				podsList, err := config.client.CoreV1().Pods(config.ns).List(metav1.ListOptions{})
 				if err != nil {
@@ -605,12 +605,12 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 		})
 	})
 
-	Context("Pods sharing a single local PV [Serial]", func() {
+	ginkgo.Context("Pods sharing a single local PV [Serial]", func() {
 		var (
 			pv *v1.PersistentVolume
 		)
 
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			localVolume := &localTestVolume{
 				ltr: &utils.LocalTestResource{
 					Node: config.node0,
@@ -624,16 +624,16 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			framework.ExpectNoError(err)
 		})
 
-		AfterEach(func() {
+		ginkgo.AfterEach(func() {
 			if pv == nil {
 				return
 			}
-			By(fmt.Sprintf("Clean PV %s", pv.Name))
+			ginkgo.By(fmt.Sprintf("Clean PV %s", pv.Name))
 			err := config.client.CoreV1().PersistentVolumes().Delete(pv.Name, &metav1.DeleteOptions{})
 			framework.ExpectNoError(err)
 		})
 
-		It("all pods should be running", func() {
+		ginkgo.It("all pods should be running", func() {
 			var (
 				pvc   *v1.PersistentVolumeClaim
 				pods  = map[string]*v1.Pod{}
@@ -641,17 +641,17 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 				err   error
 			)
 			pvc = framework.MakePersistentVolumeClaim(makeLocalPVCConfig(config, DirectoryLocalVolumeType), config.ns)
-			By(fmt.Sprintf("Create a PVC %s", pvc.Name))
+			ginkgo.By(fmt.Sprintf("Create a PVC %s", pvc.Name))
 			pvc, err = framework.CreatePVC(config.client, config.ns, pvc)
 			framework.ExpectNoError(err)
-			By(fmt.Sprintf("Create %d pods to use this PVC", count))
+			ginkgo.By(fmt.Sprintf("Create %d pods to use this PVC", count))
 			for i := 0; i < count; i++ {
 				pod := framework.MakeSecPod(config.ns, []*v1.PersistentVolumeClaim{pvc}, false, "", false, false, selinuxLabel, nil)
 				pod, err := config.client.CoreV1().Pods(config.ns).Create(pod)
 				framework.ExpectNoError(err)
 				pods[pod.Name] = pod
 			}
-			By("Wait for all pods are running")
+			ginkgo.By("Wait for all pods are running")
 			err = wait.PollImmediate(time.Second, 5*time.Minute, func() (done bool, err error) {
 				podsList, err := config.client.CoreV1().Pods(config.ns).List(metav1.ListOptions{})
 				if err != nil {
@@ -692,7 +692,7 @@ func deletePodAndPVCs(config *localTestConfig, pod *v1.Pod) error {
 type makeLocalPodWith func(config *localTestConfig, volume *localTestVolume, nodeName string) *v1.Pod
 
 func testPodWithNodeConflict(config *localTestConfig, testVolType localVolumeType, nodeName string, makeLocalPodFunc makeLocalPodWith, bindingMode storagev1.VolumeBindingMode) {
-	By(fmt.Sprintf("local-volume-type: %s", testVolType))
+	ginkgo.By(fmt.Sprintf("local-volume-type: %s", testVolType))
 	testVols := setupLocalVolumesPVCsPVs(config, testVolType, config.node0, 1, bindingMode)
 	testVol := testVols[0]
 
@@ -708,20 +708,20 @@ func testPodWithNodeConflict(config *localTestConfig, testVolType localVolumeTyp
 
 // Test two pods at the same time, write from pod1, and read from pod2
 func twoPodsReadWriteTest(config *localTestConfig, testVol *localTestVolume) {
-	By("Creating pod1 to write to the PV")
+	ginkgo.By("Creating pod1 to write to the PV")
 	pod1, pod1Err := createLocalPod(config, testVol, nil)
 	framework.ExpectNoError(pod1Err)
 	verifyLocalPod(config, testVol, pod1, config.node0.Name)
 
 	writeCmd := createWriteCmd(volumeDir, testFile, testFileContent, testVol.localVolumeType)
 
-	By("Writing in pod1")
+	ginkgo.By("Writing in pod1")
 	podRWCmdExec(pod1, writeCmd)
 
 	// testFileContent was written after creating pod1
 	testReadFileContent(volumeDir, testFile, testFileContent, pod1, testVol.localVolumeType)
 
-	By("Creating pod2 to read from the PV")
+	ginkgo.By("Creating pod2 to read from the PV")
 	pod2, pod2Err := createLocalPod(config, testVol, nil)
 	framework.ExpectNoError(pod2Err)
 	verifyLocalPod(config, testVol, pod2, config.node0.Name)
@@ -731,45 +731,45 @@ func twoPodsReadWriteTest(config *localTestConfig, testVol *localTestVolume) {
 
 	writeCmd = createWriteCmd(volumeDir, testFile, testVol.ltr.Path /*writeTestFileContent*/, testVol.localVolumeType)
 
-	By("Writing in pod2")
+	ginkgo.By("Writing in pod2")
 	podRWCmdExec(pod2, writeCmd)
 
-	By("Reading in pod1")
+	ginkgo.By("Reading in pod1")
 	testReadFileContent(volumeDir, testFile, testVol.ltr.Path, pod1, testVol.localVolumeType)
 
-	By("Deleting pod1")
+	ginkgo.By("Deleting pod1")
 	framework.DeletePodOrFail(config.client, config.ns, pod1.Name)
-	By("Deleting pod2")
+	ginkgo.By("Deleting pod2")
 	framework.DeletePodOrFail(config.client, config.ns, pod2.Name)
 }
 
 // Test two pods one after other, write from pod1, and read from pod2
 func twoPodsReadWriteSerialTest(config *localTestConfig, testVol *localTestVolume) {
-	By("Creating pod1")
+	ginkgo.By("Creating pod1")
 	pod1, pod1Err := createLocalPod(config, testVol, nil)
 	framework.ExpectNoError(pod1Err)
 	verifyLocalPod(config, testVol, pod1, config.node0.Name)
 
 	writeCmd := createWriteCmd(volumeDir, testFile, testFileContent, testVol.localVolumeType)
 
-	By("Writing in pod1")
+	ginkgo.By("Writing in pod1")
 	podRWCmdExec(pod1, writeCmd)
 
 	// testFileContent was written after creating pod1
 	testReadFileContent(volumeDir, testFile, testFileContent, pod1, testVol.localVolumeType)
 
-	By("Deleting pod1")
+	ginkgo.By("Deleting pod1")
 	framework.DeletePodOrFail(config.client, config.ns, pod1.Name)
 
-	By("Creating pod2")
+	ginkgo.By("Creating pod2")
 	pod2, pod2Err := createLocalPod(config, testVol, nil)
 	framework.ExpectNoError(pod2Err)
 	verifyLocalPod(config, testVol, pod2, config.node0.Name)
 
-	By("Reading in pod2")
+	ginkgo.By("Reading in pod2")
 	testReadFileContent(volumeDir, testFile, testFileContent, pod2, testVol.localVolumeType)
 
-	By("Deleting pod2")
+	ginkgo.By("Deleting pod2")
 	framework.DeletePodOrFail(config.client, config.ns, pod2.Name)
 }
 
@@ -810,7 +810,7 @@ func setupLocalVolumes(config *localTestConfig, localVolumeType localVolumeType,
 	vols := []*localTestVolume{}
 	for i := 0; i < count; i++ {
 		ltrType, ok := setupLocalVolumeMap[localVolumeType]
-		Expect(ok).To(BeTrue())
+		gomega.Expect(ok).To(gomega.BeTrue())
 		ltr := config.ltrMgr.Create(node, ltrType, nil)
 		vols = append(vols, &localTestVolume{
 			ltr:             ltr,
@@ -822,7 +822,7 @@ func setupLocalVolumes(config *localTestConfig, localVolumeType localVolumeType,
 
 func cleanupLocalPVCsPVs(config *localTestConfig, volumes []*localTestVolume) {
 	for _, volume := range volumes {
-		By("Cleaning up PVC and PV")
+		ginkgo.By("Cleaning up PVC and PV")
 		errs := framework.PVPVCCleanup(config.client, config.ns, volume.pv, volume.pvc)
 		if len(errs) > 0 {
 			framework.Failf("Failed to delete PV and/or PVC: %v", utilerrors.NewAggregate(errs))
@@ -847,7 +847,7 @@ func verifyLocalPod(config *localTestConfig, volume *localTestVolume, pod *v1.Po
 	podNodeName, err := podNodeName(config, pod)
 	framework.ExpectNoError(err)
 	e2elog.Logf("pod %q created on Node %q", pod.Name, podNodeName)
-	Expect(podNodeName).To(Equal(expectedNodeName))
+	gomega.Expect(podNodeName).To(gomega.Equal(expectedNodeName))
 }
 
 func makeLocalPVCConfig(config *localTestConfig, volumeType localVolumeType) framework.PersistentVolumeClaimConfig {
@@ -928,11 +928,11 @@ func createLocalPVCsPVs(config *localTestConfig, volumes []*localTestVolume, mod
 			for _, volume := range volumes {
 				pvc, err := config.client.CoreV1().PersistentVolumeClaims(volume.pvc.Namespace).Get(volume.pvc.Name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
-				Expect(pvc.Status.Phase).To(Equal(v1.ClaimPending))
+				gomega.Expect(pvc.Status.Phase).To(gomega.Equal(v1.ClaimPending))
 			}
 			return false, nil
 		})
-		Expect(err).To(HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 	}
 }
 
@@ -984,7 +984,7 @@ func makeLocalPodWithNodeName(config *localTestConfig, volume *localTestVolume, 
 }
 
 func createLocalPod(config *localTestConfig, volume *localTestVolume, fsGroup *int64) (*v1.Pod, error) {
-	By("Creating a pod")
+	ginkgo.By("Creating a pod")
 	return framework.CreateSecPod(config.client, config.ns, []*v1.PersistentVolumeClaim{volume.pvc}, false, "", false, false, selinuxLabel, fsGroup, framework.PodStartShortTimeout)
 }
 
@@ -1024,7 +1024,7 @@ func createReadCmd(testFileDir string, testFile string, volumeType localVolumeTy
 func testReadFileContent(testFileDir string, testFile string, testFileContent string, pod *v1.Pod, volumeType localVolumeType) {
 	readCmd := createReadCmd(testFileDir, testFile, volumeType)
 	readOut := podRWCmdExec(pod, readCmd)
-	Expect(readOut).To(ContainSubstring(testFileContent))
+	gomega.Expect(readOut).To(gomega.ContainSubstring(testFileContent))
 }
 
 // Execute a read or write command in a pod.
@@ -1045,10 +1045,10 @@ func setupLocalVolumesPVCsPVs(
 	count int,
 	mode storagev1.VolumeBindingMode) []*localTestVolume {
 
-	By("Initializing test volumes")
+	ginkgo.By("Initializing test volumes")
 	testVols := setupLocalVolumes(config, localVolumeType, node, count)
 
-	By("Creating local PVCs and PVs")
+	ginkgo.By("Creating local PVCs and PVs")
 	createLocalPVCsPVs(config, testVols, mode)
 
 	return testVols
@@ -1165,10 +1165,10 @@ func validateStatefulSet(config *localTestConfig, ss *appsv1.StatefulSet, anti b
 
 	if anti {
 		// Verify that each pod is on a different node
-		Expect(nodes.Len()).To(Equal(len(pods.Items)))
+		gomega.Expect(nodes.Len()).To(gomega.Equal(len(pods.Items)))
 	} else {
 		// Verify that all pods are on same node.
-		Expect(nodes.Len()).To(Equal(1))
+		gomega.Expect(nodes.Len()).To(gomega.Equal(1))
 	}
 
 	// Validate all PVCs are bound

--- a/test/e2e/storage/pv_protection.go
+++ b/test/e2e/storage/pv_protection.go
@@ -19,8 +19,8 @@ package storage
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +48,7 @@ var _ = utils.SIGDescribe("PV Protection", func() {
 	)
 
 	f := framework.NewDefaultFramework("pv-protection")
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
 		nameSpace = f.Namespace.Name
 		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(client, framework.TestContext.NodeSchedulableTimeout))
@@ -73,60 +73,60 @@ var _ = utils.SIGDescribe("PV Protection", func() {
 			StorageClassName: &emptyStorageClass,
 		}
 
-		By("Creating a PV")
+		ginkgo.By("Creating a PV")
 		// make the pv definitions
 		pv = framework.MakePersistentVolume(pvConfig)
 		// create the PV
 		pv, err = client.CoreV1().PersistentVolumes().Create(pv)
 		framework.ExpectNoError(err, "Error creating PV")
 
-		By("Waiting for PV to enter phase Available")
+		ginkgo.By("Waiting for PV to enter phase Available")
 		framework.ExpectNoError(framework.WaitForPersistentVolumePhase(v1.VolumeAvailable, client, pv.Name, 1*time.Second, 30*time.Second))
 
-		By("Checking that PV Protection finalizer is set")
+		ginkgo.By("Checking that PV Protection finalizer is set")
 		pv, err = client.CoreV1().PersistentVolumes().Get(pv.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While getting PV status")
-		Expect(slice.ContainsString(pv.ObjectMeta.Finalizers, volumeutil.PVProtectionFinalizer, nil)).To(BeTrue(), "PV Protection finalizer(%v) is not set in %v", volumeutil.PVProtectionFinalizer, pv.ObjectMeta.Finalizers)
+		gomega.Expect(slice.ContainsString(pv.ObjectMeta.Finalizers, volumeutil.PVProtectionFinalizer, nil)).To(gomega.BeTrue(), "PV Protection finalizer(%v) is not set in %v", volumeutil.PVProtectionFinalizer, pv.ObjectMeta.Finalizers)
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		e2elog.Logf("AfterEach: Cleaning up test resources.")
 		if errs := framework.PVPVCCleanup(client, nameSpace, pv, pvc); len(errs) > 0 {
 			framework.Failf("AfterEach: Failed to delete PVC and/or PV. Errors: %v", utilerrors.NewAggregate(errs))
 		}
 	})
 
-	It("Verify \"immediate\" deletion of a PV that is not bound to a PVC", func() {
-		By("Deleting the PV")
+	ginkgo.It("Verify \"immediate\" deletion of a PV that is not bound to a PVC", func() {
+		ginkgo.By("Deleting the PV")
 		err = client.CoreV1().PersistentVolumes().Delete(pv.Name, metav1.NewDeleteOptions(0))
 		framework.ExpectNoError(err, "Error deleting PV")
 		framework.WaitForPersistentVolumeDeleted(client, pv.Name, framework.Poll, framework.PVDeletingTimeout)
 	})
 
-	It("Verify that PV bound to a PVC is not removed immediately", func() {
-		By("Creating a PVC")
+	ginkgo.It("Verify that PV bound to a PVC is not removed immediately", func() {
+		ginkgo.By("Creating a PVC")
 		pvc = framework.MakePersistentVolumeClaim(pvcConfig, nameSpace)
 		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)
 		framework.ExpectNoError(err, "Error creating PVC")
 
-		By("Waiting for PVC to become Bound")
+		ginkgo.By("Waiting for PVC to become Bound")
 		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, nameSpace, pvc.Name, framework.Poll, framework.ClaimBindingTimeout)
 		framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
 
-		By("Deleting the PV, however, the PV must not be removed from the system as it's bound to a PVC")
+		ginkgo.By("Deleting the PV, however, the PV must not be removed from the system as it's bound to a PVC")
 		err = client.CoreV1().PersistentVolumes().Delete(pv.Name, metav1.NewDeleteOptions(0))
 		framework.ExpectNoError(err, "Error deleting PV")
 
-		By("Checking that the PV status is Terminating")
+		ginkgo.By("Checking that the PV status is Terminating")
 		pv, err = client.CoreV1().PersistentVolumes().Get(pv.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While checking PV status")
-		Expect(pv.ObjectMeta.DeletionTimestamp).NotTo(Equal(nil))
+		gomega.Expect(pv.ObjectMeta.DeletionTimestamp).NotTo(gomega.Equal(nil))
 
-		By("Deleting the PVC that is bound to the PV")
+		ginkgo.By("Deleting the PVC that is bound to the PV")
 		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, metav1.NewDeleteOptions(0))
 		framework.ExpectNoError(err, "Error deleting PVC")
 
-		By("Checking that the PV is automatically removed from the system because it's no longer bound to a PVC")
+		ginkgo.By("Checking that the PV is automatically removed from the system because it's no longer bound to a PVC")
 		framework.WaitForPersistentVolumeDeleted(client, pv.Name, framework.Poll, framework.PVDeletingTimeout)
 	})
 })

--- a/test/e2e/storage/pvc_protection.go
+++ b/test/e2e/storage/pvc_protection.go
@@ -17,8 +17,8 @@ limitations under the License.
 package storage
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,12 +41,12 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 	)
 
 	f := framework.NewDefaultFramework("pvc-protection")
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
 		nameSpace = f.Namespace.Name
 		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(client, framework.TestContext.NodeSchedulableTimeout))
 
-		By("Creating a PVC")
+		ginkgo.By("Creating a PVC")
 		suffix := "pvc-protection"
 		framework.SkipIfNoDefaultStorageClass(client)
 		testStorageClass := testsuites.StorageClassTest{
@@ -57,86 +57,86 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 		framework.ExpectNoError(err, "Error creating PVC")
 		pvcCreatedAndNotDeleted = true
 
-		By("Creating a Pod that becomes Running and therefore is actively using the PVC")
+		ginkgo.By("Creating a Pod that becomes Running and therefore is actively using the PVC")
 		pvcClaims := []*v1.PersistentVolumeClaim{pvc}
 		pod, err = framework.CreatePod(client, nameSpace, nil, pvcClaims, false, "")
 		framework.ExpectNoError(err, "While creating pod that uses the PVC or waiting for the Pod to become Running")
 
-		By("Waiting for PVC to become Bound")
+		ginkgo.By("Waiting for PVC to become Bound")
 		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, nameSpace, pvc.Name, framework.Poll, framework.ClaimBindingTimeout)
 		framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
 
-		By("Checking that PVC Protection finalizer is set")
+		ginkgo.By("Checking that PVC Protection finalizer is set")
 		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While getting PVC status")
-		Expect(slice.ContainsString(pvc.ObjectMeta.Finalizers, volumeutil.PVCProtectionFinalizer, nil)).To(BeTrue(), "PVC Protection finalizer(%v) is not set in %v", volumeutil.PVCProtectionFinalizer, pvc.ObjectMeta.Finalizers)
+		gomega.Expect(slice.ContainsString(pvc.ObjectMeta.Finalizers, volumeutil.PVCProtectionFinalizer, nil)).To(gomega.BeTrue(), "PVC Protection finalizer(%v) is not set in %v", volumeutil.PVCProtectionFinalizer, pvc.ObjectMeta.Finalizers)
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		if pvcCreatedAndNotDeleted {
 			framework.DeletePersistentVolumeClaim(client, pvc.Name, nameSpace)
 		}
 	})
 
-	It("Verify \"immediate\" deletion of a PVC that is not in active use by a pod", func() {
-		By("Deleting the pod using the PVC")
+	ginkgo.It("Verify \"immediate\" deletion of a PVC that is not in active use by a pod", func() {
+		ginkgo.By("Deleting the pod using the PVC")
 		err = framework.DeletePodWithWait(f, client, pod)
 		framework.ExpectNoError(err, "Error terminating and deleting pod")
 
-		By("Deleting the PVC")
+		ginkgo.By("Deleting the PVC")
 		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, metav1.NewDeleteOptions(0))
 		framework.ExpectNoError(err, "Error deleting PVC")
 		framework.WaitForPersistentVolumeClaimDeleted(client, pvc.Namespace, pvc.Name, framework.Poll, framework.ClaimDeletingTimeout)
 		pvcCreatedAndNotDeleted = false
 	})
 
-	It("Verify that PVC in active use by a pod is not removed immediately", func() {
-		By("Deleting the PVC, however, the PVC must not be removed from the system as it's in active use by a pod")
+	ginkgo.It("Verify that PVC in active use by a pod is not removed immediately", func() {
+		ginkgo.By("Deleting the PVC, however, the PVC must not be removed from the system as it's in active use by a pod")
 		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, metav1.NewDeleteOptions(0))
 		framework.ExpectNoError(err, "Error deleting PVC")
 
-		By("Checking that the PVC status is Terminating")
+		ginkgo.By("Checking that the PVC status is Terminating")
 		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While checking PVC status")
-		Expect(pvc.ObjectMeta.DeletionTimestamp).NotTo(Equal(nil))
+		gomega.Expect(pvc.ObjectMeta.DeletionTimestamp).NotTo(gomega.Equal(nil))
 
-		By("Deleting the pod that uses the PVC")
+		ginkgo.By("Deleting the pod that uses the PVC")
 		err = framework.DeletePodWithWait(f, client, pod)
 		framework.ExpectNoError(err, "Error terminating and deleting pod")
 
-		By("Checking that the PVC is automatically removed from the system because it's no longer in active use by a pod")
+		ginkgo.By("Checking that the PVC is automatically removed from the system because it's no longer in active use by a pod")
 		framework.WaitForPersistentVolumeClaimDeleted(client, pvc.Namespace, pvc.Name, framework.Poll, framework.ClaimDeletingTimeout)
 		pvcCreatedAndNotDeleted = false
 	})
 
-	It("Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable", func() {
-		By("Deleting the PVC, however, the PVC must not be removed from the system as it's in active use by a pod")
+	ginkgo.It("Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable", func() {
+		ginkgo.By("Deleting the PVC, however, the PVC must not be removed from the system as it's in active use by a pod")
 		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, metav1.NewDeleteOptions(0))
 		framework.ExpectNoError(err, "Error deleting PVC")
 
-		By("Checking that the PVC status is Terminating")
+		ginkgo.By("Checking that the PVC status is Terminating")
 		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While checking PVC status")
-		Expect(pvc.ObjectMeta.DeletionTimestamp).NotTo(Equal(nil))
+		gomega.Expect(pvc.ObjectMeta.DeletionTimestamp).NotTo(gomega.Equal(nil))
 
-		By("Creating second Pod whose scheduling fails because it uses a PVC that is being deleted")
+		ginkgo.By("Creating second Pod whose scheduling fails because it uses a PVC that is being deleted")
 		secondPod, err2 := framework.CreateUnschedulablePod(client, nameSpace, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
 		framework.ExpectNoError(err2, "While creating second pod that uses a PVC that is being deleted and that is Unschedulable")
 
-		By("Deleting the second pod that uses the PVC that is being deleted")
+		ginkgo.By("Deleting the second pod that uses the PVC that is being deleted")
 		err = framework.DeletePodWithWait(f, client, secondPod)
 		framework.ExpectNoError(err, "Error terminating and deleting pod")
 
-		By("Checking again that the PVC status is Terminating")
+		ginkgo.By("Checking again that the PVC status is Terminating")
 		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While checking PVC status")
-		Expect(pvc.ObjectMeta.DeletionTimestamp).NotTo(Equal(nil))
+		gomega.Expect(pvc.ObjectMeta.DeletionTimestamp).NotTo(gomega.Equal(nil))
 
-		By("Deleting the first pod that uses the PVC")
+		ginkgo.By("Deleting the first pod that uses the PVC")
 		err = framework.DeletePodWithWait(f, client, pod)
 		framework.ExpectNoError(err, "Error terminating and deleting pod")
 
-		By("Checking that the PVC is automatically removed from the system because it's no longer in active use by a pod")
+		ginkgo.By("Checking that the PVC is automatically removed from the system because it's no longer in active use by a pod")
 		framework.WaitForPersistentVolumeClaimDeleted(client, pvc.Namespace, pvc.Name, framework.Poll, framework.ClaimDeletingTimeout)
 		pvcCreatedAndNotDeleted = false
 	})

--- a/test/e2e/storage/subpath.go
+++ b/test/e2e/storage/subpath.go
@@ -24,18 +24,18 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 )
 
 var _ = utils.SIGDescribe("Subpath", func() {
 	f := framework.NewDefaultFramework("subpath")
 
-	Context("Atomic writer volumes", func() {
+	ginkgo.Context("Atomic writer volumes", func() {
 		var err error
 		var privilegedSecurityContext bool = false
 
-		BeforeEach(func() {
-			By("Setting up data")
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("Setting up data")
 			secret := &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "my-secret"}, Data: map[string][]byte{"secret-key": []byte("secret-value")}}
 			secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(secret)
 			if err != nil && !apierrors.IsAlreadyExists(err) {

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -88,8 +88,8 @@ func DefineTestSuite(driver TestDriver, tsInits []func() TestSuite) {
 		suite := testSuiteInit()
 		for _, pattern := range suite.getTestSuiteInfo().testPatterns {
 			p := pattern
-			Context(getTestNameStr(suite, p), func() {
-				BeforeEach(func() {
+			ginkgo.Context(getTestNameStr(suite, p), func() {
+				ginkgo.BeforeEach(func() {
 					// Skip unsupported tests to avoid unnecessary resource initialization
 					skipUnsupportedTest(driver, p)
 				})
@@ -214,7 +214,7 @@ func createGenericVolumeTestResource(driver TestDriver, config *PerTestConfig, p
 			claimSize := dDriver.GetClaimSize()
 			r.sc = dDriver.GetDynamicProvisionStorageClass(r.config, fsType)
 
-			By("creating a StorageClass " + r.sc.Name)
+			ginkgo.By("creating a StorageClass " + r.sc.Name)
 			var err error
 			r.sc, err = cs.StorageV1().StorageClasses().Create(r.sc)
 			framework.ExpectNoError(err)
@@ -244,12 +244,12 @@ func (r *genericVolumeTestResource) cleanupResource() {
 	if r.pvc != nil || r.pv != nil {
 		switch volType {
 		case testpatterns.PreprovisionedPV:
-			By("Deleting pv and pvc")
+			ginkgo.By("Deleting pv and pvc")
 			if errs := framework.PVPVCCleanup(f.ClientSet, f.Namespace.Name, r.pv, r.pvc); len(errs) != 0 {
 				framework.Failf("Failed to delete PVC or PV: %v", utilerrors.NewAggregate(errs))
 			}
 		case testpatterns.DynamicPV:
-			By("Deleting pvc")
+			ginkgo.By("Deleting pvc")
 			// We only delete the PVC so that PV (and disk) can be cleaned up by dynamic provisioner
 			if r.pv != nil && r.pv.Spec.PersistentVolumeReclaimPolicy != v1.PersistentVolumeReclaimDelete {
 				framework.Failf("Test framework does not currently support Dynamically Provisioned Persistent Volume %v specified with reclaim policy that isnt %v",
@@ -269,7 +269,7 @@ func (r *genericVolumeTestResource) cleanupResource() {
 	}
 
 	if r.sc != nil {
-		By("Deleting sc")
+		ginkgo.By("Deleting sc")
 		deleteStorageClass(f.ClientSet, r.sc.Name)
 	}
 
@@ -330,7 +330,7 @@ func createVolumeSourceWithPVCPVFromDynamicProvisionSC(
 	cs := f.ClientSet
 	ns := f.Namespace.Name
 
-	By("creating a claim")
+	ginkgo.By("creating a claim")
 	pvc := getClaim(claimSize, ns)
 	pvc.Spec.StorageClassName = &sc.Name
 	if volMode != "" {
@@ -455,12 +455,12 @@ func StartPodLogs(f *framework.Framework) func() {
 	ns := f.Namespace
 
 	to := podlogs.LogOutput{
-		StatusWriter: GinkgoWriter,
+		StatusWriter: ginkgo.GinkgoWriter,
 	}
 	if framework.TestContext.ReportDir == "" {
-		to.LogWriter = GinkgoWriter
+		to.LogWriter = ginkgo.GinkgoWriter
 	} else {
-		test := CurrentGinkgoTestDescription()
+		test := ginkgo.CurrentGinkgoTestDescription()
 		reg := regexp.MustCompile("[^a-zA-Z0-9_-]+")
 		// We end the prefix with a slash to ensure that all logs
 		// end up in a directory named after the current test.
@@ -476,7 +476,7 @@ func StartPodLogs(f *framework.Framework) func() {
 	// after a failed test. Logging them live is only useful for interactive
 	// debugging, not when we collect reports.
 	if framework.TestContext.ReportDir == "" {
-		podlogs.WatchPods(ctx, cs, ns.Name, GinkgoWriter)
+		podlogs.WatchPods(ctx, cs, ns.Name, ginkgo.GinkgoWriter)
 	}
 
 	return cancel

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,7 +73,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		l     local
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		// Check preconditions.
 		if pattern.VolMode == v1.PersistentVolumeBlock && !dInfo.Capabilities[CapBlock] {
 			framework.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolMode)
@@ -115,7 +115,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 	//      [   node1   ]                           ==>        [   node1   ]
 	//          /    \      <- same volume mode                   /    \
 	//   [volume1]  [volume2]                              [volume1]  [volume2]
-	It("should access to two volumes with the same volume mode and retain data across pod recreation on the same node", func() {
+	ginkgo.It("should access to two volumes with the same volume mode and retain data across pod recreation on the same node", func() {
 		// Currently, multiple volumes are not generally available for pre-provisoined volume,
 		// because containerized storage servers, such as iSCSI and rbd, are just returning
 		// a static volume inside container, not actually creating a new volume per request.
@@ -144,7 +144,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 	//      [   node1   ]                           ==>        [   node2   ]
 	//          /    \      <- same volume mode                   /    \
 	//   [volume1]  [volume2]                              [volume1]  [volume2]
-	It("should access to two volumes with the same volume mode and retain data across pod recreation on different node", func() {
+	ginkgo.It("should access to two volumes with the same volume mode and retain data across pod recreation on different node", func() {
 		// Currently, multiple volumes are not generally available for pre-provisoined volume,
 		// because containerized storage servers, such as iSCSI and rbd, are just returning
 		// a static volume inside container, not actually creating a new volume per request.
@@ -182,7 +182,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 	//      [   node1   ]                          ==>        [   node1   ]
 	//          /    \      <- different volume mode             /    \
 	//   [volume1]  [volume2]                              [volume1]  [volume2]
-	It("should access to two volumes with different volume mode and retain data across pod recreation on the same node", func() {
+	ginkgo.It("should access to two volumes with different volume mode and retain data across pod recreation on the same node", func() {
 		if pattern.VolMode == v1.PersistentVolumeFilesystem {
 			framework.Skipf("Filesystem volume case should be covered by block volume case -- skipping")
 		}
@@ -220,7 +220,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 	//      [   node1   ]                          ==>        [   node2   ]
 	//          /    \      <- different volume mode             /    \
 	//   [volume1]  [volume2]                              [volume1]  [volume2]
-	It("should access to two volumes with different volume mode and retain data across pod recreation on different node", func() {
+	ginkgo.It("should access to two volumes with different volume mode and retain data across pod recreation on different node", func() {
 		if pattern.VolMode == v1.PersistentVolumeFilesystem {
 			framework.Skipf("Filesystem volume case should be covered by block volume case -- skipping")
 		}
@@ -267,7 +267,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 	// [   node1   ]
 	//   \      /     <- same volume mode
 	//   [volume1]
-	It("should concurrently access the single volume from pods on the same node", func() {
+	ginkgo.It("should concurrently access the single volume from pods on the same node", func() {
 		init()
 		defer cleanup()
 
@@ -291,7 +291,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 	// [   node1   ] [   node2   ]
 	//         \      /     <- same volume mode
 	//         [volume1]
-	It("should concurrently access the single volume from pods on different node", func() {
+	ginkgo.It("should concurrently access the single volume from pods on different node", func() {
 		init()
 		defer cleanup()
 
@@ -324,7 +324,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 // If readSeedBase > 0, read test are done before write/read test assuming that there is already data written.
 func testAccessMultipleVolumes(f *framework.Framework, cs clientset.Interface, ns string,
 	node framework.NodeSelection, pvcs []*v1.PersistentVolumeClaim, readSeedBase int64, writeSeedBase int64) string {
-	By(fmt.Sprintf("Creating pod on %+v with multiple volumes", node))
+	ginkgo.By(fmt.Sprintf("Creating pod on %+v with multiple volumes", node))
 	pod, err := framework.CreateSecPodWithNodeSelection(cs, ns, pvcs,
 		false, "", false, false, framework.SELinuxLabel,
 		nil, node, framework.PodStartTimeout)
@@ -338,18 +338,18 @@ func testAccessMultipleVolumes(f *framework.Framework, cs clientset.Interface, n
 		// CreateSecPodWithNodeSelection make volumes accessible via /mnt/volume({i} + 1)
 		index := i + 1
 		path := fmt.Sprintf("/mnt/volume%d", index)
-		By(fmt.Sprintf("Checking if the volume%d exists as expected volume mode (%s)", index, *pvc.Spec.VolumeMode))
+		ginkgo.By(fmt.Sprintf("Checking if the volume%d exists as expected volume mode (%s)", index, *pvc.Spec.VolumeMode))
 		utils.CheckVolumeModeOfPath(pod, *pvc.Spec.VolumeMode, path)
 
 		if readSeedBase > 0 {
-			By(fmt.Sprintf("Checking if read from the volume%d works properly", index))
+			ginkgo.By(fmt.Sprintf("Checking if read from the volume%d works properly", index))
 			utils.CheckReadFromPath(pod, *pvc.Spec.VolumeMode, path, byteLen, readSeedBase+int64(i))
 		}
 
-		By(fmt.Sprintf("Checking if write to the volume%d works properly", index))
+		ginkgo.By(fmt.Sprintf("Checking if write to the volume%d works properly", index))
 		utils.CheckWriteToPath(pod, *pvc.Spec.VolumeMode, path, byteLen, writeSeedBase+int64(i))
 
-		By(fmt.Sprintf("Checking if read from the volume%d works properly", index))
+		ginkgo.By(fmt.Sprintf("Checking if read from the volume%d works properly", index))
 		utils.CheckReadFromPath(pod, *pvc.Spec.VolumeMode, path, byteLen, writeSeedBase+int64(i))
 	}
 
@@ -397,7 +397,7 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 	// Create each pod with pvc
 	for i := 0; i < numPods; i++ {
 		index := i + 1
-		By(fmt.Sprintf("Creating pod%d with a volume on %+v", index, node))
+		ginkgo.By(fmt.Sprintf("Creating pod%d with a volume on %+v", index, node))
 		pod, err := framework.CreateSecPodWithNodeSelection(cs, ns,
 			[]*v1.PersistentVolumeClaim{pvc},
 			false, "", false, false, framework.SELinuxLabel,
@@ -425,11 +425,11 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 	// Check if volume can be accessed from each pod
 	for i, pod := range pods {
 		index := i + 1
-		By(fmt.Sprintf("Checking if the volume in pod%d exists as expected volume mode (%s)", index, *pvc.Spec.VolumeMode))
+		ginkgo.By(fmt.Sprintf("Checking if the volume in pod%d exists as expected volume mode (%s)", index, *pvc.Spec.VolumeMode))
 		utils.CheckVolumeModeOfPath(pod, *pvc.Spec.VolumeMode, path)
 
 		if i != 0 {
-			By(fmt.Sprintf("From pod%d, checking if reading the data that pod%d write works properly", index, index-1))
+			ginkgo.By(fmt.Sprintf("From pod%d, checking if reading the data that pod%d write works properly", index, index-1))
 			// For 1st pod, no one has written data yet, so pass the read check
 			utils.CheckReadFromPath(pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 		}
@@ -437,10 +437,10 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 		// Update the seed and check if write/read works properly
 		seed = time.Now().UTC().UnixNano()
 
-		By(fmt.Sprintf("Checking if write to the volume in pod%d works properly", index))
+		ginkgo.By(fmt.Sprintf("Checking if write to the volume in pod%d works properly", index))
 		utils.CheckWriteToPath(pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 
-		By(fmt.Sprintf("Checking if read from the volume in pod%d works properly", index))
+		ginkgo.By(fmt.Sprintf("Checking if read from the volume in pod%d works properly", index))
 		utils.CheckReadFromPath(pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 	}
 
@@ -456,24 +456,24 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 	for i, pod := range pods {
 		index := i + 1
 		// index of pod and index of pvc match, because pods are created above way
-		By(fmt.Sprintf("Rechecking if the volume in pod%d exists as expected volume mode (%s)", index, *pvc.Spec.VolumeMode))
+		ginkgo.By(fmt.Sprintf("Rechecking if the volume in pod%d exists as expected volume mode (%s)", index, *pvc.Spec.VolumeMode))
 		utils.CheckVolumeModeOfPath(pod, *pvc.Spec.VolumeMode, "/mnt/volume1")
 
 		if i == 0 {
 			// This time there should be data that last pod wrote, for 1st pod
-			By(fmt.Sprintf("From pod%d, rechecking if reading the data that last pod write works properly", index))
+			ginkgo.By(fmt.Sprintf("From pod%d, rechecking if reading the data that last pod write works properly", index))
 		} else {
-			By(fmt.Sprintf("From pod%d, rechecking if reading the data that pod%d write works properly", index, index-1))
+			ginkgo.By(fmt.Sprintf("From pod%d, rechecking if reading the data that pod%d write works properly", index, index-1))
 		}
 		utils.CheckReadFromPath(pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 
 		// Update the seed and check if write/read works properly
 		seed = time.Now().UTC().UnixNano()
 
-		By(fmt.Sprintf("Rechecking if write to the volume in pod%d works properly", index))
+		ginkgo.By(fmt.Sprintf("Rechecking if write to the volume in pod%d works properly", index))
 		utils.CheckWriteToPath(pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 
-		By(fmt.Sprintf("Rechecking if read from the volume in pod%d works properly", index))
+		ginkgo.By(fmt.Sprintf("Rechecking if read from the volume in pod%d works properly", index))
 		utils.CheckReadFromPath(pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 	}
 }

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -82,9 +82,9 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 		dDriver DynamicPVTestDriver
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		// Check preconditions.
-		Expect(pattern.SnapshotType).To(Equal(testpatterns.DynamicCreatedSnapshot))
+		gomega.Expect(pattern.SnapshotType).To(gomega.Equal(testpatterns.DynamicCreatedSnapshot))
 		dInfo := driver.GetDriverInfo()
 		ok := false
 		sDriver, ok = driver.(SnapshottableTestDriver)
@@ -103,7 +103,7 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 	// f must run inside an It or Context callback.
 	f := framework.NewDefaultFramework("snapshotting")
 
-	It("should create snapshot with defaults [Feature:VolumeSnapshotDataSource]", func() {
+	ginkgo.It("should create snapshot with defaults [Feature:VolumeSnapshotDataSource]", func() {
 		cs := f.ClientSet
 		dc := f.DynamicClient
 
@@ -122,7 +122,7 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 		pvc.Spec.StorageClassName = &class.Name
 		e2elog.Logf("In creating storage class object and pvc object for driver - sc: %v, pvc: %v", class, pvc)
 
-		By("creating a StorageClass " + class.Name)
+		ginkgo.By("creating a StorageClass " + class.Name)
 		class, err := cs.StorageV1().StorageClasses().Create(class)
 		framework.ExpectNoError(err)
 		defer func() {
@@ -130,7 +130,7 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 			framework.ExpectNoError(cs.StorageV1().StorageClasses().Delete(class.Name, nil))
 		}()
 
-		By("creating a claim")
+		ginkgo.By("creating a claim")
 		pvc, err = cs.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)
 		framework.ExpectNoError(err)
 		defer func() {
@@ -144,7 +144,7 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, cs, pvc.Namespace, pvc.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		framework.ExpectNoError(err)
 
-		By("checking the claim")
+		ginkgo.By("checking the claim")
 		// Get new copy of the claim
 		pvc, err = cs.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
@@ -153,7 +153,7 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 		pv, err := cs.CoreV1().PersistentVolumes().Get(pvc.Spec.VolumeName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
-		By("creating a SnapshotClass")
+		ginkgo.By("creating a SnapshotClass")
 		vsc, err = dc.Resource(snapshotClassGVR).Create(vsc, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		defer func() {
@@ -161,7 +161,7 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 			framework.ExpectNoError(dc.Resource(snapshotClassGVR).Delete(vsc.GetName(), nil))
 		}()
 
-		By("creating a snapshot")
+		ginkgo.By("creating a snapshot")
 		snapshot := getSnapshot(pvc.Name, pvc.Namespace, vsc.GetName())
 
 		snapshot, err = dc.Resource(snapshotGVR).Namespace(snapshot.GetNamespace()).Create(snapshot, metav1.CreateOptions{})
@@ -177,7 +177,7 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 		err = WaitForSnapshotReady(dc, snapshot.GetNamespace(), snapshot.GetName(), framework.Poll, framework.SnapshotCreateTimeout)
 		framework.ExpectNoError(err)
 
-		By("checking the snapshot")
+		ginkgo.By("checking the snapshot")
 		// Get new copy of the snapshot
 		snapshot, err = dc.Resource(snapshotGVR).Namespace(snapshot.GetNamespace()).Get(snapshot.GetName(), metav1.GetOptions{})
 		framework.ExpectNoError(err)
@@ -193,11 +193,11 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 		persistentVolumeRef := snapshotContentSpec["persistentVolumeRef"].(map[string]interface{})
 
 		// Check SnapshotContent properties
-		By("checking the SnapshotContent")
-		Expect(snapshotContentSpec["snapshotClassName"]).To(Equal(vsc.GetName()))
-		Expect(volumeSnapshotRef["name"]).To(Equal(snapshot.GetName()))
-		Expect(volumeSnapshotRef["namespace"]).To(Equal(snapshot.GetNamespace()))
-		Expect(persistentVolumeRef["name"]).To(Equal(pv.Name))
+		ginkgo.By("checking the SnapshotContent")
+		gomega.Expect(snapshotContentSpec["snapshotClassName"]).To(gomega.Equal(vsc.GetName()))
+		gomega.Expect(volumeSnapshotRef["name"]).To(gomega.Equal(snapshot.GetName()))
+		gomega.Expect(volumeSnapshotRef["namespace"]).To(gomega.Equal(snapshot.GetNamespace()))
+		gomega.Expect(persistentVolumeRef["name"]).To(gomega.Equal(pv.Name))
 	})
 }
 

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -34,8 +34,8 @@ import (
 
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 )
 
 var (
@@ -147,9 +147,9 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 
 	cleanup := func() {
 		if l.pod != nil {
-			By("Deleting pod")
+			ginkgo.By("Deleting pod")
 			err := framework.DeletePodWithWait(f, f.ClientSet, l.pod)
-			Expect(err).ToNot(HaveOccurred(), "while deleting pod")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while deleting pod")
 			l.pod = nil
 		}
 
@@ -166,7 +166,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		validateMigrationVolumeOpCounts(f.ClientSet, driver.GetDriverInfo().InTreePluginName, l.intreeOps, l.migratedOps)
 	}
 
-	It("should support non-existent path", func() {
+	ginkgo.It("should support non-existent path", func() {
 		init()
 		defer cleanup()
 
@@ -177,7 +177,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testReadFile(f, l.filePathInVolume, l.pod, 1)
 	})
 
-	It("should support existing directory", func() {
+	ginkgo.It("should support existing directory", func() {
 		init()
 		defer cleanup()
 
@@ -191,7 +191,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testReadFile(f, l.filePathInVolume, l.pod, 1)
 	})
 
-	It("should support existing single file", func() {
+	ginkgo.It("should support existing single file", func() {
 		init()
 		defer cleanup()
 
@@ -202,7 +202,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testReadFile(f, l.filePathInSubpath, l.pod, 0)
 	})
 
-	It("should support file as subpath", func() {
+	ginkgo.It("should support file as subpath", func() {
 		init()
 		defer cleanup()
 
@@ -212,7 +212,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		TestBasicSubpath(f, f.Namespace.Name, l.pod)
 	})
 
-	It("should fail if subpath directory is outside the volume [Slow]", func() {
+	ginkgo.It("should fail if subpath directory is outside the volume [Slow]", func() {
 		init()
 		defer cleanup()
 
@@ -223,7 +223,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testPodFailSubpath(f, l.pod, false)
 	})
 
-	It("should fail if subpath file is outside the volume [Slow]", func() {
+	ginkgo.It("should fail if subpath file is outside the volume [Slow]", func() {
 		init()
 		defer cleanup()
 
@@ -234,7 +234,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testPodFailSubpath(f, l.pod, false)
 	})
 
-	It("should fail if non-existent subpath is outside the volume [Slow]", func() {
+	ginkgo.It("should fail if non-existent subpath is outside the volume [Slow]", func() {
 		init()
 		defer cleanup()
 
@@ -245,7 +245,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testPodFailSubpath(f, l.pod, false)
 	})
 
-	It("should fail if subpath with backstepping is outside the volume [Slow]", func() {
+	ginkgo.It("should fail if subpath with backstepping is outside the volume [Slow]", func() {
 		init()
 		defer cleanup()
 
@@ -256,7 +256,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testPodFailSubpath(f, l.pod, false)
 	})
 
-	It("should support creating multiple subpath from same volumes [Slow]", func() {
+	ginkgo.It("should support creating multiple subpath from same volumes [Slow]", func() {
 		init()
 		defer cleanup()
 
@@ -282,7 +282,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testMultipleReads(f, l.pod, 0, filepath1, filepath2)
 	})
 
-	It("should support restarting containers using directory as subpath [Slow]", func() {
+	ginkgo.It("should support restarting containers using directory as subpath [Slow]", func() {
 		init()
 		defer cleanup()
 
@@ -292,7 +292,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testPodContainerRestart(f, l.pod)
 	})
 
-	It("should support restarting containers using file as subpath [Slow]", func() {
+	ginkgo.It("should support restarting containers using file as subpath [Slow]", func() {
 		init()
 		defer cleanup()
 
@@ -302,14 +302,14 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testPodContainerRestart(f, l.pod)
 	})
 
-	It("should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]", func() {
+	ginkgo.It("should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]", func() {
 		init()
 		defer cleanup()
 
 		testSubpathReconstruction(f, l.pod, false)
 	})
 
-	It("should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]", func() {
+	ginkgo.It("should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]", func() {
 		init()
 		defer cleanup()
 
@@ -321,7 +321,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testSubpathReconstruction(f, l.pod, true)
 	})
 
-	It("should support readOnly directory specified in the volumeMount", func() {
+	ginkgo.It("should support readOnly directory specified in the volumeMount", func() {
 		init()
 		defer cleanup()
 
@@ -336,7 +336,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testReadFile(f, l.filePathInSubpath, l.pod, 0)
 	})
 
-	It("should support readOnly file specified in the volumeMount", func() {
+	ginkgo.It("should support readOnly file specified in the volumeMount", func() {
 		init()
 		defer cleanup()
 
@@ -351,7 +351,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testReadFile(f, volumePath, l.pod, 0)
 	})
 
-	It("should support existing directories when readOnly specified in the volumeSource", func() {
+	ginkgo.It("should support existing directories when readOnly specified in the volumeSource", func() {
 		init()
 		defer cleanup()
 		if l.roVolSource == nil {
@@ -379,7 +379,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testReadFile(f, l.filePathInSubpath, l.pod, 0)
 	})
 
-	It("should verify container cannot write to subpath readonly volumes [Slow]", func() {
+	ginkgo.It("should verify container cannot write to subpath readonly volumes [Slow]", func() {
 		init()
 		defer cleanup()
 		if l.roVolSource == nil {
@@ -399,7 +399,7 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		testPodFailSubpath(f, l.pod, true)
 	})
 
-	It("should be able to unmount after the subpath directory is deleted", func() {
+	ginkgo.It("should be able to unmount after the subpath directory is deleted", func() {
 		init()
 		defer cleanup()
 
@@ -407,23 +407,23 @@ func (s *subPathTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		l.pod.Spec.Containers[1].Image = imageutils.GetE2EImage(imageutils.BusyBox)
 		l.pod.Spec.Containers[1].Command = []string{"/bin/sh", "-ec", "sleep 100000"}
 
-		By(fmt.Sprintf("Creating pod %s", l.pod.Name))
+		ginkgo.By(fmt.Sprintf("Creating pod %s", l.pod.Name))
 		removeUnusedContainers(l.pod)
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(l.pod)
-		Expect(err).ToNot(HaveOccurred(), "while creating pod")
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while creating pod")
 		defer func() {
-			By(fmt.Sprintf("Deleting pod %s", pod.Name))
+			ginkgo.By(fmt.Sprintf("Deleting pod %s", pod.Name))
 			framework.DeletePodWithWait(f, f.ClientSet, pod)
 		}()
 
 		// Wait for pod to be running
 		err = framework.WaitForPodRunningInNamespace(f.ClientSet, l.pod)
-		Expect(err).ToNot(HaveOccurred(), "while waiting for pod to be running")
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while waiting for pod to be running")
 
 		// Exec into container that mounted the volume, delete subpath directory
 		rmCmd := fmt.Sprintf("rm -rf %s", l.subPathDir)
 		_, err = podContainerExec(l.pod, 1, rmCmd)
-		Expect(err).ToNot(HaveOccurred(), "while removing subpath directory")
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while removing subpath directory")
 
 		// Delete pod (from defer) and wait for it to be successfully deleted
 	})
@@ -440,11 +440,11 @@ func TestBasicSubpath(f *framework.Framework, contents string, pod *v1.Pod) {
 func TestBasicSubpathFile(f *framework.Framework, contents string, pod *v1.Pod, filepath string) {
 	setReadCommand(filepath, &pod.Spec.Containers[0])
 
-	By(fmt.Sprintf("Creating pod %s", pod.Name))
+	ginkgo.By(fmt.Sprintf("Creating pod %s", pod.Name))
 	removeUnusedContainers(pod)
 	f.TestContainerOutput("atomic-volume-subpath", pod, 0, []string{contents})
 
-	By(fmt.Sprintf("Deleting pod %s", pod.Name))
+	ginkgo.By(fmt.Sprintf("Deleting pod %s", pod.Name))
 	err := framework.DeletePodWithWait(f, f.ClientSet, pod)
 	framework.ExpectNoError(err, "while deleting pod")
 }
@@ -672,7 +672,7 @@ func addMultipleWrites(container *v1.Container, file1 string, file2 string) {
 }
 
 func testMultipleReads(f *framework.Framework, pod *v1.Pod, containerIndex int, file1 string, file2 string) {
-	By(fmt.Sprintf("Creating pod %s", pod.Name))
+	ginkgo.By(fmt.Sprintf("Creating pod %s", pod.Name))
 	removeUnusedContainers(pod)
 	f.TestContainerOutput("multi_subpath", pod, containerIndex, []string{
 		"content of file \"" + file1 + "\": mount-tester new file",
@@ -690,13 +690,13 @@ func setReadCommand(file string, container *v1.Container) {
 func testReadFile(f *framework.Framework, file string, pod *v1.Pod, containerIndex int) {
 	setReadCommand(file, &pod.Spec.Containers[containerIndex])
 
-	By(fmt.Sprintf("Creating pod %s", pod.Name))
+	ginkgo.By(fmt.Sprintf("Creating pod %s", pod.Name))
 	removeUnusedContainers(pod)
 	f.TestContainerOutput("subpath", pod, containerIndex, []string{
 		"content of file \"" + file + "\": mount-tester new file",
 	})
 
-	By(fmt.Sprintf("Deleting pod %s", pod.Name))
+	ginkgo.By(fmt.Sprintf("Deleting pod %s", pod.Name))
 	err := framework.DeletePodWithWait(f, f.ClientSet, pod)
 	framework.ExpectNoError(err, "while deleting pod")
 }
@@ -706,14 +706,14 @@ func testPodFailSubpath(f *framework.Framework, pod *v1.Pod, allowContainerTermi
 }
 
 func testPodFailSubpathError(f *framework.Framework, pod *v1.Pod, errorMsg string, allowContainerTerminationError bool) {
-	By(fmt.Sprintf("Creating pod %s", pod.Name))
+	ginkgo.By(fmt.Sprintf("Creating pod %s", pod.Name))
 	removeUnusedContainers(pod)
 	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
-	Expect(err).ToNot(HaveOccurred(), "while creating pod")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while creating pod")
 	defer func() {
 		framework.DeletePodWithWait(f, f.ClientSet, pod)
 	}()
-	By("Checking for subpath error in container status")
+	ginkgo.By("Checking for subpath error in container status")
 	err = waitForPodSubpathError(f, pod, allowContainerTerminationError)
 	framework.ExpectNoError(err, "while waiting for subpath failure")
 }
@@ -786,23 +786,23 @@ func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
 	}
 
 	// Start pod
-	By(fmt.Sprintf("Creating pod %s", pod.Name))
+	ginkgo.By(fmt.Sprintf("Creating pod %s", pod.Name))
 	removeUnusedContainers(pod)
 	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
-	Expect(err).ToNot(HaveOccurred(), "while creating pod")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while creating pod")
 	defer func() {
 		framework.DeletePodWithWait(f, f.ClientSet, pod)
 	}()
 	err = framework.WaitForPodRunningInNamespace(f.ClientSet, pod)
-	Expect(err).ToNot(HaveOccurred(), "while waiting for pod to be running")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while waiting for pod to be running")
 
-	By("Failing liveness probe")
+	ginkgo.By("Failing liveness probe")
 	out, err := podContainerExec(pod, 1, fmt.Sprintf("rm %v", probeFilePath))
 	e2elog.Logf("Pod exec output: %v", out)
-	Expect(err).ToNot(HaveOccurred(), "while failing liveness probe")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while failing liveness probe")
 
 	// Check that container has restarted
-	By("Waiting for container to restart")
+	ginkgo.By("Waiting for container to restart")
 	restarts := int32(0)
 	err = wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(pod.Name, metav1.GetOptions{})
@@ -821,17 +821,17 @@ func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
 		}
 		return false, nil
 	})
-	Expect(err).ToNot(HaveOccurred(), "while waiting for container to restart")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while waiting for container to restart")
 
 	// Fix liveness probe
-	By("Rewriting the file")
+	ginkgo.By("Rewriting the file")
 	writeCmd := fmt.Sprintf("echo test-after > %v", probeFilePath)
 	out, err = podContainerExec(pod, 1, writeCmd)
 	e2elog.Logf("Pod exec output: %v", out)
-	Expect(err).ToNot(HaveOccurred(), "while rewriting the probe file")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while rewriting the probe file")
 
 	// Wait for container restarts to stabilize
-	By("Waiting for container to stop restarting")
+	ginkgo.By("Waiting for container to stop restarting")
 	stableCount := int(0)
 	stableThreshold := int(time.Minute / framework.Poll)
 	err = wait.PollImmediate(framework.Poll, 2*time.Minute, func() (bool, error) {
@@ -857,7 +857,7 @@ func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
 		}
 		return false, nil
 	})
-	Expect(err).ToNot(HaveOccurred(), "while waiting for container to stabilize")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while waiting for container to stabilize")
 }
 
 func testSubpathReconstruction(f *framework.Framework, pod *v1.Pod, forceDelete bool) {
@@ -874,30 +874,30 @@ func testSubpathReconstruction(f *framework.Framework, pod *v1.Pod, forceDelete 
 	gracePeriod := int64(30)
 	pod.Spec.TerminationGracePeriodSeconds = &gracePeriod
 
-	By(fmt.Sprintf("Creating pod %s", pod.Name))
+	ginkgo.By(fmt.Sprintf("Creating pod %s", pod.Name))
 	removeUnusedContainers(pod)
 	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
-	Expect(err).ToNot(HaveOccurred(), "while creating pod")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while creating pod")
 
 	err = framework.WaitForPodRunningInNamespace(f.ClientSet, pod)
-	Expect(err).ToNot(HaveOccurred(), "while waiting for pod to be running")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while waiting for pod to be running")
 
 	pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(pod.Name, metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred(), "while getting pod")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while getting pod")
 
 	utils.TestVolumeUnmountsFromDeletedPodWithForceOption(f.ClientSet, f, pod, forceDelete, true)
 }
 
 func formatVolume(f *framework.Framework, pod *v1.Pod) {
-	By(fmt.Sprintf("Creating pod to format volume %s", pod.Name))
+	ginkgo.By(fmt.Sprintf("Creating pod to format volume %s", pod.Name))
 	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
-	Expect(err).ToNot(HaveOccurred(), "while creating volume init pod")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while creating volume init pod")
 
 	err = framework.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, pod.Namespace)
-	Expect(err).ToNot(HaveOccurred(), "while waiting for volume init pod to succeed")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while waiting for volume init pod to succeed")
 
 	err = framework.DeletePodWithWait(f, f.ClientSet, pod)
-	Expect(err).ToNot(HaveOccurred(), "while deleting volume init pod")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "while deleting volume init pod")
 }
 
 func podContainerExec(pod *v1.Pod, containerIndex int, bashExec string) (string, error) {

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -126,7 +126,7 @@ func (t *volumeIOTestSuite) defineTests(driver TestDriver, pattern testpatterns.
 		validateMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName, l.intreeOps, l.migratedOps)
 	}
 
-	It("should write files of various sizes, verify size, validate content [Slow]", func() {
+	ginkgo.It("should write files of various sizes, verify size, validate content [Slow]", func() {
 		init()
 		defer cleanup()
 
@@ -230,7 +230,7 @@ func makePodSpec(config volume.TestConfig, initCmd string, volsrc v1.VolumeSourc
 
 // Write `fsize` bytes to `fpath` in the pod, using dd and the `ddInput` file.
 func writeToFile(pod *v1.Pod, fpath, ddInput string, fsize int64) error {
-	By(fmt.Sprintf("writing %d bytes to test file %s", fsize, fpath))
+	ginkgo.By(fmt.Sprintf("writing %d bytes to test file %s", fsize, fpath))
 	loopCnt := fsize / testpatterns.MinFileSize
 	writeCmd := fmt.Sprintf("i=0; while [ $i -lt %d ]; do dd if=%s bs=%d >>%s 2>/dev/null; let i+=1; done", loopCnt, ddInput, testpatterns.MinFileSize, fpath)
 	_, err := utils.PodExec(pod, writeCmd)
@@ -240,7 +240,7 @@ func writeToFile(pod *v1.Pod, fpath, ddInput string, fsize int64) error {
 
 // Verify that the test file is the expected size and contains the expected content.
 func verifyFile(pod *v1.Pod, fpath string, expectSize int64, ddInput string) error {
-	By("verifying file size")
+	ginkgo.By("verifying file size")
 	rtnstr, err := utils.PodExec(pod, fmt.Sprintf("stat -c %%s %s", fpath))
 	if err != nil || rtnstr == "" {
 		return fmt.Errorf("unable to get file size via `stat %s`: %v", fpath, err)
@@ -253,7 +253,7 @@ func verifyFile(pod *v1.Pod, fpath string, expectSize int64, ddInput string) err
 		return fmt.Errorf("size of file %s is %d, expected %d", fpath, size, expectSize)
 	}
 
-	By("verifying file hash")
+	ginkgo.By("verifying file hash")
 	rtnstr, err = utils.PodExec(pod, fmt.Sprintf("md5sum %s | cut -d' ' -f1", fpath))
 	if err != nil {
 		return fmt.Errorf("unable to test file hash via `md5sum %s`: %v", fpath, err)
@@ -274,7 +274,7 @@ func verifyFile(pod *v1.Pod, fpath string, expectSize int64, ddInput string) err
 
 // Delete `fpath` to save some disk space on host. Delete errors are logged but ignored.
 func deleteFile(pod *v1.Pod, fpath string) {
-	By(fmt.Sprintf("deleting test file %s...", fpath))
+	ginkgo.By(fmt.Sprintf("deleting test file %s...", fpath))
 	_, err := utils.PodExec(pod, fmt.Sprintf("rm -f %s", fpath))
 	if err != nil {
 		// keep going, the test dir will be deleted when the volume is unmounted
@@ -299,7 +299,7 @@ func testVolumeIO(f *framework.Framework, cs clientset.Interface, config volume.
 
 	clientPod := makePodSpec(config, initCmd, volsrc, podSecContext)
 
-	By(fmt.Sprintf("starting %s", clientPod.Name))
+	ginkgo.By(fmt.Sprintf("starting %s", clientPod.Name))
 	podsNamespacer := cs.CoreV1().Pods(config.Namespace)
 	clientPod, err = podsNamespacer.Create(clientPod)
 	if err != nil {
@@ -307,7 +307,7 @@ func testVolumeIO(f *framework.Framework, cs clientset.Interface, config volume.
 	}
 	defer func() {
 		deleteFile(clientPod, ddInput)
-		By(fmt.Sprintf("deleting client pod %q...", clientPod.Name))
+		ginkgo.By(fmt.Sprintf("deleting client pod %q...", clientPod.Name))
 		e := framework.DeletePodWithWait(f, cs, clientPod)
 		if e != nil {
 			e2elog.Logf("client pod failed to delete: %v", e)

--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -19,8 +19,7 @@ package testsuites
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -166,17 +165,17 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 	switch pattern.VolType {
 	case testpatterns.PreprovisionedPV:
 		if pattern.VolMode == v1.PersistentVolumeBlock && !isBlockSupported {
-			It("should fail to create pod by failing to mount volume [Slow]", func() {
+			ginkgo.It("should fail to create pod by failing to mount volume [Slow]", func() {
 				init()
 				defer cleanup()
 
 				var err error
 
-				By("Creating sc")
+				ginkgo.By("Creating sc")
 				l.sc, err = l.cs.StorageV1().StorageClasses().Create(l.sc)
 				framework.ExpectNoError(err)
 
-				By("Creating pv and pvc")
+				ginkgo.By("Creating pv and pvc")
 				l.pv, err = l.cs.CoreV1().PersistentVolumes().Create(l.pv)
 				framework.ExpectNoError(err)
 
@@ -187,27 +186,27 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 
 				framework.ExpectNoError(framework.WaitOnPVandPVC(l.cs, l.ns.Name, l.pv, l.pvc))
 
-				By("Creating pod")
+				ginkgo.By("Creating pod")
 				pod, err := framework.CreateSecPodWithNodeSelection(l.cs, l.ns.Name, []*v1.PersistentVolumeClaim{l.pvc},
 					false, "", false, false, framework.SELinuxLabel,
 					nil, framework.NodeSelection{Name: l.config.ClientNodeName}, framework.PodStartTimeout)
 				defer func() {
 					framework.ExpectNoError(framework.DeletePodWithWait(f, l.cs, pod))
 				}()
-				Expect(err).To(HaveOccurred())
+				gomega.Expect(err).To(gomega.HaveOccurred())
 			})
 		} else {
-			It("should create sc, pod, pv, and pvc, read/write to the pv, and delete all created resources", func() {
+			ginkgo.It("should create sc, pod, pv, and pvc, read/write to the pv, and delete all created resources", func() {
 				init()
 				defer cleanup()
 
 				var err error
 
-				By("Creating sc")
+				ginkgo.By("Creating sc")
 				l.sc, err = l.cs.StorageV1().StorageClasses().Create(l.sc)
 				framework.ExpectNoError(err)
 
-				By("Creating pv and pvc")
+				ginkgo.By("Creating pv and pvc")
 				l.pv, err = l.cs.CoreV1().PersistentVolumes().Create(l.pv)
 				framework.ExpectNoError(err)
 
@@ -218,7 +217,7 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 
 				framework.ExpectNoError(framework.WaitOnPVandPVC(l.cs, l.ns.Name, l.pv, l.pvc))
 
-				By("Creating pod")
+				ginkgo.By("Creating pod")
 				pod, err := framework.CreateSecPodWithNodeSelection(l.cs, l.ns.Name, []*v1.PersistentVolumeClaim{l.pvc},
 					false, "", false, false, framework.SELinuxLabel,
 					nil, framework.NodeSelection{Name: l.config.ClientNodeName}, framework.PodStartTimeout)
@@ -227,45 +226,45 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 				}()
 				framework.ExpectNoError(err)
 
-				By("Checking if persistent volume exists as expected volume mode")
+				ginkgo.By("Checking if persistent volume exists as expected volume mode")
 				utils.CheckVolumeModeOfPath(pod, pattern.VolMode, "/mnt/volume1")
 
-				By("Checking if read/write to persistent volume works properly")
+				ginkgo.By("Checking if read/write to persistent volume works properly")
 				utils.CheckReadWriteToPath(pod, pattern.VolMode, "/mnt/volume1")
 			})
 			// TODO(mkimuram): Add more tests
 		}
 	case testpatterns.DynamicPV:
 		if pattern.VolMode == v1.PersistentVolumeBlock && !isBlockSupported {
-			It("should fail in binding dynamic provisioned PV to PVC", func() {
+			ginkgo.It("should fail in binding dynamic provisioned PV to PVC", func() {
 				init()
 				defer cleanup()
 
 				var err error
 
-				By("Creating sc")
+				ginkgo.By("Creating sc")
 				l.sc, err = l.cs.StorageV1().StorageClasses().Create(l.sc)
 				framework.ExpectNoError(err)
 
-				By("Creating pv and pvc")
+				ginkgo.By("Creating pv and pvc")
 				l.pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(l.pvc)
 				framework.ExpectNoError(err)
 
 				err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, l.cs, l.pvc.Namespace, l.pvc.Name, framework.Poll, framework.ClaimProvisionTimeout)
-				Expect(err).To(HaveOccurred())
+				gomega.Expect(err).To(gomega.HaveOccurred())
 			})
 		} else {
-			It("should create sc, pod, pv, and pvc, read/write to the pv, and delete all created resources", func() {
+			ginkgo.It("should create sc, pod, pv, and pvc, read/write to the pv, and delete all created resources", func() {
 				init()
 				defer cleanup()
 
 				var err error
 
-				By("Creating sc")
+				ginkgo.By("Creating sc")
 				l.sc, err = l.cs.StorageV1().StorageClasses().Create(l.sc)
 				framework.ExpectNoError(err)
 
-				By("Creating pv and pvc")
+				ginkgo.By("Creating pv and pvc")
 				l.pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(l.pvc)
 				framework.ExpectNoError(err)
 
@@ -278,7 +277,7 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 				l.pv, err = l.cs.CoreV1().PersistentVolumes().Get(l.pvc.Spec.VolumeName, metav1.GetOptions{})
 				framework.ExpectNoError(err)
 
-				By("Creating pod")
+				ginkgo.By("Creating pod")
 				pod, err := framework.CreateSecPodWithNodeSelection(l.cs, l.ns.Name, []*v1.PersistentVolumeClaim{l.pvc},
 					false, "", false, false, framework.SELinuxLabel,
 					nil, framework.NodeSelection{Name: l.config.ClientNodeName}, framework.PodStartTimeout)
@@ -287,10 +286,10 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 				}()
 				framework.ExpectNoError(err)
 
-				By("Checking if persistent volume exists as expected volume mode")
+				ginkgo.By("Checking if persistent volume exists as expected volume mode")
 				utils.CheckVolumeModeOfPath(pod, pattern.VolMode, "/mnt/volume1")
 
-				By("Checking if read/write to persistent volume works properly")
+				ginkgo.By("Checking if read/write to persistent volume works properly")
 				utils.CheckReadWriteToPath(pod, pattern.VolMode, "/mnt/volume1")
 			})
 			// TODO(mkimuram): Add more tests

--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -193,7 +193,7 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 				defer func() {
 					framework.ExpectNoError(framework.DeletePodWithWait(f, l.cs, pod))
 				}()
-				gomega.Expect(err).To(gomega.HaveOccurred())
+				framework.ExpectError(err)
 			})
 		} else {
 			ginkgo.It("should create sc, pod, pv, and pvc, read/write to the pv, and delete all created resources", func() {
@@ -251,7 +251,7 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 				framework.ExpectNoError(err)
 
 				err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, l.cs, l.pvc.Namespace, l.pvc.Name, framework.Poll, framework.ClaimProvisionTimeout)
-				gomega.Expect(err).To(gomega.HaveOccurred())
+				framework.ExpectError(err)
 			})
 		} else {
 			ginkgo.It("should create sc, pod, pv, and pvc, read/write to the pv, and delete all created resources", func() {

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -24,7 +24,7 @@ package testsuites
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -140,7 +140,7 @@ func (t *volumesTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		validateMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName, l.intreeOps, l.migratedOps)
 	}
 
-	It("should be mountable", func() {
+	ginkgo.It("should be mountable", func() {
 		skipPersistenceTest(driver)
 		init()
 		defer func() {
@@ -171,7 +171,7 @@ func (t *volumesTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		volume.TestVolumeClient(f.ClientSet, config, fsGroup, pattern.FsType, tests)
 	})
 
-	It("should allow exec of files on the volume", func() {
+	ginkgo.It("should allow exec of files on the volume", func() {
 		skipExecTest(driver)
 		init()
 		defer cleanup()
@@ -229,10 +229,10 @@ func testScriptInPod(
 			NodeName:      config.ClientNodeName,
 		},
 	}
-	By(fmt.Sprintf("Creating pod %s", pod.Name))
+	ginkgo.By(fmt.Sprintf("Creating pod %s", pod.Name))
 	f.TestContainerOutput("exec-volume-test", pod, 0, []string{fileName})
 
-	By(fmt.Sprintf("Deleting pod %s", pod.Name))
+	ginkgo.By(fmt.Sprintf("Deleting pod %s", pod.Name))
 	err := framework.DeletePodWithWait(f, f.ClientSet, pod)
 	framework.ExpectNoError(err, "while deleting pod")
 }

--- a/test/e2e/storage/utils/local.go
+++ b/test/e2e/storage/utils/local.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -99,7 +99,7 @@ func (l *ltrMgr) getTestDir() string {
 
 func (l *ltrMgr) setupLocalVolumeTmpfs(node *v1.Node, parameters map[string]string) *LocalTestResource {
 	hostDir := l.getTestDir()
-	By(fmt.Sprintf("Creating tmpfs mount point on node %q at path %q", node.Name, hostDir))
+	ginkgo.By(fmt.Sprintf("Creating tmpfs mount point on node %q at path %q", node.Name, hostDir))
 	err := l.hostExec.IssueCommand(fmt.Sprintf("mkdir -p %q && sudo mount -t tmpfs -o size=10m tmpfs-%q %q", hostDir, hostDir, hostDir), node)
 	framework.ExpectNoError(err)
 	return &LocalTestResource{
@@ -109,18 +109,18 @@ func (l *ltrMgr) setupLocalVolumeTmpfs(node *v1.Node, parameters map[string]stri
 }
 
 func (l *ltrMgr) cleanupLocalVolumeTmpfs(ltr *LocalTestResource) {
-	By(fmt.Sprintf("Unmount tmpfs mount point on node %q at path %q", ltr.Node.Name, ltr.Path))
+	ginkgo.By(fmt.Sprintf("Unmount tmpfs mount point on node %q at path %q", ltr.Node.Name, ltr.Path))
 	err := l.hostExec.IssueCommand(fmt.Sprintf("sudo umount %q", ltr.Path), ltr.Node)
 	framework.ExpectNoError(err)
 
-	By("Removing the test directory")
+	ginkgo.By("Removing the test directory")
 	err = l.hostExec.IssueCommand(fmt.Sprintf("rm -r %s", ltr.Path), ltr.Node)
 	framework.ExpectNoError(err)
 }
 
 // createAndSetupLoopDevice creates an empty file and associates a loop devie with it.
 func (l *ltrMgr) createAndSetupLoopDevice(dir string, node *v1.Node, size int) {
-	By(fmt.Sprintf("Creating block device on node %q using path %q", node.Name, dir))
+	ginkgo.By(fmt.Sprintf("Creating block device on node %q using path %q", node.Name, dir))
 	mkdirCmd := fmt.Sprintf("mkdir -p %s", dir)
 	count := size / 4096
 	// xfs requires at least 4096 blocks
@@ -155,7 +155,7 @@ func (l *ltrMgr) setupLocalVolumeBlock(node *v1.Node, parameters map[string]stri
 // teardownLoopDevice tears down loop device by its associated storage directory.
 func (l *ltrMgr) teardownLoopDevice(dir string, node *v1.Node) {
 	loopDev := l.findLoopDevice(dir, node)
-	By(fmt.Sprintf("Tear down block device %q on node %q at path %s/file", loopDev, node.Name, dir))
+	ginkgo.By(fmt.Sprintf("Tear down block device %q on node %q at path %s/file", loopDev, node.Name, dir))
 	losetupDeleteCmd := fmt.Sprintf("sudo losetup -d %s", loopDev)
 	err := l.hostExec.IssueCommand(losetupDeleteCmd, node)
 	framework.ExpectNoError(err)
@@ -164,7 +164,7 @@ func (l *ltrMgr) teardownLoopDevice(dir string, node *v1.Node) {
 
 func (l *ltrMgr) cleanupLocalVolumeBlock(ltr *LocalTestResource) {
 	l.teardownLoopDevice(ltr.loopDir, ltr.Node)
-	By(fmt.Sprintf("Removing the test directory %s", ltr.loopDir))
+	ginkgo.By(fmt.Sprintf("Removing the test directory %s", ltr.loopDir))
 	removeCmd := fmt.Sprintf("rm -r %s", ltr.loopDir)
 	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
 	framework.ExpectNoError(err)
@@ -204,7 +204,7 @@ func (l *ltrMgr) setupLocalVolumeDirectory(node *v1.Node, parameters map[string]
 }
 
 func (l *ltrMgr) cleanupLocalVolumeDirectory(ltr *LocalTestResource) {
-	By("Removing the test directory")
+	ginkgo.By("Removing the test directory")
 	removeCmd := fmt.Sprintf("rm -r %s", ltr.Path)
 	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
 	framework.ExpectNoError(err)
@@ -223,7 +223,7 @@ func (l *ltrMgr) setupLocalVolumeDirectoryLink(node *v1.Node, parameters map[str
 }
 
 func (l *ltrMgr) cleanupLocalVolumeDirectoryLink(ltr *LocalTestResource) {
-	By("Removing the test directory")
+	ginkgo.By("Removing the test directory")
 	hostDir := ltr.Path
 	hostDirBackend := hostDir + "-backend"
 	removeCmd := fmt.Sprintf("sudo rm -r %s && rm -r %s", hostDir, hostDirBackend)
@@ -243,7 +243,7 @@ func (l *ltrMgr) setupLocalVolumeDirectoryBindMounted(node *v1.Node, parameters 
 }
 
 func (l *ltrMgr) cleanupLocalVolumeDirectoryBindMounted(ltr *LocalTestResource) {
-	By("Removing the test directory")
+	ginkgo.By("Removing the test directory")
 	hostDir := ltr.Path
 	removeCmd := fmt.Sprintf("sudo umount %s && rm -r %s", hostDir, hostDir)
 	err := l.hostExec.IssueCommand(removeCmd, ltr.Node)
@@ -263,7 +263,7 @@ func (l *ltrMgr) setupLocalVolumeDirectoryLinkBindMounted(node *v1.Node, paramet
 }
 
 func (l *ltrMgr) cleanupLocalVolumeDirectoryLinkBindMounted(ltr *LocalTestResource) {
-	By("Removing the test directory")
+	ginkgo.By("Removing the test directory")
 	hostDir := ltr.Path
 	hostDirBackend := hostDir + "-backend"
 	removeCmd := fmt.Sprintf("sudo rm %s && sudo umount %s && rm -r %s", hostDir, hostDirBackend, hostDirBackend)

--- a/test/e2e/storage/volume_limits.go
+++ b/test/e2e/storage/volume_limits.go
@@ -17,7 +17,7 @@ limitations under the License.
 package storage
 
 import (
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
@@ -30,13 +30,13 @@ var _ = utils.SIGDescribe("Volume limits", func() {
 		c clientset.Interface
 	)
 	f := framework.NewDefaultFramework("volume-limits-on-node")
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("aws", "gce", "gke")
 		c = f.ClientSet
 		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
 	})
 
-	It("should verify that all nodes have volume limits", func() {
+	ginkgo.It("should verify that all nodes have volume limits", func() {
 		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 		if len(nodeList.Items) == 0 {
 			framework.Failf("Unable to find ready and schedulable Node")

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -175,7 +175,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		framework.ExpectNoError(err, "failed to create Pod %s/%s", pod.Namespace, pod.Name)
 
 		err = framework.WaitTimeoutForPodRunningInNamespace(c, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		framework.ExpectError(err)
 
 		e2elog.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
 		framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod))

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	"github.com/prometheus/common/model"
 
 	v1 "k8s.io/api/core/v1"
@@ -50,7 +50,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 	)
 	f := framework.NewDefaultFramework("pv")
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		c = f.ClientSet
 		ns = f.Namespace.Name
 		var err error
@@ -73,7 +73,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		}
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		newPvc, err := c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pvc.Name, metav1.GetOptions{})
 		if err != nil {
 			e2elog.Logf("Failed to get pvc %s/%s: %v", pvc.Namespace, pvc.Name, err)
@@ -92,7 +92,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		}
 	})
 
-	It("should create prometheus metrics for volume provisioning and attach/detach", func() {
+	ginkgo.It("should create prometheus metrics for volume provisioning and attach/detach", func() {
 		var err error
 
 		if !metricsGrabber.HasRegisteredMaster() {
@@ -107,7 +107,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 
 		pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)
 		framework.ExpectNoError(err)
-		Expect(pvc).ToNot(Equal(nil))
+		gomega.Expect(pvc).ToNot(gomega.Equal(nil))
 
 		claims := []*v1.PersistentVolumeClaim{pvc}
 
@@ -123,8 +123,8 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 
 		updatedStorageMetrics := waitForDetachAndGrabMetrics(storageOpMetrics, metricsGrabber)
 
-		Expect(len(updatedStorageMetrics.latencyMetrics)).ToNot(Equal(0), "Error fetching c-m updated storage metrics")
-		Expect(len(updatedStorageMetrics.statusMetrics)).ToNot(Equal(0), "Error fetching c-m updated storage metrics")
+		gomega.Expect(len(updatedStorageMetrics.latencyMetrics)).ToNot(gomega.Equal(0), "Error fetching c-m updated storage metrics")
+		gomega.Expect(len(updatedStorageMetrics.statusMetrics)).ToNot(gomega.Equal(0), "Error fetching c-m updated storage metrics")
 
 		volumeOperations := []string{"volume_provision", "volume_detach", "volume_attach"}
 
@@ -133,7 +133,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		}
 	})
 
-	It("should create prometheus metrics for volume provisioning errors [Slow]", func() {
+	ginkgo.It("should create prometheus metrics for volume provisioning errors [Slow]", func() {
 		var err error
 
 		if !metricsGrabber.HasRegisteredMaster() {
@@ -146,7 +146,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 
 		storageOpMetrics := getControllerStorageMetrics(controllerMetrics)
 
-		By("Creating an invalid storageclass")
+		ginkgo.By("Creating an invalid storageclass")
 		defaultClass, err := c.StorageV1().StorageClasses().Get(defaultScName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "Error getting default storageclass: %v", err)
 
@@ -165,35 +165,35 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		pvc.Spec.StorageClassName = &invalidSc.Name
 		pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)
 		framework.ExpectNoError(err, "failed to create PVC %s/%s", pvc.Namespace, pvc.Name)
-		Expect(pvc).ToNot(Equal(nil))
+		gomega.Expect(pvc).ToNot(gomega.Equal(nil))
 
 		claims := []*v1.PersistentVolumeClaim{pvc}
 
-		By("Creating a pod and expecting it to fail")
+		ginkgo.By("Creating a pod and expecting it to fail")
 		pod := framework.MakePod(ns, nil, claims, false, "")
 		pod, err = c.CoreV1().Pods(ns).Create(pod)
 		framework.ExpectNoError(err, "failed to create Pod %s/%s", pod.Namespace, pod.Name)
 
 		err = framework.WaitTimeoutForPodRunningInNamespace(c, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
-		Expect(err).To(HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 
 		e2elog.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
 		framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod))
 
-		By("Checking failure metrics")
+		ginkgo.By("Checking failure metrics")
 		updatedControllerMetrics, err := metricsGrabber.GrabFromControllerManager()
 		framework.ExpectNoError(err, "failed to get controller manager metrics")
 		updatedStorageMetrics := getControllerStorageMetrics(updatedControllerMetrics)
 
-		Expect(len(updatedStorageMetrics.statusMetrics)).ToNot(Equal(0), "Error fetching c-m updated storage metrics")
+		gomega.Expect(len(updatedStorageMetrics.statusMetrics)).ToNot(gomega.Equal(0), "Error fetching c-m updated storage metrics")
 		verifyMetricCount(storageOpMetrics, updatedStorageMetrics, "volume_provision", true)
 	})
 
-	It("should create volume metrics with the correct PVC ref", func() {
+	ginkgo.It("should create volume metrics with the correct PVC ref", func() {
 		var err error
 		pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)
 		framework.ExpectNoError(err)
-		Expect(pvc).ToNot(Equal(nil))
+		gomega.Expect(pvc).ToNot(gomega.Equal(nil))
 
 		claims := []*v1.PersistentVolumeClaim{pvc}
 		pod := framework.MakePod(ns, nil, claims, false, "")
@@ -239,18 +239,18 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		for _, key := range volumeStatKeys {
 			kubeletKeyName := fmt.Sprintf("%s_%s", kubeletmetrics.KubeletSubsystem, key)
 			found := findVolumeStatMetric(kubeletKeyName, pvc.Namespace, pvc.Name, kubeMetrics)
-			Expect(found).To(BeTrue(), "PVC %s, Namespace %s not found for %s", pvc.Name, pvc.Namespace, kubeletKeyName)
+			gomega.Expect(found).To(gomega.BeTrue(), "PVC %s, Namespace %s not found for %s", pvc.Name, pvc.Namespace, kubeletKeyName)
 		}
 
 		e2elog.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
 		framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod))
 	})
 
-	It("should create metrics for total time taken in volume operations in P/V Controller", func() {
+	ginkgo.It("should create metrics for total time taken in volume operations in P/V Controller", func() {
 		var err error
 		pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)
 		framework.ExpectNoError(err)
-		Expect(pvc).ToNot(Equal(nil))
+		gomega.Expect(pvc).ToNot(gomega.Equal(nil))
 
 		claims := []*v1.PersistentVolumeClaim{pvc}
 		pod := framework.MakePod(ns, nil, claims, false, "")
@@ -271,17 +271,17 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		metricKey := "volume_operation_total_seconds_count"
 		dimensions := []string{"operation_name", "plugin_name"}
 		valid := hasValidMetrics(metrics.Metrics(controllerMetrics), metricKey, dimensions...)
-		Expect(valid).To(BeTrue(), "Invalid metric in P/V Controller metrics: %q", metricKey)
+		gomega.Expect(valid).To(gomega.BeTrue(), "Invalid metric in P/V Controller metrics: %q", metricKey)
 
 		e2elog.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
 		framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod))
 	})
 
-	It("should create volume metrics in Volume Manager", func() {
+	ginkgo.It("should create volume metrics in Volume Manager", func() {
 		var err error
 		pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)
 		framework.ExpectNoError(err)
-		Expect(pvc).ToNot(Equal(nil))
+		gomega.Expect(pvc).ToNot(gomega.Equal(nil))
 
 		claims := []*v1.PersistentVolumeClaim{pvc}
 		pod := framework.MakePod(ns, nil, claims, false, "")
@@ -301,17 +301,17 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		totalVolumesKey := "volume_manager_total_volumes"
 		dimensions := []string{"state", "plugin_name"}
 		valid := hasValidMetrics(metrics.Metrics(kubeMetrics), totalVolumesKey, dimensions...)
-		Expect(valid).To(BeTrue(), "Invalid metric in Volume Manager metrics: %q", totalVolumesKey)
+		gomega.Expect(valid).To(gomega.BeTrue(), "Invalid metric in Volume Manager metrics: %q", totalVolumesKey)
 
 		e2elog.Logf("Deleting pod %q/%q", pod.Namespace, pod.Name)
 		framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod))
 	})
 
-	It("should create metrics for total number of volumes in A/D Controller", func() {
+	ginkgo.It("should create metrics for total number of volumes in A/D Controller", func() {
 		var err error
 		pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)
 		framework.ExpectNoError(err)
-		Expect(pvc).ToNot(Equal(nil))
+		gomega.Expect(pvc).ToNot(gomega.Equal(nil))
 
 		claims := []*v1.PersistentVolumeClaim{pvc}
 		pod := framework.MakePod(ns, nil, claims, false, "")
@@ -339,7 +339,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		// Forced detach metric should be present
 		forceDetachKey := "attachdetach_controller_forced_detaches"
 		_, ok := updatedControllerMetrics[forceDetachKey]
-		Expect(ok).To(BeTrue(), "Key %q not found in A/D Controller metrics", forceDetachKey)
+		gomega.Expect(ok).To(gomega.BeTrue(), "Key %q not found in A/D Controller metrics", forceDetachKey)
 
 		// Wait and validate
 		totalVolumesKey := "attachdetach_controller_total_volumes"
@@ -357,7 +357,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 			}
 			for pluginName, numVolumes := range updatedStates[stateName] {
 				oldNumVolumes := oldStates[stateName][pluginName]
-				Expect(numVolumes).To(BeNumerically(">=", oldNumVolumes),
+				gomega.Expect(numVolumes).To(gomega.BeNumerically(">=", oldNumVolumes),
 					"Wrong number of volumes in state %q, plugin %q: wanted >=%d, got %d",
 					stateName, pluginName, oldNumVolumes, numVolumes)
 			}
@@ -368,7 +368,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 	})
 
 	// Test for pv controller metrics, concretely: bound/unbound pv/pvc count.
-	Describe("PVController", func() {
+	ginkgo.Describe("PVController", func() {
 		const (
 			classKey     = "storage_class"
 			namespaceKey = "namespace"
@@ -414,7 +414,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		// should be 4, and the elements should be bound pv count, unbound pv count, bound
 		// pvc count, unbound pvc count in turn.
 		validator := func(metricValues []map[string]int64) {
-			Expect(len(metricValues)).To(Equal(4),
+			gomega.Expect(len(metricValues)).To(gomega.Equal(4),
 				"Wrong metric size: %d", len(metricValues))
 
 			controllerMetrics, err := metricsGrabber.GrabFromControllerManager()
@@ -430,13 +430,13 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 				// test suit are equal to expectValues.
 				actualValues := calculateRelativeValues(originMetricValues[i],
 					getPVControllerMetrics(controllerMetrics, metric.name, metric.dimension))
-				Expect(actualValues).To(Equal(expectValues),
+				gomega.Expect(actualValues).To(gomega.Equal(expectValues),
 					"Wrong pv controller metric %s(%s): wanted %v, got %v",
 					metric.name, metric.dimension, expectValues, actualValues)
 			}
 		}
 
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			if !metricsGrabber.HasRegisteredMaster() {
 				framework.Skipf("Environment does not support getting controller-manager metrics - skipping")
 			}
@@ -453,7 +453,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 			}
 		})
 
-		AfterEach(func() {
+		ginkgo.AfterEach(func() {
 			if err := framework.DeletePersistentVolume(c, pv.Name); err != nil {
 				framework.Failf("Error deleting pv: %v", err)
 			}
@@ -465,11 +465,11 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 			originMetricValues = nil
 		})
 
-		It("should create none metrics for pvc controller before creating any PV or PVC", func() {
+		ginkgo.It("should create none metrics for pvc controller before creating any PV or PVC", func() {
 			validator([]map[string]int64{nil, nil, nil, nil})
 		})
 
-		It("should create unbound pv count metrics for pvc controller after creating pv only",
+		ginkgo.It("should create unbound pv count metrics for pvc controller after creating pv only",
 			func() {
 				var err error
 				pv, err = framework.CreatePV(c, pv)
@@ -478,7 +478,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 				validator([]map[string]int64{nil, {className: 1}, nil, nil})
 			})
 
-		It("should create unbound pvc count metrics for pvc controller after creating pvc only",
+		ginkgo.It("should create unbound pvc count metrics for pvc controller after creating pvc only",
 			func() {
 				var err error
 				pvc, err = framework.CreatePVC(c, ns, pvc)
@@ -487,7 +487,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 				validator([]map[string]int64{nil, nil, nil, {ns: 1}})
 			})
 
-		It("should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc",
+		ginkgo.It("should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc",
 			func() {
 				var err error
 				pv, pvc, err = framework.CreatePVPVC(c, pvConfig, pvcConfig, ns, true)
@@ -578,10 +578,10 @@ func verifyMetricCount(oldMetrics, newMetrics *storageControllerMetrics, metricN
 
 	newLatencyCount, ok := newMetrics.latencyMetrics[metricName]
 	if !expectFailure {
-		Expect(ok).To(BeTrue(), "Error getting updated latency metrics for %s", metricName)
+		gomega.Expect(ok).To(gomega.BeTrue(), "Error getting updated latency metrics for %s", metricName)
 	}
 	newStatusCounts, ok := newMetrics.statusMetrics[metricName]
-	Expect(ok).To(BeTrue(), "Error getting updated status metrics for %s", metricName)
+	gomega.Expect(ok).To(gomega.BeTrue(), "Error getting updated status metrics for %s", metricName)
 
 	newStatusCount := int64(0)
 	if expectFailure {
@@ -594,9 +594,9 @@ func verifyMetricCount(oldMetrics, newMetrics *storageControllerMetrics, metricN
 	// even if the test is run serially.  We really just verify if new count
 	// is greater than old count
 	if !expectFailure {
-		Expect(newLatencyCount).To(BeNumerically(">", oldLatencyCount), "New latency count %d should be more than old count %d for action %s", newLatencyCount, oldLatencyCount, metricName)
+		gomega.Expect(newLatencyCount).To(gomega.BeNumerically(">", oldLatencyCount), "New latency count %d should be more than old count %d for action %s", newLatencyCount, oldLatencyCount, metricName)
 	}
-	Expect(newStatusCount).To(BeNumerically(">", oldStatusCount), "New status count %d should be more than old count %d for action %s", newStatusCount, oldStatusCount, metricName)
+	gomega.Expect(newStatusCount).To(gomega.BeNumerically(">", oldStatusCount), "New status count %d should be more than old count %d for action %s", newStatusCount, oldStatusCount, metricName)
 }
 
 func getControllerStorageMetrics(ms metrics.ControllerManagerMetrics) *storageControllerMetrics {
@@ -659,7 +659,7 @@ func findVolumeStatMetric(metricKeyName string, namespace string, pvcName string
 			}
 		}
 	}
-	Expect(errCount).To(Equal(0), "Found invalid samples")
+	gomega.Expect(errCount).To(gomega.Equal(0), "Found invalid samples")
 	return found
 }
 

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -68,7 +68,7 @@ func checkZoneFromLabelAndAffinity(pv *v1.PersistentVolume, zone string, matchZo
 // with key LabelZoneFailureDomain in PV's node affinity contains zone
 // matchZones is used to indicate if zones should match perfectly
 func checkZonesFromLabelAndAffinity(pv *v1.PersistentVolume, zones sets.String, matchZones bool) {
-	By("checking PV's zone label and node affinity terms match expected zone")
+	ginkgo.By("checking PV's zone label and node affinity terms match expected zone")
 	if pv == nil {
 		framework.Failf("nil pv passed")
 	}
@@ -222,7 +222,7 @@ func testZonalDelayedBinding(c clientset.Interface, ns string, specifyAllowedTop
 			topoZone = getRandomClusterZone(c)
 			addSingleZoneAllowedTopologyToStorageClass(c, test.Class, topoZone)
 		}
-		By(action)
+		ginkgo.By(action)
 		var claims []*v1.PersistentVolumeClaim
 		for i := 0; i < pvcCount; i++ {
 			claim := newClaim(test, ns, suffix)
@@ -253,13 +253,13 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 	var c clientset.Interface
 	var ns string
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		c = f.ClientSet
 		ns = f.Namespace.Name
 	})
 
-	Describe("DynamicProvisioner [Slow]", func() {
-		It("should provision storage with different parameters", func() {
+	ginkgo.Describe("DynamicProvisioner [Slow]", func() {
+		ginkgo.It("should provision storage with different parameters", func() {
 
 			// This test checks that dynamic provisioning can provision a volume
 			// that can be used to persist data among pods.
@@ -277,7 +277,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					ExpectedSize: "2Gi",
 					PvCheck: func(claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(c, claim, framework.NodeSelection{})
-						Expect(volume).NotTo(BeNil(), "get bound PV")
+						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
 						err := checkGCEPD(volume, "pd-ssd")
 						framework.ExpectNoError(err, "checkGCEPD pd-ssd")
@@ -294,7 +294,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					ExpectedSize: "2Gi",
 					PvCheck: func(claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(c, claim, framework.NodeSelection{})
-						Expect(volume).NotTo(BeNil(), "get bound PV")
+						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
 						err := checkGCEPD(volume, "pd-standard")
 						framework.ExpectNoError(err, "checkGCEPD pd-standard")
@@ -313,7 +313,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					ExpectedSize: "2Gi",
 					PvCheck: func(claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(c, claim, framework.NodeSelection{})
-						Expect(volume).NotTo(BeNil(), "get bound PV")
+						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
 						err := checkAWSEBS(volume, "gp2", false)
 						framework.ExpectNoError(err, "checkAWSEBS gp2")
@@ -331,7 +331,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					ExpectedSize: "4Gi", // 4 GiB is minimum for io1
 					PvCheck: func(claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(c, claim, framework.NodeSelection{})
-						Expect(volume).NotTo(BeNil(), "get bound PV")
+						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
 						err := checkAWSEBS(volume, "io1", false)
 						framework.ExpectNoError(err, "checkAWSEBS io1")
@@ -348,7 +348,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					ExpectedSize: "500Gi",
 					PvCheck: func(claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(c, claim, framework.NodeSelection{})
-						Expect(volume).NotTo(BeNil(), "get bound PV")
+						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
 						err := checkAWSEBS(volume, "sc1", false)
 						framework.ExpectNoError(err, "checkAWSEBS sc1")
@@ -365,7 +365,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					ExpectedSize: "500Gi",
 					PvCheck: func(claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(c, claim, framework.NodeSelection{})
-						Expect(volume).NotTo(BeNil(), "get bound PV")
+						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
 						err := checkAWSEBS(volume, "st1", false)
 						framework.ExpectNoError(err, "checkAWSEBS st1")
@@ -382,7 +382,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					ExpectedSize: "1Gi",
 					PvCheck: func(claim *v1.PersistentVolumeClaim) {
 						volume := testsuites.PVWriteReadSingleNodeCheck(c, claim, framework.NodeSelection{})
-						Expect(volume).NotTo(BeNil(), "get bound PV")
+						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
 						err := checkAWSEBS(volume, "gp2", true)
 						framework.ExpectNoError(err, "checkAWSEBS gp2 encrypted")
@@ -454,7 +454,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				// Remember the last supported test for subsequent test of beta API
 				betaTest = &test
 
-				By("Testing " + test.Name)
+				ginkgo.By("Testing " + test.Name)
 				suffix := fmt.Sprintf("%d", i)
 				test.Client = c
 				test.Class = newStorageClass(test, ns, suffix)
@@ -465,7 +465,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 			// Run the last test with storage.k8s.io/v1beta1 on pvc
 			if betaTest != nil {
-				By("Testing " + betaTest.Name + " with beta volume provisioning")
+				ginkgo.By("Testing " + betaTest.Name + " with beta volume provisioning")
 				class := newBetaStorageClass(*betaTest, "beta")
 				// we need to create the class manually, testDynamicProvisioning does not accept beta class
 				class, err := c.StorageV1beta1().StorageClasses().Create(class)
@@ -480,7 +480,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			}
 		})
 
-		It("should provision storage with non-default reclaim policy Retain", func() {
+		ginkgo.It("should provision storage with non-default reclaim policy Retain", func() {
 			framework.SkipUnlessProviderIs("gce", "gke")
 
 			test := testsuites.StorageClassTest{
@@ -495,7 +495,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				ExpectedSize: "1Gi",
 				PvCheck: func(claim *v1.PersistentVolumeClaim) {
 					volume := testsuites.PVWriteReadSingleNodeCheck(c, claim, framework.NodeSelection{})
-					Expect(volume).NotTo(BeNil(), "get bound PV")
+					gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
 
 					err := checkGCEPD(volume, "pd-standard")
 					framework.ExpectNoError(err, "checkGCEPD")
@@ -508,22 +508,22 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			test.Claim.Spec.StorageClassName = &test.Class.Name
 			pv := test.TestDynamicProvisioning()
 
-			By(fmt.Sprintf("waiting for the provisioned PV %q to enter phase %s", pv.Name, v1.VolumeReleased))
+			ginkgo.By(fmt.Sprintf("waiting for the provisioned PV %q to enter phase %s", pv.Name, v1.VolumeReleased))
 			framework.ExpectNoError(framework.WaitForPersistentVolumePhase(v1.VolumeReleased, c, pv.Name, 1*time.Second, 30*time.Second))
 
-			By(fmt.Sprintf("deleting the storage asset backing the PV %q", pv.Name))
+			ginkgo.By(fmt.Sprintf("deleting the storage asset backing the PV %q", pv.Name))
 			framework.ExpectNoError(framework.DeletePDWithRetry(pv.Spec.GCEPersistentDisk.PDName))
 
-			By(fmt.Sprintf("deleting the PV %q", pv.Name))
+			ginkgo.By(fmt.Sprintf("deleting the PV %q", pv.Name))
 			framework.ExpectNoError(framework.DeletePersistentVolume(c, pv.Name), "Failed to delete PV ", pv.Name)
 			framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(c, pv.Name, 1*time.Second, 30*time.Second))
 		})
 
-		It("should not provision a volume in an unmanaged GCE zone.", func() {
+		ginkgo.It("should not provision a volume in an unmanaged GCE zone.", func() {
 			framework.SkipUnlessProviderIs("gce", "gke")
 			var suffix string = "unmananged"
 
-			By("Discovering an unmanaged zone")
+			ginkgo.By("Discovering an unmanaged zone")
 			allZones := sets.NewString()     // all zones in the project
 			managedZones := sets.NewString() // subset of allZones
 
@@ -550,7 +550,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				framework.Skipf("No unmanaged zones found.")
 			}
 
-			By("Creating a StorageClass for the unmanaged zone")
+			ginkgo.By("Creating a StorageClass for the unmanaged zone")
 			test := testsuites.StorageClassTest{
 				Name:        "unmanaged_zone",
 				Provisioner: "kubernetes.io/gce-pd",
@@ -562,7 +562,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			framework.ExpectNoError(err)
 			defer deleteStorageClass(c, sc.Name)
 
-			By("Creating a claim and expecting it to timeout")
+			ginkgo.By("Creating a claim and expecting it to timeout")
 			pvc := newClaim(test, ns, suffix)
 			pvc.Spec.StorageClassName = &sc.Name
 			pvc, err = c.CoreV1().PersistentVolumeClaims(ns).Create(pvc)
@@ -573,11 +573,11 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 			// The claim should timeout phase:Pending
 			err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, pvc.Name, 2*time.Second, framework.ClaimProvisionShortTimeout)
-			Expect(err).To(HaveOccurred())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 			e2elog.Logf(err.Error())
 		})
 
-		It("should test that deleting a claim before the volume is provisioned deletes the volume.", func() {
+		ginkgo.It("should test that deleting a claim before the volume is provisioned deletes the volume.", func() {
 			// This case tests for the regressions of a bug fixed by PR #21268
 			// REGRESSION: Deleting the PVC before the PV is provisioned can result in the PV
 			// not being deleted.
@@ -587,7 +587,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 			const raceAttempts int = 100
 			var residualPVs []*v1.PersistentVolume
-			By(fmt.Sprintf("Creating and deleting PersistentVolumeClaims %d times", raceAttempts))
+			ginkgo.By(fmt.Sprintf("Creating and deleting PersistentVolumeClaims %d times", raceAttempts))
 			test := testsuites.StorageClassTest{
 				Name:        "deletion race",
 				Provisioner: "", // Use a native one based on current cloud provider
@@ -609,7 +609,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, tmpClaim.Name, ns))
 			}
 
-			By(fmt.Sprintf("Checking for residual PersistentVolumes associated with StorageClass %s", class.Name))
+			ginkgo.By(fmt.Sprintf("Checking for residual PersistentVolumes associated with StorageClass %s", class.Name))
 			residualPVs, err = waitForProvisionedVolumesDeleted(c, class.Name)
 			framework.ExpectNoError(err)
 			// Cleanup the test resources before breaking
@@ -626,18 +626,18 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			e2elog.Logf("0 PersistentVolumes remain.")
 		})
 
-		It("deletion should be idempotent", func() {
+		ginkgo.It("deletion should be idempotent", func() {
 			// This test ensures that deletion of a volume is idempotent.
 			// It creates a PV with Retain policy, deletes underlying AWS / GCE
 			// volume and changes the reclaim policy to Delete.
 			// PV controller should delete the PV even though the underlying volume
 			// is already deleted.
 			framework.SkipUnlessProviderIs("gce", "gke", "aws")
-			By("creating PD")
+			ginkgo.By("creating PD")
 			diskName, err := framework.CreatePDWithRetry()
 			framework.ExpectNoError(err)
 
-			By("creating PV")
+			ginkgo.By("creating PV")
 			pv := &v1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "volume-idempotent-delete-",
@@ -680,29 +680,29 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			pv, err = c.CoreV1().PersistentVolumes().Create(pv)
 			framework.ExpectNoError(err)
 
-			By("waiting for the PV to get Released")
+			ginkgo.By("waiting for the PV to get Released")
 			err = framework.WaitForPersistentVolumePhase(v1.VolumeReleased, c, pv.Name, 2*time.Second, framework.PVReclaimingTimeout)
 			framework.ExpectNoError(err)
 
-			By("deleting the PD")
+			ginkgo.By("deleting the PD")
 			err = framework.DeletePVSource(&pv.Spec.PersistentVolumeSource)
 			framework.ExpectNoError(err)
 
-			By("changing the PV reclaim policy")
+			ginkgo.By("changing the PV reclaim policy")
 			pv, err = c.CoreV1().PersistentVolumes().Get(pv.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 			pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimDelete
 			pv, err = c.CoreV1().PersistentVolumes().Update(pv)
 			framework.ExpectNoError(err)
 
-			By("waiting for the PV to get deleted")
+			ginkgo.By("waiting for the PV to get deleted")
 			err = framework.WaitForPersistentVolumeDeleted(c, pv.Name, 5*time.Second, framework.PVDeletingTimeout)
 			framework.ExpectNoError(err)
 		})
 	})
 
-	Describe("DynamicProvisioner External", func() {
-		It("should let an external dynamic provisioner create and delete persistent volumes [Slow]", func() {
+	ginkgo.Describe("DynamicProvisioner External", func() {
+		ginkgo.It("should let an external dynamic provisioner create and delete persistent volumes [Slow]", func() {
 			// external dynamic provisioner pods need additional permissions provided by the
 			// persistent-volume-provisioner clusterrole and a leader-locking role
 			serviceAccountName := "default"
@@ -736,11 +736,11 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				"", "get", schema.GroupResource{Group: "storage.k8s.io", Resource: "storageclasses"}, true)
 			framework.ExpectNoError(err, "Failed to update authorization")
 
-			By("creating an external dynamic provisioner pod")
+			ginkgo.By("creating an external dynamic provisioner pod")
 			pod := utils.StartExternalProvisioner(c, ns, externalPluginName)
 			defer framework.DeletePodOrFail(c, ns, pod.Name)
 
-			By("creating a StorageClass")
+			ginkgo.By("creating a StorageClass")
 			test := testsuites.StorageClassTest{
 				Client:       c,
 				Name:         "external provisioner test",
@@ -752,16 +752,16 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			test.Claim = newClaim(test, ns, "external")
 			test.Claim.Spec.StorageClassName = &test.Class.Name
 
-			By("creating a claim with a external provisioning annotation")
+			ginkgo.By("creating a claim with a external provisioning annotation")
 			test.TestDynamicProvisioning()
 		})
 	})
 
-	Describe("DynamicProvisioner Default", func() {
-		It("should create and delete default persistent volumes [Slow]", func() {
+	ginkgo.Describe("DynamicProvisioner Default", func() {
+		ginkgo.It("should create and delete default persistent volumes [Slow]", func() {
 			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
 
-			By("creating a claim with no annotation")
+			ginkgo.By("creating a claim with no annotation")
 			test := testsuites.StorageClassTest{
 				Client:       c,
 				Name:         "default",
@@ -774,7 +774,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 		})
 
 		// Modifying the default storage class can be disruptive to other tests that depend on it
-		It("should be disabled by changing the default annotation [Serial] [Disruptive]", func() {
+		ginkgo.It("should be disabled by changing the default annotation [Serial] [Disruptive]", func() {
 			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
 			scName, scErr := framework.GetDefaultStorageClassName(c)
 			if scErr != nil {
@@ -785,12 +785,12 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				ClaimSize: "2Gi",
 			}
 
-			By("setting the is-default StorageClass annotation to false")
+			ginkgo.By("setting the is-default StorageClass annotation to false")
 			verifyDefaultStorageClass(c, scName, true)
 			defer updateDefaultStorageClass(c, scName, "true")
 			updateDefaultStorageClass(c, scName, "false")
 
-			By("creating a claim with default storageclass and expecting it to timeout")
+			ginkgo.By("creating a claim with default storageclass and expecting it to timeout")
 			claim := newClaim(test, ns, "default")
 			claim, err := c.CoreV1().PersistentVolumeClaims(ns).Create(claim)
 			framework.ExpectNoError(err)
@@ -800,15 +800,15 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 			// The claim should timeout phase:Pending
 			err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, claim.Name, 2*time.Second, framework.ClaimProvisionShortTimeout)
-			Expect(err).To(HaveOccurred())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 			e2elog.Logf(err.Error())
 			claim, err = c.CoreV1().PersistentVolumeClaims(ns).Get(claim.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
-			Expect(claim.Status.Phase).To(Equal(v1.ClaimPending))
+			gomega.Expect(claim.Status.Phase).To(gomega.Equal(v1.ClaimPending))
 		})
 
 		// Modifying the default storage class can be disruptive to other tests that depend on it
-		It("should be disabled by removing the default annotation [Serial] [Disruptive]", func() {
+		ginkgo.It("should be disabled by removing the default annotation [Serial] [Disruptive]", func() {
 			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
 			scName, scErr := framework.GetDefaultStorageClassName(c)
 			if scErr != nil {
@@ -819,12 +819,12 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				ClaimSize: "2Gi",
 			}
 
-			By("removing the is-default StorageClass annotation")
+			ginkgo.By("removing the is-default StorageClass annotation")
 			verifyDefaultStorageClass(c, scName, true)
 			defer updateDefaultStorageClass(c, scName, "true")
 			updateDefaultStorageClass(c, scName, "")
 
-			By("creating a claim with default storageclass and expecting it to timeout")
+			ginkgo.By("creating a claim with default storageclass and expecting it to timeout")
 			claim := newClaim(test, ns, "default")
 			claim, err := c.CoreV1().PersistentVolumeClaims(ns).Create(claim)
 			framework.ExpectNoError(err)
@@ -834,21 +834,21 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 			// The claim should timeout phase:Pending
 			err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, claim.Name, 2*time.Second, framework.ClaimProvisionShortTimeout)
-			Expect(err).To(HaveOccurred())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 			e2elog.Logf(err.Error())
 			claim, err = c.CoreV1().PersistentVolumeClaims(ns).Get(claim.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
-			Expect(claim.Status.Phase).To(Equal(v1.ClaimPending))
+			gomega.Expect(claim.Status.Phase).To(gomega.Equal(v1.ClaimPending))
 		})
 	})
 
 	framework.KubeDescribe("GlusterDynamicProvisioner", func() {
-		It("should create and delete persistent volumes [fast]", func() {
+		ginkgo.It("should create and delete persistent volumes [fast]", func() {
 			framework.SkipIfProviderIs("gke")
-			By("creating a Gluster DP server Pod")
+			ginkgo.By("creating a Gluster DP server Pod")
 			pod := startGlusterDpServerPod(c, ns)
 			serverUrl := "http://" + pod.Status.PodIP + ":8081"
-			By("creating a StorageClass")
+			ginkgo.By("creating a StorageClass")
 			test := testsuites.StorageClassTest{
 				Client:       c,
 				Name:         "Gluster Dynamic provisioner test",
@@ -860,7 +860,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			suffix := fmt.Sprintf("glusterdptest")
 			test.Class = newStorageClass(test, ns, suffix)
 
-			By("creating a claim object with a suffix for gluster dynamic provisioner")
+			ginkgo.By("creating a claim object with a suffix for gluster dynamic provisioner")
 			test.Claim = newClaim(test, ns, suffix)
 			test.Claim.Spec.StorageClassName = &test.Class.Name
 
@@ -868,8 +868,8 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 		})
 	})
 
-	Describe("Invalid AWS KMS key", func() {
-		It("should report an error and create no PV", func() {
+	ginkgo.Describe("Invalid AWS KMS key", func() {
+		ginkgo.It("should report an error and create no PV", func() {
 			framework.SkipUnlessProviderIs("aws")
 			test := testsuites.StorageClassTest{
 				Name:        "AWS EBS with invalid KMS key",
@@ -878,7 +878,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				Parameters:  map[string]string{"kmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/55555555-5555-5555-5555-555555555555"},
 			}
 
-			By("creating a StorageClass")
+			ginkgo.By("creating a StorageClass")
 			suffix := fmt.Sprintf("invalid-aws")
 			class := newStorageClass(test, ns, suffix)
 			class, err := c.StorageV1().StorageClasses().Create(class)
@@ -888,7 +888,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				framework.ExpectNoError(c.StorageV1().StorageClasses().Delete(class.Name, nil))
 			}()
 
-			By("creating a claim object with a suffix for gluster dynamic provisioner")
+			ginkgo.By("creating a claim object with a suffix for gluster dynamic provisioner")
 			claim := newClaim(test, ns, suffix)
 			claim.Spec.StorageClassName = &class.Name
 			claim, err = c.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(claim)
@@ -932,14 +932,14 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			framework.ExpectNoError(err)
 		})
 	})
-	Describe("DynamicProvisioner delayed binding [Slow]", func() {
-		It("should create persistent volumes in the same zone as node after a pod mounting the claims is started", func() {
+	ginkgo.Describe("DynamicProvisioner delayed binding [Slow]", func() {
+		ginkgo.It("should create persistent volumes in the same zone as node after a pod mounting the claims is started", func() {
 			testZonalDelayedBinding(c, ns, false /*specifyAllowedTopology*/, 1 /*pvcCount*/)
 			testZonalDelayedBinding(c, ns, false /*specifyAllowedTopology*/, 3 /*pvcCount*/)
 		})
 	})
-	Describe("DynamicProvisioner allowedTopologies", func() {
-		It("should create persistent volume in the zone specified in allowedTopologies of storageclass", func() {
+	ginkgo.Describe("DynamicProvisioner allowedTopologies", func() {
+		ginkgo.It("should create persistent volume in the zone specified in allowedTopologies of storageclass", func() {
 			tests := []testsuites.StorageClassTest{
 				{
 					Name:           "AllowedTopologies EBS storage class test",
@@ -961,7 +961,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					e2elog.Logf("Skipping %q: cloud providers is not %v", test.Name, test.CloudProviders)
 					continue
 				}
-				By("creating a claim with class with allowedTopologies set")
+				ginkgo.By("creating a claim with class with allowedTopologies set")
 				suffix := "topology"
 				test.Client = c
 				test.Class = newStorageClass(test, ns, suffix)
@@ -974,8 +974,8 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			}
 		})
 	})
-	Describe("DynamicProvisioner delayed binding with allowedTopologies [Slow]", func() {
-		It("should create persistent volumes in the same zone as specified in allowedTopologies after a pod mounting the claims is started", func() {
+	ginkgo.Describe("DynamicProvisioner delayed binding with allowedTopologies [Slow]", func() {
+		ginkgo.It("should create persistent volumes in the same zone as specified in allowedTopologies after a pod mounting the claims is started", func() {
 			testZonalDelayedBinding(c, ns, true /*specifyAllowedTopology*/, 1 /*pvcCount*/)
 			testZonalDelayedBinding(c, ns, true /*specifyAllowedTopology*/, 3 /*pvcCount*/)
 		})
@@ -985,7 +985,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 func verifyDefaultStorageClass(c clientset.Interface, scName string, expectedDefault bool) {
 	sc, err := c.StorageV1().StorageClasses().Get(scName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	Expect(storageutil.IsDefaultAnnotation(sc.ObjectMeta)).To(Equal(expectedDefault))
+	gomega.Expect(storageutil.IsDefaultAnnotation(sc.ObjectMeta)).To(gomega.Equal(expectedDefault))
 }
 
 func updateDefaultStorageClass(c clientset.Interface, scName string, defaultStr string) {
@@ -1181,7 +1181,7 @@ func startGlusterDpServerPod(c clientset.Interface, ns string) *v1.Pod {
 
 	framework.ExpectNoError(framework.WaitForPodRunningInNamespace(c, provisionerPod))
 
-	By("locating the provisioner pod")
+	ginkgo.By("locating the provisioner pod")
 	pod, err := podClient.Get(provisionerPod.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err, "Cannot locate the provisioner pod %v: %v", provisionerPod.Name, err)
 	return pod
@@ -1231,8 +1231,8 @@ func deleteProvisionedVolumesAndDisks(c clientset.Interface, pvs []*v1.Persisten
 
 func getRandomClusterZone(c clientset.Interface) string {
 	zones, err := framework.GetClusterZones(c)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(len(zones)).ToNot(Equal(0))
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Expect(len(zones)).ToNot(gomega.Equal(0))
 
 	zonesList := zones.UnsortedList()
 	return zonesList[rand.Intn(zones.Len())]

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -573,7 +573,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 			// The claim should timeout phase:Pending
 			err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, pvc.Name, 2*time.Second, framework.ClaimProvisionShortTimeout)
-			gomega.Expect(err).To(gomega.HaveOccurred())
+			framework.ExpectError(err)
 			e2elog.Logf(err.Error())
 		})
 
@@ -800,7 +800,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 			// The claim should timeout phase:Pending
 			err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, claim.Name, 2*time.Second, framework.ClaimProvisionShortTimeout)
-			gomega.Expect(err).To(gomega.HaveOccurred())
+			framework.ExpectError(err)
 			e2elog.Logf(err.Error())
 			claim, err = c.CoreV1().PersistentVolumeClaims(ns).Get(claim.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
@@ -834,7 +834,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 			// The claim should timeout phase:Pending
 			err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, claim.Name, 2*time.Second, framework.ClaimProvisionShortTimeout)
-			gomega.Expect(err).To(gomega.HaveOccurred())
+			framework.ExpectError(err)
 			e2elog.Logf(err.Error())
 			claim, err = c.CoreV1().PersistentVolumeClaims(ns).Get(claim.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)

--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -18,7 +18,7 @@ limitations under the License.
 package storage
 
 import (
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -36,13 +36,13 @@ var _ = utils.SIGDescribe("Volumes", func() {
 	var cs clientset.Interface
 	var namespace *v1.Namespace
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		cs = f.ClientSet
 		namespace = f.Namespace
 	})
 
-	Describe("ConfigMap", func() {
-		It("should be mountable", func() {
+	ginkgo.Describe("ConfigMap", func() {
+		ginkgo.It("should be mountable", func() {
 			config := volume.TestConfig{
 				Namespace: namespace.Name,
 				Prefix:    "configmap",

--- a/test/e2e/storage/vsphere/persistent_volumes-vsphere.go
+++ b/test/e2e/storage/vsphere/persistent_volumes-vsphere.go
@@ -19,8 +19,8 @@ package vsphere
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -58,7 +58,7 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere", func() {
 		4. Create a POD using the PVC.
 		5. Verify Disk and Attached to the node.
 	*/
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		c = f.ClientSet
@@ -95,23 +95,23 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere", func() {
 				StorageClassName: &emptyStorageClass,
 			}
 		}
-		By("Creating the PV and PVC")
+		ginkgo.By("Creating the PV and PVC")
 		pv, pvc, err = framework.CreatePVPVC(c, pvConfig, pvcConfig, ns, false)
 		framework.ExpectNoError(err)
 		framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv, pvc))
 
-		By("Creating the Client Pod")
+		ginkgo.By("Creating the Client Pod")
 		clientPod, err = framework.CreateClientPod(c, ns, pvc)
 		framework.ExpectNoError(err)
 		node = clientPod.Spec.NodeName
 
-		By("Verify disk should be attached to the node")
+		ginkgo.By("Verify disk should be attached to the node")
 		isAttached, err := diskIsAttached(volumePath, node)
 		framework.ExpectNoError(err)
-		Expect(isAttached).To(BeTrue(), "disk is not attached with the node")
+		gomega.Expect(isAttached).To(gomega.BeTrue(), "disk is not attached with the node")
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		e2elog.Logf("AfterEach: Cleaning up test resources")
 		if c != nil {
 			framework.ExpectNoError(framework.DeletePodWithWait(f, c, clientPod), "AfterEach: failed to delete pod ", clientPod.Name)
@@ -147,12 +147,12 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere", func() {
 		2. Delete POD, POD deletion should succeed.
 	*/
 
-	It("should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach", func() {
-		By("Deleting the Claim")
+	ginkgo.It("should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach", func() {
+		ginkgo.By("Deleting the Claim")
 		framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)
 		pvc = nil
 
-		By("Deleting the Pod")
+		ginkgo.By("Deleting the Pod")
 		framework.ExpectNoError(framework.DeletePodWithWait(f, c, clientPod), "Failed to delete pod ", clientPod.Name)
 	})
 
@@ -163,12 +163,12 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere", func() {
 		1. Delete PV.
 		2. Delete POD, POD deletion should succeed.
 	*/
-	It("should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach", func() {
-		By("Deleting the Persistent Volume")
+	ginkgo.It("should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach", func() {
+		ginkgo.By("Deleting the Persistent Volume")
 		framework.ExpectNoError(framework.DeletePersistentVolume(c, pv.Name), "Failed to delete PV ", pv.Name)
 		pv = nil
 
-		By("Deleting the pod")
+		ginkgo.By("Deleting the pod")
 		framework.ExpectNoError(framework.DeletePodWithWait(f, c, clientPod), "Failed to delete pod ", clientPod.Name)
 	})
 	/*
@@ -178,7 +178,7 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere", func() {
 		2. Restart kubelet
 		3. Verify that written file is accessible after kubelet restart
 	*/
-	It("should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]", func() {
+	ginkgo.It("should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]", func() {
 		utils.TestKubeletRestartsAndRestoresMount(c, f, clientPod)
 	})
 
@@ -193,7 +193,7 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere", func() {
 		4. Start kubelet.
 		5. Verify that volume mount not to be found.
 	*/
-	It("should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]", func() {
+	ginkgo.It("should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]", func() {
 		utils.TestVolumeUnmountsFromDeletedPod(c, f, clientPod)
 	})
 
@@ -205,15 +205,15 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere", func() {
 		2. Wait for namespace to get deleted. (Namespace deletion should trigger deletion of belonging pods)
 		3. Verify volume should be detached from the node.
 	*/
-	It("should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume", func() {
-		By("Deleting the Namespace")
+	ginkgo.It("should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume", func() {
+		ginkgo.By("Deleting the Namespace")
 		err := c.CoreV1().Namespaces().Delete(ns, nil)
 		framework.ExpectNoError(err)
 
 		err = framework.WaitForNamespacesDeleted(c, []string{ns}, 3*time.Minute)
 		framework.ExpectNoError(err)
 
-		By("Verifying Persistent Disk detaches")
+		ginkgo.By("Verifying Persistent Disk detaches")
 		waitForVSphereDiskToDetach(volumePath, node)
 	})
 })

--- a/test/e2e/storage/vsphere/pv_reclaimpolicy.go
+++ b/test/e2e/storage/vsphere/pv_reclaimpolicy.go
@@ -20,8 +20,8 @@ import (
 	"strconv"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,14 +42,14 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
 		nodeInfo   *NodeInfo
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		c = f.ClientSet
 		ns = f.Namespace.Name
 		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
 	})
 
 	utils.SIGDescribe("persistentvolumereclaim:vsphere", func() {
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			framework.SkipUnlessProviderIs("vsphere")
 			Bootstrap(f)
 			nodeInfo = GetReadySchedulableRandomNodeInfo()
@@ -58,7 +58,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
 			volumePath = ""
 		})
 
-		AfterEach(func() {
+		ginkgo.AfterEach(func() {
 			testCleanupVSpherePersistentVolumeReclaim(c, nodeInfo, ns, volumePath, pv, pvc)
 		})
 
@@ -74,7 +74,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
 			5. Delete PVC
 			6. Verify PV is deleted automatically.
 		*/
-		It("should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted", func() {
+		ginkgo.It("should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted", func() {
 			var err error
 			volumePath, pv, pvc, err = testSetupVSpherePersistentVolumeReclaim(c, nodeInfo, ns, v1.PersistentVolumeReclaimDelete)
 			framework.ExpectNoError(err)
@@ -82,7 +82,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
 			deletePVCAfterBind(c, ns, pvc, pv)
 			pvc = nil
 
-			By("verify pv is deleted")
+			ginkgo.By("verify pv is deleted")
 			err = framework.WaitForPersistentVolumeDeleted(c, pv.Name, 3*time.Second, 300*time.Second)
 			framework.ExpectNoError(err)
 
@@ -102,7 +102,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
 			8. Delete the pod.
 			9. Verify PV should be detached from the node and automatically deleted.
 		*/
-		It("should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod", func() {
+		ginkgo.It("should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod", func() {
 			var err error
 
 			volumePath, pv, pvc, err = testSetupVSpherePersistentVolumeReclaim(c, nodeInfo, ns, v1.PersistentVolumeReclaimDelete)
@@ -110,35 +110,35 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
 			// Wait for PV and PVC to Bind
 			framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv, pvc))
 
-			By("Creating the Pod")
+			ginkgo.By("Creating the Pod")
 			pod, err := framework.CreateClientPod(c, ns, pvc)
 			framework.ExpectNoError(err)
 
-			By("Deleting the Claim")
+			ginkgo.By("Deleting the Claim")
 			framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)
 			pvc = nil
 
 			// Verify PV is Present, after PVC is deleted and PV status should be Failed.
 			pv, err := c.CoreV1().PersistentVolumes().Get(pv.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
-			Expect(framework.WaitForPersistentVolumePhase(v1.VolumeFailed, c, pv.Name, 1*time.Second, 60*time.Second)).NotTo(HaveOccurred())
+			gomega.Expect(framework.WaitForPersistentVolumePhase(v1.VolumeFailed, c, pv.Name, 1*time.Second, 60*time.Second)).NotTo(gomega.HaveOccurred())
 
-			By("Verify the volume is attached to the node")
+			ginkgo.By("Verify the volume is attached to the node")
 			isVolumeAttached, verifyDiskAttachedError := diskIsAttached(pv.Spec.VsphereVolume.VolumePath, pod.Spec.NodeName)
-			Expect(verifyDiskAttachedError).NotTo(HaveOccurred())
-			Expect(isVolumeAttached).To(BeTrue())
+			gomega.Expect(verifyDiskAttachedError).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isVolumeAttached).To(gomega.BeTrue())
 
-			By("Verify the volume is accessible and available in the pod")
+			ginkgo.By("Verify the volume is accessible and available in the pod")
 			verifyVSphereVolumesAccessible(c, pod, []*v1.PersistentVolume{pv})
 			e2elog.Logf("Verified that Volume is accessible in the POD after deleting PV claim")
 
-			By("Deleting the Pod")
+			ginkgo.By("Deleting the Pod")
 			framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod), "Failed to delete pod ", pod.Name)
 
-			By("Verify PV is detached from the node after Pod is deleted")
-			Expect(waitForVSphereDiskToDetach(pv.Spec.VsphereVolume.VolumePath, pod.Spec.NodeName)).NotTo(HaveOccurred())
+			ginkgo.By("Verify PV is detached from the node after Pod is deleted")
+			gomega.Expect(waitForVSphereDiskToDetach(pv.Spec.VsphereVolume.VolumePath, pod.Spec.NodeName)).NotTo(gomega.HaveOccurred())
 
-			By("Verify PV should be deleted automatically")
+			ginkgo.By("Verify PV should be deleted automatically")
 			framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(c, pv.Name, 1*time.Second, 30*time.Second))
 			pv = nil
 			volumePath = ""
@@ -162,7 +162,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
 			11. Created POD using PVC created in Step 10 and verify volume content is matching.
 		*/
 
-		It("should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted", func() {
+		ginkgo.It("should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted", func() {
 			var err error
 			var volumeFileContent = "hello from vsphere cloud provider, Random Content is :" + strconv.FormatInt(time.Now().UnixNano(), 10)
 
@@ -171,27 +171,27 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
 
 			writeContentToVSpherePV(c, pvc, volumeFileContent)
 
-			By("Delete PVC")
+			ginkgo.By("Delete PVC")
 			framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)
 			pvc = nil
 
-			By("Verify PV is retained")
+			ginkgo.By("Verify PV is retained")
 			e2elog.Logf("Waiting for PV %v to become Released", pv.Name)
 			err = framework.WaitForPersistentVolumePhase(v1.VolumeReleased, c, pv.Name, 3*time.Second, 300*time.Second)
 			framework.ExpectNoError(err)
 			framework.ExpectNoError(framework.DeletePersistentVolume(c, pv.Name), "Failed to delete PV ", pv.Name)
 
-			By("Creating the PV for same volume path")
+			ginkgo.By("Creating the PV for same volume path")
 			pv = getVSpherePersistentVolumeSpec(volumePath, v1.PersistentVolumeReclaimRetain, nil)
 			pv, err = c.CoreV1().PersistentVolumes().Create(pv)
 			framework.ExpectNoError(err)
 
-			By("creating the pvc")
+			ginkgo.By("creating the pvc")
 			pvc = getVSpherePersistentVolumeClaimSpec(ns, nil)
 			pvc, err = c.CoreV1().PersistentVolumeClaims(ns).Create(pvc)
 			framework.ExpectNoError(err)
 
-			By("wait for the pv and pvc to bind")
+			ginkgo.By("wait for the pv and pvc to bind")
 			framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv, pvc))
 			verifyContentOfVSpherePV(c, pvc, volumeFileContent)
 
@@ -201,19 +201,19 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
 
 // Test Setup for persistentvolumereclaim tests for vSphere Provider
 func testSetupVSpherePersistentVolumeReclaim(c clientset.Interface, nodeInfo *NodeInfo, ns string, persistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy) (volumePath string, pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim, err error) {
-	By("running testSetupVSpherePersistentVolumeReclaim")
-	By("creating vmdk")
+	ginkgo.By("running testSetupVSpherePersistentVolumeReclaim")
+	ginkgo.By("creating vmdk")
 	volumePath, err = nodeInfo.VSphere.CreateVolume(&VolumeOptions{}, nodeInfo.DataCenterRef)
 	if err != nil {
 		return
 	}
-	By("creating the pv")
+	ginkgo.By("creating the pv")
 	pv = getVSpherePersistentVolumeSpec(volumePath, persistentVolumeReclaimPolicy, nil)
 	pv, err = c.CoreV1().PersistentVolumes().Create(pv)
 	if err != nil {
 		return
 	}
-	By("creating the pvc")
+	ginkgo.By("creating the pvc")
 	pvc = getVSpherePersistentVolumeClaimSpec(ns, nil)
 	pvc, err = c.CoreV1().PersistentVolumeClaims(ns).Create(pvc)
 	return
@@ -221,7 +221,7 @@ func testSetupVSpherePersistentVolumeReclaim(c clientset.Interface, nodeInfo *No
 
 // Test Cleanup for persistentvolumereclaim tests for vSphere Provider
 func testCleanupVSpherePersistentVolumeReclaim(c clientset.Interface, nodeInfo *NodeInfo, ns string, volumePath string, pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim) {
-	By("running testCleanupVSpherePersistentVolumeReclaim")
+	ginkgo.By("running testCleanupVSpherePersistentVolumeReclaim")
 	if len(volumePath) > 0 {
 		err := nodeInfo.VSphere.DeleteVolume(volumePath, nodeInfo.DataCenterRef)
 		framework.ExpectNoError(err)
@@ -238,10 +238,10 @@ func testCleanupVSpherePersistentVolumeReclaim(c clientset.Interface, nodeInfo *
 func deletePVCAfterBind(c clientset.Interface, ns string, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) {
 	var err error
 
-	By("wait for the pv and pvc to bind")
+	ginkgo.By("wait for the pv and pvc to bind")
 	framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv, pvc))
 
-	By("delete pvc")
+	ginkgo.By("delete pvc")
 	framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)
 	pvc, err = c.CoreV1().PersistentVolumeClaims(ns).Get(pvc.Name, metav1.GetOptions{})
 	if !apierrs.IsNotFound(err) {

--- a/test/e2e/storage/vsphere/pvc_label_selector.go
+++ b/test/e2e/storage/vsphere/pvc_label_selector.go
@@ -19,7 +19,7 @@ package vsphere
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -57,7 +57,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:LabelSelector]", func() {
 		err        error
 		nodeInfo   *NodeInfo
 	)
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		c = f.ClientSet
 		ns = f.Namespace.Name
@@ -72,67 +72,67 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:LabelSelector]", func() {
 	})
 
 	utils.SIGDescribe("Selector-Label Volume Binding:vsphere", func() {
-		AfterEach(func() {
-			By("Running clean up actions")
+		ginkgo.AfterEach(func() {
+			ginkgo.By("Running clean up actions")
 			if framework.ProviderIs("vsphere") {
 				testCleanupVSpherePVClabelselector(c, ns, nodeInfo, volumePath, pv_ssd, pvc_ssd, pvc_vvol)
 			}
 		})
-		It("should bind volume with claim for given label", func() {
+		ginkgo.It("should bind volume with claim for given label", func() {
 			volumePath, pv_ssd, pvc_ssd, pvc_vvol, err = testSetupVSpherePVClabelselector(c, nodeInfo, ns, ssdlabels, vvollabels)
 			framework.ExpectNoError(err)
 
-			By("wait for the pvc_ssd to bind with pv_ssd")
+			ginkgo.By("wait for the pvc_ssd to bind with pv_ssd")
 			framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv_ssd, pvc_ssd))
 
-			By("Verify status of pvc_vvol is pending")
+			ginkgo.By("Verify status of pvc_vvol is pending")
 			err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, c, ns, pvc_vvol.Name, 3*time.Second, 300*time.Second)
 			framework.ExpectNoError(err)
 
-			By("delete pvc_ssd")
+			ginkgo.By("delete pvc_ssd")
 			framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc_ssd.Name, ns), "Failed to delete PVC ", pvc_ssd.Name)
 
-			By("verify pv_ssd is deleted")
+			ginkgo.By("verify pv_ssd is deleted")
 			err = framework.WaitForPersistentVolumeDeleted(c, pv_ssd.Name, 3*time.Second, 300*time.Second)
 			framework.ExpectNoError(err)
 			volumePath = ""
 
-			By("delete pvc_vvol")
+			ginkgo.By("delete pvc_vvol")
 			framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc_vvol.Name, ns), "Failed to delete PVC ", pvc_vvol.Name)
 		})
 	})
 })
 
 func testSetupVSpherePVClabelselector(c clientset.Interface, nodeInfo *NodeInfo, ns string, ssdlabels map[string]string, vvollabels map[string]string) (volumePath string, pv_ssd *v1.PersistentVolume, pvc_ssd *v1.PersistentVolumeClaim, pvc_vvol *v1.PersistentVolumeClaim, err error) {
-	By("creating vmdk")
+	ginkgo.By("creating vmdk")
 	volumePath = ""
 	volumePath, err = nodeInfo.VSphere.CreateVolume(&VolumeOptions{}, nodeInfo.DataCenterRef)
 	if err != nil {
 		return
 	}
 
-	By("creating the pv with label volume-type:ssd")
+	ginkgo.By("creating the pv with label volume-type:ssd")
 	pv_ssd = getVSpherePersistentVolumeSpec(volumePath, v1.PersistentVolumeReclaimDelete, ssdlabels)
 	pv_ssd, err = c.CoreV1().PersistentVolumes().Create(pv_ssd)
 	if err != nil {
 		return
 	}
 
-	By("creating pvc with label selector to match with volume-type:vvol")
+	ginkgo.By("creating pvc with label selector to match with volume-type:vvol")
 	pvc_vvol = getVSpherePersistentVolumeClaimSpec(ns, vvollabels)
 	pvc_vvol, err = c.CoreV1().PersistentVolumeClaims(ns).Create(pvc_vvol)
 	if err != nil {
 		return
 	}
 
-	By("creating pvc with label selector to match with volume-type:ssd")
+	ginkgo.By("creating pvc with label selector to match with volume-type:ssd")
 	pvc_ssd = getVSpherePersistentVolumeClaimSpec(ns, ssdlabels)
 	pvc_ssd, err = c.CoreV1().PersistentVolumeClaims(ns).Create(pvc_ssd)
 	return
 }
 
 func testCleanupVSpherePVClabelselector(c clientset.Interface, ns string, nodeInfo *NodeInfo, volumePath string, pv_ssd *v1.PersistentVolume, pvc_ssd *v1.PersistentVolumeClaim, pvc_vvol *v1.PersistentVolumeClaim) {
-	By("running testCleanupVSpherePVClabelselector")
+	ginkgo.By("running testCleanupVSpherePVClabelselector")
 	if len(volumePath) > 0 {
 		nodeInfo.VSphere.DeleteVolume(volumePath, nodeInfo.DataCenterRef)
 	}

--- a/test/e2e/storage/vsphere/vsphere_common.go
+++ b/test/e2e/storage/vsphere/vsphere_common.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"strconv"
 
-	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -67,7 +67,7 @@ const (
 
 func GetAndExpectStringEnvVar(varName string) string {
 	varValue := os.Getenv(varName)
-	Expect(varValue).NotTo(BeEmpty(), "ENV "+varName+" is not set")
+	gomega.Expect(varValue).NotTo(gomega.BeEmpty(), "ENV "+varName+" is not set")
 	return varValue
 }
 

--- a/test/e2e/storage/vsphere/vsphere_scale.go
+++ b/test/e2e/storage/vsphere/vsphere_scale.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"strconv"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
 	storageV1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,7 +67,7 @@ var _ = utils.SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 		scNames           = []string{storageclass1, storageclass2, storageclass3, storageclass4}
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
@@ -79,8 +79,8 @@ var _ = utils.SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 		volumesPerPod = GetAndExpectIntEnvVar(VCPScaleVolumesPerPod)
 
 		numberOfInstances = GetAndExpectIntEnvVar(VCPScaleInstances)
-		Expect(numberOfInstances > 5).NotTo(BeTrue(), "Maximum allowed instances are 5")
-		Expect(numberOfInstances > volumeCount).NotTo(BeTrue(), "Number of instances should be less than the total volume count")
+		gomega.Expect(numberOfInstances > 5).NotTo(gomega.BeTrue(), "Maximum allowed instances are 5")
+		gomega.Expect(numberOfInstances > volumeCount).NotTo(gomega.BeTrue(), "Number of instances should be less than the total volume count")
 
 		policyName = GetAndExpectStringEnvVar(SPBMPolicyName)
 		datastoreName = GetAndExpectStringEnvVar(StorageClassDatastoreName)
@@ -108,14 +108,14 @@ var _ = utils.SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 		}
 	})
 
-	It("vsphere scale tests", func() {
+	ginkgo.It("vsphere scale tests", func() {
 		var pvcClaimList []string
 		nodeVolumeMap := make(map[string][]string)
 		// Volumes will be provisioned with each different types of Storage Class
 		scArrays := make([]*storageV1.StorageClass, len(scNames))
 		for index, scname := range scNames {
 			// Create vSphere Storage Class
-			By(fmt.Sprintf("Creating Storage Class : %q", scname))
+			ginkgo.By(fmt.Sprintf("Creating Storage Class : %q", scname))
 			var sc *storageV1.StorageClass
 			scParams := make(map[string]string)
 			var err error
@@ -130,7 +130,7 @@ var _ = utils.SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 				scParams[Datastore] = datastoreName
 			}
 			sc, err = client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec(scname, scParams, nil))
-			Expect(sc).NotTo(BeNil(), "Storage class is empty")
+			gomega.Expect(sc).NotTo(gomega.BeNil(), "Storage class is empty")
 			framework.ExpectNoError(err, "Failed to create storage class")
 			defer client.StorageV1().StorageClasses().Delete(scname, nil)
 			scArrays[index] = sc
@@ -154,11 +154,11 @@ var _ = utils.SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 		podList, err := client.CoreV1().Pods(namespace).List(metav1.ListOptions{})
 		for _, pod := range podList.Items {
 			pvcClaimList = append(pvcClaimList, getClaimsForPod(&pod, volumesPerPod)...)
-			By("Deleting pod")
+			ginkgo.By("Deleting pod")
 			err = framework.DeletePodWithWait(f, client, &pod)
 			framework.ExpectNoError(err)
 		}
-		By("Waiting for volumes to be detached from the node")
+		ginkgo.By("Waiting for volumes to be detached from the node")
 		err = waitForVSphereDisksToDetach(nodeVolumeMap)
 		framework.ExpectNoError(err)
 
@@ -182,7 +182,7 @@ func getClaimsForPod(pod *v1.Pod, volumesPerPod int) []string {
 
 // VolumeCreateAndAttach peforms create and attach operations of vSphere persistent volumes at scale
 func VolumeCreateAndAttach(client clientset.Interface, namespace string, sc []*storageV1.StorageClass, volumeCountPerInstance int, volumesPerPod int, nodeSelectorList []*NodeSelector, nodeVolumeMapChan chan map[string][]string) {
-	defer GinkgoRecover()
+	defer ginkgo.GinkgoRecover()
 	nodeVolumeMap := make(map[string][]string)
 	nodeSelectorIndex := 0
 	for index := 0; index < volumeCountPerInstance; index = index + volumesPerPod {
@@ -191,17 +191,17 @@ func VolumeCreateAndAttach(client clientset.Interface, namespace string, sc []*s
 		}
 		pvclaims := make([]*v1.PersistentVolumeClaim, volumesPerPod)
 		for i := 0; i < volumesPerPod; i++ {
-			By("Creating PVC using the Storage Class")
+			ginkgo.By("Creating PVC using the Storage Class")
 			pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", sc[index%len(sc)]))
 			framework.ExpectNoError(err)
 			pvclaims[i] = pvclaim
 		}
 
-		By("Waiting for claim to be in bound phase")
+		ginkgo.By("Waiting for claim to be in bound phase")
 		persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
 		framework.ExpectNoError(err)
 
-		By("Creating pod to attach PV to the node")
+		ginkgo.By("Creating pod to attach PV to the node")
 		nodeSelector := nodeSelectorList[nodeSelectorIndex%len(nodeSelectorList)]
 		// Create pod to attach Volume to Node
 		pod, err := framework.CreatePod(client, namespace, map[string]string{nodeSelector.labelKey: nodeSelector.labelValue}, pvclaims, false, "")
@@ -210,7 +210,7 @@ func VolumeCreateAndAttach(client clientset.Interface, namespace string, sc []*s
 		for _, pv := range persistentvolumes {
 			nodeVolumeMap[pod.Spec.NodeName] = append(nodeVolumeMap[pod.Spec.NodeName], pv.Spec.VsphereVolume.VolumePath)
 		}
-		By("Verify the volume is accessible and available in the pod")
+		ginkgo.By("Verify the volume is accessible and available in the pod")
 		verifyVSphereVolumesAccessible(client, pod, persistentvolumes)
 		nodeSelectorIndex++
 	}

--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -404,7 +404,7 @@ func verifyVSphereVolumesAccessible(c clientset.Interface, pod *v1.Pod, persiste
 		// Verify disks are attached to the node
 		isAttached, err := diskIsAttached(pv.Spec.VsphereVolume.VolumePath, nodeName)
 		framework.ExpectNoError(err)
-		Expect(isAttached).To(BeTrue(), fmt.Sprintf("disk %v is not attached with the node", pv.Spec.VsphereVolume.VolumePath))
+		gomega.Expect(isAttached).To(gomega.BeTrue(), fmt.Sprintf("disk %v is not attached with the node", pv.Spec.VsphereVolume.VolumePath))
 		// Verify Volumes are accessible
 		filepath := filepath.Join("/mnt/", fmt.Sprintf("volume%v", index+1), "/emptyFile.txt")
 		_, err = framework.LookForStringInPodExec(namespace, pod.Name, []string{"/bin/touch", filepath}, "", time.Minute)
@@ -441,7 +441,7 @@ func verifyVolumeCreationOnRightZone(persistentvolumes []*v1.PersistentVolume, n
 				}
 			}
 		}
-		Expect(commonDatastores).To(ContainElement(datastoreRef.Value), "PV was created in an unsupported zone.")
+		gomega.Expect(commonDatastores).To(gomega.ContainElement(datastoreRef.Value), "PV was created in an unsupported zone.")
 	}
 }
 
@@ -631,7 +631,7 @@ func getVMXFilePath(vmObject *object.VirtualMachine) (vmxPath string) {
 	var nodeVM mo.VirtualMachine
 	err := vmObject.Properties(ctx, vmObject.Reference(), []string{"config.files"}, &nodeVM)
 	framework.ExpectNoError(err)
-	Expect(nodeVM.Config).NotTo(BeNil())
+	gomega.Expect(nodeVM.Config).NotTo(gomega.BeNil())
 
 	vmxPath = nodeVM.Config.Files.VmPathName
 	e2elog.Logf("vmx file path is %s", vmxPath)
@@ -643,7 +643,7 @@ func verifyReadyNodeCount(client clientset.Interface, expectedNodes int) bool {
 	numNodes := 0
 	for i := 0; i < 36; i++ {
 		nodeList := framework.GetReadySchedulableNodesOrDie(client)
-		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
+		gomega.Expect(nodeList.Items).NotTo(gomega.BeEmpty(), "Unable to find ready and schedulable Node")
 
 		numNodes = len(nodeList.Items)
 		if numNodes == expectedNodes {
@@ -777,7 +777,7 @@ func getUUIDFromProviderID(providerID string) string {
 // GetAllReadySchedulableNodeInfos returns NodeInfo objects for all nodes with Ready and schedulable state
 func GetReadySchedulableNodeInfos() []*NodeInfo {
 	nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-	Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
+	gomega.Expect(nodeList.Items).NotTo(gomega.BeEmpty(), "Unable to find ready and schedulable Node")
 	var nodesInfo []*NodeInfo
 	for _, node := range nodeList.Items {
 		nodeInfo := TestContext.NodeMapper.GetNodeInfo(node.Name)
@@ -793,7 +793,7 @@ func GetReadySchedulableNodeInfos() []*NodeInfo {
 // and it's associated NodeInfo object is returned.
 func GetReadySchedulableRandomNodeInfo() *NodeInfo {
 	nodesInfo := GetReadySchedulableNodeInfos()
-	Expect(nodesInfo).NotTo(BeEmpty())
+	gomega.Expect(nodesInfo).NotTo(gomega.BeEmpty())
 	return nodesInfo[rand.Int()%len(nodesInfo)]
 }
 
@@ -815,7 +815,7 @@ func invokeVCenterServiceControl(command, service, host string) error {
 func expectVolumeToBeAttached(nodeName, volumePath string) {
 	isAttached, err := diskIsAttached(volumePath, nodeName)
 	framework.ExpectNoError(err)
-	Expect(isAttached).To(BeTrue(), fmt.Sprintf("disk: %s is not attached with the node", volumePath))
+	gomega.Expect(isAttached).To(gomega.BeTrue(), fmt.Sprintf("disk: %s is not attached with the node", volumePath))
 }
 
 // expectVolumesToBeAttached checks if the given Volumes are attached to the
@@ -824,7 +824,7 @@ func expectVolumesToBeAttached(pods []*v1.Pod, volumePaths []string) {
 	for i, pod := range pods {
 		nodeName := pod.Spec.NodeName
 		volumePath := volumePaths[i]
-		By(fmt.Sprintf("Verifying that volume %v is attached to node %v", volumePath, nodeName))
+		ginkgo.By(fmt.Sprintf("Verifying that volume %v is attached to node %v", volumePath, nodeName))
 		expectVolumeToBeAttached(nodeName, volumePath)
 	}
 }
@@ -835,7 +835,7 @@ func expectFilesToBeAccessible(namespace string, pods []*v1.Pod, filePaths []str
 	for i, pod := range pods {
 		podName := pod.Name
 		filePath := filePaths[i]
-		By(fmt.Sprintf("Verifying that file %v is accessible on pod %v", filePath, podName))
+		ginkgo.By(fmt.Sprintf("Verifying that file %v is accessible on pod %v", filePath, podName))
 		verifyFilesExistOnVSphereVolume(namespace, podName, filePath)
 	}
 }
@@ -861,7 +861,7 @@ func expectFileContentsToMatch(namespace string, pods []*v1.Pod, filePaths []str
 	for i, pod := range pods {
 		podName := pod.Name
 		filePath := filePaths[i]
-		By(fmt.Sprintf("Matching file content for %v on pod %v", filePath, podName))
+		ginkgo.By(fmt.Sprintf("Matching file content for %v on pod %v", filePath, podName))
 		expectFileContentToMatch(namespace, podName, filePath, contents[i])
 	}
 }

--- a/test/e2e/storage/vsphere/vsphere_volume_cluster_ds.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_cluster_ds.go
@@ -17,8 +17,8 @@ limitations under the License.
 package vsphere
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -46,7 +46,7 @@ var _ = utils.SIGDescribe("Volume Provisioning On Clustered Datastore [Feature:v
 		nodeInfo         *NodeInfo
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
@@ -66,10 +66,10 @@ var _ = utils.SIGDescribe("Volume Provisioning On Clustered Datastore [Feature:v
 		6. Delete the volume
 	*/
 
-	It("verify static provisioning on clustered datastore", func() {
+	ginkgo.It("verify static provisioning on clustered datastore", func() {
 		var volumePath string
 
-		By("creating a test vsphere volume")
+		ginkgo.By("creating a test vsphere volume")
 		volumeOptions := new(VolumeOptions)
 		volumeOptions.CapacityKB = 2097152
 		volumeOptions.Name = "e2e-vmdk-" + namespace
@@ -79,31 +79,31 @@ var _ = utils.SIGDescribe("Volume Provisioning On Clustered Datastore [Feature:v
 		framework.ExpectNoError(err)
 
 		defer func() {
-			By("Deleting the vsphere volume")
+			ginkgo.By("Deleting the vsphere volume")
 			nodeInfo.VSphere.DeleteVolume(volumePath, nodeInfo.DataCenterRef)
 		}()
 
 		podspec := getVSpherePodSpecWithVolumePaths([]string{volumePath}, nil, nil)
 
-		By("Creating pod")
+		ginkgo.By("Creating pod")
 		pod, err := client.CoreV1().Pods(namespace).Create(podspec)
 		framework.ExpectNoError(err)
-		By("Waiting for pod to be ready")
-		Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(Succeed())
+		ginkgo.By("Waiting for pod to be ready")
+		gomega.Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(gomega.Succeed())
 
 		// get fresh pod info
 		pod, err = client.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		nodeName := pod.Spec.NodeName
 
-		By("Verifying volume is attached")
+		ginkgo.By("Verifying volume is attached")
 		expectVolumeToBeAttached(nodeName, volumePath)
 
-		By("Deleting pod")
+		ginkgo.By("Deleting pod")
 		err = framework.DeletePodWithWait(f, client, pod)
 		framework.ExpectNoError(err)
 
-		By("Waiting for volumes to be detached from the node")
+		ginkgo.By("Waiting for volumes to be detached from the node")
 		err = waitForVSphereDiskToDetach(volumePath, nodeName)
 		framework.ExpectNoError(err)
 	})
@@ -113,7 +113,7 @@ var _ = utils.SIGDescribe("Volume Provisioning On Clustered Datastore [Feature:v
 		1. Create storage class parameter and specify datastore to be a clustered datastore name
 		2. invokeValidPolicyTest - util to do e2e dynamic provision test
 	*/
-	It("verify dynamic provision with default parameter on clustered datastore", func() {
+	ginkgo.It("verify dynamic provision with default parameter on clustered datastore", func() {
 		scParameters[Datastore] = clusterDatastore
 		invokeValidPolicyTest(f, client, namespace, scParameters)
 	})
@@ -123,7 +123,7 @@ var _ = utils.SIGDescribe("Volume Provisioning On Clustered Datastore [Feature:v
 		1. Create storage class parameter and specify storage policy to be a tag based spbm policy
 		2. invokeValidPolicyTest - util to do e2e dynamic provision test
 	*/
-	It("verify dynamic provision with spbm policy on clustered datastore", func() {
+	ginkgo.It("verify dynamic provision with spbm policy on clustered datastore", func() {
 		policyDatastoreCluster := GetAndExpectStringEnvVar(SPBMPolicyDataStoreCluster)
 		scParameters[SpbmStoragePolicy] = policyDatastoreCluster
 		invokeValidPolicyTest(f, client, namespace, scParameters)

--- a/test/e2e/storage/vsphere/vsphere_volume_datastore.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_datastore.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -69,7 +68,7 @@ var _ = utils.SIGDescribe("Volume Provisioning on Datastore [Feature:vsphere]", 
 		scParameters[Datastore] = InvalidDatastore
 		scParameters[DiskFormat] = ThinDisk
 		err := invokeInvalidDatastoreTestNeg(client, namespace, scParameters)
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		framework.ExpectError(err)
 		errorMsg := `Failed to provision volume with StorageClass \"` + DatastoreSCName + `\": Datastore ` + InvalidDatastore + ` not found`
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -90,7 +89,7 @@ func invokeInvalidDatastoreTestNeg(client clientset.Interface, namespace string,
 
 	ginkgo.By("Expect claim to fail provisioning volume")
 	err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
-	gomega.Expect(err).To(gomega.HaveOccurred())
+	framework.ExpectError(err)
 
 	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(metav1.ListOptions{})
 	return fmt.Errorf("Failure message: %+q", eventList.Items[0].Message)

--- a/test/e2e/storage/vsphere/vsphere_volume_datastore.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_datastore.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -52,7 +52,7 @@ var _ = utils.SIGDescribe("Volume Provisioning on Datastore [Feature:vsphere]", 
 		namespace    string
 		scParameters map[string]string
 	)
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
@@ -64,12 +64,12 @@ var _ = utils.SIGDescribe("Volume Provisioning on Datastore [Feature:vsphere]", 
 		}
 	})
 
-	It("verify dynamically provisioned pv using storageclass fails on an invalid datastore", func() {
-		By("Invoking Test for invalid datastore")
+	ginkgo.It("verify dynamically provisioned pv using storageclass fails on an invalid datastore", func() {
+		ginkgo.By("Invoking Test for invalid datastore")
 		scParameters[Datastore] = InvalidDatastore
 		scParameters[DiskFormat] = ThinDisk
 		err := invokeInvalidDatastoreTestNeg(client, namespace, scParameters)
-		Expect(err).To(HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 		errorMsg := `Failed to provision volume with StorageClass \"` + DatastoreSCName + `\": Datastore ` + InvalidDatastore + ` not found`
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -78,19 +78,19 @@ var _ = utils.SIGDescribe("Volume Provisioning on Datastore [Feature:vsphere]", 
 })
 
 func invokeInvalidDatastoreTestNeg(client clientset.Interface, namespace string, scParameters map[string]string) error {
-	By("Creating Storage Class With Invalid Datastore")
+	ginkgo.By("Creating Storage Class With Invalid Datastore")
 	storageclass, err := client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec(DatastoreSCName, scParameters, nil))
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
-	By("Creating PVC using the Storage Class")
+	ginkgo.By("Creating PVC using the Storage Class")
 	pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 
-	By("Expect claim to fail provisioning volume")
+	ginkgo.By("Expect claim to fail provisioning volume")
 	err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
-	Expect(err).To(HaveOccurred())
+	gomega.Expect(err).To(gomega.HaveOccurred())
 
 	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(metav1.ListOptions{})
 	return fmt.Errorf("Failure message: %+q", eventList.Items[0].Message)

--- a/test/e2e/storage/vsphere/vsphere_volume_diskformat.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_diskformat.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 
@@ -65,7 +65,7 @@ var _ = utils.SIGDescribe("Volume Disk Format [Feature:vsphere]", func() {
 		nodeKeyValueLabel map[string]string
 		nodeLabelValue    string
 	)
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
@@ -86,16 +86,16 @@ var _ = utils.SIGDescribe("Volume Disk Format [Feature:vsphere]", func() {
 		}
 	})
 
-	It("verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass", func() {
-		By("Invoking Test for diskformat: eagerzeroedthick")
+	ginkgo.It("verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass", func() {
+		ginkgo.By("Invoking Test for diskformat: eagerzeroedthick")
 		invokeTest(f, client, namespace, nodeName, nodeKeyValueLabel, "eagerzeroedthick")
 	})
-	It("verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass", func() {
-		By("Invoking Test for diskformat: zeroedthick")
+	ginkgo.It("verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass", func() {
+		ginkgo.By("Invoking Test for diskformat: zeroedthick")
 		invokeTest(f, client, namespace, nodeName, nodeKeyValueLabel, "zeroedthick")
 	})
-	It("verify disk format type - thin is honored for dynamically provisioned pv using storageclass", func() {
-		By("Invoking Test for diskformat: thin")
+	ginkgo.It("verify disk format type - thin is honored for dynamically provisioned pv using storageclass", func() {
+		ginkgo.By("Invoking Test for diskformat: thin")
 		invokeTest(f, client, namespace, nodeName, nodeKeyValueLabel, "thin")
 	})
 })
@@ -106,14 +106,14 @@ func invokeTest(f *framework.Framework, client clientset.Interface, namespace st
 	scParameters := make(map[string]string)
 	scParameters["diskformat"] = diskFormat
 
-	By("Creating Storage Class With DiskFormat")
+	ginkgo.By("Creating Storage Class With DiskFormat")
 	storageClassSpec := getVSphereStorageClassSpec("thinsc", scParameters, nil)
 	storageclass, err := client.StorageV1().StorageClasses().Create(storageClassSpec)
 	framework.ExpectNoError(err)
 
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
-	By("Creating PVC using the Storage Class")
+	ginkgo.By("Creating PVC using the Storage Class")
 	pvclaimSpec := getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass)
 	pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Create(pvclaimSpec)
 	framework.ExpectNoError(err)
@@ -122,7 +122,7 @@ func invokeTest(f *framework.Framework, client clientset.Interface, namespace st
 		client.CoreV1().PersistentVolumeClaims(namespace).Delete(pvclaimSpec.Name, nil)
 	}()
 
-	By("Waiting for claim to be in bound phase")
+	ginkgo.By("Waiting for claim to be in bound phase")
 	err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 	framework.ExpectNoError(err)
 
@@ -138,32 +138,32 @@ func invokeTest(f *framework.Framework, client clientset.Interface, namespace st
 		PV is required to be attached to the Node. so that using govmomi API we can grab Disk's Backing Info
 		to check EagerlyScrub and ThinProvisioned property
 	*/
-	By("Creating pod to attach PV to the node")
+	ginkgo.By("Creating pod to attach PV to the node")
 	// Create pod to attach Volume to Node
 	podSpec := getVSpherePodSpecWithClaim(pvclaim.Name, nodeKeyValueLabel, "while true ; do sleep 2 ; done")
 	pod, err := client.CoreV1().Pods(namespace).Create(podSpec)
 	framework.ExpectNoError(err)
 
-	By("Waiting for pod to be running")
-	Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(Succeed())
+	ginkgo.By("Waiting for pod to be running")
+	gomega.Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(gomega.Succeed())
 
 	isAttached, err := diskIsAttached(pv.Spec.VsphereVolume.VolumePath, nodeName)
-	Expect(isAttached).To(BeTrue())
+	gomega.Expect(isAttached).To(gomega.BeTrue())
 	framework.ExpectNoError(err)
 
-	By("Verify Disk Format")
-	Expect(verifyDiskFormat(client, nodeName, pv.Spec.VsphereVolume.VolumePath, diskFormat)).To(BeTrue(), "DiskFormat Verification Failed")
+	ginkgo.By("Verify Disk Format")
+	gomega.Expect(verifyDiskFormat(client, nodeName, pv.Spec.VsphereVolume.VolumePath, diskFormat)).To(gomega.BeTrue(), "DiskFormat Verification Failed")
 
 	var volumePaths []string
 	volumePaths = append(volumePaths, pv.Spec.VsphereVolume.VolumePath)
 
-	By("Delete pod and wait for volume to be detached from node")
+	ginkgo.By("Delete pod and wait for volume to be detached from node")
 	deletePodAndWaitForVolumeToDetach(f, client, pod, nodeName, volumePaths)
 
 }
 
 func verifyDiskFormat(client clientset.Interface, nodeName string, pvVolumePath string, diskFormat string) bool {
-	By("Verifing disk format")
+	ginkgo.By("Verifing disk format")
 	eagerlyScrub := false
 	thinProvisioned := false
 	diskFound := false
@@ -194,7 +194,7 @@ func verifyDiskFormat(client clientset.Interface, nodeName string, pvVolumePath 
 		}
 	}
 
-	Expect(diskFound).To(BeTrue(), "Failed to find disk")
+	gomega.Expect(diskFound).To(gomega.BeTrue(), "Failed to find disk")
 	isDiskFormatCorrect := false
 	if diskFormat == "eagerzeroedthick" {
 		if eagerlyScrub == true && thinProvisioned == false {

--- a/test/e2e/storage/vsphere/vsphere_volume_disksize.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_disksize.go
@@ -19,8 +19,8 @@ package vsphere
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,7 +50,7 @@ var _ = utils.SIGDescribe("Volume Disk Size [Feature:vsphere]", func() {
 		scParameters map[string]string
 		datastore    string
 	)
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
@@ -59,38 +59,38 @@ var _ = utils.SIGDescribe("Volume Disk Size [Feature:vsphere]", func() {
 		datastore = GetAndExpectStringEnvVar(StorageClassDatastoreName)
 	})
 
-	It("verify dynamically provisioned pv has size rounded up correctly", func() {
-		By("Invoking Test disk size")
+	ginkgo.It("verify dynamically provisioned pv has size rounded up correctly", func() {
+		ginkgo.By("Invoking Test disk size")
 		scParameters[Datastore] = datastore
 		scParameters[DiskFormat] = ThinDisk
 		diskSize := "1"
 		expectedDiskSize := "1Mi"
 
-		By("Creating Storage Class")
+		ginkgo.By("Creating Storage Class")
 		storageclass, err := client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec(DiskSizeSCName, scParameters, nil))
 		framework.ExpectNoError(err)
 		defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
-		By("Creating PVC using the Storage Class")
+		ginkgo.By("Creating PVC using the Storage Class")
 		pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, diskSize, storageclass))
 		framework.ExpectNoError(err)
 		defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 
-		By("Waiting for claim to be in bound phase")
+		ginkgo.By("Waiting for claim to be in bound phase")
 		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
 		framework.ExpectNoError(err)
 
-		By("Getting new copy of PVC")
+		ginkgo.By("Getting new copy of PVC")
 		pvclaim, err = client.CoreV1().PersistentVolumeClaims(pvclaim.Namespace).Get(pvclaim.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
-		By("Getting PV created")
+		ginkgo.By("Getting PV created")
 		pv, err := client.CoreV1().PersistentVolumes().Get(pvclaim.Spec.VolumeName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
-		By("Verifying if provisioned PV has the correct size")
+		ginkgo.By("Verifying if provisioned PV has the correct size")
 		expectedCapacity := resource.MustParse(expectedDiskSize)
 		pvCapacity := pv.Spec.Capacity[v1.ResourceName(v1.ResourceStorage)]
-		Expect(pvCapacity.Value()).To(Equal(expectedCapacity.Value()))
+		gomega.Expect(pvCapacity.Value()).To(gomega.Equal(expectedCapacity.Value()))
 	})
 })

--- a/test/e2e/storage/vsphere/vsphere_volume_fstype.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_fstype.go
@@ -126,7 +126,7 @@ func invokeTestForInvalidFstype(f *framework.Framework, client clientset.Interfa
 	pvclaims = append(pvclaims, pvclaim)
 	// Create pod to attach Volume to Node
 	pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, ExecCommand)
-	gomega.Expect(err).To(gomega.HaveOccurred())
+	framework.ExpectError(err)
 
 	eventList, err := client.CoreV1().Events(namespace).List(metav1.ListOptions{})
 

--- a/test/e2e/storage/vsphere/vsphere_volume_fstype.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_fstype.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -69,26 +69,26 @@ var _ = utils.SIGDescribe("Volume FStype [Feature:vsphere]", func() {
 		client    clientset.Interface
 		namespace string
 	)
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
 		namespace = f.Namespace.Name
-		Expect(GetReadySchedulableNodeInfos()).NotTo(BeEmpty())
+		gomega.Expect(GetReadySchedulableNodeInfos()).NotTo(gomega.BeEmpty())
 	})
 
-	It("verify fstype - ext3 formatted volume", func() {
-		By("Invoking Test for fstype: ext3")
+	ginkgo.It("verify fstype - ext3 formatted volume", func() {
+		ginkgo.By("Invoking Test for fstype: ext3")
 		invokeTestForFstype(f, client, namespace, Ext3FSType, Ext3FSType)
 	})
 
-	It("verify fstype - default value should be ext4", func() {
-		By("Invoking Test for fstype: Default Value - ext4")
+	ginkgo.It("verify fstype - default value should be ext4", func() {
+		ginkgo.By("Invoking Test for fstype: Default Value - ext4")
 		invokeTestForFstype(f, client, namespace, "", Ext4FSType)
 	})
 
-	It("verify invalid fstype", func() {
-		By("Invoking Test for fstype: invalid Value")
+	ginkgo.It("verify invalid fstype", func() {
+		ginkgo.By("Invoking Test for fstype: invalid Value")
 		invokeTestForInvalidFstype(f, client, namespace, InvalidFSType)
 	})
 })
@@ -99,7 +99,7 @@ func invokeTestForFstype(f *framework.Framework, client clientset.Interface, nam
 	scParameters["fstype"] = fstype
 
 	// Create Persistent Volume
-	By("Creating Storage Class With Fstype")
+	ginkgo.By("Creating Storage Class With Fstype")
 	pvclaim, persistentvolumes := createVolume(client, namespace, scParameters)
 
 	// Create Pod and verify the persistent volume is accessible
@@ -110,7 +110,7 @@ func invokeTestForFstype(f *framework.Framework, client clientset.Interface, nam
 	// Detach and delete volume
 	detachVolume(f, client, pod, persistentvolumes[0].Spec.VsphereVolume.VolumePath)
 	err = framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
-	Expect(err).To(BeNil())
+	gomega.Expect(err).To(gomega.BeNil())
 }
 
 func invokeTestForInvalidFstype(f *framework.Framework, client clientset.Interface, namespace string, fstype string) {
@@ -118,24 +118,24 @@ func invokeTestForInvalidFstype(f *framework.Framework, client clientset.Interfa
 	scParameters["fstype"] = fstype
 
 	// Create Persistent Volume
-	By("Creating Storage Class With Invalid Fstype")
+	ginkgo.By("Creating Storage Class With Invalid Fstype")
 	pvclaim, persistentvolumes := createVolume(client, namespace, scParameters)
 
-	By("Creating pod to attach PV to the node")
+	ginkgo.By("Creating pod to attach PV to the node")
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
 	// Create pod to attach Volume to Node
 	pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, ExecCommand)
-	Expect(err).To(HaveOccurred())
+	gomega.Expect(err).To(gomega.HaveOccurred())
 
 	eventList, err := client.CoreV1().Events(namespace).List(metav1.ListOptions{})
 
 	// Detach and delete volume
 	detachVolume(f, client, pod, persistentvolumes[0].Spec.VsphereVolume.VolumePath)
 	err = framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
-	Expect(err).To(BeNil())
+	gomega.Expect(err).To(gomega.BeNil())
 
-	Expect(eventList.Items).NotTo(BeEmpty())
+	gomega.Expect(eventList.Items).NotTo(gomega.BeEmpty())
 	errorMsg := `MountVolume.MountDevice failed for volume "` + persistentvolumes[0].Name + `" : executable file not found`
 	isFound := false
 	for _, item := range eventList.Items {
@@ -143,7 +143,7 @@ func invokeTestForInvalidFstype(f *framework.Framework, client clientset.Interfa
 			isFound = true
 		}
 	}
-	Expect(isFound).To(BeTrue(), "Unable to verify MountVolume.MountDevice failure")
+	gomega.Expect(isFound).To(gomega.BeTrue(), "Unable to verify MountVolume.MountDevice failure")
 }
 
 func createVolume(client clientset.Interface, namespace string, scParameters map[string]string) (*v1.PersistentVolumeClaim, []*v1.PersistentVolume) {
@@ -151,13 +151,13 @@ func createVolume(client clientset.Interface, namespace string, scParameters map
 	framework.ExpectNoError(err)
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
-	By("Creating PVC using the Storage Class")
+	ginkgo.By("Creating PVC using the Storage Class")
 	pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Create(getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
-	By("Waiting for claim to be in bound phase")
+	ginkgo.By("Waiting for claim to be in bound phase")
 	persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
 	framework.ExpectNoError(err)
 	return pvclaim, persistentvolumes
@@ -166,13 +166,13 @@ func createVolume(client clientset.Interface, namespace string, scParameters map
 func createPodAndVerifyVolumeAccessible(client clientset.Interface, namespace string, pvclaim *v1.PersistentVolumeClaim, persistentvolumes []*v1.PersistentVolume) *v1.Pod {
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
-	By("Creating pod to attach PV to the node")
+	ginkgo.By("Creating pod to attach PV to the node")
 	// Create pod to attach Volume to Node
 	pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, ExecCommand)
 	framework.ExpectNoError(err)
 
 	// Asserts: Right disk is attached to the pod
-	By("Verify the volume is accessible and available in the pod")
+	ginkgo.By("Verify the volume is accessible and available in the pod")
 	verifyVSphereVolumesAccessible(client, pod, persistentvolumes)
 	return pod
 }
@@ -180,11 +180,11 @@ func createPodAndVerifyVolumeAccessible(client clientset.Interface, namespace st
 // detachVolume delete the volume passed in the argument and wait until volume is detached from the node,
 func detachVolume(f *framework.Framework, client clientset.Interface, pod *v1.Pod, volPath string) {
 	pod, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
-	Expect(err).To(BeNil())
+	gomega.Expect(err).To(gomega.BeNil())
 	nodeName := pod.Spec.NodeName
-	By("Deleting pod")
+	ginkgo.By("Deleting pod")
 	framework.DeletePodWithWait(f, client, pod)
 
-	By("Waiting for volumes to be detached from the node")
+	ginkgo.By("Waiting for volumes to be detached from the node")
 	waitForVSphereDiskToDetach(volPath, nodeName)
 }

--- a/test/e2e/storage/vsphere/vsphere_volume_master_restart.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_master_restart.go
@@ -19,8 +19,8 @@ package vsphere
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,7 +55,7 @@ var _ = utils.SIGDescribe("Volume Attach Verify [Feature:vsphere][Serial][Disrup
 		nodeNameList          []string
 		nodeInfo              *NodeInfo
 	)
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
@@ -79,22 +79,22 @@ var _ = utils.SIGDescribe("Volume Attach Verify [Feature:vsphere][Serial][Disrup
 		}
 	})
 
-	It("verify volume remains attached after master kubelet restart", func() {
+	ginkgo.It("verify volume remains attached after master kubelet restart", func() {
 		// Create pod on each node
 		for i := 0; i < numNodes; i++ {
-			By(fmt.Sprintf("%d: Creating a test vsphere volume", i))
+			ginkgo.By(fmt.Sprintf("%d: Creating a test vsphere volume", i))
 			volumePath, err := nodeInfo.VSphere.CreateVolume(&VolumeOptions{}, nodeInfo.DataCenterRef)
 			framework.ExpectNoError(err)
 			volumePaths = append(volumePaths, volumePath)
 
-			By(fmt.Sprintf("Creating pod %d on node %v", i, nodeNameList[i]))
+			ginkgo.By(fmt.Sprintf("Creating pod %d on node %v", i, nodeNameList[i]))
 			podspec := getVSpherePodSpecWithVolumePaths([]string{volumePath}, nodeKeyValueLabelList[i], nil)
 			pod, err := client.CoreV1().Pods(namespace).Create(podspec)
 			framework.ExpectNoError(err)
 			defer framework.DeletePodWithWait(f, client, pod)
 
-			By("Waiting for pod to be ready")
-			Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(Succeed())
+			ginkgo.By("Waiting for pod to be ready")
+			gomega.Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(gomega.Succeed())
 
 			pod, err = client.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
@@ -102,16 +102,16 @@ var _ = utils.SIGDescribe("Volume Attach Verify [Feature:vsphere][Serial][Disrup
 			pods = append(pods, pod)
 
 			nodeName := pod.Spec.NodeName
-			By(fmt.Sprintf("Verify volume %s is attached to the node %s", volumePath, nodeName))
+			ginkgo.By(fmt.Sprintf("Verify volume %s is attached to the node %s", volumePath, nodeName))
 			expectVolumeToBeAttached(nodeName, volumePath)
 		}
 
-		By("Restarting kubelet on master node")
+		ginkgo.By("Restarting kubelet on master node")
 		masterAddress := framework.GetMasterHost() + ":22"
 		err := framework.RestartKubelet(masterAddress)
 		framework.ExpectNoError(err, "Unable to restart kubelet on master node")
 
-		By("Verifying the kubelet on master node is up")
+		ginkgo.By("Verifying the kubelet on master node is up")
 		err = framework.WaitForKubeletUp(masterAddress)
 		framework.ExpectNoError(err)
 
@@ -119,18 +119,18 @@ var _ = utils.SIGDescribe("Volume Attach Verify [Feature:vsphere][Serial][Disrup
 			volumePath := volumePaths[i]
 			nodeName := pod.Spec.NodeName
 
-			By(fmt.Sprintf("After master restart, verify volume %v is attached to the node %v", volumePath, nodeName))
+			ginkgo.By(fmt.Sprintf("After master restart, verify volume %v is attached to the node %v", volumePath, nodeName))
 			expectVolumeToBeAttached(nodeName, volumePath)
 
-			By(fmt.Sprintf("Deleting pod on node %s", nodeName))
+			ginkgo.By(fmt.Sprintf("Deleting pod on node %s", nodeName))
 			err = framework.DeletePodWithWait(f, client, pod)
 			framework.ExpectNoError(err)
 
-			By(fmt.Sprintf("Waiting for volume %s to be detached from the node %s", volumePath, nodeName))
+			ginkgo.By(fmt.Sprintf("Waiting for volume %s to be detached from the node %s", volumePath, nodeName))
 			err = waitForVSphereDiskToDetach(volumePath, nodeName)
 			framework.ExpectNoError(err)
 
-			By(fmt.Sprintf("Deleting volume %s", volumePath))
+			ginkgo.By(fmt.Sprintf("Deleting volume %s", volumePath))
 			err = nodeInfo.VSphere.DeleteVolume(volumePath, nodeInfo.DataCenterRef)
 			framework.ExpectNoError(err)
 		}

--- a/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"os"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	"github.com/vmware/govmomi/object"
 
 	clientset "k8s.io/client-go/kubernetes"
@@ -38,7 +38,7 @@ var _ = utils.SIGDescribe("Node Unregister [Feature:vsphere] [Slow] [Disruptive]
 		err        error
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
@@ -46,14 +46,14 @@ var _ = utils.SIGDescribe("Node Unregister [Feature:vsphere] [Slow] [Disruptive]
 		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(client, framework.TestContext.NodeSchedulableTimeout))
 		framework.ExpectNoError(err)
 		workingDir = os.Getenv("VSPHERE_WORKING_DIR")
-		Expect(workingDir).NotTo(BeEmpty())
+		gomega.Expect(workingDir).NotTo(gomega.BeEmpty())
 
 	})
 
-	It("node unregister", func() {
-		By("Get total Ready nodes")
+	ginkgo.It("node unregister", func() {
+		ginkgo.By("Get total Ready nodes")
 		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		Expect(len(nodeList.Items) > 1).To(BeTrue(), "At least 2 nodes are required for this test")
+		gomega.Expect(len(nodeList.Items) > 1).To(gomega.BeTrue(), "At least 2 nodes are required for this test")
 
 		totalNodesCount := len(nodeList.Items)
 		nodeVM := nodeList.Items[0]
@@ -75,44 +75,44 @@ var _ = utils.SIGDescribe("Node Unregister [Feature:vsphere] [Slow] [Disruptive]
 		framework.ExpectNoError(err)
 
 		// Unregister Node VM
-		By("Unregister a node VM")
+		ginkgo.By("Unregister a node VM")
 		unregisterNodeVM(nodeVM.ObjectMeta.Name, vmObject)
 
 		// Ready nodes should be 1 less
-		By("Verifying the ready node counts")
-		Expect(verifyReadyNodeCount(f.ClientSet, totalNodesCount-1)).To(BeTrue(), "Unable to verify expected ready node count")
+		ginkgo.By("Verifying the ready node counts")
+		gomega.Expect(verifyReadyNodeCount(f.ClientSet, totalNodesCount-1)).To(gomega.BeTrue(), "Unable to verify expected ready node count")
 
 		nodeList = framework.GetReadySchedulableNodesOrDie(client)
-		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
+		gomega.Expect(nodeList.Items).NotTo(gomega.BeEmpty(), "Unable to find ready and schedulable Node")
 
 		var nodeNameList []string
 		for _, node := range nodeList.Items {
 			nodeNameList = append(nodeNameList, node.ObjectMeta.Name)
 		}
-		Expect(nodeNameList).NotTo(ContainElement(nodeVM.ObjectMeta.Name))
+		gomega.Expect(nodeNameList).NotTo(gomega.ContainElement(nodeVM.ObjectMeta.Name))
 
 		// Register Node VM
-		By("Register back the node VM")
+		ginkgo.By("Register back the node VM")
 		registerNodeVM(nodeVM.ObjectMeta.Name, workingDir, vmxFilePath, vmPool, vmHost)
 
 		// Ready nodes should be equal to earlier count
-		By("Verifying the ready node counts")
-		Expect(verifyReadyNodeCount(f.ClientSet, totalNodesCount)).To(BeTrue(), "Unable to verify expected ready node count")
+		ginkgo.By("Verifying the ready node counts")
+		gomega.Expect(verifyReadyNodeCount(f.ClientSet, totalNodesCount)).To(gomega.BeTrue(), "Unable to verify expected ready node count")
 
 		nodeList = framework.GetReadySchedulableNodesOrDie(client)
-		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
+		gomega.Expect(nodeList.Items).NotTo(gomega.BeEmpty(), "Unable to find ready and schedulable Node")
 
 		nodeNameList = nodeNameList[:0]
 		for _, node := range nodeList.Items {
 			nodeNameList = append(nodeNameList, node.ObjectMeta.Name)
 		}
-		Expect(nodeNameList).To(ContainElement(nodeVM.ObjectMeta.Name))
+		gomega.Expect(nodeNameList).To(gomega.ContainElement(nodeVM.ObjectMeta.Name))
 
 		// Sanity test that pod provisioning works
-		By("Sanity check for volume lifecycle")
+		ginkgo.By("Sanity check for volume lifecycle")
 		scParameters := make(map[string]string)
 		storagePolicy := os.Getenv("VSPHERE_SPBM_GOLD_POLICY")
-		Expect(storagePolicy).NotTo(BeEmpty(), "Please set VSPHERE_SPBM_GOLD_POLICY system environment")
+		gomega.Expect(storagePolicy).NotTo(gomega.BeEmpty(), "Please set VSPHERE_SPBM_GOLD_POLICY system environment")
 		scParameters[SpbmStoragePolicy] = storagePolicy
 		invokeValidPolicyTest(f, client, namespace, scParameters)
 	})

--- a/test/e2e/storage/vsphere/vsphere_volume_perf.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_perf.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	storageV1 "k8s.io/api/storage/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -61,7 +61,7 @@ var _ = utils.SIGDescribe("vcp-performance [Feature:vsphere]", func() {
 		iterations       int
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
@@ -76,18 +76,18 @@ var _ = utils.SIGDescribe("vcp-performance [Feature:vsphere]", func() {
 		datastoreName = GetAndExpectStringEnvVar(StorageClassDatastoreName)
 
 		nodes := framework.GetReadySchedulableNodesOrDie(client)
-		Expect(len(nodes.Items)).To(BeNumerically(">=", 1), "Requires at least %d nodes (not %d)", 2, len(nodes.Items))
+		gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">=", 1), "Requires at least %d nodes (not %d)", 2, len(nodes.Items))
 
 		msg := fmt.Sprintf("Cannot attach %d volumes to %d nodes. Maximum volumes that can be attached on %d nodes is %d", volumeCount, len(nodes.Items), len(nodes.Items), SCSIUnitsAvailablePerNode*len(nodes.Items))
-		Expect(volumeCount).To(BeNumerically("<=", SCSIUnitsAvailablePerNode*len(nodes.Items)), msg)
+		gomega.Expect(volumeCount).To(gomega.BeNumerically("<=", SCSIUnitsAvailablePerNode*len(nodes.Items)), msg)
 
 		msg = fmt.Sprintf("Cannot attach %d volumes per pod. Maximum volumes that can be attached per pod is %d", volumesPerPod, SCSIUnitsAvailablePerNode)
-		Expect(volumesPerPod).To(BeNumerically("<=", SCSIUnitsAvailablePerNode), msg)
+		gomega.Expect(volumesPerPod).To(gomega.BeNumerically("<=", SCSIUnitsAvailablePerNode), msg)
 
 		nodeSelectorList = createNodeLabels(client, namespace, nodes)
 	})
 
-	It("vcp performance tests", func() {
+	ginkgo.It("vcp performance tests", func() {
 		scList := getTestStorageClasses(client, policyName, datastoreName)
 		defer func(scList []*storageV1.StorageClass) {
 			for _, sc := range scList {
@@ -124,7 +124,7 @@ func getTestStorageClasses(client clientset.Interface, policyName, datastoreName
 	scArrays := make([]*storageV1.StorageClass, len(scNames))
 	for index, scname := range scNames {
 		// Create vSphere Storage Class
-		By(fmt.Sprintf("Creating Storage Class : %v", scname))
+		ginkgo.By(fmt.Sprintf("Creating Storage Class : %v", scname))
 		var sc *storageV1.StorageClass
 		var err error
 		switch scname {
@@ -147,7 +147,7 @@ func getTestStorageClasses(client clientset.Interface, policyName, datastoreName
 			scWithDatastoreSpec := getVSphereStorageClassSpec(storageclass4, scWithDSParameters, nil)
 			sc, err = client.StorageV1().StorageClasses().Create(scWithDatastoreSpec)
 		}
-		Expect(sc).NotTo(BeNil())
+		gomega.Expect(sc).NotTo(gomega.BeNil())
 		framework.ExpectNoError(err)
 		scArrays[index] = sc
 	}
@@ -165,7 +165,7 @@ func invokeVolumeLifeCyclePerformance(f *framework.Framework, client clientset.I
 	latency = make(map[string]float64)
 	numPods := volumeCount / volumesPerPod
 
-	By(fmt.Sprintf("Creating %d PVCs", volumeCount))
+	ginkgo.By(fmt.Sprintf("Creating %d PVCs", volumeCount))
 	start := time.Now()
 	for i := 0; i < numPods; i++ {
 		var pvclaims []*v1.PersistentVolumeClaim
@@ -185,7 +185,7 @@ func invokeVolumeLifeCyclePerformance(f *framework.Framework, client clientset.I
 	elapsed := time.Since(start)
 	latency[CreateOp] = elapsed.Seconds()
 
-	By("Creating pod to attach PVs to the node")
+	ginkgo.By("Creating pod to attach PVs to the node")
 	start = time.Now()
 	for i, pvclaims := range totalpvclaims {
 		nodeSelector := nodeSelectorList[i%len(nodeSelectorList)]
@@ -202,7 +202,7 @@ func invokeVolumeLifeCyclePerformance(f *framework.Framework, client clientset.I
 		verifyVSphereVolumesAccessible(client, pod, totalpvs[i])
 	}
 
-	By("Deleting pods")
+	ginkgo.By("Deleting pods")
 	start = time.Now()
 	for _, pod := range totalpods {
 		err := framework.DeletePodWithWait(f, client, pod)
@@ -220,7 +220,7 @@ func invokeVolumeLifeCyclePerformance(f *framework.Framework, client clientset.I
 	err := waitForVSphereDisksToDetach(nodeVolumeMap)
 	framework.ExpectNoError(err)
 
-	By("Deleting the PVCs")
+	ginkgo.By("Deleting the PVCs")
 	start = time.Now()
 	for _, pvclaims := range totalpvclaims {
 		for _, pvc := range pvclaims {

--- a/test/e2e/storage/vsphere/vsphere_volume_placement.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_placement.go
@@ -21,8 +21,8 @@ import (
 	"strconv"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
@@ -47,7 +47,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		nodeInfo           *NodeInfo
 		vsp                *VSphere
 	)
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		c = f.ClientSet
@@ -59,13 +59,13 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 			nodeInfo = TestContext.NodeMapper.GetNodeInfo(node1Name)
 			vsp = nodeInfo.VSphere
 		}
-		By("creating vmdk")
+		ginkgo.By("creating vmdk")
 		volumePath, err := vsp.CreateVolume(&VolumeOptions{}, nodeInfo.DataCenterRef)
 		framework.ExpectNoError(err)
 		volumePaths = append(volumePaths, volumePath)
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		for _, volumePath := range volumePaths {
 			vsp.DeleteVolume(volumePath, nodeInfo.DataCenterRef)
 		}
@@ -102,7 +102,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 
 	*/
 
-	It("should create and delete pod with the same volume source on the same worker node", func() {
+	ginkgo.It("should create and delete pod with the same volume source on the same worker node", func() {
 		var volumeFiles []string
 		pod := createPodWithVolumeAndNodeSelector(c, ns, node1Name, node1KeyValueLabel, volumePaths)
 
@@ -113,7 +113,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		createAndVerifyFilesOnVolume(ns, pod.Name, []string{newEmptyFileName}, volumeFiles)
 		deletePodAndWaitForVolumeToDetach(f, c, pod, node1Name, volumePaths)
 
-		By(fmt.Sprintf("Creating pod on the same node: %v", node1Name))
+		ginkgo.By(fmt.Sprintf("Creating pod on the same node: %v", node1Name))
 		pod = createPodWithVolumeAndNodeSelector(c, ns, node1Name, node1KeyValueLabel, volumePaths)
 
 		// Create empty files on the mounted volumes on the pod to verify volume is writable
@@ -142,7 +142,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		13. Delete pod.
 	*/
 
-	It("should create and delete pod with the same volume source attach/detach to different worker nodes", func() {
+	ginkgo.It("should create and delete pod with the same volume source attach/detach to different worker nodes", func() {
 		var volumeFiles []string
 		pod := createPodWithVolumeAndNodeSelector(c, ns, node1Name, node1KeyValueLabel, volumePaths)
 		// Create empty files on the mounted volumes on the pod to verify volume is writable
@@ -152,7 +152,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		createAndVerifyFilesOnVolume(ns, pod.Name, []string{newEmptyFileName}, volumeFiles)
 		deletePodAndWaitForVolumeToDetach(f, c, pod, node1Name, volumePaths)
 
-		By(fmt.Sprintf("Creating pod on the another node: %v", node2Name))
+		ginkgo.By(fmt.Sprintf("Creating pod on the another node: %v", node2Name))
 		pod = createPodWithVolumeAndNodeSelector(c, ns, node2Name, node2KeyValueLabel, volumePaths)
 
 		newEmptyFileName = fmt.Sprintf("/mnt/volume1/%v_2.txt", ns)
@@ -177,13 +177,13 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		10. Wait for vmdk1 and vmdk2 to be detached from node.
 	*/
 
-	It("should create and delete pod with multiple volumes from same datastore", func() {
-		By("creating another vmdk")
+	ginkgo.It("should create and delete pod with multiple volumes from same datastore", func() {
+		ginkgo.By("creating another vmdk")
 		volumePath, err := vsp.CreateVolume(&VolumeOptions{}, nodeInfo.DataCenterRef)
 		framework.ExpectNoError(err)
 		volumePaths = append(volumePaths, volumePath)
 
-		By(fmt.Sprintf("Creating pod on the node: %v with volume: %v and volume: %v", node1Name, volumePaths[0], volumePaths[1]))
+		ginkgo.By(fmt.Sprintf("Creating pod on the node: %v with volume: %v and volume: %v", node1Name, volumePaths[0], volumePaths[1]))
 		pod := createPodWithVolumeAndNodeSelector(c, ns, node1Name, node1KeyValueLabel, volumePaths)
 		// Create empty files on the mounted volumes on the pod to verify volume is writable
 		// Verify newly and previously created files present on the volume mounted on the pod
@@ -193,7 +193,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		}
 		createAndVerifyFilesOnVolume(ns, pod.Name, volumeFiles, volumeFiles)
 		deletePodAndWaitForVolumeToDetach(f, c, pod, node1Name, volumePaths)
-		By(fmt.Sprintf("Creating pod on the node: %v with volume :%v and volume: %v", node1Name, volumePaths[0], volumePaths[1]))
+		ginkgo.By(fmt.Sprintf("Creating pod on the node: %v with volume :%v and volume: %v", node1Name, volumePaths[0], volumePaths[1]))
 		pod = createPodWithVolumeAndNodeSelector(c, ns, node1Name, node1KeyValueLabel, volumePaths)
 		// Create empty files on the mounted volumes on the pod to verify volume is writable
 		// Verify newly and previously created files present on the volume mounted on the pod
@@ -219,8 +219,8 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		9. Delete POD.
 		10. Wait for vmdk1 and vmdk2 to be detached from node.
 	*/
-	It("should create and delete pod with multiple volumes from different datastore", func() {
-		By("creating another vmdk on non default shared datastore")
+	ginkgo.It("should create and delete pod with multiple volumes from different datastore", func() {
+		ginkgo.By("creating another vmdk on non default shared datastore")
 		var volumeOptions *VolumeOptions
 		volumeOptions = new(VolumeOptions)
 		volumeOptions.CapacityKB = 2097152
@@ -231,7 +231,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		framework.ExpectNoError(err)
 		volumePaths = append(volumePaths, volumePath)
 
-		By(fmt.Sprintf("Creating pod on the node: %v with volume :%v  and volume: %v", node1Name, volumePaths[0], volumePaths[1]))
+		ginkgo.By(fmt.Sprintf("Creating pod on the node: %v with volume :%v  and volume: %v", node1Name, volumePaths[0], volumePaths[1]))
 		pod := createPodWithVolumeAndNodeSelector(c, ns, node1Name, node1KeyValueLabel, volumePaths)
 
 		// Create empty files on the mounted volumes on the pod to verify volume is writable
@@ -243,7 +243,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		createAndVerifyFilesOnVolume(ns, pod.Name, volumeFiles, volumeFiles)
 		deletePodAndWaitForVolumeToDetach(f, c, pod, node1Name, volumePaths)
 
-		By(fmt.Sprintf("Creating pod on the node: %v with volume :%v  and volume: %v", node1Name, volumePaths[0], volumePaths[1]))
+		ginkgo.By(fmt.Sprintf("Creating pod on the node: %v with volume :%v  and volume: %v", node1Name, volumePaths[0], volumePaths[1]))
 		pod = createPodWithVolumeAndNodeSelector(c, ns, node1Name, node1KeyValueLabel, volumePaths)
 		// Create empty files on the mounted volumes on the pod to verify volume is writable
 		// Verify newly and previously created files present on the volume mounted on the pod
@@ -271,7 +271,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		    10. Repeatedly (5 times) perform step 4 to 9 and verify associated volume's content is matching.
 		    11. Wait for vmdk1 and vmdk2 to be detached from node.
 	*/
-	It("test back to back pod creation and deletion with different volume sources on the same worker node", func() {
+	ginkgo.It("test back to back pod creation and deletion with different volume sources on the same worker node", func() {
 		var (
 			podA                *v1.Pod
 			podB                *v1.Pod
@@ -282,10 +282,10 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		)
 
 		defer func() {
-			By("clean up undeleted pods")
+			ginkgo.By("clean up undeleted pods")
 			framework.ExpectNoError(framework.DeletePodWithWait(f, c, podA), "defer: Failed to delete pod ", podA.Name)
 			framework.ExpectNoError(framework.DeletePodWithWait(f, c, podB), "defer: Failed to delete pod ", podB.Name)
-			By(fmt.Sprintf("wait for volumes to be detached from the node: %v", node1Name))
+			ginkgo.By(fmt.Sprintf("wait for volumes to be detached from the node: %v", node1Name))
 			for _, volumePath := range volumePaths {
 				framework.ExpectNoError(waitForVSphereDiskToDetach(volumePath, node1Name))
 			}
@@ -293,17 +293,17 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 
 		testvolumePathsPodA = append(testvolumePathsPodA, volumePaths[0])
 		// Create another VMDK Volume
-		By("creating another vmdk")
+		ginkgo.By("creating another vmdk")
 		volumePath, err := vsp.CreateVolume(&VolumeOptions{}, nodeInfo.DataCenterRef)
 		framework.ExpectNoError(err)
 		volumePaths = append(volumePaths, volumePath)
 		testvolumePathsPodB = append(testvolumePathsPodA, volumePath)
 
 		for index := 0; index < 5; index++ {
-			By(fmt.Sprintf("Creating pod-A on the node: %v with volume: %v", node1Name, testvolumePathsPodA[0]))
+			ginkgo.By(fmt.Sprintf("Creating pod-A on the node: %v with volume: %v", node1Name, testvolumePathsPodA[0]))
 			podA = createPodWithVolumeAndNodeSelector(c, ns, node1Name, node1KeyValueLabel, testvolumePathsPodA)
 
-			By(fmt.Sprintf("Creating pod-B on the node: %v with volume: %v", node1Name, testvolumePathsPodB[0]))
+			ginkgo.By(fmt.Sprintf("Creating pod-B on the node: %v with volume: %v", node1Name, testvolumePathsPodB[0]))
 			podB = createPodWithVolumeAndNodeSelector(c, ns, node1Name, node1KeyValueLabel, testvolumePathsPodB)
 
 			podAFileName := fmt.Sprintf("/mnt/volume1/podA_%v_%v.txt", ns, index+1)
@@ -312,21 +312,21 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 			podBFiles = append(podBFiles, podBFileName)
 
 			// Create empty files on the mounted volumes on the pod to verify volume is writable
-			By("Creating empty file on volume mounted on pod-A")
+			ginkgo.By("Creating empty file on volume mounted on pod-A")
 			framework.CreateEmptyFileOnPod(ns, podA.Name, podAFileName)
 
-			By("Creating empty file volume mounted on pod-B")
+			ginkgo.By("Creating empty file volume mounted on pod-B")
 			framework.CreateEmptyFileOnPod(ns, podB.Name, podBFileName)
 
 			// Verify newly and previously created files present on the volume mounted on the pod
-			By("Verify newly Created file and previously created files present on volume mounted on pod-A")
+			ginkgo.By("Verify newly Created file and previously created files present on volume mounted on pod-A")
 			verifyFilesExistOnVSphereVolume(ns, podA.Name, podAFiles...)
-			By("Verify newly Created file and previously created files present on volume mounted on pod-B")
+			ginkgo.By("Verify newly Created file and previously created files present on volume mounted on pod-B")
 			verifyFilesExistOnVSphereVolume(ns, podB.Name, podBFiles...)
 
-			By("Deleting pod-A")
+			ginkgo.By("Deleting pod-A")
 			framework.ExpectNoError(framework.DeletePodWithWait(f, c, podA), "Failed to delete pod ", podA.Name)
-			By("Deleting pod-B")
+			ginkgo.By("Deleting pod-B")
 			framework.ExpectNoError(framework.DeletePodWithWait(f, c, podB), "Failed to delete pod ", podB.Name)
 		}
 	})
@@ -354,38 +354,38 @@ func testSetupVolumePlacement(client clientset.Interface, namespace string) (nod
 func createPodWithVolumeAndNodeSelector(client clientset.Interface, namespace string, nodeName string, nodeKeyValueLabel map[string]string, volumePaths []string) *v1.Pod {
 	var pod *v1.Pod
 	var err error
-	By(fmt.Sprintf("Creating pod on the node: %v", nodeName))
+	ginkgo.By(fmt.Sprintf("Creating pod on the node: %v", nodeName))
 	podspec := getVSpherePodSpecWithVolumePaths(volumePaths, nodeKeyValueLabel, nil)
 
 	pod, err = client.CoreV1().Pods(namespace).Create(podspec)
 	framework.ExpectNoError(err)
-	By("Waiting for pod to be ready")
-	Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(Succeed())
+	ginkgo.By("Waiting for pod to be ready")
+	gomega.Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(gomega.Succeed())
 
-	By(fmt.Sprintf("Verify volume is attached to the node:%v", nodeName))
+	ginkgo.By(fmt.Sprintf("Verify volume is attached to the node:%v", nodeName))
 	for _, volumePath := range volumePaths {
 		isAttached, err := diskIsAttached(volumePath, nodeName)
 		framework.ExpectNoError(err)
-		Expect(isAttached).To(BeTrue(), "disk:"+volumePath+" is not attached with the node")
+		gomega.Expect(isAttached).To(gomega.BeTrue(), "disk:"+volumePath+" is not attached with the node")
 	}
 	return pod
 }
 
 func createAndVerifyFilesOnVolume(namespace string, podname string, newEmptyfilesToCreate []string, filesToCheck []string) {
 	// Create empty files on the mounted volumes on the pod to verify volume is writable
-	By(fmt.Sprintf("Creating empty file on volume mounted on: %v", podname))
+	ginkgo.By(fmt.Sprintf("Creating empty file on volume mounted on: %v", podname))
 	createEmptyFilesOnVSphereVolume(namespace, podname, newEmptyfilesToCreate)
 
 	// Verify newly and previously created files present on the volume mounted on the pod
-	By(fmt.Sprintf("Verify newly Created file and previously created files present on volume mounted on: %v", podname))
+	ginkgo.By(fmt.Sprintf("Verify newly Created file and previously created files present on volume mounted on: %v", podname))
 	verifyFilesExistOnVSphereVolume(namespace, podname, filesToCheck...)
 }
 
 func deletePodAndWaitForVolumeToDetach(f *framework.Framework, c clientset.Interface, pod *v1.Pod, nodeName string, volumePaths []string) {
-	By("Deleting pod")
+	ginkgo.By("Deleting pod")
 	framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod), "Failed to delete pod ", pod.Name)
 
-	By("Waiting for volume to be detached from the node")
+	ginkgo.By("Waiting for volume to be detached from the node")
 	for _, volumePath := range volumePaths {
 		framework.ExpectNoError(waitForVSphereDiskToDetach(volumePath, nodeName))
 	}

--- a/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go
@@ -23,8 +23,8 @@ import (
 
 	"strings"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -97,7 +97,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		tagPolicy    string
 		masterNode   string
 	)
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
@@ -111,13 +111,13 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
 		masternodes, _ := framework.GetMasterAndWorkerNodesOrDie(client)
-		Expect(masternodes).NotTo(BeEmpty())
+		gomega.Expect(masternodes).NotTo(gomega.BeEmpty())
 		masterNode = masternodes.List()[0]
 	})
 
 	// Valid policy.
-	It("verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass", func() {
-		By(fmt.Sprintf("Invoking test for VSAN policy hostFailuresToTolerate: %s, cacheReservation: %s", HostFailuresToTolerateCapabilityVal, CacheReservationCapabilityVal))
+	ginkgo.It("verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass", func() {
+		ginkgo.By(fmt.Sprintf("Invoking test for VSAN policy hostFailuresToTolerate: %s, cacheReservation: %s", HostFailuresToTolerateCapabilityVal, CacheReservationCapabilityVal))
 		scParameters[Policy_HostFailuresToTolerate] = HostFailuresToTolerateCapabilityVal
 		scParameters[Policy_CacheReservation] = CacheReservationCapabilityVal
 		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
@@ -125,8 +125,8 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 	})
 
 	// Valid policy.
-	It("verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass", func() {
-		By(fmt.Sprintf("Invoking test for VSAN policy diskStripes: %s, objectSpaceReservation: %s", DiskStripesCapabilityVal, ObjectSpaceReservationCapabilityVal))
+	ginkgo.It("verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass", func() {
+		ginkgo.By(fmt.Sprintf("Invoking test for VSAN policy diskStripes: %s, objectSpaceReservation: %s", DiskStripesCapabilityVal, ObjectSpaceReservationCapabilityVal))
 		scParameters[Policy_DiskStripes] = "1"
 		scParameters[Policy_ObjectSpaceReservation] = "30"
 		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
@@ -134,8 +134,8 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 	})
 
 	// Valid policy.
-	It("verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass", func() {
-		By(fmt.Sprintf("Invoking test for VSAN policy diskStripes: %s, objectSpaceReservation: %s", DiskStripesCapabilityVal, ObjectSpaceReservationCapabilityVal))
+	ginkgo.It("verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass", func() {
+		ginkgo.By(fmt.Sprintf("Invoking test for VSAN policy diskStripes: %s, objectSpaceReservation: %s", DiskStripesCapabilityVal, ObjectSpaceReservationCapabilityVal))
 		scParameters[Policy_DiskStripes] = DiskStripesCapabilityVal
 		scParameters[Policy_ObjectSpaceReservation] = ObjectSpaceReservationCapabilityVal
 		scParameters[Datastore] = VsanDatastore
@@ -144,8 +144,8 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 	})
 
 	// Valid policy.
-	It("verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass", func() {
-		By(fmt.Sprintf("Invoking test for VSAN policy objectSpaceReservation: %s, iopsLimit: %s", ObjectSpaceReservationCapabilityVal, IopsLimitCapabilityVal))
+	ginkgo.It("verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass", func() {
+		ginkgo.By(fmt.Sprintf("Invoking test for VSAN policy objectSpaceReservation: %s, iopsLimit: %s", ObjectSpaceReservationCapabilityVal, IopsLimitCapabilityVal))
 		scParameters[Policy_ObjectSpaceReservation] = ObjectSpaceReservationCapabilityVal
 		scParameters[Policy_IopsLimit] = IopsLimitCapabilityVal
 		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
@@ -153,13 +153,13 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 	})
 
 	// Invalid VSAN storage capabilities parameters.
-	It("verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass", func() {
-		By(fmt.Sprintf("Invoking test for VSAN policy objectSpaceReserve: %s, stripeWidth: %s", ObjectSpaceReservationCapabilityVal, StripeWidthCapabilityVal))
+	ginkgo.It("verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass", func() {
+		ginkgo.By(fmt.Sprintf("Invoking test for VSAN policy objectSpaceReserve: %s, stripeWidth: %s", ObjectSpaceReservationCapabilityVal, StripeWidthCapabilityVal))
 		scParameters["objectSpaceReserve"] = ObjectSpaceReservationCapabilityVal
 		scParameters[Policy_DiskStripes] = StripeWidthCapabilityVal
 		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		Expect(err).To(HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 		errorMsg := "invalid option \\\"objectSpaceReserve\\\" for volume plugin kubernetes.io/vsphere-volume"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -168,13 +168,13 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 
 	// Invalid policy on a VSAN test bed.
 	// diskStripes value has to be between 1 and 12.
-	It("verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass", func() {
-		By(fmt.Sprintf("Invoking test for VSAN policy diskStripes: %s, cacheReservation: %s", DiskStripesCapabilityInvalidVal, CacheReservationCapabilityVal))
+	ginkgo.It("verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass", func() {
+		ginkgo.By(fmt.Sprintf("Invoking test for VSAN policy diskStripes: %s, cacheReservation: %s", DiskStripesCapabilityInvalidVal, CacheReservationCapabilityVal))
 		scParameters[Policy_DiskStripes] = DiskStripesCapabilityInvalidVal
 		scParameters[Policy_CacheReservation] = CacheReservationCapabilityVal
 		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		Expect(err).To(HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 		errorMsg := "Invalid value for " + Policy_DiskStripes + "."
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -183,12 +183,12 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 
 	// Invalid policy on a VSAN test bed.
 	// hostFailuresToTolerate value has to be between 0 and 3 including.
-	It("verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass", func() {
-		By(fmt.Sprintf("Invoking test for VSAN policy hostFailuresToTolerate: %s", HostFailuresToTolerateCapabilityInvalidVal))
+	ginkgo.It("verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass", func() {
+		ginkgo.By(fmt.Sprintf("Invoking test for VSAN policy hostFailuresToTolerate: %s", HostFailuresToTolerateCapabilityInvalidVal))
 		scParameters[Policy_HostFailuresToTolerate] = HostFailuresToTolerateCapabilityInvalidVal
 		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		Expect(err).To(HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 		errorMsg := "Invalid value for " + Policy_HostFailuresToTolerate + "."
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -197,14 +197,14 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 
 	// Specify a valid VSAN policy on a non-VSAN test bed.
 	// The test should fail.
-	It("verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass", func() {
-		By(fmt.Sprintf("Invoking test for VSAN policy diskStripes: %s, objectSpaceReservation: %s and a non-VSAN datastore: %s", DiskStripesCapabilityVal, ObjectSpaceReservationCapabilityVal, VmfsDatastore))
+	ginkgo.It("verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass", func() {
+		ginkgo.By(fmt.Sprintf("Invoking test for VSAN policy diskStripes: %s, objectSpaceReservation: %s and a non-VSAN datastore: %s", DiskStripesCapabilityVal, ObjectSpaceReservationCapabilityVal, VmfsDatastore))
 		scParameters[Policy_DiskStripes] = DiskStripesCapabilityVal
 		scParameters[Policy_ObjectSpaceReservation] = ObjectSpaceReservationCapabilityVal
 		scParameters[Datastore] = VmfsDatastore
 		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		Expect(err).To(HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 		errorMsg := "The specified datastore: \\\"" + VmfsDatastore + "\\\" is not a VSAN datastore. " +
 			"The policy parameters will work only with VSAN Datastore."
 		if !strings.Contains(err.Error(), errorMsg) {
@@ -212,15 +212,15 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		}
 	})
 
-	It("verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass", func() {
-		By(fmt.Sprintf("Invoking test for SPBM policy: %s", policyName))
+	ginkgo.It("verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass", func() {
+		ginkgo.By(fmt.Sprintf("Invoking test for SPBM policy: %s", policyName))
 		scParameters[SpbmStoragePolicy] = policyName
 		scParameters[DiskFormat] = ThinDisk
 		e2elog.Logf("Invoking test for SPBM storage policy: %+v", scParameters)
 		invokeValidPolicyTest(f, client, namespace, scParameters)
 	})
 
-	It("verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy", func() {
+	ginkgo.It("verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy", func() {
 		scParameters[Policy_DiskStripes] = DiskStripesCapabilityMaxVal
 		scParameters[Policy_ObjectSpaceReservation] = ObjectSpaceReservationCapabilityVal
 		scParameters[Datastore] = VsanDatastore
@@ -229,42 +229,42 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		invokeStaleDummyVMTestWithStoragePolicy(client, masterNode, namespace, kubernetesClusterName, scParameters)
 	})
 
-	It("verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass", func() {
-		By(fmt.Sprintf("Invoking test for SPBM policy: %s and datastore: %s", tagPolicy, VsanDatastore))
+	ginkgo.It("verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass", func() {
+		ginkgo.By(fmt.Sprintf("Invoking test for SPBM policy: %s and datastore: %s", tagPolicy, VsanDatastore))
 		scParameters[SpbmStoragePolicy] = tagPolicy
 		scParameters[Datastore] = VsanDatastore
 		scParameters[DiskFormat] = ThinDisk
 		e2elog.Logf("Invoking test for SPBM storage policy on a non-compatible datastore: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		Expect(err).To(HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 		errorMsg := "User specified datastore is not compatible with the storagePolicy: \\\"" + tagPolicy + "\\\""
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
-	It("verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass", func() {
-		By(fmt.Sprintf("Invoking test for SPBM policy: %s", BronzeStoragePolicy))
+	ginkgo.It("verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass", func() {
+		ginkgo.By(fmt.Sprintf("Invoking test for SPBM policy: %s", BronzeStoragePolicy))
 		scParameters[SpbmStoragePolicy] = BronzeStoragePolicy
 		scParameters[DiskFormat] = ThinDisk
 		e2elog.Logf("Invoking test for non-existing SPBM storage policy: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		Expect(err).To(HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 		errorMsg := "no pbm profile found with name: \\\"" + BronzeStoragePolicy + "\\"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
-	It("verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass", func() {
-		By(fmt.Sprintf("Invoking test for SPBM policy: %s with VSAN storage capabilities", policyName))
+	ginkgo.It("verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass", func() {
+		ginkgo.By(fmt.Sprintf("Invoking test for SPBM policy: %s with VSAN storage capabilities", policyName))
 		scParameters[SpbmStoragePolicy] = policyName
-		Expect(scParameters[SpbmStoragePolicy]).NotTo(BeEmpty())
+		gomega.Expect(scParameters[SpbmStoragePolicy]).NotTo(gomega.BeEmpty())
 		scParameters[Policy_DiskStripes] = DiskStripesCapabilityVal
 		scParameters[DiskFormat] = ThinDisk
 		e2elog.Logf("Invoking test for SPBM storage policy and VSAN capabilities together: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		Expect(err).To(HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 		errorMsg := "Cannot specify storage policy capabilities along with storage policy name. Please specify only one"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -273,71 +273,71 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 })
 
 func invokeValidPolicyTest(f *framework.Framework, client clientset.Interface, namespace string, scParameters map[string]string) {
-	By("Creating Storage Class With storage policy params")
+	ginkgo.By("Creating Storage Class With storage policy params")
 	storageclass, err := client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec("storagepolicysc", scParameters, nil))
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
-	By("Creating PVC using the Storage Class")
+	ginkgo.By("Creating PVC using the Storage Class")
 	pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
-	By("Waiting for claim to be in bound phase")
+	ginkgo.By("Waiting for claim to be in bound phase")
 	persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
 	framework.ExpectNoError(err)
 
-	By("Creating pod to attach PV to the node")
+	ginkgo.By("Creating pod to attach PV to the node")
 	// Create pod to attach Volume to Node
 	pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, "")
 	framework.ExpectNoError(err)
 
-	By("Verify the volume is accessible and available in the pod")
+	ginkgo.By("Verify the volume is accessible and available in the pod")
 	verifyVSphereVolumesAccessible(client, pod, persistentvolumes)
 
-	By("Deleting pod")
+	ginkgo.By("Deleting pod")
 	framework.DeletePodWithWait(f, client, pod)
 
-	By("Waiting for volumes to be detached from the node")
+	ginkgo.By("Waiting for volumes to be detached from the node")
 	waitForVSphereDiskToDetach(persistentvolumes[0].Spec.VsphereVolume.VolumePath, pod.Spec.NodeName)
 }
 
 func invokeInvalidPolicyTestNeg(client clientset.Interface, namespace string, scParameters map[string]string) error {
-	By("Creating Storage Class With storage policy params")
+	ginkgo.By("Creating Storage Class With storage policy params")
 	storageclass, err := client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec("storagepolicysc", scParameters, nil))
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
-	By("Creating PVC using the Storage Class")
+	ginkgo.By("Creating PVC using the Storage Class")
 	pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 
-	By("Waiting for claim to be in bound phase")
+	ginkgo.By("Waiting for claim to be in bound phase")
 	err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
-	Expect(err).To(HaveOccurred())
+	gomega.Expect(err).To(gomega.HaveOccurred())
 
 	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(metav1.ListOptions{})
 	return fmt.Errorf("Failure message: %+q", eventList.Items[0].Message)
 }
 
 func invokeStaleDummyVMTestWithStoragePolicy(client clientset.Interface, masterNode string, namespace string, clusterName string, scParameters map[string]string) {
-	By("Creating Storage Class With storage policy params")
+	ginkgo.By("Creating Storage Class With storage policy params")
 	storageclass, err := client.StorageV1().StorageClasses().Create(getVSphereStorageClassSpec("storagepolicysc", scParameters, nil))
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
-	By("Creating PVC using the Storage Class")
+	ginkgo.By("Creating PVC using the Storage Class")
 	pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
-	By("Expect claim to fail provisioning volume")
+	ginkgo.By("Expect claim to fail provisioning volume")
 	_, err = framework.WaitForPVClaimBoundPhase(client, pvclaims, 2*time.Minute)
-	Expect(err).To(HaveOccurred())
+	gomega.Expect(err).To(gomega.HaveOccurred())
 
 	updatedClaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(pvclaim.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
@@ -351,5 +351,5 @@ func invokeStaleDummyVMTestWithStoragePolicy(client clientset.Interface, masterN
 	dummyVMFullName := DummyVMPrefixName + "-" + fmt.Sprint(fnvHash.Sum32())
 	errorMsg := "Dummy VM - " + vmName + "is still present. Failing the test.."
 	nodeInfo := TestContext.NodeMapper.GetNodeInfo(masterNode)
-	Expect(nodeInfo.VSphere.IsVMPresent(dummyVMFullName, nodeInfo.DataCenterRef)).NotTo(BeTrue(), errorMsg)
+	gomega.Expect(nodeInfo.VSphere.IsVMPresent(dummyVMFullName, nodeInfo.DataCenterRef)).NotTo(gomega.BeTrue(), errorMsg)
 }

--- a/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go
@@ -159,7 +159,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[Policy_DiskStripes] = StripeWidthCapabilityVal
 		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		framework.ExpectError(err)
 		errorMsg := "invalid option \\\"objectSpaceReserve\\\" for volume plugin kubernetes.io/vsphere-volume"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -174,7 +174,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[Policy_CacheReservation] = CacheReservationCapabilityVal
 		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		framework.ExpectError(err)
 		errorMsg := "Invalid value for " + Policy_DiskStripes + "."
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -188,7 +188,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[Policy_HostFailuresToTolerate] = HostFailuresToTolerateCapabilityInvalidVal
 		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		framework.ExpectError(err)
 		errorMsg := "Invalid value for " + Policy_HostFailuresToTolerate + "."
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -204,7 +204,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[Datastore] = VmfsDatastore
 		e2elog.Logf("Invoking test for VSAN storage capabilities: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		framework.ExpectError(err)
 		errorMsg := "The specified datastore: \\\"" + VmfsDatastore + "\\\" is not a VSAN datastore. " +
 			"The policy parameters will work only with VSAN Datastore."
 		if !strings.Contains(err.Error(), errorMsg) {
@@ -236,7 +236,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[DiskFormat] = ThinDisk
 		e2elog.Logf("Invoking test for SPBM storage policy on a non-compatible datastore: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		framework.ExpectError(err)
 		errorMsg := "User specified datastore is not compatible with the storagePolicy: \\\"" + tagPolicy + "\\\""
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -249,7 +249,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[DiskFormat] = ThinDisk
 		e2elog.Logf("Invoking test for non-existing SPBM storage policy: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		framework.ExpectError(err)
 		errorMsg := "no pbm profile found with name: \\\"" + BronzeStoragePolicy + "\\"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -264,7 +264,7 @@ var _ = utils.SIGDescribe("Storage Policy Based Volume Provisioning [Feature:vsp
 		scParameters[DiskFormat] = ThinDisk
 		e2elog.Logf("Invoking test for SPBM storage policy and VSAN capabilities together: %+v", scParameters)
 		err := invokeInvalidPolicyTestNeg(client, namespace, scParameters)
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		framework.ExpectError(err)
 		errorMsg := "Cannot specify storage policy capabilities along with storage policy name. Please specify only one"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -317,7 +317,7 @@ func invokeInvalidPolicyTestNeg(client clientset.Interface, namespace string, sc
 
 	ginkgo.By("Waiting for claim to be in bound phase")
 	err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
-	gomega.Expect(err).To(gomega.HaveOccurred())
+	framework.ExpectError(err)
 
 	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(metav1.ListOptions{})
 	return fmt.Errorf("Failure message: %+q", eventList.Items[0].Message)
@@ -337,7 +337,7 @@ func invokeStaleDummyVMTestWithStoragePolicy(client clientset.Interface, masterN
 	pvclaims = append(pvclaims, pvclaim)
 	ginkgo.By("Expect claim to fail provisioning volume")
 	_, err = framework.WaitForPVClaimBoundPhase(client, pvclaims, 2*time.Minute)
-	gomega.Expect(err).To(gomega.HaveOccurred())
+	framework.ExpectError(err)
 
 	updatedClaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(pvclaim.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)

--- a/test/e2e/storage/vsphere/vsphere_zone_support.go
+++ b/test/e2e/storage/vsphere/vsphere_zone_support.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -94,7 +94,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		zoneC           string
 		zoneD           string
 	)
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("vsphere")
 		Bootstrap(f)
 		client = f.ClientSet
@@ -115,52 +115,52 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		}
 	})
 
-	It("Verify dynamically created pv with allowed zones specified in storage class, shows the right zone information on its labels", func() {
-		By(fmt.Sprintf("Creating storage class with the following zones : %s", zoneA))
+	ginkgo.It("Verify dynamically created pv with allowed zones specified in storage class, shows the right zone information on its labels", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with the following zones : %s", zoneA))
 		zones = append(zones, zoneA)
 		verifyPVZoneLabels(client, namespace, nil, zones)
 	})
 
-	It("Verify dynamically created pv with multiple zones specified in the storage class, shows both the zones on its labels", func() {
-		By(fmt.Sprintf("Creating storage class with the following zones : %s, %s", zoneA, zoneB))
+	ginkgo.It("Verify dynamically created pv with multiple zones specified in the storage class, shows both the zones on its labels", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with the following zones : %s, %s", zoneA, zoneB))
 		zones = append(zones, zoneA)
 		zones = append(zones, zoneB)
 		verifyPVZoneLabels(client, namespace, nil, zones)
 	})
 
-	It("Verify PVC creation with invalid zone specified in storage class fails", func() {
-		By(fmt.Sprintf("Creating storage class with unknown zone : %s", zoneD))
+	ginkgo.It("Verify PVC creation with invalid zone specified in storage class fails", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with unknown zone : %s", zoneD))
 		zones = append(zones, zoneD)
 		err := verifyPVCCreationFails(client, namespace, nil, zones)
-		Expect(err).To(HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
 		errorMsg := "Failed to find a shared datastore matching zone [" + zoneD + "]"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
 		}
 	})
 
-	It("Verify a pod is created and attached to a dynamically created PV, based on allowed zones specified in storage class ", func() {
-		By(fmt.Sprintf("Creating storage class with zones :%s", zoneA))
+	ginkgo.It("Verify a pod is created and attached to a dynamically created PV, based on allowed zones specified in storage class ", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with zones :%s", zoneA))
 		zones = append(zones, zoneA)
 		verifyPVCAndPodCreationSucceeds(client, namespace, nil, zones)
 	})
 
-	It("Verify a pod is created and attached to a dynamically created PV, based on multiple zones specified in storage class ", func() {
-		By(fmt.Sprintf("Creating storage class with zones :%s, %s", zoneA, zoneB))
+	ginkgo.It("Verify a pod is created and attached to a dynamically created PV, based on multiple zones specified in storage class ", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with zones :%s, %s", zoneA, zoneB))
 		zones = append(zones, zoneA)
 		zones = append(zones, zoneB)
 		verifyPVCAndPodCreationSucceeds(client, namespace, nil, zones)
 	})
 
-	It("Verify a pod is created and attached to a dynamically created PV, based on the allowed zones and datastore specified in storage class", func() {
-		By(fmt.Sprintf("Creating storage class with zone :%s and datastore :%s", zoneA, vsanDatastore1))
+	ginkgo.It("Verify a pod is created and attached to a dynamically created PV, based on the allowed zones and datastore specified in storage class", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s and datastore :%s", zoneA, vsanDatastore1))
 		scParameters[Datastore] = vsanDatastore1
 		zones = append(zones, zoneA)
 		verifyPVCAndPodCreationSucceeds(client, namespace, scParameters, zones)
 	})
 
-	It("Verify PVC creation with incompatible datastore and zone combination specified in storage class fails", func() {
-		By(fmt.Sprintf("Creating storage class with zone :%s and datastore :%s", zoneC, vsanDatastore1))
+	ginkgo.It("Verify PVC creation with incompatible datastore and zone combination specified in storage class fails", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s and datastore :%s", zoneC, vsanDatastore1))
 		scParameters[Datastore] = vsanDatastore1
 		zones = append(zones, zoneC)
 		err := verifyPVCCreationFails(client, namespace, scParameters, zones)
@@ -170,22 +170,22 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		}
 	})
 
-	It("Verify a pod is created and attached to a dynamically created PV, based on the allowed zones and storage policy specified in storage class", func() {
-		By(fmt.Sprintf("Creating storage class with zone :%s and storage policy :%s", zoneA, compatPolicy))
+	ginkgo.It("Verify a pod is created and attached to a dynamically created PV, based on the allowed zones and storage policy specified in storage class", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s and storage policy :%s", zoneA, compatPolicy))
 		scParameters[SpbmStoragePolicy] = compatPolicy
 		zones = append(zones, zoneA)
 		verifyPVCAndPodCreationSucceeds(client, namespace, scParameters, zones)
 	})
 
-	It("Verify a pod is created on a non-Workspace zone and attached to a dynamically created PV, based on the allowed zones and storage policy specified in storage class", func() {
-		By(fmt.Sprintf("Creating storage class with zone :%s and storage policy :%s", zoneB, compatPolicy))
+	ginkgo.It("Verify a pod is created on a non-Workspace zone and attached to a dynamically created PV, based on the allowed zones and storage policy specified in storage class", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s and storage policy :%s", zoneB, compatPolicy))
 		scParameters[SpbmStoragePolicy] = compatPolicy
 		zones = append(zones, zoneB)
 		verifyPVCAndPodCreationSucceeds(client, namespace, scParameters, zones)
 	})
 
-	It("Verify PVC creation with incompatible storagePolicy and zone combination specified in storage class fails", func() {
-		By(fmt.Sprintf("Creating storage class with zone :%s and storage policy :%s", zoneA, nonCompatPolicy))
+	ginkgo.It("Verify PVC creation with incompatible storagePolicy and zone combination specified in storage class fails", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s and storage policy :%s", zoneA, nonCompatPolicy))
 		scParameters[SpbmStoragePolicy] = nonCompatPolicy
 		zones = append(zones, zoneA)
 		err := verifyPVCCreationFails(client, namespace, scParameters, zones)
@@ -195,16 +195,16 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		}
 	})
 
-	It("Verify a pod is created and attached to a dynamically created PV, based on the allowed zones, datastore and storage policy specified in storage class", func() {
-		By(fmt.Sprintf("Creating storage class with zone :%s datastore :%s and storagePolicy :%s", zoneA, vsanDatastore1, compatPolicy))
+	ginkgo.It("Verify a pod is created and attached to a dynamically created PV, based on the allowed zones, datastore and storage policy specified in storage class", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s datastore :%s and storagePolicy :%s", zoneA, vsanDatastore1, compatPolicy))
 		scParameters[SpbmStoragePolicy] = compatPolicy
 		scParameters[Datastore] = vsanDatastore1
 		zones = append(zones, zoneA)
 		verifyPVCAndPodCreationSucceeds(client, namespace, scParameters, zones)
 	})
 
-	It("Verify PVC creation with incompatible storage policy along with compatible zone and datastore combination specified in storage class fails", func() {
-		By(fmt.Sprintf("Creating storage class with zone :%s datastore :%s and storagePolicy :%s", zoneA, vsanDatastore1, nonCompatPolicy))
+	ginkgo.It("Verify PVC creation with incompatible storage policy along with compatible zone and datastore combination specified in storage class fails", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s datastore :%s and storagePolicy :%s", zoneA, vsanDatastore1, nonCompatPolicy))
 		scParameters[SpbmStoragePolicy] = nonCompatPolicy
 		scParameters[Datastore] = vsanDatastore1
 		zones = append(zones, zoneA)
@@ -215,8 +215,8 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		}
 	})
 
-	It("Verify PVC creation with incompatible zone along with compatible storagePolicy and datastore combination specified in storage class fails", func() {
-		By(fmt.Sprintf("Creating storage class with zone :%s datastore :%s and storagePolicy :%s", zoneC, vsanDatastore2, compatPolicy))
+	ginkgo.It("Verify PVC creation with incompatible zone along with compatible storagePolicy and datastore combination specified in storage class fails", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s datastore :%s and storagePolicy :%s", zoneC, vsanDatastore2, compatPolicy))
 		scParameters[SpbmStoragePolicy] = compatPolicy
 		scParameters[Datastore] = vsanDatastore2
 		zones = append(zones, zoneC)
@@ -227,8 +227,8 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		}
 	})
 
-	It("Verify PVC creation fails if no zones are specified in the storage class (No shared datastores exist among all the nodes)", func() {
-		By(fmt.Sprintf("Creating storage class with no zones"))
+	ginkgo.It("Verify PVC creation fails if no zones are specified in the storage class (No shared datastores exist among all the nodes)", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with no zones"))
 		err := verifyPVCCreationFails(client, namespace, nil, nil)
 		errorMsg := "No shared datastores found in the Kubernetes cluster"
 		if !strings.Contains(err.Error(), errorMsg) {
@@ -236,8 +236,8 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		}
 	})
 
-	It("Verify PVC creation fails if only datastore is specified in the storage class (No shared datastores exist among all the nodes)", func() {
-		By(fmt.Sprintf("Creating storage class with datastore :%s", vsanDatastore1))
+	ginkgo.It("Verify PVC creation fails if only datastore is specified in the storage class (No shared datastores exist among all the nodes)", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with datastore :%s", vsanDatastore1))
 		scParameters[Datastore] = vsanDatastore1
 		err := verifyPVCCreationFails(client, namespace, scParameters, nil)
 		errorMsg := "No shared datastores found in the Kubernetes cluster"
@@ -246,8 +246,8 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		}
 	})
 
-	It("Verify PVC creation fails if only storage policy is specified in the storage class (No shared datastores exist among all the nodes)", func() {
-		By(fmt.Sprintf("Creating storage class with storage policy :%s", compatPolicy))
+	ginkgo.It("Verify PVC creation fails if only storage policy is specified in the storage class (No shared datastores exist among all the nodes)", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with storage policy :%s", compatPolicy))
 		scParameters[SpbmStoragePolicy] = compatPolicy
 		err := verifyPVCCreationFails(client, namespace, scParameters, nil)
 		errorMsg := "No shared datastores found in the Kubernetes cluster"
@@ -256,8 +256,8 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		}
 	})
 
-	It("Verify PVC creation with compatible policy and datastore without any zones specified in the storage class fails (No shared datastores exist among all the nodes)", func() {
-		By(fmt.Sprintf("Creating storage class with storage policy :%s and datastore :%s", compatPolicy, vsanDatastore1))
+	ginkgo.It("Verify PVC creation with compatible policy and datastore without any zones specified in the storage class fails (No shared datastores exist among all the nodes)", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with storage policy :%s and datastore :%s", compatPolicy, vsanDatastore1))
 		scParameters[SpbmStoragePolicy] = compatPolicy
 		scParameters[Datastore] = vsanDatastore1
 		err := verifyPVCCreationFails(client, namespace, scParameters, nil)
@@ -267,8 +267,8 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		}
 	})
 
-	It("Verify PVC creation fails if the availability zone specified in the storage class have no shared datastores under it.", func() {
-		By(fmt.Sprintf("Creating storage class with zone :%s", zoneC))
+	ginkgo.It("Verify PVC creation fails if the availability zone specified in the storage class have no shared datastores under it.", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with zone :%s", zoneC))
 		zones = append(zones, zoneC)
 		err := verifyPVCCreationFails(client, namespace, nil, zones)
 		errorMsg := "Failed to find a shared datastore matching zone [" + zoneC + "]"
@@ -277,8 +277,8 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		}
 	})
 
-	It("Verify a pod is created and attached to a dynamically created PV, based on multiple zones specified in the storage class. (No shared datastores exist among both zones)", func() {
-		By(fmt.Sprintf("Creating storage class with the following zones :%s and %s", zoneA, zoneC))
+	ginkgo.It("Verify a pod is created and attached to a dynamically created PV, based on multiple zones specified in the storage class. (No shared datastores exist among both zones)", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with the following zones :%s and %s", zoneA, zoneC))
 		zones = append(zones, zoneA)
 		zones = append(zones, zoneC)
 		err := verifyPVCCreationFails(client, namespace, nil, zones)
@@ -288,8 +288,8 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		}
 	})
 
-	It("Verify PVC creation with an invalid VSAN capability along with a compatible zone combination specified in storage class fails", func() {
-		By(fmt.Sprintf("Creating storage class with %s :%s and zone :%s", Policy_HostFailuresToTolerate, HostFailuresToTolerateCapabilityInvalidVal, zoneA))
+	ginkgo.It("Verify PVC creation with an invalid VSAN capability along with a compatible zone combination specified in storage class fails", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with %s :%s and zone :%s", Policy_HostFailuresToTolerate, HostFailuresToTolerateCapabilityInvalidVal, zoneA))
 		scParameters[Policy_HostFailuresToTolerate] = HostFailuresToTolerateCapabilityInvalidVal
 		zones = append(zones, zoneA)
 		err := verifyPVCCreationFails(client, namespace, scParameters, zones)
@@ -299,8 +299,8 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		}
 	})
 
-	It("Verify a pod is created and attached to a dynamically created PV, based on a VSAN capability, datastore and compatible zone specified in storage class", func() {
-		By(fmt.Sprintf("Creating storage class with %s :%s, %s :%s, datastore :%s and zone :%s", Policy_ObjectSpaceReservation, ObjectSpaceReservationCapabilityVal, Policy_IopsLimit, IopsLimitCapabilityVal, vsanDatastore1, zoneA))
+	ginkgo.It("Verify a pod is created and attached to a dynamically created PV, based on a VSAN capability, datastore and compatible zone specified in storage class", func() {
+		ginkgo.By(fmt.Sprintf("Creating storage class with %s :%s, %s :%s, datastore :%s and zone :%s", Policy_ObjectSpaceReservation, ObjectSpaceReservationCapabilityVal, Policy_IopsLimit, IopsLimitCapabilityVal, vsanDatastore1, zoneA))
 		scParameters[Policy_ObjectSpaceReservation] = ObjectSpaceReservationCapabilityVal
 		scParameters[Policy_IopsLimit] = IopsLimitCapabilityVal
 		scParameters[Datastore] = vsanDatastore1
@@ -314,31 +314,31 @@ func verifyPVCAndPodCreationSucceeds(client clientset.Interface, namespace strin
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
-	By("Creating PVC using the Storage Class")
+	ginkgo.By("Creating PVC using the Storage Class")
 	pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
-	By("Waiting for claim to be in bound phase")
+	ginkgo.By("Waiting for claim to be in bound phase")
 	persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
 	framework.ExpectNoError(err)
 
-	By("Creating pod to attach PV to the node")
+	ginkgo.By("Creating pod to attach PV to the node")
 	pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, "")
 	framework.ExpectNoError(err)
 
-	By("Verify persistent volume was created on the right zone")
+	ginkgo.By("Verify persistent volume was created on the right zone")
 	verifyVolumeCreationOnRightZone(persistentvolumes, pod.Spec.NodeName, zones)
 
-	By("Verify the volume is accessible and available in the pod")
+	ginkgo.By("Verify the volume is accessible and available in the pod")
 	verifyVSphereVolumesAccessible(client, pod, persistentvolumes)
 
-	By("Deleting pod")
+	ginkgo.By("Deleting pod")
 	framework.DeletePodWithWait(f, client, pod)
 
-	By("Waiting for volumes to be detached from the node")
+	ginkgo.By("Waiting for volumes to be detached from the node")
 	waitForVSphereDiskToDetach(persistentvolumes[0].Spec.VsphereVolume.VolumePath, pod.Spec.NodeName)
 }
 
@@ -347,7 +347,7 @@ func verifyPVCCreationFails(client clientset.Interface, namespace string, scPara
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
-	By("Creating PVC using the Storage Class")
+	ginkgo.By("Creating PVC using the Storage Class")
 	pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
@@ -355,9 +355,9 @@ func verifyPVCCreationFails(client clientset.Interface, namespace string, scPara
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
 
-	By("Waiting for claim to be in bound phase")
+	ginkgo.By("Waiting for claim to be in bound phase")
 	err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
-	Expect(err).To(HaveOccurred())
+	gomega.Expect(err).To(gomega.HaveOccurred())
 
 	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(metav1.ListOptions{})
 	e2elog.Logf("Failure message : %+q", eventList.Items[0].Message)
@@ -369,23 +369,23 @@ func verifyPVZoneLabels(client clientset.Interface, namespace string, scParamete
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create storage class with err: %v", err))
 	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
 
-	By("Creating PVC using the storage class")
+	ginkgo.By("Creating PVC using the storage class")
 	pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClass(namespace, "2Gi", storageclass))
 	framework.ExpectNoError(err)
 	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
-	By("Waiting for claim to be in bound phase")
+	ginkgo.By("Waiting for claim to be in bound phase")
 	persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
 	framework.ExpectNoError(err)
 
-	By("Verify zone information is present in the volume labels")
+	ginkgo.By("Verify zone information is present in the volume labels")
 	for _, pv := range persistentvolumes {
 		// Multiple zones are separated with "__"
 		pvZoneLabels := strings.Split(pv.ObjectMeta.Labels["failure-domain.beta.kubernetes.io/zone"], "__")
 		for _, zone := range zones {
-			Expect(pvZoneLabels).Should(ContainElement(zone), "Incorrect or missing zone labels in pv.")
+			gomega.Expect(pvZoneLabels).Should(gomega.ContainElement(zone), "Incorrect or missing zone labels in pv.")
 		}
 	}
 }

--- a/test/e2e/storage/vsphere/vsphere_zone_support.go
+++ b/test/e2e/storage/vsphere/vsphere_zone_support.go
@@ -132,7 +132,7 @@ var _ = utils.SIGDescribe("Zone Support", func() {
 		ginkgo.By(fmt.Sprintf("Creating storage class with unknown zone : %s", zoneD))
 		zones = append(zones, zoneD)
 		err := verifyPVCCreationFails(client, namespace, nil, zones)
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		framework.ExpectError(err)
 		errorMsg := "Failed to find a shared datastore matching zone [" + zoneD + "]"
 		if !strings.Contains(err.Error(), errorMsg) {
 			framework.ExpectNoError(err, errorMsg)
@@ -357,7 +357,7 @@ func verifyPVCCreationFails(client clientset.Interface, namespace string, scPara
 
 	ginkgo.By("Waiting for claim to be in bound phase")
 	err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
-	gomega.Expect(err).To(gomega.HaveOccurred())
+	framework.ExpectError(err)
 
 	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(metav1.ListOptions{})
 	e2elog.Logf("Failure message : %+q", eventList.Items[0].Message)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
/sig testing

**What this PR does / why we need it**:

in test/e2e/storage:
1. cleanup dot imports
2. make test error checking more readable

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #77706

**Special notes for your reviewer**:

/assign @oomichi

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
