### PR TITLE
Fix some service tags not supported issues for Azure LoadBalancer service

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
@@ -447,3 +447,60 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 		assert.Equal(t, owns, c.expected, "TestCase[%d]: %s", i, c.desc)
 	}
 }
+
+func TestGetServiceTags(t *testing.T) {
+	tests := []struct {
+		desc     string
+		service  *v1.Service
+		expected []string
+	}{
+		{
+			desc:     "nil should be returned when service is nil",
+			service:  nil,
+			expected: nil,
+		},
+		{
+			desc:     "nil should be returned when service has no annotations",
+			service:  &v1.Service{},
+			expected: nil,
+		},
+		{
+			desc: "single tag should be returned when service has set one annotations",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceAnnotationAllowedServiceTag: "tag1",
+					},
+				},
+			},
+			expected: []string{"tag1"},
+		},
+		{
+			desc: "multiple tags should be returned when service has set multi-annotations",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceAnnotationAllowedServiceTag: "tag1, tag2",
+					},
+				},
+			},
+			expected: []string{"tag1", "tag2"},
+		},
+		{
+			desc: "correct tags should be returned when comma or spaces are included in the annotations",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceAnnotationAllowedServiceTag: ", tag1, ",
+					},
+				},
+			},
+			expected: []string{"tag1"},
+		},
+	}
+
+	for i, c := range tests {
+		tags := getServiceTags(c.service)
+		assert.Equal(t, tags, c.expected, "TestCase[%d]: %s", i, c.desc)
+	}
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Azure cloud provider has a limited support for service tags by annotations:

https://github.com/kubernetes/kubernetes/blob/32b37f5a85e8f2987f8367e611147cd4d4dfa4f9/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go#L96-L97

But according to https://docs.microsoft.com/en-us/azure/virtual-network/security-overview#service-tags, there are actually much more service tags than this list. Hence, errors would happen if the service tag is not included in the above list.

This PR fixes the issue by removing the static list from the cloud provider and let Azure API validate whether the service tag is supported or not. If illegal service tags are provided, error events would be sent for the service.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #77717

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix some service tags not supported issues for Azure LoadBalancer service
```

/sig azure
/kind bug
/priority important-soon