### PR TITLE
apiextensions: always sort structural schema violations, not only in condition

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
@@ -18,6 +18,7 @@ package schema
 
 import (
 	"reflect"
+	"sort"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -61,6 +62,12 @@ func ValidateStructural(s *Structural, fldPath *field.Path) field.ErrorList {
 
 	allErrs = append(allErrs, validateStructuralInvariants(s, rootLevel, fldPath)...)
 	allErrs = append(allErrs, validateStructuralCompleteness(s, fldPath)...)
+
+	// sort error messages. Otherwise, the errors slice will change every time due to
+	// maps in the types and randomized iteration.
+	sort.Slice(allErrs, func(i, j int) bool {
+		return allErrs[i].Error() < allErrs[j].Error()
+	})
 
 	return allErrs
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
@@ -18,7 +18,6 @@ package nonstructuralschema
 
 import (
 	"fmt"
-	"sort"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -114,12 +113,6 @@ func calculateCondition(in *apiextensions.CustomResourceDefinition) *apiextensio
 	if len(allErrs) == 0 {
 		return nil
 	}
-
-	// sort error messages. Otherwise, the condition message will change every sync due to
-	// randomized map iteration.
-	sort.Slice(allErrs, func(i, j int) bool {
-		return allErrs[i].Error() < allErrs[j].Error()
-	})
 
 	cond.Status = apiextensions.ConditionTrue
 	cond.Reason = "Violations"


### PR DESCRIPTION
These errors are also presented to the user via API validation, not only via the condition.
Random order is confusing.