### PR TITLE
apiextensions: ignore ObjectMeta from webhook converted objects other than labels and annotations

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
@@ -51,7 +51,8 @@ message ConversionResponse {
 
   // `convertedObjects` is the list of converted version of `request.objects` if the `result` is successful otherwise empty.
   // The webhook is expected to set apiVersion of these objects to the ConversionRequest.desiredAPIVersion. The list
-  // must also has the same size as input list with the same objects in the same order(i.e. equal UIDs and object meta)
+  // must also have the same size as the input list with the same objects in the same order (equal kind, UID, name and namespace).
+  // The webhook is allowed to mutate labels and annotations. Any other change to the metadata is silently ignored.
   repeated k8s.io.apimachinery.pkg.runtime.RawExtension convertedObjects = 2;
 
   // `result` contains the result of conversion with extra details if the conversion failed. `result.status` determines if

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
@@ -456,7 +456,8 @@ type ConversionResponse struct {
 	UID types.UID `json:"uid" protobuf:"bytes,1,name=uid"`
 	// `convertedObjects` is the list of converted version of `request.objects` if the `result` is successful otherwise empty.
 	// The webhook is expected to set apiVersion of these objects to the ConversionRequest.desiredAPIVersion. The list
-	// must also has the same size as input list with the same objects in the same order(i.e. equal UIDs and object meta)
+	// must also have the same size as the input list with the same objects in the same order (equal kind, UID, name and namespace).
+	// The webhook is allowed to mutate labels and annotations. Any other change to the metadata is silently ignored.
 	ConvertedObjects []runtime.RawExtension `json:"convertedObjects" protobuf:"bytes,2,rep,name=convertedObjects"`
 	// `result` contains the result of conversion with extra details if the conversion failed. `result.status` determines if
 	// the conversion failed or succeeded. The `result.status` field is required and represent the success or failure of the

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/BUILD
@@ -16,11 +16,14 @@ go_library(
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/features:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/webhook:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
@@ -45,13 +48,18 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["converter_test.go"],
+    srcs = [
+        "converter_test.go",
+        "webhook_converter_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/webhook:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/webhook_converter_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/webhook_converter_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversion
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestRestoreObjectMeta(t *testing.T) {
+	tests := []struct {
+		name      string
+		original  map[string]interface{}
+		converted map[string]interface{}
+		expected  map[string]interface{}
+		wantErr   bool
+	}{
+		{"no converted metadata",
+			map[string]interface{}{"metadata": map[string]interface{}{}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"spec": map[string]interface{}{}},
+			map[string]interface{}{"spec": map[string]interface{}{}},
+			true,
+		},
+		{"invalid converted metadata",
+			map[string]interface{}{"metadata": map[string]interface{}{}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": []interface{}{"foo"}},
+			map[string]interface{}{"metadata": []interface{}{"foo"}},
+			true,
+		},
+		{"no original metadata",
+			map[string]interface{}{"spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{}, "spec": map[string]interface{}{}},
+			false,
+		},
+		{"invalid original metadata",
+			map[string]interface{}{"metadata": []interface{}{"foo"}},
+			map[string]interface{}{"metadata": map[string]interface{}{}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": []interface{}{"foo"}, "spec": map[string]interface{}{}},
+			true,
+		},
+		{"changed label, annotations and non-label",
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo":         "bar",
+				"labels":      map[string]interface{}{"a": "A", "b": "B"},
+				"annotations": map[string]interface{}{"a": "1", "b": "2"},
+			}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo":         "abc",
+				"labels":      map[string]interface{}{"a": "AA", "b": "B"},
+				"annotations": map[string]interface{}{"a": "1", "b": "22"},
+			}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo":         "bar",
+				"labels":      map[string]interface{}{"a": "AA", "b": "B"},
+				"annotations": map[string]interface{}{"a": "1", "b": "22"},
+			}, "spec": map[string]interface{}{}},
+			false,
+		},
+		{"added labels and annotations",
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo": "bar",
+			}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo":         "abc",
+				"labels":      map[string]interface{}{"a": "AA", "b": "B"},
+				"annotations": map[string]interface{}{"a": "1", "b": "22"},
+			}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo":         "bar",
+				"labels":      map[string]interface{}{"a": "AA", "b": "B"},
+				"annotations": map[string]interface{}{"a": "1", "b": "22"},
+			}, "spec": map[string]interface{}{}},
+			false,
+		},
+		{"added labels and annotations, with nil before",
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo":         "bar",
+				"labels":      nil,
+				"annotations": nil,
+			}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo":         "abc",
+				"labels":      map[string]interface{}{"a": "AA", "b": "B"},
+				"annotations": map[string]interface{}{"a": "1", "b": "22"},
+			}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo":         "bar",
+				"labels":      map[string]interface{}{"a": "AA", "b": "B"},
+				"annotations": map[string]interface{}{"a": "1", "b": "22"},
+			}, "spec": map[string]interface{}{}},
+			false,
+		},
+		{"removed labels and annotations",
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo":         "bar",
+				"labels":      map[string]interface{}{"a": "AA", "b": "B"},
+				"annotations": map[string]interface{}{"a": "1", "b": "22"},
+			}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo": "abc",
+			}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo": "bar",
+			}, "spec": map[string]interface{}{}},
+			false,
+		},
+		{"nil'ed labels and annotations",
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo":         "bar",
+				"labels":      map[string]interface{}{"a": "AA", "b": "B"},
+				"annotations": map[string]interface{}{"a": "1", "b": "22"},
+			}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo":         "abc",
+				"labels":      nil,
+				"annotations": nil,
+			}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo": "bar",
+			}, "spec": map[string]interface{}{}},
+			false,
+		},
+		{"added labels and annotations",
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo": "bar",
+			}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo":         "abc",
+				"labels":      map[string]interface{}{"a": nil, "b": "B"},
+				"annotations": map[string]interface{}{"a": nil, "b": "22"},
+			}, "spec": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{
+				"foo": "bar",
+			}, "spec": map[string]interface{}{}},
+			true,
+		},
+		{"invalid label key",
+			map[string]interface{}{"metadata": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{"labels": map[string]interface{}{"some/non-qualified/label": "x"}}},
+			map[string]interface{}{"metadata": map[string]interface{}{}},
+			true,
+		},
+		{"invalid annotation key",
+			map[string]interface{}{"metadata": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{"labels": map[string]interface{}{"some/non-qualified/label": "x"}}},
+			map[string]interface{}{"metadata": map[string]interface{}{}},
+			true,
+		},
+		{"invalid label value",
+			map[string]interface{}{"metadata": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{"labels": map[string]interface{}{"foo": "üäö"}}},
+			map[string]interface{}{"metadata": map[string]interface{}{}},
+			true,
+		},
+		{"too big label value",
+			map[string]interface{}{"metadata": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{"labels": map[string]interface{}{"foo": strings.Repeat("x", validation.LabelValueMaxLength+1)}}},
+			map[string]interface{}{"metadata": map[string]interface{}{}},
+			true,
+		},
+		{"too big annotation value",
+			map[string]interface{}{"metadata": map[string]interface{}{}},
+			map[string]interface{}{"metadata": map[string]interface{}{"annotations": map[string]interface{}{"foo": strings.Repeat("x", 256*(1<<10)+1)}}},
+			map[string]interface{}{"metadata": map[string]interface{}{}},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := restoreObjectMeta(&unstructured.Unstructured{Object: tt.original}, &unstructured.Unstructured{Object: tt.converted}); err == nil && tt.wantErr {
+				t.Fatalf("expected error, but didn't get one")
+			} else if err != nil && !tt.wantErr {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tt.converted, tt.expected) {
+				t.Errorf("unexpected result: %s", diff.ObjectDiff(tt.expected, tt.converted))
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/webhook_converter_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/webhook_converter_test.go
@@ -28,11 +28,11 @@ import (
 
 func TestRestoreObjectMeta(t *testing.T) {
 	tests := []struct {
-		name      string
-		original  map[string]interface{}
-		converted map[string]interface{}
-		expected  map[string]interface{}
-		wantErr   bool
+		name          string
+		original      map[string]interface{}
+		converted     map[string]interface{}
+		expected      map[string]interface{}
+		expectedError bool
 	}{
 		{"no converted metadata",
 			map[string]interface{}{"metadata": map[string]interface{}{}, "spec": map[string]interface{}{}},
@@ -187,9 +187,9 @@ func TestRestoreObjectMeta(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := restoreObjectMeta(&unstructured.Unstructured{Object: tt.original}, &unstructured.Unstructured{Object: tt.converted}); err == nil && tt.wantErr {
+			if err := restoreObjectMeta(&unstructured.Unstructured{Object: tt.original}, &unstructured.Unstructured{Object: tt.converted}); err == nil && tt.expectedError {
 				t.Fatalf("expected error, but didn't get one")
-			} else if err != nil && !tt.wantErr {
+			} else if err != nil && !tt.expectedError {
 				t.Fatalf("unexpected error: %v", err)
 			}
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/72160

Specified in https://github.com/kubernetes/enhancements/pull/1063.

TODOs:
- [x] unit tests
- [x] webhook integration test

```release-note
In CRD webhook conversion ignore changes to metadata other than for labels and annotations.
```