### PR TITLE
Use framework.ExpectNoError() for e2e/lifecycle/bootstrap

### DIFF
--- a/test/e2e/lifecycle/bootstrap/bootstrap_token_cleaner.go
+++ b/test/e2e/lifecycle/bootstrap/bootstrap_token_cleaner.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -45,41 +44,41 @@ var _ = lifecycle.SIGDescribe("[Feature:BootstrapTokens]", func() {
 			By("delete the bootstrap token secret")
 			err := c.CoreV1().Secrets(metav1.NamespaceSystem).Delete(secretNeedClean, &metav1.DeleteOptions{})
 			secretNeedClean = ""
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}
 	})
 	It("should delete the token secret when the secret expired", func() {
 		By("create a new expired bootstrap token secret")
 		tokenId, err := GenerateTokenId()
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		tokenSecret, err := GenerateTokenSecret()
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		secret := newTokenSecret(tokenId, tokenSecret)
 		addSecretExpiration(secret, TimeStringFromNow(-time.Hour))
 		_, err = c.CoreV1().Secrets(metav1.NamespaceSystem).Create(secret)
 
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("wait for the bootstrap token secret be deleted")
 		err = WaitForBootstrapTokenSecretToDisappear(c, tokenId)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 	It("should not delete the token secret when the secret is not expired", func() {
 		By("create a new expired bootstrap token secret")
 		tokenId, err := GenerateTokenId()
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		tokenSecret, err := GenerateTokenSecret()
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		secret := newTokenSecret(tokenId, tokenSecret)
 		addSecretExpiration(secret, TimeStringFromNow(time.Hour))
 		_, err = c.CoreV1().Secrets(metav1.NamespaceSystem).Create(secret)
 		secretNeedClean = bootstrapapi.BootstrapTokenSecretPrefix + tokenId
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("wait for the bootstrap token secret not be deleted")
 		err = WaitForBootstrapTokenSecretNotDisappear(c, tokenId, 20*time.Second)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The e2e test framework has ExpectNoError() for readable test code.
This replaces Expect(err).NotTo(HaveOccurred()) with it for e2e/lifecycle/bootstrap.

Ref: #77103

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
