### PR TITLE
Remove the `host` label from the kubelet http traffic metrics

### DIFF
--- a/pkg/kubelet/server/metrics/metrics.go
+++ b/pkg/kubelet/server/metrics/metrics.go
@@ -38,7 +38,7 @@ var (
 		// server_type aims to differentiate the readonly server and the readwrite server.
 		// long_running marks whether the request is long-running or not.
 		// Currently, long-running requests include exec/attach/portforward/debug.
-		[]string{"method", "path", "host", "server_type", "long_running"},
+		[]string{"method", "path", "server_type", "long_running"},
 	)
 	// HTTPRequestsDuration tracks the duration in seconds to serve http requests.
 	HTTPRequestsDuration = prometheus.NewHistogramVec(
@@ -49,7 +49,7 @@ var (
 			// Use DefBuckets for now, will customize the buckets if necessary.
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{"method", "path", "host", "server_type", "long_running"},
+		[]string{"method", "path", "server_type", "long_running"},
 	)
 	// HTTPInflightRequests tracks the number of the inflight http requests.
 	HTTPInflightRequests = prometheus.NewGaugeVec(
@@ -58,7 +58,7 @@ var (
 			Name:      "http_inflight_requests",
 			Help:      "Number of the inflight http requests",
 		},
-		[]string{"method", "path", "host", "server_type", "long_running"},
+		[]string{"method", "path", "server_type", "long_running"},
 	)
 )
 

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -859,17 +859,17 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		serverType = "readwrite"
 	}
 
-	method, path, host := req.Method, trimURLPath(req.URL.Path), req.URL.Host
+	method, path := req.Method, trimURLPath(req.URL.Path)
 
 	longRunning := strconv.FormatBool(isLongRunningRequest(path))
 
-	servermetrics.HTTPRequests.WithLabelValues(method, path, host, serverType, longRunning).Inc()
+	servermetrics.HTTPRequests.WithLabelValues(method, path, serverType, longRunning).Inc()
 
-	servermetrics.HTTPInflightRequests.WithLabelValues(method, path, host, serverType, longRunning).Inc()
-	defer servermetrics.HTTPInflightRequests.WithLabelValues(method, path, host, serverType, longRunning).Dec()
+	servermetrics.HTTPInflightRequests.WithLabelValues(method, path, serverType, longRunning).Inc()
+	defer servermetrics.HTTPInflightRequests.WithLabelValues(method, path, serverType, longRunning).Dec()
 
 	startTime := time.Now()
-	defer servermetrics.HTTPRequestsDuration.WithLabelValues(method, path, host, serverType, longRunning).Observe(servermetrics.SinceInSeconds(startTime))
+	defer servermetrics.HTTPRequestsDuration.WithLabelValues(method, path, serverType, longRunning).Observe(servermetrics.SinceInSeconds(startTime))
 
 	s.restfulCont.ServeHTTP(w, req)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
All the http requests coming into kubelet should have the same `host` info. Therefore, it is not very useful to have the `host` label here.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None.

**Special notes for your reviewer**:
The metrics were added in https://github.com/kubernetes/kubernetes/pull/75228.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
