### PR TITLE
Adds staging directory for kubectl code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -448,6 +448,7 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30
 	k8s.io/kube-proxy => ./staging/src/k8s.io/kube-proxy
 	k8s.io/kube-scheduler => ./staging/src/k8s.io/kube-scheduler
+	k8s.io/kubectl => ./staging/src/k8s.io/kubectl
 	k8s.io/kubelet => ./staging/src/k8s.io/kubelet
 	k8s.io/legacy-cloud-providers => ./staging/src/k8s.io/legacy-cloud-providers
 	k8s.io/metrics => ./staging/src/k8s.io/metrics

--- a/staging/README.md
+++ b/staging/README.md
@@ -23,6 +23,7 @@ Repositories currently staged here:
 - [`k8s.io/kube-controller-manager`](https://github.com/kubernetes/kube-controller-manager)
 - [`k8s.io/kube-proxy`](https://github.com/kubernetes/kube-proxy)
 - [`k8s.io/kube-scheduler`](https://github.com/kubernetes/kube-scheduler)
+- [`k8s.io/kubectl`](https://github.com/kubernetes/kubectl)
 - [`k8s.io/kubelet`](https://github.com/kubernetes/kubelet)
 - [`k8s.io/legacy-cloud-providers`](https://github.com/kubernetes/legacy-cloud-providers)
 - [`k8s.io/metrics`](https://github.com/kubernetes/metrics)

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -622,3 +622,16 @@ rules:
       dir: staging/src/k8s.io/cri-api
     name: release-1.15
     go: 1.12.5
+- destination: kubectl
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/kubectl
+    name: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/kubectl
+    name: release-1.15
+    go: 1.12.5
+

--- a/staging/repos_generated.bzl
+++ b/staging/repos_generated.bzl
@@ -32,6 +32,7 @@ staging_repos = [
     "k8s.io/kube-controller-manager",
     "k8s.io/kube-proxy",
     "k8s.io/kube-scheduler",
+    "k8s.io/kubectl",
     "k8s.io/kubelet",
     "k8s.io/legacy-cloud-providers",
     "k8s.io/metrics",

--- a/staging/src/BUILD
+++ b/staging/src/BUILD
@@ -31,6 +31,7 @@ filegroup(
         "//staging/src/k8s.io/kube-controller-manager:all-srcs",
         "//staging/src/k8s.io/kube-proxy:all-srcs",
         "//staging/src/k8s.io/kube-scheduler:all-srcs",
+        "//staging/src/k8s.io/kubectl:all-srcs",
         "//staging/src/k8s.io/kubelet:all-srcs",
         "//staging/src/k8s.io/legacy-cloud-providers:all-srcs",
         "//staging/src/k8s.io/metrics:all-srcs",

--- a/staging/src/k8s.io/kubectl/.github/PULL_REQUEST_TEMPLATE.md
+++ b/staging/src/k8s.io/kubectl/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,2 @@
+Sorry, we do not accept changes directly against this repository. Please see
+CONTRIBUTING.md for information on where and how to contribute instead.

--- a/staging/src/k8s.io/kubectl/BUILD
+++ b/staging/src/k8s.io/kubectl/BUILD
@@ -1,0 +1,13 @@
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/kubectl/CONTRIBUTING.md
+++ b/staging/src/k8s.io/kubectl/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing guidelines
+
+## How to become a contributor and submit your own code
+
+This repository does not directly accept contributions. Code in this repository is currently being copied from staging within the [Kubernetes repository](https://github.com/kubernetes/kubernetes/tree/master/staging). In order to contribute code to this repository, the coder must modify kubectl code in [staging](https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/kubectl).
+
+See [this doc](https://github.com/kubernetes/community/blob/master/sig-cli/CONTRIBUTING.md) for how to contribute code.

--- a/staging/src/k8s.io/kubectl/LICENSE
+++ b/staging/src/k8s.io/kubectl/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/staging/src/k8s.io/kubectl/OWNERS
+++ b/staging/src/k8s.io/kubectl/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-cli-maintainers
+reviewers:
+- sig-cli
+labels:
+- area/kubectl
+- sig/cli

--- a/staging/src/k8s.io/kubectl/README.md
+++ b/staging/src/k8s.io/kubectl/README.md
@@ -1,0 +1,42 @@
+# Kubectl
+
+![kubectl logo](./images/kubectl-logo-medium.png)
+
+[![Build Status](https://travis-ci.org/kubernetes/kubectl.svg?branch=master)](https://travis-ci.org/kubernetes/kubectl) [![GoDoc](https://godoc.org/k8s.io/kubectl?status.svg)](https://godoc.org/k8s.io/kubectl)
+
+The `k8s.io/kubectl` repo is used to track issues for the kubectl cli distributed
+with `k8s.io/kubernetes`. It also contains packages intended for use by client
+programs. E.g. these packages are vendored into `k8s.io/kubernetes` for use in
+the [kubectl](https://github.com/kubernetes/kubernetes/tree/master/cmd/kubectl)
+cli client. That client will eventually move here too.
+
+# Contribution Requirements
+
+- Full unit-test coverage.
+
+- Go tools compliant (`go get`, `go test`, etc.). It needs to be vendorable
+  somewhere else.
+
+- No dependence on `k8s.io/kubernetes`. Dependence on other repositories is fine.
+
+- Code must be usefully [commented](https://golang.org/doc/effective_go.html#commentary).
+  Not only for developers on the project, but also for external users of these packages.
+
+- When reviewing PRs, you are encouraged to use Golang's [code review
+  comments](https://github.com/golang/go/wiki/CodeReviewComments) page.
+
+- Packages in this repository should aspire to implement sensible, small
+  interfaces and import a limited set of dependencies.
+
+## Dependencies
+
+Dependencies are managed using [dep](https://github.com/golang/dep). Please
+refer to its documentation if needed.
+
+## Community, discussion, contribution, and support
+
+See [this document](https://github.com/kubernetes/community/tree/master/sig-cli) for how to reach the maintainers of this project.
+
+### Code of conduct
+
+Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).

--- a/staging/src/k8s.io/kubectl/SECURITY_CONTACTS
+++ b/staging/src/k8s.io/kubectl/SECURITY_CONTACTS
@@ -1,0 +1,17 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Committee to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+cjcullen
+joelsmith
+liggitt
+philips
+tallclair

--- a/staging/src/k8s.io/kubectl/code-of-conduct.md
+++ b/staging/src/k8s.io/kubectl/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -1,0 +1,7 @@
+// This is a generated file. Do not edit directly.
+
+module k8s.io/kubectl
+
+go 1.12
+
+replace k8s.io/kubectl => ../kubectl

--- a/vendor/k8s.io/kubectl
+++ b/vendor/k8s.io/kubectl
@@ -1,0 +1,1 @@
+../../staging/src/k8s.io/kubectl


### PR DESCRIPTION
* Creates staging directory for kubectl code
* Adds the following initial files to this directory:
  - .github/PULL_REQUEST_TEMPLATE.md
  - code-of-conduct.md
  - LICENSE
  - OWNERS
  - README.md
  - SECURITY_CONTACTS
* Code committed to the kubectl staging directory will be published to: https://github.com/kubernetes/kubectl


For more infomation please see the initial KEP describing kubectl staging move:
https://github.com/kubernetes/enhancements/pull/949

as well as:
https://github.com/kubernetes/enhancements/pull/1028

```release-note
NONE
```

/kind cleanup
/sig cli
/area kubectl