### PR TITLE
Address kubelet runtimeclass.Manager panic

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -657,7 +657,13 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.runtimeService = runtimeService
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClass) {
-		klet.runtimeClassManager = runtimeclass.NewManager(kubeDeps.KubeClient)
+		runtimeClassManager, err := runtimeclass.NewManager(kubeDeps.KubeClient)
+
+		if err != nil {
+			return nil, err
+		}
+
+		klet.runtimeClassManager = runtimeClassManager
 	}
 
 	runtime, err := kuberuntime.NewKubeGenericRuntimeManager(

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -61,7 +61,7 @@ func TestCreatePodSandbox(t *testing.T) {
 func TestCreatePodSandbox_RuntimeClass(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RuntimeClass, true)()
 
-	rcm := runtimeclass.NewManager(rctest.NewPopulatedClient())
+	rcm, _ := runtimeclass.NewManager(rctest.NewPopulatedClient())
 	defer rctest.StartManagerSync(rcm)()
 
 	fakeRuntime, _, m, err := createTestRuntimeManager()

--- a/pkg/kubelet/runtimeclass/runtimeclass_manager.go
+++ b/pkg/kubelet/runtimeclass/runtimeclass_manager.go
@@ -32,16 +32,22 @@ type Manager struct {
 }
 
 // NewManager returns a new RuntimeClass Manager. Run must be called before the manager can be used.
-func NewManager(client clientset.Interface) *Manager {
+func NewManager(client clientset.Interface) (*Manager, error) {
+	if client == nil {
+		return nil, fmt.Errorf("cannot create Manager because client is nil")
+	}
+
 	const resyncPeriod = 0
 
 	factory := informers.NewSharedInformerFactory(client, resyncPeriod)
 	lister := factory.Node().V1beta1().RuntimeClasses().Lister()
 
-	return &Manager{
+	manager := &Manager{
 		informerFactory: factory,
 		lister:          lister,
 	}
+
+	return manager, nil
 }
 
 // Start starts syncing the RuntimeClass cache with the apiserver.

--- a/pkg/kubelet/runtimeclass/runtimeclass_manager_test.go
+++ b/pkg/kubelet/runtimeclass/runtimeclass_manager_test.go
@@ -39,7 +39,7 @@ func TestLookupRuntimeHandler(t *testing.T) {
 		{rcn: pointer.StringPtr("phantom"), expectError: true},
 	}
 
-	manager := runtimeclass.NewManager(rctest.NewPopulatedClient())
+	manager, _ := runtimeclass.NewManager(rctest.NewPopulatedClient())
 	defer rctest.StartManagerSync(manager)()
 
 	for _, test := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
We were not ensuring that the `Manager` was using a non-nil client,
which created the possibility for runtime panics.

Now, we check that a non-nil client is passed during the `NewManager`,
allowing us to return a descriptive error message during the Manager's
initialization, which we handle as we handle errors creating other
managers in `pkg/kubelet/kubelet.go#NewMainKubelet`.

**Special notes for your reviewer**:
cc @yastij 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
