### PR TITLE
Swap mapfile out in update-codegen

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -62,16 +62,18 @@ GV_DIRS_CSV=$(IFS=',';echo "${GV_DIRS[*]// /,}";IFS=$)
 # update- and verify- scripts.
 ${clientgen} --output-base "${KUBE_ROOT}/vendor" --output-package="k8s.io/client-go" --clientset-name="kubernetes" --input-base="k8s.io/kubernetes/vendor/k8s.io/api" --input="${GV_DIRS_CSV}" --go-header-file "${KUBE_ROOT}/hack/boilerplate/boilerplate.generatego.txt" "$@"
 
-mapfile -t listergen_external_apis < <(
+listergen_external_apis=()
+kube::util::read-array listergen_external_apis < <(
   cd "${KUBE_ROOT}/staging/src"
   find k8s.io/api -name types.go -print0 | xargs -0 -n1 dirname | sort
 )
 listergen_external_apis_csv=$(IFS=,; echo "${listergen_external_apis[*]}")
 ${listergen} --output-base "${KUBE_ROOT}/vendor" --output-package "k8s.io/client-go/listers" --input-dirs "${listergen_external_apis_csv}" --go-header-file "${KUBE_ROOT}/hack/boilerplate/boilerplate.generatego.txt" "$@"
 
-mapfile -t informergen_external_apis < <(
+informergen_external_apis=()
+# because client-gen doesn't do policy/v1alpha1, we have to skip it too
+kube::util::read-array informergen_external_apis < <(
   cd "${KUBE_ROOT}/staging/src"
-  # because client-gen doesn't do policy/v1alpha1, we have to skip it too
   find k8s.io/api -name types.go -print0 | xargs -0 -n1 dirname | sort | grep -v pkg.apis.policy.v1alpha1
 )
 informergen_external_apis_csv=$(IFS=,; echo "${informergen_external_apis[*]}")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Don't use mapfile in `hack/update-codegen.sh`. Fixes compatibility with bash 3.

Was erroneously introduced in https://github.com/kubernetes/kubernetes/pull/76482.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
