### PR TITLE
Fix suggested cmd usage kubectl exec

### DIFF
--- a/pkg/kubectl/cmd/exec/exec.go
+++ b/pkg/kubectl/cmd/exec/exec.go
@@ -24,7 +24,6 @@ import (
 
 	dockerterm "github.com/docker/docker/pkg/term"
 	"github.com/spf13/cobra"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -32,6 +31,7 @@ import (
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
@@ -203,7 +203,7 @@ func (p *ExecOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn []s
 		p.FullCmdName = cmdParent.CommandPath()
 	}
 	if len(p.FullCmdName) > 0 && cmdutil.IsSiblingCommandExists(cmd, "describe") {
-		p.SuggestedCmdUsage = fmt.Sprintf("Use '%s describe %s -n %s' to see all of the containers in this pod.", p.FullCmdName, p.ResourceName, p.Namespace)
+		p.SuggestedCmdUsage = fmt.Sprintf("Use '%s describe pod/%%s -n %s' to see all of the containers in this pod.", p.FullCmdName, p.Namespace)
 	}
 
 	p.Config, err = f.ToRESTConfig()
@@ -324,7 +324,8 @@ func (p *ExecOptions) Run() error {
 		if len(pod.Spec.Containers) > 1 {
 			usageString := fmt.Sprintf("Defaulting container name to %s.", pod.Spec.Containers[0].Name)
 			if len(p.SuggestedCmdUsage) > 0 {
-				usageString = fmt.Sprintf("%s\n%s", usageString, p.SuggestedCmdUsage)
+				suggestedCmdUsage := fmt.Sprintf(p.SuggestedCmdUsage, pod.Name)
+				usageString = fmt.Sprintf("%s\n%s", usageString, suggestedCmdUsage)
 			}
 			fmt.Fprintf(p.ErrOut, "%s\n", usageString)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

this suggestion show when the pod have more than one containers.

in my previous PR #73664 i change the `PodName` in `SuggestedCmdUsage` to `ResourceName` and now i realized it was wrong.

it should give suggestion
`Use 'kubectl describe pod/POD -n NAMESPACE' to see all of the containers in this pod.`
instead of
`Use 'kubectl describe TYPE/NAME -n NAMESPACE' to see all of the containers in this pod.`
because not all `TYPE/NAME` will show the containers inside pod when run `kubectl describe` eg: `kubectl describe service/NAME`. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
