### PR TITLE
kubeadm: prevent PSP blocking of upgrade image prepull

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/BUILD
+++ b/cmd/kubeadm/app/phases/upgrade/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/pkg/version:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/phases/upgrade/prepull.go
+++ b/cmd/kubeadm/app/phases/upgrade/prepull.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/pkg/errors"
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 const (
@@ -183,6 +184,11 @@ func buildPrePullDaemonSet(component, image string) *apps.DaemonSet {
 					},
 					Tolerations:                   []v1.Toleration{constants.ControlPlaneToleration},
 					TerminationGracePeriodSeconds: &gracePeriodSecs,
+					// Explicitly add a PodSecurityContext to allow these Pods to run as non-root.
+					// This prevents restrictive PSPs from blocking the Pod creation.
+					SecurityContext: &v1.PodSecurityContext{
+						RunAsUser: utilpointer.Int64Ptr(999),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
kubeadm: prevent PSP blocking of upgrade image prepull

If the cluster has a PSP that blocks Pods from running as root
the DS that handles upgrade prepull will fail to create its Pods.

Workaround that by adding a PodSecurityContext with RunAsUser=999.

see the discussions here:
https://github.com/kubernetes/kubeadm/issues/1208
https://github.com/kubernetes/kubernetes/issues/77787

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#1208

**Special notes for your reviewer**:
example ClusterRole + PSP are here:
https://gist.github.com/praseodym/88ea84fef721f0da5ecf6b1f42ba77d7#file-psp-clusterroles-yaml

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: prevent PSP blocking of upgrade image prepull by using a non-root user
```
/priority important-longterm
/kind bug
@kubernetes/sig-cluster-lifecycle-pr-reviews 
cc @praseodym

holding on review from:
cc @mauilion @joshrosso 
/hold
