### PR TITLE
Use TCP instead of ICMP to check outbound connectivity

### DIFF
--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -47,13 +47,13 @@ var _ = SIGDescribe("Networking", func() {
 	})
 
 	ginkgo.It("should provide Internet connection for containers [Feature:Networking-IPv4]", func() {
-		ginkgo.By("Running container which tries to ping 8.8.8.8")
+		ginkgo.By("Running container which tries to connect to 8.8.8.8")
 		framework.ExpectNoError(
 			framework.CheckConnectivityToHost(f, "", "connectivity-test", "8.8.8.8", 53, 30))
 	})
 
 	ginkgo.It("should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]", func() {
-		ginkgo.By("Running container which tries to ping 2001:4860:4860::8888")
+		ginkgo.By("Running container which tries to connect to 2001:4860:4860::8888")
 		framework.ExpectNoError(
 			framework.CheckConnectivityToHost(f, "", "connectivity-test", "2001:4860:4860::8888", 53, 30))
 	})

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -49,13 +49,13 @@ var _ = SIGDescribe("Networking", func() {
 	ginkgo.It("should provide Internet connection for containers [Feature:Networking-IPv4]", func() {
 		ginkgo.By("Running container which tries to ping 8.8.8.8")
 		framework.ExpectNoError(
-			framework.CheckConnectivityToHost(f, "", "ping-test", "8.8.8.8", framework.IPv4PingCommand, 30))
+			framework.CheckConnectivityToHost(f, "", "connectivity-test", "8.8.8.8", 53, 30))
 	})
 
 	ginkgo.It("should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]", func() {
 		ginkgo.By("Running container which tries to ping 2001:4860:4860::8888")
 		framework.ExpectNoError(
-			framework.CheckConnectivityToHost(f, "", "ping-test", "2001:4860:4860::8888", framework.IPv6PingCommand, 30))
+			framework.CheckConnectivityToHost(f, "", "connectivity-test", "2001:4860:4860::8888", 53, 30))
 	})
 
 	// First test because it has no dependencies on variables created later on.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR updates the networking e2e test on Azure to use ```nc``` instead of ```ping``` for IPv4 tests. This is because Azure's LB drops ICMP packets for security reasons. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #75172

**Special notes for your reviewer**:

This PR only includes fix for IPv4 test, because the current busybox image doesn't have ```nc``` support for IPv6. Will prepare an image with ```nc``` support for IPv6 and update the rest tests in the future.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
