### PR TITLE
Remove selected IP from backup-volfile-servers list to avoid warning in mount logs.

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -371,18 +371,26 @@ func (b *glusterfsMounter) setUpAtInternal(dir string) error {
 		}
 	}
 
-	//Add backup-volfile-servers and auto_unmount options.
-	options = append(options, "backup-volfile-servers="+dstrings.Join(addrlist[:], ":"))
-	options = append(options, "auto_unmount")
-
-	mountOptions := volutil.JoinMountOptions(b.mountOptions, options)
-	// with `backup-volfile-servers` mount option in place, it is not required to
-	// iterate over all the servers in the addrlist. A mount attempt with this option
-	// will fetch all the servers mentioned in the backup-volfile-servers list.
-	// Refer to backup-volfile-servers @ http://docs.gluster.org/en/latest/Administrator%20Guide/Setting%20Up%20Clients/
-
 	if (len(addrlist) > 0) && (addrlist[0] != "") {
 		ip := addrlist[rand.Intn(len(addrlist))]
+
+		// Add backup-volfile-servers and auto_unmount options.
+		// When ip is also in backup-volfile-servers, there will be a warning:
+		// "gf_remember_backup_volfile_server] 0-glusterfs: failed to set volfile server: File exists".
+		addr.Delete(ip)
+		backups := addr.List()
+		// Avoid an invalid empty backup-volfile-servers option.
+		if len(backups) > 0 {
+			options = append(options, "backup-volfile-servers="+dstrings.Join(addrlist[:], ":"))
+		}
+		options = append(options, "auto_unmount")
+
+		mountOptions := volutil.JoinMountOptions(b.mountOptions, options)
+		// with `backup-volfile-servers` mount option in place, it is not required to
+		// iterate over all the servers in the addrlist. A mount attempt with this option
+		// will fetch all the servers mentioned in the backup-volfile-servers list.
+		// Refer to backup-volfile-servers @ http://docs.gluster.org/en/latest/Administrator%20Guide/Setting%20Up%20Clients/
+
 		errs = b.mounter.Mount(ip+":"+b.path, dir, "glusterfs", mountOptions)
 		if errs == nil {
 			klog.Infof("successfully mounted directory %s", dir)


### PR DESCRIPTION
**What type of PR is this?**

/kind ?

**What this PR does / why we need it**:

in pkg/volume/glusterfs/glusterfs.go:
remove the selected ip from backup servers' ip set.

**Which issue(s) this PR fixes**:

"[glusterfsd.c:825:gf_remember_backup_volfile_server] 0-glusterfs: failed to set volfile server: File exists" when the selected ip is also in backups.

**Special notes for your reviewer**:

test with k8s v1.10.0 and glusterfs v6.1 on centos 7.2.1511(kernel 3.15.6 smp x86_64 gnu/linux).

@xichengliudui @jsafrane @humblec thanks a lot.
so embarrassed.

i am so sorry about the first two prs.
because i had done prs from kubernetes/kubernetes to nagexiucai/kubernetes, so my hot branch for this pr will always be with irrelevant commits, and i can not compress them locally, `git log --author="nagexiucai"` shows just one commit.
therefore, i had deleted the hot branch twice, as the results, #77711 and #77769 breaks.
now i had revised pr's title and make "just one commit in one pr" true.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
