### PR TITLE
Fill ContainerStateTerminated with value from kubecontainer.PodStatus

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1987,6 +1987,7 @@ func (kl *Kubelet) dispatchWork(pod *v1.Pod, syncType kubetypes.SyncPodType, mir
 			if podStatus, err := kl.podCache.Get(pod.UID); err == nil {
 				kl.statusManager.TerminatePod(pod, podStatus)
 			} else {
+				klog.V(3).Infof("Didn't find pod %q in cache", format.Pod(pod))
 				kl.statusManager.TerminatePod(pod, nil)
 			}
 		}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1984,7 +1984,11 @@ func (kl *Kubelet) dispatchWork(pod *v1.Pod, syncType kubetypes.SyncPodType, mir
 			// handle the work item. Check if the DeletionTimestamp has been
 			// set, and force a status update to trigger a pod deletion request
 			// to the apiserver.
-			kl.statusManager.TerminatePod(pod)
+			if podStatus, err := kl.podCache.Get(pod.UID); err == nil {
+				kl.statusManager.TerminatePod(pod, podStatus)
+			} else {
+				kl.statusManager.TerminatePod(pod, nil)
+			}
 		}
 		return
 	}

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -356,7 +356,7 @@ func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUp
 	}
 	if pod.Spec.RestartPolicy != v1.RestartPolicyAlways && oldStatus.Phase == v1.PodFailed && status.Phase != v1.PodFailed {
 		klog.Errorf("terminated pod %v attempted illegal transition to non-terminated state", pod.Name)
-		return false;
+		return false
 	}
 
 	// Set ContainersReadyCondition.LastTransitionTime.

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -574,7 +574,7 @@ func TestTerminatePod(t *testing.T) {
 	testPod.Status = getRandomPodStatus()
 	testPod.Status.Phase = v1.PodRunning
 
-	syncer.TerminatePod(testPod)
+	syncer.TerminatePod(testPod, nil)
 
 	t.Logf("we expect the container statuses to have changed to terminated")
 	newStatus := expectPodStatus(t, syncer, testPod)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently in manager#TerminatePod, we construct ContainerStateTerminated with default values.
This results in non-intuitive output (quoted from issues #58711) :
```
Status Manager: adding pod: "f7eb64a7-74d5-11e9-aa89-122245370f70", with status: ('\x05', {Failed [{Initialized True 0001-01-01 00:00:00
```
This PR passes kubecontainer.PodStatus from Kubelet#dispatchWork so that the ContainerStateTerminated can be constructed with meaningful values.

Also adds check for Pod status so that failed state is not rolled back to success.

```release-note
NONE
```
