### PR TITLE
Add rules for publishing release-1.15 branches

### DIFF
--- a/staging/publishing/rules-godeps.yaml
+++ b/staging/publishing/rules-godeps.yaml
@@ -8,11 +8,6 @@ rules:
 - destination: code-generator
   branches:
   - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/code-generator
-    name: release-1.11
-    go: 1.10.2
-  - source:
       branch: release-1.12
       dir: staging/src/k8s.io/code-generator
     name: release-1.12
@@ -31,11 +26,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/apimachinery
-    name: release-1.11
-    go: 1.10.2
-  - source:
       branch: release-1.12
       dir: staging/src/k8s.io/apimachinery
     name: release-1.12
@@ -53,14 +43,6 @@ rules:
 - destination: api
   library: true
   branches:
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/api
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
   - source:
       branch: release-1.12
       dir: staging/src/k8s.io/api
@@ -88,16 +70,6 @@ rules:
 - destination: client-go
   library: true
   branches:
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/client-go
-    name: release-8.0
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
   - source:
       branch: release-1.12
       dir: staging/src/k8s.io/client-go
@@ -147,18 +119,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/apiserver
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-    - repository: client-go
-      branch: release-8.0
-  - source:
       branch: release-1.12
       dir: staging/src/k8s.io/apiserver
     name: release-1.12
@@ -198,20 +158,6 @@ rules:
         branch: release-1.14
 - destination: kube-aggregator
   branches:
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-    - repository: client-go
-      branch: release-8.0
-    - repository: apiserver
-      branch: release-1.11
   - source:
       branch: release-1.12
       dir: staging/src/k8s.io/kube-aggregator
@@ -258,24 +204,6 @@ rules:
         branch: release-1.14
 - destination: sample-apiserver
   branches:
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-    - repository: client-go
-      branch: release-8.0
-    - repository: apiserver
-      branch: release-1.11
-    - repository: code-generator
-      branch: release-1.11
-    required-packages:
-    - k8s.io/code-generator
   - source:
       branch: release-1.12
       dir: staging/src/k8s.io/sample-apiserver
@@ -343,22 +271,6 @@ rules:
 - destination: sample-controller
   branches:
   - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-    - repository: client-go
-      branch: release-8.0
-    - repository: code-generator
-      branch: release-1.11
-    required-packages:
-    - k8s.io/code-generator
-  - source:
       branch: release-1.12
       dir: staging/src/k8s.io/sample-controller
     name: release-1.12
@@ -420,24 +332,6 @@ rules:
 - destination: apiextensions-apiserver
   branches:
   - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-    - repository: client-go
-      branch: release-8.0
-    - repository: apiserver
-      branch: release-1.11
-    - repository: code-generator
-      branch: release-1.11
-    required-packages:
-    - k8s.io/code-generator
-  - source:
       branch: release-1.12
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.12
@@ -496,18 +390,6 @@ rules:
 - destination: metrics
   library: true
   branches:
-  - source:
-      branch: release-1.11
-      dir: staging/src/k8s.io/metrics
-    name: release-1.11
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.11
-    - repository: api
-      branch: release-1.11
-    - repository: client-go
-      branch: release-8.0
   - source:
       branch: release-1.12
       dir: staging/src/k8s.io/metrics

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -11,6 +11,11 @@ rules:
       branch: master
       dir: staging/src/k8s.io/code-generator
     name: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.15
+    go: 1.12.5
 - destination: apimachinery
   library: true
   branches:
@@ -18,6 +23,11 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apimachinery
     name: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.15
+    go: 1.12.5
 - destination: api
   library: true
   branches:
@@ -28,6 +38,14 @@ rules:
     dependencies:
     - repository: apimachinery
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/api
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.15
 - destination: client-go
   library: true
   branches:
@@ -40,6 +58,16 @@ rules:
       branch: master
     - repository: api
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/client-go
+    name: release-12.0
+    go: 1.12.5
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.15
+      - repository: api
+        branch: release-1.15
   smoke-test: |
     # assumes GO111MODULE=on
     go build ./...
@@ -54,6 +82,14 @@ rules:
     dependencies:
     - repository: apimachinery
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/component-base
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.15
 - destination: apiserver
   library: true
   branches:
@@ -70,6 +106,20 @@ rules:
       branch: master
     - repository: component-base
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: api
+      branch: release-1.15
+    - repository: client-go
+      branch: release-12.0
+    - repository: component-base
+      branch: release-1.15
 - destination: kube-aggregator
   branches:
   - source:
@@ -89,6 +139,24 @@ rules:
       branch: master
     - repository: code-generator
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: api
+      branch: release-1.15
+    - repository: client-go
+      branch: release-12.0
+    - repository: apiserver
+      branch: release-1.15
+    - repository: component-base
+      branch: release-1.15
+    - repository: code-generator
+      branch: release-1.15
 - destination: sample-apiserver
   branches:
   - source:
@@ -108,6 +176,26 @@ rules:
       branch: master
     - repository: component-base
       branch: master
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: api
+      branch: release-1.15
+    - repository: client-go
+      branch: release-12.0
+    - repository: apiserver
+      branch: release-1.15
+    - repository: code-generator
+      branch: release-1.15
+    - repository: component-base
+      branch: release-1.15
     required-packages:
     - k8s.io/code-generator
   smoke-test: |
@@ -130,6 +218,24 @@ rules:
       branch: master
     - repository: component-base
       branch: master
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: api
+      branch: release-1.15
+    - repository: client-go
+      branch: release-12.0
+    - repository: code-generator
+      branch: release-1.15
+    - repository: component-base
+      branch: release-1.15
     required-packages:
     - k8s.io/code-generator
   smoke-test: |
@@ -156,6 +262,26 @@ rules:
       branch: master
     required-packages:
     - k8s.io/code-generator
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: api
+      branch: release-1.15
+    - repository: client-go
+      branch: release-12.0
+    - repository: apiserver
+      branch: release-1.15
+    - repository: code-generator
+      branch: release-1.15
+    - repository: component-base
+      branch: release-1.15
+    required-packages:
+    - k8s.io/code-generator
 - destination: metrics
   library: true
   branches:
@@ -172,6 +298,20 @@ rules:
       branch: master
     - repository: code-generator
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/metrics
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: api
+      branch: release-1.15
+    - repository: client-go
+      branch: release-12.0
+    - repository: code-generator
+      branch: release-1.15
 - destination: cli-runtime
   library: true
   branches:
@@ -186,6 +326,18 @@ rules:
       branch: master
     - repository: client-go
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: api
+      branch: release-1.15
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: client-go
+      branch: release-12.0
 - destination: sample-cli-plugin
   library: false
   branches:
@@ -204,6 +356,22 @@ rules:
       branch: master
     - repository: component-base
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: api
+      branch: release-1.15
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: cli-runtime
+      branch: release-1.15
+    - repository: client-go
+      branch: release-12.0
+    - repository: component-base
+      branch: release-1.15
 - destination: kube-proxy
   library: true
   branches:
@@ -216,6 +384,16 @@ rules:
       branch: master
     - repository: component-base
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: component-base
+      branch: release-1.15
 - destination: kubelet
   library: true
   branches:
@@ -230,6 +408,18 @@ rules:
       branch: master
     - repository: component-base
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: api
+      branch: release-1.15
+    - repository: component-base
+      branch: release-1.15
 - destination: kube-scheduler
   library: true
   branches:
@@ -244,6 +434,18 @@ rules:
       branch: master
     - repository: component-base
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: apiserver
+      branch: release-1.15
+    - repository: component-base
+      branch: release-1.15
 - destination: kube-controller-manager
   library: true
   branches:
@@ -258,6 +460,18 @@ rules:
       branch: master
     - repository: component-base
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: apiserver
+      branch: release-1.15
+    - repository: component-base
+      branch: release-1.15
 - destination: cluster-bootstrap
   library: true
   branches:
@@ -270,6 +484,16 @@ rules:
       branch: master
     - repository: api
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: api
+      branch: release-1.15
 - destination: cloud-provider
   library: true
   branches:
@@ -284,6 +508,18 @@ rules:
       branch: master
     - repository: client-go
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/cloud-provider
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: api
+      branch: release-1.15
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: client-go
+      branch: release-12.0
 - destination: csi-translation-lib
   library: true
   branches:
@@ -298,6 +534,18 @@ rules:
       branch: master
     - repository: cloud-provider
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/csi-translation-lib
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: api
+      branch: release-1.15
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: cloud-provider
+      branch: release-1.15
 - destination: legacy-cloud-providers
   library: true
   branches:
@@ -316,6 +564,22 @@ rules:
       branch: master
     - repository: csi-translation-lib
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/legacy-cloud-providers
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: api
+      branch: release-1.15
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: client-go
+      branch: release-12.0
+    - repository: cloud-provider
+      branch: release-1.15
+    - repository: csi-translation-lib
+      branch: release-1.15
 - destination: node-api
   library: true
   branches:
@@ -332,6 +596,20 @@ rules:
       branch: master
     - repository: code-generator
       branch: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/node-api
+    name: release-1.15
+    go: 1.12.5
+    dependencies:
+    - repository: api
+      branch: release-1.15
+    - repository: apimachinery
+      branch: release-1.15
+    - repository: client-go
+      branch: release-12.0
+    - repository: code-generator
+      branch: release-1.15
 - destination: cri-api
   library: true
   branches:
@@ -339,3 +617,8 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cri-api
     name: master
+  - source:
+      branch: release-1.15
+      dir: staging/src/k8s.io/cri-api
+    name: release-1.15
+    go: 1.12.5


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/77871

1.15 branch will be cut tomorrow, so I figured it would be good to have the PR out early this time. :) 
Ref: https://github.com/kubernetes/sig-release/tree/master/releases/release-1.15#timeline

This PR also removes rules for publishing patch releases for 1.11.

/hold
Until:
1. the 1.15 branch is actually created
2. it's confirmed that it's ok to remove 1.11 rules

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
