### PR TITLE
Extract `getSwapIsOn` from NewContainerManager

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -19,13 +19,11 @@ limitations under the License.
 package cm
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -206,18 +204,14 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	}
 
 	if failSwapOn {
-		// Check whether swap is enabled. The Kubelet does not support running with swap enabled.
-		swapData, err := ioutil.ReadFile("/proc/swaps")
+		swapIsOn, err := getSwapIsOn()
+
 		if err != nil {
 			return nil, err
 		}
-		swapData = bytes.TrimSpace(swapData) // extra trailing \n
-		swapLines := strings.Split(string(swapData), "\n")
 
-		// If there is more than one line (table headers) in /proc/swaps, swap is enabled and we should
-		// error out unless --fail-swap-on is set to false.
-		if len(swapLines) > 1 {
-			return nil, fmt.Errorf("Running with swap on is not supported, please disable swap! or set --fail-swap-on flag to false. /proc/swaps contained: %v", swapLines)
+		if swapIsOn {
+			return nil, fmt.Errorf("Running with swap on is not supported, please disable swap! or set --fail-swap-on flag to false.")
 		}
 	}
 

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -18,10 +18,13 @@ package cm
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 
@@ -269,4 +272,17 @@ func GetRuntimeContainer(containerRuntime, runtimeCgroups string) (string, error
 		return cont, nil
 	}
 	return runtimeCgroups, nil
+}
+
+func getSwapIsOn() (bool, error) {
+	swapData, err := ioutil.ReadFile("/proc/swaps")
+	if err != nil {
+		return false, err
+	}
+
+	swapData = bytes.TrimSpace(swapData) // extra trailing \n
+	swapLines := strings.Split(string(swapData), "\n")
+
+	swapIsOn := len(swapLines) > 1
+	return swapIsOn, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Extract `getSwapIsOn` function from `NewContainerManager` and place in
`helpers_linux.go`. This extraction makes `NewContainerManager` more
readable, as it is shorter and less concerned with the implementation
details of how to check if swap is on.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
