### PR TITLE
Move helper functions to `helpers_linux.go`

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -24,12 +24,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"k8s.io/klog"
@@ -59,7 +57,6 @@ import (
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/util/oom"
-	"k8s.io/kubernetes/pkg/util/procfs"
 	utilsysctl "k8s.io/kubernetes/pkg/util/sysctl"
 	utilpath "k8s.io/utils/path"
 )
@@ -501,21 +498,6 @@ func (cm *containerManagerImpl) setupNode(activePods ActivePodsFunc) error {
 	return nil
 }
 
-func getContainerNameForProcess(name, pidFile string) (string, error) {
-	pids, err := getPidsForProcess(name, pidFile)
-	if err != nil {
-		return "", fmt.Errorf("failed to detect process id for %q - %v", name, err)
-	}
-	if len(pids) == 0 {
-		return "", nil
-	}
-	cont, err := getContainer(pids[0])
-	if err != nil {
-		return "", err
-	}
-	return cont, nil
-}
-
 func (cm *containerManagerImpl) GetNodeConfig() NodeConfig {
 	cm.RLock()
 	defer cm.RUnlock()
@@ -661,63 +643,6 @@ func (cm *containerManagerImpl) SystemCgroupsLimit() v1.ResourceList {
 	}
 }
 
-func isProcessRunningInHost(pid int) (bool, error) {
-	// Get init pid namespace.
-	initPidNs, err := os.Readlink("/proc/1/ns/pid")
-	if err != nil {
-		return false, fmt.Errorf("failed to find pid namespace of init process")
-	}
-	klog.V(10).Infof("init pid ns is %q", initPidNs)
-	processPidNs, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", pid))
-	if err != nil {
-		return false, fmt.Errorf("failed to find pid namespace of process %q", pid)
-	}
-	klog.V(10).Infof("Pid %d pid ns is %q", pid, processPidNs)
-	return initPidNs == processPidNs, nil
-}
-
-func getPidFromPidFile(pidFile string) (int, error) {
-	file, err := os.Open(pidFile)
-	if err != nil {
-		return 0, fmt.Errorf("error opening pid file %s: %v", pidFile, err)
-	}
-	defer file.Close()
-
-	data, err := ioutil.ReadAll(file)
-	if err != nil {
-		return 0, fmt.Errorf("error reading pid file %s: %v", pidFile, err)
-	}
-
-	pid, err := strconv.Atoi(string(data))
-	if err != nil {
-		return 0, fmt.Errorf("error parsing %s as a number: %v", string(data), err)
-	}
-
-	return pid, nil
-}
-
-func getPidsForProcess(name, pidFile string) ([]int, error) {
-	if len(pidFile) == 0 {
-		return procfs.PidOf(name)
-	}
-
-	pid, err := getPidFromPidFile(pidFile)
-	if err == nil {
-		return []int{pid}, nil
-	}
-
-	// Try to lookup pid by process name
-	pids, err2 := procfs.PidOf(name)
-	if err2 == nil {
-		return pids, nil
-	}
-
-	// Return error from getPidFromPidFile since that should have worked
-	// and is the real source of the problem.
-	klog.V(4).Infof("unable to get pid from %s: %v", pidFile, err)
-	return []int{}, err
-}
-
 // Ensures that the Docker daemon is in the desired container.
 // Temporarily export the function to be used by dockershim.
 // TODO(yujuhong): Move this function to dockershim once kubelet migrates to
@@ -781,51 +706,6 @@ func ensureProcessInContainerWithOOMScore(pid int, oomScoreAdj int, manager *fs.
 	return utilerrors.NewAggregate(errs)
 }
 
-// getContainer returns the cgroup associated with the specified pid.
-// It enforces a unified hierarchy for memory and cpu cgroups.
-// On systemd environments, it uses the name=systemd cgroup for the specified pid.
-func getContainer(pid int) (string, error) {
-	cgs, err := cgroups.ParseCgroupFile(fmt.Sprintf("/proc/%d/cgroup", pid))
-	if err != nil {
-		return "", err
-	}
-
-	cpu, found := cgs["cpu"]
-	if !found {
-		return "", cgroups.NewNotFoundError("cpu")
-	}
-	memory, found := cgs["memory"]
-	if !found {
-		return "", cgroups.NewNotFoundError("memory")
-	}
-
-	// since we use this container for accounting, we need to ensure its a unified hierarchy.
-	if cpu != memory {
-		return "", fmt.Errorf("cpu and memory cgroup hierarchy not unified.  cpu: %s, memory: %s", cpu, memory)
-	}
-
-	// on systemd, every pid is in a unified cgroup hierarchy (name=systemd as seen in systemd-cgls)
-	// cpu and memory accounting is off by default, users may choose to enable it per unit or globally.
-	// users could enable CPU and memory accounting globally via /etc/systemd/system.conf (DefaultCPUAccounting=true DefaultMemoryAccounting=true).
-	// users could also enable CPU and memory accounting per unit via CPUAccounting=true and MemoryAccounting=true
-	// we only warn if accounting is not enabled for CPU or memory so as to not break local development flows where kubelet is launched in a terminal.
-	// for example, the cgroup for the user session will be something like /user.slice/user-X.slice/session-X.scope, but the cpu and memory
-	// cgroup will be the closest ancestor where accounting is performed (most likely /) on systems that launch docker containers.
-	// as a result, on those systems, you will not get cpu or memory accounting statistics for kubelet.
-	// in addition, you would not get memory or cpu accounting for the runtime unless accounting was enabled on its unit (or globally).
-	if systemd, found := cgs["name=systemd"]; found {
-		if systemd != cpu {
-			klog.Warningf("CPUAccounting not enabled for pid: %d", pid)
-		}
-		if systemd != memory {
-			klog.Warningf("MemoryAccounting not enabled for pid: %d", pid)
-		}
-		return systemd, nil
-	}
-
-	return cpu, nil
-}
-
 // Ensures the system container is created and all non-kernel threads and process 1
 // without a container are moved to it.
 //
@@ -877,13 +757,6 @@ func ensureSystemCgroups(rootCgroupPath string, manager *fs.Manager) error {
 	}
 
 	return utilerrors.NewAggregate(errs)
-}
-
-// Determines whether the specified PID is a kernel PID.
-func isKernelPid(pid int) bool {
-	// Kernel threads have no associated executable.
-	_, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
-	return err != nil
 }
 
 func (cm *containerManagerImpl) GetCapacity() v1.ResourceList {

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -19,19 +19,23 @@ package cm
 import (
 	"bufio"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/api/v1/resource"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/util/procfs"
 )
 
 const (
@@ -269,4 +273,128 @@ func GetRuntimeContainer(containerRuntime, runtimeCgroups string) (string, error
 		return cont, nil
 	}
 	return runtimeCgroups, nil
+}
+
+func getContainerNameForProcess(name, pidFile string) (string, error) {
+	pids, err := getPidsForProcess(name, pidFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to detect process id for %q - %v", name, err)
+	}
+	if len(pids) == 0 {
+		return "", nil
+	}
+	cont, err := getContainer(pids[0])
+	if err != nil {
+		return "", err
+	}
+	return cont, nil
+}
+
+func isProcessRunningInHost(pid int) (bool, error) {
+	// Get init pid namespace.
+	initPidNs, err := os.Readlink("/proc/1/ns/pid")
+	if err != nil {
+		return false, fmt.Errorf("failed to find pid namespace of init process")
+	}
+	klog.V(10).Infof("init pid ns is %q", initPidNs)
+	processPidNs, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", pid))
+	if err != nil {
+		return false, fmt.Errorf("failed to find pid namespace of process %q", pid)
+	}
+	klog.V(10).Infof("Pid %d pid ns is %q", pid, processPidNs)
+	return initPidNs == processPidNs, nil
+}
+
+func getPidFromPidFile(pidFile string) (int, error) {
+	file, err := os.Open(pidFile)
+	if err != nil {
+		return 0, fmt.Errorf("error opening pid file %s: %v", pidFile, err)
+	}
+	defer file.Close()
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		return 0, fmt.Errorf("error reading pid file %s: %v", pidFile, err)
+	}
+
+	pid, err := strconv.Atoi(string(data))
+	if err != nil {
+		return 0, fmt.Errorf("error parsing %s as a number: %v", string(data), err)
+	}
+
+	return pid, nil
+}
+
+func getPidsForProcess(name, pidFile string) ([]int, error) {
+	if len(pidFile) == 0 {
+		return procfs.PidOf(name)
+	}
+
+	pid, err := getPidFromPidFile(pidFile)
+	if err == nil {
+		return []int{pid}, nil
+	}
+
+	// Try to lookup pid by process name
+	pids, err2 := procfs.PidOf(name)
+	if err2 == nil {
+		return pids, nil
+	}
+
+	// Return error from getPidFromPidFile since that should have worked
+	// and is the real source of the problem.
+	klog.V(4).Infof("unable to get pid from %s: %v", pidFile, err)
+	return []int{}, err
+}
+
+// getContainer returns the cgroup associated with the specified pid.
+// It enforces a unified hierarchy for memory and cpu cgroups.
+// On systemd environments, it uses the name=systemd cgroup for the specified pid.
+func getContainer(pid int) (string, error) {
+	cgs, err := cgroups.ParseCgroupFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return "", err
+	}
+
+	cpu, found := cgs["cpu"]
+	if !found {
+		return "", cgroups.NewNotFoundError("cpu")
+	}
+	memory, found := cgs["memory"]
+	if !found {
+		return "", cgroups.NewNotFoundError("memory")
+	}
+
+	// since we use this container for accounting, we need to ensure its a unified hierarchy.
+	if cpu != memory {
+		return "", fmt.Errorf("cpu and memory cgroup hierarchy not unified.  cpu: %s, memory: %s", cpu, memory)
+	}
+
+	// on systemd, every pid is in a unified cgroup hierarchy (name=systemd as seen in systemd-cgls)
+	// cpu and memory accounting is off by default, users may choose to enable it per unit or globally.
+	// users could enable CPU and memory accounting globally via /etc/systemd/system.conf (DefaultCPUAccounting=true DefaultMemoryAccounting=true).
+	// users could also enable CPU and memory accounting per unit via CPUAccounting=true and MemoryAccounting=true
+	// we only warn if accounting is not enabled for CPU or memory so as to not break local development flows where kubelet is launched in a terminal.
+	// for example, the cgroup for the user session will be something like /user.slice/user-X.slice/session-X.scope, but the cpu and memory
+	// cgroup will be the closest ancestor where accounting is performed (most likely /) on systems that launch docker containers.
+	// as a result, on those systems, you will not get cpu or memory accounting statistics for kubelet.
+	// in addition, you would not get memory or cpu accounting for the runtime unless accounting was enabled on its unit (or globally).
+	if systemd, found := cgs["name=systemd"]; found {
+		if systemd != cpu {
+			klog.Warningf("CPUAccounting not enabled for pid: %d", pid)
+		}
+		if systemd != memory {
+			klog.Warningf("MemoryAccounting not enabled for pid: %d", pid)
+		}
+		return systemd, nil
+	}
+
+	return cpu, nil
+}
+
+// Determines whether the specified PID is a kernel PID.
+func isKernelPid(pid int) bool {
+	// Kernel threads have no associated executable.
+	_, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+	return err != nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There were a variety of helper functions defined in
`container_manager_linux.go`, which could just as easily be defined in
`helpers_linux.go`. Move the helper functions to `helpers_linux.go`
so `container_manager_linux.go` is more focused on the logic of managing
containers, and less focused on interacting with the OS (i.e. making
calculations about pids, etc...)

**Special notes for your reviewer**:
/sig node
/priority backlog

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
