### PR TITLE
Fix error injection surface in FakeRuntimeService

### DIFF
--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
@@ -126,6 +126,7 @@ func (r *FakeRuntimeService) popError(f string) error {
 		return nil
 	}
 	err, errs := errs[0], errs[1:]
+	r.Errors[f] = errs
 	return err
 }
 
@@ -144,6 +145,9 @@ func (r *FakeRuntimeService) Version(apiVersion string) (*runtimeapi.VersionResp
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "Version")
+	if err := r.popError("Version"); err != nil {
+		return nil, err
+	}
 
 	return &runtimeapi.VersionResponse{
 		Version:           FakeVersion,
@@ -158,6 +162,9 @@ func (r *FakeRuntimeService) Status() (*runtimeapi.RuntimeStatus, error) {
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "Status")
+	if err := r.popError("Status"); err != nil {
+		return nil, err
+	}
 
 	return r.FakeStatus, nil
 }
@@ -167,6 +174,9 @@ func (r *FakeRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig, 
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "RunPodSandbox")
+	if err := r.popError("RunPodSandbox"); err != nil {
+		return "", err
+	}
 
 	// PodSandboxID should be randomized for real container runtime, but here just use
 	// fixed name from BuildSandboxName() for easily making fake sandboxes.
@@ -196,6 +206,9 @@ func (r *FakeRuntimeService) StopPodSandbox(podSandboxID string) error {
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "StopPodSandbox")
+	if err := r.popError("StopPodSandbox"); err != nil {
+		return err
+	}
 
 	if s, ok := r.Sandboxes[podSandboxID]; ok {
 		s.State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
@@ -211,6 +224,9 @@ func (r *FakeRuntimeService) RemovePodSandbox(podSandboxID string) error {
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "RemovePodSandbox")
+	if err := r.popError("RemovePodSandbox"); err != nil {
+		return err
+	}
 
 	// Remove the pod sandbox
 	delete(r.Sandboxes, podSandboxID)
@@ -223,6 +239,9 @@ func (r *FakeRuntimeService) PodSandboxStatus(podSandboxID string) (*runtimeapi.
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "PodSandboxStatus")
+	if err := r.popError("PodSandboxStatus"); err != nil {
+		return nil, err
+	}
 
 	s, ok := r.Sandboxes[podSandboxID]
 	if !ok {
@@ -238,6 +257,9 @@ func (r *FakeRuntimeService) ListPodSandbox(filter *runtimeapi.PodSandboxFilter)
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "ListPodSandbox")
+	if err := r.popError("ListPodSandbox"); err != nil {
+		return nil, err
+	}
 
 	result := make([]*runtimeapi.PodSandbox, 0)
 	for id, s := range r.Sandboxes {
@@ -272,6 +294,10 @@ func (r *FakeRuntimeService) PortForward(*runtimeapi.PortForwardRequest) (*runti
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "PortForward")
+	if err := r.popError("PortForward"); err != nil {
+		return nil, err
+	}
+
 	return &runtimeapi.PortForwardResponse{}, nil
 }
 
@@ -280,6 +306,9 @@ func (r *FakeRuntimeService) CreateContainer(podSandboxID string, config *runtim
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "CreateContainer")
+	if err := r.popError("CreateContainer"); err != nil {
+		return "", err
+	}
 
 	// ContainerID should be randomized for real container runtime, but here just use
 	// fixed BuildContainerName() for easily making fake containers.
@@ -309,6 +338,9 @@ func (r *FakeRuntimeService) StartContainer(containerID string) error {
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "StartContainer")
+	if err := r.popError("StartContainer"); err != nil {
+		return err
+	}
 
 	c, ok := r.Containers[containerID]
 	if !ok {
@@ -327,6 +359,9 @@ func (r *FakeRuntimeService) StopContainer(containerID string, timeout int64) er
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "StopContainer")
+	if err := r.popError("StopContainer"); err != nil {
+		return err
+	}
 
 	c, ok := r.Containers[containerID]
 	if !ok {
@@ -347,6 +382,9 @@ func (r *FakeRuntimeService) RemoveContainer(containerID string) error {
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "RemoveContainer")
+	if err := r.popError("RemoveContainer"); err != nil {
+		return err
+	}
 
 	// Remove the container
 	delete(r.Containers, containerID)
@@ -359,6 +397,9 @@ func (r *FakeRuntimeService) ListContainers(filter *runtimeapi.ContainerFilter) 
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "ListContainers")
+	if err := r.popError("ListContainers"); err != nil {
+		return nil, err
+	}
 
 	result := make([]*runtimeapi.Container, 0)
 	for _, s := range r.Containers {
@@ -398,6 +439,9 @@ func (r *FakeRuntimeService) ContainerStatus(containerID string) (*runtimeapi.Co
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "ContainerStatus")
+	if err := r.popError("ContainerStatus"); err != nil {
+		return nil, err
+	}
 
 	c, ok := r.Containers[containerID]
 	if !ok {
@@ -413,7 +457,7 @@ func (r *FakeRuntimeService) UpdateContainerResources(string, *runtimeapi.LinuxC
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "UpdateContainerResources")
-	return nil
+	return r.popError("UpdateContainerResources")
 }
 
 func (r *FakeRuntimeService) ExecSync(containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error) {
@@ -421,7 +465,8 @@ func (r *FakeRuntimeService) ExecSync(containerID string, cmd []string, timeout 
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "ExecSync")
-	return nil, nil, nil
+	err = r.popError("ExecSync")
+	return
 }
 
 func (r *FakeRuntimeService) Exec(*runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
@@ -429,6 +474,10 @@ func (r *FakeRuntimeService) Exec(*runtimeapi.ExecRequest) (*runtimeapi.ExecResp
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "Exec")
+	if err := r.popError("Exec"); err != nil {
+		return nil, err
+	}
+
 	return &runtimeapi.ExecResponse{}, nil
 }
 
@@ -437,11 +486,19 @@ func (r *FakeRuntimeService) Attach(req *runtimeapi.AttachRequest) (*runtimeapi.
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "Attach")
+	if err := r.popError("Attach"); err != nil {
+		return nil, err
+	}
+
 	return &runtimeapi.AttachResponse{}, nil
 }
 
 func (r *FakeRuntimeService) UpdateRuntimeConfig(runtimeCOnfig *runtimeapi.RuntimeConfig) error {
-	return nil
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "UpdateRuntimeConfig")
+	return r.popError("UpdateRuntimeConfig")
 }
 
 func (r *FakeRuntimeService) SetFakeContainerStats(containerStats []*runtimeapi.ContainerStats) {
@@ -459,6 +516,9 @@ func (r *FakeRuntimeService) ContainerStats(containerID string) (*runtimeapi.Con
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "ContainerStats")
+	if err := r.popError("ContainerStats"); err != nil {
+		return nil, err
+	}
 
 	s, found := r.FakeContainerStats[containerID]
 	if !found {
@@ -472,6 +532,9 @@ func (r *FakeRuntimeService) ListContainerStats(filter *runtimeapi.ContainerStat
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "ListContainerStats")
+	if err := r.popError("ListContainerStats"); err != nil {
+		return nil, err
+	}
 
 	var result []*runtimeapi.ContainerStats
 	for _, c := range r.Containers {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind bug

**What this PR does / why we need it**:

Fixes the CRI runtime service fake to properly pop errors when popError is called, as they were not being removed from the internal slice. Additionally extends the error injection to cover the full runtime service surface instead of only ReopenContainerLog.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
