### PR TITLE
Automated cherry pick of #77029: Update k8s-dns-node-cache image version

### DIFF
--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -108,7 +108,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: k8s.gcr.io/k8s-dns-node-cache:1.15.0
+        image: k8s.gcr.io/k8s-dns-node-cache:1.15.2
         resources:
           limits:
             memory: 30Mi


### PR DESCRIPTION
Cherry pick of #77029 on release-1.13.

#77029: Update k8s-dns-node-cache image version

```release-note
Upgraded node-cache to image 1.15.2 to pick up vulnerability fixes.
```