### PR TITLE
Bump ip-masq-agent version to v2.3.0

### DIFF
--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
-# https://github.com/kubernetes-incubator/ip-masq-agent/blob/v2.0.0/README.md
+# https://github.com/kubernetes-incubator/ip-masq-agent/blob/v2.3.0/README.md
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -32,7 +32,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: k8s.gcr.io/ip-masq-agent-amd64:v2.1.1
+        image: k8s.gcr.io/ip-masq-agent-amd64:v2.3.0
         args:
           - --masq-chain=IP-MASQ
         resources:


### PR DESCRIPTION
Fixed vulnerabilities: 
CVE-2018-15688 CVE-2017-15670 CVE-2017-18269 CVE-2017-16997 CVE-2017-15804 CVE-2018-18311 CVE-2018-18312 CVE-2018-18314 CVE-2017-1000408

```release-note
Bump ip-masq-agent to v2.3.0 to fix vulnerabilities.
```
