### PR TITLE
Bump ip-masq-agent version to v2.3.0

### DIFF
--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -8,14 +8,14 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
-# https://github.com/kubernetes-incubator/ip-masq-agent/blob/v2.0.0/README.md
+# https://github.com/kubernetes-incubator/ip-masq-agent/blob/v2.3.0/README.md
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: ip-masq-agent
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: Reconcile  
+    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   template:
     metadata:
@@ -29,7 +29,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: k8s.gcr.io/ip-masq-agent-amd64:v2.1.1
+        image: k8s.gcr.io/ip-masq-agent-amd64:v2.3.0
         args:
           - --masq-chain=IP-MASQ
         resources:
@@ -42,7 +42,7 @@ spec:
           - name: config
             mountPath: /etc/config
       nodeSelector:
-        beta.kubernetes.io/masq-agent-ds-ready: "true"  
+        beta.kubernetes.io/masq-agent-ds-ready: "true"
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
Fixed vulnerabilities: 
CVE-2018-15688 CVE-2017-15670 CVE-2017-18269 CVE-2017-16997 CVE-2017-15804 CVE-2018-18311 CVE-2018-18312 CVE-2018-18314 CVE-2017-1000408

```release-note
Bump ip-masq-agent version to v2.3.0 to fix vulnerabilities
```
