### PR TITLE
Staging legacy fake cloud provider

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -50,7 +50,6 @@ pkg/apis/rbac/validation
 pkg/apis/storage
 pkg/apis/storage/v1
 pkg/apis/storage/v1beta1
-pkg/cloudprovider/providers/fake
 pkg/cloudprovider/providers/photon
 pkg/controller
 pkg/controller/apis/config/v1alpha1

--- a/pkg/cloudprovider/providers/BUILD
+++ b/pkg/cloudprovider/providers/BUILD
@@ -36,7 +36,6 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//pkg/cloudprovider/providers/cloudstack:all-srcs",
-        "//pkg/cloudprovider/providers/fake:all-srcs",
         "//pkg/cloudprovider/providers/openstack:all-srcs",
         "//pkg/cloudprovider/providers/ovirt:all-srcs",
         "//pkg/cloudprovider/providers/photon:all-srcs",

--- a/pkg/controller/cloud/BUILD
+++ b/pkg/controller/cloud/BUILD
@@ -46,7 +46,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/cloudprovider/providers/fake:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/controller/testutil:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
@@ -60,6 +59,7 @@ go_test(
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/fake:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/controller/cloud/node_controller_test.go
+++ b/pkg/controller/cloud/node_controller_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/record"
 	cloudprovider "k8s.io/cloud-provider"
-	fakecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
+	fakecloud "k8s.io/cloud-provider/fake"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/testutil"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
@@ -135,7 +135,7 @@ func TestEnsureNodeExistsByProviderID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			fc := &fakecloud.FakeCloud{
+			fc := &fakecloud.Cloud{
 				ExistsByProviderID: tc.existsByProviderID,
 				Err:                tc.nodeNameErr,
 				ErrByProviderID:    tc.providerIDErr,
@@ -199,7 +199,7 @@ func TestNodeInitialized(t *testing.T) {
 
 	factory := informers.NewSharedInformerFactory(fnh, controller.NoResyncPeriodFunc())
 
-	fakeCloud := &fakecloud.FakeCloud{
+	fakeCloud := &fakecloud.Cloud{
 		InstanceTypes: map[types.NodeName]string{
 			types.NodeName("node0"): "t1.micro",
 		},
@@ -264,7 +264,7 @@ func TestNodeIgnored(t *testing.T) {
 
 	factory := informers.NewSharedInformerFactory(fnh, controller.NoResyncPeriodFunc())
 
-	fakeCloud := &fakecloud.FakeCloud{
+	fakeCloud := &fakecloud.Cloud{
 		InstanceTypes: map[types.NodeName]string{
 			types.NodeName("node0"): "t1.micro",
 		},
@@ -336,7 +336,7 @@ func TestGCECondition(t *testing.T) {
 
 	factory := informers.NewSharedInformerFactory(fnh, controller.NoResyncPeriodFunc())
 
-	fakeCloud := &fakecloud.FakeCloud{
+	fakeCloud := &fakecloud.Cloud{
 		InstanceTypes: map[types.NodeName]string{
 			types.NodeName("node0"): "t1.micro",
 		},
@@ -421,7 +421,7 @@ func TestZoneInitialized(t *testing.T) {
 
 	factory := informers.NewSharedInformerFactory(fnh, controller.NoResyncPeriodFunc())
 
-	fakeCloud := &fakecloud.FakeCloud{
+	fakeCloud := &fakecloud.Cloud{
 		InstanceTypes: map[types.NodeName]string{
 			types.NodeName("node0"): "t1.micro",
 		},
@@ -511,7 +511,7 @@ func TestNodeAddresses(t *testing.T) {
 
 	factory := informers.NewSharedInformerFactory(fnh, controller.NoResyncPeriodFunc())
 
-	fakeCloud := &fakecloud.FakeCloud{
+	fakeCloud := &fakecloud.Cloud{
 		InstanceTypes: map[types.NodeName]string{},
 		Addresses: []v1.NodeAddress{
 			{
@@ -624,7 +624,7 @@ func TestNodeProvidedIPAddresses(t *testing.T) {
 
 	factory := informers.NewSharedInformerFactory(fnh, controller.NoResyncPeriodFunc())
 
-	fakeCloud := &fakecloud.FakeCloud{
+	fakeCloud := &fakecloud.Cloud{
 		InstanceTypes: map[types.NodeName]string{
 			types.NodeName("node0"):           "t1.micro",
 			types.NodeName("node0.aws.12345"): "t2.macro",
@@ -839,7 +839,7 @@ func TestNodeAddressesNotUpdate(t *testing.T) {
 
 	factory := informers.NewSharedInformerFactory(fnh, controller.NoResyncPeriodFunc())
 
-	fakeCloud := &fakecloud.FakeCloud{
+	fakeCloud := &fakecloud.Cloud{
 		InstanceTypes: map[types.NodeName]string{},
 		Addresses: []v1.NodeAddress{
 			{
@@ -914,7 +914,7 @@ func TestNodeProviderID(t *testing.T) {
 
 	factory := informers.NewSharedInformerFactory(fnh, controller.NoResyncPeriodFunc())
 
-	fakeCloud := &fakecloud.FakeCloud{
+	fakeCloud := &fakecloud.Cloud{
 		InstanceTypes: map[types.NodeName]string{},
 		Addresses: []v1.NodeAddress{
 			{
@@ -997,7 +997,7 @@ func TestNodeProviderIDAlreadySet(t *testing.T) {
 
 	factory := informers.NewSharedInformerFactory(fnh, controller.NoResyncPeriodFunc())
 
-	fakeCloud := &fakecloud.FakeCloud{
+	fakeCloud := &fakecloud.Cloud{
 		InstanceTypes: map[types.NodeName]string{},
 		Addresses: []v1.NodeAddress{
 			{

--- a/pkg/controller/cloud/node_lifecycle_controller_test.go
+++ b/pkg/controller/cloud/node_lifecycle_controller_test.go
@@ -30,8 +30,8 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	fakecloud "k8s.io/cloud-provider/fake"
 	"k8s.io/klog"
-	fakecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
 	"k8s.io/kubernetes/pkg/controller/testutil"
 )
 
@@ -39,7 +39,7 @@ func Test_NodesDeleted(t *testing.T) {
 	testcases := []struct {
 		name        string
 		fnh         *testutil.FakeNodeHandler
-		fakeCloud   *fakecloud.FakeCloud
+		fakeCloud   *fakecloud.Cloud
 		deleteNodes []*v1.Node
 	}{
 		{
@@ -66,7 +66,7 @@ func Test_NodesDeleted(t *testing.T) {
 				DeletedNodes: []*v1.Node{},
 				Clientset:    fake.NewSimpleClientset(),
 			},
-			fakeCloud: &fakecloud.FakeCloud{
+			fakeCloud: &fakecloud.Cloud{
 				ExistsByProviderID: false,
 			},
 			deleteNodes: []*v1.Node{
@@ -100,7 +100,7 @@ func Test_NodesDeleted(t *testing.T) {
 				DeletedNodes: []*v1.Node{},
 				Clientset:    fake.NewSimpleClientset(),
 			},
-			fakeCloud: &fakecloud.FakeCloud{
+			fakeCloud: &fakecloud.Cloud{
 				ExistsByProviderID: false,
 				ErrByProviderID:    errors.New("err!"),
 			},
@@ -133,7 +133,7 @@ func Test_NodesDeleted(t *testing.T) {
 				DeletedNodes: []*v1.Node{},
 				Clientset:    fake.NewSimpleClientset(),
 			},
-			fakeCloud: &fakecloud.FakeCloud{
+			fakeCloud: &fakecloud.Cloud{
 				ExistsByProviderID: true,
 			},
 			deleteNodes: []*v1.Node{},
@@ -162,7 +162,7 @@ func Test_NodesDeleted(t *testing.T) {
 				DeletedNodes: []*v1.Node{},
 				Clientset:    fake.NewSimpleClientset(),
 			},
-			fakeCloud: &fakecloud.FakeCloud{
+			fakeCloud: &fakecloud.Cloud{
 				ExistsByProviderID: false,
 			},
 			deleteNodes: []*v1.Node{
@@ -193,7 +193,7 @@ func Test_NodesDeleted(t *testing.T) {
 				DeletedNodes: []*v1.Node{},
 				Clientset:    fake.NewSimpleClientset(),
 			},
-			fakeCloud: &fakecloud.FakeCloud{
+			fakeCloud: &fakecloud.Cloud{
 				NodeShutdown:       false,
 				ExistsByProviderID: true,
 				ExtID: map[types.NodeName]string{
@@ -229,7 +229,7 @@ func Test_NodesDeleted(t *testing.T) {
 				DeletedNodes: []*v1.Node{},
 				Clientset:    fake.NewSimpleClientset(),
 			},
-			fakeCloud: &fakecloud.FakeCloud{
+			fakeCloud: &fakecloud.Cloud{
 				ExistsByProviderID: false,
 			},
 			deleteNodes: []*v1.Node{},
@@ -270,7 +270,7 @@ func Test_NodesShutdown(t *testing.T) {
 	testcases := []struct {
 		name         string
 		fnh          *testutil.FakeNodeHandler
-		fakeCloud    *fakecloud.FakeCloud
+		fakeCloud    *fakecloud.Cloud
 		updatedNodes []*v1.Node
 	}{
 		{
@@ -297,7 +297,7 @@ func Test_NodesShutdown(t *testing.T) {
 				UpdatedNodes: []*v1.Node{},
 				Clientset:    fake.NewSimpleClientset(),
 			},
-			fakeCloud: &fakecloud.FakeCloud{
+			fakeCloud: &fakecloud.Cloud{
 				NodeShutdown:            true,
 				ErrShutdownByProviderID: nil,
 			},
@@ -349,7 +349,7 @@ func Test_NodesShutdown(t *testing.T) {
 				UpdatedNodes: []*v1.Node{},
 				Clientset:    fake.NewSimpleClientset(),
 			},
-			fakeCloud: &fakecloud.FakeCloud{
+			fakeCloud: &fakecloud.Cloud{
 				NodeShutdown:            false,
 				ErrShutdownByProviderID: errors.New("err!"),
 			},
@@ -379,7 +379,7 @@ func Test_NodesShutdown(t *testing.T) {
 				UpdatedNodes: []*v1.Node{},
 				Clientset:    fake.NewSimpleClientset(),
 			},
-			fakeCloud: &fakecloud.FakeCloud{
+			fakeCloud: &fakecloud.Cloud{
 				NodeShutdown:            false,
 				ErrShutdownByProviderID: nil,
 			},
@@ -409,7 +409,7 @@ func Test_NodesShutdown(t *testing.T) {
 				UpdatedNodes: []*v1.Node{},
 				Clientset:    fake.NewSimpleClientset(),
 			},
-			fakeCloud: &fakecloud.FakeCloud{
+			fakeCloud: &fakecloud.Cloud{
 				NodeShutdown:            true,
 				ErrShutdownByProviderID: nil,
 			},

--- a/pkg/controller/route/BUILD
+++ b/pkg/controller/route/BUILD
@@ -42,7 +42,6 @@ go_test(
     srcs = ["route_controller_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/cloudprovider/providers/fake:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/controller/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
@@ -52,6 +51,7 @@ go_test(
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/fake:go_default_library",
     ],
 )
 

--- a/pkg/controller/route/route_controller_test.go
+++ b/pkg/controller/route/route_controller_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	cloudprovider "k8s.io/cloud-provider"
-	fakecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
+	fakecloud "k8s.io/cloud-provider/fake"
 	"k8s.io/kubernetes/pkg/controller"
 	nodeutil "k8s.io/kubernetes/pkg/controller/util/node"
 )
@@ -226,9 +226,9 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 	for i, testCase := range testCases {
-		cloud := &fakecloud.FakeCloud{RouteMap: make(map[string]*fakecloud.FakeRoute)}
+		cloud := &fakecloud.Cloud{RouteMap: make(map[string]*fakecloud.Route)}
 		for _, route := range testCase.initialRoutes {
-			fakeRoute := &fakecloud.FakeRoute{}
+			fakeRoute := &fakecloud.Route{}
 			fakeRoute.ClusterName = cluster
 			fakeRoute.Route = *route
 			cloud.RouteMap[route.Name] = fakeRoute

--- a/pkg/controller/service/BUILD
+++ b/pkg/controller/service/BUILD
@@ -43,7 +43,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/api/testapi:go_default_library",
-        "//pkg/cloudprovider/providers/fake:go_default_library",
         "//pkg/controller:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
@@ -54,6 +53,7 @@ go_test(
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/fake:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/cloudresource/BUILD
+++ b/pkg/kubelet/cloudresource/BUILD
@@ -19,9 +19,9 @@ go_test(
     srcs = ["cloud_request_manager_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/cloudprovider/providers/fake:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/fake:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/cloudresource/cloud_request_manager_test.go
+++ b/pkg/kubelet/cloudresource/cloud_request_manager_test.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
+	"k8s.io/cloud-provider/fake"
 )
 
 func createNodeInternalIPAddress(address string) []v1.NodeAddress {
@@ -38,7 +38,7 @@ func createNodeInternalIPAddress(address string) []v1.NodeAddress {
 
 func TestNodeAddressesDelay(t *testing.T) {
 	syncPeriod := 100 * time.Millisecond
-	cloud := &fake.FakeCloud{
+	cloud := &fake.Cloud{
 		Addresses: createNodeInternalIPAddress("10.0.1.12"),
 		// Set the request delay so the manager timeouts and collects the node addresses later
 		RequestDelay: 200 * time.Millisecond,
@@ -82,7 +82,7 @@ func TestNodeAddressesDelay(t *testing.T) {
 }
 
 func TestNodeAddressesUsesLastSuccess(t *testing.T) {
-	cloud := &fake.FakeCloud{}
+	cloud := &fake.Cloud{}
 	manager := NewSyncManager(cloud, "defaultNode", 0).(*cloudResourceSyncManager)
 
 	// These tests are stateful and order dependant.

--- a/pkg/kubelet/nodestatus/BUILD
+++ b/pkg/kubelet/nodestatus/BUILD
@@ -46,7 +46,6 @@ go_test(
     srcs = ["setters_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/cloudprovider/providers/fake:go_default_library",
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/container/testing:go_default_library",
@@ -62,6 +61,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/fake:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	fakecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
+	fakecloud "k8s.io/cloud-provider/fake"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubecontainertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
@@ -249,7 +249,7 @@ func TestNodeAddress(t *testing.T) {
 			}
 			hostname := testKubeletHostname
 			externalCloudProvider := false
-			cloud := &fakecloud.FakeCloud{
+			cloud := &fakecloud.Cloud{
 				Addresses: testCase.nodeAddresses,
 				Err:       nil,
 			}

--- a/pkg/volume/azure_file/BUILD
+++ b/pkg/volume/azure_file/BUILD
@@ -38,7 +38,6 @@ go_test(
     srcs = ["azure_file_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/cloudprovider/providers/fake:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
@@ -46,6 +45,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/fake:go_default_library",
         "//staging/src/k8s.io/legacy-cloud-providers/azure:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library",
     ],

--- a/pkg/volume/azure_file/azure_file_test.go
+++ b/pkg/volume/azure_file/azure_file_test.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
-	fakecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
+	fakecloud "k8s.io/cloud-provider/fake"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
@@ -119,7 +119,7 @@ func TestPluginWithoutCloudProvider(t *testing.T) {
 func TestPluginWithOtherCloudProvider(t *testing.T) {
 	tmpDir := getTestTempDir(t)
 	defer os.RemoveAll(tmpDir)
-	cloud := &fakecloud.FakeCloud{}
+	cloud := &fakecloud.Cloud{}
 	testPlugin(t, tmpDir, volumetest.NewFakeVolumeHostWithCloudProvider(tmpDir, nil, nil, cloud))
 }
 

--- a/pkg/volume/vsphere_volume/BUILD
+++ b/pkg/volume/vsphere_volume/BUILD
@@ -45,7 +45,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/cloudprovider/providers/fake:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
@@ -54,6 +53,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/fake:go_default_library",
         "//staging/src/k8s.io/legacy-cloud-providers/vsphere:go_default_library",
         "//staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/pkg/volume/vsphere_volume/vsphere_volume_test.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utiltesting "k8s.io/client-go/util/testing"
 	cloudprovider "k8s.io/cloud-provider"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
+	"k8s.io/cloud-provider/fake"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
@@ -203,7 +203,7 @@ func TestUnsupportedCloudProvider(t *testing.T) {
 	}{
 		{name: "nil cloudprovider", cloudProvider: nil},
 		{name: "vSphere", cloudProvider: &vsphere.VSphere{}, success: true},
-		{name: "fake cloudprovider", cloudProvider: &fake.FakeCloud{}},
+		{name: "fake cloudprovider", cloudProvider: &fake.Cloud{}},
 	}
 
 	for _, tc := range testcases {

--- a/staging/src/k8s.io/cloud-provider/BUILD
+++ b/staging/src/k8s.io/cloud-provider/BUILD
@@ -35,6 +35,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//staging/src/k8s.io/cloud-provider/fake:all-srcs",
         "//staging/src/k8s.io/cloud-provider/node:all-srcs",
         "//staging/src/k8s.io/cloud-provider/service/helpers:all-srcs",
         "//staging/src/k8s.io/cloud-provider/volume:all-srcs",

--- a/staging/src/k8s.io/cloud-provider/fake/BUILD
+++ b/staging/src/k8s.io/cloud-provider/fake/BUILD
@@ -11,7 +11,8 @@ go_library(
         "doc.go",
         "fake.go",
     ],
-    importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/fake",
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/cloud-provider/fake",
+    importpath = "k8s.io/cloud-provider/fake",
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/staging/src/k8s.io/cloud-provider/fake/doc.go
+++ b/staging/src/k8s.io/cloud-provider/fake/doc.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 // Package fake is a test-double implementation of cloudprovider
 // Interface, LoadBalancer and Instances. It is useful for testing.
-package fake // import "k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
+package fake // import "k8s.io/cloud-provider/fake"

--- a/staging/src/k8s.io/cloud-provider/fake/fake.go
+++ b/staging/src/k8s.io/cloud-provider/fake/fake.go
@@ -31,8 +31,8 @@ import (
 
 const defaultProviderName = "fake"
 
-// FakeBalancer is a fake storage of balancer information
-type FakeBalancer struct {
+// Balancer is a fake storage of balancer information
+type Balancer struct {
 	Name           string
 	Region         string
 	LoadBalancerIP string
@@ -40,21 +40,22 @@ type FakeBalancer struct {
 	Hosts          []*v1.Node
 }
 
-type FakeUpdateBalancerCall struct {
+// UpdateBalancerCall represents a fake call to update load balancers
+type UpdateBalancerCall struct {
 	Service *v1.Service
 	Hosts   []*v1.Node
 }
 
-var _ cloudprovider.Interface = (*FakeCloud)(nil)
-var _ cloudprovider.Instances = (*FakeCloud)(nil)
-var _ cloudprovider.LoadBalancer = (*FakeCloud)(nil)
-var _ cloudprovider.Routes = (*FakeCloud)(nil)
-var _ cloudprovider.Zones = (*FakeCloud)(nil)
-var _ cloudprovider.PVLabeler = (*FakeCloud)(nil)
-var _ cloudprovider.Clusters = (*FakeCloud)(nil)
+var _ cloudprovider.Interface = (*Cloud)(nil)
+var _ cloudprovider.Instances = (*Cloud)(nil)
+var _ cloudprovider.LoadBalancer = (*Cloud)(nil)
+var _ cloudprovider.Routes = (*Cloud)(nil)
+var _ cloudprovider.Zones = (*Cloud)(nil)
+var _ cloudprovider.PVLabeler = (*Cloud)(nil)
+var _ cloudprovider.Clusters = (*Cloud)(nil)
 
-// FakeCloud is a test-double implementation of Interface, LoadBalancer, Instances, and Routes. It is useful for testing.
-type FakeCloud struct {
+// Cloud is a test-double implementation of Interface, LoadBalancer, Instances, and Routes. It is useful for testing.
+type Cloud struct {
 	Exists bool
 	Err    error
 
@@ -73,9 +74,9 @@ type FakeCloud struct {
 	ClusterList   []string
 	MasterName    string
 	ExternalIP    net.IP
-	Balancers     map[string]FakeBalancer
-	UpdateCalls   []FakeUpdateBalancerCall
-	RouteMap      map[string]*FakeRoute
+	Balancers     map[string]Balancer
+	UpdateCalls   []UpdateBalancerCall
+	RouteMap      map[string]*Route
 	Lock          sync.Mutex
 	Provider      string
 	addCallLock   sync.Mutex
@@ -85,12 +86,13 @@ type FakeCloud struct {
 	RequestDelay time.Duration
 }
 
-type FakeRoute struct {
+// Route is a representation of an advanced routing rule.
+type Route struct {
 	ClusterName string
 	Route       cloudprovider.Route
 }
 
-func (f *FakeCloud) addCall(desc string) {
+func (f *Cloud) addCall(desc string) {
 	f.addCallLock.Lock()
 	defer f.addCallLock.Unlock()
 
@@ -99,29 +101,32 @@ func (f *FakeCloud) addCall(desc string) {
 	f.Calls = append(f.Calls, desc)
 }
 
-// ClearCalls clears internal record of method calls to this FakeCloud.
-func (f *FakeCloud) ClearCalls() {
+// ClearCalls clears internal record of method calls to this Cloud.
+func (f *Cloud) ClearCalls() {
 	f.Calls = []string{}
 }
 
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
-func (f *FakeCloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
+func (f *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
 }
 
-func (f *FakeCloud) ListClusters(ctx context.Context) ([]string, error) {
+// ListClusters lists the names of the available clusters.
+func (f *Cloud) ListClusters(ctx context.Context) ([]string, error) {
 	return f.ClusterList, f.Err
 }
 
-func (f *FakeCloud) Master(ctx context.Context, name string) (string, error) {
+// Master gets back the address (either DNS name or IP address) of the master node for the cluster.
+func (f *Cloud) Master(ctx context.Context, name string) (string, error) {
 	return f.MasterName, f.Err
 }
 
-func (f *FakeCloud) Clusters() (cloudprovider.Clusters, bool) {
+// Clusters returns a clusters interface.  Also returns true if the interface is supported, false otherwise.
+func (f *Cloud) Clusters() (cloudprovider.Clusters, bool) {
 	return f, true
 }
 
 // ProviderName returns the cloud provider ID.
-func (f *FakeCloud) ProviderName() string {
+func (f *Cloud) ProviderName() string {
 	if f.Provider == "" {
 		return defaultProviderName
 	}
@@ -129,33 +134,35 @@ func (f *FakeCloud) ProviderName() string {
 }
 
 // HasClusterID returns true if the cluster has a clusterID
-func (f *FakeCloud) HasClusterID() bool {
+func (f *Cloud) HasClusterID() bool {
 	return true
 }
 
 // LoadBalancer returns a fake implementation of LoadBalancer.
 // Actually it just returns f itself.
-func (f *FakeCloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+func (f *Cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	return f, true
 }
 
 // Instances returns a fake implementation of Instances.
 //
 // Actually it just returns f itself.
-func (f *FakeCloud) Instances() (cloudprovider.Instances, bool) {
+func (f *Cloud) Instances() (cloudprovider.Instances, bool) {
 	return f, true
 }
 
-func (f *FakeCloud) Zones() (cloudprovider.Zones, bool) {
+// Zones returns a zones interface. Also returns true if the interface is supported, false otherwise.
+func (f *Cloud) Zones() (cloudprovider.Zones, bool) {
 	return f, true
 }
 
-func (f *FakeCloud) Routes() (cloudprovider.Routes, bool) {
+// Routes returns a routes interface along with whether the interface is supported.
+func (f *Cloud) Routes() (cloudprovider.Routes, bool) {
 	return f, true
 }
 
 // GetLoadBalancer is a stub implementation of LoadBalancer.GetLoadBalancer.
-func (f *FakeCloud) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
+func (f *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
 	status := &v1.LoadBalancerStatus{}
 	status.Ingress = []v1.LoadBalancerIngress{{IP: f.ExternalIP.String()}}
 
@@ -163,17 +170,17 @@ func (f *FakeCloud) GetLoadBalancer(ctx context.Context, clusterName string, ser
 }
 
 // GetLoadBalancerName is a stub implementation of LoadBalancer.GetLoadBalancerName.
-func (f *FakeCloud) GetLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string {
+func (f *Cloud) GetLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string {
 	// TODO: replace DefaultLoadBalancerName to generate more meaningful loadbalancer names.
 	return cloudprovider.DefaultLoadBalancerName(service)
 }
 
 // EnsureLoadBalancer is a test-spy implementation of LoadBalancer.EnsureLoadBalancer.
 // It adds an entry "create" into the internal method call record.
-func (f *FakeCloud) EnsureLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
+func (f *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
 	f.addCall("create")
 	if f.Balancers == nil {
-		f.Balancers = make(map[string]FakeBalancer)
+		f.Balancers = make(map[string]Balancer)
 	}
 
 	name := f.GetLoadBalancerName(ctx, clusterName, service)
@@ -185,7 +192,7 @@ func (f *FakeCloud) EnsureLoadBalancer(ctx context.Context, clusterName string, 
 	}
 	region := zone.Region
 
-	f.Balancers[name] = FakeBalancer{name, region, spec.LoadBalancerIP, spec.Ports, nodes}
+	f.Balancers[name] = Balancer{name, region, spec.LoadBalancerIP, spec.Ports, nodes}
 
 	status := &v1.LoadBalancerStatus{}
 	status.Ingress = []v1.LoadBalancerIngress{{IP: f.ExternalIP.String()}}
@@ -195,38 +202,42 @@ func (f *FakeCloud) EnsureLoadBalancer(ctx context.Context, clusterName string, 
 
 // UpdateLoadBalancer is a test-spy implementation of LoadBalancer.UpdateLoadBalancer.
 // It adds an entry "update" into the internal method call record.
-func (f *FakeCloud) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
+func (f *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
 	f.addCall("update")
-	f.UpdateCalls = append(f.UpdateCalls, FakeUpdateBalancerCall{service, nodes})
+	f.UpdateCalls = append(f.UpdateCalls, UpdateBalancerCall{service, nodes})
 	return f.Err
 }
 
 // EnsureLoadBalancerDeleted is a test-spy implementation of LoadBalancer.EnsureLoadBalancerDeleted.
 // It adds an entry "delete" into the internal method call record.
-func (f *FakeCloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
+func (f *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
 	f.addCall("delete")
 	return f.Err
 }
 
-func (f *FakeCloud) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
+// AddSSHKeyToAllInstances adds an SSH public key as a legal identity for all instances
+// expected format for the key is standard ssh-keygen format: <protocol> <blob>
+func (f *Cloud) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
 	return cloudprovider.NotImplemented
 }
 
-// Implementation of Instances.CurrentNodeName
-func (f *FakeCloud) CurrentNodeName(ctx context.Context, hostname string) (types.NodeName, error) {
+// CurrentNodeName returns the name of the node we are currently running on
+// On most clouds (e.g. GCE) this is the hostname, so we provide the hostname
+func (f *Cloud) CurrentNodeName(ctx context.Context, hostname string) (types.NodeName, error) {
 	return types.NodeName(hostname), nil
 }
 
 // NodeAddresses is a test-spy implementation of Instances.NodeAddresses.
 // It adds an entry "node-addresses" into the internal method call record.
-func (f *FakeCloud) NodeAddresses(ctx context.Context, instance types.NodeName) ([]v1.NodeAddress, error) {
+func (f *Cloud) NodeAddresses(ctx context.Context, instance types.NodeName) ([]v1.NodeAddress, error) {
 	f.addCall("node-addresses")
 	f.addressesMux.Lock()
 	defer f.addressesMux.Unlock()
 	return f.Addresses, f.Err
 }
 
-func (f *FakeCloud) SetNodeAddresses(nodeAddresses []v1.NodeAddress) {
+// SetNodeAddresses sets the addresses for a node
+func (f *Cloud) SetNodeAddresses(nodeAddresses []v1.NodeAddress) {
 	f.addressesMux.Lock()
 	defer f.addressesMux.Unlock()
 	f.Addresses = nodeAddresses
@@ -234,7 +245,7 @@ func (f *FakeCloud) SetNodeAddresses(nodeAddresses []v1.NodeAddress) {
 
 // NodeAddressesByProviderID is a test-spy implementation of Instances.NodeAddressesByProviderID.
 // It adds an entry "node-addresses-by-provider-id" into the internal method call record.
-func (f *FakeCloud) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
+func (f *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
 	f.addCall("node-addresses-by-provider-id")
 	f.addressesMux.Lock()
 	defer f.addressesMux.Unlock()
@@ -242,39 +253,39 @@ func (f *FakeCloud) NodeAddressesByProviderID(ctx context.Context, providerID st
 }
 
 // InstanceID returns the cloud provider ID of the node with the specified Name.
-func (f *FakeCloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
+func (f *Cloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	f.addCall("instance-id")
 	return f.ExtID[nodeName], nil
 }
 
 // InstanceType returns the type of the specified instance.
-func (f *FakeCloud) InstanceType(ctx context.Context, instance types.NodeName) (string, error) {
+func (f *Cloud) InstanceType(ctx context.Context, instance types.NodeName) (string, error) {
 	f.addCall("instance-type")
 	return f.InstanceTypes[instance], nil
 }
 
 // InstanceTypeByProviderID returns the type of the specified instance.
-func (f *FakeCloud) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
+func (f *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
 	f.addCall("instance-type-by-provider-id")
 	return f.InstanceTypes[types.NodeName(providerID)], nil
 }
 
 // InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
 // If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
-func (f *FakeCloud) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
+func (f *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
 	f.addCall("instance-exists-by-provider-id")
 	return f.ExistsByProviderID, f.ErrByProviderID
 }
 
 // InstanceShutdownByProviderID returns true if the instances is in safe state to detach volumes
-func (f *FakeCloud) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
+func (f *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
 	f.addCall("instance-shutdown-by-provider-id")
 	return f.NodeShutdown, f.ErrShutdownByProviderID
 }
 
 // List is a test-spy implementation of Instances.List.
 // It adds an entry "list" into the internal method call record.
-func (f *FakeCloud) List(filter string) ([]types.NodeName, error) {
+func (f *Cloud) List(filter string) ([]types.NodeName, error) {
 	f.addCall("list")
 	result := []types.NodeName{}
 	for _, machine := range f.Machines {
@@ -285,7 +296,11 @@ func (f *FakeCloud) List(filter string) ([]types.NodeName, error) {
 	return result, f.Err
 }
 
-func (f *FakeCloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
+// GetZone returns the Zone containing the current failure zone and locality region that the program is running in
+// In most cases, this method is called from the kubelet querying a local metadata service to acquire its zone.
+// For the case of external cloud providers, use GetZoneByProviderID or GetZoneByNodeName since GetZone
+// can no longer be called from the kubelets.
+func (f *Cloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 	f.addCall("get-zone")
 	return f.Zone, f.Err
 }
@@ -293,7 +308,7 @@ func (f *FakeCloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 // GetZoneByProviderID implements Zones.GetZoneByProviderID
 // This is particularly useful in external cloud providers where the kubelet
 // does not initialize node data.
-func (f *FakeCloud) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
+func (f *Cloud) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
 	f.addCall("get-zone-by-provider-id")
 	return f.Zone, f.Err
 }
@@ -301,12 +316,13 @@ func (f *FakeCloud) GetZoneByProviderID(ctx context.Context, providerID string) 
 // GetZoneByNodeName implements Zones.GetZoneByNodeName
 // This is particularly useful in external cloud providers where the kubelet
 // does not initialize node data.
-func (f *FakeCloud) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
+func (f *Cloud) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
 	f.addCall("get-zone-by-node-name")
 	return f.Zone, f.Err
 }
 
-func (f *FakeCloud) ListRoutes(ctx context.Context, clusterName string) ([]*cloudprovider.Route, error) {
+// ListRoutes lists all managed routes that belong to the specified clusterName
+func (f *Cloud) ListRoutes(ctx context.Context, clusterName string) ([]*cloudprovider.Route, error) {
 	f.Lock.Lock()
 	defer f.Lock.Unlock()
 	f.addCall("list-routes")
@@ -320,7 +336,10 @@ func (f *FakeCloud) ListRoutes(ctx context.Context, clusterName string) ([]*clou
 	return routes, f.Err
 }
 
-func (f *FakeCloud) CreateRoute(ctx context.Context, clusterName string, nameHint string, route *cloudprovider.Route) error {
+// CreateRoute creates the described managed route
+// route.Name will be ignored, although the cloud-provider may use nameHint
+// to create a more user-meaningful name.
+func (f *Cloud) CreateRoute(ctx context.Context, clusterName string, nameHint string, route *cloudprovider.Route) error {
 	f.Lock.Lock()
 	defer f.Lock.Unlock()
 	f.addCall("create-route")
@@ -329,7 +348,7 @@ func (f *FakeCloud) CreateRoute(ctx context.Context, clusterName string, nameHin
 		f.Err = fmt.Errorf("route %q already exists", name)
 		return f.Err
 	}
-	fakeRoute := FakeRoute{}
+	fakeRoute := Route{}
 	fakeRoute.Route = *route
 	fakeRoute.Route.Name = name
 	fakeRoute.ClusterName = clusterName
@@ -337,7 +356,9 @@ func (f *FakeCloud) CreateRoute(ctx context.Context, clusterName string, nameHin
 	return nil
 }
 
-func (f *FakeCloud) DeleteRoute(ctx context.Context, clusterName string, route *cloudprovider.Route) error {
+// DeleteRoute deletes the specified managed route
+// Route should be as returned by ListRoutes
+func (f *Cloud) DeleteRoute(ctx context.Context, clusterName string, route *cloudprovider.Route) error {
 	f.Lock.Lock()
 	defer f.Lock.Unlock()
 	f.addCall("delete-route")
@@ -350,8 +371,9 @@ func (f *FakeCloud) DeleteRoute(ctx context.Context, clusterName string, route *
 	return nil
 }
 
-func (c *FakeCloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error) {
-	if val, ok := c.VolumeLabelMap[pv.Name]; ok {
+// GetLabelsForVolume returns the labels for a PersistentVolume
+func (f *Cloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error) {
+	if val, ok := f.VolumeLabelMap[pv.Name]; ok {
 		return val, nil
 	}
 	return nil, fmt.Errorf("label not found for volume")

--- a/test/integration/serving/BUILD
+++ b/test/integration/serving/BUILD
@@ -21,10 +21,10 @@ go_test(
         "//cmd/kube-apiserver/app/testing:go_default_library",
         "//cmd/kube-controller-manager/app/testing:go_default_library",
         "//cmd/kube-scheduler/app/testing:go_default_library",
-        "//pkg/cloudprovider/providers/fake:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/fake:go_default_library",
         "//test/integration/framework:go_default_library",
     ],
 )

--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -31,11 +31,11 @@ import (
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/options"
 	"k8s.io/cloud-provider"
+	"k8s.io/cloud-provider/fake"
 	cloudctrlmgrtesting "k8s.io/kubernetes/cmd/cloud-controller-manager/app/testing"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	kubectrlmgrtesting "k8s.io/kubernetes/cmd/kube-controller-manager/app/testing"
 	kubeschedulertesting "k8s.io/kubernetes/cmd/kube-scheduler/app/testing"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -321,5 +321,5 @@ func intPtr(x int) *int {
 }
 
 func fakeCloudProviderFactory(io.Reader) (cloudprovider.Interface, error) {
-	return &fake.FakeCloud{}, nil
+	return &fake.Cloud{}, nil
 }

--- a/test/integration/volume/BUILD
+++ b/test/integration/volume/BUILD
@@ -16,7 +16,6 @@ go_test(
     tags = ["integration"],
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
-        "//pkg/cloudprovider/providers/fake:go_default_library",
         "//pkg/controller/volume/attachdetach:go_default_library",
         "//pkg/controller/volume/attachdetach/cache:go_default_library",
         "//pkg/controller/volume/persistentvolume:go_default_library",
@@ -38,6 +37,7 @@ go_test(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/tools/reference:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/fake:go_default_library",
         "//test/integration/framework:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/test/integration/volume/attach_detach_test.go
+++ b/test/integration/volume/attach_detach_test.go
@@ -32,7 +32,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	fakecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
+	fakecloud "k8s.io/cloud-provider/fake"
 	"k8s.io/kubernetes/pkg/controller/volume/attachdetach"
 	volumecache "k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache"
 	"k8s.io/kubernetes/pkg/controller/volume/persistentvolume"
@@ -422,7 +422,7 @@ func createAdClients(ns *v1.Namespace, t *testing.T, server *httptest.Server, sy
 		Detachers:              nil,
 	}
 	plugins := []volume.VolumePlugin{plugin}
-	cloud := &fakecloud.FakeCloud{}
+	cloud := &fakecloud.Cloud{}
 	informers := clientgoinformers.NewSharedInformerFactory(testClient, resyncPeriod)
 	ctrl, err := attachdetach.NewAttachDetachController(
 		testClient,

--- a/test/integration/volume/persistent_volumes_test.go
+++ b/test/integration/volume/persistent_volumes_test.go
@@ -34,8 +34,8 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	ref "k8s.io/client-go/tools/reference"
+	fakecloud "k8s.io/cloud-provider/fake"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	fakecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
 	persistentvolumecontroller "k8s.io/kubernetes/pkg/controller/volume/persistentvolume"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
@@ -1123,7 +1123,7 @@ func createClients(ns *v1.Namespace, t *testing.T, s *httptest.Server, syncPerio
 		Detachers:              nil,
 	}
 	plugins := []volume.VolumePlugin{plugin}
-	cloud := &fakecloud.FakeCloud{}
+	cloud := &fakecloud.Cloud{}
 	informers := informers.NewSharedInformerFactory(testClient, getSyncPeriod(syncPeriod))
 	ctrl, err := persistentvolumecontroller.NewController(
 		persistentvolumecontroller.ControllerParameters{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1530,6 +1530,7 @@ k8s.io/client-go/util/testing
 k8s.io/client-go/util/workqueue
 # k8s.io/cloud-provider v0.0.0 => ./staging/src/k8s.io/cloud-provider
 k8s.io/cloud-provider
+k8s.io/cloud-provider/fake
 k8s.io/cloud-provider/node/helpers
 k8s.io/cloud-provider/service/helpers
 k8s.io/cloud-provider/volume


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Staging the fake Cloud Provider as part of [KEP 20190125-removing-in-tree-providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20190125-removing-in-tree-providers.md). Staging repo setup here https://github.com/kubernetes/legacy-cloud-providers

Ref: #75910

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/sig cloud-provider aws
/priority important-longterm
/cc @andrewsykim @cheftako 