### PR TITLE
Revert "fix shellcheck failures of hack/verify-no-vendor-cycles.sh"

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -28,6 +28,7 @@
 ./hack/pin-dependency.sh
 ./hack/test-integration.sh
 ./hack/update-vendor.sh
+./hack/verify-no-vendor-cycles.sh
 ./hack/verify-test-featuregates.sh
 ./test/cmd/batch.sh
 ./test/cmd/certificate.sh


### PR DESCRIPTION
This reverts commit e25e5a63e7b27e65b0118c3bfedfe1dec84c3f7c.



**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
https://github.com/kubernetes/kubernetes/pull/77055 made changes that rendered the `verify-no-vendor-cycles.sh` check ineffective (it passed immediately on https://github.com/kubernetes/kubernetes/pull/77837 which introduced vendor cycles)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```