### PR TITLE
test/e2e/scheduling/ubernetes_lite: Report zones in checkZoneSpreading failures

### DIFF
--- a/test/e2e/scheduling/ubernetes_lite.go
+++ b/test/e2e/scheduling/ubernetes_lite.go
@@ -159,17 +159,20 @@ func checkZoneSpreading(c clientset.Interface, pods *v1.PodList, zoneNames []str
 	}
 	minPodsPerZone := math.MaxInt32
 	maxPodsPerZone := 0
-	for _, podCount := range podsPerZone {
+	var minZone, maxZone string
+	for podZone, podCount := range podsPerZone {
 		if podCount < minPodsPerZone {
 			minPodsPerZone = podCount
+			minZone = podZone
 		}
 		if podCount > maxPodsPerZone {
 			maxPodsPerZone = podCount
+			maxZone = podZone
 		}
 	}
 	Expect(minPodsPerZone).To(BeNumerically("~", maxPodsPerZone, 1),
-		"Pods were not evenly spread across zones.  %d in one zone and %d in another zone",
-		minPodsPerZone, maxPodsPerZone)
+		"Pods were not evenly spread across zones.  %d in %s and %d in %s",
+		minPodsPerZone, minZone, maxPodsPerZone, maxZone)
 	return true, nil
 }
 


### PR DESCRIPTION
Because:

```
Pods were not evenly spread across zones.  0 in us-east-1a and 4 in us-east-1b
```

will be more useful than the [current][1]:

```
Pods were not evenly spread across zones.  0 in one zone and 4 in another zone
```

```release-note
NONE
```

[1]: https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_release/3440/rehearse-3440-pull-ci-openshift-installer-master-e2e-aws-upi/30