### PR TITLE
Publish DeleteOptions parameters for deletecollection endpoints in OpenAPI spec

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -806,6 +806,13 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
 				Writes(versionedStatus).
 				Returns(http.StatusOK, "OK", versionedStatus)
+			if isCollectionDeleter {
+				route.Reads(versionedDeleterObject)
+				route.ParameterNamed("body").Required(false)
+				if err := AddObjectParams(ws, route, versionedDeleteOptions); err != nil {
+					return nil, err
+				}
+			}
 			if err := AddObjectParams(ws, route, versionedListOptions); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Deletecollection endpoint handles `DeleteOptions` but we didn't register it in API installer, as a result `DeleteOptions` query & body parameters aren't reflected in our openapi spec.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Publish DeleteOptions parameters for deletecollection endpoints in OpenAPI spec
```

/sig api-machinery