### PR TITLE
fix: verify metadata is non-nil in resource allocation

### DIFF
--- a/pkg/scheduler/algorithm/priorities/balanced_resource_allocation_test.go
+++ b/pkg/scheduler/algorithm/priorities/balanced_resource_allocation_test.go
@@ -402,19 +402,34 @@ func TestBalancedResourceAllocation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			nodeNameToInfo := schedulernodeinfo.CreateNodeNameToInfoMap(test.pods, test.nodes)
-			if len(test.pod.Spec.Volumes) > 0 {
-				maxVolumes := 5
-				for _, info := range nodeNameToInfo {
-					info.TransientInfo.TransNodeInfo.AllocatableVolumesCount = getExistingVolumeCountForNode(info.Pods(), maxVolumes)
-					info.TransientInfo.TransNodeInfo.RequestedVolumes = len(test.pod.Spec.Volumes)
+			metadata := &priorityMetadata{
+				nonZeroRequest: getNonZeroRequests(test.pod),
+			}
+
+			for _, hasMeta := range []bool{true, false} {
+				if len(test.pod.Spec.Volumes) > 0 {
+					maxVolumes := 5
+					for _, info := range nodeNameToInfo {
+						info.TransientInfo.TransNodeInfo.AllocatableVolumesCount = getExistingVolumeCountForNode(info.Pods(), maxVolumes)
+						info.TransientInfo.TransNodeInfo.RequestedVolumes = len(test.pod.Spec.Volumes)
+					}
 				}
-			}
-			list, err := priorityFunction(BalancedResourceAllocationMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if !reflect.DeepEqual(test.expectedList, list) {
-				t.Errorf("expected %#v, got %#v", test.expectedList, list)
+
+				var function PriorityFunction
+				if hasMeta {
+					function = priorityFunction(BalancedResourceAllocationMap, nil, metadata)
+				} else {
+					function = priorityFunction(BalancedResourceAllocationMap, nil, nil)
+				}
+
+				list, err := function(test.pod, nodeNameToInfo, test.nodes)
+
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if !reflect.DeepEqual(test.expectedList, list) {
+					t.Errorf("hasMeta %#v expected %#v, got %#v", hasMeta, test.expectedList, list)
+				}
 			}
 		})
 	}

--- a/pkg/scheduler/algorithm/priorities/resource_limits.go
+++ b/pkg/scheduler/algorithm/priorities/resource_limits.go
@@ -43,7 +43,7 @@ func ResourceLimitsPriorityMap(pod *v1.Pod, meta interface{}, nodeInfo *schedule
 
 	// compute pod limits
 	var podLimits *schedulernodeinfo.Resource
-	if priorityMeta, ok := meta.(*priorityMetadata); ok && priorityMeta != nil {
+	if priorityMeta, ok := meta.(*priorityMetadata); ok {
 		// We were able to parse metadata, use podLimits from there.
 		podLimits = priorityMeta.podLimits
 	} else {


### PR DESCRIPTION
 /kind bug

**What this PR does / why we need it**:

Fix a bug when metadata is nil in resource allocation.

It crashes when `meta` is of type `*priorityMetadata` but equals to `nil`

Related to https://github.com/kubernetes/kubernetes/pull/77498#pullrequestreview-236991355

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
