### PR TITLE
Add phase runner to kubeadm reset

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -86,7 +86,6 @@ go_test(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/v1beta2:go_default_library",
-        "//cmd/kubeadm/app/apis/kubeadm/validation:go_default_library",
         "//cmd/kubeadm/app/cmd/options:go_default_library",
         "//cmd/kubeadm/app/componentconfigs:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",

--- a/cmd/kubeadm/app/cmd/cmd.go
+++ b/cmd/kubeadm/app/cmd/cmd.go
@@ -84,7 +84,7 @@ func NewKubeadmCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	cmds.AddCommand(NewCmdConfig(out))
 	cmds.AddCommand(NewCmdInit(out, nil))
 	cmds.AddCommand(NewCmdJoin(out, nil))
-	cmds.AddCommand(NewCmdReset(in, out))
+	cmds.AddCommand(NewCmdReset(in, out, nil))
 	cmds.AddCommand(NewCmdVersion(out))
 	cmds.AddCommand(NewCmdToken(out, err))
 	cmds.AddCommand(upgrade.NewCmdUpgrade(out))

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -127,4 +127,7 @@ const (
 
 	// SkipCertificateKeyPrint flag instruct kubeadm to skip printing certificate key used to encrypt certs by 'kubeadm init'.
 	SkipCertificateKeyPrint = "skip-certificate-key-print"
+
+	// ForceReset flag instruct kubeadm to reset the node without prompting for confirmation
+	ForceReset = "force"
 )

--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -26,8 +25,6 @@ import (
 	"github.com/lithammer/dedent"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
@@ -83,21 +80,6 @@ func assertDirEmpty(t *testing.T, path string) {
 	if len(errors) != 0 {
 		t.Errorf("directory not empty: [%v]", errors)
 	}
-}
-
-func TestNewReset(t *testing.T) {
-	var in io.Reader
-	certsDir := kubeadmapiv1beta2.DefaultCertificatesDir
-	criSocketPath := kubeadmconstants.DefaultDockerCRISocket
-	forceReset := true
-
-	ignorePreflightErrors := []string{"all"}
-	ignorePreflightErrorsSet, _ := validation.ValidateIgnorePreflightErrors(ignorePreflightErrors)
-	NewReset(in, ignorePreflightErrorsSet, forceReset, certsDir, criSocketPath)
-
-	ignorePreflightErrors = []string{}
-	ignorePreflightErrorsSet, _ = validation.ValidateIgnorePreflightErrors(ignorePreflightErrors)
-	NewReset(in, ignorePreflightErrorsSet, forceReset, certsDir, criSocketPath)
 }
 
 func TestConfigDirCleaner(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Add phase runner to kubeadm reset

**Which issue(s) this PR fixes**:
Refs https://github.com/kubernetes/kubeadm/issues/1425
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: expose the kubeadm reset command as phases
```

/priority important-soon