### PR TITLE
tests: Replaces dnsmasq usage with CoreDNS

### DIFF
--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -221,13 +221,13 @@ func (t *dnsNameserverTest) run(isIPv6 bool) {
 	defer t.restoreDNSConfigMap(originalConfigMapData)
 
 	if isIPv6 {
-		t.createDNSServer(map[string]string{
+		t.createDNSServer(t.f.Namespace.Name, map[string]string{
 			"abc.acme.local": "2606:4700:4700::1111",
 			"def.acme.local": "2606:4700:4700::2222",
 			"widget.local":   "2606:4700:4700::3333",
 		})
 	} else {
-		t.createDNSServer(map[string]string{
+		t.createDNSServer(t.f.Namespace.Name, map[string]string{
 			"abc.acme.local": "1.1.1.1",
 			"def.acme.local": "2.2.2.2",
 			"widget.local":   "3.3.3.3",
@@ -317,7 +317,7 @@ func (t *dnsPtrFwdTest) run(isIPv6 bool) {
 	originalConfigMapData := t.fetchDNSConfigMapData()
 	defer t.restoreDNSConfigMap(originalConfigMapData)
 
-	t.createDNSServerWithPtrRecord(isIPv6)
+	t.createDNSServerWithPtrRecord(t.f.Namespace.Name, isIPv6)
 	defer t.deleteDNSServerPod()
 
 	// Should still be able to lookup public nameserver without explicit upstream nameserver set.
@@ -401,11 +401,11 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
 
 	fooHostname := "foo.example.com"
 	if isIPv6 {
-		t.createDNSServer(map[string]string{
+		t.createDNSServer(t.f.Namespace.Name, map[string]string{
 			fooHostname: "2001:db8::29",
 		})
 	} else {
-		t.createDNSServer(map[string]string{
+		t.createDNSServer(t.f.Namespace.Name, map[string]string{
 			fooHostname: "192.0.2.123",
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

/sig windows
/sig testing

**What this PR does / why we need it**:

``dnsmasq`` is a Linux specific binary. In order for the tests to also pass on Windows, CoreDNS should be used instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes: #77935
Depends On: #77861

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
