### PR TITLE
Allow aggregate-to-view roles to get jobs status

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -301,7 +301,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: "system:aggregate-to-view", Labels: map[string]string{"rbac.authorization.k8s.io/aggregate-to-view": "true"}},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule(Read...).Groups(legacyGroup).Resources("pods", "replicationcontrollers", "replicationcontrollers/scale", "serviceaccounts",
-					"services", "endpoints", "persistentvolumeclaims", "persistentvolumeclaims/status", "configmaps").RuleOrDie(),
+					"services", "services/status", "endpoints", "persistentvolumeclaims", "persistentvolumeclaims/status", "configmaps").RuleOrDie(),
 				rbacv1helpers.NewRule(Read...).Groups(legacyGroup).Resources("limitranges", "resourcequotas", "bindings", "events",
 					"pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status", "pods/log").RuleOrDie(),
 				// read access to namespaces at the namespace scope means you can read *this* namespace.  This can be used as an
@@ -310,14 +310,14 @@ func ClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(Read...).Groups(appsGroup).Resources(
 					"controllerrevisions",
-					"statefulsets", "statefulsets/scale",
-					"daemonsets",
-					"deployments", "deployments/scale",
-					"replicasets", "replicasets/scale").RuleOrDie(),
+					"statefulsets", "statefulsets/status", "statefulsets/scale",
+					"daemonsets", "daemonsets/status",
+					"deployments", "deployments/status", "deployments/scale",
+					"replicasets", "replicasets/status", "replicasets/scale").RuleOrDie(),
 
 				rbacv1helpers.NewRule(Read...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers", "horizontalpodautoscalers/status").RuleOrDie(),
 
-				rbacv1helpers.NewRule(Read...).Groups(batchGroup).Resources("jobs", "cronjobs", "jobs/status").RuleOrDie(),
+				rbacv1helpers.NewRule(Read...).Groups(batchGroup).Resources("jobs", "cronjobs", "cronjobs/status", "jobs/status").RuleOrDie(),
 
 				rbacv1helpers.NewRule(Read...).Groups(extensionsGroup).Resources("daemonsets", "daemonsets/status", "deployments", "deployments/scale", "deployments/status",
 					"ingresses", "ingresses/status", "replicasets", "replicasets/scale", "replicasets/status", "replicationcontrollers/scale",
@@ -325,7 +325,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(Read...).Groups(policyGroup).Resources("poddisruptionbudgets", "poddisruptionbudgets/status").RuleOrDie(),
 
-				rbacv1helpers.NewRule(Read...).Groups(networkingGroup).Resources("networkpolicies", "ingresses").RuleOrDie(),
+				rbacv1helpers.NewRule(Read...).Groups(networkingGroup).Resources("networkpolicies", "ingresses", "ingresses/status").RuleOrDie(),
 			},
 		},
 		{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -301,7 +301,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: "system:aggregate-to-view", Labels: map[string]string{"rbac.authorization.k8s.io/aggregate-to-view": "true"}},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule(Read...).Groups(legacyGroup).Resources("pods", "replicationcontrollers", "replicationcontrollers/scale", "serviceaccounts",
-					"services", "endpoints", "persistentvolumeclaims", "configmaps").RuleOrDie(),
+					"services", "endpoints", "persistentvolumeclaims", "persistentvolumeclaims/status", "configmaps").RuleOrDie(),
 				rbacv1helpers.NewRule(Read...).Groups(legacyGroup).Resources("limitranges", "resourcequotas", "bindings", "events",
 					"pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status", "pods/log").RuleOrDie(),
 				// read access to namespaces at the namespace scope means you can read *this* namespace.  This can be used as an

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -319,7 +319,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(Read...).Groups(batchGroup).Resources("jobs", "cronjobs", "jobs/status").RuleOrDie(),
 
-				rbacv1helpers.NewRule(Read...).Groups(extensionsGroup).Resources("daemonsets", "daemonsets/status", "deployments", "deployments/scale", "deployments/status",												 
+				rbacv1helpers.NewRule(Read...).Groups(extensionsGroup).Resources("daemonsets", "daemonsets/status", "deployments", "deployments/scale", "deployments/status",
 					"ingresses", "ingresses/status", "replicasets", "replicasets/scale", "replicasets/status", "replicationcontrollers/scale",
 					"networkpolicies").RuleOrDie(),
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -315,15 +315,15 @@ func ClusterRoles() []rbacv1.ClusterRole {
 					"deployments", "deployments/scale",
 					"replicasets", "replicasets/scale").RuleOrDie(),
 
-				rbacv1helpers.NewRule(Read...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
+				rbacv1helpers.NewRule(Read...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers", "horizontalpodautoscalers/status").RuleOrDie(),
 
 				rbacv1helpers.NewRule(Read...).Groups(batchGroup).Resources("jobs", "cronjobs", "jobs/status").RuleOrDie(),
 
-				rbacv1helpers.NewRule(Read...).Groups(extensionsGroup).Resources("daemonsets", "deployments", "deployments/scale",
-					"ingresses", "replicasets", "replicasets/scale", "replicationcontrollers/scale",
+				rbacv1helpers.NewRule(Read...).Groups(extensionsGroup).Resources("daemonsets", "daemonsets/status", "deployments", "deployments/scale", "deployments/status",												 
+					"ingresses", "ingresses/status", "replicasets", "replicasets/scale", "replicasets/status", "replicationcontrollers/scale",
 					"networkpolicies").RuleOrDie(),
 
-				rbacv1helpers.NewRule(Read...).Groups(policyGroup).Resources("poddisruptionbudgets").RuleOrDie(),
+				rbacv1helpers.NewRule(Read...).Groups(policyGroup).Resources("poddisruptionbudgets", "poddisruptionbudgets/status").RuleOrDie(),
 
 				rbacv1helpers.NewRule(Read...).Groups(networkingGroup).Resources("networkpolicies", "ingresses").RuleOrDie(),
 			},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -283,7 +283,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(Write...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
 
-				rbacv1helpers.NewRule(Write...).Groups(batchGroup).Resources("jobs", "cronjobs", "jobs/status").RuleOrDie(),
+				rbacv1helpers.NewRule(Write...).Groups(batchGroup).Resources("jobs", "cronjobs").RuleOrDie(),
 
 				rbacv1helpers.NewRule(Write...).Groups(extensionsGroup).Resources("daemonsets",
 					"deployments", "deployments/scale", "deployments/rollback", "ingresses",
@@ -317,7 +317,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(Read...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
 
-				rbacv1helpers.NewRule(Read...).Groups(batchGroup).Resources("jobs", "cronjobs").RuleOrDie(),
+				rbacv1helpers.NewRule(Read...).Groups(batchGroup).Resources("jobs", "cronjobs", "jobs/status").RuleOrDie(),
 
 				rbacv1helpers.NewRule(Read...).Groups(extensionsGroup).Resources("daemonsets", "deployments", "deployments/scale",
 					"ingresses", "replicasets", "replicasets/scale", "replicationcontrollers/scale",

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -283,7 +283,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(Write...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
 
-				rbacv1helpers.NewRule(Write...).Groups(batchGroup).Resources("jobs", "cronjobs").RuleOrDie(),
+				rbacv1helpers.NewRule(Write...).Groups(batchGroup).Resources("jobs", "cronjobs", "jobs/status").RuleOrDie(),
 
 				rbacv1helpers.NewRule(Write...).Groups(extensionsGroup).Resources("daemonsets",
 					"deployments", "deployments/scale", "deployments/rollback", "ingresses",

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -289,6 +289,7 @@ items:
     - autoscaling
     resources:
     - horizontalpodautoscalers
+    - horizontalpodautoscalers/status
     verbs:
     - get
     - list
@@ -307,12 +308,16 @@ items:
     - extensions
     resources:
     - daemonsets
+    - daemonsets/status
     - deployments
+    - deployments/status
     - deployments/scale
     - ingresses
+    - ingresses/status
     - networkpolicies
     - replicasets
     - replicasets/scale
+    - replicasets/status
     - replicationcontrollers/scale
     verbs:
     - get
@@ -322,6 +327,7 @@ items:
     - policy
     resources:
     - poddisruptionbudgets
+    - poddisruptionbudgets/status
     verbs:
     - get
     - list

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -146,17 +146,13 @@ items:
     - apps
     resources:
     - daemonsets
-    - daemonsets/status
     - deployments
     - deployments/rollback
     - deployments/scale
-    - deployments/status
     - replicasets
     - replicasets/scale
-    - replicasets/status
     - statefulsets
     - statefulsets/scale
-    - statefulsets/status
     verbs:
     - create
     - delete
@@ -216,7 +212,6 @@ items:
     - networking.k8s.io
     resources:
     - ingresses
-    - ingresses/status
     - networkpolicies
     verbs:
     - create
@@ -283,14 +278,14 @@ items:
     - daemonsets
     - daemonsets/status
     - deployments
-    - deployments/status
     - deployments/scale
+    - deployments/status
     - replicasets
-    - replicasets/status
     - replicasets/scale
+    - replicasets/status
     - statefulsets
-    - statefulsets/status
     - statefulsets/scale
+    - statefulsets/status
     verbs:
     - get
     - list
@@ -347,6 +342,7 @@ items:
     - networking.k8s.io
     resources:
     - ingresses
+    - ingresses/status
     - networkpolicies
     verbs:
     - get

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -236,6 +236,7 @@ items:
     - configmaps
     - endpoints
     - persistentvolumeclaims
+    - persistentvolumeclaims/status
     - pods
     - replicationcontrollers
     - replicationcontrollers/scale
@@ -297,6 +298,7 @@ items:
     resources:
     - cronjobs
     - jobs
+    - jobs/status
     verbs:
     - get
     - list

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -281,12 +281,16 @@ items:
     resources:
     - controllerrevisions
     - daemonsets
+    - daemonsets/status
     - deployments
     - deployments/scale
+    - deployments/status
     - replicasets
     - replicasets/scale
+    - replicasets/status
     - statefulsets
     - statefulsets/scale
+    - statefulsets/status
     verbs:
     - get
     - list

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -310,8 +310,8 @@ items:
     - daemonsets
     - daemonsets/status
     - deployments
-    - deployments/status
     - deployments/scale
+    - deployments/status
     - ingresses
     - ingresses/status
     - networkpolicies

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -283,14 +283,14 @@ items:
     - daemonsets
     - daemonsets/status
     - deployments
-    - deployments/scale
     - deployments/status
+    - deployments/scale
     - replicasets
-    - replicasets/scale
     - replicasets/status
+    - replicasets/scale
     - statefulsets
-    - statefulsets/scale
     - statefulsets/status
+    - statefulsets/scale
     verbs:
     - get
     - list

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -146,13 +146,17 @@ items:
     - apps
     resources:
     - daemonsets
+    - daemonsets/status
     - deployments
     - deployments/rollback
     - deployments/scale
+    - deployments/status
     - replicasets
     - replicasets/scale
+    - replicasets/status
     - statefulsets
     - statefulsets/scale
+    - statefulsets/status
     verbs:
     - create
     - delete
@@ -212,6 +216,7 @@ items:
     - networking.k8s.io
     resources:
     - ingresses
+    - ingresses/status
     - networkpolicies
     verbs:
     - create
@@ -242,6 +247,7 @@ items:
     - replicationcontrollers/scale
     - serviceaccounts
     - services
+    - services/status
     verbs:
     - get
     - list
@@ -298,6 +304,7 @@ items:
     - batch
     resources:
     - cronjobs
+    - cronjobs/status
     - jobs
     - jobs/status
     verbs:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature 

**What this PR does / why we need it**:

Right now users/accounts with role `admin` or `edit` can create, update and delete jobs, but are not allowed to pull the status of a job that they create.  This change extends `aggregate-to-view` rules to include `jobs/status`.

**Does this PR introduce a user-facing change?**:

```release-note
The default `view`, `edit`, and `admin` cluster roles now include read access to status subresources.
```
