### PR TITLE
Prevent Kubelet from clearing terminated pod status

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -32,7 +32,7 @@ import (
 	"time"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -1976,9 +1976,10 @@ func (kl *Kubelet) syncLoopIteration(configCh <-chan kubetypes.PodUpdate, handle
 }
 
 // dispatchWork starts the asynchronous sync of the pod in a pod worker.
-// If the pod is terminated, dispatchWork
+// If the pod is terminated, dispatchWork will perform no action.
 func (kl *Kubelet) dispatchWork(pod *v1.Pod, syncType kubetypes.SyncPodType, mirrorPod *v1.Pod, start time.Time) {
 	if kl.podIsTerminated(pod) {
+		klog.V(4).Infof("Pod %q is terminated, ignoring remaining sync work: %s", format.Pod(pod), syncType)
 		if pod.DeletionTimestamp != nil {
 			// If the pod is in a terminated state, there is no pod worker to
 			// handle the work item. Check if the DeletionTimestamp has been

--- a/pkg/kubelet/status/BUILD
+++ b/pkg/kubelet/status/BUILD
@@ -54,6 +54,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",


### PR DESCRIPTION
Fixes #58711

The kubelet must not allow a container that was reported failed in a restartPolicy=Never pod to be reported to the apiserver as success. If a client deletes a restartPolicy=Never pod, the dispatchWork and status manager race to update the container status. When dispatchWork (specifically podIsTerminated) returns true, it means all containers are stopped, which means status in the container is accurate. However, the TerminatePod method then clears this status. This results in a
pod that has been reported with status.phase=Failed getting reset to status.phase.Succeeded on the next sync to the apiserver, which is a violation of the guarantees around terminal phase.  A higher level controller watching this could see "pod succeeded" instead of "pod failed", causing it to incorrectly take action based on perceived success.

TerminatePod was introduced in #22155 and handled an error where the previous naive status update implementation sent too many requests. In the intervening 13 releases, we have dramatically improved status handling and corrected the logic that would have sent duplicate updates
and so this code can now be safely removed. Also, this was not a reliable way to ensure pod termination status because updateStatusInternal does not guarantee an update is sent to the
pod status channel (because the channel may be full), so this code was already subtly broken beyond just the issue with pod status.

TODO:

* [ ] needs reproducer e2e test

/kind bug

This is a candidate for backport because any production system that relies on pod phase transition being one way could be broken by a drain (jobs, higher level orchestrators, etc).

```release-note
Terminating a restartPolicy=Never pod no longer has a chance to report the pod succeeded when it actually failed.
```