### PR TITLE
don't log initalNode in standalone kubelets

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -217,7 +217,7 @@ func (kl *Kubelet) getRuntime() kubecontainer.Runtime {
 // GetNode returns the node info for the configured node name of this Kubelet.
 func (kl *Kubelet) GetNode() (*v1.Node, error) {
 	if kl.kubeClient == nil {
-		return kl.initialNode()
+		return kl.initialNode(false)
 	}
 	return kl.nodeInfo.GetNodeInfo(string(kl.nodeName))
 }
@@ -233,7 +233,7 @@ func (kl *Kubelet) getNodeAnyWay() (*v1.Node, error) {
 			return n, nil
 		}
 	}
-	return kl.initialNode()
+	return kl.initialNode(false)
 }
 
 // GetNodeConfig returns the container manager node config.


### PR DESCRIPTION
Logs are impressively spammy right now and not useful:

https://storage.googleapis.com/mikedanese/kubelet.log

/kind cleanup
/sig node

```release-note
NONE
```
