### PR TITLE
Unset the current-context when delete-context is issued

### DIFF
--- a/pkg/kubectl/cmd/config/delete_context.go
+++ b/pkg/kubectl/cmd/config/delete_context.go
@@ -77,6 +77,7 @@ func runDeleteContext(out, errOut io.Writer, configAccess clientcmd.ConfigAccess
 	}
 
 	delete(config.Contexts, name)
+	config.CurrentContext = ""
 
 	if err := clientcmd.ModifyConfig(configAccess, *config, true); err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

If you try to delete the current context by running the command `kubectl config delete-context ` it deletes the context but it does not unset the current-context(deleted). 

For eg: 

```
user$ kubectl config set-context test
Context "test" created.
user$ kubectl config current-context test
error: current-context is not set
user$ kubectl config use-context test
Switched to context "test".
user$ kubectl config current-context 
test
user$ kubectl config delete-context test
warning: this removed your active context, use "kubectl config use-context" to select a different one
deleted context test from /Users/hpandey/.kube/config

user$ kubectl config current-context 
test
```

So even after deleting the context `test` current-context is still pointed to it. 
 
This PR is to set the `current-context` to `""` when `delete-context` command is issued

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE

```
