### PR TITLE
Revert "[Re-Apply][Distroless] Convert the GCE manifests for master containers."

### DIFF
--- a/cluster/gce/gci/apiserver_manifest_test.go
+++ b/cluster/gce/gci/apiserver_manifest_test.go
@@ -94,12 +94,11 @@ func (c *kubeAPIServerManifestTestCase) invokeTest(e kubeAPIServerEnv, kubeEnv s
 
 func TestEncryptionProviderFlag(t *testing.T) {
 	var (
-		//  command": [
-		//   "/usr/local/bin/kube-apiserver " - Index 0,
-		//   "--flag1=val1",   - Index 1,
-		//   "--flag2=val2",   - Index 2,
-		//   ...
-		//   "--flagN=valN",   - Index N,
+		//	command": [
+		//   "/bin/sh", - Index 0
+		//   "-c",      - Index 1
+		//   "exec /usr/local/bin/kube-apiserver " - Index 2
+		execArgsIndex        = 2
 		encryptionConfigFlag = "--encryption-provider-config"
 	)
 
@@ -133,15 +132,10 @@ func TestEncryptionProviderFlag(t *testing.T) {
 
 			c.invokeTest(e, deployHelperEnv)
 
-			var flagIsInArg bool
-			var flag, execArgs string
-			for _, execArgs = range c.pod.Spec.Containers[0].Args[1:] {
-				if strings.Contains(execArgs, encryptionConfigFlag) {
-					flagIsInArg = true
-					flag = fmt.Sprintf("%s=%s", encryptionConfigFlag, e.EncryptionProviderConfigPath)
-					break
-				}
-			}
+			execArgs := c.pod.Spec.Containers[0].Command[execArgsIndex]
+			flagIsInArg := strings.Contains(execArgs, encryptionConfigFlag)
+			flag := fmt.Sprintf("%s=%s", encryptionConfigFlag, e.EncryptionProviderConfigPath)
+
 			switch {
 			case tc.wantFlag && !flagIsInArg:
 				t.Fatalf("Got %q,\n want flags to contain %q", execArgs, flag)

--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -25,12 +25,10 @@
       }
     },
     "command": [
-      "/usr/local/bin/kube-apiserver"
-    ],
-    "args": [
-      "--allow-privileged={{pillar['allow_privileged']}}",
-      {{params}}
-    ],
+                 "/bin/sh",
+                 "-c",
+                 "exec /usr/local/bin/kube-apiserver {{params}} --allow-privileged={{pillar['allow_privileged']}} 1>>/var/log/kube-apiserver.log 2>&1"
+               ],
     {{container_env}}
     "livenessProbe": {
       "httpGet": {

--- a/cluster/gce/manifests/kube-controller-manager.manifest
+++ b/cluster/gce/manifests/kube-controller-manager.manifest
@@ -25,11 +25,10 @@
       }
     },
     "command": [
-      "/usr/local/bin/kube-controller-manager"
-    ],
-    "args": [
-      {{params}}
-    ],
+                 "/bin/sh",
+                 "-c",
+                 "exec /usr/local/bin/kube-controller-manager {{params}} 1>>/var/log/kube-controller-manager.log 2>&1"
+               ],
     {{container_env}}
     "livenessProbe": {
       "httpGet": {

--- a/cluster/gce/manifests/kube-scheduler.manifest
+++ b/cluster/gce/manifests/kube-scheduler.manifest
@@ -25,11 +25,10 @@
       }
     },
     "command": [
-      "/usr/local/bin/kube-scheduler"
-    ],
-    "args": [
-      {{params}}
-    ],
+                 "/bin/sh",
+                 "-c",
+                 "exec /usr/local/bin/kube-scheduler {{params}} 1>>/var/log/kube-scheduler.log 2>&1"
+               ],
     "livenessProbe": {
       "httpGet": {
         "host": "127.0.0.1",


### PR DESCRIPTION
Reverts kubernetes/kubernetes#76396

Sorry for reverting the change again, but we have evidence that it makes gce 5000 node test failing.

The problems we are seeing with this PR:
1. Some errors are logged multiple times (i.e. ERRORSs 3x, WARNINGs 2x)
2. All nonempty attempts of kube-logrotate are making kube-apiserver slow enough to triger leaderelection of kube-controller-manager and kube-scheduler.

While 1. is quite easy to understand, the reason for 2. is not known yet.
I'm happy to collaborate with anyone who is interested in rolling forward this PR again to understand the issue and make sure third roll forward will be the successful one :)

/assign @wojtek-t
/cc @mm4tt @krzysied
