### PR TITLE
Allow Kubelet to run with no Azure identity

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go
@@ -28,6 +28,11 @@ import (
 	"k8s.io/klog"
 )
 
+var (
+	// ErrorNoAuth indicates that no credentials are provided.
+	ErrorNoAuth = fmt.Errorf("no credentials provided for Azure cloud provider")
+)
+
 // AzureAuthConfig holds auth related part of cloud config
 type AzureAuthConfig struct {
 	// The cloud environment identifier. Takes values from https://github.com/Azure/go-autorest/blob/ec5f4903f77ed9927ac95b19ab8e44ada64c1356/autorest/azure/environments.go#L13
@@ -104,7 +109,7 @@ func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment) (
 			env.ServiceManagementEndpoint)
 	}
 
-	return nil, fmt.Errorf("No credentials provided for AAD application %s", config.AADClientID)
+	return nil, ErrorNoAuth
 }
 
 // ParseAzureEnvironment returns azure environment by name

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -248,7 +248,14 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 	}
 
 	servicePrincipalToken, err := auth.GetServicePrincipalToken(&config.AzureAuthConfig, env)
-	if err != nil {
+	if err == auth.ErrorNoAuth {
+		if !config.UseInstanceMetadata {
+			// No credentials provided, useInstanceMetadata should be enabled.
+			return nil, fmt.Errorf("useInstanceMetadata must be enabled without Azure credentials")
+		}
+
+		klog.V(2).Infof("Azure cloud provider is starting without credentials")
+	} else if err != nil {
 		return nil, err
 	}
 
@@ -348,6 +355,27 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 		}
 	}
 
+	az := Cloud{
+		Config:                 *config,
+		Environment:            *env,
+		nodeZones:              map[string]sets.String{},
+		nodeResourceGroups:     map[string]string{},
+		unmanagedNodes:         sets.NewString(),
+		routeCIDRs:             map[string]string{},
+		resourceRequestBackoff: resourceRequestBackoff,
+	}
+	az.metadata, err = NewInstanceMetadataService(metadataURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// No credentials provided, InstanceMetadataService would be used for getting Azure resources.
+	// Note that this only applies to Kubelet, controller-manager should configure credentials for managing Azure resources.
+	if servicePrincipalToken == nil {
+		return &az, nil
+	}
+
+	// Initialize Azure clients.
 	azClientConfig := &azClientConfig{
 		subscriptionID:                 config.SubscriptionID,
 		resourceManagerEndpoint:        env.ResourceManagerEndpoint,
@@ -358,36 +386,21 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 		CloudProviderBackoffDuration:   config.CloudProviderBackoffDuration,
 		ShouldOmitCloudProviderBackoff: config.shouldOmitCloudProviderBackoff(),
 	}
-	az := Cloud{
-		Config:                 *config,
-		Environment:            *env,
-		nodeZones:              map[string]sets.String{},
-		nodeResourceGroups:     map[string]string{},
-		unmanagedNodes:         sets.NewString(),
-		routeCIDRs:             map[string]string{},
-		resourceRequestBackoff: resourceRequestBackoff,
-
-		DisksClient:                     newAzDisksClient(azClientConfig),
-		SnapshotsClient:                 newSnapshotsClient(azClientConfig),
-		RoutesClient:                    newAzRoutesClient(azClientConfig),
-		SubnetsClient:                   newAzSubnetsClient(azClientConfig),
-		InterfacesClient:                newAzInterfacesClient(azClientConfig),
-		RouteTablesClient:               newAzRouteTablesClient(azClientConfig),
-		LoadBalancerClient:              newAzLoadBalancersClient(azClientConfig),
-		SecurityGroupsClient:            newAzSecurityGroupsClient(azClientConfig),
-		StorageAccountClient:            newAzStorageAccountClient(azClientConfig),
-		VirtualMachinesClient:           newAzVirtualMachinesClient(azClientConfig),
-		PublicIPAddressesClient:         newAzPublicIPAddressesClient(azClientConfig),
-		VirtualMachineSizesClient:       newAzVirtualMachineSizesClient(azClientConfig),
-		VirtualMachineScaleSetsClient:   newAzVirtualMachineScaleSetsClient(azClientConfig),
-		VirtualMachineScaleSetVMsClient: newAzVirtualMachineScaleSetVMsClient(azClientConfig),
-		FileClient:                      &azureFileClient{env: *env},
-	}
-
-	az.metadata, err = NewInstanceMetadataService(metadataURL)
-	if err != nil {
-		return nil, err
-	}
+	az.DisksClient = newAzDisksClient(azClientConfig)
+	az.SnapshotsClient = newSnapshotsClient(azClientConfig)
+	az.RoutesClient = newAzRoutesClient(azClientConfig)
+	az.SubnetsClient = newAzSubnetsClient(azClientConfig)
+	az.InterfacesClient = newAzInterfacesClient(azClientConfig)
+	az.RouteTablesClient = newAzRouteTablesClient(azClientConfig)
+	az.LoadBalancerClient = newAzLoadBalancersClient(azClientConfig)
+	az.SecurityGroupsClient = newAzSecurityGroupsClient(azClientConfig)
+	az.StorageAccountClient = newAzStorageAccountClient(azClientConfig)
+	az.VirtualMachinesClient = newAzVirtualMachinesClient(azClientConfig)
+	az.PublicIPAddressesClient = newAzPublicIPAddressesClient(azClientConfig)
+	az.VirtualMachineSizesClient = newAzVirtualMachineSizesClient(azClientConfig)
+	az.VirtualMachineScaleSetsClient = newAzVirtualMachineScaleSetsClient(azClientConfig)
+	az.VirtualMachineScaleSetVMsClient = newAzVirtualMachineScaleSetVMsClient(azClientConfig)
+	az.FileClient = &azureFileClient{env: *env}
 
 	if az.MaximumLoadBalancerRuleCount == 0 {
 		az.MaximumLoadBalancerRuleCount = maximumLoadBalancerRuleCount


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug
/sig azure

**What this PR does / why we need it**:

Allow Kubelet to run with no Azure identity. useInstanceMetadata should be enabled and Kubelet would use IMDS to get node's information.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #77309

**Special notes for your reviewer**:

#77851 is also required for no identity working.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kubelet could be run with no Azure identity now. A sample cloud provider configure is:  `{"vmType": "vmss", "useInstanceMetadata": true, "subscriptionId": "<subscriptionId>"}`
```
