### PR TITLE
Fix incorrect azuredisk lun error

### DIFF
--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -82,7 +82,7 @@ func (a *azureDiskAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (
 		klog.V(2).Infof("GetDiskLun returned: %v. Initiating attaching volume %q to node %q.", err, volumeSource.DataDiskURI, nodeName)
 
 		isManagedDisk := (*volumeSource.Kind == v1.AzureManagedDisk)
-		err = diskController.AttachDisk(isManagedDisk, volumeSource.DiskName, volumeSource.DataDiskURI, nodeName, compute.CachingTypes(*volumeSource.CachingMode))
+		lun, err = diskController.AttachDisk(isManagedDisk, volumeSource.DiskName, volumeSource.DataDiskURI, nodeName, compute.CachingTypes(*volumeSource.CachingMode))
 		if err == nil {
 			klog.V(2).Infof("Attach operation successful: volume %q attached to node %q.", volumeSource.DataDiskURI, nodeName)
 		} else {

--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -44,7 +44,7 @@ type DiskController interface {
 	DeleteManagedDisk(diskURI string) error
 
 	// Attaches the disk to the host machine.
-	AttachDisk(isManagedDisk bool, diskName, diskUri string, nodeName types.NodeName, cachingMode compute.CachingTypes) error
+	AttachDisk(isManagedDisk bool, diskName, diskUri string, nodeName types.NodeName, cachingMode compute.CachingTypes) (int32, error)
 	// Detaches the disk, identified by disk name or uri, from the host machine.
 	DetachDisk(diskName, diskUri string, nodeName types.NodeName) error
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
@@ -36,7 +36,7 @@ func TestAttachDisk(t *testing.T) {
 
 	diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/disk-name", c.SubscriptionID, c.ResourceGroup)
 
-	err := common.AttachDisk(true, "", diskURI, "node1", compute.CachingTypesReadOnly)
+	_, err := common.AttachDisk(true, "", diskURI, "node1", compute.CachingTypesReadOnly)
 	if err != nil {
 		fmt.Printf("TestAttachDisk return expected error: %v", err)
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
With PR(https://github.com/kubernetes/kubernetes/pull/77483),  azure disk is not working well, error message is like following:
```
Operation for "\"kubernetes.io/azure-disk//<pvc-resource-id>\"" failed. No retries permitted until 2019-05-15 07:37:44.323108693 +0000 UTC m=+297.614031734 (durationBeforeRetry 1m4s). Error: "MountVolume.WaitForAttach failed for volume \"pvc-dceb8b43-76e3-11e9-a1ab-000d3aa2e18b\" (UniqueName: \"kubernetes.io/azure-disk//<pvc-resource-id>\") pod \"sh\" (UID: \"dcd1c6b5-76e3-11e9-a1ab-000d3aa2e18b\") : azureDisk - WaitForAttach failed within timeout node (k8s-agentpool2-20421826-vmss000000) diskId:(k8s-vmss-dynamic-pvc-dceb8b43-76e3-11e9-a1ab-000d3aa2e18b) lun:(-1)"
```

This PR fixed the issue, after attach disk succeeded, it will return actual lun num other than -1

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #77911

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix incorrect azuredisk lun error
```

/kind bug
/assign @feiskyer 
/priority important-soon
/sig azure

