### PR TITLE
Fix golint failures of test/e2e/autoscaling

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -590,7 +590,6 @@ staging/src/k8s.io/sample-apiserver/pkg/apis/wardle
 staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1
 staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer
 staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder
-test/e2e/autoscaling
 test/e2e/chaosmonkey
 test/e2e/common
 test/e2e/lifecycle/bootstrap

--- a/test/e2e/autoscaling/autoscaling_timer.go
+++ b/test/e2e/autoscaling/autoscaling_timer.go
@@ -25,15 +25,15 @@ import (
 	"k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 )
 
 var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling", func() {
 	f := framework.NewDefaultFramework("autoscaling")
 
 	SIGDescribe("Autoscaling a service", func() {
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			// Check if Cloud Autoscaler is enabled by trying to get its ConfigMap.
 			_, err := f.ClientSet.CoreV1().ConfigMaps("kube-system").Get("cluster-autoscaler-status", metav1.GetOptions{})
 			if err != nil {
@@ -41,12 +41,12 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 			}
 		})
 
-		Context("from 1 pod and 3 nodes to 8 pods and >=4 nodes", func() {
+		ginkgo.Context("from 1 pod and 3 nodes to 8 pods and >=4 nodes", func() {
 			const nodesNum = 3       // Expect there to be 3 nodes before and after the test.
 			var nodeGroupName string // Set by BeforeEach, used by AfterEach to scale this node group down after the test.
 			var nodes *v1.NodeList   // Set by BeforeEach, used by Measure to calculate CPU request based on node's sizes.
 
-			BeforeEach(func() {
+			ginkgo.BeforeEach(func() {
 				// Make sure there is only 1 node group, otherwise this test becomes useless.
 				nodeGroups := strings.Split(framework.TestContext.CloudConfig.NodeInstanceGroup, ",")
 				if len(nodeGroups) != 1 {
@@ -64,10 +64,10 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 				// Make sure all nodes are schedulable, otherwise we are in some kind of a problem state.
 				nodes = framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 				schedulableCount := len(nodes.Items)
-				Expect(schedulableCount).To(Equal(nodeGroupSize), "not all nodes are schedulable")
+				gomega.Expect(schedulableCount).To(gomega.Equal(nodeGroupSize), "not all nodes are schedulable")
 			})
 
-			AfterEach(func() {
+			ginkgo.AfterEach(func() {
 				// Attempt cleanup only if a node group was targeted for scale up.
 				// Otherwise the test was probably skipped and we'll get a gcloud error due to invalid parameters.
 				if len(nodeGroupName) > 0 {
@@ -77,7 +77,7 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 				}
 			})
 
-			Measure("takes less than 15 minutes", func(b Benchmarker) {
+			ginkgo.Measure("takes less than 15 minutes", func(b ginkgo.Benchmarker) {
 				// Measured over multiple samples, scaling takes 10 +/- 2 minutes, so 15 minutes should be fully sufficient.
 				const timeToWait = 15 * time.Minute
 
@@ -85,8 +85,8 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 				// This test expects that 8 pods will not fit in 'nodesNum' nodes, but will fit in >='nodesNum'+1 nodes.
 				// Make it so that 'nodesNum' pods fit perfectly per node.
 				nodeCpus := nodes.Items[0].Status.Allocatable[v1.ResourceCPU]
-				nodeCpuMillis := (&nodeCpus).MilliValue()
-				cpuRequestMillis := int64(nodeCpuMillis / nodesNum)
+				nodeCPUMillis := (&nodeCpus).MilliValue()
+				cpuRequestMillis := int64(nodeCPUMillis / nodesNum)
 
 				// Start the service we want to scale and wait for it to be up and running.
 				nodeMemoryBytes := nodes.Items[0].Status.Allocatable[v1.ResourceMemory]
@@ -99,10 +99,10 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 
 				// Enable Horizontal Pod Autoscaler with 50% target utilization and
 				// scale up the CPU usage to trigger autoscaling to 8 pods for target to be satisfied.
-				targetCpuUtilizationPercent := int32(50)
-				hpa := common.CreateCPUHorizontalPodAutoscaler(resourceConsumer, targetCpuUtilizationPercent, 1, 10)
+				targetCPUUtilizationPercent := int32(50)
+				hpa := common.CreateCPUHorizontalPodAutoscaler(resourceConsumer, targetCPUUtilizationPercent, 1, 10)
 				defer common.DeleteHorizontalPodAutoscaler(resourceConsumer, hpa.Name)
-				cpuLoad := 8 * cpuRequestMillis * int64(targetCpuUtilizationPercent) / 100 // 8 pods utilized to the target level
+				cpuLoad := 8 * cpuRequestMillis * int64(targetCPUUtilizationPercent) / 100 // 8 pods utilized to the target level
 				resourceConsumer.ConsumeCPU(int(cpuLoad))
 
 				// Measure the time it takes for the service to scale to 8 pods with 50% CPU utilization each.

--- a/test/e2e/autoscaling/cluster_autoscaler_scalability.go
+++ b/test/e2e/autoscaling/cluster_autoscaler_scalability.go
@@ -33,8 +33,8 @@ import (
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	"k8s.io/klog"
 )
 
@@ -65,7 +65,7 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 	var originalSizes map[string]int
 	var sum int
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("gce", "gke", "kubemark")
 
 		// Check if Cloud Autoscaler is enabled by trying to get its ConfigMap.
@@ -81,7 +81,7 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 			for _, mig := range strings.Split(framework.TestContext.CloudConfig.NodeInstanceGroup, ",") {
 				size, err := framework.GroupSize(mig)
 				framework.ExpectNoError(err)
-				By(fmt.Sprintf("Initial size of %s: %d", mig, size))
+				ginkgo.By(fmt.Sprintf("Initial size of %s: %d", mig, size))
 				originalSizes[mig] = size
 				sum += size
 			}
@@ -91,13 +91,13 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 
 		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 		nodeCount = len(nodes.Items)
-		Expect(nodeCount).NotTo(BeZero())
+		gomega.Expect(nodeCount).NotTo(gomega.BeZero())
 		cpu := nodes.Items[0].Status.Capacity[v1.ResourceCPU]
 		mem := nodes.Items[0].Status.Capacity[v1.ResourceMemory]
 		coresPerNode = int((&cpu).MilliValue() / 1000)
 		memCapacityMb = int((&mem).Value() / 1024 / 1024)
 
-		Expect(nodeCount).Should(Equal(sum))
+		gomega.Expect(nodeCount).Should(gomega.Equal(sum))
 
 		if framework.ProviderIs("gke") {
 			val, err := isAutoscalerEnabled(3)
@@ -109,8 +109,8 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 		}
 	})
 
-	AfterEach(func() {
-		By(fmt.Sprintf("Restoring initial size of the cluster"))
+	ginkgo.AfterEach(func() {
+		ginkgo.By(fmt.Sprintf("Restoring initial size of the cluster"))
 		setMigSizes(originalSizes)
 		framework.ExpectNoError(framework.WaitForReadyNodes(c, nodeCount, scaleDownTimeout))
 		nodes, err := c.CoreV1().Nodes().List(metav1.ListOptions{})
@@ -132,7 +132,7 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 		klog.Infof("Made nodes schedulable again in %v", time.Since(s).String())
 	})
 
-	It("should scale up at all [Feature:ClusterAutoscalerScalability1]", func() {
+	ginkgo.It("should scale up at all [Feature:ClusterAutoscalerScalability1]", func() {
 		perNodeReservation := int(float64(memCapacityMb) * 0.95)
 		replicasPerNode := 10
 
@@ -155,7 +155,7 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 		defer testCleanup()
 	})
 
-	It("should scale up twice [Feature:ClusterAutoscalerScalability2]", func() {
+	ginkgo.It("should scale up twice [Feature:ClusterAutoscalerScalability2]", func() {
 		perNodeReservation := int(float64(memCapacityMb) * 0.95)
 		replicasPerNode := 10
 		additionalNodes1 := int(math.Ceil(0.7 * maxNodes))
@@ -204,7 +204,7 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 		klog.Infof("Scaled up twice")
 	})
 
-	It("should scale down empty nodes [Feature:ClusterAutoscalerScalability3]", func() {
+	ginkgo.It("should scale down empty nodes [Feature:ClusterAutoscalerScalability3]", func() {
 		perNodeReservation := int(float64(memCapacityMb) * 0.7)
 		replicas := int(math.Ceil(maxNodes * 0.7))
 		totalNodes := maxNodes
@@ -232,7 +232,7 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 			}, scaleDownTimeout))
 	})
 
-	It("should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]", func() {
+	ginkgo.It("should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]", func() {
 		perPodReservation := int(float64(memCapacityMb) * 0.01)
 		// underutilizedNodes are 10% full
 		underutilizedPerNodeReplicas := 10
@@ -291,7 +291,7 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 		}, timeout))
 	})
 
-	It("shouldn't scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]", func() {
+	ginkgo.It("shouldn't scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]", func() {
 		fullReservation := int(float64(memCapacityMb) * 0.9)
 		hostPortPodReservation := int(float64(memCapacityMb) * 0.3)
 		totalNodes := maxNodes
@@ -307,28 +307,28 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 		fullNodesCount := divider
 		underutilizedNodesCount := totalNodes - fullNodesCount
 
-		By("Reserving full nodes")
+		ginkgo.By("Reserving full nodes")
 		// run RC1 w/o host port
 		cleanup := ReserveMemory(f, "filling-pod", fullNodesCount, fullNodesCount*fullReservation, true, largeScaleUpTimeout*2)
 		defer cleanup()
 
-		By("Reserving host ports on remaining nodes")
+		ginkgo.By("Reserving host ports on remaining nodes")
 		// run RC2 w/ host port
 		cleanup2 := createHostPortPodsWithMemory(f, "underutilizing-host-port-pod", underutilizedNodesCount, reservedPort, underutilizedNodesCount*hostPortPodReservation, largeScaleUpTimeout)
 		defer cleanup2()
 
 		waitForAllCaPodsReadyInNamespace(f, c)
 		// wait and check scale down doesn't occur
-		By(fmt.Sprintf("Sleeping %v minutes...", scaleDownTimeout.Minutes()))
+		ginkgo.By(fmt.Sprintf("Sleeping %v minutes...", scaleDownTimeout.Minutes()))
 		time.Sleep(scaleDownTimeout)
 
-		By("Checking if the number of nodes is as expected")
+		ginkgo.By("Checking if the number of nodes is as expected")
 		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 		klog.Infof("Nodes: %v, expected: %v", len(nodes.Items), totalNodes)
-		Expect(len(nodes.Items)).Should(Equal(totalNodes))
+		gomega.Expect(len(nodes.Items)).Should(gomega.Equal(totalNodes))
 	})
 
-	Specify("CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]", func() {
+	ginkgo.Specify("CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]", func() {
 		// Start a number of pods saturating existing nodes.
 		perNodeReservation := int(float64(memCapacityMb) * 0.80)
 		replicasPerNode := 10
@@ -348,7 +348,7 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 		defer framework.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, podsConfig.Name)
 
 		// Ensure that no new nodes have been added so far.
-		Expect(framework.NumberOfReadyNodes(f.ClientSet)).To(Equal(nodeCount))
+		gomega.Expect(framework.NumberOfReadyNodes(f.ClientSet)).To(gomega.Equal(nodeCount))
 
 		// Start a number of schedulable pods to ensure CA reacts.
 		additionalNodes := maxNodes - nodeCount
@@ -375,7 +375,7 @@ func anyKey(input map[string]int) string {
 func simpleScaleUpTestWithTolerance(f *framework.Framework, config *scaleUpTestConfig, tolerateMissingNodeCount int, tolerateMissingPodCount int) func() error {
 	// resize cluster to start size
 	// run rc based on config
-	By(fmt.Sprintf("Running RC %v from config", config.extraPods.Name))
+	ginkgo.By(fmt.Sprintf("Running RC %v from config", config.extraPods.Name))
 	start := time.Now()
 	framework.ExpectNoError(framework.RunRC(*config.extraPods))
 	// check results
@@ -461,7 +461,7 @@ func addAnnotation(f *framework.Framework, nodes []v1.Node, key, value string) e
 }
 
 func createHostPortPodsWithMemory(f *framework.Framework, id string, replicas, port, megabytes int, timeout time.Duration) func() error {
-	By(fmt.Sprintf("Running RC which reserves host port and memory"))
+	ginkgo.By(fmt.Sprintf("Running RC which reserves host port and memory"))
 	request := int64(1024 * 1024 * megabytes / replicas)
 	config := &testutils.RCConfig{
 		Client:     f.ClientSet,

--- a/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
+++ b/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
@@ -33,7 +33,7 @@ import (
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/instrumentation/monitoring"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 	"golang.org/x/oauth2/google"
 )
 
@@ -45,13 +45,13 @@ const (
 )
 
 var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver)", func() {
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		framework.SkipUnlessProviderIs("gce", "gke")
 	})
 
 	f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
 
-	It("should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]", func() {
+	ginkgo.It("should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]", func() {
 		initialReplicas := 2
 		// metric should cause scale down
 		metricValue := int64(100)
@@ -66,7 +66,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: Custom Me
 		tc.Run()
 	})
 
-	It("should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]", func() {
+	ginkgo.It("should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]", func() {
 		initialReplicas := 2
 		// metric should cause scale down
 		metricValue := int64(100)
@@ -83,7 +83,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: Custom Me
 		tc.Run()
 	})
 
-	It("should scale down with External Metric with target value from Stackdriver [Feature:CustomMetricsAutoscaling]", func() {
+	ginkgo.It("should scale down with External Metric with target value from Stackdriver [Feature:CustomMetricsAutoscaling]", func() {
 		initialReplicas := 2
 		// metric should cause scale down
 		metricValue := externalMetricValue
@@ -106,7 +106,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: Custom Me
 		tc.Run()
 	})
 
-	It("should scale down with External Metric with target average value from Stackdriver [Feature:CustomMetricsAutoscaling]", func() {
+	ginkgo.It("should scale down with External Metric with target average value from Stackdriver [Feature:CustomMetricsAutoscaling]", func() {
 		initialReplicas := 2
 		// metric should cause scale down
 		metricValue := externalMetricValue
@@ -129,7 +129,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: Custom Me
 		tc.Run()
 	})
 
-	It("should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]", func() {
+	ginkgo.It("should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]", func() {
 		initialReplicas := 2
 		// metric should cause scale down
 		metricValue := int64(100)
@@ -144,7 +144,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: Custom Me
 		tc.Run()
 	})
 
-	It("should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]", func() {
+	ginkgo.It("should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]", func() {
 		initialReplicas := 1
 		// metric 1 would cause a scale down, if not for metric 2
 		metric1Value := int64(100)
@@ -175,7 +175,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: Custom Me
 		tc.Run()
 	})
 
-	It("should scale up with two External metrics from Stackdriver [Feature:CustomMetricsAutoscaling]", func() {
+	ginkgo.It("should scale up with two External metrics from Stackdriver [Feature:CustomMetricsAutoscaling]", func() {
 		initialReplicas := 1
 		// metric 1 would cause a scale down, if not for metric 2
 		metric1Value := externalMetricValue
@@ -216,6 +216,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: Custom Me
 	})
 })
 
+// CustomMetricTestCase is a struct for test cases.
 type CustomMetricTestCase struct {
 	framework       *framework.Framework
 	hpa             *as.HorizontalPodAutoscaler
@@ -226,8 +227,9 @@ type CustomMetricTestCase struct {
 	scaledReplicas  int
 }
 
+// Run starts test case.
 func (tc *CustomMetricTestCase) Run() {
-	projectId := framework.TestContext.CloudConfig.ProjectID
+	projectID := framework.TestContext.CloudConfig.ProjectID
 
 	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, gcm.CloudPlatformScope)
@@ -251,11 +253,11 @@ func (tc *CustomMetricTestCase) Run() {
 	}
 
 	// Set up a cluster: create a custom metric and set up k8s-sd adapter
-	err = monitoring.CreateDescriptors(gcmService, projectId)
+	err = monitoring.CreateDescriptors(gcmService, projectID)
 	if err != nil {
 		framework.Failf("Failed to create metric descriptor: %v", err)
 	}
-	defer monitoring.CleanupDescriptors(gcmService, projectId)
+	defer monitoring.CleanupDescriptors(gcmService, projectID)
 
 	err = monitoring.CreateAdapter(monitoring.AdapterDefault)
 	if err != nil {

--- a/test/e2e/autoscaling/framework.go
+++ b/test/e2e/autoscaling/framework.go
@@ -18,6 +18,7 @@ package autoscaling
 
 import "github.com/onsi/ginkgo"
 
+// SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
 	return ginkgo.Describe("[sig-autoscaling] "+text, body)
 }

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 )
 
 // These tests don't seem to be running properly in parallel: issue: #20338.
@@ -37,20 +37,20 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", fu
 
 	SIGDescribe("[Serial] [Slow] Deployment", func() {
 		// CPU tests via deployments
-		It(titleUp, func() {
+		ginkgo.It(titleUp, func() {
 			scaleUp("test-deployment", common.KindDeployment, false, rc, f)
 		})
-		It(titleDown, func() {
+		ginkgo.It(titleDown, func() {
 			scaleDown("test-deployment", common.KindDeployment, false, rc, f)
 		})
 	})
 
 	SIGDescribe("[Serial] [Slow] ReplicaSet", func() {
 		// CPU tests via ReplicaSets
-		It(titleUp, func() {
+		ginkgo.It(titleUp, func() {
 			scaleUp("rs", common.KindReplicaSet, false, rc, f)
 		})
-		It(titleDown, func() {
+		ginkgo.It(titleDown, func() {
 			scaleDown("rs", common.KindReplicaSet, false, rc, f)
 		})
 	})
@@ -58,16 +58,16 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", fu
 	// These tests take ~20 minutes each.
 	SIGDescribe("[Serial] [Slow] ReplicationController", func() {
 		// CPU tests via replication controllers
-		It(titleUp+" and verify decision stability", func() {
+		ginkgo.It(titleUp+" and verify decision stability", func() {
 			scaleUp("rc", common.KindRC, true, rc, f)
 		})
-		It(titleDown+" and verify decision stability", func() {
+		ginkgo.It(titleDown+" and verify decision stability", func() {
 			scaleDown("rc", common.KindRC, true, rc, f)
 		})
 	})
 
 	SIGDescribe("ReplicationController light", func() {
-		It("Should scale from 1 pod to 2 pods", func() {
+		ginkgo.It("Should scale from 1 pod to 2 pods", func() {
 			scaleTest := &HPAScaleTest{
 				initPods:                    1,
 				totalInitialCPUUsage:        150,
@@ -79,7 +79,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", fu
 			}
 			scaleTest.run("rc-light", common.KindRC, rc, f)
 		})
-		It("Should scale from 2 pods to 1 pod", func() {
+		ginkgo.It("Should scale from 2 pods to 1 pod", func() {
 			scaleTest := &HPAScaleTest{
 				initPods:                    2,
 				totalInitialCPUUsage:        50,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This fixes golint failures of the following file:
- test/e2e/autoscaling/autoscaling_timer.go
- test/e2e/autoscaling/cluster_autoscaler_scalability.go
- test/e2e/autoscaling/cluster_size_autoscaling.go
- test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
- test/e2e/autoscaling/dns_autoscaling.go
- test/e2e/autoscaling/framework.go
- test/e2e/autoscaling/horizontal_pod_autoscaling.go

**Which issue(s) this PR fixes**:
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
