### PR TITLE
Kubeadm: Add etcd supported version for v1.16

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -390,6 +390,7 @@ var (
 		13: "3.2.24",
 		14: "3.3.10",
 		15: "3.3.10",
+		16: "3.3.10",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Add etcd supported version for v1.16

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cluster-lifecycle
/area kubeadm
/priority important-soon
@kubernetes/sig-cluster-lifecycle-pr-reviews

/assign @neolit123 