### PR TITLE
Handle updates removing remaining finalizers on deleted objects

### DIFF
--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -129,6 +129,7 @@ func (d *namespacedResourcesDeleter) Delete(nsName string) error {
 
 	// Delete the namespace if it is already finalized.
 	if d.deleteNamespaceWhenDone && finalized(namespace) {
+		// TODO(liggitt): just return in 1.16, once n-1 apiservers automatically delete when finalizers are all removed
 		return d.deleteNamespace(namespace)
 	}
 
@@ -155,6 +156,7 @@ func (d *namespacedResourcesDeleter) Delete(nsName string) error {
 
 	// Check if we can delete now.
 	if d.deleteNamespaceWhenDone && finalized(namespace) {
+		// TODO(liggitt): just return in 1.16, once n-1 apiservers automatically delete when finalizers are all removed
 		return d.deleteNamespace(namespace)
 	}
 	return nil

--- a/pkg/registry/core/namespace/storage/BUILD
+++ b/pkg/registry/core/namespace/storage/BUILD
@@ -13,6 +13,7 @@ go_test(
     deps = [
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
@@ -40,6 +41,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",

--- a/pkg/registry/core/namespace/storage/storage_test.go
+++ b/pkg/registry/core/namespace/storage/storage_test.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -164,6 +165,194 @@ func TestDeleteNamespaceWithIncompleteFinalizers(t *testing.T) {
 	if _, _, err := storage.Delete(ctx, "foo", nil); err == nil {
 		t.Errorf("unexpected error: %v", err)
 	}
+	// should still exist
+	_, err := storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateDeletingNamespaceWithIncompleteMetadataFinalizers(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.store.DestroyFunc()
+	key := "namespaces/foo"
+	ctx := genericapirequest.NewContext()
+	now := metav1.Now()
+	namespace := &api.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "foo",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"example.com/foo"},
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{},
+		},
+		Status: api.NamespaceStatus{Phase: api.NamespaceActive},
+	}
+	if err := storage.store.Storage.Create(ctx, key, namespace, nil, 0, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns, err := storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, _, err = storage.Update(ctx, "foo", rest.DefaultUpdatedObjectInfo(ns), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// should still exist
+	_, err = storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateDeletingNamespaceWithIncompleteSpecFinalizers(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.store.DestroyFunc()
+	key := "namespaces/foo"
+	ctx := genericapirequest.NewContext()
+	now := metav1.Now()
+	namespace := &api.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "foo",
+			DeletionTimestamp: &now,
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		},
+		Status: api.NamespaceStatus{Phase: api.NamespaceActive},
+	}
+	if err := storage.store.Storage.Create(ctx, key, namespace, nil, 0, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns, err := storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, _, err = storage.Update(ctx, "foo", rest.DefaultUpdatedObjectInfo(ns), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// should still exist
+	_, err = storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateDeletingNamespaceWithCompleteFinalizers(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.store.DestroyFunc()
+	key := "namespaces/foo"
+	ctx := genericapirequest.NewContext()
+	now := metav1.Now()
+	namespace := &api.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "foo",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"example.com/foo"},
+		},
+		Status: api.NamespaceStatus{Phase: api.NamespaceActive},
+	}
+	if err := storage.store.Storage.Create(ctx, key, namespace, nil, 0, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns, err := storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns.(*api.Namespace).Finalizers = nil
+	if _, _, err = storage.Update(ctx, "foo", rest.DefaultUpdatedObjectInfo(ns), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// should not exist
+	_, err = storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestFinalizeDeletingNamespaceWithCompleteFinalizers(t *testing.T) {
+	// get finalize storage
+	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
+	restOptions := generic.RESTOptions{StorageConfig: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "namespaces"}
+	storage, _, finalizeStorage := NewREST(restOptions)
+
+	defer server.Terminate(t)
+	defer storage.store.DestroyFunc()
+	defer finalizeStorage.store.DestroyFunc()
+	key := "namespaces/foo"
+	ctx := genericapirequest.NewContext()
+	now := metav1.Now()
+	namespace := &api.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "foo",
+			DeletionTimestamp: &now,
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		},
+		Status: api.NamespaceStatus{Phase: api.NamespaceActive},
+	}
+	if err := storage.store.Storage.Create(ctx, key, namespace, nil, 0, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns, err := storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns.(*api.Namespace).Spec.Finalizers = nil
+	if _, _, err = finalizeStorage.Update(ctx, "foo", rest.DefaultUpdatedObjectInfo(ns), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// should not exist
+	_, err = storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestFinalizeDeletingNamespaceWithIncompleteMetadataFinalizers(t *testing.T) {
+	// get finalize storage
+	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
+	restOptions := generic.RESTOptions{StorageConfig: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "namespaces"}
+	storage, _, finalizeStorage := NewREST(restOptions)
+
+	defer server.Terminate(t)
+	defer storage.store.DestroyFunc()
+	defer finalizeStorage.store.DestroyFunc()
+	key := "namespaces/foo"
+	ctx := genericapirequest.NewContext()
+	now := metav1.Now()
+	namespace := &api.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "foo",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"example.com/foo"},
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		},
+		Status: api.NamespaceStatus{Phase: api.NamespaceActive},
+	}
+	if err := storage.store.Storage.Create(ctx, key, namespace, nil, 0, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns, err := storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns.(*api.Namespace).Spec.Finalizers = nil
+	if _, _, err = finalizeStorage.Update(ctx, "foo", rest.DefaultUpdatedObjectInfo(ns), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// should still exist
+	_, err = storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestDeleteNamespaceWithCompleteFinalizers(t *testing.T) {
@@ -188,6 +377,11 @@ func TestDeleteNamespaceWithCompleteFinalizers(t *testing.T) {
 	}
 	if _, _, err := storage.Delete(ctx, "foo", nil); err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+	// should not exist
+	_, err := storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
 	}
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -156,7 +156,12 @@ func (c *CRDFinalizer) sync(key string) error {
 	}
 
 	// and now issue another delete, which should clean it all up if no finalizers remain or no-op if they do
-	return c.crdClient.CustomResourceDefinitions().Delete(crd.Name, nil)
+	// TODO(liggitt): just return in 1.16, once n-1 apiservers automatically delete when finalizers are all removed
+	err = c.crdClient.CustomResourceDefinitions().Delete(crd.Name, nil)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }
 
 func (c *CRDFinalizer) deleteInstances(crd *apiextensions.CustomResourceDefinition) (apiextensions.CustomResourceDefinitionCondition, error) {

--- a/test/integration/apiserver/admissionwebhook/admission_test.go
+++ b/test/integration/apiserver/admissionwebhook/admission_test.go
@@ -729,16 +729,6 @@ func testNamespaceDelete(c *testContext) {
 		c.t.Error(err)
 		return
 	}
-
-	// then run the final delete and make sure admission is called again
-	c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkDeleteOptions, v1beta1.Delete, obj.GetName(), obj.GetNamespace(), false, false, true)
-	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), &metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
-	if err != nil {
-		c.t.Error(err)
-		return
-	}
-	c.admissionHolder.verify(c.t)
-
 	// verify namespace is gone
 	obj, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(obj.GetName(), metav1.GetOptions{})
 	if err == nil || !errors.IsNotFound(err) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Avoids making all finalizer implementers do a separate delete after removing their finalizer

**Which issue(s) this PR fixes**:
Fixes #77944

**Does this PR introduce a user-facing change?**:
```release-note
Updates that remove remaining `metadata.finalizers` from  an object that is pending deletion (non-nil metadata.deletionTimestamp) and has no graceful deletion pending (nil or 0 metadata.deletionGracePeriodSeconds) now results in immediate deletion of the object.
```

/sig api-machinery
/cc @caesarxuchao 