### PR TITLE
Windows GCE nodes: use CNI plugins v0.8.0 release.

### DIFF
--- a/cluster/gce/windows/common.psm1
+++ b/cluster/gce/windows/common.psm1
@@ -123,9 +123,10 @@ function Validate-SHA1 {
 }
 
 # Attempts to download the file from URLs, trying each URL until it succeeds.
-# It will loop through the URLs list forever until it has a success.
-# If successful, it will write the file to OutFile. You can optionally provide a SHA1 Hash
-# argument, in which case it will attempt to validate the downloaded file against the hash.
+# It will loop through the URLs list forever until it has a success. If
+# successful, it will write the file to OutFile. You can optionally provide a
+# SHA1 Hash argument, in which case it will attempt to validate the downloaded
+# file against the hash.
 function MustDownload-File {
   param (
     [parameter(Mandatory=$false)] [string]$Hash,


### PR DESCRIPTION
/kind bug

This PR makes Windows nodes in clusters on GCE use the latest official containernetworking/plugins release (https://github.com/containernetworking/plugins/releases/tag/v0.8.0). We pushed the existing package of CNI binaries (https://github.com/yujuhong/gce-k8s-windows-testing/pull/8) to include https://github.com/containernetworking/plugins/pull/286, which is present in the v0.8.0 release.

This PR satisfies some of the issues raised in https://github.com/kubernetes/kubernetes/issues/74759.

Tested by running the cluster/gce/windows/smoke-test.sh once.

```release-note
NONE
```