### PR TITLE
Use ExpectNoError() for e2e/upgrades

### DIFF
--- a/test/e2e/upgrades/cassandra.go
+++ b/test/e2e/upgrades/cassandra.go
@@ -100,8 +100,10 @@ func (t *CassandraUpgradeTest) Setup(f *framework.Framework) {
 	e2elog.Logf("Service endpoint is up")
 
 	ginkgo.By("Adding 2 dummy users")
-	gomega.Expect(t.addUser("Alice")).NotTo(gomega.HaveOccurred())
-	gomega.Expect(t.addUser("Bob")).NotTo(gomega.HaveOccurred())
+	err = t.addUser("Alice")
+	framework.ExpectNoError(err)
+	err = t.addUser("Bob")
+	framework.ExpectNoError(err)
 	t.successfulWrites = 2
 
 	ginkgo.By("Verifying that the users exist")

--- a/test/e2e/upgrades/etcd.go
+++ b/test/e2e/upgrades/etcd.go
@@ -95,8 +95,10 @@ func (t *EtcdUpgradeTest) Setup(f *framework.Framework) {
 	e2elog.Logf("Service endpoint is up")
 
 	ginkgo.By("Adding 2 dummy users")
-	gomega.Expect(t.addUser("Alice")).NotTo(gomega.HaveOccurred())
-	gomega.Expect(t.addUser("Bob")).NotTo(gomega.HaveOccurred())
+	err = t.addUser("Alice")
+	framework.ExpectNoError(err)
+	err = t.addUser("Bob")
+	framework.ExpectNoError(err)
 	t.successfulWrites = 2
 
 	ginkgo.By("Verifying that the users exist")

--- a/test/e2e/upgrades/kube_proxy_migration.go
+++ b/test/e2e/upgrades/kube_proxy_migration.go
@@ -30,7 +30,6 @@ import (
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 const (
@@ -50,7 +49,8 @@ func (KubeProxyUpgradeTest) Name() string { return "[sig-network] kube-proxy-upg
 // Setup verifies kube-proxy static pods is running before upgrade.
 func (t *KubeProxyUpgradeTest) Setup(f *framework.Framework) {
 	ginkgo.By("Waiting for kube-proxy static pods running and ready")
-	gomega.Expect(waitForKubeProxyStaticPodsRunning(f.ClientSet)).NotTo(gomega.HaveOccurred())
+	err := waitForKubeProxyStaticPodsRunning(f.ClientSet)
+	framework.ExpectNoError(err)
 }
 
 // Test validates if kube-proxy is migrated from static pods to DaemonSet.
@@ -62,10 +62,12 @@ func (t *KubeProxyUpgradeTest) Test(f *framework.Framework, done <-chan struct{}
 	<-done
 
 	ginkgo.By("Waiting for kube-proxy static pods disappear")
-	gomega.Expect(waitForKubeProxyStaticPodsDisappear(c)).NotTo(gomega.HaveOccurred())
+	err := waitForKubeProxyStaticPodsDisappear(c)
+	framework.ExpectNoError(err)
 
 	ginkgo.By("Waiting for kube-proxy DaemonSet running and ready")
-	gomega.Expect(waitForKubeProxyDaemonSetRunning(c)).NotTo(gomega.HaveOccurred())
+	err = waitForKubeProxyDaemonSetRunning(c)
+	framework.ExpectNoError(err)
 }
 
 // Teardown does nothing.
@@ -82,7 +84,8 @@ func (KubeProxyDowngradeTest) Name() string { return "[sig-network] kube-proxy-d
 // Setup verifies kube-proxy DaemonSet is running before upgrade.
 func (t *KubeProxyDowngradeTest) Setup(f *framework.Framework) {
 	ginkgo.By("Waiting for kube-proxy DaemonSet running and ready")
-	gomega.Expect(waitForKubeProxyDaemonSetRunning(f.ClientSet)).NotTo(gomega.HaveOccurred())
+	err := waitForKubeProxyDaemonSetRunning(f.ClientSet)
+	framework.ExpectNoError(err)
 }
 
 // Test validates if kube-proxy is migrated from DaemonSet to static pods.
@@ -94,10 +97,12 @@ func (t *KubeProxyDowngradeTest) Test(f *framework.Framework, done <-chan struct
 	<-done
 
 	ginkgo.By("Waiting for kube-proxy DaemonSet disappear")
-	gomega.Expect(waitForKubeProxyDaemonSetDisappear(c)).NotTo(gomega.HaveOccurred())
+	err := waitForKubeProxyDaemonSetDisappear(c)
+	framework.ExpectNoError(err)
 
 	ginkgo.By("Waiting for kube-proxy static pods running and ready")
-	gomega.Expect(waitForKubeProxyStaticPodsRunning(c)).NotTo(gomega.HaveOccurred())
+	err = waitForKubeProxyStaticPodsRunning(c)
+	framework.ExpectNoError(err)
 }
 
 // Teardown does nothing.

--- a/test/e2e/upgrades/mysql.go
+++ b/test/e2e/upgrades/mysql.go
@@ -110,8 +110,10 @@ func (t *MySQLUpgradeTest) Setup(f *framework.Framework) {
 	e2elog.Logf("Service endpoint is up")
 
 	ginkgo.By("Adding 2 names to the database")
-	gomega.Expect(t.addName(strconv.Itoa(t.nextWrite))).NotTo(gomega.HaveOccurred())
-	gomega.Expect(t.addName(strconv.Itoa(t.nextWrite))).NotTo(gomega.HaveOccurred())
+	err = t.addName(strconv.Itoa(t.nextWrite))
+	framework.ExpectNoError(err)
+	err = t.addName(strconv.Itoa(t.nextWrite))
+	framework.ExpectNoError(err)
 
 	ginkgo.By("Verifying that the 2 names have been inserted")
 	count, err := t.countNames()


### PR DESCRIPTION


**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The e2e test framework has ExpectNoError() for readable test code.
This replaces Expect(err).NotTo(HaveOccurred()) with it.

ref: https://github.com/kubernetes/kubernetes/issues/77103

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
