### PR TITLE
remove zmerlynn@ from cluster/gce/OWNERS

### DIFF
--- a/cluster/gce/OWNERS
+++ b/cluster/gce/OWNERS
@@ -10,7 +10,6 @@ reviewers:
   - MaciekPytel
   - jingax10
   - yujuhong
-  - zmerlynn
 approvers:
   - bowei
   - cjcullen
@@ -21,4 +20,3 @@ approvers:
   - MaciekPytel
   - jingax10
   - yujuhong
-  - zmerlynn


### PR DESCRIPTION
Your watch has ended. Less PRs than I expected!

/kind cleanup
/assign zmerlynn
/sig gcp
/priority backlog

```release-note
NONE
```
