### PR TITLE
[WIP] test: add unit tests for azure cloudprovider backoff implementation

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -322,12 +322,12 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 				Duration: time.Duration(config.CloudProviderBackoffDuration) * time.Second,
 				Jitter:   config.CloudProviderBackoffJitter,
 			}
-			klog.V(2).Infof("Azure cloudprovider using backoff configuration: retries=%d, exponent=%f, duration=%d, jitter=%f",
-				config.CloudProviderBackoffRetries,
-				config.CloudProviderBackoffExponent,
-				config.CloudProviderBackoffDuration,
-				config.CloudProviderBackoffJitter)
 		}
+		klog.V(2).Infof("Azure cloudprovider using backoff configuration: retries=%d, exponent=%f, duration=%d, jitter=%f",
+			config.CloudProviderBackoffRetries,
+			config.CloudProviderBackoffExponent,
+			config.CloudProviderBackoffDuration,
+			config.CloudProviderBackoffJitter)
 	} else {
 		// CloudProviderBackoffRetries will be set to 1 by default as the requirements of Azure SDK.
 		config.CloudProviderBackoffRetries = 1

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
@@ -32,18 +32,13 @@ import (
 	"k8s.io/klog"
 )
 
-// requestBackoff if backoff is disabled in cloud provider it
-// returns a new Backoff object steps = 1
-// This is to make sure that the requested command executes
-// at least once
+// requestBackoff returns a wait.Backoff object
+// If backoff is disabled in cloud provider a "bypass" backoff object will be returned
 func (az *Cloud) requestBackoff() (resourceRequestBackoff wait.Backoff) {
 	if az.CloudProviderBackoff {
 		return az.resourceRequestBackoff
 	}
-	resourceRequestBackoff = wait.Backoff{
-		Steps: 1,
-	}
-	return resourceRequestBackoff
+	return backoffBypass
 }
 
 // Event creates a event for the specified object.

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff_test.go
@@ -20,6 +20,12 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	cloudprovider "k8s.io/cloud-provider"
 )
 
 func TestShouldRetryHTTPRequest(t *testing.T) {
@@ -135,6 +141,137 @@ func TestProcessRetryResponse(t *testing.T) {
 		}
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+		}
+	}
+}
+
+func TestRequestBackoff(t *testing.T) {
+	var durationZeroValue time.Duration
+	explicitDurationValue := time.Second
+	explicitFactorValue := float64(2)
+	explicitStepsValue := 6
+	explicitJitterValue := float64(4)
+	type expectedResponse struct {
+		expectedDuration time.Duration
+		expectedFactor   float64
+		expectedSteps    int
+		expectedJitter   float64
+		expectedCap      time.Duration
+	}
+	expectedResponseBackoffDisabled := expectedResponse{
+		expectedSteps: 1,
+	}
+	cases := []struct {
+		cloud    *Cloud
+		expected expectedResponse
+	}{
+		// Default (backoff not enabled) case
+		{
+			cloud:    &Cloud{},
+			expected: expectedResponseBackoffDisabled,
+		},
+		// Backoff enabled with values
+		{
+			cloud: &Cloud{
+				Config: Config{
+					CloudProviderBackoff: true,
+				},
+				resourceRequestBackoff: wait.Backoff{
+					Duration: explicitDurationValue,
+					Factor:   explicitFactorValue,
+					Steps:    explicitStepsValue,
+					Jitter:   explicitJitterValue,
+				},
+			},
+			expected: expectedResponse{
+				expectedDuration: explicitDurationValue,
+				expectedFactor:   explicitFactorValue,
+				expectedSteps:    explicitStepsValue,
+				expectedJitter:   explicitJitterValue,
+				expectedCap:      durationZeroValue,
+			},
+		},
+		// Values provided but not explicitly enabled
+		{
+			cloud: &Cloud{
+				resourceRequestBackoff: wait.Backoff{
+					Duration: explicitDurationValue,
+					Factor:   explicitFactorValue,
+					Steps:    explicitStepsValue,
+					Jitter:   explicitJitterValue,
+				},
+			},
+			expected: expectedResponseBackoffDisabled,
+		},
+	}
+
+	for _, c := range cases {
+		backoff := c.cloud.requestBackoff()
+		if c.expected.expectedDuration != backoff.Duration {
+			t.Fatalf("Expected backoff.Duration to be %s, instead got %s", c.expected.expectedDuration, backoff.Duration)
+		}
+		if c.expected.expectedFactor != backoff.Factor {
+			t.Fatalf("Expected backoff.Factor to be %f, instead got %f", c.expected.expectedFactor, backoff.Factor)
+		}
+		if c.expected.expectedSteps != backoff.Steps {
+			t.Fatalf("Expected backoff.Steps to be %d, instead got %d", c.expected.expectedSteps, backoff.Steps)
+		}
+		if c.expected.expectedJitter != backoff.Jitter {
+			t.Fatalf("Expected backoff.Jitter to be %f, instead got %f", c.expected.expectedJitter, backoff.Jitter)
+		}
+		if c.expected.expectedCap != backoff.Cap {
+			t.Fatalf("Expected backoff.Cap to be %s, instead got %s", c.expected.expectedCap, backoff.Cap)
+		}
+	}
+}
+
+func TestGetVirtualMachineWithRetry(t *testing.T) {
+	type expectedResponse struct {
+		expectedVM  compute.VirtualMachine
+		expectedErr error
+	}
+	explicitVMNameValue := "bar"
+	dataSource, fakeCache := newFakeCacheVirtualMachine(t)
+	dataSource.set(map[string]*compute.VirtualMachine{explicitVMNameValue: &compute.VirtualMachine{Name: &explicitVMNameValue}})
+	cases := []struct {
+		cloud    *Cloud
+		vmName   types.NodeName
+		expected expectedResponse
+	}{
+		// Backoff not enabled, get non-existent vm
+		{
+			cloud: &Cloud{
+				vmCache: fakeCache,
+			},
+			vmName: "foo",
+			expected: expectedResponse{
+				expectedErr: cloudprovider.InstanceNotFound,
+			},
+		},
+		// Backoff not enabled, get existent vm
+		{
+			cloud: &Cloud{
+				vmCache: fakeCache,
+			},
+			vmName: types.NodeName(explicitVMNameValue),
+			expected: expectedResponse{
+				expectedVM: compute.VirtualMachine{
+					Name: &explicitVMNameValue,
+				},
+				expectedErr: nil,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		vm, err := c.cloud.GetVirtualMachineWithRetry(c.vmName)
+		if c.expected.expectedErr != err {
+			t.Fatalf("Expected err to be %s, instead got %s", c.expected.expectedErr, err)
+		}
+		if c.expected.expectedVM.Name != nil {
+			if *c.expected.expectedVM.Name != *vm.Name {
+				t.Fatalf("Expected vm Name to be %s, instead got %s", *c.expected.expectedVM.Name, *vm.Name)
+			}
 		}
 	}
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff_test.go
@@ -280,27 +280,40 @@ func TestListVirtualMachinesWithRetry(t *testing.T) {
 		expectedErr error
 	}
 	numVMs := 8
-	getClusterResources(az, numVMs, 4)
 	cases := []struct {
 		cloud    *Cloud
 		expected expectedResponse
+		addVMs   int
 	}{
-		// List vms
+		// Initial (zero vms in cloud) test
 		{
 			cloud: az,
 			expected: expectedResponse{
 				expectedErr: nil,
 			},
 		},
+		// Add vms to cloud to get responses back from List operation
+		{
+			cloud: az,
+			expected: expectedResponse{
+				expectedErr: nil,
+			},
+			addVMs: numVMs,
+		},
 	}
 
 	for _, c := range cases {
+		var expectedVMs int
+		if c.addVMs > 0 {
+			getClusterResources(az, numVMs, 4)
+			expectedVMs = numVMs
+		}
 		vms, err := c.cloud.ListVirtualMachinesWithRetry("rg")
 		if c.expected.expectedErr != err {
 			t.Fatalf("Expected err to be %s, instead got %s", c.expected.expectedErr, err)
 		}
-		if len(vms) != numVMs {
-			t.Fatalf("Expected %d vms from ListVirtualMachinesWithRetry(rg), instead got %d", numVMs, len(vms))
+		if len(vms) != expectedVMs {
+			t.Fatalf("Expected %d vms from ListVirtualMachinesWithRetry(rg), instead got %d", expectedVMs, len(vms))
 		}
 	}
 }
@@ -311,27 +324,40 @@ func TestListVirtualMachines(t *testing.T) {
 		expectedErr error
 	}
 	numVMs := 8
-	getClusterResources(az, numVMs, 4)
 	cases := []struct {
 		cloud    *Cloud
 		expected expectedResponse
+		addVMs   int
 	}{
-		// List vms
+		// Initial (zero vms in cloud) test
 		{
 			cloud: az,
 			expected: expectedResponse{
 				expectedErr: nil,
 			},
 		},
+		// Add vms to cloud to get responses back from List operation
+		{
+			cloud: az,
+			expected: expectedResponse{
+				expectedErr: nil,
+			},
+			addVMs: numVMs,
+		},
 	}
 
 	for _, c := range cases {
+		var expectedVMs int
+		if c.addVMs > 0 {
+			getClusterResources(az, numVMs, 4)
+			expectedVMs = numVMs
+		}
 		vms, err := c.cloud.ListVirtualMachines("rg")
 		if c.expected.expectedErr != err {
 			t.Fatalf("Expected err to be %s, instead got %s", c.expected.expectedErr, err)
 		}
-		if len(vms) != numVMs {
-			t.Fatalf("Expected %d vms from ListVirtualMachines(rg), instead got %d", numVMs, len(vms))
+		if len(vms) != expectedVMs {
+			t.Fatalf("Expected %d vms from ListVirtualMachines(rg), instead got %d", expectedVMs, len(vms))
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Adds unit test coverage to Azure cloudprovider backoff implementations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
