### PR TITLE
Bug fix: failed to run integration test by using bazel

### DIFF
--- a/test/integration/apiserver/admissionwebhook/BUILD
+++ b/test/integration/apiserver/admissionwebhook/BUILD
@@ -7,6 +7,7 @@ go_test(
         "broken_webhook_test.go",
         "main_test.go",
     ],
+    rundir = ".",
     tags = [
         "etcd",
         "integration",

--- a/test/integration/auth/BUILD
+++ b/test/integration/auth/BUILD
@@ -18,6 +18,7 @@ go_test(
         "rbac_test.go",
         "svcaccttoken_test.go",
     ],
+    rundir = ".",
     tags = ["integration"],
     deps = [
         "//cmd/kube-apiserver/app/options:go_default_library",

--- a/test/integration/client/BUILD
+++ b/test/integration/client/BUILD
@@ -13,6 +13,7 @@ go_test(
         "dynamic_client_test.go",
         "main_test.go",
     ],
+    rundir = ".",
     tags = ["integration"],
     deps = [
         "//cmd/kube-apiserver/app/testing:go_default_library",

--- a/test/integration/dryrun/BUILD
+++ b/test/integration/dryrun/BUILD
@@ -12,6 +12,7 @@ go_test(
         "dryrun_test.go",
         "main_test.go",
     ],
+    rundir = ".",
     tags = [
         "etcd",
         "integration",

--- a/test/integration/garbagecollector/BUILD
+++ b/test/integration/garbagecollector/BUILD
@@ -8,6 +8,7 @@ go_test(
         "garbage_collector_test.go",
         "main_test.go",
     ],
+    rundir = ".",
     tags = ["integration"],
     deps = [
         "//cmd/kube-apiserver/app/testing:go_default_library",

--- a/test/integration/kubelet/BUILD
+++ b/test/integration/kubelet/BUILD
@@ -6,6 +6,7 @@ go_test(
         "main_test.go",
         "watch_manager_test.go",
     ],
+    rundir = ".",
     tags = ["integration"],
     deps = [
         "//cmd/kube-apiserver/app/testing:go_default_library",

--- a/test/integration/master/BUILD
+++ b/test/integration/master/BUILD
@@ -21,6 +21,7 @@ go_test(
         "synthetic_master_test.go",
     ],
     embed = [":go_default_library"],
+    rundir = ".",
     tags = ["integration"],
     deps = [
         "//cmd/kube-apiserver/app/options:go_default_library",

--- a/test/integration/scale/BUILD
+++ b/test/integration/scale/BUILD
@@ -9,6 +9,7 @@ go_test(
     name = "go_default_test",
     size = "large",
     srcs = ["scale_test.go"],
+    rundir = ".",
     tags = ["integration"],
     deps = [
         "//cmd/kube-apiserver/app/testing:go_default_library",

--- a/test/integration/serving/BUILD
+++ b/test/integration/serving/BUILD
@@ -12,6 +12,7 @@ go_test(
         "main_test.go",
         "serving_test.go",
     ],
+    rundir = ".",
     tags = [
         "etcd",
         "integration",

--- a/test/integration/tls/BUILD
+++ b/test/integration/tls/BUILD
@@ -7,6 +7,7 @@ go_test(
         "ciphers_test.go",
         "main_test.go",
     ],
+    rundir = ".",
     tags = ["integration"],
     deps = [
         "//cmd/kube-apiserver/app/testing:go_default_library",


### PR DESCRIPTION
Signed-off-by: Bin Lu <bin.lu@arm.com>

**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:
Run "bazel test --config integration //test/integration/kubelet/..." you will see the error below.
```
--- FAIL: TestWatchBasedManager (0.32s)
    testserver.go:195: failed to launch server: failed to set default ServerRunOptions: error creating self-signed certificates: unable to generate self signed cert: failed to write cert fixture to cmd/kube-apiserver/app/testing/testdata/127.0.0.1_10.0.0.1_kubernetes.default.svc-kubernetes.default-kubernetes-localhost.crt: open cmd/kube-apiserver/app/testing/testdata/127.0.0.1_10.0.0.1_kubernetes.default.svc-kubernetes.default-kubernetes-localhost.crt: no such file or directory

```
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
None
**Does this PR introduce a user-facing change?**:
None
```
None
```
