### PR TITLE
kube-apiserver: use proxy client cert in /proxy transport

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -212,7 +212,8 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 	fs.StringVar(&s.ProxyClientCertFile, "proxy-client-cert-file", s.ProxyClientCertFile, ""+
 		"Client certificate used to prove the identity of the aggregator or kube-apiserver "+
 		"when it must call out during a request. This includes proxying requests to a user "+
-		"api-server and calling out to webhook admission plugins. It is expected that this "+
+		"api-server, calling out to webhook admission plugins and proxied request from the "+
+		"/proxy subresource of services. It is expected that this "+
 		"cert includes a signature from the CA in the --requestheader-client-ca-file flag. "+
 		"That CA is published in the 'extension-apiserver-authentication' configmap in "+
 		"the kube-system namespace. Components receiving calls from kube-aggregator should "+
@@ -220,7 +221,8 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 	fs.StringVar(&s.ProxyClientKeyFile, "proxy-client-key-file", s.ProxyClientKeyFile, ""+
 		"Private key for the client certificate used to prove the identity of the aggregator or kube-apiserver "+
 		"when it must call out during a request. This includes proxying requests to a user "+
-		"api-server and calling out to webhook admission plugins.")
+		"api-server, calling out to webhook admission plugins and proxied request from the "+
+		"/proxy subresource of services.")
 
 	fs.BoolVar(&s.EnableAggregatorRouting, "enable-aggregator-routing", s.EnableAggregatorRouting,
 		"Turns on aggregator routing requests to endpoints IP rather than cluster IP.")


### PR DESCRIPTION
We claim `--proxy-client-cert/key` are used when calling out during requests to identify as kube-apiserver. We don't do so for /proxy subresources.

```release-note
Use the kube-apiserver `--proxy-client-cert/key` client certificate in /proxy subresources to identify as kube-apiserver.
```