### PR TITLE
add process start time metric to metric probes since they use counters

### DIFF
--- a/pkg/kubelet/server/BUILD
+++ b/pkg/kubelet/server/BUILD
@@ -46,6 +46,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/server/routes:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flushwriter:go_default_library",
         "//staging/src/k8s.io/component-base/logs:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/google/cadvisor/container:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -55,6 +55,7 @@ import (
 	"k8s.io/apiserver/pkg/server/routes"
 	"k8s.io/apiserver/pkg/util/flushwriter"
 	"k8s.io/component-base/logs"
+	compbasemetrics "k8s.io/component-base/metrics"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/v1/validation"
@@ -321,6 +322,7 @@ func (s *Server) InstallDefaultHandlers() {
 
 	// prober metrics are exposed under a different endpoint
 	p := prometheus.NewRegistry()
+	compbasemetrics.RegisterProcessStartTime(p)
 	p.MustRegister(prober.ProberResults)
 	s.restfulCont.Handle(proberMetricsPath,
 		promhttp.HandlerFor(p, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}),

--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 	github.com/prometheus/common v0.0.0-20181126121408-4724e9255275
+	github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a
 	github.com/spf13/pflag v1.0.1
 	github.com/stretchr/testify v1.2.2
 	k8s.io/apimachinery v0.0.0

--- a/staging/src/k8s.io/component-base/metrics/BUILD
+++ b/staging/src/k8s.io/component-base/metrics/BUILD
@@ -14,6 +14,7 @@ go_library(
         "histogram.go",
         "metric.go",
         "opts.go",
+        "processstarttime.go",
         "registry.go",
         "summary.go",
         "version_parser.go",
@@ -26,6 +27,7 @@ go_library(
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
+        "//vendor/github.com/prometheus/procfs:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/component-base/metrics/processstarttime.go
+++ b/staging/src/k8s.io/component-base/metrics/processstarttime.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/procfs"
+	"k8s.io/klog"
+	"os"
+	"time"
+)
+
+var processStartTime = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "process_start_time_seconds",
+		Help: "Start time of the process since unix epoch in seconds.",
+	},
+	[]string{},
+)
+
+// RegisterProcessStartTime registers the process_start_time_seconds to
+// a prometheus registry. This metric needs to be included to ensure counter
+// data fidelity.
+func RegisterProcessStartTime(registerer prometheus.Registerer) error {
+	start, err := getProcessStart()
+	if err != nil {
+		klog.Errorf("Could not get process start time, %v", err)
+		start = float64(time.Now().Unix())
+	}
+	processStartTime.WithLabelValues().Set(start)
+	return registerer.Register(processStartTime)
+}
+
+func getProcessStart() (float64, error) {
+	pid := os.Getpid()
+	p, err := procfs.NewProc(pid)
+	if err != nil {
+		return 0, err
+	}
+
+	if stat, err := p.NewStat(); err == nil {
+		return stat.StartTime()
+	}
+	return 0, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1559,6 +1559,7 @@ k8s.io/component-base/config/validation
 k8s.io/component-base/featuregate
 k8s.io/component-base/featuregate/testing
 k8s.io/component-base/logs
+k8s.io/component-base/metrics
 # k8s.io/cri-api v0.0.0 => ./staging/src/k8s.io/cri-api
 k8s.io/cri-api/pkg/apis
 k8s.io/cri-api/pkg/apis/runtime/v1alpha2


### PR DESCRIPTION
Currently the metrics/probes endpoint in the kubelet exposes a set of counters. However, this endpoint does not export the process start time, which is required for counter data fidelity. This PR adds that metric. 

**What type of PR is this?**
/kind bug

```release-note
metrics added to kubelet endpoint 'metrics/probes':

   process_start_time_seconds 
```
/sig instrumentation node
/cc @brancz @dashpole 
