### PR TITLE
Don't rely on defaults enforce flags we rely on in tests

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -2255,14 +2255,14 @@ func startLocalProxy() (srv *httptest.Server, logs *bytes.Buffer) {
 func createApplyCustomResource(resource, namespace, name string, crd *crd.TestCrd) error {
 	ns := fmt.Sprintf("--namespace=%v", namespace)
 	ginkgo.By("successfully create CR")
-	if _, err := framework.RunKubectlInput(resource, ns, "create", "-f", "-"); err != nil {
+	if _, err := framework.RunKubectlInput(resource, ns, "create", "--validate=true", "-f", "-"); err != nil {
 		return fmt.Errorf("failed to create CR %s in namespace %s: %v", resource, ns, err)
 	}
 	if _, err := framework.RunKubectl(ns, "delete", crd.GetPluralName(), name); err != nil {
 		return fmt.Errorf("failed to delete CR %s: %v", name, err)
 	}
 	ginkgo.By("successfully apply CR")
-	if _, err := framework.RunKubectlInput(resource, ns, "apply", "-f", "-"); err != nil {
+	if _, err := framework.RunKubectlInput(resource, ns, "apply", "--validate=true", "-f", "-"); err != nil {
 		return fmt.Errorf("failed to apply CR %s in namespace %s: %v", resource, ns, err)
 	}
 	if _, err := framework.RunKubectl(ns, "delete", crd.GetPluralName(), name); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We should not rely on defaults, but explicitly set values we rely on in the tests.

**Special notes for your reviewer**:
/assign @sttts

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
