### PR TITLE
promote statefulset e2e test case should have a working scale subresource to conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -36,6 +36,7 @@ test/e2e/apps/statefulset.go: "should perform canary updates and phased rolling 
 test/e2e/apps/statefulset.go: "Scaling should happen in predictable order and halt if any stateful pod is unhealthy"
 test/e2e/apps/statefulset.go: "Burst scaling should run to completion even with unhealthy pods"
 test/e2e/apps/statefulset.go: "Should recreate evicted statefulset"
+test/e2e/apps/statefulset.go: "should have a working scale subresource"
 test/e2e/auth/service_accounts.go: "should mount an API token into pods"
 test/e2e/auth/service_accounts.go: "should allow opting out of API token automount"
 test/e2e/common/configmap.go: "should be consumable via environment variable"

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -789,7 +789,12 @@ var _ = SIGDescribe("StatefulSet", func() {
 			}, framework.StatefulPodTimeout, 2*time.Second).Should(gomega.BeNil())
 		})
 
-		ginkgo.It("should have a working scale subresource", func() {
+		/*
+			Release : v1.15
+			Testname: StatefulSet, Replicas update
+			Description: StatefulSet subresource MUST get Scale and get updated the Statefulset scale subresource, then verify the Statefulset Replicas was modified and validate the updated Replicas of Statefulset
+		*/
+		framework.ConformanceIt("should have a working scale subresource", func() {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			ss := framework.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, labels)
 			sst := framework.NewStatefulSetTester(c)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
>
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR to promote statefulset e2e test case `should have a working scale subresource` to conformance
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**: 

This PR to promote statefulset e2e test case `should have a working scale subresource` to conformance

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/area conformance
/area testing
@kubernetes/cncf-conformance-wg
@spiffxp @brahmaroutu @timothysc 