### PR TITLE
Use os package for Windows IsPrivilegedUserCheck

### DIFF
--- a/cmd/kubeadm/app/preflight/checks_windows.go
+++ b/cmd/kubeadm/app/preflight/checks_windows.go
@@ -19,28 +19,38 @@ limitations under the License.
 package preflight
 
 import (
-	"os/exec"
-	"strings"
+	"os/user"
 
 	"github.com/pkg/errors"
 )
 
-// Check validates if an user has elevated (administrator) privileges.
+// The "Well-known SID" of Administrator group
+// https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems
+const administratorSID = "S-1-5-32-544"
+
+// Check validates if a user has elevated (administrator) privileges.
 func (ipuc IsPrivilegedUserCheck) Check() (warnings, errorList []error) {
 	errorList = []error{}
 
-	// The "Well-known SID" of Administrator group is S-1-5-32-544
-	// The following powershell will return "True" if run as an administrator, "False" otherwise
-	// See https://msdn.microsoft.com/en-us/library/cc980032.aspx
-	args := []string{"[bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match \"S-1-5-32-544\")"}
-	isAdmin, err := exec.Command("powershell", args...).Output()
-
+	currUser, err := user.Current()
 	if err != nil {
-		errorList = append(errorList, errors.Wrap(err, "unable to determine if user is running as administrator"))
-	} else if strings.EqualFold(strings.TrimSpace(string(isAdmin)), "false") {
-		errorList = append(errorList, errors.New("user is not running as administrator"))
+		errorList = append(errorList, errors.New("cannot get current user"))
+		return nil, errorList
 	}
 
+	groupIds, err := currUser.GroupIds()
+	if err != nil {
+		errorList = append(errorList, errors.New("cannot get group IDs for current user"))
+		return nil, errorList
+	}
+
+	for _, sid := range groupIds {
+		if sid == administratorSID {
+			return nil, errorList
+		}
+	}
+
+	errorList = append(errorList, errors.New("user is not running as administrator"))
 	return nil, errorList
 }
 


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Previously, we used a powershell command to determine if the current user was in the Administrator group. Using powershell and parsing the output is more fragile than system calls so this PR moves to using the os/user package.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
"S-1-5-32-544" is the SID for the built-in Administrators group
https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
