### PR TITLE
cluster/gce: fix unset variable when insecure port is enabled

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2847,7 +2847,7 @@ function wait-till-apiserver-ready() {
 
 function ensure-bootstrap-kubectl-auth {
   # Creating an authenticated kubeconfig is only necessary if the insecure port is disabled.
-  if [[ -n "${KUBE_BOOTSTRAP_TOKEN}" ]]; then
+  if [[ -n "${KUBE_BOOTSTRAP_TOKEN:-}" ]]; then
     create-kubeconfig "cluster-bootstrap" ${KUBE_BOOTSTRAP_TOKEN}
     export KUBECONFIG=/etc/srv/kubernetes/cluster-bootstrap/kubeconfig
   fi


### PR DESCRIPTION
Still working on getting sig-gcp e2e tests green again.

Introduced in https://github.com/kubernetes/kubernetes/pull/77447

https://testgrid.k8s.io/sig-gcp-master#gci-gke

/kind bug
/kind failing-test
/sig gcp

```release-note
NONE
```
