### PR TITLE
Fix broken hack/verify-symbols.sh

### DIFF
--- a/hack/verify-symbols.sh
+++ b/hack/verify-symbols.sh
@@ -23,7 +23,15 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-make -C "${KUBE_ROOT}" WHAT=cmd/hyperkube
+kube::util::ensure-temp-dir
+OUTPUT="${KUBE_TEMP}"/symbols-output
+cleanup() {
+	rm -rf "${OUTPUT}"
+}
+trap "cleanup" EXIT SIGINT
+mkdir -p "${OUTPUT}"
+
+GOLDFLAGS="-w" make -C "${KUBE_ROOT}" WHAT=cmd/hyperkube
 
 # Add other BADSYMBOLS here.
 BADSYMBOLS=(
@@ -31,14 +39,20 @@ BADSYMBOLS=(
   "testify"
   "testing[.]"
   "TestOnlySetFatalOnDecodeError"
+  "TrackStorageCleanup"
 )
 
 # b/c hyperkube binds everything simply check that for bad symbols
-SYMBOLS="$(go tool nm "${KUBE_OUTPUT_HOSTBIN}/hyperkube")"
+go tool nm "${KUBE_OUTPUT_HOSTBIN}/hyperkube" > "${OUTPUT}/hyperkube-symbols"
+
+if ! grep -q "NewHyperKubeCommand" "${OUTPUT}/hyperkube-symbols"; then
+  echo "No symbols found in hyperkube binary."
+  exit 1
+fi
 
 RESULT=0
 for BADSYMBOL in "${BADSYMBOLS[@]}"; do
-  if FOUND=$(echo "${SYMBOLS}" | grep "${BADSYMBOL}"); then
+  if FOUND=$(grep "${BADSYMBOL}" < "${OUTPUT}/hyperkube-symbols"); then
     echo "Found bad symbol '${BADSYMBOL}':"
     echo "$FOUND"
     RESULT=1

--- a/hack/verify-symbols.sh
+++ b/hack/verify-symbols.sh
@@ -34,11 +34,11 @@ BADSYMBOLS=(
 )
 
 # b/c hyperkube binds everything simply check that for bad symbols
-SYMBOLS="$(nm "${KUBE_OUTPUT_HOSTBIN}/hyperkube")"
+SYMBOLS="$(go tool nm "${KUBE_OUTPUT_HOSTBIN}/hyperkube")"
 
 RESULT=0
 for BADSYMBOL in "${BADSYMBOLS[@]}"; do
-  if FOUND=$(echo "$SYMBOLS" | grep "$BADSYMBOL"); then
+  if FOUND=$(echo "${SYMBOLS}" | grep "${BADSYMBOL}"); then
     echo "Found bad symbol '${BADSYMBOL}':"
     echo "$FOUND"
     RESULT=1


### PR DESCRIPTION
The operating system nm does not output anything anymore for our go binaries. `go tool nm` does.

Fixing #77983