### PR TITLE
seperation of network call in KubernetesReleaseVersion

### DIFF
--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -65,6 +65,9 @@ func KubernetesReleaseVersion(version string) (string, error) {
 	return kubernetesReleaseVersion(version, fetchFromURL)
 }
 
+// kubernetesReleaseVersion is a helper function to fetch
+// available version information. Used for testing to eliminate
+// the need for internet calls.
 func kubernetesReleaseVersion(version string, fetcher func(string, time.Duration) (string, error)) (string, error) {
 	ver := normalizedBuildVersion(version)
 	if len(ver) != 0 {

--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -62,6 +62,10 @@ var (
 //  latest-1    (latest release in 1.x, including alpha/beta)
 //  latest-1.0  (and similarly 1.1, 1.2, 1.3, ...)
 func KubernetesReleaseVersion(version string) (string, error) {
+	return kubernetesReleaseVersion(version, fetchFromURL)
+}
+
+func kubernetesReleaseVersion(version string, fetcher func(string, time.Duration) (string, error)) (string, error) {
 	ver := normalizedBuildVersion(version)
 	if len(ver) != 0 {
 		return ver, nil
@@ -87,7 +91,7 @@ func KubernetesReleaseVersion(version string) (string, error) {
 		clientVersion, clientVersionErr := kubeadmVersion(pkgversion.Get().String())
 		// Fetch version from the internet.
 		url := fmt.Sprintf("%s/%s.txt", bucketURL, versionLabel)
-		body, err := fetchFromURL(url, getReleaseVersionTimeout)
+		body, err := fetcher(url, getReleaseVersionTimeout)
 		if err != nil {
 			// If the network operaton was successful but the server did not reply with StatusOK
 			if body != "" {
@@ -97,18 +101,18 @@ func KubernetesReleaseVersion(version string) (string, error) {
 				// Handle air-gapped environments by falling back to the client version.
 				klog.Warningf("could not fetch a Kubernetes version from the internet: %v", err)
 				klog.Warningf("falling back to the local client version: %s", clientVersion)
-				return KubernetesReleaseVersion(clientVersion)
+				return kubernetesReleaseVersion(clientVersion, fetcher)
 			}
 		}
 
 		if clientVersionErr != nil {
 			if err != nil {
 				klog.Warningf("could not obtain neither client nor remote version; fall back to: %s", constants.CurrentKubernetesVersion)
-				return KubernetesReleaseVersion(constants.CurrentKubernetesVersion.String())
+				return kubernetesReleaseVersion(constants.CurrentKubernetesVersion.String(), fetcher)
 			}
 
 			klog.Warningf("could not obtain client version; using remote version: %s", body)
-			return KubernetesReleaseVersion(body)
+			return kubernetesReleaseVersion(body, fetcher)
 		}
 
 		// both the client and the remote version are obtained; validate them and pick a stable version
@@ -117,7 +121,7 @@ func KubernetesReleaseVersion(version string) (string, error) {
 			return "", err
 		}
 		// Re-validate received version and return.
-		return KubernetesReleaseVersion(body)
+		return kubernetesReleaseVersion(body, fetcher)
 	}
 	return "", errors.Errorf("version %q doesn't match patterns for neither semantic version nor labels (stable, latest, ...)", version)
 }

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -52,7 +52,7 @@ func TestValidVersion(t *testing.T) {
 	for _, s := range validVersions {
 		t.Run(s, func(t *testing.T) {
 			fileFetcher := func(url string, timeout time.Duration) (string, error) {
-				return "", errors.New("Should not make internet call")
+				return "", errors.New("should not make internet call")
 			}
 			ver, err := kubernetesReleaseVersion(s, fileFetcher)
 			t.Log("Valid: ", s, ver, err)
@@ -77,7 +77,7 @@ func TestInvalidVersion(t *testing.T) {
 	for _, s := range invalidVersions {
 		t.Run(s, func(t *testing.T) {
 			fileFetcher := func(url string, timeout time.Duration) (string, error) {
-				return "", errors.New("Should not make internet call")
+				return "should not make internet calls", errors.New("should not make internet call")
 			}
 			ver, err := kubernetesReleaseVersion(s, fileFetcher)
 			t.Log("Invalid: ", s, ver, err)
@@ -100,7 +100,7 @@ func TestValidConvenientForUserVersion(t *testing.T) {
 	for _, s := range validVersions {
 		t.Run(s, func(t *testing.T) {
 			fileFetcher := func(url string, timeout time.Duration) (string, error) {
-				return "", errors.New("Should not make internet call")
+				return "", errors.New("should not make internet call")
 			}
 			ver, err := kubernetesReleaseVersion(s, fileFetcher)
 			t.Log("Valid: ", s, ver, err)

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -19,7 +19,6 @@ package util
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"path"
 	"strings"
 	"testing"
@@ -117,19 +116,18 @@ func TestValidConvenientForUserVersion(t *testing.T) {
 func TestVersionFromNetwork(t *testing.T) {
 	type T struct {
 		Content       string
-		Status        int
 		Expected      string
 		ErrorExpected bool
 	}
 	cases := map[string]T{
-		"stable":     {"stable-1", http.StatusOK, "v1.4.6", false}, // recursive pointer to stable-1
-		"stable-1":   {"v1.4.6", http.StatusOK, "v1.4.6", false},
-		"stable-1.3": {"v1.3.10", http.StatusOK, "v1.3.10", false},
-		"latest":     {"v1.6.0-alpha.0", http.StatusOK, "v1.6.0-alpha.0", false},
-		"latest-1.3": {"v1.3.11-beta.0", http.StatusOK, "v1.3.11-beta.0", false},
-		"empty":      {"", http.StatusOK, "", true},
-		"garbage":    {"<?xml version='1.0'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>", http.StatusOK, "", true},
-		"unknown":    {"The requested URL was not found on this server.", http.StatusNotFound, "", true},
+		"stable":     {"stable-1", "v1.4.6", false}, // recursive pointer to stable-1
+		"stable-1":   {"v1.4.6", "v1.4.6", false},
+		"stable-1.3": {"v1.3.10", "v1.3.10", false},
+		"latest":     {"v1.6.0-alpha.0", "v1.6.0-alpha.0", false},
+		"latest-1.3": {"v1.3.11-beta.0", "v1.3.11-beta.0", false},
+		"empty":      {"", "", true},
+		"garbage":    {"<?xml version='1.0'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>", "", true},
+		"unknown":    {"The requested URL was not found on this server.", "", true},
 	}
 
 	fileFetcher := func(url string, timeout time.Duration) (string, error) {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Made network calls package local so unit tests would be able to mock them out. I did not put them behind a full interface due to it adding unnecessary complexity for something we are not even sure should ever be supported (fetching the version from someplace other then a URL.)

**Which issue(s) this PR fixes**:
Fixes #https://github.com/kubernetes/kubeadm/issues/902

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
