### PR TITLE
Automated cherry pick of #77874: fix CVE-2019-11244: `kubectl --http-cache=<world-accessible

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached_discovery.go
@@ -164,7 +164,7 @@ func (d *CachedDiscoveryClient) getCachedFile(filename string) ([]byte, error) {
 }
 
 func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Object) error {
-	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filename), 0750); err != nil {
 		return err
 	}
 
@@ -183,7 +183,7 @@ func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Obj
 		return err
 	}
 
-	err = os.Chmod(f.Name(), 0755)
+	err = os.Chmod(f.Name(), 0660)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/client-go/discovery/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached_discovery_test.go
@@ -19,6 +19,7 @@ package discovery
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -93,6 +94,32 @@ func TestNewCachedDiscoveryClient_TTL(t *testing.T) {
 
 	cdc.ServerGroups()
 	assert.Equal(c.groupCalls, 2)
+}
+
+func TestNewCachedDiscoveryClient_PathPerm(t *testing.T) {
+	assert := assert.New(t)
+
+	d, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	os.RemoveAll(d)
+	defer os.RemoveAll(d)
+
+	c := fakeDiscoveryClient{}
+	cdc := newCachedDiscoveryClient(&c, d, 1*time.Nanosecond)
+	cdc.ServerGroups()
+
+	err = filepath.Walk(d, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			assert.Equal(os.FileMode(0750), info.Mode().Perm())
+		} else {
+			assert.Equal(os.FileMode(0660), info.Mode().Perm())
+		}
+		return nil
+	})
+	assert.NoError(err)
 }
 
 type fakeDiscoveryClient struct {

--- a/staging/src/k8s.io/client-go/discovery/round_tripper.go
+++ b/staging/src/k8s.io/client-go/discovery/round_tripper.go
@@ -18,6 +18,7 @@ package discovery
 
 import (
 	"net/http"
+	"os"
 	"path/filepath"
 
 	"github.com/gregjones/httpcache"
@@ -35,6 +36,8 @@ type cacheRoundTripper struct {
 // corresponding requests.
 func newCacheRoundTripper(cacheDir string, rt http.RoundTripper) http.RoundTripper {
 	d := diskv.New(diskv.Options{
+		PathPerm: os.FileMode(0750),
+		FilePerm: os.FileMode(0660),
 		BasePath: cacheDir,
 		TempDir:  filepath.Join(cacheDir, ".diskv-temp"),
 	})


### PR DESCRIPTION
Cherry pick of #77874 on release-1.13.

#77874: fix CVE-2019-11244: `kubectl --http-cache=<world-accessible