### PR TITLE
Code cleanup for for probe/http

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/probe"
 	execprobe "k8s.io/kubernetes/pkg/probe/exec"
-	httprobe "k8s.io/kubernetes/pkg/probe/http"
+	httpprobe "k8s.io/kubernetes/pkg/probe/http"
 	tcprobe "k8s.io/kubernetes/pkg/probe/tcp"
 	"k8s.io/utils/exec"
 
@@ -50,8 +50,8 @@ type prober struct {
 	// probe types needs different httprobe instances so they don't
 	// share a connection pool which can cause collsions to the
 	// same host:port and transient failures. See #49740.
-	readinessHTTP httprobe.Prober
-	livenessHTTP  httprobe.Prober
+	readinessHTTP httpprobe.Prober
+	livenessHTTP  httpprobe.Prober
 	tcp           tcprobe.Prober
 	runner        kubecontainer.ContainerCommandRunner
 
@@ -69,8 +69,8 @@ func newProber(
 	const followNonLocalRedirects = false
 	return &prober{
 		exec:          execprobe.New(),
-		readinessHTTP: httprobe.New(followNonLocalRedirects),
-		livenessHTTP:  httprobe.New(followNonLocalRedirects),
+		readinessHTTP: httpprobe.New(followNonLocalRedirects),
+		livenessHTTP:  httpprobe.New(followNonLocalRedirects),
 		tcp:           tcprobe.New(),
 		runner:        runner,
 		refManager:    refManager,

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -67,7 +67,8 @@ func TestHTTPProbeProxy(t *testing.T) {
 	defer unsetEnv("no_proxy")()
 	defer unsetEnv("NO_PROXY")()
 
-	prober := New(true)
+	followNonLocalRedirects := true
+	prober := New(followNonLocalRedirects)
 
 	go func() {
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -122,7 +123,8 @@ func TestHTTPProbeChecker(t *testing.T) {
 		}
 	}
 
-	prober := New(true)
+	followNonLocalRedirects := true
+	prober := New(followNonLocalRedirects)
 	testCases := []struct {
 		handler    func(w http.ResponseWriter, r *http.Request)
 		reqHeaders http.Header
@@ -299,14 +301,16 @@ func TestHTTPProbeChecker_NonLocalRedirects(t *testing.T) {
 	}
 	for desc, test := range testCases {
 		t.Run(desc+"-local", func(t *testing.T) {
-			prober := New(false)
+			followNonLocalRedirects := false
+			prober := New(followNonLocalRedirects)
 			target, err := url.Parse(server.URL + "/redirect?loc=" + url.QueryEscape(test.redirect))
 			require.NoError(t, err)
 			result, _, _ := prober.Probe(target, nil, wait.ForeverTestTimeout)
 			assert.Equal(t, test.expectLocalResult, result)
 		})
 		t.Run(desc+"-nonlocal", func(t *testing.T) {
-			prober := New(true)
+			followNonLocalRedirects := true
+			prober := New(followNonLocalRedirects)
 			target, err := url.Parse(server.URL + "/redirect?loc=" + url.QueryEscape(test.redirect))
 			require.NoError(t, err)
 			result, _, _ := prober.Probe(target, nil, wait.ForeverTestTimeout)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Two small code cleanup changes for `probe/http`.

- Tests name the `followNonLocalRedirects` variable before passing to
`New`, so its clear what the boolean flag in the construct impacts.
- Change import name from `httprobe` to `httpprobe` when used by
`pkg/kubelet/prober/prober.go`. Establishes consistency with other uses
in the repo.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
