### PR TITLE
Automated cherry pick of #78029: Terminate watchers when watch cache is destroyed

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -234,6 +234,7 @@ func NewCacherFromConfig(config Config) *Cacher {
 	cacher.stopWg.Add(1)
 	go func() {
 		defer cacher.stopWg.Done()
+		defer cacher.terminateAllWatchers()
 		wait.Until(
 			func() {
 				if !cacher.isStopped() {


### PR DESCRIPTION
Cherry pick of #78029 on release-1.13.

#78029: Terminate watchers when watch cache is destroyed

## How Has This Been Tested?
* [x]   Added new testing to cover
* [x]   Tested locally/manually
* [x]   Consideration given to upgrade scenarios

## Type of change:
* [x]   Bug fix (non-breaking change which fixes standing issues #74105 #71138)

## Criticality / Risk / Complexity / Benefit:
* [x]   Easily triggered in common usage scenario
* [x]   ~~Panic, crash,~~ hang

## Checklist:
* [x]   I have discussed the change with SIG(s) leadership and they:
  
  * [x]   agree it is valid for cherry picking to this branch.
  * [x]   suggest it is also required on other branches (1.12: #78036, 1.13: #78035, 1.14: #78034).
* [x]   I have reviewed the release note.

