### PR TITLE
clean singleton event when calling finishSeries

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/BUILD
+++ b/staging/src/k8s.io/client-go/tools/events/BUILD
@@ -38,6 +38,7 @@ go_test(
         "//staging/src/k8s.io/api/events/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/tools/reference:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -67,20 +67,20 @@ type eventBroadcasterImpl struct {
 
 // NewBroadcaster Creates a new event broadcaster.
 func NewBroadcaster(sink EventSink) EventBroadcaster {
-	return newBroadcaster(sink, defaultSleepDuration)
+	return newBroadcaster(sink, defaultSleepDuration, map[eventKey]*v1beta1.Event{})
 }
 
 // NewBroadcasterForTest Creates a new event broadcaster for test purposes.
-func newBroadcaster(sink EventSink, sleepDuration time.Duration) EventBroadcaster {
+func newBroadcaster(sink EventSink, sleepDuration time.Duration, eventCache map[eventKey]*v1beta1.Event) EventBroadcaster {
 	return &eventBroadcasterImpl{
 		Broadcaster:   watch.NewBroadcaster(maxQueuedEvents, watch.DropIfChannelFull),
-		eventCache:    map[eventKey]*v1beta1.Event{},
+		eventCache:    eventCache,
 		sleepDuration: sleepDuration,
 		sink:          sink,
 	}
 }
 
-// TODO: add test for refreshExistingEventSeries
+// refreshExistingEventSeries refresh events TTL
 func (e *eventBroadcasterImpl) refreshExistingEventSeries() {
 	// TODO: Investigate whether lock contention won't be a problem
 	e.mu.Lock()
@@ -94,19 +94,23 @@ func (e *eventBroadcasterImpl) refreshExistingEventSeries() {
 	}
 }
 
-// TODO: add test for finishSeries
+// finishSeries checks if a series has ended and either:
+// - write final count to the apiserver
+// - delete a singleton event (i.e. series field is nil) from the cache
 func (e *eventBroadcasterImpl) finishSeries() {
 	// TODO: Investigate whether lock contention won't be a problem
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	for isomorphicKey, event := range e.eventCache {
-		eventSeries := event.Series
-		if eventSeries != nil {
-			if eventSeries.LastObservedTime.Time.Add(finishTime).Before(time.Now()) {
+		eventSerie := event.Series
+		if eventSerie != nil {
+			if eventSerie.LastObservedTime.Time.Before(time.Now().Add(-finishTime)) {
 				if _, retry := recordEvent(e.sink, event); !retry {
 					delete(e.eventCache, isomorphicKey)
 				}
 			}
+		} else if event.EventTime.Time.Before(time.Now().Add(-finishTime)) {
+			delete(e.eventCache, isomorphicKey)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: 

This handles two bugs:

-  when the cache contains singleton event (i.e. series field is nil) it removes it from the cache, otherwise it might stay there until it is seen again

- avoid mutating `LastObservedTime` as Add doesn't deepCopy the time struct

it also adds test that exercise this code path 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/assign @wojtek-t 
/priority important-soon

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
