### PR TITLE
update LastObservedTime instead of eventTime

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -130,7 +130,7 @@ func (e *eventBroadcasterImpl) recordToSink(event *v1beta1.Event, clock clock.Cl
 			if isIsomorphic {
 				if isomorphicEvent.Series != nil {
 					isomorphicEvent.Series.Count++
-					isomorphicEvent.EventTime = metav1.MicroTime{Time: clock.Now()}
+					isomorphicEvent.Series.LastObservedTime = metav1.MicroTime{Time: clock.Now()}
 					return nil
 				}
 				isomorphicEvent.Series = &v1beta1.EventSeries{


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

We shoul update `LastObservedTime` instead of `EventTime` which first time we've seen this event

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/assign @wojtek-t 
/sig scalability
/sig api-machinery
/priority important-soon

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
