### PR TITLE
Drop debug log in prune

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm.go
@@ -17,8 +17,6 @@ limitations under the License.
 package pruning
 
 import (
-	"fmt"
-
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 )
 
@@ -50,7 +48,6 @@ func prune(x interface{}, s *structuralschema.Structural) {
 			} else {
 				delete(x, k)
 			}
-			fmt.Printf("deleting %q => %#v\n", k, x)
 		}
 	case []interface{}:
 		if s == nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR removes a debug log in prune func.

```release-note
NONE
```
