### PR TITLE
Skips metrics gathering for test if not on gce, gke, or aws

### DIFF
--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -507,6 +507,10 @@ func getVolumeOpsFromMetricsForPlugin(ms metrics.Metrics, pluginName string) opC
 }
 
 func getVolumeOpCounts(c clientset.Interface, pluginName string) opCounts {
+	if !framework.ProviderIs("gce", "gke", "aws") {
+		return opCounts{}
+	}
+
 	nodeLimit := 25
 
 	metricsGrabber, err := metrics.NewMetricsGrabber(c, nil, true, false, true, false, false)


### PR DESCRIPTION
Non cloud-providers dont use the same metrics server (or a metrics server at all). We enable it for gce, gke, aws for now, other cloud providers can enable more in the future

/sig storage
/kind bug
/priority important-soon

/assign @mkimuram @msau42 

```release-note
NONE
```
