### PR TITLE
Implement CRI detection for Windows

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/defaults_windows.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/defaults_windows.go
@@ -22,5 +22,5 @@ const (
 	// DefaultCACertPath defines default location of CA certificate on Windows
 	DefaultCACertPath = "C:/etc/kubernetes/pki/ca.crt"
 	// DefaultUrlScheme defines default socket url prefix
-	DefaultUrlScheme = "tcp"
+	DefaultUrlScheme = "npipe"
 )

--- a/cmd/kubeadm/app/constants/constants_windows.go
+++ b/cmd/kubeadm/app/constants/constants_windows.go
@@ -20,5 +20,5 @@ package constants
 
 const (
 	// DefaultDockerCRISocket defines the default Docker CRI socket
-	DefaultDockerCRISocket = "tcp://localhost:2375"
+	DefaultDockerCRISocket = "npipe:////./pipe/docker_engine"
 )

--- a/cmd/kubeadm/app/util/runtime/BUILD
+++ b/cmd/kubeadm/app/util/runtime/BUILD
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["runtime.go"],
+    srcs = [
+        "runtime.go",
+        "runtime_unix.go",
+        "runtime_windows.go",
+    ],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime",
     visibility = ["//visibility:public"],
     deps = [
@@ -10,7 +14,12 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:windows": [
+            "//vendor/github.com/Microsoft/go-winio:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_test(

--- a/cmd/kubeadm/app/util/runtime/runtime.go
+++ b/cmd/kubeadm/app/util/runtime/runtime.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"os"
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
@@ -180,23 +179,8 @@ func (runtime *DockerRuntime) ImageExists(image string) (bool, error) {
 	return err == nil, nil
 }
 
-// isExistingSocket checks if path exists and is domain socket
-func isExistingSocket(path string) bool {
-	fileInfo, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-
-	return fileInfo.Mode()&os.ModeSocket != 0
-}
-
 // detectCRISocketImpl is separated out only for test purposes, DON'T call it directly, use DetectCRISocket instead
 func detectCRISocketImpl(isSocket func(string) bool) (string, error) {
-	const (
-		dockerSocket     = "/var/run/docker.sock" // The Docker socket is not CRI compatible
-		containerdSocket = "/run/containerd/containerd.sock"
-	)
-
 	foundCRISockets := []string{}
 	knownCRISockets := []string{
 		// Docker and containerd sockets are special cased below, hence not to be included here
@@ -233,9 +217,5 @@ func detectCRISocketImpl(isSocket func(string) bool) (string, error) {
 
 // DetectCRISocket uses a list of known CRI sockets to detect one. If more than one or none is discovered, an error is returned.
 func DetectCRISocket() (string, error) {
-	if goruntime.GOOS != "linux" {
-		return constants.DefaultDockerCRISocket, nil
-	}
-
 	return detectCRISocketImpl(isExistingSocket)
 }

--- a/cmd/kubeadm/app/util/runtime/runtime_unix.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_unix.go
@@ -1,7 +1,7 @@
-// +build windows
+// +build !windows
 
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,11 +16,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package util
+
+import (
+	"os"
+)
 
 const (
-	// DefaultCACertPath defines default location of CA certificate on Windows
-	DefaultCACertPath = "C:/etc/kubernetes/pki/ca.crt"
-	// DefaultUrlScheme defines default socket url prefix
-	DefaultUrlScheme = "npipe"
+	dockerSocket     = "/var/run/docker.sock" // The Docker socket is not CRI compatible
+	containerdSocket = "/run/containerd/containerd.sock"
 )
+
+// isExistingSocket checks if path exists and is domain socket
+func isExistingSocket(path string) bool {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	return fileInfo.Mode()&os.ModeSocket != 0
+}

--- a/cmd/kubeadm/app/util/runtime/runtime_windows.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_windows.go
@@ -1,7 +1,7 @@
 // +build windows
 
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,11 +16,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package util
+
+import (
+	winio "github.com/Microsoft/go-winio"
+)
 
 const (
-	// DefaultCACertPath defines default location of CA certificate on Windows
-	DefaultCACertPath = "C:/etc/kubernetes/pki/ca.crt"
-	// DefaultUrlScheme defines default socket url prefix
-	DefaultUrlScheme = "npipe"
+	dockerSocket     = "//./pipe/docker_engine"         // The Docker socket is not CRI compatible
+	containerdSocket = "//./pipe/containerd-containerd" // Proposed containerd named pipe for Windows
 )
+
+// isExistingSocket checks if path exists and is domain socket
+func isExistingSocket(path string) bool {
+	_, err := winio.DialPipe(path, nil)
+	if err != nil {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR implements CRI detection for Windows using named pipes for either Docker or ContainerD. It also fixes up CRI socket validation so that it is compatible with Windows.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Ran the tests for validation and runtime with no failures.

Manually checked that Docker CRI could be detected on Windows machine. I verified that it was detecting the CRI and not just defaulting to Docker.
```
I0522 17:30:12.774696    7232 join.go:364] [preflight] found NodeName empty; using OS hostname as NodeName
I0522 17:30:12.836675    7232 initconfiguration.go:105] detected and using CRI socket: npipe:////./pipe/docker_engine
[preflight] Running pre-flight checks
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: implement CRI detection for Windows worker nodes
```