### PR TITLE
Use no-priority best-effort pod as the preemptor in BenchmarkGetPodsToPreempt

### DIFF
--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -147,7 +147,7 @@ func (sp SyncPodType) String() string {
 // to make admission and scheduling decisions.
 func IsCriticalPod(pod *v1.Pod) bool {
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodPriority) {
-		if pod.Spec.Priority != nil && IsCriticalPodBasedOnPriority(*pod.Spec.Priority) {
+		if pod != nil && pod.Spec.Priority != nil && IsCriticalPodBasedOnPriority(*pod.Spec.Priority) {
 			return true
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
I see the following when running BenchmarkGetPodsToPreempt :
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x280 pc=0x1d2f91a]

goroutine 10 [running]:
k8s.io/kubernetes/pkg/kubelet/types.IsCriticalPod(0x0, 0x1019ace)
	/Users/yute/go-workspace/src/k8s.io/kubernetes/pkg/kubelet/types/pod_update.go:150 +0x5a
k8s.io/kubernetes/pkg/kubelet/types.Preemptable(0x0, 0xc000158380, 0x20b1d69)
	/Users/yute/go-workspace/src/k8s.io/kubernetes/pkg/kubelet/types/pod_update.go:165 +0x2f
k8s.io/kubernetes/pkg/kubelet/preemption.sortPodsByQOS(0x0, 0xc0000a0400, 0x6e, 0x80, 0x0, 0x203000, 0x203000, 0xc0000a0400, 0x11c4d5a, 0x6e, ...)
	/Users/yute/go-workspace/src/k8s.io/kubernetes/pkg/kubelet/preemption/preemption.go:231 +0xdf
k8s.io/kubernetes/pkg/kubelet/preemption.getPodsToPreempt(0x0, 0xc0000a0400, 0x6e, 0x80, 0xc00007cf48, 0x1, 0x1, 0x80, 0x1d045458, 0x1d04545800000000, ...)
	/Users/yute/go-workspace/src/k8s.io/kubernetes/pkg/kubelet/preemption/preemption.go:119 +0x6a
k8s.io/kubernetes/pkg/kubelet/preemption.BenchmarkGetPodsToPreempt(0xc00013e1a0)
	/Users/yute/go-workspace/src/k8s.io/kubernetes/pkg/kubelet/preemption/preemption_test.go:153 +0x1b2
```
This PR fixes the panic by using no-priority best-effort pod as the preemptor in BenchmarkGetPodsToPreempt.

```release-note
NONE
```
