### PR TITLE
CSI migration e2e: do not skip tests if metricsGrabber.HasRegisteredM…

### DIFF
--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -512,11 +512,12 @@ func getVolumeOpCounts(c clientset.Interface, pluginName string) opCounts {
 	metricsGrabber, err := metrics.NewMetricsGrabber(c, nil, true, false, true, false, false)
 
 	if err != nil {
-		framework.Failf("Error creating metrics grabber : %v", err)
+		framework.ExpectNoError(err, "Error creating metrics grabber: %v", err)
 	}
 
 	if !metricsGrabber.HasRegisteredMaster() {
-		framework.Skipf("Environment does not support getting controller-manager metrics - skipping")
+		e2elog.Logf("Warning: Environment does not support getting controller-manager metrics")
+		return opCounts{}
 	}
 
 	controllerMetrics, err := metricsGrabber.GrabFromControllerManager()

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -118,12 +118,11 @@ func (t *volumesTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 
 		// Now do the more expensive test initialization.
 		l.config, l.testCleanup = driver.PrepareTest(f)
+		l.intreeOps, l.migratedOps = getMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName)
 		l.resource = createGenericVolumeTestResource(driver, l.config, pattern)
 		if l.resource.volSource == nil {
 			framework.Skipf("Driver %q does not define volumeSource - skipping", dInfo.Name)
 		}
-
-		l.intreeOps, l.migratedOps = getMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName)
 	}
 
 	cleanup := func() {


### PR DESCRIPTION
…aster() is true

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: Removes PD leaks in PD test suites

**Which issue(s) this PR fixes**: Fixes https://github.com/kubernetes/kubernetes/issues/78050

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @davidz627 