### PR TITLE
Change lock type to write lock in eventBroadcasterImpl

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -59,7 +59,7 @@ type eventKey struct {
 
 type eventBroadcasterImpl struct {
 	*watch.Broadcaster
-	mu            sync.RWMutex
+	mu            sync.Mutex
 	eventCache    map[eventKey]*v1beta1.Event
 	sleepDuration time.Duration
 	sink          EventSink


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently all operations in event_broadcaster use eventBroadcasterImpl.mu as write lock.

This PR changes the declaration to sync.Mutex .
This avoids unneeded complexity in locking.

```release-note
NONE
```
