### PR TITLE
set podAntiAffinity for coredns

### DIFF
--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -169,6 +169,19 @@ spec:
             items:
             - key: Corefile
               path: Corefile
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - kube-dns
+              topologyKey: kubernetes.io/hostname
+
 ---
 apiVersion: v1
 kind: Service

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -300,6 +300,18 @@ spec:
             items:
             - key: Corefile
               path: Corefile
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - kube-dns
+              topologyKey: kubernetes.io/hostname
 `
 
 	// CoreDNSConfigMap is the CoreDNS ConfigMap manifest


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
**What this PR does / why we need it**:
CoreDNS addon can be running on any node, it'd be better to use podAntiAffinity spread these pods.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**: 

**Does this PR introduce a user-facing change?**:
```release-note
Try to run CoreDNS containers on different nodes (using podAntiAffinity).
```
