### PR TITLE
Fix issue of kubectl logs with flag --since-time

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
@@ -164,13 +164,14 @@ func (_ Time) OpenAPISchemaType() []string { return []string{"string"} }
 func (_ Time) OpenAPISchemaFormat() string { return "date-time" }
 
 // MarshalQueryParameter converts to a URL query parameter value
+// Use RFC3339Nano to ensure milliseconds supporting.
 func (t Time) MarshalQueryParameter() (string, error) {
 	if t.IsZero() {
 		// Encode unset/nil objects as an empty string
 		return "", nil
 	}
 
-	return t.UTC().Format(time.RFC3339), nil
+	return t.UTC().Format(time.RFC3339Nano), nil
 }
 
 // Fuzz satisfies fuzz.Interface.


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
- What this PR does:
 Change RFC3339 to RFC3339Nano in time.go to ensure nanosecond support.
- why we need it:
 1. In util.go, actually we already coded for supporting RFC3339 Nanosecond, but in time.go, the code missed the Nano supporting which caused this issue.
 2. docker command with flag --since has no such issue.

**Which issue(s) this PR fixes**:
Fixes #77856

**Special notes for your reviewer**:
we don't need to modify "time.Parse(time.RFC3339, str)" in time.go, as from my test result. Parse function won't lost the milliseconds, only Format func will.

UT test PASS for this case with the code changes.

/sig cli

BR
-Francis