### PR TITLE
Update the environment variable NETWORK from e2e to default

### DIFF
--- a/cluster/kubemark/gce/config-default.sh
+++ b/cluster/kubemark/gce/config-default.sh
@@ -49,7 +49,7 @@ if [[ "${NODE_OS_DISTRIBUTION}" == "debian" ]]; then
     NODE_ACCELERATORS=""
 fi
 
-NETWORK=${KUBE_GCE_NETWORK:-e2e}
+NETWORK=${KUBE_GCE_NETWORK:-default}
 if [[ "${CREATE_CUSTOM_NETWORK}" == true ]]; then
   SUBNETWORK="${SUBNETWORK:-${NETWORK}-custom-subnet}"
 fi


### PR DESCRIPTION
In GCE cluster, the network which is set up by default is "default" . So when we run start_kubemark.sh, it fails because there is no network created called "e2e" .
NAME                                          NETWORK  DIRECTION  PRIORITY  ALLOW    DENY  DISABLED
kubernetes-kubemark-master-https  default  INGRESS    1000      tcp:443        False


/kind failing-test

**What this PR does / why we need it**:  This is to fix failing kubemark setup in GCE cluster

