### PR TITLE
Fix for setting kubelet client certificate file path through kubeadm config

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/defaults.go
+++ b/cmd/kubeadm/app/componentconfigs/defaults.go
@@ -88,9 +88,11 @@ func DefaultKubeletConfiguration(internalcfg *kubeadmapi.ClusterConfiguration) {
 	}
 
 	// Enforce security-related kubelet options
-
-	// Require all clients to the kubelet API to have client certs signed by the cluster CA
-	externalkubeletcfg.Authentication.X509.ClientCAFile = filepath.Join(internalcfg.CertificatesDir, constants.CACertName)
+	if externalkubeletcfg.Authentication.X509.ClientCAFile == "" {
+		// Require all clients to the kubelet API to have client certs signed by the cluster CA
+		// Set it to default path
+		externalkubeletcfg.Authentication.X509.ClientCAFile = filepath.Join(internalcfg.CertificatesDir, constants.CACertName)
+	}
 	externalkubeletcfg.Authentication.Anonymous.Enabled = utilpointer.BoolPtr(false)
 
 	// On every client request to the kubelet API, execute a webhook (SubjectAccessReview request) to the API server


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes setting the kubelet client certificate file path through kubeadm configg file

**Which issue(s) this PR fixes**:

Fixes #78075

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

No
