### PR TITLE
Automated cherry pick of #77362: Don't use mapfile as it isn't bash 3 compatible #77910: fix unbound array variable #77985: fix unbound variable release.sh #78048: Don't use declare -g in build #78059: Check KUBE_SERVER_PLATFORMS existence

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -137,8 +137,8 @@ readonly KUBE_NODE_BINARIES_WIN=("${KUBE_NODE_BINARIES[@]/%/.exe}")
 # NOTE: All functions that return lists should use newlines.
 # bash functions can't return arrays, and spaces are tricky, so newline
 # separators are the preferred pattern.
-# To transform a string of newline-separated items to an array, use mapfile -t:
-# mapfile -t FOO <<< "$(kube::golang::dups a b c a)"
+# To transform a string of newline-separated items to an array, use kube::util::read-array:
+# kube::util::read-array FOO < <(kube::golang::dups a b c a)
 #
 # ALWAYS remember to quote your subshells. Not doing so will break in
 # bash 4.3, and potentially cause other issues.
@@ -172,33 +172,33 @@ kube::golang::setup_platforms() {
 
     # Deduplicate to ensure the intersection trick with kube::golang::dups
     # is not defeated by duplicates in user input.
-    mapfile -t platforms <<< "$(kube::golang::dedup "${platforms[@]}")"
+    kube::util::read-array platforms < <(kube::golang::dedup "${platforms[@]}")
 
     # Use kube::golang::dups to restrict the builds to the platforms in
     # KUBE_SUPPORTED_*_PLATFORMS. Items should only appear at most once in each
     # set, so if they appear twice after the merge they are in the intersection.
-    mapfile -t KUBE_SERVER_PLATFORMS <<< "$(kube::golang::dups \
+    kube::util::read-array KUBE_SERVER_PLATFORMS < <(kube::golang::dups \
         "${platforms[@]}" \
         "${KUBE_SUPPORTED_SERVER_PLATFORMS[@]}" \
-      )"
+      )
     readonly KUBE_SERVER_PLATFORMS
 
-    mapfile -t KUBE_NODE_PLATFORMS <<< "$(kube::golang::dups \
+    kube::util::read-array KUBE_NODE_PLATFORMS < <(kube::golang::dups \
         "${platforms[@]}" \
         "${KUBE_SUPPORTED_NODE_PLATFORMS[@]}" \
-      )"
+      )
     readonly KUBE_NODE_PLATFORMS
 
-    mapfile -t KUBE_TEST_PLATFORMS <<< "$(kube::golang::dups \
+    kube::util::read-array KUBE_TEST_PLATFORMS < <(kube::golang::dups \
         "${platforms[@]}" \
         "${KUBE_SUPPORTED_TEST_PLATFORMS[@]}" \
-      )"
+      )
     readonly KUBE_TEST_PLATFORMS
 
-    mapfile -t KUBE_CLIENT_PLATFORMS <<< "$(kube::golang::dups \
+    kube::util::read-array KUBE_CLIENT_PLATFORMS < <(kube::golang::dups \
         "${platforms[@]}" \
         "${KUBE_SUPPORTED_CLIENT_PLATFORMS[@]}" \
-      )"
+      )
     readonly KUBE_CLIENT_PLATFORMS
 
   elif [[ "${KUBE_FASTBUILD:-}" == "true" ]]; then

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -163,6 +163,8 @@ kube::golang::dedup() {
 # to readonly.
 # The configured vars will only contain platforms allowed by the
 # KUBE_SUPPORTED* vars at the top of this file.
+declare -a -g KUBE_SERVER_PLATFORMS
+declare -a -g KUBE_CLIENT_PLATFORMS
 kube::golang::setup_platforms() {
   if [[ -n "${KUBE_BUILD_PLATFORMS:-}" ]]; then
     # KUBE_BUILD_PLATFORMS needs to be read into an array before the next
@@ -202,20 +204,23 @@ kube::golang::setup_platforms() {
     readonly KUBE_CLIENT_PLATFORMS
 
   elif [[ "${KUBE_FASTBUILD:-}" == "true" ]]; then
-    readonly KUBE_SERVER_PLATFORMS=(linux/amd64)
+    KUBE_SERVER_PLATFORMS=(linux/amd64)
+    readonly KUBE_SERVER_PLATFORMS
     readonly KUBE_NODE_PLATFORMS=(linux/amd64)
     if [[ "${KUBE_BUILDER_OS:-}" == "darwin"* ]]; then
       readonly KUBE_TEST_PLATFORMS=(
         darwin/amd64
         linux/amd64
       )
-      readonly KUBE_CLIENT_PLATFORMS=(
+      KUBE_CLIENT_PLATFORMS=(
         darwin/amd64
         linux/amd64
-      )
+      ) 
+      readonly KUBE_CLIENT_PLATFORMS
     else
       readonly KUBE_TEST_PLATFORMS=(linux/amd64)
-      readonly KUBE_CLIENT_PLATFORMS=(linux/amd64)
+      KUBE_CLIENT_PLATFORMS=(linux/amd64)
+      readonly KUBE_CLIENT_PLATFORMS
     fi
   else
     KUBE_SERVER_PLATFORMS=("${KUBE_SUPPORTED_SERVER_PLATFORMS[@]}")

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -165,6 +165,8 @@ kube::golang::dedup() {
 # KUBE_SUPPORTED* vars at the top of this file.
 declare -a -g KUBE_SERVER_PLATFORMS
 declare -a -g KUBE_CLIENT_PLATFORMS
+declare -a -g KUBE_NODE_PLATFORMS
+declare -a -g KUBE_TEST_PLATFORMS
 kube::golang::setup_platforms() {
   if [[ -n "${KUBE_BUILD_PLATFORMS:-}" ]]; then
     # KUBE_BUILD_PLATFORMS needs to be read into an array before the next
@@ -206,19 +208,22 @@ kube::golang::setup_platforms() {
   elif [[ "${KUBE_FASTBUILD:-}" == "true" ]]; then
     KUBE_SERVER_PLATFORMS=(linux/amd64)
     readonly KUBE_SERVER_PLATFORMS
-    readonly KUBE_NODE_PLATFORMS=(linux/amd64)
+    KUBE_NODE_PLATFORMS=(linux/amd64)
+    readonly KUBE_NODE_PLATFORMS
     if [[ "${KUBE_BUILDER_OS:-}" == "darwin"* ]]; then
-      readonly KUBE_TEST_PLATFORMS=(
+      KUBE_TEST_PLATFORMS=(
         darwin/amd64
         linux/amd64
       )
+      readonly KUBE_TEST_PLATFORMS
       KUBE_CLIENT_PLATFORMS=(
         darwin/amd64
         linux/amd64
       ) 
       readonly KUBE_CLIENT_PLATFORMS
     else
-      readonly KUBE_TEST_PLATFORMS=(linux/amd64)
+      KUBE_TEST_PLATFORMS=(linux/amd64)
+      readonly KUBE_TEST_PLATFORMS
       KUBE_CLIENT_PLATFORMS=(linux/amd64)
       readonly KUBE_CLIENT_PLATFORMS
     fi

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -302,7 +302,7 @@ kube::golang::server_test_targets() {
 IFS=" " read -ra KUBE_TEST_SERVER_TARGETS <<< "$(kube::golang::server_test_targets)"
 readonly KUBE_TEST_SERVER_TARGETS
 readonly KUBE_TEST_SERVER_BINARIES=("${KUBE_TEST_SERVER_TARGETS[@]##*/}")
-readonly KUBE_TEST_SERVER_PLATFORMS=("${KUBE_SERVER_PLATFORMS[@]}")
+readonly KUBE_TEST_SERVER_PLATFORMS=("${KUBE_SERVER_PLATFORMS[@]:+"${KUBE_SERVER_PLATFORMS[@]}"}")
 
 # Gigabytes necessary for parallel platform builds.
 # As of January 2018, RAM usage is exceeding 30G

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -163,10 +163,10 @@ kube::golang::dedup() {
 # to readonly.
 # The configured vars will only contain platforms allowed by the
 # KUBE_SUPPORTED* vars at the top of this file.
-declare -a -g KUBE_SERVER_PLATFORMS
-declare -a -g KUBE_CLIENT_PLATFORMS
-declare -a -g KUBE_NODE_PLATFORMS
-declare -a -g KUBE_TEST_PLATFORMS
+declare -a KUBE_SERVER_PLATFORMS
+declare -a KUBE_CLIENT_PLATFORMS
+declare -a KUBE_NODE_PLATFORMS
+declare -a KUBE_TEST_PLATFORMS
 kube::golang::setup_platforms() {
   if [[ -n "${KUBE_BUILD_PLATFORMS:-}" ]]; then
     # KUBE_BUILD_PLATFORMS needs to be read into an array before the next
@@ -219,7 +219,7 @@ kube::golang::setup_platforms() {
       KUBE_CLIENT_PLATFORMS=(
         darwin/amd64
         linux/amd64
-      ) 
+      )
       readonly KUBE_CLIENT_PLATFORMS
     else
       KUBE_TEST_PLATFORMS=(linux/amd64)

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -817,6 +817,23 @@ function kube::util::require-jq {
   fi
 }
 
+# kube::util::read-array
+# Reads in stdin and adds it line by line to the array provided. This can be
+# used instead of "mapfile -t", and is bash 3 compatible.
+#
+# Assumed vars:
+#   $1 (name of array to create/modify)
+#
+# Example usage:
+# kube::util::read-array files < <(ls -1)
+#
+function kube::util::read-array {
+  local i=0
+  unset -v "$1"
+  while IFS= read -r "$1[i++]"; do :; done
+  eval "[[ \${$1[--i]} ]]" || unset "$1[i]" # ensures last element isn't empty
+}
+
 # Some useful colors.
 if [[ -z "${color_start-}" ]]; then
   declare -r color_start="\033["


### PR DESCRIPTION
Cherry pick of #77362 #77910 #77985 #78048 #78059 on release-1.14.

#77362: Don't use mapfile as it isn't bash 3 compatible
#77910: fix unbound array variable
#77985: fix unbound variable release.sh
#78048: Don't use declare -g in build
#78059: Check KUBE_SERVER_PLATFORMS existence

```release-note
NONE
```