### PR TITLE
feat: use e2elog instead framework in test e2e framework

### DIFF
--- a/test/e2e/framework/endpoints/wait.go
+++ b/test/e2e/framework/endpoints/wait.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
 const (
@@ -42,12 +43,12 @@ func WaitForEndpoint(c clientset.Interface, ns, name string) error {
 	for t := time.Now(); time.Since(t) < registerTimeout; time.Sleep(framework.Poll) {
 		endpoint, err := c.CoreV1().Endpoints(ns).Get(name, metav1.GetOptions{})
 		if apierrs.IsNotFound(err) {
-			framework.Logf("Endpoint %s/%s is not ready yet", ns, name)
+			e2elog.Logf("Endpoint %s/%s is not ready yet", ns, name)
 			continue
 		}
 		framework.ExpectNoError(err, "Failed to get endpoints for %s/%s", ns, name)
 		if len(endpoint.Subsets) == 0 || len(endpoint.Subsets[0].Addresses) == 0 {
-			framework.Logf("Endpoint %s/%s is not ready yet", ns, name)
+			e2elog.Logf("Endpoint %s/%s is not ready yet", ns, name)
 			continue
 		}
 		return nil

--- a/test/e2e/framework/ingress/BUILD
+++ b/test/e2e/framework/ingress/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/testfiles:go_default_library",
         "//test/e2e/manifest:go_default_library",
         "//test/utils:go_default_library",

--- a/test/e2e/framework/providers/aws/BUILD
+++ b/test/e2e/framework/providers/aws/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/legacy-cloud-providers/aws:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/awserr:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",

--- a/test/e2e/framework/providers/aws/aws.go
+++ b/test/e2e/framework/providers/aws/aws.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	awscloud "k8s.io/legacy-cloud-providers/aws"
 )
 
@@ -114,7 +115,7 @@ func (p *Provider) DeletePD(pdName string) error {
 	_, err := client.DeleteVolume(request)
 	if err != nil {
 		if awsError, ok := err.(awserr.Error); ok && awsError.Code() == "InvalidVolume.NotFound" {
-			framework.Logf("volume deletion implicitly succeeded because volume %q does not exist.", pdName)
+			e2elog.Logf("volume deletion implicitly succeeded because volume %q does not exist.", pdName)
 		} else {
 			return fmt.Errorf("error deleting EBS volumes: %v", err)
 		}
@@ -144,7 +145,7 @@ func newAWSClient(zone string) *ec2.EC2 {
 		zone = framework.TestContext.CloudConfig.Zone
 	}
 	if zone == "" {
-		framework.Logf("Warning: No AWS zone configured!")
+		e2elog.Logf("Warning: No AWS zone configured!")
 		cfg = nil
 	} else {
 		region := zone[:len(zone)-1]

--- a/test/e2e/framework/providers/azure/BUILD
+++ b/test/e2e/framework/providers/azure/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//staging/src/k8s.io/legacy-cloud-providers/azure:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
     ],
 )
 

--- a/test/e2e/framework/providers/azure/azure.go
+++ b/test/e2e/framework/providers/azure/azure.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/legacy-cloud-providers/azure"
 )
 
@@ -37,7 +38,7 @@ func newProvider() (framework.ProviderInterface, error) {
 	}
 	config, err := os.Open(framework.TestContext.CloudConfig.ConfigFile)
 	if err != nil {
-		framework.Logf("Couldn't open cloud provider configuration %s: %#v",
+		e2elog.Logf("Couldn't open cloud provider configuration %s: %#v",
 			framework.TestContext.CloudConfig.ConfigFile, err)
 	}
 	defer config.Close()
@@ -72,7 +73,7 @@ func (p *Provider) CreatePD(zone string) (string, error) {
 // DeletePD deletes a persistent volume
 func (p *Provider) DeletePD(pdName string) error {
 	if err := p.azureCloud.DeleteVolume(pdName); err != nil {
-		framework.Logf("failed to delete Azure volume %q: %v", pdName, err)
+		e2elog.Logf("failed to delete Azure volume %q: %v", pdName, err)
 		return err
 	}
 	return nil

--- a/test/e2e/framework/providers/gce/BUILD
+++ b/test/e2e/framework/providers/gce/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//staging/src/k8s.io/cloud-provider:go_default_library",
         "//staging/src/k8s.io/legacy-cloud-providers/gce:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/utils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",

--- a/test/e2e/framework/providers/gce/firewall.go
+++ b/test/e2e/framework/providers/gce/firewall.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	gcecloud "k8s.io/legacy-cloud-providers/gce"
 )
 
@@ -395,7 +396,7 @@ func VerifyFirewallRule(res, exp *compute.Firewall, network string, portsSubset 
 
 // WaitForFirewallRule waits for the specified firewall existence
 func WaitForFirewallRule(gceCloud *gcecloud.Cloud, fwName string, exist bool, timeout time.Duration) (*compute.Firewall, error) {
-	framework.Logf("Waiting up to %v for firewall %v exist=%v", timeout, fwName, exist)
+	e2elog.Logf("Waiting up to %v for firewall %v exist=%v", timeout, fwName, exist)
 	var fw *compute.Firewall
 	var err error
 

--- a/test/e2e/framework/providers/gce/gce.go
+++ b/test/e2e/framework/providers/gce/gce.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	gcecloud "k8s.io/legacy-cloud-providers/gce"
 )
 
@@ -41,7 +42,7 @@ func init() {
 }
 
 func factory() (framework.ProviderInterface, error) {
-	framework.Logf("Fetching cloud provider for %q\r", framework.TestContext.Provider)
+	e2elog.Logf("Fetching cloud provider for %q\r", framework.TestContext.Provider)
 	zone := framework.TestContext.CloudConfig.Zone
 	region := framework.TestContext.CloudConfig.Region
 
@@ -175,7 +176,7 @@ func (p *Provider) EnsureLoadBalancerResourcesDeleted(ip, portRange string) erro
 		}
 		for _, item := range list.Items {
 			if item.PortRange == portRange && item.IPAddress == ip {
-				framework.Logf("found a load balancer: %v", item)
+				e2elog.Logf("found a load balancer: %v", item)
 				return false, nil
 			}
 		}
@@ -229,7 +230,7 @@ func (p *Provider) DeletePD(pdName string) error {
 			return nil
 		}
 
-		framework.Logf("error deleting PD %q: %v", pdName, err)
+		e2elog.Logf("error deleting PD %q: %v", pdName, err)
 	}
 	return err
 }
@@ -256,7 +257,7 @@ func (p *Provider) DeletePVSource(pvSource *v1.PersistentVolumeSource) error {
 func (p *Provider) CleanupServiceResources(c clientset.Interface, loadBalancerName, region, zone string) {
 	if pollErr := wait.Poll(5*time.Second, framework.LoadBalancerCleanupTimeout, func() (bool, error) {
 		if err := p.cleanupGCEResources(c, loadBalancerName, region, zone); err != nil {
-			framework.Logf("Still waiting for glbc to cleanup: %v", err)
+			e2elog.Logf("Still waiting for glbc to cleanup: %v", err)
 			return false, nil
 		}
 		return true, nil
@@ -347,7 +348,7 @@ func SetInstanceTags(cloudConfig framework.CloudConfig, instanceName, zone strin
 	if err != nil {
 		framework.Failf("failed to set instance tags: %v", err)
 	}
-	framework.Logf("Sent request to set tags %v on instance: %v", tags, instanceName)
+	e2elog.Logf("Sent request to set tags %v on instance: %v", tags, instanceName)
 	return resTags.Items
 }
 
@@ -355,7 +356,7 @@ func SetInstanceTags(cloudConfig framework.CloudConfig, instanceName, zone strin
 func GetNodeTags(c clientset.Interface, cloudConfig framework.CloudConfig) []string {
 	nodes := framework.GetReadySchedulableNodesOrDie(c)
 	if len(nodes.Items) == 0 {
-		framework.Logf("GetNodeTags: Found 0 node.")
+		e2elog.Logf("GetNodeTags: Found 0 node.")
 		return []string{}
 	}
 	return GetInstanceTags(cloudConfig, nodes.Items[0].Name).Items

--- a/test/e2e/framework/providers/gce/ingress.go
+++ b/test/e2e/framework/providers/gce/ingress.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -87,7 +88,7 @@ func (cont *IngressController) CleanupIngressController() error {
 func (cont *IngressController) CleanupIngressControllerWithTimeout(timeout time.Duration) error {
 	pollErr := wait.Poll(5*time.Second, timeout, func() (bool, error) {
 		if err := cont.Cleanup(false); err != nil {
-			framework.Logf("Monitoring glbc's cleanup of gce resources:\n%v", err)
+			e2elog.Logf("Monitoring glbc's cleanup of gce resources:\n%v", err)
 			return false, nil
 		}
 		return true, nil
@@ -108,7 +109,7 @@ func (cont *IngressController) CleanupIngressControllerWithTimeout(timeout time.
 	// throw out confusing events.
 	if ipErr := wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
 		if err := cont.deleteStaticIPs(); err != nil {
-			framework.Logf("Failed to delete static-ip: %v\n", err)
+			e2elog.Logf("Failed to delete static-ip: %v\n", err)
 			return false, nil
 		}
 		return true, nil
@@ -127,7 +128,7 @@ func (cont *IngressController) CleanupIngressControllerWithTimeout(timeout time.
 }
 
 func (cont *IngressController) getL7AddonUID() (string, error) {
-	framework.Logf("Retrieving UID from config map: %v/%v", metav1.NamespaceSystem, uidConfigMap)
+	e2elog.Logf("Retrieving UID from config map: %v/%v", metav1.NamespaceSystem, uidConfigMap)
 	cm, err := cont.Client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(uidConfigMap, metav1.GetOptions{})
 	if err != nil {
 		return "", err
@@ -296,7 +297,7 @@ func (cont *IngressController) deleteURLMap(del bool) (msg string) {
 			continue
 		}
 		if del {
-			framework.Logf("Deleting url-map: %s", um.Name)
+			e2elog.Logf("Deleting url-map: %s", um.Name)
 			if err := gceCloud.DeleteURLMap(um.Name); err != nil &&
 				!cont.isHTTPErrorCode(err, http.StatusNotFound) {
 				msg += fmt.Sprintf("Failed to delete url map %v\n", um.Name)
@@ -332,7 +333,7 @@ func (cont *IngressController) deleteBackendService(del bool) (msg string) {
 		return fmt.Sprintf("Failed to list backend services: %v", err)
 	}
 	if len(beList) == 0 {
-		framework.Logf("No backend services found")
+		e2elog.Logf("No backend services found")
 		return msg
 	}
 	for _, be := range beList {
@@ -340,7 +341,7 @@ func (cont *IngressController) deleteBackendService(del bool) (msg string) {
 			continue
 		}
 		if del {
-			framework.Logf("Deleting backed-service: %s", be.Name)
+			e2elog.Logf("Deleting backed-service: %s", be.Name)
 			if err := gceCloud.DeleteGlobalBackendService(be.Name); err != nil &&
 				!cont.isHTTPErrorCode(err, http.StatusNotFound) {
 				msg += fmt.Sprintf("Failed to delete backend service %v: %v\n", be.Name, err)
@@ -369,7 +370,7 @@ func (cont *IngressController) deleteHTTPHealthCheck(del bool) (msg string) {
 			continue
 		}
 		if del {
-			framework.Logf("Deleting http-health-check: %s", hc.Name)
+			e2elog.Logf("Deleting http-health-check: %s", hc.Name)
 			if err := gceCloud.DeleteHTTPHealthCheck(hc.Name); err != nil &&
 				!cont.isHTTPErrorCode(err, http.StatusNotFound) {
 				msg += fmt.Sprintf("Failed to delete HTTP health check %v\n", hc.Name)
@@ -410,7 +411,7 @@ func (cont *IngressController) deleteSSLCertificate(del bool) (msg string) {
 				continue
 			}
 			if del {
-				framework.Logf("Deleting ssl-certificate: %s", s.Name)
+				e2elog.Logf("Deleting ssl-certificate: %s", s.Name)
 				if err := gceCloud.DeleteSslCertificate(s.Name); err != nil &&
 					!cont.isHTTPErrorCode(err, http.StatusNotFound) {
 					msg += fmt.Sprintf("Failed to delete ssl certificates: %v\n", s.Name)
@@ -456,7 +457,7 @@ func (cont *IngressController) deleteInstanceGroup(del bool) (msg string) {
 			continue
 		}
 		if del {
-			framework.Logf("Deleting instance-group: %s", ig.Name)
+			e2elog.Logf("Deleting instance-group: %s", ig.Name)
 			if err := gceCloud.DeleteInstanceGroup(ig.Name, cont.Cloud.Zone); err != nil &&
 				!cont.isHTTPErrorCode(err, http.StatusNotFound) {
 				msg += fmt.Sprintf("Failed to delete instance group %v\n", ig.Name)
@@ -478,7 +479,7 @@ func (cont *IngressController) deleteNetworkEndpointGroup(del bool) (msg string)
 			return msg
 		}
 		// Do not return error as NEG is still alpha.
-		framework.Logf("Failed to list network endpoint group: %v", err)
+		e2elog.Logf("Failed to list network endpoint group: %v", err)
 		return msg
 	}
 	if len(negList) == 0 {
@@ -489,7 +490,7 @@ func (cont *IngressController) deleteNetworkEndpointGroup(del bool) (msg string)
 			continue
 		}
 		if del {
-			framework.Logf("Deleting network-endpoint-group: %s", neg.Name)
+			e2elog.Logf("Deleting network-endpoint-group: %s", neg.Name)
 			if err := gceCloud.DeleteNetworkEndpointGroup(neg.Name, cont.Cloud.Zone); err != nil &&
 				!cont.isHTTPErrorCode(err, http.StatusNotFound) {
 				msg += fmt.Sprintf("Failed to delete network endpoint group %v\n", neg.Name)
@@ -557,11 +558,11 @@ func (cont *IngressController) canDeleteNEG(resourceName, creationTimestamp stri
 func canDeleteWithTimestamp(resourceName, creationTimestamp string) bool {
 	createdTime, err := time.Parse(time.RFC3339, creationTimestamp)
 	if err != nil {
-		framework.Logf("WARNING: Failed to parse creation timestamp %v for %v: %v", creationTimestamp, resourceName, err)
+		e2elog.Logf("WARNING: Failed to parse creation timestamp %v for %v: %v", creationTimestamp, resourceName, err)
 		return false
 	}
 	if time.Since(createdTime) > maxAge {
-		framework.Logf("%v created on %v IS too old", resourceName, creationTimestamp)
+		e2elog.Logf("%v created on %v IS too old", resourceName, creationTimestamp)
 		return true
 	}
 	return false
@@ -620,7 +621,7 @@ func (cont *IngressController) WaitForNegBackendService(svcPorts map[string]v1.S
 	return wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
 		err := cont.verifyBackendMode(svcPorts, negBackend)
 		if err != nil {
-			framework.Logf("Err while checking if backend service is using NEG: %v", err)
+			e2elog.Logf("Err while checking if backend service is using NEG: %v", err)
 			return false, nil
 		}
 		return true, nil
@@ -632,7 +633,7 @@ func (cont *IngressController) WaitForIgBackendService(svcPorts map[string]v1.Se
 	return wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
 		err := cont.verifyBackendMode(svcPorts, igBackend)
 		if err != nil {
-			framework.Logf("Err while checking if backend service is using IG: %v", err)
+			e2elog.Logf("Err while checking if backend service is using IG: %v", err)
 			return false, nil
 		}
 		return true, nil
@@ -766,9 +767,9 @@ func (cont *IngressController) Init() error {
 	// There's a name limit imposed by GCE. The controller will truncate.
 	testName := fmt.Sprintf("k8s-fw-foo-app-X-%v--%v", cont.Ns, cont.UID)
 	if len(testName) > nameLenLimit {
-		framework.Logf("WARNING: test name including cluster UID: %v is over the GCE limit of %v", testName, nameLenLimit)
+		e2elog.Logf("WARNING: test name including cluster UID: %v is over the GCE limit of %v", testName, nameLenLimit)
 	} else {
-		framework.Logf("Detected cluster UID %v", cont.UID)
+		e2elog.Logf("Detected cluster UID %v", cont.UID)
 	}
 	return nil
 }
@@ -782,9 +783,9 @@ func (cont *IngressController) CreateStaticIP(name string) string {
 	if err := gceCloud.ReserveGlobalAddress(addr); err != nil {
 		if delErr := gceCloud.DeleteGlobalAddress(name); delErr != nil {
 			if cont.isHTTPErrorCode(delErr, http.StatusNotFound) {
-				framework.Logf("Static ip with name %v was not allocated, nothing to delete", name)
+				e2elog.Logf("Static ip with name %v was not allocated, nothing to delete", name)
 			} else {
-				framework.Logf("Failed to delete static ip %v: %v", name, delErr)
+				e2elog.Logf("Failed to delete static ip %v: %v", name, delErr)
 			}
 		}
 		framework.Failf("Failed to allocate static ip %v: %v", name, err)
@@ -796,7 +797,7 @@ func (cont *IngressController) CreateStaticIP(name string) string {
 	}
 
 	cont.staticIPName = ip.Name
-	framework.Logf("Reserved static ip %v: %v", cont.staticIPName, ip.Address)
+	e2elog.Logf("Reserved static ip %v: %v", cont.staticIPName, ip.Address)
 	return ip.Address
 }
 
@@ -816,7 +817,7 @@ func (cont *IngressController) deleteStaticIPs() error {
 		for _, ip := range e2eIPs {
 			ips = append(ips, ip.Name)
 		}
-		framework.Logf("None of the remaining %d static-ips were created by this e2e: %v", len(ips), strings.Join(ips, ", "))
+		e2elog.Logf("None of the remaining %d static-ips were created by this e2e: %v", len(ips), strings.Join(ips, ", "))
 	}
 	return nil
 }
@@ -842,32 +843,32 @@ func gcloudComputeResourceList(resource, regex, project string, out interface{})
 				errMsg = fmt.Sprintf("%v, stderr %v", errMsg, string(osExitErr.Stderr))
 			}
 		}
-		framework.Logf("Error running gcloud command 'gcloud %s': err: %v, output: %v, status: %d, msg: %v", strings.Join(command, " "), err, string(output), errCode, errMsg)
+		e2elog.Logf("Error running gcloud command 'gcloud %s': err: %v, output: %v, status: %d, msg: %v", strings.Join(command, " "), err, string(output), errCode, errMsg)
 	}
 	if err := json.Unmarshal([]byte(output), out); err != nil {
-		framework.Logf("Error unmarshalling gcloud output for %v: %v, output: %v", resource, err, string(output))
+		e2elog.Logf("Error unmarshalling gcloud output for %v: %v, output: %v", resource, err, string(output))
 	}
 }
 
 // GcloudComputeResourceDelete deletes the specified compute resource by name and project.
 func GcloudComputeResourceDelete(resource, name, project string, args ...string) error {
-	framework.Logf("Deleting %v: %v", resource, name)
+	e2elog.Logf("Deleting %v: %v", resource, name)
 	argList := append([]string{"compute", resource, "delete", name, fmt.Sprintf("--project=%v", project), "-q"}, args...)
 	output, err := exec.Command("gcloud", argList...).CombinedOutput()
 	if err != nil {
-		framework.Logf("Error deleting %v, output: %v\nerror: %+v", resource, string(output), err)
+		e2elog.Logf("Error deleting %v, output: %v\nerror: %+v", resource, string(output), err)
 	}
 	return err
 }
 
 // GcloudComputeResourceCreate creates a compute resource with a name and arguments.
 func GcloudComputeResourceCreate(resource, name, project string, args ...string) error {
-	framework.Logf("Creating %v in project %v: %v", resource, project, name)
+	e2elog.Logf("Creating %v in project %v: %v", resource, project, name)
 	argsList := append([]string{"compute", resource, "create", name, fmt.Sprintf("--project=%v", project)}, args...)
-	framework.Logf("Running command: gcloud %+v", strings.Join(argsList, " "))
+	e2elog.Logf("Running command: gcloud %+v", strings.Join(argsList, " "))
 	output, err := exec.Command("gcloud", argsList...).CombinedOutput()
 	if err != nil {
-		framework.Logf("Error creating %v, output: %v\nerror: %+v", resource, string(output), err)
+		e2elog.Logf("Error creating %v, output: %v\nerror: %+v", resource, string(output), err)
 	}
 	return err
 }

--- a/test/e2e/framework/providers/gce/recreate_node.go
+++ b/test/e2e/framework/providers/gce/recreate_node.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 )
 
@@ -52,7 +53,7 @@ var _ = ginkgo.Describe("Recreate [Feature:Recreate]", func() {
 		originalNodes, err = framework.CheckNodesReady(f.ClientSet, numNodes, framework.NodeReadyInitialTimeout)
 		framework.ExpectNoError(err)
 
-		framework.Logf("Got the following nodes before recreate %v", nodeNames(originalNodes))
+		e2elog.Logf("Got the following nodes before recreate %v", nodeNames(originalNodes))
 
 		ps, err = testutils.NewPodStore(f.ClientSet, systemNamespace, labels.Everything(), fields.Everything())
 		allPods := ps.List()
@@ -77,7 +78,7 @@ var _ = ginkgo.Describe("Recreate [Feature:Recreate]", func() {
 			framework.ExpectNoError(err)
 
 			for _, e := range events.Items {
-				framework.Logf("event for %v: %v %v: %v", e.InvolvedObject.Name, e.Source, e.Reason, e.Message)
+				e2elog.Logf("event for %v: %v %v: %v", e.InvolvedObject.Name, e.Source, e.Reason, e.Message)
 			}
 		}
 		if ps != nil {
@@ -104,7 +105,7 @@ func testRecreate(c clientset.Interface, ps *testutils.PodStore, systemNamespace
 
 	nodesAfter, err := framework.CheckNodesReady(c, len(nodes), framework.RestartNodeReadyAgainTimeout)
 	framework.ExpectNoError(err)
-	framework.Logf("Got the following nodes after recreate: %v", nodeNames(nodesAfter))
+	e2elog.Logf("Got the following nodes after recreate: %v", nodeNames(nodesAfter))
 
 	if len(nodes) != len(nodesAfter) {
 		framework.Failf("Had %d nodes before nodes were recreated, but now only have %d",

--- a/test/e2e/framework/providers/gce/util.go
+++ b/test/e2e/framework/providers/gce/util.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
 // RecreateNodes recreates the given nodes in a managed instance group.
@@ -61,7 +62,7 @@ func RecreateNodes(c clientset.Interface, nodes []v1.Node) error {
 
 		args = append(args, fmt.Sprintf("--instances=%s", strings.Join(nodeNames, ",")))
 		args = append(args, fmt.Sprintf("--zone=%s", zone))
-		framework.Logf("Recreating instance group %s.", instanceGroup)
+		e2elog.Logf("Recreating instance group %s.", instanceGroup)
 		stdout, stderr, err := framework.RunCmd("gcloud", args...)
 		if err != nil {
 			return fmt.Errorf("error recreating nodes: %s\nstdout: %s\nstderr: %s", err, stdout, stderr)
@@ -78,7 +79,7 @@ func WaitForNodeBootIdsToChange(c clientset.Interface, nodes []v1.Node, timeout 
 		if err := wait.Poll(30*time.Second, timeout, func() (bool, error) {
 			newNode, err := c.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
 			if err != nil {
-				framework.Logf("Could not get node info: %s. Retrying in %v.", err, 30*time.Second)
+				e2elog.Logf("Could not get node info: %s. Retrying in %v.", err, 30*time.Second)
 				return false, nil
 			}
 			return node.Status.NodeInfo.BootID != newNode.Status.NodeInfo.BootID, nil

--- a/test/e2e/framework/replicaset/BUILD
+++ b/test/e2e/framework/replicaset/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/apps/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/utils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
     ],

--- a/test/e2e/framework/replicaset/rest.go
+++ b/test/e2e/framework/replicaset/rest.go
@@ -24,12 +24,13 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 )
 
 // UpdateReplicaSetWithRetries updates replicaset template with retries.
 func UpdateReplicaSetWithRetries(c clientset.Interface, namespace, name string, applyUpdate testutils.UpdateReplicaSetFunc) (*apps.ReplicaSet, error) {
-	return testutils.UpdateReplicaSetWithRetries(c, namespace, name, applyUpdate, framework.Logf, framework.Poll, framework.PollShortTimeout)
+	return testutils.UpdateReplicaSetWithRetries(c, namespace, name, applyUpdate, e2elog.Logf, framework.Poll, framework.PollShortTimeout)
 }
 
 // CheckNewRSAnnotations check if the new RS's annotation is as expected

--- a/test/e2e/framework/volume/BUILD
+++ b/test/e2e/framework/volume/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
@@ -259,7 +260,7 @@ func CreateStorageServer(cs clientset.Interface, config TestConfig) (pod *v1.Pod
 	gomega.Expect(pod).NotTo(gomega.BeNil(), "storage server pod should not be nil")
 	ip = pod.Status.PodIP
 	gomega.Expect(len(ip)).NotTo(gomega.BeZero(), fmt.Sprintf("pod %s's IP should not be empty", pod.Name))
-	framework.Logf("%s server pod IP address: %s", config.Prefix, ip)
+	e2elog.Logf("%s server pod IP address: %s", config.Prefix, ip)
 	return pod, ip
 }
 
@@ -353,7 +354,7 @@ func StartVolumeServer(client clientset.Interface, config TestConfig) *v1.Pod {
 	// ok if the server pod already exists. TODO: make this controllable by callers
 	if err != nil {
 		if apierrs.IsAlreadyExists(err) {
-			framework.Logf("Ignore \"already-exists\" error, re-get pod...")
+			e2elog.Logf("Ignore \"already-exists\" error, re-get pod...")
 			ginkgo.By(fmt.Sprintf("re-getting the %q server pod", serverPodName))
 			serverPod, err = podClient.Get(serverPodName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Cannot re-get the server pod %q: %v", serverPodName, err)
@@ -391,17 +392,17 @@ func CleanUpVolumeServerWithSecret(f *framework.Framework, serverPod *v1.Pod, se
 	ns := f.Namespace
 
 	if secret != nil {
-		framework.Logf("Deleting server secret %q...", secret.Name)
+		e2elog.Logf("Deleting server secret %q...", secret.Name)
 		err := cs.CoreV1().Secrets(ns.Name).Delete(secret.Name, &metav1.DeleteOptions{})
 		if err != nil {
-			framework.Logf("Delete secret failed: %v", err)
+			e2elog.Logf("Delete secret failed: %v", err)
 		}
 	}
 
-	framework.Logf("Deleting server pod %q...", serverPod.Name)
+	e2elog.Logf("Deleting server pod %q...", serverPod.Name)
 	err := framework.DeletePodWithWait(f, cs, serverPod)
 	if err != nil {
-		framework.Logf("Server pod delete failed: %v", err)
+		e2elog.Logf("Server pod delete failed: %v", err)
 	}
 }
 
@@ -630,7 +631,7 @@ func GenerateWriteandExecuteScriptFileCmd(content, fileName, filePath string) []
 		fullPath := filepath.Join(filePath, scriptName)
 
 		cmd := "echo \"" + content + "\" > " + fullPath + "; .\\" + fullPath
-		framework.Logf("generated pod command %s", cmd)
+		e2elog.Logf("generated pod command %s", cmd)
 		return []string{"powershell", "/c", cmd}
 	}
 	scriptName := fmt.Sprintf("%s.sh", fileName)


### PR DESCRIPTION
/kind cleanup
/sig testing

**What this PR does / why we need it**:

ref: https://github.com/kubernetes/kubernetes/issues/77359

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
