### PR TITLE
serviceaccounts/token should return 405 instead of 404

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -69,6 +69,8 @@ kube::log::status "Starting kube-apiserver"
   --cert-dir="${TMP_DIR}/certs" \
   --runtime-config="api/all=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true,extensions/v1beta1/replicationcontrollers=true" \
   --token-auth-file="${TMP_DIR}/tokenauth.csv" \
+  --service-account-issuer="https://kubernetes.devault.svc/" \
+  --service-account-signing-key-file="${KUBE_ROOT}/staging/src/k8s.io/client-go/util/cert/testdata/dontUseThisKey.pem" \
   --logtostderr \
   --v=2 \
   --service-cluster-ip-range="10.0.0.0/24" >"${API_LOGFILE}" 2>&1 &


### PR DESCRIPTION
When TokenRequest featues is enabled but the issuer is not configured.
This also fixes serviceaccounts/token not showing up in openapi
discovery.

/sig auth
/kind bug

```release-note
NONE
```

@kubernetes/sig-auth-bugs @micahhausler 
