### PR TITLE
data attribute was missing for apiextensions-apiserver test cases

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["testserver.go"],
+    data = glob(["testdata/**"]),
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing",
     importpath = "k8s.io/apiextensions-apiserver/pkg/cmd/server/testing",
     visibility = ["//visibility:public"],

--- a/test/integration/apiserver/BUILD
+++ b/test/integration/apiserver/BUILD
@@ -16,6 +16,7 @@ go_test(
         "patch_test.go",
         "print_test.go",
     ],
+    rundir = ".",
     tags = [
         "etcd",
         "integration",


### PR DESCRIPTION
Signed-off-by: Bin Lu <bin.lu@arm.com>

**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:
If without the data attribute, the testdata folder can not be found in test, such as:
```
failed to create config from options: error creating self-signed certificates: unable to generate self signed cert: failed to write cert fixture to staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testdata/localhost_127.0.0.1_localhost.crt: open staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testdata/localhost_127.0.0.1_localhost.crt: no such file or directory
```
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
None
**Does this PR introduce a user-facing change?**:
None
```release-note
None
```
