### PR TITLE
Check error return from podBackoffQ.Pop

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -344,9 +344,13 @@ func (p *PriorityQueue) flushBackoffQCompleted() {
 		boTime, found := p.podBackoff.GetBackoffTime(nsNameForPod(pod))
 		if !found {
 			klog.Errorf("Unable to find backoff value for pod %v in backoffQ", nsNameForPod(pod))
-			p.podBackoffQ.Pop()
-			p.activeQ.Add(rawPodInfo)
-			defer p.cond.Broadcast()
+			_, err := p.podBackoffQ.Pop()
+			if err != nil {
+				klog.Errorf("Unable to pop pod %v from backoffQ.", nsNameForPod(pod))
+			} else {
+				p.activeQ.Add(rawPodInfo)
+				defer p.cond.Broadcast()
+			}
 			continue
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In PriorityQueue#flushBackoffQCompleted, error return from podBackoffQ.Pop is not checked when backoff value for pod is not found.

This PR adds the check.

```release-note
NONE
```
