### PR TITLE
Obtain write lock after pods to move have been determined

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -366,8 +366,7 @@ func (p *PriorityQueue) flushBackoffQCompleted() {
 // flushUnschedulableQLeftover moves pod which stays in unschedulableQ longer than the durationStayUnschedulableQ
 // to activeQ.
 func (p *PriorityQueue) flushUnschedulableQLeftover() {
-	p.lock.Lock()
-	defer p.lock.Unlock()
+	p.lock.RLock()
 
 	var podsToMove []*framework.PodInfo
 	currentTime := p.clock.Now()
@@ -377,8 +376,11 @@ func (p *PriorityQueue) flushUnschedulableQLeftover() {
 			podsToMove = append(podsToMove, pInfo)
 		}
 	}
+	p.lock.RUnlock()
 
 	if len(podsToMove) > 0 {
+		p.lock.Lock()
+		defer p.lock.Unlock()
 		p.movePodsToActiveQueue(podsToMove)
 	}
 }

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -381,7 +381,13 @@ func (p *PriorityQueue) flushUnschedulableQLeftover() {
 	if len(podsToMove) > 0 {
 		p.lock.Lock()
 		defer p.lock.Unlock()
-		p.movePodsToActiveQueue(podsToMove)
+		var podsToMove2 []*framework.PodInfo
+		for _, podInfo := range podsToMove {
+			if pod := p.unschedulableQ.get(podInfo.Pod); pod != nil {
+				podsToMove2 = append(podsToMove2, podInfo)
+			}
+		}
+		p.movePodsToActiveQueue(podsToMove2)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In PriorityQueue#flushUnschedulableQLeftover, we obtain write lock at the beginning of the func.

Write lock is only needed when the pods to move have been determined.

```release-note
NONE
```
