### PR TITLE
Remove kubectl log

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"sync"
 	"time"
 
@@ -138,17 +137,11 @@ func NewCmdLogs(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		Short:                 i18n.T("Print the logs for a container in a pod"),
 		Long:                  "Print the logs for a container in a pod or specified resource. If the pod has only one container, the container name is optional.",
 		Example:               logsExample,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			if len(os.Args) > 1 && os.Args[1] == "log" {
-				fmt.Fprintf(o.ErrOut, "%s is DEPRECATED and will be removed in a future version. Use %s instead.\n", "log", "logs")
-			}
-		},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.RunLogs())
 		},
-		Aliases: []string{"log"},
 	}
 	cmd.Flags().BoolVar(&o.AllContainers, "all-containers", o.AllContainers, "Get all containers' logs in the pod(s).")
 	cmd.Flags().BoolVarP(&o.Follow, "follow", "f", o.Follow, "Specify if the logs should be streamed.")

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1298,7 +1298,7 @@ metadata:
 			Testname: Kubectl, logs
 			Description: When a Pod is running then it MUST generate logs.
 			Starting a Pod should have a expected log line. Also log command options MUST work as expected and described below.
-				‘kubectl log -tail=1’ should generate a output of one line, the last line in the log.
+				‘kubectl logs -tail=1’ should generate a output of one line, the last line in the log.
 				‘kubectl --limit-bytes=1’ should generate a single byte output.
 				‘kubectl --tail=1 --timestamp should generate one line with timestamp in RFC3339 format
 				‘kubectl --since=1s’ should output logs that are only 1 second older from now
@@ -1321,17 +1321,17 @@ metadata:
 			framework.ExpectNoError(err)
 
 			ginkgo.By("limiting log lines")
-			out := framework.RunKubectlOrDie("log", podName, containerName, nsFlag, "--tail=1")
+			out := framework.RunKubectlOrDie("logs", podName, containerName, nsFlag, "--tail=1")
 			gomega.Expect(len(out)).NotTo(gomega.BeZero())
 			framework.ExpectEqual(len(lines(out)), 1)
 
 			ginkgo.By("limiting log bytes")
-			out = framework.RunKubectlOrDie("log", podName, containerName, nsFlag, "--limit-bytes=1")
+			out = framework.RunKubectlOrDie("logs", podName, containerName, nsFlag, "--limit-bytes=1")
 			framework.ExpectEqual(len(lines(out)), 1)
 			framework.ExpectEqual(len(out), 1)
 
 			ginkgo.By("exposing timestamps")
-			out = framework.RunKubectlOrDie("log", podName, containerName, nsFlag, "--tail=1", "--timestamps")
+			out = framework.RunKubectlOrDie("logs", podName, containerName, nsFlag, "--tail=1", "--timestamps")
 			l := lines(out)
 			framework.ExpectEqual(len(l), 1)
 			words := strings.Split(l[0], " ")
@@ -1347,9 +1347,9 @@ metadata:
 			// because the granularity is only 1 second and
 			// it could end up rounding the wrong way.
 			time.Sleep(2500 * time.Millisecond) // ensure that startup logs on the node are seen as older than 1s
-			recentOut := framework.RunKubectlOrDie("log", podName, containerName, nsFlag, "--since=1s")
+			recentOut := framework.RunKubectlOrDie("logs", podName, containerName, nsFlag, "--since=1s")
 			recent := len(strings.Split(recentOut, "\n"))
-			olderOut := framework.RunKubectlOrDie("log", podName, containerName, nsFlag, "--since=24h")
+			olderOut := framework.RunKubectlOrDie("logs", podName, containerName, nsFlag, "--since=24h")
 			older := len(strings.Split(olderOut, "\n"))
 			gomega.Expect(recent).To(gomega.BeNumerically("<", older), "expected recent(%v) to be less than older(%v)\nrecent lines:\n%v\nolder lines:\n%v\n", recent, older, recentOut, olderOut)
 		})


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change
/kind cleanup

**What this PR does / why we need it**:
`kubectl log` was deprecated back in https://github.com/kubernetes/kubernetes/commit/cb872e92432d3925ae0e762310709fee9275cdb1 which is even before first release. I think we are now ready to finally remove that command.

**Special notes for your reviewer**:
/assign @liggitt 

**Does this PR introduce a user-facing change?**:
```release-note
Remove kubectl log, use kubectl logs instead
```
