### PR TITLE
WIP: client-go: wire context.Context

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -142,6 +142,12 @@ func NewRequest(client HTTPClient, verb string, baseURL *url.URL, versionedAPIPa
 	return r
 }
 
+// WithContext allows to set a context for the request that will be used for timeouts, deadlines and cancellations.
+func (r *Request) WithContext(ctx context.Context) *Request {
+	r.ctx = ctx
+	return r
+}
+
 // Prefix adds segments to the relative beginning to the request path. These
 // items will be placed before the optional Namespace, Resource, or Name sections.
 // Setting AbsPath will clear any previously set Prefix segments


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Allow to pass the `context.Context` to the rest.Config and have the client-go use it to deal with deadlines and cancellation. The implementation makes it opt-in (`.WithContext(ctx)`) so this is not a breaking change.

```release-note
NONE
```
