### PR TITLE
Remove  pkg/kubectl/cmd/rollout from lintignore with changes

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -130,7 +130,6 @@ pkg/kubectl/cmd/plugin
 pkg/kubectl/cmd/portforward
 pkg/kubectl/cmd/replace
 pkg/kubectl/cmd/rollingupdate
-pkg/kubectl/cmd/rollout
 pkg/kubectl/cmd/run
 pkg/kubectl/cmd/scale
 pkg/kubectl/cmd/set

--- a/pkg/kubectl/cmd/rollout/rollout_history.go
+++ b/pkg/kubectl/cmd/rollout/rollout_history.go
@@ -43,8 +43,8 @@ var (
 		kubectl rollout history daemonset/abc --revision=3`)
 )
 
-// RolloutHistoryOptions holds the options for 'rollout history' sub command
-type RolloutHistoryOptions struct {
+// HistoryOptions holds the options for 'rollout history' sub command
+type HistoryOptions struct {
 	PrintFlags *genericclioptions.PrintFlags
 	ToPrinter  func(string) (printers.ResourcePrinter, error)
 
@@ -62,9 +62,9 @@ type RolloutHistoryOptions struct {
 	genericclioptions.IOStreams
 }
 
-// NewRolloutHistoryOptions returns an initialized RolloutHistoryOptions instance
-func NewRolloutHistoryOptions(streams genericclioptions.IOStreams) *RolloutHistoryOptions {
-	return &RolloutHistoryOptions{
+// NewHistoryOptions returns an initialized HistoryOptions instance
+func NewHistoryOptions(streams genericclioptions.IOStreams) *HistoryOptions {
+	return &HistoryOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
 		IOStreams:  streams,
 	}
@@ -72,7 +72,7 @@ func NewRolloutHistoryOptions(streams genericclioptions.IOStreams) *RolloutHisto
 
 // NewCmdRolloutHistory returns a Command instance for RolloutHistory sub command
 func NewCmdRolloutHistory(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
-	o := NewRolloutHistoryOptions(streams)
+	o := NewHistoryOptions(streams)
 
 	validArgs := []string{"deployment", "daemonset", "statefulset"}
 
@@ -101,7 +101,7 @@ func NewCmdRolloutHistory(f cmdutil.Factory, streams genericclioptions.IOStreams
 }
 
 // Complete completes al the required options
-func (o *RolloutHistoryOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+func (o *HistoryOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	o.Resources = args
 
 	var err error
@@ -122,7 +122,7 @@ func (o *RolloutHistoryOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, 
 }
 
 // Validate makes sure all the provided values for command-line options are valid
-func (o *RolloutHistoryOptions) Validate() error {
+func (o *HistoryOptions) Validate() error {
 	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		return fmt.Errorf("required resource not specified")
 	}
@@ -134,7 +134,7 @@ func (o *RolloutHistoryOptions) Validate() error {
 }
 
 // Run performs the execution of 'rollout history' sub command
-func (o *RolloutHistoryOptions) Run() error {
+func (o *HistoryOptions) Run() error {
 
 	r := o.Builder().
 		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -116,6 +116,7 @@ func (o *PauseOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	return nil
 }
 
+// Validate checks validation of 'rollout pause' options
 func (o *PauseOptions) Validate() error {
 	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		return fmt.Errorf("required resource not specified")

--- a/pkg/kubectl/cmd/rollout/rollout_restart.go
+++ b/pkg/kubectl/cmd/rollout/rollout_restart.go
@@ -120,6 +120,7 @@ func (o *RestartOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	return nil
 }
 
+// Validate checks validation of 'rollout restart' options
 func (o *RestartOptions) Validate() error {
 	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		return fmt.Errorf("required resource not specified")

--- a/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -120,6 +120,7 @@ func (o *ResumeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 	return nil
 }
 
+// Validate checks validation of 'rollout resume' options
 func (o *ResumeOptions) Validate() error {
 	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		return fmt.Errorf("required resource not specified")

--- a/pkg/kubectl/cmd/rollout/rollout_status.go
+++ b/pkg/kubectl/cmd/rollout/rollout_status.go
@@ -60,8 +60,8 @@ var (
 		kubectl rollout status deployment/nginx`)
 )
 
-// RolloutStatusOptions holds the command-line options for 'rollout status' sub command
-type RolloutStatusOptions struct {
+// StatusOptions holds the command-line options for 'rollout status' sub command
+type StatusOptions struct {
 	PrintFlags *genericclioptions.PrintFlags
 
 	Namespace        string
@@ -80,9 +80,9 @@ type RolloutStatusOptions struct {
 	genericclioptions.IOStreams
 }
 
-// NewRolloutStatusOptions returns an initialized RolloutStatusOptions instance
-func NewRolloutStatusOptions(streams genericclioptions.IOStreams) *RolloutStatusOptions {
-	return &RolloutStatusOptions{
+// NewStatusOptions returns an initialized StatusOptions instance
+func NewStatusOptions(streams genericclioptions.IOStreams) *StatusOptions {
+	return &StatusOptions{
 		PrintFlags:      genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
 		FilenameOptions: &resource.FilenameOptions{},
 		IOStreams:       streams,
@@ -93,7 +93,7 @@ func NewRolloutStatusOptions(streams genericclioptions.IOStreams) *RolloutStatus
 
 // NewCmdRolloutStatus returns a Command instance for the 'rollout status' sub command
 func NewCmdRolloutStatus(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
-	o := NewRolloutStatusOptions(streams)
+	o := NewStatusOptions(streams)
 
 	validArgs := []string{"deployment", "daemonset", "statefulset"}
 
@@ -121,7 +121,7 @@ func NewCmdRolloutStatus(f cmdutil.Factory, streams genericclioptions.IOStreams)
 }
 
 // Complete completes all the required options
-func (o *RolloutStatusOptions) Complete(f cmdutil.Factory, args []string) error {
+func (o *StatusOptions) Complete(f cmdutil.Factory, args []string) error {
 	o.Builder = f.NewBuilder
 
 	var err error
@@ -147,7 +147,7 @@ func (o *RolloutStatusOptions) Complete(f cmdutil.Factory, args []string) error 
 }
 
 // Validate makes sure all the provided values for command-line options are valid
-func (o *RolloutStatusOptions) Validate() error {
+func (o *StatusOptions) Validate() error {
 	if len(o.BuilderArgs) == 0 && cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames, o.FilenameOptions.Kustomize) {
 		return fmt.Errorf("required resource not specified")
 	}
@@ -160,7 +160,7 @@ func (o *RolloutStatusOptions) Validate() error {
 }
 
 // Run performs the execution of 'rollout status' sub command
-func (o *RolloutStatusOptions) Run() error {
+func (o *StatusOptions) Run() error {
 	r := o.Builder().
 		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
 		NamespaceParam(o.Namespace).DefaultNamespace().

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -125,6 +125,7 @@ func (o *UndoOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 	return err
 }
 
+// Validate checks validation of 'rollout undo' options
 func (o *UndoOptions) Validate() error {
 	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		return fmt.Errorf("required resource not specified")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
General linter cleanup

**Which issue(s) this PR fixes**:
Part of #68026

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
