### PR TITLE
Remove pkg/util/goroutinemap/exponentialbackoff from lintignore with changes

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -182,7 +182,6 @@ pkg/serviceaccount
 pkg/ssh
 pkg/util/config
 pkg/util/ebtables
-pkg/util/goroutinemap/exponentialbackoff
 pkg/util/labels # See previous effort in PR #80685
 pkg/util/oom
 pkg/util/procfs

--- a/pkg/util/goroutinemap/exponentialbackoff/exponential_backoff.go
+++ b/pkg/util/goroutinemap/exponentialbackoff/exponential_backoff.go
@@ -55,6 +55,8 @@ func (expBackoff *ExponentialBackoff) SafeToRetry(operationName string) error {
 	return nil
 }
 
+// Update sets the passed error on the ExponentialBackoff struct and updates
+// the internal duration and timestamp.
 func (expBackoff *ExponentialBackoff) Update(err *error) {
 	if expBackoff.durationBeforeRetry == 0 {
 		expBackoff.durationBeforeRetry = initialDurationBeforeRetry
@@ -69,6 +71,8 @@ func (expBackoff *ExponentialBackoff) Update(err *error) {
 	expBackoff.lastErrorTime = time.Now()
 }
 
+// GenerateNoRetriesPermittedMsg generates and returns the message for an failed
+// operation.
 func (expBackoff *ExponentialBackoff) GenerateNoRetriesPermittedMsg(operationName string) string {
 	return fmt.Sprintf("Operation for %q failed. No retries permitted until %v (durationBeforeRetry %v). Error: %q",
 		operationName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fix golint failures of pkg/util/goroutinemap/exponentialbackoff

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
