### PR TITLE
Add pending operation log for debug purpose

### DIFF
--- a/pkg/util/goroutinemap/exponentialbackoff/exponential_backoff.go
+++ b/pkg/util/goroutinemap/exponentialbackoff/exponential_backoff.go
@@ -45,13 +45,18 @@ type ExponentialBackoff struct {
 	durationBeforeRetry time.Duration
 }
 
+func NewExponentialBackoff() ExponentialBackoff {
+	return ExponentialBackoff{
+		lastErrorTime: time.Now(),
+	}
+}
+
 // SafeToRetry returns an error if the durationBeforeRetry period for the given
 // lastErrorTime has not yet expired. Otherwise it returns nil.
 func (expBackoff *ExponentialBackoff) SafeToRetry(operationName string) error {
 	if time.Since(expBackoff.lastErrorTime) <= expBackoff.durationBeforeRetry {
 		return NewExponentialBackoffError(operationName, *expBackoff)
 	}
-
 	return nil
 }
 
@@ -75,6 +80,11 @@ func (expBackoff *ExponentialBackoff) GenerateNoRetriesPermittedMsg(operationNam
 		expBackoff.lastErrorTime.Add(expBackoff.durationBeforeRetry),
 		expBackoff.durationBeforeRetry,
 		expBackoff.lastError)
+}
+
+// ElapsedTime returns the elapsed time since its start or last error
+func (expBackoff *ExponentialBackoff) ElapsedTime(operationName string) time.Duration {
+	return time.Since(expBackoff.lastErrorTime)
 }
 
 // NewExponentialBackoffError returns a new instance of ExponentialBackoff error.

--- a/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go
+++ b/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go
@@ -108,6 +108,8 @@ func (grm *nestedPendingOperations) Run(
 		if previousOp.operationPending {
 			// Operation is pending
 			operationKey := getOperationKey(volumeName, podName)
+			klog.V(5).Infof("operationKey[%s] is still in progress, ignoring new operation on pod/volume(%s/%s)", operationKey, podName, volumeName)
+			klog.V(5).Infof("time has elapsed for the pending operation %s is %s", operationKey, previousOp.expBackoff.ElapsedTime(operationKey))
 			return NewAlreadyExistsError(operationKey)
 		}
 
@@ -119,7 +121,7 @@ func (grm *nestedPendingOperations) Run(
 			}
 			// previous operation and new operation are different. reset op. name and exp. backoff
 			grm.operations[previousOpIndex].operationName = generatedOperations.OperationName
-			grm.operations[previousOpIndex].expBackoff = exponentialbackoff.ExponentialBackoff{}
+			grm.operations[previousOpIndex].expBackoff = exponentialbackoff.NewExponentialBackoff()
 		}
 
 		// Update existing operation to mark as pending.
@@ -134,7 +136,7 @@ func (grm *nestedPendingOperations) Run(
 				volumeName:       volumeName,
 				podName:          podName,
 				operationName:    generatedOperations.OperationName,
-				expBackoff:       exponentialbackoff.ExponentialBackoff{},
+				expBackoff:       exponentialbackoff.NewExponentialBackoff(),
 			})
 	}
 


### PR DESCRIPTION
Current log for nestedPendingOperations is not enough for debug
use when there are lots of volume operations requested by either
kubelet or controller manager, also it is hard to identify the slow
operations.

This commit might help for developers/admins

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind cleanup


**What this PR does / why we need it**:
During log triage, it's not easy to figure out  the slow and pending operations for volumes, adding logs
can help a lot in this case.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
