### PR TITLE
add framework helper function

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -378,6 +378,9 @@ func (f *framework) appendPlugins(plugins *config.Plugins) error {
 				f.prefilterPlugins = append(f.prefilterPlugins, p)
 			}
 		} else {
+			if _, exists := f.registry[name]; !exists {
+				return fmt.Errorf("%q plugin %q does not exist in registry", ext, name)
+			}
 			return fmt.Errorf("%q plugin %q does not exist", ext, name)
 		}
 		return nil

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
@@ -340,6 +340,12 @@ func (f *framework) appendPlugins(plugins *config.Plugins) error {
 					return extendErr
 				}
 				f.prebindPlugins = append(f.prebindPlugins, p)
+			case "postbind":
+				p, ok := pg.(PostbindPlugin)
+				if !ok {
+					return extendErr
+				}
+				f.postbindPlugins = append(f.postbindPlugins, p)
 			case "unreserve":
 				p, ok := pg.(UnreservePlugin)
 				if !ok {
@@ -364,6 +370,12 @@ func (f *framework) appendPlugins(plugins *config.Plugins) error {
 					return extendErr
 				}
 				f.bindPlugins = append(f.bindPlugins, p)
+			case "prefilter":
+				p, ok := pg.(PrefilterPlugin)
+				if !ok {
+					return extendErr
+				}
+				f.prefilterPlugins = append(f.prefilterPlugins, p)
 			}
 		} else {
 			return fmt.Errorf("%q plugin %q does not exist", ext, name)
@@ -383,6 +395,10 @@ func (f *framework) appendPlugins(plugins *config.Plugins) error {
 			plugins: plugins.PreBind,
 		},
 		{
+			name:    "postbind",
+			plugins: plugins.PostBind,
+		},
+		{
 			name:    "unreserve",
 			plugins: plugins.Unreserve,
 		},
@@ -397,6 +413,10 @@ func (f *framework) appendPlugins(plugins *config.Plugins) error {
 		{
 			name:    "bind",
 			plugins: plugins.Bind,
+		},
+		{
+			name:    "prefilter",
+			plugins: plugins.PreFilter,
 		},
 	}
 

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -74,6 +74,7 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 	for name, factory := range r {
 		// initialize only needed plugins
 		if _, ok := pg[name]; !ok {
+			klog.V(2).Infof("Skipped initialize plugin %v, since register doesn't contain", name)
 			continue
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
create a helper function instead of having a for loop for every extension point
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
