### PR TITLE
Wait for waitforattach goroutine before exiting

### DIFF
--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -360,9 +361,12 @@ func TestAttacherWithCSIDriver(t *testing.T) {
 				t.Log("plugin is not attachable")
 				return
 			}
-
+			var wg sync.WaitGroup
+			wg.Add(1)
 			go func(volSpec *volume.Spec, expectAttach bool) {
 				attachID, err := csiAttacher.Attach(volSpec, types.NodeName("node"))
+				defer wg.Done()
+
 				if err != nil {
 					t.Errorf("Attach() failed: %s", err)
 				}
@@ -378,6 +382,7 @@ func TestAttacherWithCSIDriver(t *testing.T) {
 				}
 				markVolumeAttached(t, csiAttacher.k8s, fakeWatcher, expectedAttachID, status)
 			}
+			wg.Wait()
 		})
 	}
 }


### PR DESCRIPTION
This test suite fails in weird ways without waiting for the
goroutine. 

