### PR TITLE
Fix ./pkg/kubelet golint issues

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -142,7 +142,6 @@ pkg/kubectl/describe/versioned
 pkg/kubectl/generate
 pkg/kubectl/generate/versioned
 pkg/kubectl/metricsutil
-pkg/kubelet
 pkg/kubelet/apis/config
 pkg/kubelet/apis/config/v1beta1
 pkg/kubelet/apis/deviceplugin/v1beta1

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1604,7 +1604,7 @@ func TestGenerateAPIPodStatusWithReasonCache(t *testing.T) {
 	for i, test := range tests {
 		kubelet.reasonCache = NewReasonCache()
 		for n, e := range test.reasons {
-			kubelet.reasonCache.add(pod.UID, n, e, "")
+			kubelet.reasonCache.Add(pod.UID, n, e, "")
 		}
 		pod.Spec.Containers = test.containers
 		pod.Status.ContainerStatuses = test.oldStatuses
@@ -1617,7 +1617,7 @@ func TestGenerateAPIPodStatusWithReasonCache(t *testing.T) {
 	for i, test := range tests {
 		kubelet.reasonCache = NewReasonCache()
 		for n, e := range test.reasons {
-			kubelet.reasonCache.add(pod.UID, n, e, "")
+			kubelet.reasonCache.Add(pod.UID, n, e, "")
 		}
 		pod.Spec.InitContainers = test.containers
 		pod.Status.InitContainerStatuses = test.oldStatuses
@@ -1667,8 +1667,8 @@ func TestGenerateAPIPodStatusWithDifferentRestartPolicies(t *testing.T) {
 			},
 		},
 	}
-	kubelet.reasonCache.add(pod.UID, "succeed", testErrorReason, "")
-	kubelet.reasonCache.add(pod.UID, "failed", testErrorReason, "")
+	kubelet.reasonCache.Add(pod.UID, "succeed", testErrorReason, "")
+	kubelet.reasonCache.Add(pod.UID, "failed", testErrorReason, "")
 	for c, test := range []struct {
 		restartPolicy                v1.RestartPolicy
 		expectedState                map[string]v1.ContainerState

--- a/pkg/kubelet/reason_cache.go
+++ b/pkg/kubelet/reason_cache.go
@@ -40,8 +40,8 @@ type ReasonCache struct {
 	cache *lru.Cache
 }
 
-// Reason is the cached item in ReasonCache
-type reasonItem struct {
+// ReasonItem is the cached item in ReasonCache
+type ReasonItem struct {
 	Err     error
 	Message string
 }
@@ -60,11 +60,11 @@ func (c *ReasonCache) composeKey(uid types.UID, name string) string {
 	return fmt.Sprintf("%s_%s", uid, name)
 }
 
-// add adds error reason into the cache
-func (c *ReasonCache) add(uid types.UID, name string, reason error, message string) {
+// Add adds error reason into the cache
+func (c *ReasonCache) Add(uid types.UID, name string, reason error, message string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.cache.Add(c.composeKey(uid, name), reasonItem{reason, message})
+	c.cache.Add(c.composeKey(uid, name), ReasonItem{reason, message})
 }
 
 // Update updates the reason cache with the SyncPodResult. Only SyncResult with
@@ -76,7 +76,7 @@ func (c *ReasonCache) Update(uid types.UID, result kubecontainer.PodSyncResult) 
 		}
 		name := r.Target.(string)
 		if r.Error != nil {
-			c.add(uid, name, r.Error, r.Message)
+			c.Add(uid, name, r.Error, r.Message)
 		} else {
 			c.Remove(uid, name)
 		}
@@ -93,13 +93,13 @@ func (c *ReasonCache) Remove(uid types.UID, name string) {
 // Get gets error reason from the cache. The return values are error reason, error message and
 // whether an error reason is found in the cache. If no error reason is found, empty string will
 // be returned for error reason and error message.
-func (c *ReasonCache) Get(uid types.UID, name string) (*reasonItem, bool) {
+func (c *ReasonCache) Get(uid types.UID, name string) (*ReasonItem, bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	value, ok := c.cache.Get(c.composeKey(uid, name))
 	if !ok {
 		return nil, false
 	}
-	info := value.(reasonItem)
+	info := value.(ReasonItem)
 	return &info, true
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix the golint issues for the kubelet. We do this, by clarifying which
components of `pkg/kubelet/reason_cache.go` should be exported. After
this is merged, I'd like to remove `pkg/kubelet/reason_cache.go` out of
the `kubelet` package and into its own package. This diff is a precursor
for those efforts.

**Which issue(s) this PR fixes**:
Ref #68026

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
