### PR TITLE
Backport of #78137: godeps: update vmware/govmomi to v0.20.1

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -3319,168 +3319,168 @@
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/find",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/list",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/lookup",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/lookup/methods",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/lookup/simulator",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/lookup/types",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/nfc",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/object",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/pbm",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/pbm/methods",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/pbm/types",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/property",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/session",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/simulator",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/simulator/esx",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/simulator/vpx",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/sts",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/sts/internal",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/sts/simulator",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/task",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vapi/internal",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vapi/rest",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vapi/simulator",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vapi/tags",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/debug",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/methods",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/mo",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/progress",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/soap",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/types",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/xml",
-			"Comment": "v0.20.0",
-			"Rev": "bdf05b6cab86b1e9f40ee80a4d2cb07a0c25ef78"
+			"Comment": "v0.20.1",
+			"Rev": "4514987f2ddb8875c44cff1d5a24c59425fa6b92"
 		},
 		{
 			"ImportPath": "github.com/vmware/photon-controller-go-sdk/SSPI",

--- a/vendor/github.com/vmware/govmomi/sts/signer.go
+++ b/vendor/github.com/vmware/govmomi/sts/signer.go
@@ -265,8 +265,11 @@ func (s *Signer) SignRequest(req *http.Request) error {
 		}
 		bhash := sha256.New().Sum(body)
 
-		// Port in the signature must be that of the reverse proxy port, vCenter's default is port 80
-		port := "80" // TODO: get from lookup service
+		port := req.URL.Port()
+		if port == "" {
+			port = "80" // Default port for the "Host" header on the server side
+		}
+
 		var buf bytes.Buffer
 		msg := []string{
 			nonce,


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug

**Which issue(s) this PR fixes**:

Fixes #77360

**Special notes for your reviewer**:

Cannot cherry-pick #78137 (go mod vs godep)

Includes fix for SAML token auth with vSphere and zones API

See also: #75742

**Does this PR introduce a user-facing change?**:

```release-note
Fix vSphere SAML token auth when using Zones
```
