### PR TITLE
Ensure kubernetes master is properly tainted in GCE.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -746,6 +746,7 @@ function construct-linux-kubelet-flags {
       #TODO(mikedanese): allow static pods to start before creating a client
       #flags+=" --bootstrap-kubeconfig=/var/lib/kubelet/bootstrap-kubeconfig"
       #flags+=" --kubeconfig=/var/lib/kubelet/kubeconfig"
+      flags+=" --register-with-taints=node-role.kubernetes.io/master=:NoSchedule"
       flags+=" --kubeconfig=/var/lib/kubelet/bootstrap-kubeconfig"
       flags+=" --register-schedulable=false"
     fi


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Ensures that the node-role.kubernetes.io/master taint is applied to the master with NoSchedule.

**Which issue(s) this PR fixes**: 
Fixes #78147

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Ensures that the node-role.kubernetes.io/master taint is applied to the master with NoSchedule on GCE.
```
