### PR TITLE
add list node permission to system:aws-cloud-provider for 1.14.3 release

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -478,7 +478,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "system:aws-cloud-provider"},
 			Rules: []rbacv1.PolicyRule{
-				rbacv1helpers.NewRule("get", "patch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "patch", "list").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 				eventsRule(),
 			},
 		},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -371,6 +371,7 @@ items:
     - nodes
     verbs:
     - get
+    - list
     - patch
   - apiGroups:
     - ""


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR added necessary permission to make aws.go optimization in #78101 work with release 1.14 

**Which issue(s) this PR fixes**:
Fixes #78101

**Special notes for your reviewer**:
1. this change will only be pushed to 1.14, as starting 1.15, cloud provider related roles will no longer be maintained by kubernetes

**Does this PR introduce a user-facing change?**:
no

**Release note:**
```release-note
Added list node permission to `system:aws-cloud-provider` cluster role to allow an optimization in aws-ebs volume provisioner
```

/assign @mcrute 
/cc @micahhausler @justinsb 
/sig aws cloud-provider
/priority critical-urgent
