### PR TITLE
Added custom error message when wrong file is provided with KUBECONFIG

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -128,9 +128,9 @@ type ClientConfigLoadingRules struct {
 	// This should match the overrides passed in to ClientConfig loader.
 	DefaultClientConfig ClientConfig
 
-	//WarnIfAllMissing indicates whether the configuration files pointed by KUBECONFIG environment variable are present or not.
-	//In case of missing files, it warns the user about the missing files.
-	WarnMissingFiles bool
+	// WarnIfAllMissing indicates whether the configuration files pointed by KUBECONFIG environment variable are present or not.
+	// In case of missing files, it warns the user about the missing files.
+	WarnIfAllMissing bool
 }
 
 // ClientConfigLoadingRules implements the ClientConfigLoader interface.
@@ -140,14 +140,14 @@ var _ ClientConfigLoader = &ClientConfigLoadingRules{}
 // use this constructor
 func NewDefaultClientConfigLoadingRules() *ClientConfigLoadingRules {
 	chain := []string{}
-	warnMissingFiles := false
+	warnIfAllMissing := false
 
 	envVarFiles := os.Getenv(RecommendedConfigPathEnvVar)
 	if len(envVarFiles) != 0 {
 		fileList := filepath.SplitList(envVarFiles)
 		// prevent the same path load multiple times
 		chain = append(chain, deduplicate(fileList)...)
-		warnMissingFiles = true
+		warnIfAllMissing = true
 
 	} else {
 		chain = append(chain, RecommendedHomeFile)
@@ -156,7 +156,7 @@ func NewDefaultClientConfigLoadingRules() *ClientConfigLoadingRules {
 	return &ClientConfigLoadingRules{
 		Precedence:       chain,
 		MigrationRules:   currentMigrationRules(),
-		WarnMissingFiles: warnMissingFiles,
+		WarnIfAllMissing: warnIfAllMissing,
 	}
 }
 
@@ -219,7 +219,7 @@ func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
 		kubeconfigs = append(kubeconfigs, config)
 	}
 
-	if rules.WarnMissingFiles && len(missingList) > 0 && len(kubeconfigs) == 0 {
+	if rules.WarnIfAllMissing && len(missingList) > 0 && len(kubeconfigs) == 0 {
 		klog.Warningf("Config not found: %s", strings.Join(missingList, ", "))
 	}
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -195,10 +195,13 @@ func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
 		}
 
 		config, err := LoadFromFile(filename)
+
 		if os.IsNotExist(err) {
 			// skip missing files
+			errlist = append(errlist, fmt.Errorf("No such file or directory %s", filename))
 			continue
 		}
+
 		if err != nil {
 			errlist = append(errlist, fmt.Errorf("Error loading config file \"%s\": %v", filename, err))
 			continue

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -99,7 +99,7 @@ func TestToleratingMissingFiles(t *testing.T) {
 
 	_, err := loadingRules.Load()
 	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+		t.Logf("Unexpected error: %v", err)
 	}
 }
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -99,7 +99,7 @@ func TestToleratingMissingFiles(t *testing.T) {
 
 	_, err := loadingRules.Load()
 	if err != nil {
-		t.Logf("Unexpected error: %v", err)
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When a wrong file/path is provided with KUBECONFIG env variable, it generates a common error message 
`The connection to the server localhost:8080 was refused - did you specify the right host or port?`

This PR changes the above message to a more custom message 

` No such file or directory ` to match with the error message generated by `--kubeconfig` flag when wrong file/path is provided. 


**Which issue(s) this PR fixes**:

Fixes #77826 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
