### PR TITLE
kubelet: Fix log directory path for long pod names

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -178,6 +178,16 @@ func BuildContainerLogsDirectory(podNamespace, podName string, podUID types.UID,
 
 // BuildPodLogsDirectory builds absolute log directory path for a pod sandbox.
 func BuildPodLogsDirectory(podNamespace, podName string, podUID types.UID) string {
+	podNamespaceLength := len(podNamespace)
+	podNameLength := len(podName)
+	podUIDLength := len(string(podUID))
+	delimeterLength := 2
+	// 255 is the maximum number of characters for filenames on most modern filesystems.
+	// Even though we are creating a directory the directory name is limited to
+	// 255 characters as well.
+	if podNamespaceLength+podNameLength+podUIDLength+delimeterLength > 255 {
+		podName = podName[0 : 255-podNamespaceLength-podUIDLength-delimeterLength]
+	}
 	return filepath.Join(podLogsRootDirectory, strings.Join([]string{podNamespace, podName,
 		string(podUID)}, logPathDelimiter))
 }

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -393,5 +395,12 @@ func TestNamespacesForPod(t *testing.T) {
 		t.Logf("TestCase: %s", desc)
 		actual := namespacesForPod(test.input)
 		assert.Equal(t, test.expected, actual)
+	}
+}
+
+func TestMaxDirectoryLength(t *testing.T) {
+	dir := BuildPodLogsDirectory("namespace-a", strings.Repeat("a", 253), "b0b67e30-aa3b-4ea3-bd6e-cd2b0e61930e")
+	if len(path.Base(dir)) > 255 {
+		t.Fatal("Base name cannot exceed 255")
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Creating a directory name over 255 characters will fail due to filesystem limitations limiting names to 255 characters. Trim the podName to allow the namespace and UID to be inserted.

ref: https://github.com/kubernetes/kubernetes/pull/74441
ref: https://bugzilla.redhat.com/show_bug.cgi?id=1711544

**Special notes for your reviewer**:
/cc @Random-Liu @dashpole @sjenning @derekwaynecarr 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
