### PR TITLE
Fix alpha CRD openapi e2e

### DIFF
--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -309,6 +310,10 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Feature:CustomResourcePublish
 		}
 
 		ginkgo.By("mark a version not serverd")
+		crd.Crd, err = crd.APIExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.Crd.Name, metav1.GetOptions{})
+		if err != nil {
+			framework.Failf("%v", err)
+		}
 		crd.Crd.Spec.Versions[1].Served = false
 		crd.Crd, err = crd.APIExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(crd.Crd)
 		if err != nil {
@@ -579,9 +584,11 @@ properties:
     properties:
       dummy:
         description: Dummy property.
+        type: object
   status:
     description: Status of Waldo
     type: object
     properties:
       bars:
-        description: List of Bars and their statuses.`)
+        description: List of Bars and their statuses.
+        type: array`)


### PR DESCRIPTION
/kind failing-test

**What this PR does / why we need it**:
make schema structural so it can be published

```
- lastTransitionTime: "2019-05-21T22:37:25Z"
   message: '[spec.validation.openAPIV3Schema.properties[spec].properties[dummy].type:
     Required value: must not be empty for specified object fields, spec.validation.openAPIV3Schema.properties[status].properties[bars].type:
     Required value: must not be empty for specified object fields]'
   reason: Violations
   status: "True"
   type: NonStructuralSchema
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref #78087 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @liggitt @sttts 
/test pull-kubernetes-e2e-gce-alpha-features