### PR TITLE
Manually revert #76976

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/BUILD
@@ -82,7 +82,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
-        "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/cloud-provider/volume:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
@@ -36,7 +36,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/kubernetes/fake"
 	cloudvolume "k8s.io/cloud-provider/volume"
 )
 
@@ -1874,118 +1873,6 @@ func TestRegionIsValid(t *testing.T) {
 	}
 
 	assert.False(t, isRegionValid("pl-fake-991a", fake.metadata), "expected region 'pl-fake-991' to be invalid but it was not")
-}
-
-func TestGetCandidateZonesForDynamicVolume(t *testing.T) {
-	tests := []struct {
-		name          string
-		labels        map[string]string
-		ready         bool
-		expectedZones sets.String
-	}{
-		{
-			name:          "master node with role label",
-			labels:        map[string]string{labelKeyNodeRole: nodeMasterRole, v1.LabelZoneFailureDomain: "us-east-1a"},
-			ready:         true,
-			expectedZones: sets.NewString(),
-		},
-		{
-			name:          "master node with master label empty",
-			labels:        map[string]string{labelKeyNodeMaster: "", v1.LabelZoneFailureDomain: "us-east-1a"},
-			ready:         true,
-			expectedZones: sets.NewString(),
-		},
-		{
-			name:          "master node with master label true",
-			labels:        map[string]string{labelKeyNodeMaster: "true", v1.LabelZoneFailureDomain: "us-east-1a"},
-			ready:         true,
-			expectedZones: sets.NewString(),
-		},
-		{
-			name:          "master node with master label false",
-			labels:        map[string]string{labelKeyNodeMaster: "false", v1.LabelZoneFailureDomain: "us-east-1a"},
-			ready:         true,
-			expectedZones: sets.NewString("us-east-1a"),
-		},
-		{
-			name:          "minion node with role label",
-			labels:        map[string]string{labelKeyNodeRole: nodeMinionRole, v1.LabelZoneFailureDomain: "us-east-1a"},
-			ready:         true,
-			expectedZones: sets.NewString("us-east-1a"),
-		},
-		{
-			name:          "minion node with minion label",
-			labels:        map[string]string{labelKeyNodeMinion: "", v1.LabelZoneFailureDomain: "us-east-1a"},
-			ready:         true,
-			expectedZones: sets.NewString("us-east-1a"),
-		},
-		{
-			name:          "minion node with compute label",
-			labels:        map[string]string{labelKeyNodeCompute: "true", v1.LabelZoneFailureDomain: "us-east-1a"},
-			ready:         true,
-			expectedZones: sets.NewString("us-east-1a"),
-		},
-		{
-			name:          "master and minion node",
-			labels:        map[string]string{labelKeyNodeMaster: "true", labelKeyNodeCompute: "true", v1.LabelZoneFailureDomain: "us-east-1a"},
-			ready:         true,
-			expectedZones: sets.NewString("us-east-1a"),
-		},
-		{
-			name:          "node not ready",
-			labels:        map[string]string{v1.LabelZoneFailureDomain: "us-east-1a"},
-			ready:         false,
-			expectedZones: sets.NewString(),
-		},
-		{
-			name:          "node has no zone",
-			labels:        map[string]string{},
-			ready:         true,
-			expectedZones: sets.NewString(),
-		},
-		{
-			name:          "node with no label",
-			labels:        map[string]string{v1.LabelZoneFailureDomain: "us-east-1a"},
-			ready:         true,
-			expectedZones: sets.NewString("us-east-1a"),
-		},
-	}
-
-	for i, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			awsServices := newMockedFakeAWSServices(TestClusterID)
-			c, _ := newAWSCloud(CloudConfig{}, awsServices)
-			c.kubeClient = fake.NewSimpleClientset()
-			nodeName := fmt.Sprintf("node-%d", i)
-			_, err := c.kubeClient.CoreV1().Nodes().Create(&v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   nodeName,
-					Labels: test.labels,
-				},
-				Status: genNodeStatus(test.ready),
-			})
-			assert.Nil(t, err)
-			zones, err := c.GetCandidateZonesForDynamicVolume()
-			assert.Nil(t, err)
-			assert.Equal(t, test.expectedZones, zones)
-		})
-	}
-}
-
-func genNodeStatus(ready bool) v1.NodeStatus {
-	status := v1.ConditionFalse
-	if ready {
-		status = v1.ConditionTrue
-	}
-	ret := v1.NodeStatus{
-		Conditions: []v1.NodeCondition{
-			{
-				Type:   v1.NodeReady,
-				Status: status,
-			},
-		},
-	}
-	return ret
 }
 
 func newMockedFakeAWSServices(id string) *FakeAWSServices {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:

This PR manually reverts #76976 as we need to have more discussions regarding what is a proper impl. Discussions are continued in #78199

**Which issue(s) this PR fixes**:
Fixes #78199

**Special notes for your reviewer**:
I have the revert the change manually based on https://github.com/kubernetes/kubernetes/pull/76749/commits/c8edfa241714009defb7fad608ceb582e7685cdd from @mcrute 

It reverts implementation of `GetCandidateZonesForDynamicVolume()` and related helpers, constants, tests and library imports.

**Release note:**
```release-note
reverts an aws-ebs volume provisioner optimization as we need to further discuss a viable optimization
```
/sig aws cloud-provider
/priority critical-urgent

/cc @liggitt @smarterclayton @mcrute 
