### PR TITLE
Modify the return value description for MarkAllPodsNotReady

### DIFF
--- a/pkg/controller/util/node/controller_utils.go
+++ b/pkg/controller/util/node/controller_utils.go
@@ -117,7 +117,8 @@ func SetPodTerminationReason(kubeClient clientset.Interface, pod *v1.Pod, nodeNa
 }
 
 // MarkAllPodsNotReady updates ready status of all pods running on
-// given node from master return true if success
+// given node from master
+// return nil if success
 func MarkAllPodsNotReady(kubeClient clientset.Interface, node *v1.Node) error {
 	nodeName := node.Name
 	klog.V(2).Infof("Update ready status of pods on node [%v]", nodeName)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
the return value description for MarkAllPodsNotReady is incorrect.

This PR fixes the description.

```release-note
NONE
```
