### PR TITLE
Fix nil pointer dereference in metrics value calculator.

### DIFF
--- a/pkg/kubelet/server/stats/volume_stat_calculator.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator.go
@@ -138,12 +138,26 @@ func (s *volumeStatCalculator) calcAndStoreStats() {
 
 // parsePodVolumeStats converts (internal) volume.Metrics to (external) stats.VolumeStats structures
 func (s *volumeStatCalculator) parsePodVolumeStats(podName string, pvcRef *stats.PVCReference, metric *volume.Metrics, volSpec v1.Volume) stats.VolumeStats {
-	available := uint64(metric.Available.Value())
-	capacity := uint64(metric.Capacity.Value())
-	used := uint64(metric.Used.Value())
-	inodes := uint64(metric.Inodes.Value())
-	inodesFree := uint64(metric.InodesFree.Value())
-	inodesUsed := uint64(metric.InodesUsed.Value())
+
+	var available, capacity, used, inodes, inodesFree, inodesUsed uint64
+	if metric.Available != nil {
+		available = uint64(metric.Available.Value())
+	}
+	if metric.Capacity != nil {
+		capacity = uint64(metric.Capacity.Value())
+	}
+	if metric.Used != nil {
+		used = uint64(metric.Used.Value())
+	}
+	if metric.Inodes != nil {
+		inodes = uint64(metric.Inodes.Value())
+	}
+	if metric.InodesFree != nil {
+		inodesFree = uint64(metric.InodesFree.Value())
+	}
+	if metric.InodesUsed != nil {
+		inodesUsed = uint64(metric.InodesUsed.Value())
+	}
 
 	return stats.VolumeStats{
 		Name:   podName,


### PR DESCRIPTION
 Fix nil pointer dereference in metrics value calculator.
    
The metrics structure passed to volume stat calculator
can contain real stats on subset of metrics fields. For example,
the metrics structure filled by a CSI driver can have
either INODES or BYTES filled, IOW it a valid return.
In such cases the volume stat calculator panic with below
trace:
    
```    0516 21:36:19.013143   14452 runtime.go:69] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
    /home/hchiramm/gopath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:76
    /home/hchiramm/gopath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65
    /home/hchiramm/gopath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51
    /usr/local/go/src/runtime/panic.go:522
    /usr/local/go/src/runtime/panic.go:82
    /usr/local/go/src/runtime/signal_unix.go:390
    /home/hchiramm/gopath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/resource/quantity.go:697
    /home/hchiramm/gopath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/resource/quantity.go:685
    /home/hchiramm/gopath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/stats/volume_stat_calculator.go:144
    /home/hchiramm/gopath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/stats/volume_stat_calculator.go:125
    /home/hchiramm/gopath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/stats/volume_stat_calculator.go:65
    /home/hchiramm/gopath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152
    /home/hchiramm/gopath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153
    /usr/local/go/src/runtime/asm_amd64.s:1337
```

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
