### PR TITLE
Utilize all cpu cores for ParallelizeUntil in PrioritizeNodes

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -722,7 +723,11 @@ func PrioritizeNodes(
 		}
 	}
 
-	workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), func(index int) {
+	cores := runtime.NumCPU()
+	if cores < 16 {
+		cores = 16
+	}
+	workqueue.ParallelizeUntil(context.TODO(), cores, len(nodes), func(index int) {
 		nodeInfo := nodeNameToInfo[nodes[index].Name]
 		for i := range priorityConfigs {
 			if priorityConfigs[i].Function != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In PrioritizeNodes, the number of workers is hard coded to be 16 for ParallelizeUntil with Map func's.

This PR utilizes all the CPU cores.

Related to issue #78208

```release-note
NONE
```
