### PR TITLE
Short circuit error appending if alwaysCheckAllPredicates is false

### DIFF
--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -433,7 +433,7 @@ func TestGenericScheduler(t *testing.T) {
 			nodes:        []string{"2", "1"},
 			pod:          &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "2"}},
 			name:         "test error with priority map",
-			wErr:         errors.NewAggregate([]error{errPrioritize, errPrioritize}),
+			wErr:         errors.NewAggregate([]error{errPrioritize}),
 		},
 	}
 	for _, test := range tests {
@@ -720,7 +720,7 @@ func TestZeroRequest(t *testing.T) {
 
 			list, err := PrioritizeNodes(
 				test.pod, nodeNameToInfo, metaData, priorityConfigs,
-				schedulertesting.FakeNodeLister(test.nodes), []algorithm.SchedulerExtender{})
+				schedulertesting.FakeNodeLister(test.nodes), []algorithm.SchedulerExtender{}, true)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently appendError func in PrioritizeNodes always obtains lock and appends the current error.

However, when alwaysCheckAllPredicates is false, we can short circuit the appending.

Related to #78208

```release-note
NONE
```
