### PR TITLE
suppress "pod deleted" output on quiet run

### DIFF
--- a/pkg/kubectl/cmd/delete/delete.go
+++ b/pkg/kubectl/cmd/delete/delete.go
@@ -112,6 +112,7 @@ type DeleteOptions struct {
 	Timeout     time.Duration
 
 	Output string
+	Quiet bool
 
 	DynamicClient dynamic.Interface
 	Mapper        meta.RESTMapper
@@ -283,7 +284,9 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		return err
 	}
 	if found == 0 {
-		fmt.Fprintf(o.Out, "No resources found\n")
+		if !o.Quiet {
+			fmt.Fprintf(o.Out, "No resources found\n")
+		}
 		return nil
 	}
 	if !o.WaitForDeletion {
@@ -335,6 +338,10 @@ func (o *DeleteOptions) deleteResource(info *resource.Info, deleteOptions *metav
 // PrintObj for deleted objects is special because we do not have an object to print.
 // This mirrors name printer behavior
 func (o *DeleteOptions) PrintObj(info *resource.Info) {
+	if o.Quiet {
+		return
+	}
+
 	operation := "deleted"
 	groupKind := info.Mapping.GroupVersionKind
 	kindString := fmt.Sprintf("%s.%s", strings.ToLower(groupKind.Kind), groupKind.Group)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
>
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

The `kubectl run --quiet --rm --wait --attach` will print `pod "..." deleted`. This PR suppresses this output.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The `--quiet` option to `kubectl run` suppresses more output.
```
