### PR TITLE
Promote E2E tests for taint-tolerations in predicates to conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -218,6 +218,7 @@ test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if 
 test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if matching"
 test/e2e/scheduling/predicates.go: "validates that there is no conflict between pods with same hostPort but different hostIP and protocol"
 test/e2e/scheduling/predicates.go: "validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP"
+test/e2e/scheduling/predicates.go: "validates that taints-tolerations is respected if matching"
 test/e2e/storage/empty_dir_wrapper.go: "should not conflict"
 test/e2e/storage/empty_dir_wrapper.go: "should not cause race condition when used for configmaps"
 test/e2e/storage/subpath.go: "should support subpaths with secret pod"

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -481,11 +481,14 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		framework.ExpectEqual(labelPod.Spec.NodeName, nodeName)
 	})
 
-	// 1. Run a pod to get an available node, then delete the pod
-	// 2. Taint the node with a random taint
-	// 3. Try to relaunch the pod with tolerations tolerate the taints on node,
-	// and the pod's nodeName specified to the name of node found in step 1
-	ginkgo.It("validates that taints-tolerations is respected if matching", func() {
+	/*
+		Release : v1.16
+		Testname : Scheduler, taints-tolerations matching
+		Description : After removing the pod from the available node, verify that the
+		pod(with toleration against node taint) is scheduled when the node is tainted with a
+		random taint. The pod MUST be scheduled onto the node.
+	*/
+	framework.ConformanceIt("validates that taints-tolerations is respected if matching", func() {
 		nodeName := getNodeThatCanRunPodWithoutToleration(f)
 
 		ginkgo.By("Trying to apply a random taint on the found node.")
@@ -528,6 +531,10 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 	// 2. Taint the node with a random taint
 	// 3. Try to relaunch the pod still no tolerations,
 	// and the pod's nodeName specified to the name of node found in step 1
+
+	//Promotion to conformance: NO
+	//Reason: This test cannot be promoted because it uses WaitForSchedulerAfterAction which
+	//uses scheduleFailureEvent which checks Event.Type and Event.Reason fields
 	ginkgo.It("validates that taints-tolerations is respected if not matching", func() {
 		nodeName := getNodeThatCanRunPodWithoutToleration(f)
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: This PR requests to promote two existing E2E tests with respect to taint-toleration promotion under predicate scheduling to conformance.

**Which issue(s) this PR fixes**: NONE

**Special notes for your reviewer**:
The PR pushes for conformance promotion of the below two E2E tests:
1. "validates that taints-tolerations is respected if matching"
         --- Takes approximately 36 seconds for successful execution.
         --- Verifies that the pod is scheduled when the pod's toleration matches the node taint.
2. "validates that taints-tolerations is respected if not matching"
         --- Takes approximately 24 seconds for successful completion.
         --- Verifies that if there is a mismatch in pod toleration and node taint, pod scheduling is affected.

Both the tests are found to be non-disruptive and non-flaky.

**Does this PR introduce a user-facing change?**: NONE

release-note-none

/area conformance

@mgdevstack @brahmaroutu 
