### PR TITLE
Option to preconfigure a test handler when using kube-up/containerd

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2918,6 +2918,17 @@ disabled_plugins = ["restart"]
 EOF
   chmod 644 "${config_path}"
 
+  # containerd_extra_runtime_handler is the extra runtime handler to install.
+  containerd_extra_runtime_handler=${CONTAINERD_EXTRA_RUNTIME_HANDLER:-""}
+  if [[ -n "${containerd_extra_runtime_handler}" ]]; then
+    cat >> ${config_path} <<EOF
+[plugins.cri.containerd.runtimes.${containerd_extra_runtime_handler}]
+  runtime_type = "${CONTAINERD_EXTRA_RUNTIME_TYPE:-io.containerd.runc.v1}"
+[plugins.cri.containerd.runtimes.${containerd_extra_runtime_handler}.options]
+${CONTAINERD_EXTRA_RUNTIME_OPTIONS:-}
+EOF
+  fi
+
   echo "Restart containerd to load the config change"
   systemctl restart containerd
 }


### PR DESCRIPTION
Change-Id: I56a1f971d68a1914c9a8df57ffcebc2dcf1456bd

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add a preconfigured test handler that is used for e2e testing

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #78249

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
