### PR TITLE
Revert #76665: "Use consistent imageRef during container startup"

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -194,7 +194,7 @@ func (m *kubeGenericRuntimeManager) generateContainerConfig(container *v1.Contai
 		return nil, nil, err
 	}
 
-	uid, username, err := m.getImageUser(imageRef)
+	uid, username, err := m.getImageUser(container.Image)
 	if err != nil {
 		return nil, cleanupAction, err
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This reverts commit 26e3c8674e66f0d10170d34f5445f0aed207387f from #76665

The change broke the detection of user ID.

**Does this PR introduce a user-facing change?**:
```release-note
Fix broken detection of non-root image user ID
```

/sig node
/assign @yujuhong 
/priority critical-urgent