### PR TITLE
GCE: Disable the Windows defender

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -249,18 +249,16 @@ function Set-PrerequisiteOptions {
   Install-Module -Name powershell-yaml -Force
 }
 
-# Disables Windows Defender realtime scanning if this Windows node is part of a
-# test cluster.
-#
-# ${kube_env} must have already been set.
+# Disables Windows Defender realtime scanning.
+# TODO: remove this workaround once the fix is rolled out the Windows image
+# https://github.com/kubernetes/kubernetes/issues/75148
 function Disable-WindowsDefender {
   # Windows Defender periodically consumes 100% of the CPU, so disable realtime
   # scanning. Uninstalling the Windows Feature will prevent the service from
   # starting after a reboot.
   # TODO(pjh): move this step to image preparation, since we don't want to do a
   # full reboot here.
-  if ((Test-IsTestCluster ${kube_env}) -and
-      ((Get-WindowsFeature -Name 'Windows-Defender').Installed)) {
+  if ((Get-WindowsFeature -Name 'Windows-Defender').Installed) {
     Log-Output "Disabling Windows Defender service"
     Set-MpPreference -DisableRealtimeMonitoring $true
     Uninstall-WindowsFeature -Name 'Windows-Defender'


### PR DESCRIPTION
This is a workaround for https://github.com/kubernetes/kubernetes/issues/75148

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #75148

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
GCE: Disable the Windows defender to work around a bug that could cause nodes to crash and reboot
```
