### PR TITLE
Use zone from node for topology aware aws-ebs volume creation

### DIFF
--- a/pkg/volume/awsebs/BUILD
+++ b/pkg/volume/awsebs/BUILD
@@ -52,9 +52,11 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
         "//staging/src/k8s.io/legacy-cloud-providers/aws:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/volume/awsebs/aws_util.go
+++ b/pkg/volume/awsebs/aws_util.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
-	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/cloud-provider"
 	volumehelpers "k8s.io/cloud-provider/volume/helpers"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
@@ -86,9 +86,9 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner, node *
 
 	capacity := c.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 
-	zonesWithNodes, err := cloud.GetCandidateZonesForDynamicVolume()
+	zonesWithNodes, err := getCandidateZones(cloud, node)
 	if err != nil {
-		return "", 0, nil, "", fmt.Errorf("error querying for all zones: %v", err)
+		return "", 0, nil, "", fmt.Errorf("error finding candidate zone for pvc: %v", err)
 	}
 
 	volumeOptions, err := populateVolumeOptions(c.plugin.GetPluginName(), c.options.PVC.Name, capacity, tags, c.options.Parameters, node, allowedTopologies, zonesWithNodes)
@@ -123,6 +123,20 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner, node *
 	}
 
 	return name, volumeOptions.CapacityGB, labels, fstype, nil
+}
+
+// getCandidateZones finds possible zones that a volume can be created in
+func getCandidateZones(cloud *aws.Cloud, selectedNode *v1.Node) (sets.String, error) {
+	if selectedNode != nil {
+		// For topology aware volume provisioning, node is already selected so we use the zone from
+		// selected node directly instead of candidate zones.
+		// We can assume the information is always available as node controller shall maintain it.
+		return sets.NewString(), nil
+	}
+
+	// For non-topology-aware volumes (those that binds immediately), we fall back to original logic to query
+	// cloud provider for possible zones
+	return cloud.GetCandidateZonesForDynamicVolume()
 }
 
 // returns volumeOptions for EBS based on storageclass parameters and node configuration


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
For topology aware (`WaitForFirstConsumer`) volume provisioning, node is already selected when we call cloud provider to create the volume. In aws-ebs volume provisioner, we currently still list ec2 instances for getting candidate zones, which is inefficient and redundant.

This PR keeps same behavior for volumes that need to bind immediately, but use zone info from bound node for topology aware volumes. If node for some reason does not have zone info recorded (which is unexpected), we double check with cloud provider.

With some 50pvc batch provisioning banchmark, this optimization can reduce 75% DescribeInstances calls, and reduce 50% peak QPS.

**Which issue(s) this PR fixes**:
Fixes #76975 

**Special notes for your reviewer**:
This issue is also being discussed in #78199 and #76976 , as reducing cloud provider calls is anyway necessary for optimizing topo aware volume provisioning code path, and whether and how to optimize finding zone for bind immediately volumes can be an orthogonal problem.


**Does this PR introduce a user-facing change?**:
No

**Release Note:**
```release-note
Use zone from node for topology aware aws-ebs volume creation to reduce unnecessary cloud provider calls
```

/sig storage aws scalability
/priority important-soon
/cc @msau42 @gnufied @liggitt @smarterclayton @mcrute 

