### PR TITLE
Use framework.ExpectError() for e2e/common

### DIFF
--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -26,7 +26,6 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("[sig-node] ConfigMap", func() {
@@ -132,7 +131,7 @@ var _ = Describe("[sig-node] ConfigMap", func() {
 	*/
 	framework.ConformanceIt("should fail to create ConfigMap with empty key", func() {
 		configMap, err := newConfigMapWithEmptyKey(f)
-		Expect(err).To(HaveOccurred(), "created configMap %q with empty key in namespace %q", configMap.Name, f.Namespace.Name)
+		framework.ExpectError(err, "created configMap %q with empty key in namespace %q", configMap.Name, f.Namespace.Name)
 	})
 })
 

--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -551,7 +551,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		volumeMountPath := "/etc/configmap-volumes"
 		podName := "pod-configmaps-" + string(uuid.NewUUID())
 		err := createNonOptionalConfigMapPod(f, volumeMountPath, podName)
-		Expect(err).To(HaveOccurred(), "created pod %q with non-optional configMap in namespace %q", podName, f.Namespace.Name)
+		framework.ExpectError(err, "created pod %q with non-optional configMap in namespace %q", podName, f.Namespace.Name)
 	})
 
 	//ConfigMap object defined for the pod, If a key is specified which is not present in the ConfigMap,
@@ -561,7 +561,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		volumeMountPath := "/etc/configmap-volumes"
 		podName := "pod-configmaps-" + string(uuid.NewUUID())
 		err := createNonOptionalConfigMapPodWithConfig(f, volumeMountPath, podName)
-		Expect(err).To(HaveOccurred(), "created pod %q with non-optional configMap in namespace %q", podName, f.Namespace.Name)
+		framework.ExpectError(err, "created pod %q with non-optional configMap in namespace %q", podName, f.Namespace.Name)
 	})
 })
 

--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -383,7 +383,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		pod = podClient.Create(pod)
 
 		err := framework.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
-		Expect(err).To(HaveOccurred(), "while waiting for pod to be running")
+		framework.ExpectError(err, "while waiting for pod to be running")
 
 		By("updating the pod")
 		podClient.Update(podName, func(pod *v1.Pod) {
@@ -651,7 +651,7 @@ func testPodFailSubpath(f *framework.Framework, pod *v1.Pod) {
 	}()
 
 	err := framework.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
-	Expect(err).To(HaveOccurred(), "while waiting for pod to be running")
+	framework.ExpectError(err, "while waiting for pod to be running")
 }
 
 // Tests that the existing subpath mount is detected when a container restarts

--- a/test/e2e/common/privileged.go
+++ b/test/e2e/common/privileged.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -76,7 +75,7 @@ func (c *PrivilegedPodTestConfig) run(containerName string, expectSuccess bool) 
 		framework.ExpectNoError(err,
 			fmt.Sprintf("could not remove dummy1 link: %v", err))
 	} else {
-		gomega.Expect(err).To(gomega.HaveOccurred(), msg)
+		framework.ExpectError(err, msg)
 	}
 }
 

--- a/test/e2e/common/projected_configmap.go
+++ b/test/e2e/common/projected_configmap.go
@@ -492,7 +492,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 		volumeMountPath := "/etc/projected-configmap-volumes"
 		podName := "pod-projected-configmaps-" + string(uuid.NewUUID())
 		err := createNonOptionalConfigMapPod(f, volumeMountPath, podName)
-		gomega.Expect(err).To(gomega.HaveOccurred(), "created pod %q with non-optional configMap in namespace %q", podName, f.Namespace.Name)
+		framework.ExpectError(err, "created pod %q with non-optional configMap in namespace %q", podName, f.Namespace.Name)
 	})
 
 	//ConfigMap object defined for the pod, If a key is specified which is not present in the ConfigMap,
@@ -502,7 +502,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 		volumeMountPath := "/etc/configmap-volumes"
 		podName := "pod-configmaps-" + string(uuid.NewUUID())
 		err := createNonOptionalConfigMapPodWithConfig(f, volumeMountPath, podName)
-		gomega.Expect(err).To(gomega.HaveOccurred(), "created pod %q with non-optional configMap in namespace %q", podName, f.Namespace.Name)
+		framework.ExpectError(err, "created pod %q with non-optional configMap in namespace %q", podName, f.Namespace.Name)
 	})
 })
 

--- a/test/e2e/common/projected_secret.go
+++ b/test/e2e/common/projected_secret.go
@@ -410,7 +410,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 		volumeMountPath := "/etc/projected-secret-volumes"
 		podName := "pod-secrets-" + string(uuid.NewUUID())
 		err := createNonOptionalSecretPod(f, volumeMountPath, podName)
-		gomega.Expect(err).To(gomega.HaveOccurred(), "created pod %q with non-optional secret in namespace %q", podName, f.Namespace.Name)
+		framework.ExpectError(err, "created pod %q with non-optional secret in namespace %q", podName, f.Namespace.Name)
 	})
 
 	//Secret object defined for the pod, If a key is specified which is not present in the secret,
@@ -420,7 +420,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 		volumeMountPath := "/etc/secret-volumes"
 		podName := "pod-secrets-" + string(uuid.NewUUID())
 		err := createNonOptionalSecretPodWithSecret(f, volumeMountPath, podName)
-		gomega.Expect(err).To(gomega.HaveOccurred(), "created pod %q with non-optional secret in namespace %q", podName, f.Namespace.Name)
+		framework.ExpectError(err, "created pod %q with non-optional secret in namespace %q", podName, f.Namespace.Name)
 	})
 })
 

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -26,7 +26,6 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("[sig-api-machinery] Secrets", func() {
@@ -133,7 +132,7 @@ var _ = Describe("[sig-api-machinery] Secrets", func() {
 	*/
 	framework.ConformanceIt("should fail to create secret due to empty secret key", func() {
 		secret, err := createEmptyKeySecretForTest(f)
-		Expect(err).To(HaveOccurred(), "created secret %q with empty key in namespace %q", secret.Name, f.Namespace.Name)
+		framework.ExpectError(err, "created secret %q with empty key in namespace %q", secret.Name, f.Namespace.Name)
 	})
 })
 

--- a/test/e2e/common/secrets_volume.go
+++ b/test/e2e/common/secrets_volume.go
@@ -375,7 +375,7 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		volumeMountPath := "/etc/secret-volumes"
 		podName := "pod-secrets-" + string(uuid.NewUUID())
 		err := createNonOptionalSecretPod(f, volumeMountPath, podName)
-		Expect(err).To(HaveOccurred(), "created pod %q with non-optional secret in namespace %q", podName, f.Namespace.Name)
+		framework.ExpectError(err, "created pod %q with non-optional secret in namespace %q", podName, f.Namespace.Name)
 	})
 
 	//Secret object defined for the pod, If a key is specified which is not present in the secret,
@@ -385,7 +385,7 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		volumeMountPath := "/etc/secret-volumes"
 		podName := "pod-secrets-" + string(uuid.NewUUID())
 		err := createNonOptionalSecretPodWithSecret(f, volumeMountPath, podName)
-		Expect(err).To(HaveOccurred(), "created pod %q with non-optional secret in namespace %q", podName, f.Namespace.Name)
+		framework.ExpectError(err, "created pod %q with non-optional secret in namespace %q", podName, f.Namespace.Name)
 	})
 })
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The e2e test framework has ExpectError() for readable test code.
This replaces Expect(err).To(HaveOccurred()) with it.

**Which issue(s) this PR fixes**:
Ref: #77706

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/sig testing