### PR TITLE
Moved `GetPodPriority` into a common library kubernetes#78220

### DIFF
--- a/pkg/apis/scheduling/helpers.go
+++ b/pkg/apis/scheduling/helpers.go
@@ -19,6 +19,7 @@ package scheduling
 import (
 	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/api/core/v1"
 )
 
 // SystemPriorityClasses define system priority classes that are auto-created at cluster bootstrapping.
@@ -62,4 +63,15 @@ func IsKnownSystemPriorityClass(pc *PriorityClass) (bool, error) {
 		}
 	}
 	return false, fmt.Errorf("%v is not a known system priority class", pc.Name)
+}
+
+// GetPodPriority returns priority of the given pod.
+func GetPodPriority(pod *v1.Pod) int32 {
+	if pod.Spec.Priority != nil {
+		return *pod.Spec.Priority
+	}
+	// When priority of a running pod is nil, it means it was created at a time
+	// that there was no global default priority class and the priority class
+	// name of the pod was empty. So, we resolve to the static default priority.
+	return DefaultPriorityWhenNoDefaultClassExists
 }

--- a/pkg/apis/scheduling/helpers_test.go
+++ b/pkg/apis/scheduling/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestIsKnownSystemPriorityClass(t *testing.T) {
@@ -50,5 +51,41 @@ func TestIsKnownSystemPriorityClass(t *testing.T) {
 		if is, err := IsKnownSystemPriorityClass(test.pc); test.expected != is {
 			t.Errorf("Test [%v]: Expected %v, but got %v. Error: %v", test.name, test.expected, is, err)
 		}
+	}
+}
+
+// TestGetPodPriority tests GetPodPriority function.
+func TestGetPodPriority(t *testing.T) {
+	p := int32(20)
+	tests := []struct {
+		name             string
+		pod              *corev1.Pod
+		expectedPriority int32
+	}{
+		{
+			name: "no priority pod resolves to static default priority",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "container", Image: "image"}},
+				},
+			},
+			expectedPriority: DefaultPriorityWhenNoDefaultClassExists,
+		},
+		{
+			name: "pod with priority resolves correctly",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "container", Image: "image"}},
+					Priority: &p,
+				},
+			},
+			expectedPriority: p,
+		},
+	}
+	for _, test := range tests {
+		if GetPodPriority(test.pod) != test.expectedPriority {
+			t.Errorf("expected pod priority: %v, got %v", test.expectedPriority, GetPodPriority(test.pod))
+		}
+
 	}
 }

--- a/pkg/apis/scheduling/helpers_test.go
+++ b/pkg/apis/scheduling/helpers_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 )
 
 func TestIsKnownSystemPriorityClass(t *testing.T) {
@@ -59,13 +59,13 @@ func TestGetPodPriority(t *testing.T) {
 	p := int32(20)
 	tests := []struct {
 		name             string
-		pod              *corev1.Pod
+		pod              *v1.Pod
 		expectedPriority int32
 	}{
 		{
 			name: "no priority pod resolves to static default priority",
-			pod: &corev1.Pod{
-				Spec: corev1.PodSpec{Containers: []corev1.Container{
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{Containers: []v1.Container{
 					{Name: "container", Image: "image"}},
 				},
 			},
@@ -73,8 +73,8 @@ func TestGetPodPriority(t *testing.T) {
 		},
 		{
 			name: "pod with priority resolves correctly",
-			pod: &corev1.Pod{
-				Spec: corev1.PodSpec{Containers: []corev1.Container{
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{Containers: []v1.Container{
 					{Name: "container", Image: "image"}},
 					Priority: &p,
 				},

--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -31,7 +31,7 @@ import (
 	statsapi "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
-	schedulerutils "k8s.io/kubernetes/pkg/scheduler/util"
+	"k8s.io/kubernetes/pkg/apis/scheduling"
 )
 
 const (
@@ -510,8 +510,8 @@ func priority(p1, p2 *v1.Pod) int {
 		// If priority is not enabled, all pods are equal.
 		return 0
 	}
-	priority1 := schedulerutils.GetPodPriority(p1)
-	priority2 := schedulerutils.GetPodPriority(p2)
+	priority1 := scheduling.GetPodPriority(p1)
+	priority2 := scheduling.GetPodPriority(p2)
 	if priority1 == priority2 {
 		return 0
 	}

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -34,6 +34,7 @@ import (
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	schedulertesting "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/kubernetes/pkg/scheduler/util"
+	"k8s.io/kubernetes/pkg/apis/scheduling"
 )
 
 type fitPredicate func(pod *v1.Pod, node *v1.Node) (bool, error)
@@ -207,9 +208,9 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(
 	}
 	// As the first step, remove all the lower priority pods from the node and
 	// check if the given pod can be scheduled.
-	podPriority := util.GetPodPriority(pod)
+	podPriority := scheduling.GetPodPriority(pod)
 	for _, p := range nodeInfoCopy.Pods() {
-		if util.GetPodPriority(p) < podPriority {
+		if scheduling.GetPodPriority(p) < podPriority {
 			potentialVictims.Items = append(potentialVictims.Items, p)
 			removePod(p)
 		}

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -41,6 +41,7 @@ import (
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/util"
+	"k8s.io/kubernetes/pkg/apis/scheduling"
 )
 
 var (
@@ -154,8 +155,8 @@ func newPodInfoNoTimestamp(pod *v1.Pod) *framework.PodInfo {
 func activeQComp(podInfo1, podInfo2 interface{}) bool {
 	pInfo1 := podInfo1.(*framework.PodInfo)
 	pInfo2 := podInfo2.(*framework.PodInfo)
-	prio1 := util.GetPodPriority(pInfo1.Pod)
-	prio2 := util.GetPodPriority(pInfo2.Pod)
+	prio1 := scheduling.GetPodPriority(pInfo1.Pod)
+	prio2 := scheduling.GetPodPriority(pInfo2.Pod)
 	return (prio1 > prio2) || (prio1 == prio2 && pInfo1.Timestamp.Before(pInfo2.Timestamp))
 }
 

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -33,6 +33,7 @@ import (
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/util"
+	"k8s.io/kubernetes/pkg/apis/scheduling"
 )
 
 var negPriority, lowPriority, midPriority, highPriority, veryHighPriority = int32(-100), int32(0), int32(100), int32(1000), int32(10000)
@@ -157,8 +158,8 @@ type fakeFramework struct{}
 
 func (*fakeFramework) QueueSortFunc() framework.LessFunc {
 	return func(podInfo1, podInfo2 *framework.PodInfo) bool {
-		prio1 := util.GetPodPriority(podInfo1.Pod)
-		prio2 := util.GetPodPriority(podInfo2.Pod)
+		prio1 := scheduling.GetPodPriority(podInfo1.Pod)
+		prio2 := scheduling.GetPodPriority(podInfo2.Pod)
 		return prio1 < prio2
 	}
 }

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -25,47 +25,13 @@ import (
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 )
 
-// TestGetPodPriority tests GetPodPriority function.
-func TestGetPodPriority(t *testing.T) {
-	p := int32(20)
-	tests := []struct {
-		name             string
-		pod              *v1.Pod
-		expectedPriority int32
-	}{
-		{
-			name: "no priority pod resolves to static default priority",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{Containers: []v1.Container{
-					{Name: "container", Image: "image"}},
-				},
-			},
-			expectedPriority: scheduling.DefaultPriorityWhenNoDefaultClassExists,
-		},
-		{
-			name: "pod with priority resolves correctly",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{Containers: []v1.Container{
-					{Name: "container", Image: "image"}},
-					Priority: &p,
-				},
-			},
-			expectedPriority: p,
-		},
-	}
-	for _, test := range tests {
-		if GetPodPriority(test.pod) != test.expectedPriority {
-			t.Errorf("expected pod priority: %v, got %v", test.expectedPriority, GetPodPriority(test.pod))
-		}
 
-	}
-}
 
 // TestSortableList tests SortableList by storing pods in the list and sorting
 // them by their priority.
 func TestSortableList(t *testing.T) {
 	higherPriority := func(pod1, pod2 interface{}) bool {
-		return GetPodPriority(pod1.(*v1.Pod)) > GetPodPriority(pod2.(*v1.Pod))
+		return scheduling.GetPodPriority(pod1.(*v1.Pod)) > scheduling.GetPodPriority(pod2.(*v1.Pod))
 	}
 	podList := SortableList{CompFunc: higherPriority}
 	// Add a few Pods with different priorities from lowest to highest priority.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removed dependency to load scheduler code for function GetPodPriority

**Which issue(s) this PR fixes**:
Fixes #78220 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
