### PR TITLE
fix azure retry issue when return 2XX with error

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
@@ -596,8 +596,9 @@ func shouldRetryHTTPRequest(resp *http.Response, err error) bool {
 	return false
 }
 
+// processHTTPRetryResponse : return true means stop retry, false means continue retry
 func (az *Cloud) processHTTPRetryResponse(service *v1.Service, reason string, resp *http.Response, err error) (bool, error) {
-	if resp != nil && isSuccessHTTPResponse(resp) {
+	if err == nil && resp != nil && isSuccessHTTPResponse(resp) {
 		// HTTP 2xx suggests a successful response
 		return true, nil
 	}
@@ -620,7 +621,7 @@ func (az *Cloud) processHTTPRetryResponse(service *v1.Service, reason string, re
 }
 
 func (az *Cloud) processHTTPResponse(service *v1.Service, reason string, resp *http.Response, err error) error {
-	if isSuccessHTTPResponse(resp) {
+	if err == nil && isSuccessHTTPResponse(resp) {
 		// HTTP 2xx suggests a successful response
 		return nil
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff_test.go
@@ -120,6 +120,11 @@ func TestProcessRetryResponse(t *testing.T) {
 			stop: true,
 		},
 		{
+			code: http.StatusOK,
+			err:  fmt.Errorf("some error"),
+			stop: false,
+		},
+		{
 			code: 399,
 			stop: true,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
With this PR, when azure API call return <200, error>, it would regard as error and continue retry.
As we could find in error case, and also talked with VMSS team, return 2XX does not mean the operation is successful(doc: https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/Addendum.md#creating-or-updating-resources), there could also be error condition, e.g.

httpStatusCode	200
resultCode		NetworkingInternalOperationError


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #78172

**Special notes for your reviewer**:
Note: this code change will affect all error retry including following places:
```
./azure_backoff.go:             done, retryError := az.processHTTPRetryResponse(service, "CreateOrUpdateSecurityGroup", resp, err)
./azure_backoff.go:             done, retryError := az.processHTTPRetryResponse(service, "CreateOrUpdateLoadBalancer", resp, err)
./azure_backoff.go:             return az.processHTTPRetryResponse(service, "CreateOrUpdatePublicIPAddress", resp, err)
./azure_backoff.go:             return az.processHTTPRetryResponse(service, "CreateOrUpdateInterface", resp, err)
./azure_backoff.go:             return az.processHTTPRetryResponse(service, "DeletePublicIPAddress", resp, err)
./azure_backoff.go:             done, err := az.processHTTPRetryResponse(service, "DeleteLoadBalancer", resp, err)
./azure_backoff.go:             done, retryError := az.processHTTPRetryResponse(nil, "", resp, err)
./azure_backoff.go:             done, retryError := az.processHTTPRetryResponse(nil, "", resp, err)
./azure_backoff.go:             return az.processHTTPRetryResponse(nil, "", resp, err)
./azure_backoff.go:             return az.processHTTPRetryResponse(nil, "", resp, err)
./azure_backoff.go:// processHTTPRetryResponse : return true means stop retry, false means continue retry
./azure_backoff.go:func (az *Cloud) processHTTPRetryResponse(service *v1.Service, reason string, resp *http.Response, err error) (bool, error) {
./azure_backoff.go:                     klog.Errorf("processHTTPRetryResponse: backoff failure, will retry, err=%v", err)
./azure_backoff.go:                     klog.Errorf("processHTTPRetryResponse: backoff failure, will retry, HTTP response=%d", resp.StatusCode)
./azure_backoff.go:             klog.Errorf("processHTTPRetryResponse failure with err: %v", err)
./azure_backoff.go:             klog.Errorf("processHTTPRetryResponse failure with HTTP response %q", resp.Status)
./azure_backoff_test.go:                res, err := az.processHTTPRetryResponse(nil, "", resp, test.err)
./azure_controller_common.go:                   return c.cloud.processHTTPRetryResponse(nil, "", resp, err)
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix azure retry issue when return 2XX with error
```

/hold
Let's hold on for VMSS team do the final confirmation and also code review.

/kind bug
/assign @feiskyer 
/priority important-soon
/sig azure
