### PR TITLE
add scheduling queue to framework handle

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -41,7 +41,6 @@ import (
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
-	internalqueue "k8s.io/kubernetes/pkg/scheduler/internal/queue"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	"k8s.io/kubernetes/pkg/scheduler/util"
@@ -153,7 +152,7 @@ type ScheduleResult struct {
 
 type genericScheduler struct {
 	cache                    internalcache.Cache
-	schedulingQueue          internalqueue.SchedulingQueue
+	schedulingQueue          framework.SchedulingQueue
 	predicates               map[string]predicates.FitPredicate
 	priorityMetaProducer     priorities.PriorityMetadataProducer
 	predicateMetaProducer    predicates.PredicateMetadataProducer
@@ -560,7 +559,7 @@ func (g *genericScheduler) findNodesThatFit(pod *v1.Pod, nodes []*v1.Node) ([]*v
 // to run on the node given in nodeInfo to meta and nodeInfo. It returns 1) whether
 // any pod was found, 2) augmented meta data, 3) augmented nodeInfo.
 func addNominatedPods(pod *v1.Pod, meta predicates.PredicateMetadata,
-	nodeInfo *schedulernodeinfo.NodeInfo, queue internalqueue.SchedulingQueue) (bool, predicates.PredicateMetadata,
+	nodeInfo *schedulernodeinfo.NodeInfo, queue framework.SchedulingQueue) (bool, predicates.PredicateMetadata,
 	*schedulernodeinfo.NodeInfo) {
 	if queue == nil || nodeInfo == nil || nodeInfo.Node() == nil {
 		// This may happen only in tests.
@@ -601,7 +600,7 @@ func podFitsOnNode(
 	meta predicates.PredicateMetadata,
 	info *schedulernodeinfo.NodeInfo,
 	predicateFuncs map[string]predicates.FitPredicate,
-	queue internalqueue.SchedulingQueue,
+	queue framework.SchedulingQueue,
 	alwaysCheckAllPredicates bool,
 ) (bool, []predicates.PredicateFailureReason, error) {
 	var failedPredicates []predicates.PredicateFailureReason
@@ -969,7 +968,7 @@ func selectNodesForPreemption(pod *v1.Pod,
 	potentialNodes []*v1.Node,
 	fitPredicates map[string]predicates.FitPredicate,
 	metadataProducer predicates.PredicateMetadataProducer,
-	queue internalqueue.SchedulingQueue,
+	queue framework.SchedulingQueue,
 	pdbs []*policy.PodDisruptionBudget,
 ) (map[*v1.Node]*schedulerapi.Victims, error) {
 	nodeToVictims := map[*v1.Node]*schedulerapi.Victims{}
@@ -1057,7 +1056,7 @@ func selectVictimsOnNode(
 	meta predicates.PredicateMetadata,
 	nodeInfo *schedulernodeinfo.NodeInfo,
 	fitPredicates map[string]predicates.FitPredicate,
-	queue internalqueue.SchedulingQueue,
+	queue framework.SchedulingQueue,
 	pdbs []*policy.PodDisruptionBudget,
 ) ([]*v1.Pod, int, bool) {
 	if nodeInfo == nil {
@@ -1212,7 +1211,7 @@ func podPassesBasicChecks(pod *v1.Pod, pvcLister corelisters.PersistentVolumeCla
 // NewGenericScheduler creates a genericScheduler object.
 func NewGenericScheduler(
 	cache internalcache.Cache,
-	podQueue internalqueue.SchedulingQueue,
+	podQueue framework.SchedulingQueue,
 	predicates map[string]predicates.FitPredicate,
 	predicateMetaProducer predicates.PredicateMetadataProducer,
 	prioritizers []priorities.PriorityConfig,

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -363,3 +363,7 @@ func pluginsNeeded(plugins *config.Plugins) map[string]struct{} {
 func (f *framework) SchedulingQueue() SchedulingQueue {
 	return f.schedulingQueue
 }
+
+func (f *framework) SchedulingQueueHandle() SchedulingQueueHandle {
+	return f.schedulingQueue
+}

--- a/pkg/scheduler/internal/cache/debugger/comparer.go
+++ b/pkg/scheduler/internal/cache/debugger/comparer.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
-	internalqueue "k8s.io/kubernetes/pkg/scheduler/internal/queue"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
@@ -34,7 +34,7 @@ type CacheComparer struct {
 	NodeLister corelisters.NodeLister
 	PodLister  corelisters.PodLister
 	Cache      internalcache.Cache
-	PodQueue   internalqueue.SchedulingQueue
+	PodQueue   framework.SchedulingQueue
 }
 
 // Compare compares the nodes and pods of NodeLister with Cache.Snapshot.

--- a/pkg/scheduler/internal/cache/debugger/debugger.go
+++ b/pkg/scheduler/internal/cache/debugger/debugger.go
@@ -21,8 +21,8 @@ import (
 	"os/signal"
 
 	corelisters "k8s.io/client-go/listers/core/v1"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
-	internalqueue "k8s.io/kubernetes/pkg/scheduler/internal/queue"
 )
 
 // CacheDebugger provides ways to check and write cache information for debugging.
@@ -36,7 +36,7 @@ func New(
 	nodeLister corelisters.NodeLister,
 	podLister corelisters.PodLister,
 	cache internalcache.Cache,
-	podQueue internalqueue.SchedulingQueue,
+	podQueue framework.SchedulingQueue,
 ) *CacheDebugger {
 	return &CacheDebugger{
 		Comparer: CacheComparer{

--- a/pkg/scheduler/internal/cache/debugger/dumper.go
+++ b/pkg/scheduler/internal/cache/debugger/dumper.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/klog"
 
 	"k8s.io/api/core/v1"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
-	"k8s.io/kubernetes/pkg/scheduler/internal/queue"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
@@ -32,7 +32,7 @@ import (
 // scheduler logs for debugging purposes.
 type CacheDumper struct {
 	cache    internalcache.Cache
-	podQueue queue.SchedulingQueue
+	podQueue framework.SchedulingQueue
 }
 
 // DumpAll writes cached nodes and scheduling queue information to the scheduler logs.

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -59,7 +59,7 @@ import (
 
 // EmptyFramework is an empty framework used in tests.
 // Note: If the test runs in goroutine, please don't using this variable to avoid a race condition.
-var EmptyFramework, _ = framework.NewFramework(EmptyPluginRegistry, nil, EmptyPluginConfig)
+var EmptyFramework, _ = framework.NewFramework(EmptyPluginRegistry, nil, EmptyPluginConfig, nil, nil)
 
 // EmptyPluginConfig is an empty plugin config used in tests.
 var EmptyPluginConfig = []kubeschedulerconfig.PluginConfig{}
@@ -699,7 +699,7 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache internalcache.C
 }
 
 func setupTestSchedulerLongBindingWithRetry(queuedPodStore *clientcache.FIFO, scache internalcache.Cache, informerFactory informers.SharedInformerFactory, predicateMap map[string]predicates.FitPredicate, stop chan struct{}, bindingTime time.Duration) (*Scheduler, chan *v1.Binding) {
-	framework, _ := framework.NewFramework(EmptyPluginRegistry, nil, []kubeschedulerconfig.PluginConfig{})
+	framework, _ := framework.NewFramework(EmptyPluginRegistry, nil, []kubeschedulerconfig.PluginConfig{}, nil, nil)
 	algo := core.NewGenericScheduler(
 		scache,
 		internalqueue.NewSchedulingQueue(nil, nil),

--- a/pkg/scheduler/testutil.go
+++ b/pkg/scheduler/testutil.go
@@ -52,7 +52,7 @@ func (fc *FakeConfigurator) GetHardPodAffinitySymmetricWeight() int32 {
 }
 
 // MakeDefaultErrorFunc is not implemented yet.
-func (fc *FakeConfigurator) MakeDefaultErrorFunc(backoff *internalqueue.PodBackoffMap, podQueue internalqueue.SchedulingQueue) func(pod *v1.Pod, err error) {
+func (fc *FakeConfigurator) MakeDefaultErrorFunc(backoff *internalqueue.PodBackoffMap, podQueue framework.SchedulingQueue) func(pod *v1.Pod, err error) {
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/sig scheduling

**What this PR does / why we need it**:
Exposes `SchedulingQueue` from `FrameworkHandle`

**Which issue(s) this PR fixes**:
Fixes #77746

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Expose scheduling queue to scheduling framework plugins
```