### PR TITLE
Automated cherry pick of #71560: Don't log a warning to override hostname if there's no

### DIFF
--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -139,7 +139,7 @@ func NodeAddress(nodeIP net.IP, // typically Kubelet.nodeIP
 					// no existing Hostname address found, add it
 					glog.Warningf("adding overridden hostname of %v to cloudprovider-reported addresses", hostname)
 					nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeHostName, Address: hostname})
-				} else {
+				} else if existingHostnameAddress.Address != hostname {
 					// override the Hostname address reported by the cloud provider
 					glog.Warningf("replacing cloudprovider-reported hostname of %v with overridden hostname of %v", existingHostnameAddress.Address, hostname)
 					existingHostnameAddress.Address = hostname


### PR DESCRIPTION
Cherry pick of #71560 on release-1.12.

#71560: Don't log a warning to override hostname if there's no