### PR TITLE
CVE-2019-11248: /debug/pprof exposed on kubelet's healthz port

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -711,9 +711,10 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 	}
 
 	if s.HealthzPort > 0 {
-		healthz.DefaultHealthz()
+		mux := http.NewServeMux()
+		healthz.InstallHandler(mux)
 		go wait.Until(func() {
-			err := http.ListenAndServe(net.JoinHostPort(s.HealthzBindAddress, strconv.Itoa(int(s.HealthzPort))), nil)
+			err := http.ListenAndServe(net.JoinHostPort(s.HealthzBindAddress, strconv.Itoa(int(s.HealthzPort))), mux)
 			if err != nil {
 				klog.Errorf("Starting healthz server failed: %v", err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/doc.go
@@ -17,5 +17,5 @@ limitations under the License.
 // Package healthz implements basic http server health checking.
 // Usage:
 //   import "k8s.io/apiserver/pkg/server/healthz"
-//   healthz.DefaultHealthz()
+//   healthz.InstallHandler(mux)
 package healthz // import "k8s.io/apiserver/pkg/server/healthz"

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -37,15 +37,6 @@ type HealthzChecker interface {
 	Check(req *http.Request) error
 }
 
-var defaultHealthz = sync.Once{}
-
-// DefaultHealthz installs the default healthz check to the http.DefaultServeMux.
-func DefaultHealthz(checks ...HealthzChecker) {
-	defaultHealthz.Do(func() {
-		InstallHandler(http.DefaultServeMux, checks...)
-	})
-}
-
 // PingHealthz returns true automatically when checked
 var PingHealthz HealthzChecker = ping{}
 


### PR DESCRIPTION
Fixes #81023

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Using the default server mux is an anti-pattern, with similar concerns to global variables & flags.

Move the Kubelet's healthz server off of the default mux, and remove the default healthz method to discourage its use.

**Does this PR introduce a user-facing change?**:
```release-note
Fixes CVE-2019-11248: /debug/pprof exposed on kubelet's healthz port
```

/sig node
/assign @dashpole 