### PR TITLE
Set containerd oom score adj to -999.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2899,6 +2899,7 @@ EOF
   cat > "${config_path}" <<EOF
 # Kubernetes doesn't use containerd restart manager.
 disabled_plugins = ["restart"]
+oom_score = -999
 
 [debug]
   level = "${CONTAINERD_LOG_LEVEL:-"info"}"


### PR DESCRIPTION
As a critical system daemon, containerd should have max killable oom score adj.

Signed-off-by: Lantao Liu <lantaol@google.com>

```release-note
none
```
