### PR TITLE
Scheduler changes to introduce alpha support for Pod Overhead

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -726,6 +726,9 @@ func (c *VolumeZoneChecker) predicate(pod *v1.Pod, meta PredicateMetadata, nodeI
 // the max in each dimension iteratively. In contrast, we sum the resource vectors for
 // regular containers since they run simultaneously.
 //
+// If Pod Overhead is specified and the feature gate is set, the resources defined for Overhead
+// are added to the calculated Resource request sum
+//
 // Example:
 //
 // Pod:
@@ -754,6 +757,11 @@ func GetResourceRequest(pod *v1.Pod) *schedulernodeinfo.Resource {
 	// take max_resource(sum_pod, any_init_container)
 	for _, container := range pod.Spec.InitContainers {
 		result.SetMaxResource(container.Resources.Requests)
+	}
+
+	// If Overhead is being utilized, add to the total requests for the pod
+	if pod.Spec.Overhead != nil && utilfeature.DefaultFeatureGate.Enabled(features.PodOverhead) {
+		result.Add(pod.Spec.Overhead)
 	}
 
 	return result

--- a/pkg/scheduler/nodeinfo/BUILD
+++ b/pkg/scheduler/nodeinfo/BUILD
@@ -11,12 +11,14 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
+        "//pkg/features:go_default_library",
         "//pkg/scheduler/algorithm/priorities/util:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/storage/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )
@@ -30,11 +32,14 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/nodeinfo/node_info_test.go
+++ b/pkg/scheduler/nodeinfo/node_info_test.go
@@ -26,6 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 func TestNewResource(t *testing.T) {
@@ -540,6 +543,9 @@ func TestNodeInfoClone(t *testing.T) {
 }
 
 func TestNodeInfoAddPod(t *testing.T) {
+
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodOverhead, true)()
+
 	nodeName := "test-node"
 	pods := []*v1.Pod{
 		{
@@ -567,6 +573,9 @@ func TestNodeInfoAddPod(t *testing.T) {
 					},
 				},
 				NodeName: nodeName,
+				Overhead: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("500m"),
+				},
 			},
 		},
 		{
@@ -580,8 +589,7 @@ func TestNodeInfoAddPod(t *testing.T) {
 					{
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("200m"),
-								v1.ResourceMemory: resource.MustParse("1Ki"),
+								v1.ResourceCPU: resource.MustParse("200m"),
 							},
 						},
 						Ports: []v1.ContainerPort{
@@ -594,6 +602,10 @@ func TestNodeInfoAddPod(t *testing.T) {
 					},
 				},
 				NodeName: nodeName,
+				Overhead: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("500m"),
+					v1.ResourceMemory: resource.MustParse("500"),
+				},
 			},
 		},
 	}
@@ -604,15 +616,15 @@ func TestNodeInfoAddPod(t *testing.T) {
 			},
 		},
 		requestedResource: &Resource{
-			MilliCPU:         300,
-			Memory:           1524,
+			MilliCPU:         1300,
+			Memory:           1000,
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
 		},
 		nonzeroRequest: &Resource{
-			MilliCPU:         300,
-			Memory:           1524,
+			MilliCPU:         1300,
+			Memory:           209716200, //200MB + 1000 specified in requests/overhead
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
@@ -653,6 +665,9 @@ func TestNodeInfoAddPod(t *testing.T) {
 						},
 					},
 					NodeName: nodeName,
+					Overhead: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("500m"),
+					},
 				},
 			},
 			{
@@ -666,8 +681,7 @@ func TestNodeInfoAddPod(t *testing.T) {
 						{
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse("200m"),
-									v1.ResourceMemory: resource.MustParse("1Ki"),
+									v1.ResourceCPU: resource.MustParse("200m"),
 								},
 							},
 							Ports: []v1.ContainerPort{
@@ -680,6 +694,10 @@ func TestNodeInfoAddPod(t *testing.T) {
 						},
 					},
 					NodeName: nodeName,
+					Overhead: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("500m"),
+						v1.ResourceMemory: resource.MustParse("500"),
+					},
 				},
 			},
 		},
@@ -702,10 +720,21 @@ func TestNodeInfoAddPod(t *testing.T) {
 }
 
 func TestNodeInfoRemovePod(t *testing.T) {
+
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodOverhead, true)()
+
 	nodeName := "test-node"
 	pods := []*v1.Pod{
 		makeBasePod(t, nodeName, "test-1", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}}),
 		makeBasePod(t, nodeName, "test-2", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
+	}
+
+	// add pod Overhead
+	for _, pod := range pods {
+		pod.Spec.Overhead = v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("500m"),
+			v1.ResourceMemory: resource.MustParse("500"),
+		}
 	}
 
 	tests := []struct {
@@ -723,15 +752,15 @@ func TestNodeInfoRemovePod(t *testing.T) {
 					},
 				},
 				requestedResource: &Resource{
-					MilliCPU:         300,
-					Memory:           1524,
+					MilliCPU:         1300,
+					Memory:           2524,
 					EphemeralStorage: 0,
 					AllowedPodNumber: 0,
 					ScalarResources:  map[v1.ResourceName]int64(nil),
 				},
 				nonzeroRequest: &Resource{
-					MilliCPU:         300,
-					Memory:           1524,
+					MilliCPU:         1300,
+					Memory:           2524,
 					EphemeralStorage: 0,
 					AllowedPodNumber: 0,
 					ScalarResources:  map[v1.ResourceName]int64(nil),
@@ -772,6 +801,10 @@ func TestNodeInfoRemovePod(t *testing.T) {
 								},
 							},
 							NodeName: nodeName,
+							Overhead: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("500m"),
+								v1.ResourceMemory: resource.MustParse("500"),
+							},
 						},
 					},
 					{
@@ -799,6 +832,10 @@ func TestNodeInfoRemovePod(t *testing.T) {
 								},
 							},
 							NodeName: nodeName,
+							Overhead: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("500m"),
+								v1.ResourceMemory: resource.MustParse("500"),
+							},
 						},
 					},
 				},
@@ -830,6 +867,10 @@ func TestNodeInfoRemovePod(t *testing.T) {
 						},
 					},
 					NodeName: nodeName,
+					Overhead: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("500m"),
+						v1.ResourceMemory: resource.MustParse("500"),
+					},
 				},
 			},
 			errExpected: false,
@@ -840,15 +881,15 @@ func TestNodeInfoRemovePod(t *testing.T) {
 					},
 				},
 				requestedResource: &Resource{
-					MilliCPU:         200,
-					Memory:           1024,
+					MilliCPU:         700,
+					Memory:           1524,
 					EphemeralStorage: 0,
 					AllowedPodNumber: 0,
 					ScalarResources:  map[v1.ResourceName]int64(nil),
 				},
 				nonzeroRequest: &Resource{
-					MilliCPU:         200,
-					Memory:           1024,
+					MilliCPU:         700,
+					Memory:           1524,
 					EphemeralStorage: 0,
 					AllowedPodNumber: 0,
 					ScalarResources:  map[v1.ResourceName]int64(nil),
@@ -888,6 +929,10 @@ func TestNodeInfoRemovePod(t *testing.T) {
 								},
 							},
 							NodeName: nodeName,
+							Overhead: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("500m"),
+								v1.ResourceMemory: resource.MustParse("500"),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds initial support for alpha-feature PodOverhead as part of the changes described in the  [Pod Overhead KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20190226-pod-overhead.md).

**Special notes for your reviewer**:

This just handles requests, and as is doesn't provide great error messages.  May want to do further refactoring, separating explicit requests from the pod overhead in order to provide better error messages.
 
```release-note
Introduction of the pod overhead feature to the scheduler.  This functionality is alpha-level as of 
Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.gate. 
```
