### PR TITLE
Add a special-cased runtime handler for dockershim

### DIFF
--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -96,7 +96,7 @@ func (ds *dockerService) RunPodSandbox(ctx context.Context, r *runtimeapi.RunPod
 	}
 
 	// Step 2: Create the sandbox container.
-	if r.GetRuntimeHandler() != "" {
+	if r.GetRuntimeHandler() != "" && r.GetRuntimeHandler() != runtimeName {
 		return nil, fmt.Errorf("RuntimeHandler %q not supported", r.GetRuntimeHandler())
 	}
 	createConfig, err := ds.makeSandboxDockerConfig(config, image)

--- a/test/e2e/common/runtimeclass.go
+++ b/test/e2e/common/runtimeclass.go
@@ -38,6 +38,9 @@ const (
 	// PreconfiguredRuntimeHandler is the name of the runtime handler that is expected to be
 	// preconfigured in the test environment.
 	PreconfiguredRuntimeHandler = "test-handler"
+	// DockerRuntimeHandler is a hardcoded runtime handler that is accepted by dockershim, and
+	// treated equivalently to a nil runtime handler.
+	DockerRuntimeHandler = "docker"
 )
 
 var _ = Describe("[sig-node] RuntimeClass", func() {
@@ -59,9 +62,12 @@ var _ = Describe("[sig-node] RuntimeClass", func() {
 	// This test requires that the PreconfiguredRuntimeHandler has already been set up on nodes.
 	It("should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]", func() {
 		// The built-in docker runtime does not support configuring runtime handlers.
-		framework.SkipIfContainerRuntimeIs("docker")
+		handler := PreconfiguredRuntimeHandler
+		if framework.TestContext.ContainerRuntime == "docker" {
+			handler = DockerRuntimeHandler
+		}
 
-		rcName := createRuntimeClass(f, "preconfigured-handler", PreconfiguredRuntimeHandler)
+		rcName := createRuntimeClass(f, "preconfigured-handler", handler)
 		pod := createRuntimeClassPod(f, rcName)
 		expectPodSuccess(f, pod)
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
In the RuntimeClass beta API released with v1.14, the runtime Handler field is no longer permitted to be empty. Since dockershim doesn't accept a non-empty runtime handler, it means that pods run with docker shim must leave RuntimeClass empty.

This PR adds a hard coded runtime handler that is accepted by dockershim, the `docker` handler. This lets dockershim nodes take advantage of the new scheduling & overhead features being added to runtime class, and also lets us test handler usage in the cluster E2E tests running on docker.

**Does this PR introduce a user-facing change?**:
```release-note
The dockershim container runtime now accepts the `docker` runtime handler from a RuntimeClass.
```

/sig node
/priority important-soon
/cc @egernst @yastij 
/assign @yujuhong 
/milestone v1.15