### PR TITLE
fix test flake when kubectl e2e and crd-openapi e2e run in parallel

### DIFF
--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -598,4 +598,6 @@ properties:
     properties:
       bars:
         description: List of Bars and their statuses.
-        type: array`)
+        type: array
+        items:
+          type: object`)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Fixes test flake. [kubectl e2e test](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/kubectl/kubectl.go) may fail if it runs in parallel with [crd openapi e2e test](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/apimachinery/crd_publish_openapi.go): 

https://storage.googleapis.com/k8s-gubernator/triage/index.html?text=array%20should%20have%20exactly%20one%20sub-item&test=%5C%5Bsig%5C-cli%5C%5D%5C%20Kubectl

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
mitigates https://github.com/kubernetes/kubernetes/pull/78234#issuecomment-495821109

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @sttts @liggitt 