### PR TITLE
not check initContianer status when all container status is running

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1047,6 +1047,39 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
 			},
 		},
+		"next init container to run status is nil and all container's status is running; do nothing": {
+			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyAlways },
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				status.ContainerStatuses = []*kubecontainer.ContainerStatus{
+					{
+						ID:   kubecontainer.ContainerID{ID: "initid1"},
+						Name: "init1", State: kubecontainer.ContainerStateExited,
+						Hash: kubecontainer.HashContainer(&basePod.Spec.InitContainers[0]),
+					},
+					{
+						ID:   kubecontainer.ContainerID{ID: "initid2"},
+						Name: "init2", State: kubecontainer.ContainerStateExited,
+						Hash: kubecontainer.HashContainer(&basePod.Spec.InitContainers[1]),
+					},
+					{
+						ID:   kubecontainer.ContainerID{ID: "id1"},
+						Name: "foo1", State: kubecontainer.ContainerStateRunning,
+						Hash: kubecontainer.HashContainer(&basePod.Spec.Containers[0]),
+					},
+					{
+						ID:   kubecontainer.ContainerID{ID: "id2"},
+						Name: "foo2", State: kubecontainer.ContainerStateRunning,
+						Hash: kubecontainer.HashContainer(&basePod.Spec.Containers[1]),
+					},
+					{
+						ID:   kubecontainer.ContainerID{ID: "id3"},
+						Name: "foo3", State: kubecontainer.ContainerStateRunning,
+						Hash: kubecontainer.HashContainer(&basePod.Spec.Containers[2]),
+					},
+				}
+			},
+			actions: noAction,
+		},
 	} {
 		pod, status := makeBasePodAndStatusWithInitContainers()
 		if test.mutatePodFn != nil {


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
initContainers will be removed when --maximum-dead-containers or --maximum-dead-containers-per-container is satisfied.
Then initContainer's status will be nil, and initContainers will be think as not done. 
computePodActions  return changes and initContainer be recreated.
This may cause init setting error,because the pod has been running for a period and setting has been changed.
on the other hand, when the initContainer exited, it will be gc again and then be created again.
This process will be done again and again.






**Which issue(s) this PR fixes**:
Fixes  #77859

**Special notes for your reviewer**:
how i found this:
create pod by yaml
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp-pod
  labels:
    app: myapp
spec:
  containers:
  - name: myapp-container
    image: busybox
    command: ['sh', '-c', 'echo The app is running! && sleep 3600']
  initContainers:
  - name: init-myservice
    image: busybox
    command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
  - name: init-mydb
    image: busybox
    command: ['sh', '-c', 'until nslookup mydb; do echo waiting for mydb; sleep 2; done;']
```
```yaml
kind: Service
apiVersion: v1
metadata:
  name: myservice
spec:
  ports:
    - protocol: TCP
      port: 80
      targetPort: 9376
---
kind: Service
apiVersion: v1
metadata:
  name: mydb
spec:
  ports:
    - protocol: TCP
      port: 80
      targetPort: 9377
```
when gc happened, if the last initContainer init-mydb is removed, init-mydb is recreated.
if the initContainer init-myservice, it is ok.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
