### PR TITLE
Return early if alwaysCheckAllPredicates is false in podFitsOnNode

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -653,7 +653,7 @@ func podFitsOnNode(
 						klog.V(5).Infoln("since alwaysCheckAllPredicates has not been set, the predicate " +
 							"evaluation is short circuited and there are chances " +
 							"of other predicates failing as well.")
-						break
+						return len(failedPredicates) == 0, failedPredicates, nil
 					}
 				}
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently in podFitsOnNode, if alwaysCheckAllPredicates is false, break statement is used inside the inner loop. However, if this is from the first iteration of outer loop, the outer loop may run again.

This PR replaces the break with return so that the second iteration of the outer loop is skipped.

```release-note
NONE
```
