### PR TITLE
[WIP] Replace integer.RoundToInt32() calls with math.Round()

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -504,7 +504,7 @@ func getReplicaSetFraction(rs apps.ReplicaSet, d apps.Deployment) int32 {
 	// We should never proportionally scale up from zero which means rs.spec.replicas and annotatedReplicas
 	// will never be zero here.
 	newRSsize := (float64(*(rs.Spec.Replicas) * deploymentReplicas)) / float64(annotatedReplicas)
-	return integer.RoundToInt32(newRSsize) - *(rs.Spec.Replicas)
+	return int32(math.Round(newRSsize)) - *(rs.Spec.Replicas)
 }
 
 // GetAllReplicaSets returns the old and new replica sets targeted by the given Deployment. It gets PodList and ReplicaSetList from client interface.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

To remove `integer.RoundToInt32()` from `k/utils` since it's buggy.

**Which issue(s) this PR fixes**:

Addresses [k/utils#78](https://github.com/kubernetes/utils/pull/78)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
