### PR TITLE
Add go-bindata dependency installation

### DIFF
--- a/translations/README.md
+++ b/translations/README.md
@@ -41,6 +41,14 @@ file. `poedit` does this automatically on save, but you can also run
 We use the English translation as the `msgid`.
 
 ## Regenerating the bindata file
+
+With the `mo` files up to date, you can now convert the generated files
+into code using `go-bindata` command which can be installed with:
+
+```console
+go get github.com/go-bindata/go-bindata/...
+```
+
 Run `./hack/generate-bindata.sh`, this will turn the translation files
 into generated code which will in turn be packaged into the Kubernetes
 binaries.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The `./hack/generate-bindata.sh` script requires the `go-bindata` command to be installed. This PR adds information about the dependency and how to install it.

**Special notes for your reviewer**:

I'm working on #78352 and had to install this dependency to start working on the issue.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```