### PR TITLE
Break out of loop when currentRevision is found in defaultStatefulSetControl#getStatefulSetRevisions

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -231,6 +231,7 @@ func (ssc *defaultStatefulSetControl) getStatefulSetRevisions(
 	for i := range revisions {
 		if revisions[i].Name == set.Status.CurrentRevision {
 			currentRevision = revisions[i]
+			break
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In defaultStatefulSetControl#getStatefulSetRevisions, once the currentRevision is found, we can break out of the loop.

```release-note
NONE
```
