### PR TITLE
Call removeContainer even if killContainer returns error

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -136,7 +136,6 @@ func (cgc *containerGC) removeOldestN(containers []containerGCInfo, toRemove int
 			message := "Container is in unknown state, try killing it before removal"
 			if err := cgc.manager.killContainer(nil, id, containers[i].name, message, nil); err != nil {
 				klog.Errorf("Failed to stop container %q: %v", containers[i].id, err)
-				continue
 			}
 		}
 		if err := cgc.manager.removeContainer(containers[i].id); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently containerGC#removeOldestN skips calling removeContainer when killContainer returns error.

However, removeOldestN returns only numToKeep containers *and* kubeGenericRuntimeManager#killContainer may have called m.containerRefManager.ClearRef

This PR calls removeContainer even if killContainer returns error.

```release-note
NONE
```
