### PR TITLE
Call getKubeletSandboxes first in containerGC#evictSandboxes

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -277,15 +277,15 @@ func (cgc *containerGC) evictSandboxes(evictTerminatedPods bool) error {
 		return err
 	}
 
+	sandboxes, err := cgc.manager.getKubeletSandboxes(true)
+	if err != nil {
+		return err
+	}
+
 	// collect all the PodSandboxId of container
 	sandboxIDs := sets.NewString()
 	for _, container := range containers {
 		sandboxIDs.Insert(container.PodSandboxId)
-	}
-
-	sandboxes, err := cgc.manager.getKubeletSandboxes(true)
-	if err != nil {
-		return err
 	}
 
 	sandboxesByPod := make(sandboxesByPodUID)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In containerGC#evictSandboxes, we use sandboxIDs to collect PodSandboxId's.
Later cgc.manager.getKubeletSandboxes is called which may return error.

This PR swaps the order of these two activities so that if cgc.manager.getKubeletSandboxes returns error, we don't collect PodSandboxId's.

```release-note
NONE
```
