### PR TITLE
Remove conntrack max from proxy tests in kubeadm

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -452,7 +452,6 @@ func TestValidateInitConfiguration(t *testing.T) {
 								MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
 							},
 							Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-								Max:                   utilpointer.Int32Ptr(2),
 								MaxPerCore:            utilpointer.Int32Ptr(1),
 								Min:                   utilpointer.Int32Ptr(1),
 								TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
@@ -499,7 +498,6 @@ func TestValidateInitConfiguration(t *testing.T) {
 								MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
 							},
 							Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-								Max:                   utilpointer.Int32Ptr(2),
 								MaxPerCore:            utilpointer.Int32Ptr(1),
 								Min:                   utilpointer.Int32Ptr(1),
 								TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},

--- a/cmd/kubeadm/app/componentconfigs/validation_test.go
+++ b/cmd/kubeadm/app/componentconfigs/validation_test.go
@@ -57,7 +57,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 							MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
 						},
 						Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-							Max:                   utilpointer.Int32Ptr(2),
 							MaxPerCore:            utilpointer.Int32Ptr(1),
 							Min:                   utilpointer.Int32Ptr(1),
 							TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
@@ -90,7 +89,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 							MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
 						},
 						Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-							Max:                   utilpointer.Int32Ptr(2),
 							MaxPerCore:            utilpointer.Int32Ptr(1),
 							Min:                   utilpointer.Int32Ptr(1),
 							TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
@@ -124,7 +122,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 							MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
 						},
 						Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-							Max:                   utilpointer.Int32Ptr(2),
 							MaxPerCore:            utilpointer.Int32Ptr(1),
 							Min:                   utilpointer.Int32Ptr(1),
 							TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
@@ -158,7 +155,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 							MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
 						},
 						Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-							Max:                   utilpointer.Int32Ptr(2),
 							MaxPerCore:            utilpointer.Int32Ptr(1),
 							Min:                   utilpointer.Int32Ptr(1),
 							TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
@@ -192,7 +188,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 							MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
 						},
 						Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-							Max:                   utilpointer.Int32Ptr(2),
 							MaxPerCore:            utilpointer.Int32Ptr(1),
 							Min:                   utilpointer.Int32Ptr(1),
 							TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
@@ -226,7 +221,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 							MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
 						},
 						Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-							Max:                   utilpointer.Int32Ptr(2),
 							MaxPerCore:            utilpointer.Int32Ptr(1),
 							Min:                   utilpointer.Int32Ptr(1),
 							TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
@@ -260,7 +254,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 							MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
 						},
 						Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-							Max:                   utilpointer.Int32Ptr(2),
 							MaxPerCore:            utilpointer.Int32Ptr(1),
 							Min:                   utilpointer.Int32Ptr(1),
 							TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
@@ -211,7 +211,6 @@ func TestEnsureProxyAddon(t *testing.T) {
 				HealthzBindAddress: "0.0.0.0:10256",
 				MetricsBindAddress: "127.0.0.1:10249",
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					Max:                   pointer.Int32Ptr(2),
 					MaxPerCore:            pointer.Int32Ptr(1),
 					Min:                   pointer.Int32Ptr(1),
 					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},

--- a/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/internal.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/internal.yaml
@@ -39,7 +39,6 @@ ComponentConfigs:
     ClusterCIDR: ""
     ConfigSyncPeriod: 15m0s
     Conntrack:
-      Max: null
       MaxPerCore: 32768
       Min: 131072
       TCPCloseWaitTimeout: 1h0m0s

--- a/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/internal_non_linux.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/internal_non_linux.yaml
@@ -39,7 +39,6 @@ ComponentConfigs:
     ClusterCIDR: ""
     ConfigSyncPeriod: 15m0s
     Conntrack:
-      Max: null
       MaxPerCore: 32768
       Min: 131072
       TCPCloseWaitTimeout: 1h0m0s

--- a/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/v1beta1.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/v1beta1.yaml
@@ -61,7 +61,6 @@ clientConnection:
 clusterCIDR: ""
 configSyncPeriod: 15m0s
 conntrack:
-  max: null
   maxPerCore: 32768
   min: 131072
   tcpCloseWaitTimeout: 1h0m0s

--- a/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/v1beta1_non_linux.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/v1beta1_non_linux.yaml
@@ -61,7 +61,6 @@ clientConnection:
 clusterCIDR: ""
 configSyncPeriod: 15m0s
 conntrack:
-  max: null
   maxPerCore: 32768
   min: 131072
   tcpCloseWaitTimeout: 1h0m0s

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted.yaml
@@ -50,7 +50,6 @@ clientConnection:
 clusterCIDR: 10.148.0.0/16
 configSyncPeriod: 15m0s
 conntrack:
-  max: null
   maxPerCore: 32768
   min: 131072
   tcpCloseWaitTimeout: 1h0m0s

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted_non_linux.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted_non_linux.yaml
@@ -50,7 +50,6 @@ clientConnection:
 clusterCIDR: 10.148.0.0/16
 configSyncPeriod: 15m0s
 conntrack:
-  max: null
   maxPerCore: 32768
   min: 131072
   tcpCloseWaitTimeout: 1h0m0s


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**: We're removing the deprecated flag ``--conntrack-max`` from kube-proxy but the tests are failing because of kubeadm test files still uses this flag.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
