### PR TITLE
Sort init container statuses using non-nested loop

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1545,18 +1545,17 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 		statuses[container.Name] = status
 	}
 
+	// Sort the container statuses since clients of this interface expect the list
+	// of containers in a pod has a deterministic order.
+	if isInitContainer {
+		return kubetypes.SortStatusesOfInitContainers(pod, statuses)
+	}
 	var containerStatuses []v1.ContainerStatus
 	for _, status := range statuses {
 		containerStatuses = append(containerStatuses, *status)
 	}
 
-	// Sort the container statuses since clients of this interface expect the list
-	// of containers in a pod has a deterministic order.
-	if isInitContainer {
-		kubetypes.SortInitContainerStatuses(pod, containerStatuses)
-	} else {
-		sort.Sort(kubetypes.SortedContainerStatuses(containerStatuses))
-	}
+	sort.Sort(kubetypes.SortedContainerStatuses(containerStatuses))
 	return containerStatuses
 }
 

--- a/pkg/kubelet/types/types.go
+++ b/pkg/kubelet/types/types.go
@@ -85,6 +85,17 @@ func SortInitContainerStatuses(p *v1.Pod, statuses []v1.ContainerStatus) {
 	}
 }
 
+func SortStatusesOfInitContainers(p *v1.Pod, statusMap map[string]*v1.ContainerStatus) []v1.ContainerStatus {
+	containers := p.Spec.InitContainers
+	statuses := []v1.ContainerStatus{}
+	for _, container := range containers {
+		if status, found := statusMap[container.Name]; found {
+			statuses = append(statuses, *status)
+		}
+	}
+	return statuses
+}
+
 // Reservation represents reserved resources for non-pod components.
 type Reservation struct {
 	// System represents resources reserved for non-kubernetes components.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
At the end of Kubelet#convertToAPIContainerStatuses, we concatenate ContainerStatus' into an array and loop over p.Spec.InitContainers to ensure correct ordering.

The loop is nested.

This PR skips the concatenation step and uses the statuses map to achieve sorting with single loop.

```release-note
NONE
```
