### PR TITLE
remove some codes never used in proxier_test

### DIFF
--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -107,24 +107,6 @@ func (fake *fakeIPSetVersioner) GetVersion() (string, error) {
 	return fake.version, fake.err
 }
 
-// New returns a new FakeSysctl
-func NewFakeSysctl() *FakeSysctl {
-	return &FakeSysctl{}
-}
-
-type FakeSysctl struct {
-}
-
-// GetSysctl returns the value for the specified sysctl setting
-func (fakeSysctl *FakeSysctl) GetSysctl(sysctl string) (int, error) {
-	return 1, nil
-}
-
-// SetSysctl modifies the specified sysctl flag to the new value
-func (fakeSysctl *FakeSysctl) SetSysctl(sysctl string, newVal int) error {
-	return nil
-}
-
 func NewFakeProxier(ipt utiliptables.Interface, ipvs utilipvs.Interface, ipset utilipset.Interface, nodeIPs []net.IP, excludeCIDRs []*net.IPNet) *Proxier {
 	fcmd := fakeexec.FakeCmd{
 		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
some codes have been here for one year and never been used , so  i guess maybe it wouldn't be used forever and them.

Which issue(s) this PR fixes:
Fixes #

/release-note-none
/priority backlog