### PR TITLE
tests: Replaces images used with agnhost (part 1)

### DIFF
--- a/test/e2e/auth/node_authn.go
+++ b/test/e2e/auth/node_authn.go
@@ -97,7 +97,7 @@ func createNodeAuthTestPod(f *framework.Framework) *v1.Pod {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{{
 				Name:    "test-node-authn",
-				Image:   imageutils.GetE2EImage(imageutils.Hostexec),
+				Image:   imageutils.GetE2EImage(imageutils.Agnhost),
 				Command: []string{"sleep", "3600"},
 			}},
 			RestartPolicy: v1.RestartPolicyNever,

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -341,8 +341,8 @@ func livenessPodSpec(readinessProbe, livenessProbe *v1.Probe) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:           "liveness",
-					Image:          imageutils.GetE2EImage(imageutils.Liveness),
-					Command:        []string{"/server"},
+					Image:          imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:           []string{"liveness"},
 					LivenessProbe:  livenessProbe,
 					ReadinessProbe: readinessProbe,
 				},

--- a/test/e2e/common/lifecycle_hook.go
+++ b/test/e2e/common/lifecycle_hook.go
@@ -103,7 +103,7 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 					},
 				},
 			}
-			podWithHook := getPodWithHook("pod-with-poststart-exec-hook", imageutils.GetE2EImage(imageutils.Hostexec), lifecycle)
+			podWithHook := getPodWithHook("pod-with-poststart-exec-hook", imageutils.GetE2EImage(imageutils.Agnhost), lifecycle)
 			testPodWithHook(podWithHook)
 		})
 		/*
@@ -119,7 +119,7 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 					},
 				},
 			}
-			podWithHook := getPodWithHook("pod-with-prestop-exec-hook", imageutils.GetE2EImage(imageutils.Hostexec), lifecycle)
+			podWithHook := getPodWithHook("pod-with-prestop-exec-hook", imageutils.GetE2EImage(imageutils.Agnhost), lifecycle)
 			testPodWithHook(podWithHook)
 		})
 		/*

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -48,29 +48,28 @@ var CurrentSuite Suite
 // only used by node e2e test.
 // TODO(random-liu): Change the image puller pod to use similar mechanism.
 var CommonImageWhiteList = sets.NewString(
+	imageutils.GetE2EImage(imageutils.Agnhost),
 	imageutils.GetE2EImage(imageutils.AuditProxy),
 	imageutils.GetE2EImage(imageutils.BusyBox),
 	imageutils.GetE2EImage(imageutils.EntrypointTester),
 	imageutils.GetE2EImage(imageutils.IpcUtils),
-	imageutils.GetE2EImage(imageutils.Liveness),
 	imageutils.GetE2EImage(imageutils.Mounttest),
 	imageutils.GetE2EImage(imageutils.MounttestUser),
 	imageutils.GetE2EImage(imageutils.Netexec),
 	imageutils.GetE2EImage(imageutils.Nginx),
 	imageutils.GetE2EImage(imageutils.ServeHostname),
 	imageutils.GetE2EImage(imageutils.TestWebserver),
-	imageutils.GetE2EImage(imageutils.Hostexec),
 	imageutils.GetE2EImage(imageutils.VolumeNFSServer),
 	imageutils.GetE2EImage(imageutils.VolumeGlusterServer),
 	imageutils.GetE2EImage(imageutils.Net),
 )
 
 type testImagesStruct struct {
+	AgnhostImage      string
 	BusyBoxImage      string
 	GBFrontendImage   string
 	GBRedisSlaveImage string
 	KittenImage       string
-	LivenessImage     string
 	MounttestImage    string
 	NautilusImage     string
 	NginxImage        string
@@ -83,11 +82,11 @@ var testImages testImagesStruct
 
 func init() {
 	testImages = testImagesStruct{
+		imageutils.GetE2EImage(imageutils.Agnhost),
 		imageutils.GetE2EImage(imageutils.BusyBox),
 		imageutils.GetE2EImage(imageutils.GBFrontend),
 		imageutils.GetE2EImage(imageutils.GBRedisSlave),
 		imageutils.GetE2EImage(imageutils.Kitten),
-		imageutils.GetE2EImage(imageutils.Liveness),
 		imageutils.GetE2EImage(imageutils.Mounttest),
 		imageutils.GetE2EImage(imageutils.Nautilus),
 		imageutils.GetE2EImage(imageutils.Nginx),

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -470,8 +470,8 @@ func NewExecPodSpec(ns, name string, hostNetwork bool) *v1.Pod {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:            "hostexec",
-					Image:           imageutils.GetE2EImage(imageutils.Hostexec),
+					Name:            "agnhost",
+					Image:           imageutils.GetE2EImage(imageutils.Agnhost),
 					ImagePullPolicy: v1.PullIfNotPresent,
 				},
 			},

--- a/test/e2e/instrumentation/logging/utils/logging_pod.go
+++ b/test/e2e/instrumentation/logging/utils/logging_pod.go
@@ -105,17 +105,8 @@ func (p *loadLoggingPod) Start(f *framework.Framework) error {
 			Containers: []api_v1.Container{
 				{
 					Name:  loggingContainerName,
-					Image: imageutils.GetE2EImage(imageutils.LogsGenerator),
-					Env: []api_v1.EnvVar{
-						{
-							Name:  "LOGS_GENERATOR_LINES_TOTAL",
-							Value: strconv.Itoa(p.expectedLinesCount),
-						},
-						{
-							Name:  "LOGS_GENERATOR_DURATION",
-							Value: p.runDuration.String(),
-						},
-					},
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"logs-generator", "-log-lines-total", strconv.Itoa(p.expectedLinesCount), "-run-duration", p.runDuration.String()},
 					Resources: api_v1.ResourceRequirements{
 						Requests: api_v1.ResourceList{
 							api_v1.ResourceCPU: *resource.NewMilliQuantity(

--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -84,7 +84,8 @@ func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string, bi
 				},
 				{
 					Name:  "portforwardtester",
-					Image: imageutils.GetE2EImage(imageutils.PortForwardTester),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"port-forward-tester"},
 					Env: []v1.EnvVar{
 						{
 							Name:  "BIND_PORT",

--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -40,9 +40,6 @@ const (
 	testProxyPort = 31235 // Firewall rule allows external traffic on ports 30000-32767. I just picked a random one.
 )
 
-var testPodImage = imageutils.GetE2EImage(imageutils.NoSnatTest)
-var testProxyImage = imageutils.GetE2EImage(imageutils.NoSnatTestProxy)
-
 var (
 	testPod = v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -55,8 +52,8 @@ var (
 			Containers: []v1.Container{
 				{
 					Name:  "no-snat-test",
-					Image: testPodImage,
-					Args:  []string{"--port", strconv.Itoa(testPodPort)},
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"no-snat-test", "--port", strconv.Itoa(testPodPort)},
 					Env: []v1.EnvVar{
 						{
 							Name:      "POD_IP",
@@ -77,8 +74,8 @@ var (
 			Containers: []v1.Container{
 				{
 					Name:  "no-snat-test-proxy",
-					Image: testProxyImage,
-					Args:  []string{"--port", strconv.Itoa(testProxyPort)},
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"no-snat-test-proxy", "--port", strconv.Itoa(testProxyPort)},
 					Ports: []v1.ContainerPort{
 						{
 							ContainerPort: testProxyPort,

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -221,7 +221,8 @@ func createGitServer(f *framework.Framework) (gitURL string, gitRepo string, cle
 			Containers: []v1.Container{
 				{
 					Name:            "git-repo",
-					Image:           imageutils.GetE2EImage(imageutils.Fakegitserver),
+					Image:           imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:            []string{"fake-gitserver"},
 					ImagePullPolicy: "IfNotPresent",
 					Ports: []v1.ContainerPort{
 						{ContainerPort: int32(containerPort)},

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -139,14 +139,10 @@ const (
 	EntrypointTester
 	// Etcd image
 	Etcd
-	// Fakegitserver image
-	Fakegitserver
 	// GBFrontend image
 	GBFrontend
 	// GBRedisSlave image
 	GBRedisSlave
-	// Hostexec image
-	Hostexec
 	// InClusterClient image
 	InClusterClient
 	// Invalid image
@@ -161,10 +157,6 @@ const (
 	JessieDnsutils
 	// Kitten image
 	Kitten
-	// Liveness image
-	Liveness
-	// LogsGenerator image
-	LogsGenerator
 	// Mounttest image
 	Mounttest
 	// MounttestUser image
@@ -185,10 +177,6 @@ const (
 	Nonewprivs
 	// NonRoot runs with a default user of 1234
 	NonRoot
-	// NoSnatTest image
-	NoSnatTest
-	// NoSnatTestProxy image
-	NoSnatTestProxy
 	// Pause - when these values are updated, also update cmd/kubelet/app/options/container_runtime.go
 	// Pause image
 	Pause
@@ -196,8 +184,6 @@ const (
 	Perl
 	// Porter image
 	Porter
-	// PortForwardTester image
-	PortForwardTester
 	// PrometheusDummyExporter image
 	PrometheusDummyExporter
 	// PrometheusToSd image
@@ -232,7 +218,7 @@ func initImageConfigs() map[int]Config {
 	configs := map[int]Config{}
 	configs[CRDConversionWebhook] = Config{e2eRegistry, "crd-conversion-webhook", "1.13rev2"}
 	configs[AdmissionWebhook] = Config{e2eRegistry, "webhook", "1.15v1"}
-	configs[Agnhost] = Config{e2eRegistry, "agnhost", "1.0"}
+	configs[Agnhost] = Config{e2eRegistry, "agnhost", "2.0"}
 	configs[Alpine] = Config{dockerLibraryRegistry, "alpine", "3.7"}
 	configs[AuthenticatedAlpine] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[APIServer] = Config{e2eRegistry, "sample-apiserver", "1.10"}
@@ -247,10 +233,8 @@ func initImageConfigs() map[int]Config {
 	configs[EchoServer] = Config{e2eRegistry, "echoserver", "2.2"}
 	configs[EntrypointTester] = Config{e2eRegistry, "entrypoint-tester", "1.0"}
 	configs[Etcd] = Config{gcRegistry, "etcd", "3.3.10"}
-	configs[Fakegitserver] = Config{e2eRegistry, "fakegitserver", "1.0"}
 	configs[GBFrontend] = Config{sampleRegistry, "gb-frontend", "v6"}
 	configs[GBRedisSlave] = Config{sampleRegistry, "gb-redisslave", "v3"}
-	configs[Hostexec] = Config{e2eRegistry, "hostexec", "1.1"}
 	configs[InClusterClient] = Config{e2eRegistry, "inclusterclient", "1.0"}
 	configs[Invalid] = Config{gcRegistry, "invalid-image", "invalid-tag"}
 	configs[InvalidRegistryImage] = Config{invalidRegistry, "alpine", "3.1"}
@@ -258,8 +242,6 @@ func initImageConfigs() map[int]Config {
 	configs[Iperf] = Config{e2eRegistry, "iperf", "1.0"}
 	configs[JessieDnsutils] = Config{e2eRegistry, "jessie-dnsutils", "1.0"}
 	configs[Kitten] = Config{e2eRegistry, "kitten", "1.0"}
-	configs[Liveness] = Config{e2eRegistry, "liveness", "1.1"}
-	configs[LogsGenerator] = Config{e2eRegistry, "logs-generator", "1.0"}
 	configs[Mounttest] = Config{e2eRegistry, "mounttest", "1.0"}
 	configs[MounttestUser] = Config{e2eRegistry, "mounttest-user", "1.0"}
 	configs[Nautilus] = Config{e2eRegistry, "nautilus", "1.0"}
@@ -270,13 +252,10 @@ func initImageConfigs() map[int]Config {
 	configs[NginxNew] = Config{dockerLibraryRegistry, "nginx", "1.15-alpine"}
 	configs[Nonewprivs] = Config{e2eRegistry, "nonewprivs", "1.0"}
 	configs[NonRoot] = Config{e2eRegistry, "nonroot", "1.0"}
-	configs[NoSnatTest] = Config{e2eRegistry, "no-snat-test", "1.0"}
-	configs[NoSnatTestProxy] = Config{e2eRegistry, "no-snat-test-proxy", "1.0"}
 	// Pause - when these values are updated, also update cmd/kubelet/app/options/container_runtime.go
 	configs[Pause] = Config{gcRegistry, "pause", "3.1"}
 	configs[Perl] = Config{dockerLibraryRegistry, "perl", "5.26"}
 	configs[Porter] = Config{e2eRegistry, "porter", "1.0"}
-	configs[PortForwardTester] = Config{e2eRegistry, "port-forward-tester", "1.0"}
 	configs[PrometheusDummyExporter] = Config{e2eRegistry, "prometheus-dummy-exporter", "v0.1.0"}
 	configs[PrometheusToSd] = Config{e2eRegistry, "prometheus-to-sd", "v0.5.0"}
 	configs[Redis] = Config{e2eRegistry, "redis", "1.0"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

/sig testing

**What this PR does / why we need it**:

Quite a few images are only used a few times in a few tests. Thus, the images are being centralized into the agnhost image, reducing the number of images that have to be pulled and used.

This PR replaces the usage of the following images with agnhost:

- fakegitserver
- hostexec
- liveness
- logs-generator
- no-snat-test
- no-snat-test-proxy
- port-forward-tester

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related: #76342
Depends On: #78389

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
