### PR TITLE
Rebase Addon resizer to distroless (version 1.8.5)

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -78,7 +78,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=gcl
-        - image: k8s.gcr.io/addon-resizer:1.8.4
+        - image: k8s.gcr.io/addon-resizer:1.8.5
           name: heapster-nanny
           resources:
             limits:
@@ -114,7 +114,7 @@ spec:
             # Specifies the smallest cluster (defined in number of nodes)
             # resources will be scaled to.
             - --minClusterSize={{ heapster_min_cluster_size }}
-        - image: k8s.gcr.io/addon-resizer:1.8.4
+        - image: k8s.gcr.io/addon-resizer:1.8.5
           name: eventer-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -79,7 +79,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=gcl
-        - image: k8s.gcr.io/addon-resizer:1.8.4
+        - image: k8s.gcr.io/addon-resizer:1.8.5
           name: heapster-nanny
           resources:
             limits:
@@ -115,7 +115,7 @@ spec:
             # Specifies the smallest cluster (defined in number of nodes)
             # resources will be scaled to.
             - --minClusterSize={{ heapster_min_cluster_size }}
-        - image: k8s.gcr.io/addon-resizer:1.8.4
+        - image: k8s.gcr.io/addon-resizer:1.8.5
           name: eventer-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -78,7 +78,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: k8s.gcr.io/addon-resizer:1.8.4
+        - image: k8s.gcr.io/addon-resizer:1.8.5
           name: heapster-nanny
           resources:
             limits:
@@ -114,7 +114,7 @@ spec:
             # Specifies the smallest cluster (defined in number of nodes)
             # resources will be scaled to.
             - --minClusterSize={{ heapster_min_cluster_size }}
-        - image: k8s.gcr.io/addon-resizer:1.8.4
+        - image: k8s.gcr.io/addon-resizer:1.8.5
           name: eventer-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -81,7 +81,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         # END_PROMETHEUS_TO_SD
-        - image: k8s.gcr.io/addon-resizer:1.8.4
+        - image: k8s.gcr.io/addon-resizer:1.8.5
           name: heapster-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -59,7 +59,7 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
-        - image: k8s.gcr.io/addon-resizer:1.8.4
+        - image: k8s.gcr.io/addon-resizer:1.8.5
           name: heapster-nanny
           resources:
             limits:

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -63,7 +63,7 @@ spec:
           name: https
           protocol: TCP
       - name: metrics-server-nanny
-        image: k8s.gcr.io/addon-resizer:1.8.4
+        image: k8s.gcr.io/addon-resizer:1.8.5
         resources:
           limits:
             cpu: 100m

--- a/cluster/addons/prometheus/kube-state-metrics-deployment.yaml
+++ b/cluster/addons/prometheus/kube-state-metrics-deployment.yaml
@@ -39,7 +39,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: addon-resizer
-        image: k8s.gcr.io/addon-resizer:1.8.4
+        image: k8s.gcr.io/addon-resizer:1.8.5
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
Rebases addon-resizer to distroless

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Rebases addon-resizer, one of core Kubernetes addons to distroless. This is part of https://github.com/kubernetes/enhancements/blob/master/keps/sig-release/20190316-rebase-images-to-distroless.md

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
