### PR TITLE
Add linux container resources to fake runtime service

### DIFF
--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
@@ -43,6 +43,9 @@ type FakeContainer struct {
 	// ContainerStatus contains the runtime information for a container.
 	runtimeapi.ContainerStatus
 
+	// LinuxResources contains the resources specific to linux containers.
+	LinuxResources *runtimeapi.LinuxContainerResources
+
 	// the sandbox id of this container
 	SandboxID string
 }
@@ -327,7 +330,8 @@ func (r *FakeRuntimeService) CreateContainer(podSandboxID string, config *runtim
 			Labels:      config.Labels,
 			Annotations: config.Annotations,
 		},
-		SandboxID: podSandboxID,
+		SandboxID:      podSandboxID,
+		LinuxResources: config.GetLinux().GetResources(),
 	}
 
 	return containerID, nil


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

Adds linux container resources to the fake to be used by tests that require them.

```release-note
NONE
```

/assign @Random-Liu 