### PR TITLE
kubeadm: Update v1beta2 doc.go

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
@@ -20,30 +20,23 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm
 
 // Package v1beta2 defines the v1beta2 version of the kubeadm configuration file format.
-// This version graduates the configuration format to BETA and is a big step towards GA.
+// This version improves on the v1beta1 format by fixing some minor issues and adding a few new fields.
 //
-//A list of changes since v1alpha3:
-//	- "apiServerEndpoint" in InitConfiguration was renamed to "localAPIEndpoint" for better clarity of what the field
-//	represents.
-//	- Common fields in ClusterConfiguration such as "*extraArgs" and "*extraVolumes" for control plane components are now moved
-//	under component structs - i.e. "apiServer", "controllerManager", "scheduler".
-//	- "auditPolicy" was removed from ClusterConfiguration. Please use "extraArgs" in "apiServer" to configure this feature instead.
-//	- "unifiedControlPlaneImage" in ClusterConfiguration was changed to a boolean field called "useHyperKubeImage".
-//	- ClusterConfiguration now has a "dns" field which can be used to select and configure the cluster DNS addon.
-//	- "featureGates" still exists under ClusterConfiguration, but there are no supported feature gates in 1.13.
-//	See the Kubernetes 1.13 changelog for further details.
-//	- Both "localEtcd" and "dns" configurations now support custom image repositories.
-//	- The "controlPlane*"-related fields in JoinConfiguration were refactored into a sub-structure.
-//	- "clusterName" was removed from JoinConfiguration and the name is now fetched from the existing cluster.
+// A list of changes since v1beta1:
+//	- "certificateKey" field is added to InitConfiguration and JoinConfiguration.
+//	- "ignorePreflightErrors" field is added to the NodeRegistrationOptions.
+//	- The JSON "omitempty" tag is used in a more places where appropriate.
+//	- The JSON "omitempty" tag of the "taints" field (inside NodeRegistrationOptions) is removed.
+//	See the Kubernetes 1.15 changelog for further details.
 //
 // Migration from old kubeadm config versions
 //
-// Please convert your v1alpha3 configuration files to v1beta2 using the "kubeadm config migrate" command of kubeadm v1.13.x
+// Please convert your v1beta1 configuration files to v1beta2 using the "kubeadm config migrate" command of kubeadm v1.15.x
 // (conversion from older releases of kubeadm config files requires older release of kubeadm as well e.g.
-//	kubeadm v1.11 should be used to migrate v1alpha1 to v1alpha2; kubeadm v1.12 should be used to translate v1alpha2 to v1alpha3)
+//	kubeadm v1.11 should be used to migrate v1alpha1 to v1alpha2; kubeadm v1.12 should be used to translate v1alpha2 to v1alpha3;
+//	kubeadm v1.13 or v1.14 should be used to translate v1alpha3 to v1beta1)
 //
-// Nevertheless, kubeadm v1.13.x will support reading from v1alpha3 version of the kubeadm config file format, but this support
-// will be dropped in the v1.14 release.
+// Nevertheless, kubeadm v1.15.x will support reading from v1beta1 version of the kubeadm config file format.
 //
 // Basics
 //
@@ -181,9 +174,12 @@ limitations under the License.
 // 	    effect: "NoSchedule"
 // 	  kubeletExtraArgs:
 // 	    cgroupDriver: "cgroupfs"
+//	  ignorePreflightErrors:
+//	  - IsPrivilegedUser
 // 	localAPIEndpoint:
 // 	  advertiseAddress: "10.100.0.1"
 // 	  bindPort: 6443
+//	certificateKey: "e6a2eb8581237ab72a4f494f30285ec12a9694d750b9785706a83bfcbbbd2204"
 // 	---
 // 	apiVersion: kubeadm.k8s.io/v1beta2
 // 	kind: ClusterConfiguration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

This change updates the doc.go file for v1beta2 config of kubeadm.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
refs kubernetes/enhancements#970 kubernetes/kubeadm#1439

**Special notes for your reviewer**:

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/priority important-longterm
/assign @fabriziopandini
/assign @neolit123

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
