### PR TITLE
Split CA paramters on manifest template expansions

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2164,7 +2164,13 @@ function start-cluster-autoscaler {
 
     local params="${AUTOSCALER_MIG_CONFIG} ${CLOUD_CONFIG_OPT} ${AUTOSCALER_EXPANDER_CONFIG:---expander=price}"
     params+=" --kubeconfig=/etc/srv/kubernetes/cluster-autoscaler/kubeconfig"
-    sed -i -e "s@{{params}}@${params}@g" "${src_file}"
+
+    # split the params into separate arguments passed to binary
+    local params_split
+    params_split=$(eval "for param in $params; do echo -n \\\"\$param\\\",; done")
+    params_split=${params_split%?}
+
+    sed -i -e "s@{{params}}@${params_split}@g" "${src_file}"
     sed -i -e "s@{{cloud_config_mount}}@${CLOUD_CONFIG_MOUNT}@g" "${src_file}"
     sed -i -e "s@{{cloud_config_volume}}@${CLOUD_CONFIG_VOLUME}@g" "${src_file}"
     sed -i -e "s@{%.*%}@@g" "${src_file}"

--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -34,7 +34,7 @@
                     "--write-status-configmap=true",
                     "--balance-similar-node-groups=true",
 		    "--expendable-pods-priority-cutoff=-10",
-                    "{{params}}"
+                    {{params}}
                 ],
                 "env": [
                     {


### PR DESCRIPTION
Split arguments to be passed to cluster autoscaler binary
so each argument is passed separately.
This is preparatory work for migrating CA to disroless base image
and passing multiple arguments together does not work if CA is
not wrapped around with shell script

/kind cleanup
```release-note
NONE
```
