### PR TITLE
fix: assign default value for pod.Status.StartTime in TestSelectNodes…

### DIFF
--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -977,6 +977,8 @@ func TestSelectNodesForPreemption(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			assignDefaultStartTime(test.pods)
+
 			nodes := []*v1.Node{}
 			for _, n := range test.nodes {
 				node := makeNode(n, 1000*5, priorityutil.DefaultMemoryRequest*5)
@@ -1198,6 +1200,8 @@ func TestPickOneNodeForPreemption(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			assignDefaultStartTime(test.pods)
+
 			nodes := []*v1.Node{}
 			for _, n := range test.nodes {
 				nodes = append(nodes, makeNode(n, priorityutil.DefaultMilliCPURequest*5, priorityutil.DefaultMemoryRequest*5))
@@ -1596,5 +1600,15 @@ func TestNumFeasibleNodesToFind(t *testing.T) {
 				t.Errorf("genericScheduler.numFeasibleNodesToFind() = %v, want %v", gotNumNodes, tt.wantNumNodes)
 			}
 		})
+	}
+}
+
+func assignDefaultStartTime(pods []*v1.Pod) {
+	now := metav1.Now()
+	for i := range pods {
+		pod := pods[i]
+		if pod.Status.StartTime == nil {
+			pod.Status.StartTime = &now
+		}
 	}
 }


### PR DESCRIPTION
/kind bug
/priority backlog

**What this PR does / why we need it**:

> TestSelectNodesForPreemption should assign pod.Status.StartTime for test Pod
>
> We can see the following in the output of TestSelectNodesForPreemption:
>
> E0525 20:52:18.093682      17 utils.go:79] pod.Status.StartTime is nil for pod a. Should not reach here.
> E0525 20:52:18.111788      17 utils.go:79] pod.Status.StartTime is nil for pod m1.2. Should not reach here.
>
> ref: #78348


**Which issue(s) this PR fixes**:

Fixes #78348

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
