### PR TITLE
Create tars locally

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -68,6 +68,10 @@ build:remote --strategy=Closure=remote
 build:remote --strategy=Genrule=remote
 build:remote --define=EXECUTOR=remote
 
+# tar locally due to https://github.com/bazelbuild/bazel/issues/8462
+build:remote --strategy=PackageTar=sandboxed
+
+
 # --config=ci-instance adds a remote instance name
 build:ci-instance --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
 


### PR DESCRIPTION
/assign @cblecker @mikedanese 

Large tarballs are not the best things to build remotely. Empirically this seems to considerably speed-up builds 

/kind cleanup
/sig testing

<!--
```release-note
NONE
```
-->

ref https://github.com/kubernetes/test-infra/issues/12282 https://github.com/bazelbuild/bazel/issues/8462