### PR TITLE
kubeadm: rename-ha-flags

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -432,6 +432,7 @@ func isAllowedFlag(flagName string) bool {
 		kubeadmcmdoptions.NodeCRISocket,
 		kubeadmcmdoptions.KubeconfigDir,
 		kubeadmcmdoptions.UploadCerts,
+		kubeadmcmdoptions.ExperimentalUploadCerts,
 		kubeadmcmdoptions.CertificateKey,
 		"print-join-command", "rootfs", "v")
 	if knownFlags.Has(flagName) {

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -69,7 +69,7 @@ var (
 					
 		Please note that the certificate-key gives access to cluster sensitive data, keep it secret!
 		As a safeguard, uploaded-certs will be deleted in two hours; If necessary, you can use 
-		"kubeadm init phase upload-certs --experimental-upload-certs" to reload certs afterward.
+		"kubeadm init phase upload-certs --upload-certs" to reload certs afterward.
 		  
 		{{else -}}
 		You can now join any number of control-plane nodes by copying certificate authorities 
@@ -257,6 +257,11 @@ func AddInitOtherFlags(flagSet *flag.FlagSet, initOptions *initOptions) {
 		&initOptions.uploadCerts, options.UploadCerts, initOptions.uploadCerts,
 		"Upload control-plane certificates to the kubeadm-certs Secret.",
 	)
+	flagSet.BoolVar(
+		&initOptions.uploadCerts, options.ExperimentalUploadCerts, initOptions.uploadCerts,
+		"Upload control-plane certificates to the kubeadm-certs Secret.",
+	)
+	flagSet.MarkDeprecated(options.ExperimentalUploadCerts, fmt.Sprintf("use --%s instead", options.UploadCerts))
 	flagSet.BoolVar(
 		&initOptions.skipCertificateKeyPrint, options.SkipCertificateKeyPrint, initOptions.skipCertificateKeyPrint,
 		"Don't print the key used to encrypt the control-plane certificates.",

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -275,6 +275,11 @@ func addJoinOtherFlags(flagSet *flag.FlagSet, joinOptions *joinOptions) {
 		&joinOptions.controlPlane, options.ControlPlane, joinOptions.controlPlane,
 		"Create a new control plane instance on this node",
 	)
+	flagSet.BoolVar(
+		&joinOptions.controlPlane, options.ExperimentalControlPlane, joinOptions.controlPlane,
+		"Create a new control plane instance on this node",
+	)
+	flagSet.MarkDeprecated(options.ExperimentalUploadCerts, fmt.Sprintf("use --%s instead", options.ControlPlane))
 }
 
 // newJoinOptions returns a struct ready for being used for creating cmd join flags.

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -117,10 +117,18 @@ const (
 	FileDiscovery = "discovery-file"
 
 	// ControlPlane flag instruct kubeadm to create a new control plane instance on this node
-	ControlPlane = "experimental-control-plane"
+	ControlPlane = "control-plane"
 
 	// UploadCerts flag instruct kubeadm to upload certificates
-	UploadCerts = "experimental-upload-certs"
+	UploadCerts = "upload-certs"
+
+	// ExperimentalControlPlane flag instruct kubeadm to create a new control plane instance on this node
+	// TODO: this flag should be removed in 1.16 cycle
+	ExperimentalControlPlane = "experimental-control-plane"
+
+	// ExperimentalUploadCerts flag instruct kubeadm to upload certificates
+	// TODO: this flag should be removed in 1.16 cycle
+	ExperimentalUploadCerts = "experimental-upload-certs"
 
 	// CertificateKey flag sets the key used to encrypt and decrypt certificate secrets
 	CertificateKey = "certificate-key"

--- a/cmd/kubeadm/app/cmd/phases/init/uploadcerts.go
+++ b/cmd/kubeadm/app/cmd/phases/init/uploadcerts.go
@@ -38,6 +38,7 @@ func NewUploadCertsPhase() workflow.Phase {
 		InheritFlags: []string{
 			options.CfgPath,
 			options.UploadCerts,
+			options.ExperimentalUploadCerts,
 			options.CertificateKey,
 			options.SkipCertificateKeyPrint,
 		},

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -40,6 +40,7 @@ func getControlPlaneJoinPhaseFlags(name string) []string {
 	flags := []string{
 		options.CfgPath,
 		options.ControlPlane,
+		options.ExperimentalControlPlane,
 		options.NodeName,
 	}
 	if name != "mark-control-plane" {

--- a/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
@@ -70,6 +70,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.APIServerBindPort,
 			options.CfgPath,
 			options.ControlPlane,
+			options.ExperimentalControlPlane,
 			options.NodeName,
 			options.FileDiscovery,
 			options.TokenDiscovery,
@@ -83,6 +84,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 		flags = []string{
 			options.CfgPath,
 			options.ControlPlane,
+			options.ExperimentalControlPlane,
 			options.FileDiscovery,
 			options.TokenDiscovery,
 			options.TokenDiscoveryCAHash,
@@ -96,6 +98,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.APIServerAdvertiseAddress,
 			options.CfgPath,
 			options.ControlPlane,
+			options.ExperimentalControlPlane,
 			options.NodeName,
 			options.FileDiscovery,
 			options.TokenDiscovery,
@@ -108,6 +111,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 		flags = []string{
 			options.CfgPath,
 			options.ControlPlane,
+			options.ExperimentalControlPlane,
 			options.FileDiscovery,
 			options.TokenDiscovery,
 			options.TokenDiscoveryCAHash,
@@ -122,6 +126,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.APIServerBindPort,
 			options.CfgPath,
 			options.ControlPlane,
+			options.ExperimentalControlPlane,
 		}
 	default:
 		flags = []string{}

--- a/cmd/kubeadm/app/cmd/phases/join/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/join/preflight.go
@@ -65,6 +65,7 @@ func NewPreflightPhase() workflow.Phase {
 			options.TLSBootstrapToken,
 			options.TokenStr,
 			options.ControlPlane,
+			options.ExperimentalControlPlane,
 			options.APIServerAdvertiseAddress,
 			options.APIServerBindPort,
 			options.NodeCRISocket,


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR renames flag “--experimental-control-plane” into “--control-plane” and “--experimental-upload-certs” into “--upload-certs”.

**Which issue(s) this PR fixes**:
Rif #kubernetes/kubeadm#1567

**Special notes for your reviewer**:
"--experimental" flags will be preserved for 1 cycle in order to minimize impact to the users

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: flag “--experimental-control-plane” is now deprecated. use “--control-plane” instead
kubeadm: flag “--experimental-upload-certs” is now deprecated. use “--upload-certs” instead
```

/sig cluster-lifecycle
/area kubeadm
/priority important-soon
@kubernetes/sig-cluster-lifecycle-pr-reviews

/assign @neolit123
/assign @rosti
/cc @yagonobre
/cc @ereslibre