### PR TITLE
apiextensions: add invalid validation schema regex test

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -1692,6 +1692,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 				invalid("spec", "validation", "openAPIV3Schema", "properties[a]", "default"),
 				invalid("spec", "validation", "openAPIV3Schema", "properties[c]", "default"),
 				invalid("spec", "validation", "openAPIV3Schema", "properties[d]", "default"),
+				invalid("spec", "validation", "openAPIV3Schema", "properties[d]", "properties[bad]", "pattern"),
 				// we also expected unpruned and valid defaults under x-kubernetes-preserve-unknown-fields. We could be more
 				// strict here, but want to encourage proper specifications by forbidding other defaults.
 				invalid("spec", "validation", "openAPIV3Schema", "properties[e]", "properties[preserveUnknownFields]", "default"),

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
@@ -17,7 +17,9 @@ limitations under the License.
 package schema
 
 import (
+	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -225,6 +227,12 @@ func validateValueValidation(v *ValueValidation, skipAnyOf, skipFirstAllOfAnyOf 
 	}
 
 	allErrs = append(allErrs, validateNestedValueValidation(v.Not, false, false, lvl, fldPath.Child("not"))...)
+
+	if len(v.Pattern) > 0 {
+		if _, err := regexp.Compile(v.Pattern); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("pattern"), v.Pattern, fmt.Sprintf("must be a valid regular expression, but isn't: %v", err)))
+		}
+	}
 
 	return allErrs
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation_test.go
@@ -139,7 +139,7 @@ func convertNullTypeToNullable(x interface{}) interface{} {
 	}
 }
 
-func TestNullable(t *testing.T) {
+func TestValidateCustomResource(t *testing.T) {
 	type args struct {
 		schema apiextensions.JSONSchemaProps
 		object interface{}
@@ -149,6 +149,7 @@ func TestNullable(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
+		// TODO: make more complete
 		{"!nullable against non-null", args{
 			apiextensions.JSONSchemaProps{
 				Properties: map[string]apiextensions.JSONSchemaProps{
@@ -235,6 +236,17 @@ func TestNullable(t *testing.T) {
 			},
 			map[string]interface{}{"field": nil},
 		}, false},
+		{"invalid regex", args{
+			apiextensions.JSONSchemaProps{
+				Properties: map[string]apiextensions.JSONSchemaProps{
+					"field": {
+						Type:    "string",
+						Pattern: "+",
+					},
+				},
+			},
+			map[string]interface{}{"field": "foo"},
+		}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -871,6 +871,19 @@ oneOf:
 			},
 		},
 		{
+			desc: "invalid regex pattern",
+			globalSchema: `
+type: object
+properties:
+  foo:
+    type: string
+    pattern: "+"
+`,
+			expectedViolations: []string{
+				"spec.validation.openAPIV3Schema.properties[foo].pattern: Invalid value: \"+\": must be a valid regular expression, but isn't: error parsing regexp: missing argument to repetition operator: `+`",
+			},
+		},
+		{
 			desc: "forbidden vendor extensions in nested value validation",
 			globalSchema: `
 type: object


### PR DESCRIPTION
Prevents https://github.com/kubernetes/kubernetes/issues/65470, and is good for published OpenAPI schemas, not to publish invalid data.

```release-note
CustomResourceDefinition with invalid regular expression in the pattern field of OpenAPI v3 validation schemas are not considere structural.
```