### PR TITLE
Switch to scheduling client v1in priority admission plugin

### DIFF
--- a/pkg/registry/scheduling/rest/BUILD
+++ b/pkg/registry/scheduling/rest/BUILD
@@ -16,7 +16,7 @@ go_library(
         "//pkg/apis/scheduling/v1alpha1:go_default_library",
         "//pkg/apis/scheduling/v1beta1:go_default_library",
         "//pkg/registry/scheduling/priorityclass/storage:go_default_library",
-        "//staging/src/k8s.io/api/scheduling/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/scheduling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
@@ -25,7 +25,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/storage:go_default_library",
-        "//staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/registry/scheduling/rest/storage_scheduling.go
+++ b/pkg/registry/scheduling/rest/storage_scheduling.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/klog"
 
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
-	schedulingclient "k8s.io/client-go/kubernetes/typed/scheduling/v1beta1"
+	schedulingclient "k8s.io/client-go/kubernetes/typed/scheduling/v1"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	schedulingapiv1 "k8s.io/kubernetes/pkg/apis/scheduling/v1"
@@ -107,12 +107,11 @@ func AddSystemPriorityClasses() genericapiserver.PostStartHookFunc {
 				_, err := schedClientSet.PriorityClasses().Get(pc.Name, metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
-						// TODO: Remove this explicit conversion after scheduling api move to v1
-						v1beta1PriorityClass := &schedulingv1beta1.PriorityClass{}
-						if err := schedulingapiv1beta1.Convert_scheduling_PriorityClass_To_v1beta1_PriorityClass(pc, v1beta1PriorityClass, nil); err != nil {
+						v1PriorityClass := &schedulingv1.PriorityClass{}
+						if err := schedulingapiv1.Convert_scheduling_PriorityClass_To_v1_PriorityClass(pc, v1PriorityClass, nil); err != nil {
 							return false, err
 						}
-						_, err := schedClientSet.PriorityClasses().Create(v1beta1PriorityClass)
+						_, err := schedClientSet.PriorityClasses().Create(v1PriorityClass)
 						if err != nil && !apierrors.IsAlreadyExists(err) {
 							return false, err
 						} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
 /kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I believe, we need this but I am not sure how to test this out as `kubectl get pc` was giving `PriorityClass.v1.scheduling.k8s.io`, perhaps it's because we set the default type to be served as `v1`.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
