### PR TITLE
build-image: cross: update make and dockerfile to use args

### DIFF
--- a/build/build-image/cross/Dockerfile
+++ b/build/build-image/cross/Dockerfile
@@ -15,7 +15,10 @@
 # This file creates a standard build environment for building cross
 # platform go binary for the architecture kubernetes cares about.
 
-FROM golang:1.12.5
+ARG GO_BASE=golang:1.12.5
+ARG PROTOBUF_VERSION=3.0.2
+ARG ETCD_VERSION=v3.2.24
+FROM $GO_BASE
 
 ENV GOARM 7
 ENV KUBE_DYNAMIC_CROSSPLATFORMS \
@@ -50,7 +53,8 @@ RUN echo "deb http://archive.ubuntu.com/ubuntu xenial main universe" > /etc/apt/
   && for platform in ${KUBE_DYNAMIC_CROSSPLATFORMS}; do apt-get install -y crossbuild-essential-${platform}; done \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN PROTOBUF_VERSION=3.0.2; ZIPNAME="protoc-${PROTOBUF_VERSION}-linux-x86_64.zip"; \
+ARG PROTOBUF_VERSION
+RUN PROTOBUF_VERSION=$PROTOBUF_VERSION; ZIPNAME="protoc-${PROTOBUF_VERSION}-linux-x86_64.zip"; \
   mkdir /tmp/protoc && cd /tmp/protoc \
   && wget "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/${ZIPNAME}" \
   && unzip "${ZIPNAME}" \
@@ -72,7 +76,8 @@ RUN go get golang.org/x/tools/cmd/cover \
     && go clean -cache
 
 # Download and symlink etcd. We need this for our integration tests.
-RUN export ETCD_VERSION=v3.2.24; \
+ARG ETCD_VERSION
+RUN export ETCD_VERSION=$ETCD_VERSION; \
   mkdir -p /usr/local/src/etcd \
   && cd /usr/local/src/etcd \
   && curl -fsSL https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz | tar -xz \

--- a/build/build-image/cross/Makefile
+++ b/build/build-image/cross/Makefile
@@ -15,13 +15,20 @@
 .PHONY:	build push
 
 IMAGE=kube-cross
-TAG=$(shell cat VERSION)
+CONTAINER_REGISTRY?=staging-k8s.gcr.io
+GO_BASE_CONTAINER?="golang"
+GO_VERSION?="1.12.5"
+GO_BASE="${GO_BASE_CONTAINER}:${GO_VERSION}"
+TAG?=$(shell cat VERSION)
+FQIN="${CONTAINER_REGISTRY}/${IMAGE}:${TAG}"
 
 
 all: push
 
 build:
-	docker build --pull -t staging-k8s.gcr.io/$(IMAGE):$(TAG) .
+	docker build --pull \
+	--build-arg GO_BASE=${GO_BASE} \
+	-t $(FQIN) .
 
 push: build
-	docker push staging-k8s.gcr.io/$(IMAGE):$(TAG)
+	docker push $(FQIN)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Update makefile and dockerfile to support args in build-image/cross

```release-note
NONE
```
