### PR TITLE
Skip GCE PD in-tree plugin tests if fstype is xfs and node distro is not ubuntu or custom

### DIFF
--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -146,7 +146,7 @@ func skipUnsupportedTest(driver TestDriver, pattern testpatterns.TestPattern) {
 		if !dInfo.SupportedFsType.Has(pattern.FsType) {
 			framework.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.FsType)
 		}
-		if pattern.FsType == "xfs" && framework.NodeOSDistroIs("gci") {
+		if pattern.FsType == "xfs" && framework.NodeOSDistroIs("gci", "cos", "windows") {
 			framework.Skipf("Distro doesn't support xfs -- skipping")
 		}
 		if pattern.FsType == "ntfs" && !framework.NodeOSDistroIs("windows") {


### PR DESCRIPTION
XFS Is not supported in other node OS distros. These tests are failing in multiple places

/kind failing-test
/sig storage
/priority important-soon

/assign @msau42 @mkimuram 

```release-note
NONE
```
