### PR TITLE
Filter on so many logs, make key information clear

### DIFF
--- a/test/integration/scheduler_perf/scheduler_test.go
+++ b/test/integration/scheduler_perf/scheduler_test.go
@@ -81,7 +81,7 @@ func TestSchedule100Node3KPods(t *testing.T) {
 	} else if min < warning3K {
 		fmt.Printf("Warning: pod scheduling throughput for 3k pods was slow for an interval... Saw an interval with very low (%v) scheduling rate!", min)
 	} else {
-		fmt.Printf("Minimal observed throughput for 3k pod test: %v\n", min)
+		fmt.Printf("Minimal observed throughput for 3k pods test: %v\n", min)
 	}
 }
 
@@ -95,7 +95,7 @@ func TestSchedule100Node3KPods(t *testing.T) {
 // 	if min := schedulePods(config); min < threshold60K {
 // 		t.Errorf("Too small pod scheduling throughput for 60k pods. Expected %v got %v", threshold60K, min)
 // 	} else {
-// 		fmt.Printf("Minimal observed throughput for 60k pod test: %v\n", min)
+// 		fmt.Printf("Minimal observed throughput for 60k pods test: %v\n", min)
 // 	}
 // }
 

--- a/test/integration/scheduler_perf/test-performance.sh
+++ b/test/integration/scheduler_perf/test-performance.sh
@@ -43,10 +43,10 @@ if ${RUN_BENCHMARK:-false}; then
   go test -c -o "perf.test"
 
   kube::log::status "performance test (benchmark) start"
-  "./perf.test" -test.bench=. -test.run=xxxx -test.cpuprofile=prof.out -test.short=false
+  "./perf.test" -test.bench=. -test.run=xxxx -test.cpuprofile=prof.out -test.short=false -v=0 -logtostderr=false
   kube::log::status "...benchmark tests finished"
 fi
 # Running density tests. It might take a long time.
 kube::log::status "performance test (density) start"
-go test -test.run=. -test.timeout=60m -test.short=false
+go test -test.run=. -test.timeout=60m -test.short=false -v=0 -logtostderr=false
 kube::log::status "...density tests finished"

--- a/test/integration/scheduler_perf/test-performance.sh
+++ b/test/integration/scheduler_perf/test-performance.sh
@@ -22,6 +22,8 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../../../
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
+glog_flags=$(kube::golang::glog_flags "$@")
+echo $glog_flags
 
 DIR_BASENAME=$(dirname "${BASH_SOURCE[0]}")
 pushd "${DIR_BASENAME}"
@@ -43,10 +45,10 @@ if ${RUN_BENCHMARK:-false}; then
   go test -c -o "perf.test"
 
   kube::log::status "performance test (benchmark) start"
-  "./perf.test" -test.bench=. -test.run=xxxx -test.cpuprofile=prof.out -test.short=false -v=0 -logtostderr=false
+  "./perf.test" $glog_flags -test.bench=. -test.run=xxxx -test.cpuprofile=prof.out -test.short=false
   kube::log::status "...benchmark tests finished"
 fi
 # Running density tests. It might take a long time.
 kube::log::status "performance test (density) start"
-go test -test.run=. -test.timeout=60m -test.short=false -v=0 -logtostderr=false
+go test $glog_flags -test.run=. -test.timeout=60m -test.short=false
 kube::log::status "...density tests finished"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
When I ran the current test script of scheduler_perf, there was so many logs(INFO level) make me lost to find out the key information there. What I do in this pr is filtering the logs by default and making the key information more clear. See it below

```
$ ./test-performance.sh 
~/workspace/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/integration/scheduler_perf ~/workspace/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/integration/scheduler_perf
etcd --advertise-client-urls http://127.0.0.1:2379 --data-dir /var/folders/_f/qtth5kfj46l3wlx0957_clv40000gn/T/tmp.2lQk8MVI --listen-client-urls http://127.0.0.1:2379 --debug > "/dev/null" 2>/dev/null
Waiting for etcd to come up.
+++ [0529 13:13:42] On try 1, etcd: : http://127.0.0.1:2379
{"action":"set","node":{"key":"/_test","value":"","modifiedIndex":4,"createdIndex":4}}
+++ [0529 13:13:42] performance test (density) start
I0529 13:13:57.422073   94243 etcd.go:80] etcd already running at http://127.0.0.1:2379
0s	rate: 178	total: 178 (qps frequency: map[178:1])
1s	rate: 535	total: 713 (qps frequency: map[178:1 535:1])
2s	rate: 504	total: 1217 (qps frequency: map[178:1 504:1 535:1])
3s	rate: 498	total: 1715 (qps frequency: map[178:1 498:1 504:1 535:1])
4s	rate: 508	total: 2223 (qps frequency: map[178:1 498:1 504:1 508:1 535:1])
5s	rate: 503	total: 2726 (qps frequency: map[178:1 498:1 503:1 504:1 508:1 535:1])
Scheduled 3000 Pods in 6 seconds (500 per second on average). min QPS was 178
E0529 13:14:08.778470   94243 scheduling_queue.go:818] Error while retrieving next pod from scheduling queue: scheduling queue is closed
Minimal observed throughput for 3k pod test: 178
PASS
ok  	k8s.io/kubernetes/test/integration/scheduler_perf	11.484s
+++ [0529 13:14:09] ...density tests finished
~/workspace/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/integration/scheduler_perf
+++ [0529 13:14:09] performance test cleanup complete
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
