### PR TITLE
Check e2e test code to use ExpectError()

### DIFF
--- a/test/e2e/node/mount_propagation.go
+++ b/test/e2e/node/mount_propagation.go
@@ -175,7 +175,7 @@ var _ = SIGDescribe("Mount propagation", func() {
 					gomega.Expect(stdout).To(gomega.Equal(mountName), msg)
 				} else {
 					// We *expect* cat to return error here
-					gomega.Expect(err).To(gomega.HaveOccurred(), msg)
+					framework.ExpectError(err, msg)
 				}
 			}
 		}

--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -279,7 +279,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 					}
 				}
 				if test.disableAttach {
-					gomega.Expect(err).To(gomega.HaveOccurred(), "Unexpected VolumeAttachment found")
+					framework.ExpectError(err, "Unexpected VolumeAttachment found")
 				}
 			})
 
@@ -449,7 +449,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				}
 				if test.expectFailure {
 					err = waitForResizingCondition(pvc, m.cs, csiResizingConditionWait)
-					gomega.Expect(err).To(gomega.HaveOccurred(), "unexpected resizing condition on PVC")
+					framework.ExpectError(err, "unexpected resizing condition on PVC")
 					return
 				}
 

--- a/test/e2e/storage/utils/utils.go
+++ b/test/e2e/storage/utils/utils.go
@@ -91,7 +91,7 @@ func VerifyExecInPodFail(pod *v1.Pod, bashExec string, exitCode int) {
 				bashExec, exitCode, err)
 		}
 	}
-	gomega.Expect(err).To(gomega.HaveOccurred(), "%q should fail with exit code %d, but exit without error", bashExec, exitCode)
+	framework.ExpectError(err, "%q should fail with exit code %d, but exit without error", bashExec, exitCode)
 }
 
 // KubeletCommand performs `start`, `restart`, or `stop` on the kubelet running on the node of the target pod and waits

--- a/test/e2e/storage/volume_expand.go
+++ b/test/e2e/storage/volume_expand.go
@@ -101,7 +101,7 @@ var _ = utils.SIGDescribe("Volume expand", func() {
 		ginkgo.By("Expanding non-expandable pvc")
 		newSize := resource.MustParse("6Gi")
 		pvc, err = expandPVCSize(pvc, newSize, c)
-		gomega.Expect(err).To(gomega.HaveOccurred(), "While updating non-expandable PVC")
+		framework.ExpectError(err, "While updating non-expandable PVC")
 	})
 
 	ginkgo.It("Verify if editing PVC allows resize", func() {


### PR DESCRIPTION


**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We can use framework.ExpectError() for checking the expected error
happens. However Expect(err).To(HaveOccurred()) can be used instead
and that makes the e2e test code unreadable.
This adds the check to use framework.ExpectError() for readable code.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #77706

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
