### PR TITLE
Continue admitting the pod regardless of return value from HandleAdmissionFailure

### DIFF
--- a/pkg/kubelet/lifecycle/predicate.go
+++ b/pkg/kubelet/lifecycle/predicate.go
@@ -104,11 +104,8 @@ func (w *predicateAdmitHandler) Admit(attrs *PodAdmitAttributes) PodAdmitResult 
 		if err != nil {
 			message := fmt.Sprintf("Unexpected error while attempting to recover from admission failure: %v", err)
 			klog.Warningf("Failed to admit pod %v - %s", format.Pod(admitPod), message)
-			return PodAdmitResult{
-				Admit:   fit,
-				Reason:  "UnexpectedAdmissionError",
-				Message: message,
-			}
+			// In future syncPod loops, the kubelet will retry the pod deletion steps that it was stuck on.
+			fit = true
 		}
 	}
 	if !fit {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Over #78405, @dashpole suggested we ignore the error return from HandleAdmissionFailure and continue admitting the Pod.

In future syncPod loops, the kubelet will retry the pod deletion steps that it was stuck on.

**Which issue(s) this PR fixes**:
Fixes #78405

```release-note
NONE
```
