### PR TITLE
Add dashpole to kubelet subdirectory owners files

### DIFF
--- a/pkg/kubelet/apis/podresources/OWNERS
+++ b/pkg/kubelet/apis/podresources/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- derekwaynecarr
-- vishh
-- dchen1107
 - dashpole

--- a/pkg/kubelet/apis/resourcemetrics/OWNERS
+++ b/pkg/kubelet/apis/resourcemetrics/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- derekwaynecarr
-- vishh
-- dchen1107
 - dashpole

--- a/pkg/kubelet/apis/stats/OWNERS
+++ b/pkg/kubelet/apis/stats/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- derekwaynecarr
-- vishh
-- dchen1107
 - dashpole

--- a/pkg/kubelet/cadvisor/OWNERS
+++ b/pkg/kubelet/cadvisor/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- derekwaynecarr
-- vishh
-- dchen1107
 - dashpole

--- a/pkg/kubelet/images/OWNERS
+++ b/pkg/kubelet/images/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- derekwaynecarr
-- vishh
-- dchen1107
 - dashpole

--- a/pkg/kubelet/metrics/OWNERS
+++ b/pkg/kubelet/metrics/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- derekwaynecarr
-- vishh
-- dchen1107
 - dashpole

--- a/pkg/kubelet/oom/OWNERS
+++ b/pkg/kubelet/oom/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- derekwaynecarr
-- vishh
-- dchen1107
 - dashpole

--- a/pkg/kubelet/preemption/OWNERS
+++ b/pkg/kubelet/preemption/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- derekwaynecarr
-- vishh
-- dchen1107
 - dashpole

--- a/pkg/kubelet/stats/OWNERS
+++ b/pkg/kubelet/stats/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- derekwaynecarr
-- vishh
-- dchen1107
 - dashpole


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig node
/priority backlog

**What this PR does / why we need it**:
In the spirit of reducing approver burden for top-level kubelet owners, this PR adds me to the OWNERS files for specific subdirectories within `pkg/kubelet`.  These are directories I have either personally written (preemption, podresources, resourcemetrics), or have had major long-term contributions to (eviction, cadvisor, stats, images, oom).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @derekwaynecarr @dchen1107 