### PR TITLE
serviceaccounts: Add JWT KeyIDs to tokens

### DIFF
--- a/pkg/serviceaccount/BUILD
+++ b/pkg/serviceaccount/BUILD
@@ -60,6 +60,7 @@ go_test(
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/util/keyutil:go_default_library",
+        "//vendor/gopkg.in/square/go-jose.v2:go_default_library",
         "//vendor/gopkg.in/square/go-jose.v2/jwt:go_default_library",
     ],
 )

--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -18,9 +18,11 @@ package serviceaccount
 
 import (
 	"context"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -29,7 +31,7 @@ import (
 	jose "gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 )
@@ -53,43 +55,148 @@ type TokenGenerator interface {
 
 // JWTTokenGenerator returns a TokenGenerator that generates signed JWT tokens, using the given privateKey.
 // privateKey is a PEM-encoded byte array of a private RSA key.
-// JWTTokenAuthenticator()
 func JWTTokenGenerator(iss string, privateKey interface{}) (TokenGenerator, error) {
-	var alg jose.SignatureAlgorithm
+	var signer jose.Signer
+	var err error
 	switch pk := privateKey.(type) {
 	case *rsa.PrivateKey:
-		alg = jose.RS256
+		signer, err = signerFromRSAPrivateKey(pk)
+		if err != nil {
+			return nil, fmt.Errorf("could not generate signer for RSA keypair: %v", err)
+		}
 	case *ecdsa.PrivateKey:
-		switch pk.Curve {
-		case elliptic.P256():
-			alg = jose.ES256
-		case elliptic.P384():
-			alg = jose.ES384
-		case elliptic.P521():
-			alg = jose.ES512
-		default:
-			return nil, fmt.Errorf("unknown private key curve, must be 256, 384, or 521")
+		signer, err = signerFromECDSAPrivateKey(pk)
+		if err != nil {
+			return nil, fmt.Errorf("could not generate signer for ECDSA keypair: %v", err)
 		}
 	case jose.OpaqueSigner:
-		alg = jose.SignatureAlgorithm(pk.Public().Algorithm)
+		signer, err = signerFromOpaqueSigner(pk)
+		if err != nil {
+			return nil, fmt.Errorf("could not generate signer for OpaqueSigner: %v", err)
+		}
 	default:
 		return nil, fmt.Errorf("unknown private key type %T, must be *rsa.PrivateKey, *ecdsa.PrivateKey, or jose.OpaqueSigner", privateKey)
+	}
+
+	return &jwtTokenGenerator{
+		iss:    iss,
+		signer: signer,
+	}, nil
+}
+
+// keyIDFromPublicKey derives a key ID non-reversibly from a public key.
+//
+// The Key ID is field on a given on JWTs and JWKs that help relying parties
+// pick the correct key for verification when the identity party advertises
+// multiple keys.
+//
+// Making the derivation non-reversible makes it impossible for someone to
+// accidentally obtain the real key from the key ID and use it for token
+// validation.
+func keyIDFromPublicKey(publicKey interface{}) (string, error) {
+	publicKeyDERBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize public key to DER format: %v", err)
+	}
+
+	hasher := crypto.SHA256.New()
+	hasher.Write(publicKeyDERBytes)
+	publicKeyDERHash := hasher.Sum(nil)
+
+	keyID := base64.RawURLEncoding.EncodeToString(publicKeyDERHash)
+
+	return keyID, nil
+}
+
+func signerFromRSAPrivateKey(keyPair *rsa.PrivateKey) (jose.Signer, error) {
+	keyID, err := keyIDFromPublicKey(&keyPair.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive keyID: %v", err)
+	}
+
+	// Wrap the RSA keypair in a JOSE JWK with the designated key ID.
+	privateJWK := &jose.JSONWebKey{
+		Algorithm: string(jose.RS256),
+		Key:       keyPair,
+		KeyID:     keyID,
+		Use:       "sig",
+	}
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{
+			Algorithm: jose.RS256,
+			Key:       privateJWK,
+		},
+		nil,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create signer: %v", err)
+	}
+
+	return signer, nil
+}
+
+func signerFromECDSAPrivateKey(keyPair *ecdsa.PrivateKey) (jose.Signer, error) {
+	var alg jose.SignatureAlgorithm
+	switch keyPair.Curve {
+	case elliptic.P256():
+		alg = jose.ES256
+	case elliptic.P384():
+		alg = jose.ES384
+	case elliptic.P521():
+		alg = jose.ES512
+	default:
+		return nil, fmt.Errorf("unknown private key curve, must be 256, 384, or 521")
+	}
+
+	keyID, err := keyIDFromPublicKey(&keyPair.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive keyID: %v", err)
+	}
+
+	// Wrap the ECDSA keypair in a JOSE JWK with the designated key ID.
+	privateJWK := &jose.JSONWebKey{
+		Algorithm: string(alg),
+		Key:       keyPair,
+		KeyID:     keyID,
+		Use:       "sig",
 	}
 
 	signer, err := jose.NewSigner(
 		jose.SigningKey{
 			Algorithm: alg,
-			Key:       privateKey,
+			Key:       privateJWK,
 		},
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create signer: %v", err)
 	}
-	return &jwtTokenGenerator{
-		iss:    iss,
-		signer: signer,
-	}, nil
+
+	return signer, nil
+}
+
+func signerFromOpaqueSigner(opaqueSigner jose.OpaqueSigner) (jose.Signer, error) {
+	alg := jose.SignatureAlgorithm(opaqueSigner.Public().Algorithm)
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{
+			Algorithm: alg,
+			Key: &jose.JSONWebKey{
+				Algorithm: string(alg),
+				Key:       opaqueSigner,
+				KeyID:     opaqueSigner.Public().KeyID,
+				Use:       "sig",
+			},
+		},
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create signer: %v", err)
+	}
+
+	return signer, nil
 }
 
 type jwtTokenGenerator struct {
@@ -155,6 +262,7 @@ func (j *jwtTokenAuthenticator) AuthenticateToken(ctx context.Context, tokenData
 	public := &jwt.Claims{}
 	private := j.validator.NewPrivateClaims()
 
+	// TODO: Pick the key that has the same key ID as `tok`, if one exists.
 	var (
 		found   bool
 		errlist []error


### PR DESCRIPTION
This commit fills out the JWT "kid" (KeyID) field on most serviceaccount tokens we create.  The KeyID value we use is derived from the public key of keypair that backs the cluster's OIDC issuer.

OIDC verifiers use the KeyID to smoothly cope with key rotations:

  * During a rotation, the verifier will have multiple keys cached from the issuer, any of which could have signed the token being verified.  KeyIDs let the verifier pick the appropriate key without having to try each one.

  * Seeing a new KeyID is a trigger for the verifier to invalidate its cached keys and fetch the new set of valid keys from the identity provider.

The value we use for the KeyID is derived from the identity provider's public key by serializing it in DER format, taking the SHA256 hash, and then urlsafe base64-encoding it.  This gives a value that is strongly bound to the key, but can't be reversed to obtain the public key, which keeps people from being tempted to derive the key from the key ID and using that for verification.

Tokens based on jose OpaqueSigners are omitted for now --- I don't see any way to actually run the API server that results in an OpaqueSigner being used.

/kind feature
/sig auth

**Does this PR introduce a user-facing change?**:
```release-note
Service account tokens now include the JWT Key ID field in their header.
```
