### PR TITLE
GCE Windows nodes: leave firewall enabled.

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -230,11 +230,6 @@ function Set-EnvironmentVars {
 # Configures various settings and prerequisites needed for the rest of the
 # functions in this module and the Kubernetes binaries to operate properly.
 function Set-PrerequisiteOptions {
-  # The Windows firewall interferes with Kubernetes networking; GCE's firewall
-  # should be sufficient.
-  Log-Output "Disabling Windows Firewall"
-  Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled False
-
   # Windows updates cause the node to reboot at arbitrary times.
   Log-Output "Disabling Windows Update service"
   sc.exe config wuauserv start=disabled


### PR DESCRIPTION
/kind bug

This PR leaves the Windows firewall enabled on Windows nodes running on GCE. Back when Windows K8s was beta everybody disabled the Windows firewall to prevent any interference with Kubernetes networking. Since then things have stabilized and many users are successfully running K8s clusters with the Windows firewall enabled.

Our Windows prototype job on GCE (https://testgrid.k8s.io/google-windows#windows-prototype&width=20&sort-by-failures=) has been running with the firewall enabled for a couple weeks with no obvious change in the test results.

```release-note
Windows nodes on GCE now have the Windows firewall enabled by default.
```