### PR TITLE
Updates to the SocketMask abstraction for the TopologyManager

### DIFF
--- a/pkg/kubelet/cm/topologymanager/socketmask/socketmask.go
+++ b/pkg/kubelet/cm/topologymanager/socketmask/socketmask.go
@@ -31,6 +31,7 @@ type SocketMask interface {
 	IsEqual(mask SocketMask) bool
 	IsEmpty() bool
 	IsSet(socket int) bool
+	IsNarrowerThan(mask SocketMask) bool
 	String() string
 	Count() int
 	GetSockets() []int
@@ -114,6 +115,20 @@ func (s *socketMask) IsSet(socket int) bool {
 //IsEqual checks if masks are equal
 func (s *socketMask) IsEqual(mask SocketMask) bool {
 	return *s == *mask.(*socketMask)
+}
+
+// IsNarrowerThan checks if one mask is narrower than another.
+//
+// A mask is said to be "narrower" than another if it has lets bits set. If the
+// same number of bits are set in both masks, then the mask with more
+// lower-numbered bits set wins out.
+func (s *socketMask) IsNarrowerThan(mask SocketMask) bool {
+	if s.Count() == mask.Count() {
+		if *s < *mask.(*socketMask) {
+			return true
+		}
+	}
+	return s.Count() < mask.Count()
 }
 
 //String converts mask to string

--- a/pkg/kubelet/cm/topologymanager/socketmask/socketmask_test.go
+++ b/pkg/kubelet/cm/topologymanager/socketmask/socketmask_test.go
@@ -288,3 +288,45 @@ func TestGetSockets(t *testing.T) {
 		}
 	}
 }
+
+func TestIsNarrowerThan(t *testing.T) {
+	tcases := []struct {
+		name                  string
+		firstMask             []int
+		secondMask            []int
+		expectedFirstNarrower bool
+	}{
+		{
+			name:                  "Check narrowness of masks with unequal bits set 1/2",
+			firstMask:             []int{0},
+			secondMask:            []int{0, 1},
+			expectedFirstNarrower: true,
+		},
+		{
+			name:                  "Check narrowness of masks with unequal bits set 2/2",
+			firstMask:             []int{0, 1},
+			secondMask:            []int{0},
+			expectedFirstNarrower: false,
+		},
+		{
+			name:                  "Check narrowness of masks with equal bits set 1/2",
+			firstMask:             []int{0},
+			secondMask:            []int{1},
+			expectedFirstNarrower: true,
+		},
+		{
+			name:                  "Check narrowness of masks with equal bits set 2/2",
+			firstMask:             []int{1},
+			secondMask:            []int{0},
+			expectedFirstNarrower: false,
+		},
+	}
+	for _, tc := range tcases {
+		firstMask, _ := NewSocketMask(tc.firstMask...)
+		secondMask, _ := NewSocketMask(tc.secondMask...)
+		expectedFirstNarrower := firstMask.IsNarrowerThan(secondMask)
+		if expectedFirstNarrower != tc.expectedFirstNarrower {
+			t.Errorf("Expected value to be %v, got %v", tc.expectedFirstNarrower, expectedFirstNarrower)
+		}
+	}
+}

--- a/pkg/kubelet/cm/topologymanager/socketmask/socketmask_test.go
+++ b/pkg/kubelet/cm/topologymanager/socketmask/socketmask_test.go
@@ -49,7 +49,7 @@ func TestAdd(t *testing.T) {
 		expectedMask string
 	}{
 		{
-			name:         "Reset bit 1 SocketMask to 0",
+			name:         "New SocketMask with sockets 0 and 1 set",
 			firstSocket:  0,
 			secondSocket: 1,
 			expectedMask: "1100000000000000000000000000000000000000000000000000000000000000",
@@ -229,7 +229,7 @@ func TestIsEqual(t *testing.T) {
 		isEqual       bool
 	}{
 		{
-			name:          "And socket masks",
+			name:          "Check if two socket masks are equal",
 			firstMaskBit:  int(0),
 			secondMaskBit: int(0),
 			isEqual:       true,


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR adds a new `IsNarrowerThan()` function to the `SocketMask` abstraction for the `TopologyManager`. This function will be used in a subsequent PR to help with the clean implementation of the core `TopologyManager` abstraction itself.

It also adds a commit to fix the naming of some of the existing tests in the `SocketMask` abstraction as a side update.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
