### PR TITLE
Update the TopologyManager interfaces

### DIFF
--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -39,7 +39,7 @@ type Manager interface {
 
 //HintProvider interface is to be implemented by Hint Providers
 type HintProvider interface {
-	GetTopologyHints(pod v1.Pod, container v1.Container) ([]TopologyHint, bool)
+	GetTopologyHints(pod v1.Pod, container v1.Container) []TopologyHint
 }
 
 //Store interface is to allow Hint Providers to retrieve pod affinity
@@ -47,7 +47,10 @@ type Store interface {
 	GetAffinity(podUID string, containerName string) TopologyHint
 }
 
-// TopologyHint is a struct containing Socket Mask for a Pod
+//TopologyHint is a struct containing a SocketMask for a Container
 type TopologyHint struct {
 	SocketAffinity socketmask.SocketMask
+	// Preferred is set to true when the SocketMask encodes a preferred
+	// allocation for the Container. It is set to false otherwise.
+	Preferred bool
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR updates the core `TopologyManager` interfaces. These updates are based on discussions had about the preferred semantics of the `TopologyManager` and will be reflected in changes to PR https://github.com/kubernetes/kubernetes/pull/73580 that adds the actual `TopologyManager` implementation.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
