### PR TITLE
apiextensions: fix array-without-items structural error

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
@@ -81,7 +81,11 @@ func validateStructuralInvariants(s *Structural, lvl level, fldPath *field.Path)
 
 	allErrs := field.ErrorList{}
 
+	if s.Type == "array" && s.Items == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("items"), "must be specified"))
+	}
 	allErrs = append(allErrs, validateStructuralInvariants(s.Items, itemLevel, fldPath.Child("items"))...)
+
 	for k, v := range s.Properties {
 		allErrs = append(allErrs, validateStructuralInvariants(&v, fieldLevel, fldPath.Child("properties").Key(k))...)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -1318,6 +1318,46 @@ not:
 				"spec.validation.openAPIV3Schema.not.properties[metadata]: Forbidden: must not be specified in a nested context",
 			},
 		},
+		{
+			desc: "missing items for array",
+			globalSchema: `
+type: object
+properties:
+  slice:
+    type: array
+`,
+			expectedViolations: []string{
+				"spec.validation.openAPIV3Schema.properties[slice].items: Required value: must be specified",
+			},
+		},
+		{
+			desc: "items slice",
+			globalSchema: `
+type: object
+properties:
+  slice:
+    type: array
+    items:
+    - type: string
+    - type: integer
+`,
+			expectedCreateError: true,
+		},
+		{
+			desc: "items slice in value validation",
+			globalSchema: `
+type: object
+properties:
+  slice:
+    type: array
+    items:
+      type: string
+    not:
+      items:
+      - type: string
+`,
+			expectedCreateError: true,
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
We forgot to check for `type: array` also a scheme for `items` is specified. This lead to publishing of schemas without items, which kubectl does not like.