### PR TITLE
StorageOS volume driver: Remove call to clear mount info if already set

### DIFF
--- a/pkg/volume/storageos/storageos_util.go
+++ b/pkg/volume/storageos/storageos_util.go
@@ -88,7 +88,7 @@ func (u *storageosUtil) NewAPI(apiCfg *storageosAPIConfig) error {
 			apiPass:    defaultAPIPassword,
 			apiVersion: defaultAPIVersion,
 		}
-		klog.V(4).Infof("Using default StorageOS API settings: addr %s, version: %s", apiCfg.apiAddr, defaultAPIVersion)
+		klog.V(4).Infof("using default StorageOS API settings: addr %s, version: %s", apiCfg.apiAddr, defaultAPIVersion)
 	}
 
 	api, err := storageosapi.NewVersionedClient(apiCfg.apiAddr, defaultAPIVersion)
@@ -103,6 +103,9 @@ func (u *storageosUtil) NewAPI(apiCfg *storageosAPIConfig) error {
 // Creates a new StorageOS volume and makes it available as a device within
 // /var/lib/storageos/volumes.
 func (u *storageosUtil) CreateVolume(p *storageosProvisioner) (*storageosVolume, error) {
+
+	klog.V(4).Infof("creating StorageOS volume %q with namespace %q", p.volName, p.volNamespace)
+
 	if err := u.NewAPI(p.apiCfg); err != nil {
 		return nil, err
 	}
@@ -145,6 +148,9 @@ func (u *storageosUtil) CreateVolume(p *storageosProvisioner) (*storageosVolume,
 // or a file device.  Block devices can be used directly, but file devices must
 // be made accessible as a block device before using.
 func (u *storageosUtil) AttachVolume(b *storageosMounter) (string, error) {
+
+	klog.V(4).Infof("attaching StorageOS volume %q with namespace %q", b.volName, b.volNamespace)
+
 	if err := u.NewAPI(b.apiCfg); err != nil {
 		return "", err
 	}
@@ -159,19 +165,6 @@ func (u *storageosUtil) AttachVolume(b *storageosMounter) (string, error) {
 	if err != nil {
 		klog.Warningf("volume retrieve failed for volume %q with namespace %q (%v)", b.volName, b.volNamespace, err)
 		return "", err
-	}
-
-	// Clear any existing mount reference from the API.  These may be leftover
-	// from previous mounts where the unmount operation couldn't get access to
-	// the API credentials.
-	if vol.Mounted {
-		opts := storageostypes.VolumeUnmountOptions{
-			Name:      vol.Name,
-			Namespace: vol.Namespace,
-		}
-		if err := u.api.VolumeUnmount(opts); err != nil {
-			klog.Warningf("Couldn't clear existing StorageOS mount reference: %v", err)
-		}
 	}
 
 	srcPath := filepath.Join(b.deviceDir, vol.ID)
@@ -194,6 +187,9 @@ func (u *storageosUtil) AttachVolume(b *storageosMounter) (string, error) {
 // Detach detaches a volume from the host.  This is only needed when NBD is not
 // enabled and loop devices are used to simulate a block device.
 func (u *storageosUtil) DetachVolume(b *storageosUnmounter, devicePath string) error {
+
+	klog.V(4).Infof("detaching StorageOS volume %q with namespace %q", b.volName, b.volNamespace)
+
 	if !isLoopDevice(devicePath) {
 		return nil
 	}
@@ -205,6 +201,9 @@ func (u *storageosUtil) DetachVolume(b *storageosUnmounter, devicePath string) e
 
 // AttachDevice attaches the volume device to the host at a given mount path.
 func (u *storageosUtil) AttachDevice(b *storageosMounter, deviceMountPath string) error {
+
+	klog.V(4).Infof("attaching StorageOS device for volume %q with namespace %q", b.volName, b.volNamespace)
+
 	if err := u.NewAPI(b.apiCfg); err != nil {
 		return err
 	}
@@ -224,6 +223,9 @@ func (u *storageosUtil) AttachDevice(b *storageosMounter, deviceMountPath string
 
 // Mount mounts the volume on the host.
 func (u *storageosUtil) MountVolume(b *storageosMounter, mntDevice, deviceMountPath string) error {
+
+	klog.V(4).Infof("mounting StorageOS volume %q with namespace %q", b.volName, b.volNamespace)
+
 	notMnt, err := b.mounter.IsLikelyNotMountPoint(deviceMountPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -256,10 +258,13 @@ func (u *storageosUtil) MountVolume(b *storageosMounter, mntDevice, deviceMountP
 // Unmount removes the mount reference from the volume allowing it to be
 // re-mounted elsewhere.
 func (u *storageosUtil) UnmountVolume(b *storageosUnmounter) error {
+
+	klog.V(4).Infof("clearing StorageOS mount reference for volume %q with namespace %q", b.volName, b.volNamespace)
+
 	if err := u.NewAPI(b.apiCfg); err != nil {
 		// We can't always get the config we need, so allow the unmount to
 		// succeed even if we can't remove the mount reference from the API.
-		klog.V(4).Infof("Could not remove mount reference in the StorageOS API as no credentials available to the unmount operation")
+		klog.Warningf("could not remove mount reference in the StorageOS API as no credentials available to the unmount operation")
 		return nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

https://github.com/kubernetes/kubernetes/pull/69782 introduced a change to register (in the StorageOS API) the device attachment prior to the volume attachment.  The volume attachment code would clear any mount info, causing the StorageOS API to register the mount and then immediately de-register it.

The code to clear the mount info on volume attach is no longer needed. It was used to force-mount a volume if StorageOS thought it was already mounted.  In practice it was not needed, and administrators have other ways of clearing stale mount information if required.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #78517

**Special notes for your reviewer**:

Can we get this in the next 1.14 patch release?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
StorageOS volumes now show correct mount information (node and mount time) in the StorageOS administration CLI and UI.
```
/sig storage
/assign @gnufied @saad-ali 
/assign 
/ok-to-test
/priority important-soon
/milestone v1.14