### PR TITLE
Fix CRD defaulting of crd conversion webhook port

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/BUILD
@@ -55,11 +55,15 @@ go_test(
     name = "go_default_test",
     srcs = [
         "conversion_test.go",
+        "defaults_test.go",
         "marshal_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/defaults.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/defaults.go
@@ -24,10 +24,7 @@ import (
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	scheme.AddTypeDefaultingFunc(&CustomResourceDefinition{}, func(obj interface{}) { SetDefaults_CustomResourceDefinition(obj.(*CustomResourceDefinition)) })
-	// TODO figure out why I can't seem to get my defaulter generated
-	// return RegisterDefaults(scheme)
-	return nil
+	return RegisterDefaults(scheme)
 }
 
 func SetDefaults_CustomResourceDefinition(obj *CustomResourceDefinition) {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/defaults_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/defaults_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+func TestDefaults(t *testing.T) {
+	scheme := runtime.NewScheme()
+	AddToScheme(scheme)
+	tests := []struct {
+		name     string
+		original *CustomResourceDefinition
+		expected *CustomResourceDefinition
+	}{
+		{
+			name:     "empty",
+			original: &CustomResourceDefinition{},
+			expected: &CustomResourceDefinition{
+				Spec: CustomResourceDefinitionSpec{
+					Scope:                 NamespaceScoped,
+					Conversion:            &CustomResourceConversion{Strategy: NoneConverter},
+					PreserveUnknownFields: utilpointer.BoolPtr(true),
+				},
+			},
+		},
+		{
+			name: "conversion defaults",
+			original: &CustomResourceDefinition{
+				Spec: CustomResourceDefinitionSpec{
+					Scope: NamespaceScoped,
+					Conversion: &CustomResourceConversion{
+						Strategy: WebhookConverter,
+						WebhookClientConfig: &WebhookClientConfig{
+							Service: &ServiceReference{},
+						},
+					},
+					PreserveUnknownFields: utilpointer.BoolPtr(true),
+				},
+			},
+			expected: &CustomResourceDefinition{
+				Spec: CustomResourceDefinitionSpec{
+					Scope: NamespaceScoped,
+					Conversion: &CustomResourceConversion{
+						Strategy:                 WebhookConverter,
+						ConversionReviewVersions: []string{"v1beta1"},
+						WebhookClientConfig: &WebhookClientConfig{
+							Service: &ServiceReference{Port: utilpointer.Int32Ptr(443)},
+						},
+					},
+					PreserveUnknownFields: utilpointer.BoolPtr(true),
+				},
+			},
+		},
+		{
+			name: "storage status defaults",
+			original: &CustomResourceDefinition{
+				Spec: CustomResourceDefinitionSpec{
+					Scope:                 NamespaceScoped,
+					Conversion:            &CustomResourceConversion{Strategy: NoneConverter},
+					PreserveUnknownFields: utilpointer.BoolPtr(true),
+					Versions: []CustomResourceDefinitionVersion{
+						{Name: "v1", Storage: false, Served: true},
+						{Name: "v2", Storage: true, Served: true},
+						{Name: "v3", Storage: false, Served: true},
+					},
+				},
+			},
+			expected: &CustomResourceDefinition{
+				Spec: CustomResourceDefinitionSpec{
+					Scope:                 NamespaceScoped,
+					Conversion:            &CustomResourceConversion{Strategy: NoneConverter},
+					PreserveUnknownFields: utilpointer.BoolPtr(true),
+					Version:               "v1",
+					Versions: []CustomResourceDefinitionVersion{
+						{Name: "v1", Storage: false, Served: true},
+						{Name: "v2", Storage: true, Served: true},
+						{Name: "v3", Storage: false, Served: true},
+					},
+				},
+				Status: CustomResourceDefinitionStatus{
+					StoredVersions: []string{"v2"},
+				},
+			},
+		},
+		{
+			name: "version defaults",
+			original: &CustomResourceDefinition{
+				Spec: CustomResourceDefinitionSpec{
+					Scope:                 NamespaceScoped,
+					Conversion:            &CustomResourceConversion{Strategy: NoneConverter},
+					PreserveUnknownFields: utilpointer.BoolPtr(true),
+					Version:               "v1",
+				},
+			},
+			expected: &CustomResourceDefinition{
+				Spec: CustomResourceDefinitionSpec{
+					Scope:                 NamespaceScoped,
+					Conversion:            &CustomResourceConversion{Strategy: NoneConverter},
+					PreserveUnknownFields: utilpointer.BoolPtr(true),
+					Version:               "v1",
+					Versions: []CustomResourceDefinitionVersion{
+						{Name: "v1", Storage: true, Served: true},
+					},
+				},
+				Status: CustomResourceDefinitionStatus{
+					StoredVersions: []string{"v1"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			original := test.original
+			expected := test.expected
+			scheme.Default(original)
+			if !apiequality.Semantic.DeepEqual(original, expected) {
+				t.Errorf("expected vs got:\n%s", cmp.Diff(test.expected, original))
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
CRD defaulting was not registering the generated defaulting functions, which meant the new port field for the webhook conversion client config was not getting defaulted.

Fixes that and adds defaulting tests.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @sttts
/sig api-machinery
/milestone v1.15
/priority important-soon
/area custom-resources