### PR TITLE
Deflake TestChangeCRD

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/change_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/change_test.go
@@ -93,8 +93,8 @@ func TestChangeCRD(t *testing.T) {
 		}
 	}()
 
-	// Set up 100 loops creating and reading and watching custom resources
-	for i := 0; i < 100; i++ {
+	// Set up 10 loops creating and reading and watching custom resources
+	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind flake

**What this PR does / why we need it**:
Deflakes TestChangeCRD. 200 concurrent loops could exhaust the integration server under load and make draining the clients exceed the timeout.

See https://storage.googleapis.com/k8s-gubernator/triage/index.html?pr=1&test=TestChangeCRD

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery
/cc @sttts