### PR TITLE
Wait for pods to be garbage collected in integration test

### DIFF
--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -431,7 +431,7 @@ run_pod_tests() {
 
   ## Create valid-pod POD
   # Pre-condition: no POD exists
-  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::wait_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml "${kube_flags[@]}"
   # Post-condition: valid-pod POD is created
@@ -1036,7 +1036,7 @@ run_rc_tests() {
   kubectl create -f hack/testdata/frontend-controller.yaml "${kube_flags[@]}"
   kubectl delete rc frontend "${kube_flags[@]}"
   # Post-condition: no pods from frontend controller
-  kube::test::get_object_assert 'pods -l "name=frontend"' "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::wait_object_assert 'pods -l "name=frontend"' "{{range.items}}{{$id_field}}:{{end}}" ''
 
   ### Create replication controller frontend from JSON
   # Pre-condition: no replication controller exists


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind failing-test
/kind flake

**What this PR does / why we need it**:
Waits for garbage collected resources to be deleted after deleting a parent resource

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cli
/cc @soltysh