### PR TITLE
Unstructed helpers: document lack of slice syntax

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -32,6 +32,9 @@ import (
 // NestedFieldCopy returns a deep copy of the value of a nested field.
 // Returns false if the value is missing.
 // No error is returned for a nil field.
+//
+// Note: fields passed to this function are treated as keys within the passed
+// object; no array/slice syntax is supported.
 func NestedFieldCopy(obj map[string]interface{}, fields ...string) (interface{}, bool, error) {
 	val, found, err := NestedFieldNoCopy(obj, fields...)
 	if !found || err != nil {
@@ -43,6 +46,9 @@ func NestedFieldCopy(obj map[string]interface{}, fields ...string) (interface{},
 // NestedFieldNoCopy returns a reference to a nested field.
 // Returns false if value is not found and an error if unable
 // to traverse obj.
+//
+// Note: fields passed to this function are treated as keys within the passed
+// object; no array/slice syntax is supported.
 func NestedFieldNoCopy(obj map[string]interface{}, fields ...string) (interface{}, bool, error) {
 	var val interface{} = obj
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -67,6 +67,11 @@ func TestNestedFieldNoCopy(t *testing.T) {
 			"b": target,
 			"c": nil,
 			"d": []interface{}{"foo"},
+			"e": []interface{}{
+				map[string]interface{}{
+					"f": "bar",
+				},
+			},
 		},
 	}
 
@@ -91,13 +96,13 @@ func TestNestedFieldNoCopy(t *testing.T) {
 	assert.Nil(t, res)
 
 	// case 4: field does not exist
-	res, exists, err = NestedFieldNoCopy(obj, "a", "e")
+	res, exists, err = NestedFieldNoCopy(obj, "a", "g")
 	assert.False(t, exists)
 	assert.Nil(t, err)
 	assert.Nil(t, res)
 
 	// case 5: intermediate field does not exist
-	res, exists, err = NestedFieldNoCopy(obj, "a", "e", "f")
+	res, exists, err = NestedFieldNoCopy(obj, "a", "g", "f")
 	assert.False(t, exists)
 	assert.Nil(t, err)
 	assert.Nil(t, res)
@@ -105,6 +110,13 @@ func TestNestedFieldNoCopy(t *testing.T) {
 	// case 6: intermediate field is null
 	//         (background: happens easily in YAML)
 	res, exists, err = NestedFieldNoCopy(obj, "a", "c", "f")
+	assert.False(t, exists)
+	assert.Nil(t, err)
+	assert.Nil(t, res)
+
+	// case 7: array/slice syntax is not supported
+	//         (background: users may expect this to be supported)
+	res, exists, err = NestedFieldNoCopy(obj, "a", "e[0]")
 	assert.False(t, exists)
 	assert.Nil(t, err)
 	assert.Nil(t, res)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

New users of the dynamic client and unstructured helpers may expect those methods to support a jsonPath-like syntax for arrays (example: `containers[0]`). These methods do not support said syntax; this PR adds godoc to the central helper methods and a supporting test case that demonstrates that this syntax doesn't work.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
