### PR TITLE
choose a more unique request timeout default

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -409,7 +409,8 @@ func parseTimeout(str string) time.Duration {
 		}
 		klog.Errorf("Failed to parse %q: %v", str, err)
 	}
-	return 30 * time.Second
+	// 34 chose as a number close to 30 that is likely to be unique enough to jump out at me the next time I see a timeout.  Everyone chooses 30.
+	return 34 * time.Second
 }
 
 func isDryRun(url *url.URL) bool {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -826,10 +826,10 @@ func TestHasUID(t *testing.T) {
 }
 
 func TestParseTimeout(t *testing.T) {
-	if d := parseTimeout(""); d != 30*time.Second {
+	if d := parseTimeout(""); d != 34*time.Second {
 		t.Errorf("blank timeout produces %v", d)
 	}
-	if d := parseTimeout("not a timeout"); d != 30*time.Second {
+	if d := parseTimeout("not a timeout"); d != 34*time.Second {
 		t.Errorf("bad timeout produces %v", d)
 	}
 	if d := parseTimeout("10s"); d != 10*time.Second {


### PR DESCRIPTION
While debugging an unusual timeout, the 30 second value is so common that it's harder to figure out exactly which timeout is involved.  Changing this to something slightly different makes it possible to differentiate the values.

@kubernetes/sig-api-machinery-pr-reviews 
/kind bug
/priority important-soon

```release-note
NONE
```