### PR TITLE
kubeadm: disallow the mixture of --config and --certificate-key

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -433,7 +433,6 @@ func isAllowedFlag(flagName string) bool {
 		kubeadmcmdoptions.KubeconfigDir,
 		kubeadmcmdoptions.UploadCerts,
 		kubeadmcmdoptions.ExperimentalUploadCerts,
-		kubeadmcmdoptions.CertificateKey,
 		"print-join-command", "rootfs", "v")
 	if knownFlags.Has(flagName) {
 		return true


### PR DESCRIPTION
**What this PR does / why we need it**:
Similar to --token, do not allow the mixture of --config and
--certificate-key.

If the user has fed a config, it is expected that the certificate
key should also be provided in the config and not from
the command line.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ACTION REQUIRED: kubeadm: the mixture of "--config" and "--certificate-key" is no longer allowed. The InitConfiguration and JoinConfiguration objects now support the "certificateKey" field and this field should be used instead of the command line argument in case a configuration file is already passed.
```

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/assign @rosti @fabriziopandini 
/priority critical-urgent
/kind bug
/milestone v1.15
