### PR TITLE
Make iptables and ipvs modes of kube-proxy MASQUERADE --random-fully if possible

### DIFF
--- a/pkg/kubelet/dockershim/network/hostport/fake_iptables.go
+++ b/pkg/kubelet/dockershim/network/hostport/fake_iptables.go
@@ -347,3 +347,7 @@ func (f *fakeIPTables) isBuiltinChain(tableName utiliptables.Table, chainName ut
 	}
 	return false
 }
+
+func (f *fakeIPTables) HasRandomFully() bool {
+	return false
+}

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1654,12 +1654,20 @@ func (proxier *Proxier) createAndLinkeKubeChain() {
 	// Install the kubernetes-specific postrouting rules. We use a whole chain for
 	// this so that it is easier to flush and change, for example if the mark
 	// value should ever change.
-	writeLine(proxier.natRules, []string{
+	// NB: THIS MUST MATCH the corresponding code in the kubelet
+	masqRule := []string{
 		"-A", string(kubePostroutingChain),
 		"-m", "comment", "--comment", `"kubernetes service traffic requiring SNAT"`,
 		"-m", "mark", "--mark", proxier.masqueradeMark,
 		"-j", "MASQUERADE",
-	}...)
+	}
+	if proxier.iptables.HasRandomFully() {
+		masqRule = append(masqRule, "--random-fully")
+		klog.V(3).Info("Using `--random-fully` in the MASQUERADE rule for iptables")
+	} else {
+		klog.V(2).Info("Not using `--random-fully` in the MASQUERADE rule for iptables because the local version of iptables does not support it")
+	}
+	writeLine(proxier.natRules, masqRule...)
 
 	// Install the kubernetes-specific masquerade mark rule. We use a whole chain for
 	// this so that it is easier to flush and change, for example if the mark

--- a/pkg/util/iptables/testing/fake.go
+++ b/pkg/util/iptables/testing/fake.go
@@ -35,17 +35,24 @@ const (
 	Recent      = "recent "
 	MatchSet    = "--match-set "
 	SrcType     = "--src-type "
+	Masquerade  = "MASQUERADE "
 )
 
 type Rule map[string]string
 
 // no-op implementation of iptables Interface
 type FakeIPTables struct {
-	Lines []byte
+	hasRandomFully bool
+	Lines          []byte
 }
 
 func NewFake() *FakeIPTables {
 	return &FakeIPTables{}
+}
+
+func (f *FakeIPTables) SetHasRandomFully(can bool) *FakeIPTables {
+	f.hasRandomFully = can
+	return f
 }
 
 func (*FakeIPTables) EnsureChain(table iptables.Table, chain iptables.Chain) (bool, error) {
@@ -110,7 +117,7 @@ func (f *FakeIPTables) GetRules(chainName string) (rules []Rule) {
 	for _, l := range strings.Split(string(f.Lines), "\n") {
 		if strings.Contains(l, fmt.Sprintf("-A %v", chainName)) {
 			newRule := Rule(map[string]string{})
-			for _, arg := range []string{Destination, Source, DPort, Protocol, Jump, ToDest, Recent, MatchSet, SrcType} {
+			for _, arg := range []string{Destination, Source, DPort, Protocol, Jump, ToDest, Recent, MatchSet, SrcType, Masquerade} {
 				tok := getToken(l, arg)
 				if tok != "" {
 					newRule[arg] = tok
@@ -120,6 +127,10 @@ func (f *FakeIPTables) GetRules(chainName string) (rules []Rule) {
 		}
 	}
 	return
+}
+
+func (f *FakeIPTables) HasRandomFully() bool {
+	return f.hasRandomFully
 }
 
 var _ = iptables.Interface(&FakeIPTables{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR makes kube-proxy in iptables or ipvs mode include `--random-fully` in the iptables rule it emits to `-j MASQUERADE`, if the local version of iptables supports that additional flag.  This greatly reduces the problems caused by a Linux kernel bug that bites when multiple flows are started at the same time.  Due to this kernel bug the flows can get mapped to the same port, and all but one of them will suffer packet drops.  This flag makes the port choice fully random, greatly reducing the probability of this port collision and consequent packet drop.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #76699

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
