### PR TITLE
labelsMatch method should return false if there is no common label

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/BUILD
@@ -26,6 +26,8 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup
/sig instrumentation
/sig api-machinery

**What this PR does / why we need it**:
`labelsMatch` method should return false if there is no common labelName and labelValue between metric labels and labelFilter.

**Which issue(s) this PR fixes**:
Fixes #78454

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
