### PR TITLE
kubeadm: apply deterministic order to certificate phases

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certlist_test.go
+++ b/cmd/kubeadm/app/phases/certs/certlist_test.go
@@ -29,6 +29,40 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
+func TestCertListOrder(t *testing.T) {
+	tests := []struct {
+		certs Certificates
+		name  string
+	}{
+		{
+			name:  "Default Certificate List",
+			certs: GetDefaultCertList(),
+		},
+		{
+			name:  "Cert list less etcd",
+			certs: GetCertsWithoutEtcd(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var lastCA *KubeadmCert
+			for i, cert := range test.certs {
+				if i > 0 && lastCA == nil {
+					t.Fatalf("CA not present in list before certificate %q", cert.Name)
+				}
+				if cert.CAName == "" {
+					lastCA = cert
+				} else {
+					if cert.CAName != lastCA.Name {
+						t.Fatalf("expected CA name %q, got %q, for certificate %q", lastCA.Name, cert.CAName, cert.Name)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestCAPointersValid(t *testing.T) {
 	tests := []struct {
 		certs Certificates


### PR DESCRIPTION
**What this PR does / why we need it**:
The existing logic already creates a proper "tree"
where a CA is always generated before the certs that are signed
by this CA, however the tree is not deterministic, because it uses a map.

Always use the default list of certs when generating the
"kubeadm init phase certs" phases. Add a unit test that
makes sure that CA always precede signed certs in the default
lists.

This solves the problem where the help screen for "kubeadm
init" cert sub-phases can have a random order.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref: https://github.com/kubernetes/kubernetes/pull/78544
xref: https://github.com/kubernetes/kubernetes/issues/70131#issuecomment-465944594

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: introduce deterministic ordering for the certificates generation in the phase command "kubeadm init phase certs" .
```

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/assign @fabriziopandini 
cc @dims @praseodym
/kind bug
/priority important-longterm
/milestone v1.16
