### PR TITLE
Automated cherry pick of #77802 upstream release 1.12

### DIFF
--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -164,10 +164,10 @@ func (m *GracefulTerminationManager) deleteRsFunc(rsToDelete *listItem) (bool, e
 	}
 	for _, rs := range rss {
 		if rsToDelete.RealServer.Equal(rs) {
-			// Delete RS with no connections
-			// For UDP, ActiveConn is always 0
-			// For TCP, InactiveConn are connections not in ESTABLISHED state
-			if rs.ActiveConn+rs.InactiveConn != 0 {
+			// For UDP traffic, no graceful termination, we immediately delete the RS
+			//     (existing connections will be deleted on the next packet because sysctlExpireNoDestConn=1)
+			// For other protocols, don't delete until all connections have expired)
+			if rsToDelete.VirtualServer.Protocol != "udp" && rs.ActiveConn+rs.InactiveConn != 0 {
 				glog.Infof("Not deleting, RS %v: %v ActiveConn, %v InactiveConn", rsToDelete.String(), rs.ActiveConn, rs.InactiveConn)
 				return false, nil
 			}


### PR DESCRIPTION
#77802 [proxier/ipvs] Disable graceful termination for UDP traffic

/sig network
/area ipvs
/kind bug

/assign @m1093782566 
cc @andrewsykim 

```release-note
IPVS: Disable graceful termination for UDP traffic to solve issues with high number of UDP connections (DNS / syslog in particular)
```