### PR TITLE
Fix golint failures of pkg/kubelet/prober pkg/kubelet/secret

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -169,12 +169,10 @@ pkg/kubelet/lifecycle
 pkg/kubelet/metrics
 pkg/kubelet/pod/testing
 pkg/kubelet/preemption
-pkg/kubelet/prober
 pkg/kubelet/prober/results
 pkg/kubelet/prober/testing
 pkg/kubelet/qos
 pkg/kubelet/remote
-pkg/kubelet/secret
 pkg/kubelet/stats
 pkg/kubelet/status
 pkg/kubelet/status/testing

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -50,8 +50,8 @@ type prober struct {
 	// probe types needs different httprobe instances so they don't
 	// share a connection pool which can cause collsions to the
 	// same host:port and transient failures. See #49740.
-	readinessHttp httprobe.Prober
-	livenessHttp  httprobe.Prober
+	readinessHTTP httprobe.Prober
+	livenessHTTP  httprobe.Prober
 	tcp           tcprobe.Prober
 	runner        kubecontainer.ContainerCommandRunner
 
@@ -69,8 +69,8 @@ func newProber(
 	const followNonLocalRedirects = false
 	return &prober{
 		exec:          execprobe.New(),
-		readinessHttp: httprobe.New(followNonLocalRedirects),
-		livenessHttp:  httprobe.New(followNonLocalRedirects),
+		readinessHTTP: httprobe.New(followNonLocalRedirects),
+		livenessHTTP:  httprobe.New(followNonLocalRedirects),
 		tcp:           tcprobe.New(),
 		runner:        runner,
 		refManager:    refManager,
@@ -175,10 +175,10 @@ func (pb *prober) runProbe(probeType probeType, p *v1.Probe, pod *v1.Pod, status
 		headers := buildHeader(p.HTTPGet.HTTPHeaders)
 		klog.V(4).Infof("HTTP-Probe Headers: %v", headers)
 		if probeType == liveness {
-			return pb.livenessHttp.Probe(url, headers, timeout)
-		} else { // readiness
-			return pb.readinessHttp.Probe(url, headers, timeout)
+			return pb.livenessHTTP.Probe(url, headers, timeout)
 		}
+		// readiness
+		return pb.readinessHTTP.Probe(url, headers, timeout)
 	}
 	if p.TCPSocket != nil {
 		port, err := extractPort(p.TCPSocket.Port, container)

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -92,6 +92,7 @@ type manager struct {
 	prober *prober
 }
 
+// NewManager creates a new prober manager instance.
 func NewManager(
 	statusManager status.Manager,
 	livenessManager results.Manager,

--- a/pkg/kubelet/secret/fake_manager.go
+++ b/pkg/kubelet/secret/fake_manager.go
@@ -25,6 +25,7 @@ import (
 type fakeManager struct {
 }
 
+// NewFakeManager creates empty/fake secret manager
 func NewFakeManager() Manager {
 	return &fakeManager{}
 }

--- a/pkg/kubelet/secret/secret_manager.go
+++ b/pkg/kubelet/secret/secret_manager.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
+// Manager interface provides methods for Kubelet to manage secrets.
 type Manager interface {
 	// Get secret by secret namespace and name.
 	GetSecret(namespace, name string) (*v1.Secret, error)
@@ -54,6 +55,7 @@ type simpleSecretManager struct {
 	kubeClient clientset.Interface
 }
 
+// NewSimpleSecretManager creates a new SecretManager instance.
 func NewSimpleSecretManager(kubeClient clientset.Interface) Manager {
 	return &simpleSecretManager{kubeClient: kubeClient}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Fix golint failures of pkg/kubelet/prober pkg/kubelet/secret

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
