### PR TITLE
Automated cherry pick of #77802 #75283 upstream release 1.11

### DIFF
--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -204,21 +204,5 @@ func (m *GracefulTerminationManager) MoveRSOutofGracefulDeleteList(uniqueRS stri
 
 // Run start a goroutine to try to delete rs in the graceful delete rsList with an interval 1 minute
 func (m *GracefulTerminationManager) Run() {
-	// before start, add leftover in delete rs to graceful delete rsList
-	vss, err := m.ipvs.GetVirtualServers()
-	if err != nil {
-		glog.Errorf("IPVS graceful delete manager failed to get IPVS virtualserver")
-	}
-	for _, vs := range vss {
-		rss, err := m.ipvs.GetRealServers(vs)
-		if err != nil {
-			glog.Errorf("IPVS graceful delete manager failed to get %v realserver", vs)
-			continue
-		}
-		for _, rs := range rss {
-			m.GracefulDeleteRS(vs, rs)
-		}
-	}
-
 	go wait.Until(m.tryDeleteRs, rsCheckDeleteInterval, wait.NeverStop)
 }

--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -164,10 +164,11 @@ func (m *GracefulTerminationManager) deleteRsFunc(rsToDelete *listItem) (bool, e
 	}
 	for _, rs := range rss {
 		if rsToDelete.RealServer.Equal(rs) {
-			// Delete RS with no connections
-			// For UDP, ActiveConn is always 0
-			// For TCP, InactiveConn are connections not in ESTABLISHED state
-			if rs.ActiveConn+rs.InactiveConn != 0 {
+			// For UDP traffic, no graceful termination, we immediately delete the RS
+			//     (existing connections will be deleted on the next packet because sysctlExpireNoDestConn=1)
+			// For other protocols, don't delete until all connections have expired)
+			if rsToDelete.VirtualServer.Protocol != "udp" && rs.ActiveConn+rs.InactiveConn != 0 {
+				glog.Infof("Not deleting, RS %v: %v ActiveConn, %v InactiveConn", rsToDelete.String(), rs.ActiveConn, rs.InactiveConn)
 				return false, nil
 			}
 			glog.Infof("Deleting rs: %s", rsToDelete.String())


### PR DESCRIPTION
#77802 [proxier/ipvs] Disable graceful termination for UDP traffic
#75283 Do not delete existing VS and RS when starting

/sig network
/area ipvs
/kind bug

/assign @m1093782566 
cc @andrewsykim 

I'm not sure we still accept cherry-picks for 1.11 but since it has graceful termination, this would bring two important fixes to this version.

```release-note
IPVS: Disable graceful termination for UDP traffic to solve issues with high number of UDP connections (DNS / syslog in particular)
IPVS: Allow for transparent kube-proxy restarts
```