### PR TITLE
kubeadm: fix conditional control-plane upgrade

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
@@ -52,6 +52,7 @@ func runControlPlane() func(c workflow.RunData) error {
 		// if this is not a control-plande node, this phase should not be executed
 		if !data.IsControlPlaneNode() {
 			fmt.Printf("[upgrade] Skipping phase. Not a control plane node")
+			return nil
 		}
 
 		// otherwise, retrieve all the info required for control plane upgrade


### PR DESCRIPTION
**What this PR does / why we need it**:
When a node is not a control-plane properly skip "control-plane"
upgrade phase.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubernetes/issues/78123
(but this is a separate fix for the `kubeadm upgrade`, not coredns related)
xref https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-upgrade-stable-master/1134419010629144577/build-log.txt

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @fabriziopandini @rosti 
/milestone v1.15
/priority critical-urgent
/kind bug
