### PR TITLE
Use go standard library for common bit operations

### DIFF
--- a/pkg/kubelet/cm/topologymanager/socketmask/socketmask.go
+++ b/pkg/kubelet/cm/topologymanager/socketmask/socketmask.go
@@ -18,6 +18,7 @@ package socketmask
 
 import (
 	"fmt"
+	"math/bits"
 )
 
 //SocketMask interface allows hint providers to create SocketMasks for TopologyHints
@@ -133,26 +134,12 @@ func (s *socketMask) IsNarrowerThan(mask SocketMask) bool {
 
 //String converts mask to string
 func (s *socketMask) String() string {
-	str := ""
-	for i := uint64(0); i < 64; i++ {
-		if (*s & (1 << i)) > 0 {
-			str += "1"
-		} else {
-			str += "0"
-		}
-	}
-	return str
+	return fmt.Sprintf("%064b", *s)
 }
 
 //Count counts number of bits in mask set to one
 func (s *socketMask) Count() int {
-	count := 0
-	for i := uint64(0); i < 64; i++ {
-		if (*s & (1 << i)) > 0 {
-			count++
-		}
-	}
-	return count
+	return bits.OnesCount64(uint64(*s))
 }
 
 //GetSockets returns each socket number with bits set to one

--- a/pkg/kubelet/cm/topologymanager/socketmask/socketmask_test.go
+++ b/pkg/kubelet/cm/topologymanager/socketmask/socketmask_test.go
@@ -29,8 +29,8 @@ func TestNewSocketMask(t *testing.T) {
 	}{
 		{
 			name:         "New SocketMask with socket 0 set",
-			socket:       int(0),
-			expectedMask: "1000000000000000000000000000000000000000000000000000000000000000",
+			socket:       0,
+			expectedMask: "0000000000000000000000000000000000000000000000000000000000000001",
 		},
 	}
 	for _, tc := range tcases {
@@ -52,7 +52,7 @@ func TestAdd(t *testing.T) {
 			name:         "New SocketMask with sockets 0 and 1 set",
 			firstSocket:  0,
 			secondSocket: 1,
-			expectedMask: "1100000000000000000000000000000000000000000000000000000000000000",
+			expectedMask: "0000000000000000000000000000000000000000000000000000000000000011",
 		},
 	}
 	for _, tc := range tcases {
@@ -77,7 +77,7 @@ func TestRemove(t *testing.T) {
 			firstSocketSet:    0,
 			secondSocketSet:   1,
 			firstSocketRemove: 0,
-			expectedMask:      "0100000000000000000000000000000000000000000000000000000000000000",
+			expectedMask:      "0000000000000000000000000000000000000000000000000000000000000010",
 		},
 	}
 	for _, tc := range tcases {
@@ -100,7 +100,7 @@ func TestAnd(t *testing.T) {
 			name:          "And socket masks",
 			firstMaskBit:  0,
 			secondMaskBit: 0,
-			andMask:       "1000000000000000000000000000000000000000000000000000000000000000",
+			andMask:       "0000000000000000000000000000000000000000000000000000000000000001",
 		},
 	}
 	for _, tc := range tcases {
@@ -122,9 +122,9 @@ func TestOr(t *testing.T) {
 	}{
 		{
 			name:          "Or socket masks",
-			firstMaskBit:  int(0),
-			secondMaskBit: int(1),
-			orMask:        "1100000000000000000000000000000000000000000000000000000000000000",
+			firstMaskBit:  0,
+			secondMaskBit: 1,
+			orMask:        "0000000000000000000000000000000000000000000000000000000000000011",
 		},
 	}
 	for _, tc := range tcases {
@@ -146,8 +146,8 @@ func TestClear(t *testing.T) {
 	}{
 		{
 			name:        "Clear socket masks",
-			firstBit:    int(0),
-			secondBit:   int(1),
+			firstBit:    0,
+			secondBit:   1,
 			clearedMask: "0000000000000000000000000000000000000000000000000000000000000000",
 		},
 	}
@@ -187,7 +187,7 @@ func TestIsEmpty(t *testing.T) {
 	}{
 		{
 			name:          "Check if mask is empty",
-			maskBit:       int(0),
+			maskBit:       0,
 			expectedEmpty: false,
 		},
 	}
@@ -208,7 +208,7 @@ func TestIsSet(t *testing.T) {
 	}{
 		{
 			name:        "Check if mask bit is set",
-			maskBit:     int(0),
+			maskBit:     0,
 			expectedSet: true,
 		},
 	}
@@ -230,8 +230,8 @@ func TestIsEqual(t *testing.T) {
 	}{
 		{
 			name:          "Check if two socket masks are equal",
-			firstMaskBit:  int(0),
-			secondMaskBit: int(0),
+			firstMaskBit:  0,
+			secondMaskBit: 0,
 			isEqual:       true,
 		},
 	}
@@ -253,7 +253,7 @@ func TestCount(t *testing.T) {
 	}{
 		{
 			name:          "Count number of bits set in full mask",
-			maskBit:       0,
+			maskBit:       42,
 			expectedCount: 1,
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
PR #72913 introduced own versions of the bit operations that are less efficient than ones from standard library. Let's not re-invent the wheel and use ones from standard library.

**Special notes for your reviewer**:
cc: @tedyu @dashpole  @klueska
PR #78451 will require rebase after this one.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
