### PR TITLE
Admit a critical pod in the kubelet even if failed to evict pods to free resources

### DIFF
--- a/pkg/kubelet/lifecycle/predicate.go
+++ b/pkg/kubelet/lifecycle/predicate.go
@@ -103,12 +103,12 @@ func (w *predicateAdmitHandler) Admit(attrs *PodAdmitAttributes) PodAdmitResult 
 		fit, reasons, err = w.admissionFailureHandler.HandleAdmissionFailure(admitPod, reasons)
 		if err != nil {
 			message := fmt.Sprintf("Unexpected error while attempting to recover from admission failure: %v", err)
-			klog.Warningf("Failed to admit pod %v - %s", format.Pod(admitPod), message)
-			return PodAdmitResult{
-				Admit:   fit,
-				Reason:  "UnexpectedAdmissionError",
-				Message: message,
-			}
+			klog.Warningf("Forcely admitted critical pod despite error %v - %s", format.Pod(admitPod), message)
+
+			// Failed to evict pods in order to free resources for a critical pod.
+			// We do admit the critical pod anyway, because in future syncPod loops,
+			// the kubelet will retry the pod deletion steps that it was stuck on.
+			fit = true
 		}
 	}
 	if !fit {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Admit a critical pod in the kubelet even if failed to evict pods to free resources

**Which issue(s) this PR fixes**:

Fixes #78405

**Special notes for your reviewer**:

In this PR I'm trying to offer a fix for #78405, introducing two changes:
1. Continue to kill pods during kubelet eviction to make room for critical pods regardless a pod failed to terminate
2. Admit a critical pod in the kubelet even if failed to evict pods to free resources

I've added tests to cover changes in `evictPodsToFreeRequests()`, while I didn't tested `Admit()` yet because it's not unit tested in `predicate_test.go` at all, while it should be indirectly tested in `kubelet_test.go` and I would like to have some inputs on what's the best way to proceed.

/hold

**Does this PR introduce a user-facing change?**:

```release-note
Admit a critical pod in the kubelet even if failed to evict pods to free resources
```