### PR TITLE
Use read lock for reconciler#getHandlers and clean up for the pluginmanager

### DIFF
--- a/pkg/kubelet/pluginmanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/pluginmanager/cache/actual_state_of_world.go
@@ -100,9 +100,7 @@ func (asw *actualStateOfWorld) RemovePlugin(socketPath string) {
 	asw.Lock()
 	defer asw.Unlock()
 
-	if _, ok := asw.socketFileToInfo[socketPath]; ok {
-		delete(asw.socketFileToInfo, socketPath)
-	}
+	delete(asw.socketFileToInfo, socketPath)
 }
 
 func (asw *actualStateOfWorld) GetRegisteredPlugins() []PluginInfo {

--- a/pkg/kubelet/pluginmanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/pluginmanager/cache/desired_state_of_world.go
@@ -147,9 +147,7 @@ func (dsw *desiredStateOfWorld) RemovePlugin(socketPath string) {
 	dsw.Lock()
 	defer dsw.Unlock()
 
-	if _, ok := dsw.socketFileToInfo[socketPath]; ok {
-		delete(dsw.socketFileToInfo, socketPath)
-	}
+	delete(dsw.socketFileToInfo, socketPath)
 }
 
 func (dsw *desiredStateOfWorld) GetPluginsToRegister() []PluginInfo {

--- a/pkg/kubelet/pluginmanager/reconciler/reconciler.go
+++ b/pkg/kubelet/pluginmanager/reconciler/reconciler.go
@@ -97,8 +97,8 @@ func (rc *reconciler) AddHandler(pluginType string, pluginHandler cache.PluginHa
 }
 
 func (rc *reconciler) getHandlers() map[string]cache.PluginHandler {
-	rc.Lock()
-	defer rc.Unlock()
+	rc.RLock()
+	defer rc.RUnlock()
 
 	return rc.handlers
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
For reconciler#getHandlers, read lock should suffice.

Also contains minor change where entry is deleted from map directly.

Related to #73891

```release-note
NONE
```
