### PR TITLE
Fix typo in SubjectAccessReview description

### DIFF
--- a/staging/src/k8s.io/api/authorization/v1/generated.proto
+++ b/staging/src/k8s.io/api/authorization/v1/generated.proto
@@ -130,7 +130,7 @@ message ResourceRule {
   repeated string resourceNames = 4;
 }
 
-// SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
+// SelfSubjectAccessReview checks whether or not the current user can perform an action.  Not filling in a
 // spec.namespace means "in all namespaces".  Self is a special case, because users should always be able
 // to check whether they can perform an action
 message SelfSubjectAccessReview {

--- a/staging/src/k8s.io/api/authorization/v1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1/types.go
@@ -46,7 +46,7 @@ type SubjectAccessReview struct {
 // +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
+// SelfSubjectAccessReview checks whether or not the current user can perform an action.  Not filling in a
 // spec.namespace means "in all namespaces".  Self is a special case, because users should always be able
 // to check whether they can perform an action
 type SelfSubjectAccessReview struct {

--- a/staging/src/k8s.io/api/authorization/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/authorization/v1/types_swagger_doc_generated.go
@@ -85,7 +85,7 @@ func (ResourceRule) SwaggerDoc() map[string]string {
 }
 
 var map_SelfSubjectAccessReview = map[string]string{
-	"":       "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
+	"":       "SelfSubjectAccessReview checks whether or not the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
 	"spec":   "Spec holds information about the request being evaluated.  user and groups must be empty",
 	"status": "Status is filled in by the server and indicates whether the request is allowed or not",
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes a small typo in the doc string for `SubjectAccessReview`.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```
