### PR TITLE
change aws encryptedCheck to exponential backoff

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -225,7 +225,7 @@ const (
 	createTagFactor       = 2.0
 	createTagSteps        = 9
 
-	// encryptedCheck* is configuration of exponential backoff for created volume to check
+	// volumeCreate* is configuration of exponential backoff for created volume to check
 	// it has not been silently removed by AWS.
 	// On a random AWS account (shared among several developers) it took 4s on
 	// average, 8s max.

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -225,8 +225,7 @@ const (
 	createTagFactor       = 2.0
 	createTagSteps        = 9
 
-	// volumeCreate* is configuration of exponential backoff for created volume to check
-	// it has not been silently removed by AWS.
+	// volumeCreate* is configuration of exponential backoff for created volume.
 	// On a random AWS account (shared among several developers) it took 4s on
 	// average, 8s max.
 	volumeCreateInitialDelay  = 5 * time.Second
@@ -2420,6 +2419,7 @@ func (c *Cloud) waitUntilVolumeAvailable(volumeName KubernetesVolumeID) error {
 		// Unreachable code
 		return err
 	}
+	time.Sleep(5 * time.Second)
 	backoff := wait.Backoff{
 		Duration: volumeCreateInitialDelay,
 		Factor:   volumeCreateBackoffFactor,

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -229,9 +229,9 @@ const (
 	// it has not been silently removed by AWS.
 	// On a random AWS account (shared among several developers) it took 4s on
 	// average, 8s max.
-	encryptedCheckInitialDelay = 1 * time.Second
-	encryptedCheckFactor       = 2.0
-	encryptedCheckSteps        = 8
+	volumeCreateInitialDelay  = 5 * time.Second
+	volumeCreateBackoffFactor = 1.2
+	volumeCreateBackoffSteps  = 10
 
 	// Number of node names that can be added to a filter. The AWS limit is 200
 	// but we are using a lower limit on purpose
@@ -2421,9 +2421,9 @@ func (c *Cloud) waitUntilVolumeAvailable(volumeName KubernetesVolumeID) error {
 		return err
 	}
 	backoff := wait.Backoff{
-		Duration: encryptedCheckInitialDelay,
-		Factor:   encryptedCheckFactor,
-		Steps:    encryptedCheckSteps,
+		Duration: volumeCreateInitialDelay,
+		Factor:   volumeCreateBackoffFactor,
+		Steps:    volumeCreateBackoffSteps,
 	}
 	err = wait.ExponentialBackoff(backoff, func() (done bool, err error) {
 		vol, err := disk.describeVolume()

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -225,12 +225,13 @@ const (
 	createTagFactor       = 2.0
 	createTagSteps        = 9
 
-	// encryptedCheck* is configuration of poll for created volume to check
+	// encryptedCheck* is configuration of exponential backoff for created volume to check
 	// it has not been silently removed by AWS.
 	// On a random AWS account (shared among several developers) it took 4s on
-	// average.
-	encryptedCheckInterval = 1 * time.Second
-	encryptedCheckTimeout  = 30 * time.Second
+	// average, 8s max.
+	encryptedCheckInitialDelay = 1 * time.Second
+	encryptedCheckFactor       = 2.0
+	encryptedCheckSteps        = 8
 
 	// Number of node names that can be added to a filter. The AWS limit is 200
 	// but we are using a lower limit on purpose
@@ -2419,8 +2420,12 @@ func (c *Cloud) waitUntilVolumeAvailable(volumeName KubernetesVolumeID) error {
 		// Unreachable code
 		return err
 	}
-
-	err = wait.Poll(encryptedCheckInterval, encryptedCheckTimeout, func() (done bool, err error) {
+	backoff := wait.Backoff{
+		Duration: encryptedCheckInitialDelay,
+		Factor:   encryptedCheckFactor,
+		Steps:    encryptedCheckSteps,
+	}
+	err = wait.ExponentialBackoff(backoff, func() (done bool, err error) {
 		vol, err := disk.describeVolume()
 		if err != nil {
 			return true, err


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
changing poll to exponential backoff for waiting to create encrypted aws volumes

**Which issue(s) this PR fixes**:
Fixes #77741

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
