### PR TITLE
Fix image status

### DIFF
--- a/pkg/kubelet/dockershim/docker_image.go
+++ b/pkg/kubelet/dockershim/docker_image.go
@@ -66,10 +66,16 @@ func (ds *dockerService) ImageStatus(_ context.Context, r *runtimeapi.ImageStatu
 
 	imageInspect, err := ds.client.InspectImageByRef(image.Image)
 	if err != nil {
-		if libdocker.IsImageNotFoundError(err) {
-			return &runtimeapi.ImageStatusResponse{}, nil
+		if !libdocker.IsImageNotFoundError(err) {
+			return nil, err
 		}
-		return nil, err
+		imageInspect, err = ds.client.InspectImageByID(image.Image)
+		if err != nil {
+			if libdocker.IsImageNotFoundError(err) {
+				return &runtimeapi.ImageStatusResponse{}, nil
+			}
+			return nil, err
+		}
 	}
 
 	imageStatus, err := imageInspectToRuntimeAPIImage(imageInspect)


### PR DESCRIPTION
This is the root cause of https://github.com/kubernetes/kubernetes/issues/78308.

Inspect image by ID doesn't work at all now. After https://github.com/kubernetes/kubernetes/pull/76665, we inspect image by ID, and find no images. `getImageUser` just silently return root in this case https://github.com/kubernetes/kubernetes/blob/26e3c8674e66f0d10170d34f5445f0aed207387f/pkg/kubelet/kuberuntime/helpers.go#L141.

This PR fixes it. Since https://github.com/kubernetes/kubernetes/pull/76665 has been reverted, I'm not sure whether we want to cherry-pick this fix to 1.14 or 1.13. But at least we should fix it in HEAD and 1.15.

```release-note
none
```

@kubernetes/sig-node-bugs 