### PR TITLE
Fix admission metrics bucket sizes

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -32,8 +32,8 @@ const (
 )
 
 var (
-	// Use buckets ranging from 25 ms to ~2.5 seconds.
-	latencyBuckets       = prometheus.ExponentialBuckets(25000, 2.5, 5)
+	// Use buckets ranging from 5 ms to 2.5 seconds (admission webhooks timeout at 30 seconds by default).
+	latencyBuckets       = []float64{0.005, 0.025, 0.1, 0.5, 2.5}
 	latencySummaryMaxAge = 5 * time.Hour
 
 	// Metrics provides access to all admission metrics.


### PR DESCRIPTION
When https://github.com/kubernetes/kubernetes/pull/72343 fixed admission metrics to use seconds instead of microseconds as the measured unit (which was totally my fault), the bucket sizes didn't get updated and so are off by 6 orders of magnitude. This fixes them.

/kind bug

```release-note
Fix admission metrics histogram bucket sizes to cover 25ms to ~2.5 seconds.
```

/sig api-machinery
/cc @logicalhan @danielqsj @brancz @sttts @liggitt @cheftako 