### PR TITLE
github size munger: don't ignore Godeps/ and vendor/

### DIFF
--- a/.generated_files
+++ b/.generated_files
@@ -22,6 +22,4 @@ file-name	generated.pb.go
 file-name	generated.proto
 file-name	types_swagger_doc_generated.go
 
-path-prefix	Godeps/
-path-prefix	vendor/
 path-prefix	pkg/generated/


### PR DESCRIPTION
It looks like the GitHub size munger has forever ignored Godeps/ and
vendor/ path prefixes.

Commit 69323c3c3931d1ff0473b50e8c2a1d04d88e5b4d does not indicate
why these were originally ignored.  Perhaps there is a rationale,
just not clearly recorded.

Still this leads to surprising "size/S" labels on patches that are
actually large and risky.  It feels it would be better to have those
show a size label that is more reflective of the risk sizing.

Signed-off-by: Tim Pepper <tpepper@vmware.com>


/kind cleanup

```release-note
NONE
```
