### PR TITLE
fix golint for /pkg/kubelet/preemption and some golint failures for /pkg/kubelet/sysctl

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -169,7 +169,6 @@ pkg/kubelet/lifecycle
 pkg/kubelet/metrics
 pkg/kubelet/pluginmanager/pluginwatcher
 pkg/kubelet/pod/testing
-pkg/kubelet/preemption
 pkg/kubelet/prober/results
 pkg/kubelet/prober/testing
 pkg/kubelet/qos

--- a/pkg/kubelet/preemption/preemption.go
+++ b/pkg/kubelet/preemption/preemption.go
@@ -50,6 +50,7 @@ type CriticalPodAdmissionHandler struct {
 
 var _ lifecycle.AdmissionFailureHandler = &CriticalPodAdmissionHandler{}
 
+// NewCriticalPodAdmissionHandler creates and initializes a new CriticalPodAdmissionHandler object.
 func NewCriticalPodAdmissionHandler(getPodsFunc eviction.ActivePodsFunc, killPodFunc eviction.KillPodFunc, recorder record.EventRecorder) *CriticalPodAdmissionHandler {
 	return &CriticalPodAdmissionHandler{
 		getPodsFunc: getPodsFunc,

--- a/pkg/kubelet/preemption/preemption_test.go
+++ b/pkg/kubelet/preemption/preemption_test.go
@@ -512,7 +512,7 @@ func parseCPUToInt64(res string) int64 {
 	return (&r).MilliValue()
 }
 
-func parseNonCpuResourceToInt64(res string) int64 {
+func parseNonCPUResourceToInt64(res string) int64 {
 	r := resource.MustParse(res)
 	return (&r).Value()
 }
@@ -528,7 +528,7 @@ func getAdmissionRequirementList(cpu, memory, pods int) admissionRequirementList
 	if memory > 0 {
 		reqs = append(reqs, &admissionRequirement{
 			resourceName: v1.ResourceMemory,
-			quantity:     parseNonCpuResourceToInt64(fmt.Sprintf("%dMi", memory)),
+			quantity:     parseNonCPUResourceToInt64(fmt.Sprintf("%dMi", memory)),
 		})
 	}
 	if pods > 0 {

--- a/pkg/kubelet/sysctl/namespace.go
+++ b/pkg/kubelet/sysctl/namespace.go
@@ -24,13 +24,13 @@ import (
 type Namespace string
 
 const (
-	// the Linux IPC namespace
+	// IpcNamespace represents the Linux IPC namespace
 	IpcNamespace = Namespace("ipc")
 
-	// the network namespace
+	// NetNamespace represents the network namespace
 	NetNamespace = Namespace("net")
 
-	// the zero value if no namespace is known
+	// UnknownNamespace represents the zero value if no namespace is known
 	UnknownNamespace = Namespace("")
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
 
/kind cleanup

**What this PR does / why we need it**:
fix golint for /pkg/kubelet/preemption
Fix some golint failures of /pkg/kubelet/sysctl

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
refer #68026
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
