### PR TITLE
Fix handling of ":" in filenames in kubectl cp

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -139,8 +139,14 @@ func extractFileSpec(arg string) (fileSpec, error) {
 	if i < 0 {
 		return fileSpec{File: arg}, nil
 	}
+
 	pod, file := arg[:i], arg[i+1:]
 	podPieces := strings.Split(pod, "/")
+
+	// Transform "pod:" into "pod:.", like scp
+	if len(file) == 0 {
+		file = "."
+	}
 
 	switch len(podPieces) {
 	case 1:

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -203,10 +203,7 @@ func (o *CopyOptions) Run(args []string) error {
 	}
 
 	if len(srcSpec.PodName) != 0 && len(destSpec.PodName) != 0 {
-		if _, err := os.Stat(args[0]); err == nil {
-			return o.copyToPod(fileSpec{File: args[0]}, destSpec, &exec.ExecOptions{})
-		}
-		return fmt.Errorf("src doesn't exist in local filesystem")
+		return fmt.Errorf("one of src or dest must be a local file, cannot copy from pod to pod")
 	}
 
 	if len(srcSpec.PodName) != 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
@@ -67,17 +67,34 @@ func TestExtractFileSpec(t *testing.T) {
 			expectedFile:      "/some/file",
 		},
 		{
+			spec:         "/::file-with-colon:",
+			expectedFile: "/::file-with-colon:",
+		},
+		{
+			spec:         ":file-with-leading-colon:",
+			expectedFile: ":file-with-leading-colon:",
+		},
+		{
+			spec:         "./::file-with-colon:",
+			expectedFile: "./::file-with-colon:",
+		},
+		{
+			spec:         "pod::",
+			expectedPod:  "pod",
+			expectedFile: ":",
+		},
+		{
 			spec:         "pod:/some/file",
 			expectedPod:  "pod",
 			expectedFile: "/some/file",
 		},
 		{
-			spec:         "/some/file",
-			expectedFile: "/some/file",
+			spec:         "file",
+			expectedFile: "file",
 		},
 		{
-			spec:      ":file:not:exist:in:local:filesystem",
-			expectErr: true,
+			spec:         "/some/file",
+			expectedFile: "/some/file",
 		},
 		{
 			spec:      "namespace/pod/invalid:/some/file",
@@ -90,24 +107,24 @@ func TestExtractFileSpec(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		spec, err := extractFileSpec(test.spec)
-		if test.expectErr && err == nil {
-			t.Errorf("unexpected non-error")
-			continue
-		}
-		if err != nil && !test.expectErr {
-			t.Errorf("unexpected error: %v", err)
-			continue
-		}
-		if spec.PodName != test.expectedPod {
-			t.Errorf("expected: %s, saw: %s", test.expectedPod, spec.PodName)
-		}
-		if spec.PodNamespace != test.expectedNamespace {
-			t.Errorf("expected: %s, saw: %s", test.expectedNamespace, spec.PodNamespace)
-		}
-		if spec.File != test.expectedFile {
-			t.Errorf("expected: %s, saw: %s", test.expectedFile, spec.File)
-		}
+		t.Run(test.spec, func(t *testing.T) {
+			spec, err := extractFileSpec(test.spec)
+			if test.expectErr && err == nil {
+				t.Errorf("unexpected non-error")
+			}
+			if err != nil && !test.expectErr {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if spec.PodName != test.expectedPod {
+				t.Errorf("expected podName: %s, saw: %s", test.expectedPod, spec.PodName)
+			}
+			if spec.PodNamespace != test.expectedNamespace {
+				t.Errorf("expected podNamespace: %s, saw: %s", test.expectedNamespace, spec.PodNamespace)
+			}
+			if spec.File != test.expectedFile {
+				t.Errorf("expected fileName: %s, saw: %s", test.expectedFile, spec.File)
+			}
+		})
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
@@ -67,6 +67,18 @@ func TestExtractFileSpec(t *testing.T) {
 			expectedFile:      "/some/file",
 		},
 		{
+			spec:              "namespace/pod:",
+			expectedPod:       "pod",
+			expectedNamespace: "namespace",
+			expectedFile:      ".",
+		},
+		{
+			spec:              "namespace/pod:",
+			expectedPod:       "pod",
+			expectedNamespace: "namespace",
+			expectedFile:      ".",
+		},
+		{
 			spec:         "/::file-with-colon:",
 			expectedFile: "/::file-with-colon:",
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/kind bug
/kind feature

**What this PR does / why we need it**:

This cleans up the filename handling and parsing inside kubectl-cp. Makes handling of files with ":" better, and adds a note in the docs about how it works.

It also adds support for the scp-like copy format "kubectl cp file ns/pod:", essentially resulting in "kubectl cp file ns/pod:.". This allows you to copy files to the containers working direcory without writing the trailing dot (a must for us who are used to scp).

And, it fixes the error message (and the strange behavior trying `copyToPod`) when trying to copy from pod to pod like: `kubectl cp pod:file pod:file`. Today it results in the strange error message "error: src doesn't exist in local filesystem"

/priority important-soon

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #72501

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for "kubectl cp file pod:" shorthand to copy into pod working directory
Make kubectl cp handle files with ":" properly
```
