### PR TITLE
Use Mutex for synchronization in imageCache

### DIFF
--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -107,8 +107,8 @@ type realImageGCManager struct {
 
 // imageCache caches latest result of ListImages.
 type imageCache struct {
-	// sync.RWMutex is the mutex protects the image cache.
-	sync.RWMutex
+	// sync.Mutex is the mutex protects the image cache.
+	sync.Mutex
 	// images is the image cache.
 	images []container.Image
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In imageCache, RWMutex was used for locking.
However, no read lock is taken in the func's.

This PR changes lock to Mutex so that we don't incur extra cost in RWMutex.

```release-note
NONE
```
