### PR TITLE
Check the correct value of Quantity for non-v1.ResourceCPU resource in GetResourceRequest

### DIFF
--- a/pkg/api/v1/resource/helpers.go
+++ b/pkg/api/v1/resource/helpers.go
@@ -86,8 +86,10 @@ func GetResourceRequest(pod *v1.Pod, resource v1.ResourceName) int64 {
 	// take max_resource(sum_pod, any_init_container)
 	for _, container := range pod.Spec.InitContainers {
 		if rQuantity, ok := container.Resources.Requests[resource]; ok {
-			if resource == v1.ResourceCPU && rQuantity.MilliValue() > totalResources {
-				totalResources = rQuantity.MilliValue()
+			if resource == v1.ResourceCPU {
+				if rQuantity.MilliValue() > totalResources {
+					totalResources = rQuantity.MilliValue()
+				}
 			} else if rQuantity.Value() > totalResources {
 				totalResources = rQuantity.Value()
 			}

--- a/pkg/api/v1/resource/helpers_test.go
+++ b/pkg/api/v1/resource/helpers_test.go
@@ -63,6 +63,31 @@ func TestDefaultResourceHelpers(t *testing.T) {
 	}
 }
 
+func TestGetResourceRequest(t *testing.T) {
+	cases := []struct {
+		pod           *v1.Pod
+		res           v1.ResourceName
+		expectedValue int64
+		expectedError error
+	}{
+		{
+			pod:           getPod("foo", "9", "", "", ""),
+			res:           v1.ResourceCPU,
+			expectedValue: 9000,
+		},
+		{
+			pod:           getPod("foo", "", "", "90Mi", ""),
+			res:           v1.ResourceMemory,
+			expectedValue: 94371840,
+		},
+	}
+	as := assert.New(t)
+	for idx, tc := range cases {
+		actual := GetResourceRequest(tc.pod, tc.res)
+		as.Equal(actual, tc.expectedValue, "expected test case [%d] to return %q; got %q instead", idx, tc.expectedValue, actual)
+	}
+}
+
 func TestExtractResourceValue(t *testing.T) {
 	cases := []struct {
 		fs            *v1.ResourceFieldSelector


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In GetResourceRequest, the condition for v1.ResourceCPU resource and rQuantity.MilliValue comparison is bundled together.

This introduces a bug where for v1.ResourceCPU whose rQuantity.MilliValue is not greater than totalResources, its rQuantity.Value would be compared again.
However the unit for v1.ResourceCPU should be Milli .

This PR fixes the bug.

```release-note
NONE
```
