### PR TITLE
add labels for leader lock resources

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -48,15 +48,18 @@ func createLockObject(objectType, namespace, name string, record rl.LeaderElecti
 		objectMeta.Annotations = map[string]string{
 			rl.LeaderElectionRecordAnnotationKey: string(recordBytes),
 		}
+		objectMeta.Labels = map[string]string{}
 		obj = &corev1.Endpoints{ObjectMeta: objectMeta}
 	case "configmaps":
 		recordBytes, _ := json.Marshal(record)
 		objectMeta.Annotations = map[string]string{
 			rl.LeaderElectionRecordAnnotationKey: string(recordBytes),
 		}
+		objectMeta.Labels = map[string]string{}
 		obj = &corev1.ConfigMap{ObjectMeta: objectMeta}
 	case "leases":
 		spec := rl.LeaderElectionRecordToLeaseSpec(&record)
+		objectMeta.Labels = map[string]string{}
 		obj = &coordinationv1.Lease{ObjectMeta: objectMeta, Spec: spec}
 	default:
 		panic("unexpected objType:" + objectType)
@@ -117,7 +120,7 @@ func testTryAcquireOrRenew(t *testing.T, objectType string) {
 				{
 					verb: "get",
 					reaction: func(action fakeclient.Action) (handled bool, ret runtime.Object, err error) {
-						return true, createLockObject(objectType, action.GetNamespace(), action.(fakeclient.GetAction).GetName(), rl.LeaderElectionRecord{}), nil
+						return true, createLockObject(objectType, action.GetNamespace(), action.(fakeclient.GetAction).GetName(), ojrl.LeaderElectionRecord{}), nil
 					},
 				},
 				{

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -72,6 +72,7 @@ func (cml *ConfigMapLock) Create(ler LeaderElectionRecord) error {
 			Annotations: map[string]string{
 				LeaderElectionRecordAnnotationKey: string(recordBytes),
 			},
+			Labels: cml.ConfigMapMeta.Labels,
 		},
 	})
 	return err
@@ -87,6 +88,7 @@ func (cml *ConfigMapLock) Update(ler LeaderElectionRecord) error {
 		return err
 	}
 	cml.cm.Annotations[LeaderElectionRecordAnnotationKey] = string(recordBytes)
+	cml.cm.Labels = cml.ConfigMapMeta.Labels
 	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Update(cml.cm)
 	return err
 }

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/endpointslock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/endpointslock.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -67,6 +67,7 @@ func (el *EndpointsLock) Create(ler LeaderElectionRecord) error {
 			Annotations: map[string]string{
 				LeaderElectionRecordAnnotationKey: string(recordBytes),
 			},
+			Labels: el.EndpointsMeta.Labels,
 		},
 	})
 	return err
@@ -82,6 +83,7 @@ func (el *EndpointsLock) Update(ler LeaderElectionRecord) error {
 		return err
 	}
 	el.e.Annotations[LeaderElectionRecordAnnotationKey] = string(recordBytes)
+	el.e.Labels = el.EndpointsMeta.Labels
 	el.e, err = el.Client.Endpoints(el.EndpointsMeta.Namespace).Update(el.e)
 	return err
 }

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
@@ -92,37 +92,7 @@ type Interface interface {
 
 // New will create a lock of a given type according to the input parameters
 func New(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient coordinationv1.CoordinationV1Interface, rlc ResourceLockConfig) (Interface, error) {
-	switch lockType {
-	case EndpointsResourceLock:
-		return &EndpointsLock{
-			EndpointsMeta: metav1.ObjectMeta{
-				Namespace: ns,
-				Name:      name,
-			},
-			Client:     coreClient,
-			LockConfig: rlc,
-		}, nil
-	case ConfigMapsResourceLock:
-		return &ConfigMapLock{
-			ConfigMapMeta: metav1.ObjectMeta{
-				Namespace: ns,
-				Name:      name,
-			},
-			Client:     coreClient,
-			LockConfig: rlc,
-		}, nil
-	case LeasesResourceLock:
-		return &LeaseLock{
-			LeaseMeta: metav1.ObjectMeta{
-				Namespace: ns,
-				Name:      name,
-			},
-			Client:     coordinationClient,
-			LockConfig: rlc,
-		}, nil
-	default:
-		return nil, fmt.Errorf("Invalid lock-type %s", lockType)
-	}
+	return NewWithLabels(lockType, ns, name, map[string]string{}, coreClient, coordinationClient, rlc)
 }
 
 // NewWithLabels will create a lock with labels of a given type according to the input parameters

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
@@ -90,7 +90,7 @@ type Interface interface {
 	Describe() string
 }
 
-// Manufacture will create a lock of a given type according to the input parameters
+// New will create a lock of a given type according to the input parameters
 func New(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient coordinationv1.CoordinationV1Interface, rlc ResourceLockConfig) (Interface, error) {
 	switch lockType {
 	case EndpointsResourceLock:
@@ -125,7 +125,7 @@ func New(lockType string, ns string, name string, coreClient corev1.CoreV1Interf
 	}
 }
 
-// Manufacture will create a lock of a given type according to the input parameters
+// NewWithLabels will create a lock with labels of a given type according to the input parameters
 func NewWithLabels(lockType string, ns string, name string, labels map[string]string, coreClient corev1.CoreV1Interface, coordinationClient coordinationv1.CoordinationV1Interface, rlc ResourceLockConfig) (Interface, error) {
 	switch lockType {
 	case EndpointsResourceLock:

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
@@ -124,3 +124,41 @@ func New(lockType string, ns string, name string, coreClient corev1.CoreV1Interf
 		return nil, fmt.Errorf("Invalid lock-type %s", lockType)
 	}
 }
+
+// Manufacture will create a lock of a given type according to the input parameters
+func NewWithLabels(lockType string, ns string, name string, labels map[string]string, coreClient corev1.CoreV1Interface, coordinationClient coordinationv1.CoordinationV1Interface, rlc ResourceLockConfig) (Interface, error) {
+	switch lockType {
+	case EndpointsResourceLock:
+		return &EndpointsLock{
+			EndpointsMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+				Labels:    labels,
+			},
+			Client:     coreClient,
+			LockConfig: rlc,
+		}, nil
+	case ConfigMapsResourceLock:
+		return &ConfigMapLock{
+			ConfigMapMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+				Labels:    labels,
+			},
+			Client:     coreClient,
+			LockConfig: rlc,
+		}, nil
+	case LeasesResourceLock:
+		return &LeaseLock{
+			LeaseMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+				Labels:    labels,
+			},
+			Client:     coordinationClient,
+			LockConfig: rlc,
+		}, nil
+	default:
+		return nil, fmt.Errorf("Invalid lock-type %s", lockType)
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
@@ -52,6 +52,7 @@ func (ll *LeaseLock) Create(ler LeaderElectionRecord) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ll.LeaseMeta.Name,
 			Namespace: ll.LeaseMeta.Namespace,
+			Labels:    ll.LeaseMeta.Labels,
 		},
 		Spec: LeaderElectionRecordToLeaseSpec(&ler),
 	})
@@ -64,6 +65,7 @@ func (ll *LeaseLock) Update(ler LeaderElectionRecord) error {
 		return errors.New("lease not initialized, call get or create first")
 	}
 	ll.lease.Spec = LeaderElectionRecordToLeaseSpec(&ler)
+	ll.lease.Labels = ll.LeaseMeta.Labels
 	var err error
 	ll.lease, err = ll.Client.Leases(ll.LeaseMeta.Namespace).Update(ll.lease)
 	return err


### PR DESCRIPTION
/kind feature
**What this PR does / why we need it**:
Enable to add lables to lock resources, which may be used in other controller to watch those resource.
