### PR TITLE
Delete pods from unschedulable queue when add operation passes

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -540,16 +540,19 @@ func (p *PriorityQueue) MoveAllToActiveQueue() {
 func (p *PriorityQueue) movePodsToActiveQueue(podInfoList []*framework.PodInfo) {
 	for _, pInfo := range podInfoList {
 		pod := pInfo.Pod
+		var err error
 		if p.isPodBackingOff(pod) {
-			if err := p.podBackoffQ.Add(pInfo); err != nil {
+			if err = p.podBackoffQ.Add(pInfo); err != nil {
 				klog.Errorf("Error adding pod %v to the backoff queue: %v", pod.Name, err)
 			}
 		} else {
-			if err := p.activeQ.Add(pInfo); err != nil {
+			if err = p.activeQ.Add(pInfo); err != nil {
 				klog.Errorf("Error adding pod %v to the scheduling queue: %v", pod.Name, err)
 			}
 		}
-		p.unschedulableQ.delete(pod)
+		if err == nil {
+			p.unschedulableQ.delete(pod)
+		}
 	}
 	p.moveRequestCycle = p.schedulingCycle
 	p.cond.Broadcast()


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As @NickrenREN reported over #78631, PriorityQueue#movePodsToActiveQueue should only remove the pod from p.unschedulableQ when add operation passes.

**Which issue(s) this PR fixes**:
Fixes #78631

```release-note
NONE
```
