### PR TITLE
Protect against panic in getItemsPtr

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
@@ -92,6 +92,10 @@ func getItemsPtr(list runtime.Object) (interface{}, error) {
 		return nil, err
 	}
 
+	// v.FieldByName would panic if v.Kind() is not Struct
+	if v.Kind() != reflect.Struct {
+		return nil, errExpectFieldItems
+	}
 	items := v.FieldByName("Items")
 	if !items.IsValid() {
 		return nil, errExpectFieldItems


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When I investigated the panic reported from issue #76075, I was looking at listing for resources.

In getItemsPtr, there are a few places where protection against panic from golang should be added.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```
