### PR TITLE
Return error from CgroupManager#Validate

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -245,8 +245,9 @@ func updateSystemdCgroupInfo(cgroupConfig *libcontainerconfigs.Cgroup, cgroupNam
 	cgroupConfig.Name = base
 }
 
-// Exists checks if all subsystem cgroups already exist
-func (m *cgroupManagerImpl) Exists(name CgroupName) bool {
+// Validate checks if all subsystem cgroups already exist
+// returns error if there is missing path
+func (m *cgroupManagerImpl) Validate(name CgroupName) error {
 	// Get map of all cgroup paths on the system for the particular cgroup
 	cgroupPaths := m.buildCgroupPaths(name)
 
@@ -274,10 +275,10 @@ func (m *cgroupManagerImpl) Exists(name CgroupName) bool {
 
 	if len(missingPaths) > 0 {
 		klog.V(4).Infof("The Cgroup %v has some missing paths: %v", name, missingPaths)
-		return false
+		return fmt.Errorf("the Cgroup %v has some missing paths: %v", name, missingPaths)
 	}
 
-	return true
+	return nil
 }
 
 // Destroy destroys the specified cgroup

--- a/pkg/kubelet/cm/cgroup_manager_unsupported.go
+++ b/pkg/kubelet/cm/cgroup_manager_unsupported.go
@@ -38,8 +38,8 @@ func (m *unsupportedCgroupManager) Name(_ CgroupName) string {
 	return ""
 }
 
-func (m *unsupportedCgroupManager) Exists(_ CgroupName) bool {
-	return false
+func (m *unsupportedCgroupManager) Validate(_ CgroupName) error {
+	return fmt.Errorf("Cgroup Manager is not supported in this build")
 }
 
 func (m *unsupportedCgroupManager) Destroy(_ *CgroupConfig) error {

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -255,8 +255,8 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 		// of note, we always use the cgroupfs driver when performing this check since
 		// the input is provided in that format.
 		// this is important because we do not want any name conversion to occur.
-		if !cgroupManager.Exists(cgroupRoot) {
-			return nil, fmt.Errorf("invalid configuration: cgroup-root %q doesn't exist", cgroupRoot)
+		if err := cgroupManager.Validate(cgroupRoot); err != nil {
+			return nil, fmt.Errorf("invalid configuration: %v", err)
 		}
 		klog.Infof("container manager verified user specified cgroup-root exists: %v", cgroupRoot)
 		// Include the top level cgroup for enforcing node allocatable into cgroup-root.

--- a/pkg/kubelet/cm/node_container_manager_linux.go
+++ b/pkg/kubelet/cm/node_container_manager_linux.go
@@ -43,7 +43,7 @@ func (cm *containerManagerImpl) createNodeAllocatableCgroups() error {
 		// The default limits for cpu shares can be very low which can lead to CPU starvation for pods.
 		ResourceParameters: getCgroupConfig(cm.internalCapacity),
 	}
-	if cm.cgroupManager.Exists(cgroupConfig.Name) {
+	if err := cm.cgroupManager.Validate(cgroupConfig.Name); err == nil {
 		return nil
 	}
 	if err := cm.cgroupManager.Create(cgroupConfig); err != nil {
@@ -132,8 +132,8 @@ func enforceExistingCgroup(cgroupManager CgroupManager, cName CgroupName, rl v1.
 		return fmt.Errorf("%q cgroup is not config properly", cgroupConfig.Name)
 	}
 	klog.V(4).Infof("Enforcing limits on cgroup %q with %d cpu shares, %d bytes of memory, and %d processes", cName, cgroupConfig.ResourceParameters.CpuShares, cgroupConfig.ResourceParameters.Memory, cgroupConfig.ResourceParameters.PidsLimit)
-	if !cgroupManager.Exists(cgroupConfig.Name) {
-		return fmt.Errorf("%q cgroup does not exist", cgroupConfig.Name)
+	if err := cgroupManager.Validate(cgroupConfig.Name); err != nil {
+		return fmt.Errorf("%q cgroup is not valid: %v", cgroupConfig.Name, err)
 	}
 	if err := cgroupManager.Update(cgroupConfig); err != nil {
 		return err

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -70,7 +70,10 @@ func (m *podContainerManagerImpl) applyLimits(pod *v1.Pod) error {
 // Exists checks if the pod's cgroup already exists
 func (m *podContainerManagerImpl) Exists(pod *v1.Pod) bool {
 	podContainerName, _ := m.GetPodContainerName(pod)
-	return m.cgroupManager.Exists(podContainerName)
+	if err := m.cgroupManager.Validate(podContainerName); err == nil {
+		return true
+	}
+	return false
 }
 
 // EnsureExists takes a pod as argument and makes sure that

--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -81,8 +81,8 @@ func (m *qosContainerManagerImpl) GetQOSContainersInfo() QOSContainersInfo {
 func (m *qosContainerManagerImpl) Start(getNodeAllocatable func() v1.ResourceList, activePods ActivePodsFunc) error {
 	cm := m.cgroupManager
 	rootContainer := m.cgroupRoot
-	if !cm.Exists(rootContainer) {
-		return fmt.Errorf("root container %v doesn't exist", rootContainer)
+	if err := cm.Validate(rootContainer); err != nil {
+		return fmt.Errorf("root container invalid: %v", err)
 	}
 
 	// Top level for Qos containers are created only for Burstable
@@ -111,7 +111,7 @@ func (m *qosContainerManagerImpl) Start(getNodeAllocatable func() v1.ResourceLis
 		m.setHugePagesUnbounded(containerConfig)
 
 		// check if it exists
-		if !cm.Exists(containerName) {
+		if err := cm.Validate(containerName); err != nil {
 			if err := cm.Create(containerConfig); err != nil {
 				return fmt.Errorf("failed to create top level %v QOS cgroup : %v", qosClass, err)
 			}

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -76,8 +76,8 @@ type CgroupManager interface {
 	Destroy(*CgroupConfig) error
 	// Update cgroup configuration.
 	Update(*CgroupConfig) error
-	// Exists checks if the cgroup already exists
-	Exists(name CgroupName) bool
+	// Validate checks if the cgroup already exists
+	Validate(name CgroupName) error
 	// Name returns the literal cgroupfs name on the host after any driver specific conversions.
 	// We would expect systemd implementation to make appropriate name conversion.
 	// For example, if we pass {"foo", "bar"}

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -112,7 +112,7 @@ const (
 )
 
 func createIfNotExists(cm cm.CgroupManager, cgroupConfig *cm.CgroupConfig) error {
-	if !cm.Exists(cgroupConfig.Name) {
+	if err := cm.Validate(cgroupConfig.Name); err != nil {
 		if err := cm.Create(cgroupConfig); err != nil {
 			return err
 		}
@@ -183,8 +183,8 @@ func runTest(f *framework.Framework) error {
 
 	expectedNAPodCgroup := cm.ParseCgroupfsToCgroupName(currentConfig.CgroupRoot)
 	expectedNAPodCgroup = cm.NewCgroupName(expectedNAPodCgroup, "kubepods")
-	if !cgroupManager.Exists(expectedNAPodCgroup) {
-		return fmt.Errorf("Expected Node Allocatable Cgroup Does not exist")
+	if err := cgroupManager.Validate(expectedNAPodCgroup); err != nil {
+		return fmt.Errorf("expected an error but got nil")
 	}
 	// TODO: Update cgroupManager to expose a Status interface to get current Cgroup Settings.
 	// The node may not have updated capacity and allocatable yet, so check that it happens eventually.
@@ -233,8 +233,8 @@ func runTest(f *framework.Framework) error {
 	}, time.Minute, 5*time.Second).Should(BeNil())
 
 	kubeReservedCgroupName := cm.NewCgroupName(cm.RootCgroupName, kubeReservedCgroup)
-	if !cgroupManager.Exists(kubeReservedCgroupName) {
-		return fmt.Errorf("Expected kube reserved cgroup Does not exist")
+	if err := cgroupManager.Validate(kubeReservedCgroupName); err != nil {
+		return fmt.Errorf("kube reserved cgroup invalid: %v", err)
 	}
 	// Expect CPU shares on kube reserved cgroup to equal it's reservation which is `100m`.
 	kubeReservedCPU := resource.MustParse(currentConfig.KubeReserved[string(v1.ResourceCPU)])
@@ -252,8 +252,8 @@ func runTest(f *framework.Framework) error {
 		return err
 	}
 	systemReservedCgroupName := cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup)
-	if !cgroupManager.Exists(systemReservedCgroupName) {
-		return fmt.Errorf("Expected system reserved cgroup Does not exist")
+	if err := cgroupManager.Validate(systemReservedCgroupName); err != nil {
+		return fmt.Errorf("system reserved cgroup invalid: %v", err)
 	}
 	// Expect CPU shares on system reserved cgroup to equal it's reservation which is `100m`.
 	systemReservedCPU := resource.MustParse(currentConfig.SystemReserved[string(v1.ResourceCPU)])


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
When troubleshooting cgroup related issues, user may have to turn on log V4 in order to know the root cause - see #78629

This PR returns error from CgroupManager#Exists so that the caller can log the error as cause.

```release-note
NONE
```
