### PR TITLE
Fix volume mount tests issue for windows

### DIFF
--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -546,10 +546,8 @@ func InjectHTML(client clientset.Interface, config TestConfig, fsGroup *int64, v
 					SecurityContext: GenerateSecurityContext(true),
 				},
 			},
-			SecurityContext: &v1.PodSecurityContext{
-				FSGroup: fsGroup,
-			},
-			RestartPolicy: v1.RestartPolicyNever,
+			SecurityContext: GeneratePodSecurityContext(fsGroup, nil),
+			RestartPolicy:   v1.RestartPolicyNever,
 			Volumes: []v1.Volume{
 				{
 					Name:         volMountName,


### PR DESCRIPTION
For windows node, security context is disabled. This PR fixes a bug so
that fsGroup will not be applied to pods that run on windows node.

Change-Id: Id9870416d2ad8ef791b3b4896d6747a2adbada2f

