### PR TITLE
Remove redundant assignment to volumeAttachment

### DIFF
--- a/pkg/registry/storage/volumeattachment/strategy.go
+++ b/pkg/registry/storage/volumeattachment/strategy.go
@@ -61,7 +61,6 @@ func (volumeAttachmentStrategy) PrepareForCreate(ctx context.Context, obj runtim
 	case storageapiv1beta1.SchemeGroupVersion:
 		// allow modification of status for v1beta1
 	default:
-		volumeAttachment := obj.(*storage.VolumeAttachment)
 		volumeAttachment.Status = storage.VolumeAttachmentStatus{}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR removes redundant assignment to volumeAttachment in volumeAttachmentStrategy#PrepareForCreate

Related to #77703

```release-note
NONE
```
