### PR TITLE
Disable KubeletPodResources on Windows

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -869,6 +869,10 @@ function construct-windows-kubelet-flags {
   # Turn off kernel memory cgroup notification.
   flags+=" --experimental-kernel-memcg-notification=false"
 
+  # TODO(#78628): Re-enable KubeletPodResources when the issue is fixed.
+  # Force disable KubeletPodResources feature on Windows until #78628 is fixed.
+  flags+=" --feature-gates=KubeletPodResources=false"
+
   KUBELET_ARGS="${flags}"
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/sig node
/sig windows
/priority critical-urgent

**What this PR does / why we need it**:
The feature caused tests to fail when it was enabled.

- https://github.com/kubernetes/kubernetes/issues/78628

Work is in progress to fix the feature, but until that work is complete,
we will disable it in the GCE scripts.

**Does this PR introduce a user-facing change?**:
```release-note
kube-up.sh scripts now disable the KubeletPodResources feature for Windows nodes, due to issue #78628.
```
