### PR TITLE
Fix #78628, LocalEndpoint should prepend path with \\.\pipe for Windows

### DIFF
--- a/pkg/kubelet/util/util_windows.go
+++ b/pkg/kubelet/util/util_windows.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -109,11 +110,12 @@ func parseEndpoint(endpoint string) (string, string, error) {
 
 // LocalEndpoint returns the full path to a windows named pipe
 func LocalEndpoint(path, file string) string {
+	pipePath := filepath.Join("//./pipe/", path, file)
 	u := url.URL{
 		Scheme: npipeProtocol,
-		Path:   path,
+		Path:   strings.Replace(pipePath, "\\", "/", -1),
 	}
-	return u.String() + "//./pipe/" + file
+	return u.String()
 }
 
 var tickCount = syscall.NewLazyDLL("kernel32.dll").NewProc("GetTickCount64")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

https://github.com/kubernetes/kubernetes/pull/77274 enabled the pod-resource endpoint by default, which wasn't tested on Windows. The code as-written creates a malformed path, and starting the kubelet fails.

**Which issue(s) this PR fixes**:

Fixes #78628

**Special notes for your reviewer**:

This is the most straightforward fix, but I don't really like it. I don't think ` \\.\pipe\var\lib\kubelet\pod-resources\kubelet` is a good path. It's not consistent with the others used on Windows: such as `\\.\pipe\docker_engine`, `\\.\pipe\dockershim`

I would prefer to clean this up and use `\\.\pipe\kubelet\pod-resources` but it will require changing more files. What do you think?

**Does this PR introduce a user-facing change?**:

```release-note
Set pod-resource endpoint to \\.\pipe\var\lib\kubelet\pod-resources\kubelet for Windows
```
