### PR TITLE
Remove inner loop for finding MinReclaim in ParseThresholdConfig

### DIFF
--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -128,11 +128,8 @@ func ParseThresholdConfig(allocatableConfig []string, evictionHard, evictionSoft
 	}
 	results = append(results, softThresholds...)
 	for i := range results {
-		for signal, minReclaim := range minReclaims {
-			if results[i].Signal == signal {
-				results[i].MinReclaim = &minReclaim
-				break
-			}
+		if minReclaim, ok := minReclaims[results[i].Signal]; ok {
+			results[i].MinReclaim = &minReclaim
 		}
 	}
 	for _, key := range allocatableConfig {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently a nested loop is used to find MinReclaim in ParseThresholdConfig.
Since minReclaims is a map, the inner loop is not needed.

This PR replaces the inner loop with map lookup.

```release-note
NONE
```
