### PR TITLE
fix: remove unnecessary conversion and several scope lint errors

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -465,5 +465,5 @@ func nodeConditionsChanged(newNode *v1.Node, oldNode *v1.Node) bool {
 }
 
 func nodeSpecUnschedulableChanged(newNode *v1.Node, oldNode *v1.Node) bool {
-	return newNode.Spec.Unschedulable != oldNode.Spec.Unschedulable && newNode.Spec.Unschedulable == false
+	return newNode.Spec.Unschedulable != oldNode.Spec.Unschedulable && !newNode.Spec.Unschedulable
 }

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -104,7 +104,9 @@ func TestSkipPodUpdate(t *testing.T) {
 			expected: false,
 		},
 	}
-	for _, test := range table {
+	for i := range table {
+		test := table[i]
+
 		t.Run(test.name, func(t *testing.T) {
 			c := NewFromConfig(&factory.Config{
 				SchedulerCache: &fakecache.Cache{

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -217,7 +217,7 @@ func initPolicyFromFile(policyFile string, policy *schedulerapi.Policy) error {
 	if err != nil {
 		return fmt.Errorf("couldn't read policy config: %v", err)
 	}
-	err = runtime.DecodeInto(latestschedulerapi.Codec, []byte(data), policy)
+	err = runtime.DecodeInto(latestschedulerapi.Codec, data, policy)
 	if err != nil {
 		return fmt.Errorf("invalid policy: %v", err)
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -275,7 +275,9 @@ func TestScheduler(t *testing.T) {
 	informerFactory.Start(stop)
 	informerFactory.WaitForCacheSync(stop)
 
-	for _, item := range table {
+	for i := range table {
+		item := table[i]
+
 		t.Run(item.name, func(t *testing.T) {
 			var gotError error
 			var gotPod *v1.Pod


### PR DESCRIPTION
/kind cleanup
/priority backlog
/sig scheduling

**What this PR does / why we need it**:

remove unnecessary conversion and several scope lint errors

```release-note
NONE
```
