### PR TITLE
Add benchmarks for yaml marshaling and unmarshaling

### DIFF
--- a/pkg/api/testing/BUILD
+++ b/pkg/api/testing/BUILD
@@ -111,5 +111,6 @@ go_test(
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/github.com/json-iterator/go:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/pkg/api/testing/serialization_test.go
+++ b/pkg/api/testing/serialization_test.go
@@ -47,6 +47,7 @@ import (
 	k8s_apps_v1 "k8s.io/kubernetes/pkg/apis/apps/v1"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	k8s_api_v1 "k8s.io/kubernetes/pkg/apis/core/v1"
+	"sigs.k8s.io/yaml"
 )
 
 // fuzzInternalObject fuzzes an arbitrary runtime object using the appropriate
@@ -610,6 +611,43 @@ func BenchmarkDecodeIntoJSONCodecGenConfigCompatibleWithStandardLibrary(b *testi
 	for i := 0; i < b.N; i++ {
 		obj := v1.Pod{}
 		if err := iter.Unmarshal(encoded[i%width], &obj); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+}
+
+// BenchmarkEncodeYAMLMarshal provides a baseline for regular YAML encode performance
+func BenchmarkEncodeYAMLMarshal(b *testing.B) {
+	items := benchmarkItems(b)
+	width := len(items)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := yaml.Marshal(&items[i%width]); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+}
+
+// BenchmarkDecodeYAML provides a baseline for regular YAML decode performance
+func BenchmarkDecodeIntoYAML(b *testing.B) {
+	codec := testapi.Default.Codec()
+	items := benchmarkItems(b)
+	width := len(items)
+	encoded := make([][]byte, width)
+	for i := range items {
+		data, err := runtime.Encode(codec, &items[i])
+		if err != nil {
+			b.Fatal(err)
+		}
+		encoded[i] = data
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		obj := v1.Pod{}
+		if err := yaml.Unmarshal(encoded[i%width], &obj); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Related: https://github.com/kubernetes-sigs/yaml/pull/19

/kind cleanup
/cc @liggitt @dims @neolit123 @sttts 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
