### PR TITLE
Revert CoreDNS to 1.3.1 in kube-up

### DIFF
--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -64,7 +64,6 @@ data:
     .:53 {
         errors
         health
-        ready
         kubernetes __PILLAR__DNS__DOMAIN__ in-addr.arpa ip6.arpa {
             pods insecure
             fallthrough in-addr.arpa ip6.arpa
@@ -116,7 +115,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.5.0
+        image: k8s.gcr.io/coredns:1.3.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -150,8 +149,8 @@ spec:
           failureThreshold: 5
         readinessProbe:
           httpGet:
-            path: /ready
-            port: 8181
+            path: /health
+            port: 8080
             scheme: HTTP
         securityContext:
           allowPrivilegeEscalation: false

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -64,7 +64,6 @@ data:
     .:53 {
         errors
         health
-        ready
         kubernetes {{ pillar['dns_domain'] }} in-addr.arpa ip6.arpa {
             pods insecure
             fallthrough in-addr.arpa ip6.arpa
@@ -116,7 +115,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.5.0
+        image: k8s.gcr.io/coredns:1.3.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -150,8 +149,8 @@ spec:
           failureThreshold: 5
         readinessProbe:
           httpGet:
-            path: /ready
-            port: 8181
+            path: /health
+            port: 8080
             scheme: HTTP
         securityContext:
           allowPrivilegeEscalation: false

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -64,7 +64,6 @@ data:
     .:53 {
         errors
         health
-        ready
         kubernetes $DNS_DOMAIN in-addr.arpa ip6.arpa {
             pods insecure
             fallthrough in-addr.arpa ip6.arpa
@@ -116,7 +115,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.5.0
+        image: k8s.gcr.io/coredns:1.3.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -150,8 +149,8 @@ spec:
           failureThreshold: 5
         readinessProbe:
           httpGet:
-            path: /ready
-            port: 8181
+            path: /health
+            port: 8080
             scheme: HTTP
         securityContext:
           allowPrivilegeEscalation: false

--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -67,7 +67,6 @@ func (t *dnsFederationsConfigMapTest) run() {
 		valid1 := map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
         health
-        ready
         kubernetes %v in-addr.arpa ip6.arpa {
             pods insecure
             upstream
@@ -84,7 +83,6 @@ func (t *dnsFederationsConfigMapTest) run() {
 		valid2 := map[string]string{
 			"Corefile": fmt.Sprintf(`:53 {
         health
-        ready
         kubernetes %v in-addr.arpa ip6.arpa {
             pods insecure
             upstream
@@ -235,7 +233,6 @@ func (t *dnsNameserverTest) run(isIPv6 bool) {
 		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
         health
-        ready
         kubernetes %v in-addr.arpa ip6.arpa {
            pods insecure
            upstream
@@ -335,7 +332,6 @@ func (t *dnsPtrFwdTest) run(isIPv6 bool) {
 		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
         health
-        ready
         kubernetes %v in-addr.arpa ip6.arpa {
            pods insecure
            upstream
@@ -447,7 +443,6 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
 		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
         health
-        ready
         kubernetes %v in-addr.arpa ip6.arpa {
            pods insecure
            upstream


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Reverts CoreDNS to 1.3.1 for k8s 1.15
Reverts changes from https://github.com/kubernetes/kubernetes/pull/78030 and https://github.com/kubernetes/kubernetes/pull/78305

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Revert the CoreDNS version to 1.3.1
```
