### PR TITLE
fix-kubeadm-upgrade-node

### DIFF
--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -141,4 +141,10 @@ const (
 
 	// ForceReset flag instruct kubeadm to reset the node without prompting for confirmation
 	ForceReset = "force"
+
+	// CertificateRenewal flag instruct kubeadm to execute certificate renewal during upgrades
+	CertificateRenewal = "certificate-renewal"
+
+	// EtcdUpgrade flag instruct kubeadm to execute etcd upgrade during upgrades
+	EtcdUpgrade = "etcd-upgrade"
 )

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
@@ -37,6 +37,8 @@ func NewControlPlane() workflow.Phase {
 		InheritFlags: []string{
 			options.DryRun,
 			options.KubeconfigPath,
+			options.CertificateRenewal,
+			options.EtcdUpgrade,
 		},
 	}
 	return phase

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -116,6 +116,8 @@ func addUpgradeNodeFlags(flagSet *flag.FlagSet, nodeOptions *nodeOptions) {
 	options.AddKubeConfigFlag(flagSet, &nodeOptions.kubeConfigPath)
 	flagSet.BoolVar(&nodeOptions.dryRun, options.DryRun, nodeOptions.dryRun, "Do not change any state, just output the actions that would be performed.")
 	flagSet.StringVar(&nodeOptions.kubeletVersion, options.KubeletVersion, nodeOptions.kubeletVersion, "The *desired* version for the kubelet config after the upgrade. If not specified, the KubernetesVersion from the kubeadm-config ConfigMap will be used")
+	flagSet.BoolVar(&nodeOptions.renewCerts, options.CertificateRenewal, nodeOptions.renewCerts, "Perform the renewal of certificates used by component changed during upgrades.")
+	flagSet.BoolVar(&nodeOptions.etcdUpgrade, options.EtcdUpgrade, nodeOptions.etcdUpgrade, "Perform the upgrade of etcd.")
 }
 
 // newNodeData returns a new nodeData struct to be used for the execution of the kubeadm upgrade node workflow.
@@ -247,8 +249,8 @@ func NewCmdUpgradeControlPlane() *cobra.Command {
 	// adds flags to the node command
 	options.AddKubeConfigFlag(cmd.Flags(), &nodeOptions.kubeConfigPath)
 	cmd.Flags().BoolVar(&nodeOptions.dryRun, options.DryRun, nodeOptions.dryRun, "Do not change any state, just output the actions that would be performed.")
-	cmd.Flags().BoolVar(&nodeOptions.etcdUpgrade, "etcd-upgrade", nodeOptions.etcdUpgrade, "Perform the upgrade of etcd.")
-	cmd.Flags().BoolVar(&nodeOptions.renewCerts, "certificate-renewal", nodeOptions.renewCerts, "Perform the renewal of certificates used by component changed during upgrades.")
+	cmd.Flags().BoolVar(&nodeOptions.etcdUpgrade, options.EtcdUpgrade, nodeOptions.etcdUpgrade, "Perform the upgrade of etcd.")
+	cmd.Flags().BoolVar(&nodeOptions.renewCerts, options.CertificateRenewal, nodeOptions.renewCerts, "Perform the renewal of certificates used by component changed during upgrades.")
 
 	// initialize the workflow runner with the list of phases
 	nodeRunner.AppendPhase(phases.NewControlPlane())


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug in the recently implemented kubeadm upgrade node command by exposing two missing flags in the parent command

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/sig cluster-lifecycle
/area kubeadm
/priority critical-urgent
/milestone v1.15
@kubernetes/sig-cluster-lifecycle-pr-reviews

/assign @neolit123
/assign @rosti