### PR TITLE
Revert "Promote resourcequota scope selectors to GA"

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -336,7 +336,7 @@ const (
 	KubeletPluginsWatcher featuregate.Feature = "KubeletPluginsWatcher"
 
 	// owner: @vikaschoudhary16
-	// GA: v1.15
+	// beta: v1.12
 	//
 	//
 	// Enable resource quota scope selectors
@@ -544,7 +544,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	PodReadinessGates:                           {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.16
 	VolumeSubpathEnvExpansion:                   {Default: true, PreRelease: featuregate.Beta},
 	KubeletPluginsWatcher:                       {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.16
-	ResourceQuotaScopeSelectors:                 {Default: true, PreRelease: featuregate.GA},
+	ResourceQuotaScopeSelectors:                 {Default: true, PreRelease: featuregate.Beta},
 	CSIBlockVolume:                              {Default: true, PreRelease: featuregate.Beta},
 	CSIInlineVolume:                             {Default: false, PreRelease: featuregate.Alpha},
 	RuntimeClass:                                {Default: true, PreRelease: featuregate.Beta},


### PR DESCRIPTION
Reverts kubernetes/kubernetes#78448

Since https://github.com/kubernetes/kubernetes/pull/76310 did not merge, there is no point in graduating the `resourceQuotaScopeSelectors` to GA.

```release-note
Revert Promotion of resource quota scope selector to GA
```


/cc @sjenning @bsalamat @k82cn @derekwaynecarr 