### PR TITLE
e2e: Skip multi-node PV test when pods scheduled on the same node

### DIFF
--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -950,6 +950,36 @@ func SetAntiAffinity(nodeSelection *NodeSelection, nodeName string) {
 	SetNodeAffinityRequirement(nodeSelection, v1.NodeSelectorOpNotIn, nodeName)
 }
 
+// SetNodeAffinityPreference sets affinity preference with specified operator to nodeName to nodeSelection
+func SetNodeAffinityPreference(nodeSelection *NodeSelection, operator v1.NodeSelectorOperator, nodeName string) {
+	// Add node-anti-affinity.
+	if nodeSelection.Affinity == nil {
+		nodeSelection.Affinity = &v1.Affinity{}
+	}
+	if nodeSelection.Affinity.NodeAffinity == nil {
+		nodeSelection.Affinity.NodeAffinity = &v1.NodeAffinity{}
+	}
+	nodeSelection.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(nodeSelection.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+		v1.PreferredSchedulingTerm{
+			Weight: int32(100),
+			Preference: v1.NodeSelectorTerm{
+				MatchFields: []v1.NodeSelectorRequirement{
+					{Key: "metadata.name", Operator: operator, Values: []string{nodeName}},
+				},
+			},
+		})
+}
+
+// SetAffinityPreference sets affinity preference to nodeName to nodeSelection
+func SetAffinityPreference(nodeSelection *NodeSelection, nodeName string) {
+	SetNodeAffinityPreference(nodeSelection, v1.NodeSelectorOpIn, nodeName)
+}
+
+// SetAntiAffinityPreference sets anti-affinity preference to nodeName to nodeSelection
+func SetAntiAffinityPreference(nodeSelection *NodeSelection, nodeName string) {
+	SetNodeAffinityPreference(nodeSelection, v1.NodeSelectorOpNotIn, nodeName)
+}
+
 // CreateClientPod defines and creates a pod with a mounted PV.  Pod runs infinite loop until killed.
 func CreateClientPod(c clientset.Interface, ns string, pvc *v1.PersistentVolumeClaim) (*v1.Pod, error) {
 	return CreatePod(c, ns, nil, []*v1.PersistentVolumeClaim{pvc}, true, "")

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -375,7 +375,9 @@ func TestAccessMultipleVolumesAcrossPodRecreation(f *framework.Framework, cs cli
 	if requiresSameNode {
 		framework.SetAffinity(&node, nodeName)
 	} else {
-		framework.SetAntiAffinity(&node, nodeName)
+		// Do not put hard requirement on the anti-affinity. In some occasions there might exist only
+		// one available node for the pod scheduling (e.g., multi-AZ cluster with one node per AZ)
+		framework.SetAntiAffinityPreference(&node, nodeName)
 	}
 
 	// Test access to multiple volumes again on the node updated above
@@ -383,7 +385,13 @@ func TestAccessMultipleVolumesAcrossPodRecreation(f *framework.Framework, cs cli
 	readSeedBase = writeSeedBase
 	// Update writeSeed with new value
 	writeSeedBase = time.Now().UTC().UnixNano()
-	_ = testAccessMultipleVolumes(f, cs, ns, node, pvcs, readSeedBase, writeSeedBase)
+	secondNodeName := testAccessMultipleVolumes(f, cs, ns, node, pvcs, readSeedBase, writeSeedBase)
+	if !requiresSameNode && (secondNodeName == nodeName) {
+		// The pod was created on the same node: presumably there was no other node available
+		// for the second pod scheduling -- this does not mean the test should fail. Skip it instead/
+		e2elog.Logf("Warning: The pod got scheduled on the same node despite requesting otherwise: skipping test")
+		framework.Skipf("No node available for the second pod found")
+	}
 }
 
 // TestConcurrentAccessToSingleVolume tests access to a single volume from multiple pods,
@@ -395,6 +403,7 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 
 	var pods []*v1.Pod
 
+	firstNodeName := ""
 	// Create each pod with pvc
 	for i := 0; i < numPods; i++ {
 		index := i + 1
@@ -411,12 +420,22 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 		pods = append(pods, pod)
 		framework.ExpectNoError(err, fmt.Sprintf("get pod%d", index))
 		actualNodeName := pod.Spec.NodeName
+		// Remember where the first pod was scheduled
+		if i == 0 {
+			firstNodeName = actualNodeName
+		}
+		// If the second pod got scheduled on the same node as the first one it means
+		// there was no available node for the second pod and the test should be skipped.
+		if !requiresSameNode && i == 1 && (actualNodeName == firstNodeName) {
+			e2elog.Logf("Warning: The pod got scheduled on the same node as the previous one: skipping test")
+			framework.Skipf("No node available for the second pod found")
+		}
 
 		// Set affinity depending on requiresSameNode
 		if requiresSameNode {
 			framework.SetAffinity(&node, actualNodeName)
 		} else {
-			framework.SetAntiAffinity(&node, actualNodeName)
+			framework.SetAntiAffinityPreference(&node, actualNodeName)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
The multi-node PV test creates a PV, starts a pod that writes data to a file on the PV, then kills the pod and starts another with node anti-affinity to read the data from the PV attached to a different node. This is problematic on multi-AZ clusters: there may only be one node in a zone and for volumes that can't be transferred among zones (AWS EBS, GCE PD, ...) the test would fail.

Figuring in advance whether we have a suitable node for the second pod scheduling would essentially mean re-implementing large part of the scheduling decision for the pod... So I thought of simply letting the second pod run and skip the test instead of failing if the test finds out it was scheduled on the same node as the first one. This is done by changing the node affinity requirement to node affinity preference.

```release-note
NONE
```
