### PR TITLE
Disable kubelet local endpoints on windows

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2213,7 +2213,12 @@ func (kl *Kubelet) ListenAndServeReadOnly(address net.IP, port uint, enableCAdvi
 
 // ListenAndServePodResources runs the kubelet podresources grpc service
 func (kl *Kubelet) ListenAndServePodResources() {
-	server.ListenAndServePodResources(util.LocalEndpoint(kl.getPodResourcesDir(), podresources.Socket), kl.podManager, kl.containerManager)
+	socket, err := util.LocalEndpoint(kl.getPodResourcesDir(), podresources.Socket)
+	if err != nil {
+		klog.V(2).Infof("Failed to get local endpoint for PodResources endpoint: %v", err)
+		return
+	}
+	server.ListenAndServePodResources(socket, kl.podManager, kl.containerManager)
 }
 
 // Delete the eligible dead container instances in a pod. Depending on the configuration, the latest dead containers may be kept around.

--- a/pkg/kubelet/util/util_unix.go
+++ b/pkg/kubelet/util/util_unix.go
@@ -128,10 +128,10 @@ func parseEndpoint(endpoint string) (string, string, error) {
 }
 
 // LocalEndpoint returns the full path to a unix socket at the given endpoint
-func LocalEndpoint(path, file string) string {
+func LocalEndpoint(path, file string) (string, error) {
 	u := url.URL{
 		Scheme: unixProtocol,
 		Path:   path,
 	}
-	return filepath.Join(u.String(), file+".sock")
+	return filepath.Join(u.String(), file+".sock"), nil
 }

--- a/pkg/kubelet/util/util_unsupported.go
+++ b/pkg/kubelet/util/util_unsupported.go
@@ -44,8 +44,8 @@ func UnlockPath(fileHandles []uintptr) {
 }
 
 // LocalEndpoint empty implementation
-func LocalEndpoint(path, file string) string {
-	return ""
+func LocalEndpoint(path, file string) (string, error) {
+	return "", fmt.Errorf("LocalEndpoints are unsupported in this build")
 }
 
 // GetBootTime empty implementation

--- a/pkg/kubelet/util/util_windows.go
+++ b/pkg/kubelet/util/util_windows.go
@@ -107,13 +107,9 @@ func parseEndpoint(endpoint string) (string, string, error) {
 	}
 }
 
-// LocalEndpoint returns the full path to a windows named pipe
-func LocalEndpoint(path, file string) string {
-	u := url.URL{
-		Scheme: npipeProtocol,
-		Path:   path,
-	}
-	return u.String() + "//./pipe/" + file
+// LocalEndpoint empty implementation
+func LocalEndpoint(path, file string) (string, error) {
+	return "", fmt.Errorf("LocalEndpoints are unsupported in this build")
 }
 
 var tickCount = syscall.NewLazyDLL("kernel32.dll").NewProc("GetTickCount64")

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -104,7 +104,10 @@ func getNodeSummary() (*stats.Summary, error) {
 }
 
 func getNodeDevices() (*podresourcesapi.ListPodResourcesResponse, error) {
-	endpoint := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)
+	endpoint, err := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting local endpoint: %v", err)
+	}
 	client, conn, err := podresources.GetClient(endpoint, defaultPodResourcesTimeout, defaultPodResourcesMaxSize)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting grpc client: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig node
/priority critical-urgent

**What this PR does / why we need it**:
This PR removes the local endpoint support for windows, and allows the kubelet to start up without the endpoint on unsupported OS's.  The LocalEndpoint support for windows added in previous releases did not work and did not have adequate testing.

Disabling this broken functionality was discussed and approved at sig-windows on June 4th, 2019.  [Notes](https://docs.google.com/document/d/1Tjxzjjuy4SQsFSUVXZbvqVb64hjNAG5CQX8bK7Yda9w/edit#)

**Which issue(s) this PR fixes**:
Fixes #78628

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @yujuhong @PatrickLang 