### PR TITLE
Flake fix: poll for webhook registration to complete in reinvocation integration tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -39,4 +39,15 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["accessors_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//vendor/github.com/google/gofuzz:go_default_library",
+    ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
@@ -66,7 +66,7 @@ type mutatingWebhookAccessor struct {
 }
 
 func (m mutatingWebhookAccessor) GetUID() string {
-	return m.Name
+	return m.uid
 }
 func (m mutatingWebhookAccessor) GetName() string {
 	return m.Name

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	fuzz "github.com/google/gofuzz"
+	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func TestMutatingWebhookAccessor(t *testing.T) {
+	f := fuzz.New()
+	for i := 0; i < 100; i++ {
+		t.Run(fmt.Sprintf("Run %d/100", i), func(t *testing.T) {
+			orig := &v1beta1.MutatingWebhook{}
+			f.Fuzz(orig)
+
+			// zero out any accessor type specific fields not included in the accessor
+			orig.ReinvocationPolicy = nil
+
+			uid := fmt.Sprintf("test.configuration.admission/%s/0", orig.Name)
+			accessor := NewMutatingWebhookAccessor(uid, orig)
+			if uid != accessor.GetUID() {
+				t.Errorf("expected GetUID to return %s, but got %s", accessor.GetUID(), uid)
+			}
+			m, ok := accessor.GetMutatingWebhook()
+			if !ok {
+				t.Errorf("expected GetMutatingWebhook to return ok for mutating webhook accessor")
+			}
+			if !reflect.DeepEqual(orig, m) {
+				t.Errorf("expected GetMutatingWebhook to return original webhook, diff:\n%s", diff.ObjectReflectDiff(orig, m))
+			}
+			if _, ok := accessor.GetValidatingWebhook(); ok {
+				t.Errorf("expected GetValidatingWebhook to be nil for mutating webhook accessor")
+			}
+			copy := &v1beta1.MutatingWebhook{
+				Name:                    accessor.GetName(),
+				ClientConfig:            accessor.GetClientConfig(),
+				Rules:                   accessor.GetRules(),
+				FailurePolicy:           accessor.GetFailurePolicy(),
+				MatchPolicy:             accessor.GetMatchPolicy(),
+				NamespaceSelector:       accessor.GetNamespaceSelector(),
+				ObjectSelector:          accessor.GetObjectSelector(),
+				SideEffects:             accessor.GetSideEffects(),
+				TimeoutSeconds:          accessor.GetTimeoutSeconds(),
+				AdmissionReviewVersions: accessor.GetAdmissionReviewVersions(),
+			}
+			if !reflect.DeepEqual(orig, copy) {
+				t.Errorf("expected mutatingWebhook to round trip through WebhookAccessor, diff:\n%s", diff.ObjectReflectDiff(orig, copy))
+			}
+		})
+	}
+}
+
+func TestValidatingWebhookAccessor(t *testing.T) {
+	f := fuzz.New()
+	for i := 0; i < 100; i++ {
+		t.Run(fmt.Sprintf("Run %d/100", i), func(t *testing.T) {
+			orig := &v1beta1.ValidatingWebhook{}
+			f.Fuzz(orig)
+			uid := fmt.Sprintf("test.configuration.admission/%s/0", orig.Name)
+			accessor := NewValidatingWebhookAccessor(uid, orig)
+			if uid != accessor.GetUID() {
+				t.Errorf("expected GetUID to return %s, but got %s", accessor.GetUID(), uid)
+			}
+			m, ok := accessor.GetValidatingWebhook()
+			if !ok {
+				t.Errorf("expected GetValidatingWebhook to return ok for validating webhook accessor")
+			}
+			if !reflect.DeepEqual(orig, m) {
+				t.Errorf("expected GetValidatingWebhook to return original webhook, diff:\n%s", diff.ObjectReflectDiff(orig, m))
+			}
+			if _, ok := accessor.GetMutatingWebhook(); ok {
+				t.Errorf("expected GetMutatingWebhook to be nil for validating webhook accessor")
+			}
+			copy := &v1beta1.ValidatingWebhook{
+				Name:                    accessor.GetName(),
+				ClientConfig:            accessor.GetClientConfig(),
+				Rules:                   accessor.GetRules(),
+				FailurePolicy:           accessor.GetFailurePolicy(),
+				MatchPolicy:             accessor.GetMatchPolicy(),
+				NamespaceSelector:       accessor.GetNamespaceSelector(),
+				ObjectSelector:          accessor.GetObjectSelector(),
+				SideEffects:             accessor.GetSideEffects(),
+				TimeoutSeconds:          accessor.GetTimeoutSeconds(),
+				AdmissionReviewVersions: accessor.GetAdmissionReviewVersions(),
+			}
+			if !reflect.DeepEqual(orig, copy) {
+				t.Errorf("expected validatingWebhook to round trip through WebhookAccessor, diff:\n%s", diff.ObjectReflectDiff(orig, copy))
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mutating
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -114,7 +115,7 @@ func TestAdmit(t *testing.T) {
 			reinvocationCtx := fakeAttr.Attributes.GetReinvocationContext()
 			reinvocationCtx.SetIsReinvoke()
 			for webhook, expectReinvoke := range tt.ExpectReinvokeWebhooks {
-				shouldReinvoke := reinvocationCtx.Value(PluginName).(*webhookReinvokeContext).ShouldReinvokeWebhook(webhook)
+				shouldReinvoke := reinvocationCtx.Value(PluginName).(*webhookReinvokeContext).ShouldReinvokeWebhook(fmt.Sprintf("test-webhooks/%s/0", webhook))
 				if expectReinvoke != shouldReinvoke {
 					t.Errorf("expected reinvocationContext.ShouldReinvokeWebhook(%s)=%t, but got %t", webhook, expectReinvoke, shouldReinvoke)
 				}


### PR DESCRIPTION
Admission webhooks registration is typically fast (<1ms), but not always immediate. This was causing the reinvocation test, which assumed immediate registration to flake.

Also found a bug in WebhookAccessor where GetUID was incorrectly returning name. Fixed that as well.

/kind flake
/sig api-machinery
/area admission-control
/priority critical-urgent

Fixes #78663

```release-note
NONE
```
