### PR TITLE
Adding a check to find out if a pod in a StatefulSet is stuck

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/klog"
 
 	apps "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/controller/history"

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -220,11 +220,14 @@ func isCreated(pod *v1.Pod) bool {
 // 1) The pod is in a pending state
 // 2) The pod is at a different revision than the update revision
 // 3) The update strategy is rolling
+// 4) The pod should be updated
 func isStatefullyStuck(set *apps.StatefulSet, pod *v1.Pod, currentRevision, updateRevision *apps.ControllerRevision) bool {
 	return isPending(pod) &&
 		getPodRevision(pod) == currentRevision.Name &&
 		currentRevision.Name != updateRevision.Name &&
-		set.Spec.UpdateStrategy.Type == apps.RollingUpdateStatefulSetStrategyType
+		set.Spec.UpdateStrategy.Type == apps.RollingUpdateStatefulSetStrategyType &&
+		set.Spec.UpdateStrategy.RollingUpdate.Partition != nil &&
+		getOrdinal(pod) >= int(*set.Spec.UpdateStrategy.RollingUpdate.Partition)
 }
 
 // isPending returns true if a pod is in a Phase of PodPending

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -220,13 +220,11 @@ func isCreated(pod *v1.Pod) bool {
 // 1) The pod is in a pending state
 // 2) The pod is at a different revision than the update revision
 // 3) The update strategy is rolling
-// 4) The set and the pod are at different generations
 func isStatefullyStuck(set *apps.StatefulSet, pod *v1.Pod, currentRevision, updateRevision *apps.ControllerRevision) bool {
 	return isPending(pod) &&
 		getPodRevision(pod) == currentRevision.Name &&
 		currentRevision.Name != updateRevision.Name &&
-		set.Spec.UpdateStrategy.Type == apps.RollingUpdateStatefulSetStrategyType &&
-		set.ObjectMeta.Generation != pod.ObjectMeta.Generation
+		set.Spec.UpdateStrategy.Type == apps.RollingUpdateStatefulSetStrategyType
 }
 
 // isPending returns true if a pod is in a Phase of PodPending

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -213,10 +213,8 @@ func TestIsStatefullyStuck(t *testing.T) {
 	pod.Status = v1.PodStatus{
 		Phase: v1.PodPending,
 	}
+	// pod.ObjectMeta.
 	setPodRevision(pod, "1")
-	pod.ObjectMeta.Generation = 1
-
-	set.ObjectMeta.Generation = 2
 	set.SetLabels(map[string]string{
 		apps.StatefulSetRevisionLabel: "2",
 	})
@@ -240,7 +238,13 @@ func TestIsStatefullyStuck(t *testing.T) {
 		Revision: 2,
 	}
 
-	set.Spec.UpdateStrategy.Type = apps.RollingUpdateStatefulSetStrategyType
+	ordinal := int32(1)
+	set.Spec.UpdateStrategy = apps.StatefulSetUpdateStrategy{
+		Type: apps.RollingUpdateStatefulSetStrategyType,
+		RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+			Partition: &ordinal,
+		},
+	}
 	if !isStatefullyStuck(set, pod, currentRevision, updateRevision) {
 		t.Error("Pod should be in a stuck state")
 	}

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -861,6 +861,96 @@ var _ = SIGDescribe("StatefulSet", func() {
 			appTester.run()
 		})
 	})
+
+	framework.KubeDescribe("When stuck at failing init container", func() {
+		ssName := "ss"
+		labels := map[string]string{
+			"foo": "bar",
+			"baz": "blah",
+		}
+		headlessSvcName := "test"
+		var ss *apps.StatefulSet
+
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("Creating service " + headlessSvcName + " in namespace " + ns)
+			headlessService := framework.CreateServiceSpec(headlessSvcName, "", true, labels)
+			_, err := c.CoreV1().Services(ns).Create(headlessService)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.AfterEach(func() {
+			if ginkgo.CurrentGinkgoTestDescription().Failed {
+				framework.DumpDebugInfo(c, ns)
+			}
+			e2elog.Logf("Deleting all statefulset in ns %v", ns)
+			framework.DeleteAllStatefulSets(c, ns)
+		})
+
+		ginkgo.It("should redeploy after update", func() {
+			ss = &apps.StatefulSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "StatefulSet",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ssName,
+					Namespace: ns,
+				},
+				Spec: apps.StatefulSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: labels,
+					},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels:      labels,
+							Annotations: map[string]string{},
+						},
+						Spec: v1.PodSpec{
+							InitContainers: []v1.Container{
+								{
+									Name:    "busybox",
+									Image:   "busybox",
+									Command: []string{"sh", "-c"},
+									Args:    []string{"false"},
+								},
+							},
+							Containers: []v1.Container{
+								{
+									Name:    "busybox",
+									Image:   "busybox",
+									Command: []string{"sh", "-c"},
+									Args:    []string{`while true; do echo "hello world"; sleep 5; done`},
+								},
+							},
+						},
+					},
+					ServiceName: headlessSvcName,
+				},
+			}
+
+			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
+			framework.SkipIfNoDefaultStorageClass(c)
+			*(ss.Spec.Replicas) = 1
+			sst := framework.NewStatefulSetTester(c)
+
+			_, err := c.AppsV1().StatefulSets(ns).Create(ss)
+			framework.ExpectNoError(err)
+
+			ginkgo.By(fmt.Sprintf("Updating stateful set template: update init container"))
+			ss, err = framework.UpdateStatefulSetWithRetries(c, ns, ss.Name, func(update *apps.StatefulSet) {
+				update.Spec.Template.Spec.InitContainers = []v1.Container{
+					{
+						Name:    "busybox",
+						Image:   "busybox",
+						Command: []string{"sh", "-c"},
+						Args:    []string{"true"},
+					},
+				}
+			})
+			framework.ExpectNoError(err)
+			sst.WaitForRunningAndReady(1, ss)
+		})
+	})
 })
 
 func kubectlExecWithRetries(args ...string) (out string) {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
There are a few cases where a StatefulSet can become bricked. Usually from something like setting an invalid image tag in the container. When this occurs, manual intervention is required in order to clear out the bad StatefulSet pods and allow k8s to spawn new ones. In this PR, I took a shot at detecting when a pod is stuck and we have reasonable confidence that replacing that pod will result in a better case than performing a no-op.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #67250 

**Special notes for your reviewer**:
This is my first core contrib, so if I missed something or borked something badly, just lemme know and I'll get on it.

If you have any suggestions on a better test that could be implemented (maybe something in `stateful_set_control_test.go`), I'm totally open to suggestions. I was having a hard time figuring out how to write that test.

I saw a suggestion on the issue to use the `new ResourceVersion precondition on Delete`, but I was having a hard time figuring out how to consume that/where the data lives. Also open to adding that condition if necessary.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adding fix to detect a stuck pod in a StatefulSet when using `RollingUpdate`. If replacing a pending pod will result in a new generation and a new revision, then we can fairly safely say that it is alright to move forward.
```

/sig apps