### PR TITLE
Error on tests ineligible for promotion to conformance

### DIFF
--- a/test/conformance/walk_test.go
+++ b/test/conformance/walk_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -124,6 +125,60 @@ func TestNormalizeTestNames(t *testing.T) {
 		actualName := normalizeTestName(tc.rawName)
 		if actualName != tc.normalizedName {
 			t.Errorf("test case[%d]: expected normalized name %q, got %q", i, tc.normalizedName, actualName)
+		}
+	}
+}
+
+func TestValidateTestName(t *testing.T) {
+	testCases := []struct {
+		testName  string
+		tagString string
+	}{
+		{
+			"a test case with no tags",
+			"",
+		},
+		{
+			"a test case with valid tags [LinuxOnly] [NodeConformance] [Serial]",
+			"",
+		},
+		{
+			"a flaky test case that is invalid [Flaky]",
+			"[Flaky]",
+		},
+		{
+			"a disruptive test case that is invalid [Disruptive]",
+			"[Disruptive]",
+		},
+		{
+			"a feature test case that is invalid [Feature:Awesome]",
+			"[Feature:Awesome]",
+		},
+		{
+			"an alpha test case that is invalid [Alpha]",
+			"[Alpha]",
+		},
+		{
+			"a test case with multiple invalid tags [Flaky][Disruptive] [Feature:Awesome] [Alpha]",
+			"[Flaky],[Disruptive],[Feature:Awesome],[Alpha]",
+		},
+		{
+			"[sig-awesome] [Disruptive] a test case with valid and invalid tags [Alpha] [Serial] [Flaky]",
+			"[Disruptive],[Alpha],[Flaky]",
+		},
+	}
+	for i, tc := range testCases {
+		err := validateTestName(tc.testName)
+		if err != nil {
+			if tc.tagString == "" {
+				t.Errorf("test case[%d]: expected no validate error, got %q", i, err.Error())
+			} else {
+				expectedMsg := fmt.Sprintf("'%s' cannot have invalid tags %s", tc.testName, tc.tagString)
+				actualMsg := err.Error()
+				if actualMsg != expectedMsg {
+					t.Errorf("test case[%d]: expected error message %q, got %q", i, expectedMsg, actualMsg)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

If there are tags in the test name that describe qualities of the
test that make it ineligible for conformance, raise an error. This
is basically the "skip list" that heptio's e2e image used to use.

Thankfully all of our existing Conformance tests lack these tags. I
considered added [Slow] to the list, but let's save that for another
day.

**Which issue(s) this PR fixes**:
Most closely related to: https://github.com/kubernetes/test-infra/issues/9697
See for prior discussion:  https://github.com/kubernetes/kubernetes/issues/62161

**Special notes for your reviewer**:
/milestone v1.15
/area conformance
/sig testing
Adding to milestone as SIG Testing chair, this doesn't meaningfully
alter the behavior of v1.15 or adjust CI signal, and I would like this
in prior to release.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```