### PR TITLE
Don't mask k8s error returned from patch

### DIFF
--- a/pkg/controller/service/BUILD
+++ b/pkg/controller/service/BUILD
@@ -57,6 +57,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",

--- a/pkg/controller/service/patch.go
+++ b/pkg/controller/service/patch.go
@@ -37,11 +37,7 @@ func patch(c v1core.CoreV1Interface, oldSvc *v1.Service, newSvc *v1.Service) (*v
 		return nil, err
 	}
 
-	updatedSvc, err := c.Services(oldSvc.Namespace).Patch(oldSvc.Name, types.StrategicMergePatchType, patchBytes, "status")
-	if err != nil {
-		return nil, fmt.Errorf("failed to patch %q for svc %s/%s: %v", patchBytes, oldSvc.Namespace, oldSvc.Name, err)
-	}
-	return updatedSvc, nil
+	return c.Services(oldSvc.Namespace).Patch(oldSvc.Name, types.StrategicMergePatchType, patchBytes, "status")
 }
 
 func getPatchBytes(oldSvc *v1.Service, newSvc *v1.Service) ([]byte, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We mistakenly mask the error returned from `Services().Patch()`, which triggers unnecessary retry on non-retriable error because service controller can't distinguish not found error from others.

Specifically this happens when service with finalizer is deleted. Example logs from https://k8s-testgrid.appspot.com/sig-network-gce#gce-lb-finalizer:
```
I0604 16:09:37.440733       1 service_controller.go:312] Deleting existing load balancer for service services-2673/service
I0604 16:10:15.534569       1 service_controller.go:798] Removing finalizer from service services-2673/service
I0604 16:10:15.544972       1 service_controller.go:813] Patching status for service services-2673/service
I0604 16:10:15.553688       1 service_controller.go:719] Finished syncing service "services-2673/service" (38.3460721s)
E0604 16:10:15.553731       1 service_controller.go:234] error processing service services-2673/service (will retry): failed to update load balancer status: failed to patch "{\"status\":{\"loadBalancer\":{\"ingress\":null}}}" for svc services-2673/service: services "service" not found
I0604 16:10:15.553773       1 service_controller.go:751] Service services-2673/service has been deleted. Attempting to cleanup load balancer resources
I0604 16:10:17.689611       1 service_controller.go:719] Finished syncing service "services-2673/service" (2.135846152s)
I0604 16:10:20.554174       1 service_controller.go:719] Finished syncing service "services-2673/service" (36.65µs)
```

/assign @andrewsykim 
cc @bowei @jiatongw 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
