### PR TITLE
Scaling should always give reason

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -617,13 +617,12 @@ func (a *HorizontalController) reconcileAutoscaler(hpav1Shared *autoscalingv1.Ho
 			desiredReplicas = metricDesiredReplicas
 			rescaleMetric = metricName
 		}
+		desiredReplicas = a.normalizeDesiredReplicas(hpa, key, currentReplicas, desiredReplicas)
 		if desiredReplicas > currentReplicas {
 			rescaleReason = fmt.Sprintf("%s above target", rescaleMetric)
-		}
-		if desiredReplicas < currentReplicas {
+		} else if desiredReplicas < currentReplicas {
 			rescaleReason = "All metrics below target"
 		}
-		desiredReplicas = a.normalizeDesiredReplicas(hpa, key, currentReplicas, desiredReplicas)
 		rescale = desiredReplicas != currentReplicas
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As #78712 stated, scaling deployment should always give reason.
After normalizeDesiredReplicas is called, desiredReplicas may have a new value, potentially altering the relationship between desiredReplicas and currentReplicas.

**Which issue(s) this PR fixes**:
Fixes #78712

```release-note
NONE
```
