### PR TITLE
Fix log level for runtime error in kubelet.go

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1821,7 +1821,7 @@ func (kl *Kubelet) syncLoop(updates <-chan kubetypes.PodUpdate, handler SyncHand
 	duration := base
 	for {
 		if err := kl.runtimeState.runtimeErrors(); err != nil {
-			klog.Infof("skipping pod synchronization - %v", err)
+			klog.Errorf("skipping pod synchronization - %v", err)
 			// exponential backoff
 			time.Sleep(duration)
 			duration = time.Duration(math.Min(float64(max), factor*float64(duration)))


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
Runtime error should be counted as Error log instead of info log. For instance, we are seeing lots of info lines as below
```
I0523 11:25:06.087934   20904 kubelet.go:1828] skipping pod synchronization - PLEG is not healthy: pleg was last seen active 3m41.395442131s ago; threshold is 3m0s.
......
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
