### PR TITLE
fix bug of replica_calculator to initialize replicaCount with currentReplicas

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -265,6 +265,7 @@ func (c *ReplicaCalculator) GetObjectPerPodMetricReplicas(currentReplicas int32,
 		return 0, 0, time.Time{}, fmt.Errorf("unable to get metric %s: %v on %s %s/%s", metricName, objectRef.Kind, namespace, objectRef.Name, err)
 	}
 
+	replicaCount = currentReplicas
 	usageRatio := float64(utilization) / (float64(targetAverageUtilization) * float64(replicaCount))
 	if math.Abs(1.0-usageRatio) > c.tolerance {
 		// update number of replicas if change is large enough

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -970,6 +970,26 @@ func TestReplicaCalcToleranceCMObject(t *testing.T) {
 	tc.runTest(t)
 }
 
+func TestReplicaCalcTolerancePerPodCMObject(t *testing.T) {
+	tc := replicaCalcTestCase{
+		currentReplicas:  4,
+		expectedReplicas: 4,
+		metric: &metricInfo{
+			metricType:              objectPerPodMetric,
+			name:                    "qps",
+			levels:                  []int64{20166},
+			perPodTargetUtilization: 5000,
+			expectedUtilization:     5042,
+			singleObject: &autoscalingv2.CrossVersionObjectReference{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "some-deployment",
+			},
+		},
+	}
+	tc.runTest(t)
+}
+
 func TestReplicaCalcToleranceCMExternal(t *testing.T) {
 	tc := replicaCalcTestCase{
 		currentReplicas:  3,


### PR DESCRIPTION
… currentReplicas

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
This is a bug of calculating desired replica for ObjectPerPod kind, since the variable "replicaCount" isn't initialized, which makes the tolerance condition always true:

    usageRatio := float64(utilization) / (float64(targetAverageUtilization) * float64(replicaCount))
    if math.Abs(1.0-usageRatio) > c.getTolerance(hpa) {
        // update number of replicas if change is large enough
	replicaCount = int32(math.Ceil(float64(utilization) / float64(targetAverageUtilization)))
    }

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
   
    Fixed a bug when calculating ObjectPerPod replicas for HPA replica_calculator and made the tolerance configuration to work as expected.

```release-note
NONE
```
