### PR TITLE
Modify kube-up to support cluster without nodes.

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -41,6 +41,10 @@ NODE_LOCAL_SSDS=${NODE_LOCAL_SSDS:-0}
 NODE_LABELS="${KUBE_NODE_LABELS:-}"
 WINDOWS_NODE_LABELS="${WINDOWS_NODE_LABELS:-}"
 
+# KUBE_CREATE_NODES can be used to avoid creating nodes, while master will be sized for NUM_NODES nodes.
+# Firewalls and node templates are still created.
+KUBE_CREATE_NODES="${KUBE_CREATE_NODES:-true}"
+
 # An extension to local SSDs allowing users to specify block/fs and SCSI/NVMe devices
 # Format of this variable will be "#,scsi/nvme,block/fs" you can specify multiple
 # configurations by separating them by a semi-colon ex. "2,scsi,fs;1,nvme,block"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -41,6 +41,10 @@ NODE_LOCAL_SSDS=${NODE_LOCAL_SSDS:-0}
 NODE_LABELS="${KUBE_NODE_LABELS:-}"
 WINDOWS_NODE_LABELS="${WINDOWS_NODE_LABELS:-}"
 
+# KUBE_CREATE_NODES can be used to avoid creating nodes, while master will be sized for NUM_NODES nodes.
+# Firewalls and node templates are still created.
+KUBE_CREATE_NODES="${KUBE_CREATE_NODES:-true}"
+
 # An extension to local SSDs allowing users to specify block/fs and SCSI/NVMe devices
 # Format of this variable will be "#,scsi/nvme,block/fs" you can specify multiple
 # configurations by separating them by a semi-colon ex. "2,scsi,fs;1,nvme,block"

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2134,9 +2134,11 @@ function kube-up() {
     create-master
     create-nodes-firewall
     create-nodes-template
-    # Windows nodes take longer to boot and setup so create them first.
-    create-windows-nodes
-    create-linux-nodes
+    if [[ "${KUBE_CREATE_NODES}" == "true" ]]; then
+      # Windows nodes take longer to boot and setup so create them first.
+      create-windows-nodes
+      create-linux-nodes
+    fi
     check-cluster
   fi
 }

--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -51,7 +51,11 @@ ALLOWED_NOTREADY_NODES="${ALLOWED_NOTREADY_NODES:-0}"
 CLUSTER_READY_ADDITIONAL_TIME_SECONDS="${CLUSTER_READY_ADDITIONAL_TIME_SECONDS:-30}"
 
 if [[ "${KUBERNETES_PROVIDER:-}" == "gce" ]]; then
-  EXPECTED_NUM_NODES="$(get-num-nodes)"
+  if [[ "${KUBE_CREATE_NODES}" == "true" ]]; then
+    EXPECTED_NUM_NODES="$(get-num-nodes)"
+  else
+    EXPECTED_NUM_NODES="0"
+  fi
   echo "Validating gce cluster, MULTIZONE=${MULTIZONE:-}"
   # In multizone mode we need to add instances for all nodes in the region.
   if [[ "${MULTIZONE:-}" == "true" ]]; then


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

As part of #78726 we need a way to create cluster with master only (in kubemark we will add special hollow nodes instead of GCE nodes) This PR adds KUBE_CREATE_NODES env flag that can be used to disable node creation.

Difference between KUBE_CREATE_NODES=false and NUM_NODES=0 is that with KUBE_CREATE_NODES=false we can still set NUM_NODES=5000 to automatically adjust master's parameters as machine type, disk size and other.


**Which issue(s) this PR fixes**:
#78726

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
