### PR TITLE
Add 'apiserver_watch_events_total' metric.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -225,6 +225,7 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				// End of results.
 				return
 			}
+			metrics.WatchEvents.WithLabelValues(kind.Group, kind.Version, kind.Kind).Inc()
 
 			obj := s.Fixup(event.Object)
 			if err := s.EmbeddedEncoder.Encode(obj, buf); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -141,6 +141,13 @@ var (
 		},
 		[]string{"group", "version", "kind"},
 	)
+	WatchEvents = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "apiserver_watch_events_total",
+			Help: "Number of events sent in watch clients",
+		},
+		[]string{"group", "version", "kind"},
+	)
 	// Because of volatality of the base metric this is pre-aggregated one. Instead of reporing current usage all the time
 	// it reports maximal usage during the last second.
 	currentInflightRequests = prometheus.NewGaugeVec(


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This adds 'apiserver_watch_events_total' metric which is incremented each time we send some event in watch.

We found this metric useful to understand the CPU usage of the kube-apiserver process.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Added a metric 'apiserver_watch_events_total' that can be used to understand the number of watch events in the system.
```
