### PR TITLE
Don't start tracking field management until object has been applied

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
@@ -47,6 +47,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -104,6 +104,10 @@ func (f *FieldManager) Update(liveObj, newObj runtime.Object, manager string) (r
 			return nil, fmt.Errorf("failed to decode managed fields: %v", err)
 		}
 	}
+	// if managed field is still empty, skip updating managed fields altogether
+	if len(managed.Fields) == 0 {
+		return newObj, nil
+	}
 	newObjVersioned, err := f.toVersioned(newObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert new object to proper version: %v", err)
@@ -165,9 +169,11 @@ func (f *FieldManager) Update(liveObj, newObj runtime.Object, manager string) (r
 // object and update the managed fields.
 func (f *FieldManager) Apply(liveObj runtime.Object, patch []byte, fieldManager string, force bool) (runtime.Object, error) {
 	// If the object doesn't have metadata, apply isn't allowed.
-	if _, err := meta.Accessor(liveObj); err != nil {
+	accessor, err := meta.Accessor(liveObj)
+	if err != nil {
 		return nil, fmt.Errorf("couldn't get accessor: %v", err)
 	}
+	missingManagedFields := (len(accessor.GetManagedFields()) == 0)
 
 	managed, err := internal.DecodeObjectManagedFields(liveObj)
 	if err != nil {
@@ -207,6 +213,23 @@ func (f *FieldManager) Apply(liveObj runtime.Object, patch []byte, fieldManager 
 	}
 
 	apiVersion := fieldpath.APIVersion(f.groupVersion.String())
+	// if managed field is missing, create a single entry for all the fields
+	if missingManagedFields {
+		unknownManager, err := internal.BuildManagerIdentifier(&metav1.ManagedFieldsEntry{
+			Manager:    "before-first-apply",
+			Operation:  metav1.ManagedFieldsOperationUpdate,
+			APIVersion: f.groupVersion.String(),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create manager for existing fields: %v", err)
+		}
+		unknownFieldSet, err := liveObjTyped.ToFieldSet()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create fieldset for existing fields: %v", err)
+		}
+		managed.Fields[unknownManager] = fieldpath.NewVersionedSet(unknownFieldSet, apiVersion, false)
+		f.stripFields(managed.Fields, unknownManager)
+	}
 	newObjTyped, managedFields, err := f.updater.Apply(liveObjTyped, patchObjTyped, apiVersion, managed.Fields, manager, force)
 	if err != nil {
 		if conflicts, ok := err.(merge.Conflicts); ok {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -75,6 +76,7 @@ func TestApplyStripsFields(t *testing.T) {
 	f := NewTestFieldManager()
 
 	obj := &corev1.Pod{}
+	obj.ObjectMeta.ManagedFields = []metav1.ManagedFieldsEntry{{}}
 
 	newObj, err := f.Apply(obj, []byte(`{
 		"apiVersion": "apps/v1",
@@ -153,6 +155,7 @@ func TestApplyDoesNotStripLabels(t *testing.T) {
 	f := NewTestFieldManager()
 
 	obj := &corev1.Pod{}
+	obj.ObjectMeta.ManagedFields = []metav1.ManagedFieldsEntry{{}}
 
 	newObj, err := f.Apply(obj, []byte(`{
 		"apiVersion": "apps/v1",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -72,6 +72,29 @@ func TestFieldManagerCreation(t *testing.T) {
 	}
 }
 
+func TestUpdateOnlyDoesNotTrackManagedFields(t *testing.T) {
+	f := NewTestFieldManager()
+
+	liveObj := &corev1.Pod{}
+
+	updatedObj := liveObj.DeepCopy()
+	updatedObj.ObjectMeta.Labels = map[string]string{"k": "v"}
+
+	newObj, err := f.Update(liveObj, updatedObj, "fieldmanager_test")
+	if err != nil {
+		t.Fatalf("failed to update object: %v", err)
+	}
+
+	accessor, err := meta.Accessor(newObj)
+	if err != nil {
+		t.Fatalf("couldn't get accessor: %v", err)
+	}
+
+	if m := accessor.GetManagedFields(); len(m) != 0 {
+		t.Fatalf("managedFields were tracked on update only: %v", m)
+	}
+}
+
 func TestApplyStripsFields(t *testing.T) {
 	f := NewTestFieldManager()
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -421,7 +421,7 @@ func (p *applyPatcher) applyPatchToCurrentObject(obj runtime.Object) (runtime.Ob
 func (p *applyPatcher) createNewObject() (runtime.Object, error) {
 	obj, err := p.creater.New(p.kind)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new object: %v", obj)
+		return nil, fmt.Errorf("failed to create new object: %v", err)
 	}
 	return p.applyPatchToCurrentObject(obj)
 }

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -193,7 +193,7 @@ func TestNoOpUpdateSameResourceVersion(t *testing.T) {
 	}
 
 	// Need to update once for some reason
-	// TODO: Remove this once possible
+	// TODO (#82042): Remove this update once possible
 	b, err := json.MarshalIndent(o, "\t", "\t")
 	if err != nil {
 		t.Fatalf("Failed to marshal created object: %v", err)

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -180,7 +180,7 @@ func TestNoOpUpdateSameResourceVersion(t *testing.T) {
 		}
 	}`)
 
-	_, err := client.CoreV1().RESTClient().Patch(types.ApplyPatchType).
+	o, err := client.CoreV1().RESTClient().Patch(types.ApplyPatchType).
 		Namespace("default").
 		Param("fieldManager", "apply_test").
 		Resource(podResource).
@@ -190,6 +190,23 @@ func TestNoOpUpdateSameResourceVersion(t *testing.T) {
 		Get()
 	if err != nil {
 		t.Fatalf("Failed to create object: %v", err)
+	}
+
+	// Need to update once for some reason
+	// TODO: Remove this once possible
+	b, err := json.MarshalIndent(o, "\t", "\t")
+	if err != nil {
+		t.Fatalf("Failed to marshal created object: %v", err)
+	}
+	_, err = client.CoreV1().RESTClient().Put().
+		Namespace("default").
+		Resource(podResource).
+		Name(podName).
+		Body(b).
+		Do().
+		Get()
+	if err != nil {
+		t.Fatalf("Failed to apply first no-op update: %v", err)
 	}
 
 	// Sleep for one second to make sure that the times of each update operation is different.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/priority important-soon
/sig api-machinery
/wg apply
cc @apelisse
cc @kwiesmueller 

**What this PR does / why we need it**:
This is one possible way to reduce the CPU and memory cost of server side apply. It means that only objects that have been applied to have managedFields present. The idea behind this is that most objects created with post or put are never applied to, so tracking managedFields on them is a waste of resources. If an object without managedFields does get applied to, we can still generate a single managedFields entry for all the existing fields, so the conflict set will be the same, but we wouldn't have any way of knowing know who is being conflicted with .

I thought of some pros and cons for this solution, but I am sure there are more I am missing.

**Pros**:
- CPU and memory cost on apiserver will be dependent on the number of objects managed by server-side apply users, which would increase more gradually as controllers decided to adopt SSA, and could be decided on a controller by controller basis, weighing the cost vs the benefits each time, instead of all the increase happening at once when the feature is enabled.
- Objects created and updated exclusively non-apply endpoints will have no change from pre-apply behavior. No new field will be added to them and no new code will be executed.
- Behavior of apply on object fields is the same as without this change (same conflicts detected as if the fields had been tracked on each preceding request)
- Conflict usefulness is only affected for applies to objects created by post or put, but most of the time human appliers would only apply to objects which were created by apply anyway, and in that case there is no change

**Cons**:
- If someone applies to an object created by post or put, the conflicts they see would not contain information about the timestamp or field manager, so conflicts become less useful.
- managedFields would also become less useful for non-apply users, because it wouldn't always be present
- Adds code path that is executed infrequently (generating the managedFields for the existing fields on first apply)
- Apply code no longer run on every modifying endpoint, so we need to separate things like union normalization from the updating of managed fields.


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
