### PR TITLE
Make the check strict to use ExpectNoError()

### DIFF
--- a/hack/verify-test-code.sh
+++ b/hack/verify-test-code.sh
@@ -25,7 +25,7 @@ mapfile -t all_e2e_files < <(find test/e2e -name '*.go' | grep -v 'test/e2e/fram
 errors_expect_no_error=()
 for file in "${all_e2e_files[@]}"
 do
-    if grep "Expect(.*)\.NotTo(.*HaveOccurred()" "${file}" > /dev/null
+    if grep -E "Expect\(.*\)\.(NotTo|ToNot)\(.*HaveOccurred\(\)" "${file}" > /dev/null
     then
         errors_expect_no_error+=( "${file}" )
     fi

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -286,7 +286,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		framework.ExpectNoError(err, "failed to delete pod")
 
 		ginkgo.By("verifying the kubelet observed the termination notice")
-		gomega.Expect(wait.Poll(time.Second*5, time.Second*30, func() (bool, error) {
+		err = wait.Poll(time.Second*5, time.Second*30, func() (bool, error) {
 			podList, err := framework.GetKubeletPods(f.ClientSet, pod.Spec.NodeName)
 			if err != nil {
 				e2elog.Logf("Unable to retrieve kubelet pods for node %v: %v", pod.Spec.NodeName, err)
@@ -304,7 +304,8 @@ var _ = framework.KubeDescribe("Pods", func() {
 			}
 			e2elog.Logf("no pod exists with the name we were looking for, assuming the termination request was observed and completed")
 			return true, nil
-		})).NotTo(gomega.HaveOccurred(), "kubelet never observed the termination notice")
+		})
+		framework.ExpectNoError(err, "kubelet never observed the termination notice")
 
 		ginkgo.By("verifying pod deletion was observed")
 		deleted := false

--- a/test/e2e/windows/density.go
+++ b/test/e2e/windows/density.go
@@ -270,8 +270,9 @@ func deletePodsSync(f *framework.Framework, pods []*v1.Pod) {
 			err := f.PodClient().Delete(pod.ObjectMeta.Name, metav1.NewDeleteOptions(30))
 			framework.ExpectNoError(err)
 
-			gomega.Expect(e2epod.WaitForPodToDisappear(f.ClientSet, f.Namespace.Name, pod.ObjectMeta.Name, labels.Everything(),
-				30*time.Second, 10*time.Minute)).NotTo(gomega.HaveOccurred())
+			err = e2epod.WaitForPodToDisappear(f.ClientSet, f.Namespace.Name, pod.ObjectMeta.Name, labels.Everything(),
+				30*time.Second, 10*time.Minute)
+			framework.ExpectNoError(err)
 		}(pod)
 	}
 	wg.Wait()


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

As https://github.com/kubernetes/kubernetes/pull/78478 we can use
ExpectNoError() instead of Expect(err).ToNot(HaveOccurred()) also.
This makes the test code check strict to cover the above case and
replaces the remaining in test/e2e/common/expansion.go

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref: https://github.com/kubernetes/kubernetes/issues/77103


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
