### PR TITLE
Fix spelling of test name

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -917,7 +917,7 @@ func TestPodFailedSchedulingMultipleTimesDoesNotBlockNewerPod(t *testing.T) {
 
 // TestHighPriorityBackoff tests that a high priority pod does not block
 // other pods if it is unschedulable
-func TestHighProirotyBackoff(t *testing.T) {
+func TestHighPriorityBackoff(t *testing.T) {
 	q := NewPriorityQueue(nil, nil)
 
 	midPod := v1.Pod{
@@ -955,7 +955,7 @@ func TestHighProirotyBackoff(t *testing.T) {
 		t.Errorf("Error while popping the head of the queue: %v", err)
 	}
 	if p != &highPod {
-		t.Errorf("Expected to get high prority pod, got: %v", p)
+		t.Errorf("Expected to get high priority pod, got: %v", p)
 	}
 	// Update pod condition to unschedulable.
 	podutil.UpdatePodCondition(&p.Status, &v1.PodCondition{
@@ -974,13 +974,13 @@ func TestHighProirotyBackoff(t *testing.T) {
 		t.Errorf("Error while popping the head of the queue: %v", err)
 	}
 	if p != &midPod {
-		t.Errorf("Expected to get mid prority pod, got: %v", p)
+		t.Errorf("Expected to get mid priority pod, got: %v", p)
 	}
 }
 
-// TestHighProirotyFlushUnschedulableQLeftover tests that pods will be moved to
+// TestHighPriorityFlushUnschedulableQLeftover tests that pods will be moved to
 // activeQ after one minutes if it is in unschedulableQ
-func TestHighProirotyFlushUnschedulableQLeftover(t *testing.T) {
+func TestHighPriorityFlushUnschedulableQLeftover(t *testing.T) {
 	q := NewPriorityQueue(nil, nil)
 	midPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Randomly happened to see this test name in some test results

/kind cleanup
/priority backlog
/proiroty critical-urgent

```release-note
NONE
```