### PR TITLE
fix serverCertificateManager not start only enable "RotateKubeletServerCertificate" in the kubelet config file.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -754,7 +754,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		klet.containerLogManager = logs.NewStubContainerLogManager()
 	}
 
-	if kubeCfg.ServerTLSBootstrap && kubeDeps.TLSOptions != nil && utilfeature.DefaultFeatureGate.Enabled(features.RotateKubeletServerCertificate) {
+	if kubeDeps.TLSOptions != nil && (utilfeature.DefaultFeatureGate.Enabled(features.RotateKubeletServerCertificate) || kubeCfg.ServerTLSBootstrap)  {
 		klet.serverCertificateManager, err = kubeletcertificate.NewKubeletServerCertificateManager(klet.kubeClient, kubeCfg, klet.nodeName, klet.getLastObservedNodeAddresses, certDirectory)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize certificate manager: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
    kubelet didn't auto renew certificate when kubelet enable feature "RotateKubeletServerCertificate" in the kubelet config file.  It will case node turn to the not-ready state when certificate expired.  This PR will fix that will start "serverCertificateManager" only enable "RotateKubeletServerCertificate" on the kubelet config， not both config file and args.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #78758 

**Special notes for your reviewer**:
 I found the error when judge when to start serverCertificateManager. Now will be both args and config files. I think should be either args of config file.

kubeCfg.ServerTLSBootstrap is control by the arg "rotate-server-certificates"
features.RotateKubeletServerCertificate is control by the feature gates "RotateKubeletServerCertificate" in the kubelet config file

https://github.com/kubernetes/kubernetes/blob/ef7808fec57284582c7bf3fc834570e5769df83e/pkg/kubelet/kubelet.go#L757-L761

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix the condition when to start serverCertificateManager.
```
