### PR TITLE
Proactively remove init Containers in CPUManager static policy

### DIFF
--- a/pkg/kubelet/cm/cpumanager/BUILD
+++ b/pkg/kubelet/cm/cpumanager/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "container_map.go",
         "cpu_assignment.go",
         "cpu_manager.go",
         "fake_cpu_manager.go",

--- a/pkg/kubelet/cm/cpumanager/BUILD
+++ b/pkg/kubelet/cm/cpumanager/BUILD
@@ -31,6 +31,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "container_map_test.go",
         "cpu_assignment_test.go",
         "cpu_manager_test.go",
         "policy_none_test.go",

--- a/pkg/kubelet/cm/cpumanager/container_map.go
+++ b/pkg/kubelet/cm/cpumanager/container_map.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpumanager
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+)
+
+// containerMap maps (podUID, containerName) -> containerID
+type containerMap map[string]map[string]string
+
+func newContainerMap() containerMap {
+	return make(containerMap)
+}
+
+func (cm containerMap) Add(p *v1.Pod, c *v1.Container, containerID string) {
+	podUID := string(p.UID)
+	if _, exists := cm[podUID]; !exists {
+		cm[podUID] = make(map[string]string)
+	}
+	cm[podUID][c.Name] = containerID
+}
+
+func (cm containerMap) Remove(containerID string) {
+	found := false
+	for podUID := range cm {
+		for containerName := range cm[podUID] {
+			if containerID == cm[podUID][containerName] {
+				delete(cm[podUID], containerName)
+				found = true
+				break
+			}
+		}
+		if len(cm[podUID]) == 0 {
+			delete(cm, podUID)
+		}
+		if found {
+			break
+		}
+	}
+}
+
+func (cm containerMap) Get(p *v1.Pod, c *v1.Container) (string, error) {
+	podUID := string(p.UID)
+	if _, exists := cm[podUID]; !exists {
+		return "", fmt.Errorf("pod %s not in containerMap", podUID)
+	}
+	if _, exists := cm[podUID][c.Name]; !exists {
+		return "", fmt.Errorf("container %s not in containerMap for pod %s", c.Name, podUID)
+	}
+	return cm[podUID][c.Name], nil
+}

--- a/pkg/kubelet/cm/cpumanager/container_map_test.go
+++ b/pkg/kubelet/cm/cpumanager/container_map_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpumanager
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	apimachinery "k8s.io/apimachinery/pkg/types"
+)
+
+func TestContainerMap(t *testing.T) {
+	testCases := []struct {
+		podUID         string
+		containerNames []string
+		containerIDs   []string
+	}{
+		{
+			"fakePodUID",
+			[]string{"fakeContainerName-1", "fakeContainerName-2"},
+			[]string{"fakeContainerID-1", "fakeContainerName-2"},
+		},
+	}
+
+	for _, tc := range testCases {
+		pod := v1.Pod{}
+		pod.UID = apimachinery.UID(tc.podUID)
+
+		// Build a new containerMap from the testCases, checking proper
+		// addition, retrieval along the way.
+		cm := newContainerMap()
+		for i := range tc.containerNames {
+			container := v1.Container{Name: tc.containerNames[i]}
+
+			cm.Add(&pod, &container, tc.containerIDs[i])
+			containerID, err := cm.Get(&pod, &container)
+			if err != nil {
+				t.Errorf("error adding and retrieving container: %v", err)
+			}
+			if containerID != tc.containerIDs[i] {
+				t.Errorf("mismatched containerIDs %v, %v", containerID, tc.containerIDs[i])
+			}
+		}
+
+		// Remove all entries from the containerMap, checking proper removal of
+		// each along the way.
+		for i := range tc.containerNames {
+			container := v1.Container{Name: tc.containerNames[i]}
+			cm.Remove(tc.containerIDs[i])
+			containerID, err := cm.Get(&pod, &container)
+			if err == nil {
+				t.Errorf("unexpected retrieval of containerID after removal: %v", containerID)
+			}
+		}
+
+		// Verify containerMap now empty.
+		if len(cm) != 0 {
+			t.Errorf("unexpected entries still in containerMap: %v", cm)
+		}
+
+	}
+}

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -140,6 +140,49 @@ func makePod(cpuRequest, cpuLimit string) *v1.Pod {
 	}
 }
 
+func makeMultiContainerPod(initCPUs, appCPUs []struct{ request, limit string }) *v1.Pod {
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{},
+			Containers:     []v1.Container{},
+		},
+	}
+
+	for i, cpu := range initCPUs {
+		pod.Spec.InitContainers = append(pod.Spec.InitContainers, v1.Container{
+			Name: "initContainer-" + string(i),
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU):    resource.MustParse(cpu.request),
+					v1.ResourceName(v1.ResourceMemory): resource.MustParse("1G"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU):    resource.MustParse(cpu.limit),
+					v1.ResourceName(v1.ResourceMemory): resource.MustParse("1G"),
+				},
+			},
+		})
+	}
+
+	for i, cpu := range appCPUs {
+		pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
+			Name: "appContainer-" + string(i),
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU):    resource.MustParse(cpu.request),
+					v1.ResourceName(v1.ResourceMemory): resource.MustParse("1G"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU):    resource.MustParse(cpu.limit),
+					v1.ResourceName(v1.ResourceMemory): resource.MustParse("1G"),
+				},
+			},
+		})
+	}
+
+	return pod
+}
+
 func TestCPUManagerAdd(t *testing.T) {
 	testPolicy := NewStaticPolicy(
 		&topology.CPUTopology{


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
```
    This patch fixes a bug in the CPUManager, whereby it doesn't honor the
    "effective requests/limits" of a Pod as defined by:

        https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resources

    The rule states that a Pod’s "effective request/limit" for a resource
    should be the larger of:
        * The highest of any particular resource request or limit
          defined on all init Containers
        * The sum of all app Containers request/limit for a
          resource

    Moreover, the rule states that:
        * The effective QoS tier is the same for init Containers
          and app containers alike

    This means that the resource requests of init Containers and app
    Containers should be able to overlap, such that the larger of the two
    becomes the "effective resource request/limit" for the Pod. Likewise,
    if a QoS tier of "Guaranteed" is determined for the Pod, then both init
    Containers and app Containers should run in this tier.

    In its current implementation, the CPU manager honors the effective QoS
    tier for both init and app containers, but doesn't honor the "effective
    request/limit" correctly.

    Instead, it treats the "effective request/limit" as:
        * The sum of all init Containers plus the sum of all app
          Containers request/limit for a resource

    It does this by not proactively removing the CPUs given to previous init
    containers when new containers are being created. In the worst case,
    this causes the CPUManager to give non-overlapping CPUs to all
    containers (whether init or app) in the "Guaranteed" QoS tier before any
    of the containers in the Pod actually start.

    This effectively blocks these Pods from running if the total number of
    CPUs being requested across init and app Containers goes beyond the
    limits of the system.

    This patch fixes this problem by updating the CPUManager static policy
    so that it proactively removes any guaranteed CPUs it has granted to
    init Containers before allocating CPUs to app containers. Since all init
    container are run sequentially, it also makes sure this proactive
    removal happens for previous init containers when allocating CPUs to
    later ones.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
