### PR TITLE
Fix kubectl apply skew test with extra properties

### DIFF
--- a/test/e2e/kubectl/BUILD
+++ b/test/e2e/kubectl/BUILD
@@ -42,6 +42,7 @@ go_library(
         "//test/utils/crd:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/elazarl/goproxy:go_default_library",
+        "//vendor/github.com/googleapis/gnostic/OpenAPIv2:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/golang.org/x/net/websocket:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Corrects one of the kubectl apply skew tests. See https://testgrid.k8s.io/sig-cli-master#skew-cluster-latest-kubectl-stable1-gce&width=5

**Special notes for your reviewer**:
* Fixes a bug in the test that was not setting up the test CRDs correctly
* Fixes a bug in the "arbitrary properties" skew test that expected success even when passing bogus data with a published schema

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @sttts @roycaihw 
/sig cli
/sig api-machinery
/priority critical-urgent
/milestone v1.15