### PR TITLE
preload metrics for legacyregistry for backwards compatibility

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/BUILD
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/BUILD
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -94,3 +94,18 @@ func NewKubeRegistry(v apimachineryversion.Info) KubeRegistry {
 		version:      parseVersion(v),
 	}
 }
+
+// NewPreloadedKubeRegistry creates a new Registry with preloaded prometheus collectors
+// already registered. This is exposed specifically to maintain backwards
+// compatibility with the global prometheus registry.
+//
+// Deprecated
+func NewPreloadedKubeRegistry(v apimachineryversion.Info, cs ...prometheus.Collector) KubeRegistry {
+	registry := &kubeRegistry{
+		PromRegistry: prometheus.NewRegistry(),
+		version:      parseVersion(v),
+	}
+
+	registry.PromRegistry.MustRegister(cs...)
+	return registry
+}


### PR DESCRIPTION
The global prometheus registry comes preloaded with process and go
metrics. Since these are not under kubernetes control, they can't be
considered stable. However, we can make a best effort to maintain
backwards compatibility by preloading the same metrics.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Please see: [Control Plane Metrics Stability KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md)

```release-note
NONE
```
/sig instrumentation
/assign @brancz 
