### PR TITLE
Don't print non-error (blank lines in this case) to stdout

### DIFF
--- a/pkg/kubectl/cmd/testing/util.go
+++ b/pkg/kubectl/cmd/testing/util.go
@@ -126,6 +126,30 @@ func TestData() (*corev1.PodList, *corev1.ServiceList, *corev1.ReplicationContro
 	return pods, svc, rc
 }
 
+// EmptyTestData returns no pod, service, or replication controller
+func EmptyTestData() (*corev1.PodList, *corev1.ServiceList, *corev1.ReplicationControllerList) {
+	pods := &corev1.PodList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "15",
+		},
+		Items: []corev1.Pod{},
+	}
+	svc := &corev1.ServiceList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "16",
+		},
+		Items: []corev1.Service{},
+	}
+
+	rc := &corev1.ReplicationControllerList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "17",
+		},
+		Items: []corev1.ReplicationController{},
+	}
+	return pods, svc, rc
+}
+
 func GenResponseWithJsonEncodedBody(bodyStruct interface{}) (*http.Response, error) {
 	jsonBytes, err := json.Marshal(bodyStruct)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The current `kubectl get all` prints blank lines to stdout (demonstrated [here](https://github.com/kubernetes/kubectl/issues/582#issue-406096344)) which it shouldn't have. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/582

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

FYI @duglin 
