### PR TITLE
Check if options returning an error

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -435,7 +435,10 @@ with the apiserver API to configure the proxy.`,
 			if err := opts.Validate(args); err != nil {
 				klog.Fatalf("failed validate: %v", err)
 			}
-			klog.Fatal(opts.Run())
+
+			if err := opts.Run(); err != nil {
+				klog.Exit(err)
+			}
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR fixes that `kube-proxy` don't log an `nil` error after a successful run.

**Which issue(s) this PR fixes**:
Fixes #78735

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kube-proxy --cleanup will return the correct exit code if the cleanup was successful
```
