### PR TITLE
Kubectl cp error using kubectl version 1.14.2 #659 && kubectl cp fails on symlinks #78211

### DIFF
--- a/pkg/kubectl/cmd/cp/cp_test.go
+++ b/pkg/kubectl/cmd/cp/cp_test.go
@@ -580,6 +580,42 @@ func TestClean(t *testing.T) {
 	}
 }
 
+func TestConvertHostDestFilename(t *testing.T) {
+	tests := []struct {
+		srcFile           string
+		destFile          string
+		convertedFilename string
+	}{
+		{
+			"test_convert_host_file",
+			"test_convert_host_dir",
+			"test_convert_host_dir/test_convert_host_file",
+		},
+	}
+	for _, test := range tests {
+		err := os.Mkdir(test.destFile, 755)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			t.FailNow()
+		}
+		defer os.RemoveAll(test.destFile)
+		err = os.Symlink(test.destFile, "symlink_convert_host")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			t.FailNow()
+		}
+		defer os.RemoveAll("symlink_convert_host")
+		out, err := convertHostDestFilename(test.srcFile, "symlink_convert_host")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			t.FailNow()
+		}
+		if out != test.convertedFilename {
+			t.Errorf("Expected: %s, saw %s", test.convertedFilename, out)
+		}
+	}
+}
+
 func TestCopyToPod(t *testing.T) {
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	ns := scheme.Codecs


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Fixes https://github.com/kubernetes/kubectl/issues/659
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/78211
Fixes https://github.com/kubernetes/kubectl/issues/659
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes a bug where kubectl cp could not copy to a folder directly on the host system. Also fixes a bug when copying to symlinked absolute paths.
```
