### PR TITLE
Update Cluster Autoscaler version to 1.15.0-beta.1

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.14.0",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.15.0-beta.1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
This PR updates CA version in gce manifests to 1.15.0-beta.1

We need to merge it during freeze because, Cluster Autoscaler imports large amount of k8s code to simulate scheduler behavior, yet it lives in separate repository. Therefore
we need to build final release candidate just at the end of k8s release cycle.

```release-note
NONE
```
