### PR TITLE
Force using Go Modules in README.md

### DIFF
--- a/staging/src/k8s.io/sample-cli-plugin/README.md
+++ b/staging/src/k8s.io/sample-cli-plugin/README.md
@@ -31,7 +31,7 @@ This is an example of how to build a kubectl plugin using the same set of tools 
 
 ```sh
 # assumes you have a working KUBECONFIG
-$ go build cmd/kubectl-ns.go
+$ GO111MODULE="on" go build cmd/kubectl-ns.go
 # place the built binary somewhere in your PATH
 $ cp ./kubectl-ns /usr/local/bin
 


### PR DESCRIPTION
Going through this README file, I was very confused when
this failed to compile by using the commands provided. I
think this change makes the intent of the README clearer.

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
As a developer who was trying to work through the README
When I checkout the [repo here](https://github.com/kubernetes/sample-cli-plugin) into my GOPATH and run `go build cmd/kubectl-ns.go`
I want the build command to succeed and output the binary

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
