### PR TITLE
kubeadm: fix minor typo in a comment

### DIFF
--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -30,7 +30,7 @@ func GetGenericImage(prefix, image, tag string) string {
 }
 
 // GetKubernetesImage generates and returns the image for the components managed in the Kubernetes main repository,
-// including the control-plane components ad kube-proxy. If specified, the HyperKube image will be used.
+// including the control-plane components and kube-proxy. If specified, the HyperKube image will be used.
 func GetKubernetesImage(image string, cfg *kubeadmapi.ClusterConfiguration) string {
 	if cfg.UseHyperKubeImage {
 		image = constants.HyperKube


### PR DESCRIPTION
Hi,

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

I just found a minor typo in a comment of a fine in kubeadm.

**Special notes for your reviewer**:

I looked at the rest of the file and didn't find any other ones.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

Thanks,
Joseph
