### PR TITLE
tag some release-blocking tests taking over 5min as [Slow]

### DIFF
--- a/test/e2e/apimachinery/chunking.go
+++ b/test/e2e/apimachinery/chunking.go
@@ -122,7 +122,7 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 		gomega.Expect(list.Items).To(gomega.HaveLen(numberOfTotalResources))
 	})
 
-	ginkgo.It("should support continue listing from the last key if the original version has been compacted away, though the list is inconsistent", func() {
+	ginkgo.It("should support continue listing from the last key if the original version has been compacted away, though the list is inconsistent [Slow]", func() {
 		ns := f.Namespace.Name
 		c := f.ClientSet
 		client := c.CoreV1().PodTemplates(ns)

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -575,7 +575,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			Testname: StatefulSet, Scaling
 			Description: StatefulSet MUST create Pods in ascending order by ordinal index when scaling up, and delete Pods in descending order when scaling down. Scaling up or down MUST pause if any Pods belonging to the StatefulSet are unhealthy. This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
 		*/
-		framework.ConformanceIt("Scaling should happen in predictable order and halt if any stateful pod is unhealthy", func() {
+		framework.ConformanceIt("Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Slow]", func() {
 			psLabels := klabels.Set(labels)
 			ginkgo.By("Initializing watcher for selector " + psLabels.String())
 			watcher, err := f.ClientSet.CoreV1().Pods(ns).Watch(metav1.ListOptions{
@@ -660,7 +660,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			Testname: StatefulSet, Burst Scaling
 			Description: StatefulSet MUST support the Parallel PodManagementPolicy for burst scaling. This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
 		*/
-		framework.ConformanceIt("Burst scaling should run to completion even with unhealthy pods", func() {
+		framework.ConformanceIt("Burst scaling should run to completion even with unhealthy pods [Slow]", func() {
 			psLabels := klabels.Set(labels)
 
 			ginkgo.By("Creating stateful set " + ssName + " in namespace " + ns)

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -79,7 +79,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", fu
 			}
 			scaleTest.run("rc-light", common.KindRC, rc, f)
 		})
-		ginkgo.It("Should scale from 2 pods to 1 pod", func() {
+		ginkgo.It("Should scale from 2 pods to 1 pod [Slow]", func() {
 			scaleTest := &HPAScaleTest{
 				initPods:                    2,
 				totalInitialCPUUsage:        50,

--- a/test/e2e/storage/testpatterns/testpattern.go
+++ b/test/e2e/storage/testpatterns/testpattern.go
@@ -128,21 +128,24 @@ var (
 
 	// XfsInlineVolume is TestPattern for "Inline-volume (xfs)"
 	XfsInlineVolume = TestPattern{
-		Name:    "Inline-volume (xfs)",
-		VolType: InlineVolume,
-		FsType:  "xfs",
+		Name:       "Inline-volume (xfs)",
+		VolType:    InlineVolume,
+		FsType:     "xfs",
+		FeatureTag: "[Slow]",
 	}
 	// XfsPreprovisionedPV is TestPattern for "Pre-provisioned PV (xfs)"
 	XfsPreprovisionedPV = TestPattern{
-		Name:    "Pre-provisioned PV (xfs)",
-		VolType: PreprovisionedPV,
-		FsType:  "xfs",
+		Name:       "Pre-provisioned PV (xfs)",
+		VolType:    PreprovisionedPV,
+		FsType:     "xfs",
+		FeatureTag: "[Slow]",
 	}
 	// XfsDynamicPV is TestPattern for "Dynamic PV (xfs)"
 	XfsDynamicPV = TestPattern{
-		Name:    "Dynamic PV (xfs)",
-		VolType: DynamicPV,
-		FsType:  "xfs",
+		Name:       "Dynamic PV (xfs)",
+		VolType:    DynamicPV,
+		FsType:     "xfs",
+		FeatureTag: "[Slow]",
 	}
 
 	// Definitions for ntfs

--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -236,7 +236,7 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 		}
 	case testpatterns.DynamicPV:
 		if pattern.VolMode == v1.PersistentVolumeBlock && !isBlockSupported {
-			ginkgo.It("should fail in binding dynamic provisioned PV to PVC", func() {
+			ginkgo.It("should fail in binding dynamic provisioned PV to PVC [Slow]", func() {
 				init()
 				defer cleanup()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

I looked at all runs over all jobs run against master or release-1.15,
ignored `[Feature:.*]` or `[Serial]` tests, and added `[Slow]` to any 
tests whose 50th percentile duration was over 5 minutes

This will mean these tests are excluded from PR jobs, and may mean the
jobs will take less time. The tests will instead be run as part of the
periodic release-blocking -slow jobs (eg:
https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-slow)

**Special notes for your reviewer**:

Misc comments:
- the apimachinery chunking test is the worst offender, at about 15min
- all test cases for all drivers that ran `[Testpattern:.*(xfs)]` were
  taking longer than 5 minutes, so I got lucky and this was an easy
  call; not sure how to support some drivers taking too long for some
  test patterns

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```