### PR TITLE
Fixed clock.fakeTimer.Stop and Reset

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/clock/clock_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/clock/clock_test.go
@@ -117,6 +117,108 @@ func TestFakeAfter(t *testing.T) {
 	}
 }
 
+func TestFakeTimer(t *testing.T) {
+	tc := NewFakeClock(time.Now())
+	if tc.HasWaiters() {
+		t.Errorf("unexpected waiter?")
+	}
+	oneSec := tc.NewTimer(time.Second)
+	twoSec := tc.NewTimer(time.Second * 2)
+	treSec := tc.NewTimer(time.Second * 3)
+	if !tc.HasWaiters() {
+		t.Errorf("unexpected lack of waiter?")
+	}
+	select {
+	case <-oneSec.C():
+		t.Errorf("unexpected channel read")
+	case <-twoSec.C():
+		t.Errorf("unexpected channel read")
+	case <-treSec.C():
+		t.Errorf("unexpected channel read")
+	default:
+	}
+	tc.Step(999999999 * time.Nanosecond) // t=.999,999,999
+	select {
+	case <-oneSec.C():
+		t.Errorf("unexpected channel read")
+	case <-twoSec.C():
+		t.Errorf("unexpected channel read")
+	case <-treSec.C():
+		t.Errorf("unexpected channel read")
+	default:
+	}
+	tc.Step(time.Nanosecond) // t=1
+	select {
+	case <-twoSec.C():
+		t.Errorf("unexpected channel read")
+	case <-treSec.C():
+		t.Errorf("unexpected channel read")
+	default:
+	}
+	select {
+	case <-oneSec.C():
+		// Expected!
+	default:
+		t.Errorf("unexpected channel non-read")
+	}
+	tc.Step(time.Nanosecond) // t=1.000,000,001
+	select {
+	case <-oneSec.C():
+		t.Errorf("unexpected channel read")
+	case <-twoSec.C():
+		t.Errorf("unexpected channel read")
+	case <-treSec.C():
+		t.Errorf("unexpected channel read")
+	default:
+	}
+	if oneSec.Stop() {
+		t.Errorf("Expected oneSec.Stop() to return false")
+	}
+	if !twoSec.Stop() {
+		t.Errorf("Expected twoSec.Stop() to return true")
+	}
+	tc.Step(time.Second) // t=2.000,000,001
+	select {
+	case <-oneSec.C():
+		t.Errorf("unexpected channel read")
+	case <-twoSec.C():
+		t.Errorf("unexpected channel read")
+	case <-treSec.C():
+		t.Errorf("unexpected channel read")
+	default:
+	}
+	if twoSec.Reset(time.Second) {
+		t.Errorf("Expected twoSec.Reset() to return false")
+	}
+	if !treSec.Reset(time.Second) {
+		t.Errorf("Expected treSec.Reset() to return true")
+	}
+	tc.Step(time.Nanosecond * 999999999) // t=3.0
+	select {
+	case <-oneSec.C():
+		t.Errorf("unexpected channel read")
+	case <-twoSec.C():
+		t.Errorf("unexpected channel read")
+	case <-treSec.C():
+		t.Errorf("unexpected channel read")
+	default:
+	}
+	tc.Step(time.Nanosecond) // t=3.000,000,001
+	select {
+	case <-oneSec.C():
+		t.Errorf("unexpected channel read")
+	case <-twoSec.C():
+		t.Errorf("unexpected channel read")
+	default:
+	}
+	select {
+	case <-treSec.C():
+		// Expected!
+	default:
+		t.Errorf("unexpected channel non-read")
+	}
+}
+
 func TestFakeTick(t *testing.T) {
 	tc := NewFakeClock(time.Now())
 	if tc.HasWaiters() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixed the way clock.fakeTimer.Stop() identified the fakeClockWaiter to remove.  The previous code never removed any fakeClockWaiter, so Stop() had no effect.

Based the return value on whether the timer's fakeClockWaiter remains among those of the fake clock.  The previous code always returned `true`, due to examining a copy of the original state of the fakeClockWaiter.

Also fixed clock.fakeTimer.Reset(), it suffered from the same fundamental misconception.

Added a test func for FakeClock timers.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #78807

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
