### PR TITLE
Improve kubectl prune-whitelist format error message

### DIFF
--- a/pkg/kubectl/cmd/apply/apply.go
+++ b/pkg/kubectl/cmd/apply/apply.go
@@ -292,7 +292,7 @@ func parsePruneResources(mapper meta.RESTMapper, gvks []string) ([]pruneResource
 	for _, groupVersionKind := range gvks {
 		gvk := strings.Split(groupVersionKind, "/")
 		if len(gvk) != 3 {
-			return nil, fmt.Errorf("invalid GroupVersionKind format: %v, please follow <group/version/kind>", groupVersionKind)
+			return nil, fmt.Errorf("invalid GroupVersionKind format: %v, please follow <group/version/kind>; use 'core' group for the ungroupped APIs", groupVersionKind)
 		}
 
 		if gvk[0] == "core" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind documentation
/area kubectl
/sig cli

`kubectl apply --prune-whitelist` requires `<group/version/kind>` format. This is fine, but it's not imediately obvious to beginners that eg. a `v1/Service` is in a `core` group. The documentation for core objects does not generally mention the group name: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
The group is only explicitly mentioned in the API reference https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#service-v1-core.
Advanced users on the other hand may know that the `core` group does in fact not exist in the API and is represented by an empty string.

It's presumably better to require the `g/v/k` format even for the core objects, as the empty core group may disappear some day. This PR addresses the difficulties by updating the error message a user is bound to get when they incorrectly specify only a `version/kind` for the core objects.

```release-note
NONE
```