### PR TITLE
Update CLI builder Label and Field selector docs

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -420,8 +420,8 @@ func (b *Builder) ResourceNames(resource string, names ...string) *Builder {
 }
 
 // LabelSelectorParam defines a selector that should be applied to the object types to load.
-// This will not affect files loaded from disk or URL. If the parameter is empty it is
-// a no-op - to select all resources invoke `b.LabelSelector(labels.Everything.String)`.
+// If the parameter is empty it is a no-op - to select all
+// resources invoke `b.LabelSelector(labels.Everything.String)`.
 func (b *Builder) LabelSelectorParam(s string) *Builder {
 	selector := strings.TrimSpace(s)
 	if len(selector) == 0 {
@@ -446,8 +446,7 @@ func (b *Builder) LabelSelector(selector string) *Builder {
 }
 
 // FieldSelectorParam defines a selector that should be applied to the object types to load.
-// This will not affect files loaded from disk or URL. If the parameter is empty it is
-// a no-op - to select all resources.
+// If the parameter is empty it is a no-op.
 func (b *Builder) FieldSelectorParam(s string) *Builder {
 	s = strings.TrimSpace(s)
 	if len(s) == 0 {


### PR DESCRIPTION
Selectors are applied to files, URLs and stdin since 5f2569c16d2b4bd8e079c8ceaf21066bb80e803a, but the code doc was never updated. This results in obvious confusion when coding against the API.

Also note that the doc for `FieldSelectorParam` is presumably an incomplete copy-paste from the original LabelSelector. I've removed the sentence altogether.

/sig cli

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind cleanup

```release-note
NONE
```