### PR TITLE
apiextensions: validate x-kubernetes-int-or-string in CRs

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
@@ -123,6 +123,9 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			if len(obj.Type) == 0 {
 				obj.Nullable = false // because this does not roundtrip through go-openapi
 			}
+			if obj.XIntOrString {
+				obj.Type = ""
+			}
 		},
 		func(obj *apiextensions.JSONSchemaPropsOrBool, c fuzz.Continue) {
 			if c.RandBool() {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
@@ -71,9 +71,13 @@ func ConvertJSONSchemaPropsWithPostProcess(in *apiextensions.JSONSchemaProps, ou
 	out.Description = in.Description
 	if in.Type != "" {
 		out.Type = spec.StringOrArray([]string{in.Type})
-		if in.Nullable {
-			out.Type = append(out.Type, "null")
-		}
+	}
+	if in.XIntOrString {
+		out.VendorExtensible.AddExtension("x-kubernetes-int-or-string", true)
+		out.Type = spec.StringOrArray{"integer", "string"}
+	}
+	if out.Type != nil && in.Nullable {
+		out.Type = append(out.Type, "null")
 	}
 	out.Format = in.Format
 	out.Title = in.Title
@@ -200,9 +204,6 @@ func ConvertJSONSchemaPropsWithPostProcess(in *apiextensions.JSONSchemaProps, ou
 	}
 	if in.XEmbeddedResource {
 		out.VendorExtensible.AddExtension("x-kubernetes-embedded-resource", true)
-	}
-	if in.XIntOrString {
-		out.VendorExtensible.AddExtension("x-kubernetes-int-or-string", true)
 	}
 
 	return nil


### PR DESCRIPTION
The go-openapi validation part (i.e. unfolding of `x-kubernetes-int-or-string: true` into something that go-openapi understands) was missing.

This PR also adds complete tests for `nullable`, also in combination with `x-kubernetes-int-or-string`.

Fixes https://github.com/kubernetes/kubernetes/issues/78817.

```release-note
CRDs get support for x-kuberntes-int-or-string to allow faithful representation of IntOrString types in CustomResources.
```