### PR TITLE
Adding defer wg.Done() Statement To logs.go

### DIFF
--- a/pkg/kubectl/cmd/logs/logs.go
+++ b/pkg/kubectl/cmd/logs/logs.go
@@ -324,6 +324,7 @@ func (o LogsOptions) parallelConsumeRequest(requests []rest.ResponseWrapper) err
 	wg.Add(len(requests))
 	for _, request := range requests {
 		go func(request rest.ResponseWrapper) {
+			defer wg.Done()
 			if err := o.ConsumeRequestFn(request, writer); err != nil {
 				if !o.IgnoreLogErrors {
 					writer.CloseWithError(err)
@@ -335,7 +336,6 @@ func (o LogsOptions) parallelConsumeRequest(requests []rest.ResponseWrapper) err
 				fmt.Fprintf(writer, "error: %v\n", err)
 			}
 
-			wg.Done()
 		}(request)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
**What this PR does / why we need it**:
Adding defer keyword to wg.Done in logs.go to ensure that it gets executed within goroutine.
**Which issue(s) this PR fixes**:
NONE
**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
