### PR TITLE
fix leader election LeaseDuration/RenewDeadline validation

### DIFF
--- a/pkg/client/leaderelectionconfig/config.go
+++ b/pkg/client/leaderelectionconfig/config.go
@@ -35,7 +35,7 @@ func BindFlags(l *componentbaseconfig.LeaderElectionConfiguration, fs *pflag.Fla
 		"election is enabled.")
 	fs.DurationVar(&l.RenewDeadline.Duration, "leader-elect-renew-deadline", l.RenewDeadline.Duration, ""+
 		"The interval between attempts by the acting master to renew a leadership slot "+
-		"before it stops leading. This must be less than or equal to the lease duration. "+
+		"before it stops leading. This must be less than the lease duration. "+
 		"This is only applicable if leader election is enabled.")
 	fs.DurationVar(&l.RetryPeriod.Duration, "leader-elect-retry-period", l.RetryPeriod.Duration, ""+
 		"The duration the clients should wait between attempting acquisition and renewal "+

--- a/staging/src/k8s.io/component-base/config/validation/validation.go
+++ b/staging/src/k8s.io/component-base/config/validation/validation.go
@@ -45,7 +45,7 @@ func ValidateLeaderElectionConfiguration(cc *config.LeaderElectionConfiguration,
 	if cc.RetryPeriod.Duration <= 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("retryPeriod"), cc.RetryPeriod, "must be greater than zero"))
 	}
-	if cc.LeaseDuration.Duration < cc.RenewDeadline.Duration {
+	if cc.LeaseDuration.Duration <= cc.RenewDeadline.Duration {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("leaseDuration"), cc.RenewDeadline, "LeaseDuration must be greater than RenewDeadline"))
 	}
 	if len(cc.ResourceLock) == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

As the definition of `RenewDeadline` mentioned: `This must be less than or equal to the lease duration.`:
https://github.com/kubernetes/kubernetes/blob/5fe910191a6a1a64872e249c4c431b0169d763ed/pkg/client/leaderelectionconfig/config.go#L36-L39 

And the validation in `component-base` is also implemented as this definition (but description is wrong): 
https://github.com/kubernetes/component-base/blob/4ec51977545472652ffe99d8f6ca92c55f018f31/config/validation/validation.go#L48-L50

The problem is the validation in `client-go`:
https://github.com/kubernetes/client-go/blob/e65ca70987a6941be583f205696e0b1b7da82002/tools/leaderelection/leaderelection.go#L77-L79

Need to fix it to align with the definition. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #78759

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix leader election LeaseDuration/RenewDeadline validation.
```
