### PR TITLE
Warn about deletion of namespaces #77992

### DIFF
--- a/pkg/kubectl/cmd/delete/BUILD
+++ b/pkg/kubectl/cmd/delete/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/printers:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/resource:go_default_library",

--- a/pkg/kubectl/cmd/delete/delete.go
+++ b/pkg/kubectl/cmd/delete/delete.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -158,6 +159,12 @@ func (o *DeleteOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Co
 			o.IgnoreNotFound = true
 		}
 	}
+
+	// If specifying to delete all namespaces, must enter a --grace-period flag
+	if (sets.NewString(args...).Has("ns") || sets.NewString(args...).Has("namespace")) && o.DeleteAll && o.GracePeriod == -1 {
+		return fmt.Errorf("--grace-period flag must be specified when you chose to delete all namespaces")
+	}
+
 	if o.DeleteNow {
 		if o.GracePeriod != -1 {
 			return fmt.Errorf("--now and --grace-period cannot be specified together")

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -1319,7 +1319,7 @@ run_namespace_tests() {
 
   kubectl create namespace my-namespace
   kube::test::get_object_assert 'namespaces/my-namespace' "{{$id_field}}" 'my-namespace'
-  output_message=$(! kubectl delete namespace -n my-namespace --all 2>&1 "${kube_flags[@]}")
+  output_message=$(! kubectl delete namespace -n my-namespace --all --grace-period=1 2>&1 "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" 'warning: deleting cluster-scoped resources'
   kube::test::if_has_string "${output_message}" 'namespace "my-namespace" deleted'
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
**What this PR does / why we need it**:
Users must now specify --grace-period flags when they try to delete all namespaces.
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/77992
**Special notes for your reviewer**:
I thought --force flags would be more appropriate, but --force is ignored with a warning (it looks like this is for backwards-compatibility) if --grace-period is not specified anyway. 
**Does this PR introduce a user-facing change?**:
```release-note
Users must now specify --grace-period flags when they try to delete all namespaces.
```
