### PR TITLE
Add non-preemptible policy to PriorityClasses

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -1952,6 +1952,10 @@ const (
 	PreemptLowerPriority PreemptionPolicy = "PreemptLowerPriority"
 	// PreemptNever means that pod never preempts other pods with lower priority.
 	PreemptNever PreemptionPolicy = "Never"
+	// NonPreemptible means that pod can not be preempted by other pods with higher priority.
+	NonPreemptible PreemptionPolicy = "NonPreemptible"
+	// NonPreemptiblePreemptNever means that pod can not be preempted by other pods with higher priority and never preempts other pods with lower priority.
+	NonPreemptiblePreemptNever PreemptionPolicy = "NonPreemptiblePreemptNever"
 )
 
 // TerminationMessagePolicy describes how termination messages are retrieved from a container.
@@ -2676,7 +2680,7 @@ type PodSpec struct {
 	// +optional
 	Priority *int32
 	// PreemptionPolicy is the Policy for preempting pods with lower priority.
-	// One of Never, PreemptLowerPriority.
+	// One of Never, PreemptLowerPriority, NonPreemptible, NonPreemptiblePreemptNever.
 	// Defaults to PreemptLowerPriority if unset.
 	// This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
 	// +optional

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -2701,7 +2701,7 @@ func validateRestartPolicy(restartPolicy *core.RestartPolicy, fldPath *field.Pat
 func ValidatePreemptionPolicy(preemptionPolicy *core.PreemptionPolicy, fldPath *field.Path) field.ErrorList {
 	allErrors := field.ErrorList{}
 	switch *preemptionPolicy {
-	case core.PreemptLowerPriority, core.PreemptNever:
+	case core.PreemptLowerPriority, core.PreemptNever, core.NonPreemptible, core.NonPreemptiblePreemptNever:
 	case "":
 		allErrors = append(allErrors, field.Required(fldPath, ""))
 	default:

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2054,6 +2054,10 @@ const (
 	PreemptLowerPriority PreemptionPolicy = "PreemptLowerPriority"
 	// PreemptNever means that pod never preempts other pods with lower priority.
 	PreemptNever PreemptionPolicy = "Never"
+	// NonPreemptible means that pod can not be preempted by other pods with higher priority.
+	NonPreemptible PreemptionPolicy = "NonPreemptible"
+	// NonPreemptiblePreemptNever means that pod can not be preempted by other pods with higher priority and never preempts other pods with lower priority.
+	NonPreemptiblePreemptNever PreemptionPolicy = "NonPreemptiblePreemptNever"
 )
 
 // TerminationMessagePolicy describes how termination messages are retrieved from a container.
@@ -2996,7 +3000,7 @@ type PodSpec struct {
 	// +optional
 	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty" protobuf:"varint,30,opt,name=enableServiceLinks"`
 	// PreemptionPolicy is the Policy for preempting pods with lower priority.
-	// One of Never, PreemptLowerPriority.
+	// One of Never, PreemptLowerPriority, NonPreemptingPriority, NonPreemptiblePreemptNever.
 	// Defaults to PreemptLowerPriority if unset.
 	// This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
 	// +optional

--- a/staging/src/k8s.io/api/scheduling/v1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1/types.go
@@ -52,7 +52,7 @@ type PriorityClass struct {
 	Description string `json:"description,omitempty" protobuf:"bytes,4,opt,name=description"`
 
 	// PreemptionPolicy is the Policy for preempting pods with lower priority.
-	// One of Never, PreemptLowerPriority.
+	// One of Never, PreemptLowerPriority, NonPreemptible, NonPreemptiblePreemptNever.
 	// Defaults to PreemptLowerPriority if unset.
 	// This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
 	// +optional

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
@@ -53,7 +53,7 @@ type PriorityClass struct {
 	Description string `json:"description,omitempty" protobuf:"bytes,4,opt,name=description"`
 
 	// PreemptionPolicy is the Policy for preempting pods with lower priority.
-	// One of Never, PreemptLowerPriority.
+	// One of Never, PreemptLowerPriority, NonPreemptible, NonPreemptiblePreemptNever.
 	// Defaults to PreemptLowerPriority if unset.
 	// This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
 	// +optional

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types.go
@@ -53,7 +53,7 @@ type PriorityClass struct {
 	Description string `json:"description,omitempty" protobuf:"bytes,4,opt,name=description"`
 
 	// PreemptionPolicy is the Policy for preempting pods with lower priority.
-	// One of Never, PreemptLowerPriority.
+	// One of Never, PreemptLowerPriority, NonPreemptible, NonPreemptiblePreemptNever.
 	// Defaults to PreemptLowerPriority if unset.
 	// This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
 	// +optional


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
As we've have non-preempting(https://github.com/kubernetes/kubernetes/pull/74614) policy, for some cases, users may need non-preemptible PriorityClasses as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
```
	// PreemptLowerPriority means that pod can preempt other pods with lower priority.
	PreemptLowerPriority PreemptionPolicy = "PreemptLowerPriority"
	// PreemptNever means that pod never preempts other pods with lower priority.
	PreemptNever PreemptionPolicy = "Never"
	// NonPreemptible means that pod can not be preempted by other pods with higher priority.
	NonPreemptible PreemptionPolicy = "NonPreemptible"
	// NonPreemptiblePreemptNever means that pod can not be preempted by other pods with higher priority and never preempts other pods with lower priority.
	NonPreemptiblePreemptNever PreemptionPolicy = "NonPreemptiblePreemptNever"
```
Need advice on the naming part.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add non-preemptible policy to PriorityClass
```
