### PR TITLE
Fix pod inconsistency between podBackoffQ/unschedulableQ and podBackoffMap for sched…

### DIFF
--- a/pkg/scheduler/internal/queue/pod_backoff_test.go
+++ b/pkg/scheduler/internal/queue/pod_backoff_test.go
@@ -20,50 +20,79 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 )
 
+var pod1 = &v1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-pod-1",
+		Namespace: "ns1",
+		UID:       ktypes.UID("tp-1"),
+	},
+	Status: v1.PodStatus{
+		NominatedNodeName: "node1",
+	},
+}
+
+var timestamp = time.Now()
+var podInfo1 = &framework.PodInfo{
+	Pod:       pod1,
+	Timestamp: timestamp,
+}
+
+// TestBackoffPod tests pod backoff duration
 func TestBackoffPod(t *testing.T) {
 	bpm := NewPodBackoffMap(1*time.Second, 10*time.Second)
 
 	tests := []struct {
 		podID            ktypes.NamespacedName
+		podInfo          *framework.PodInfo
 		expectedDuration time.Duration
 		advanceClock     time.Duration
 	}{
 		{
 			podID:            ktypes.NamespacedName{Namespace: "default", Name: "foo"},
+			podInfo:          podInfo1,
 			expectedDuration: 1 * time.Second,
 		},
 		{
 			podID:            ktypes.NamespacedName{Namespace: "default", Name: "foo"},
+			podInfo:          podInfo1,
 			expectedDuration: 2 * time.Second,
 		},
 		{
 			podID:            ktypes.NamespacedName{Namespace: "default", Name: "foo"},
+			podInfo:          podInfo1,
 			expectedDuration: 4 * time.Second,
 		},
 		{
 			podID:            ktypes.NamespacedName{Namespace: "default", Name: "foo"},
+			podInfo:          podInfo1,
 			expectedDuration: 8 * time.Second,
 		},
 		{
 			podID:            ktypes.NamespacedName{Namespace: "default", Name: "foo"},
+			podInfo:          podInfo1,
 			expectedDuration: 10 * time.Second,
 		},
 		{
 			podID:            ktypes.NamespacedName{Namespace: "default", Name: "foo"},
+			podInfo:          podInfo1,
 			expectedDuration: 10 * time.Second,
 		},
 		{
 			podID:            ktypes.NamespacedName{Namespace: "default", Name: "bar"},
+			podInfo:          podInfo1,
 			expectedDuration: 1 * time.Second,
 		},
 	}
 
 	for _, test := range tests {
 		// Backoff the pod
-		bpm.BackoffPod(test.podID)
+		bpm.BackoffPod(test.podID, podInfo1)
 		// Get backoff duration for the pod
 		duration := bpm.calculateBackoffDuration(test.podID)
 
@@ -73,21 +102,22 @@ func TestBackoffPod(t *testing.T) {
 	}
 }
 
+// TestClearPodBackoff tests clearance of pod backoff data in PodBackoffMap
 func TestClearPodBackoff(t *testing.T) {
 	bpm := NewPodBackoffMap(1*time.Second, 60*time.Second)
 	// Clear backoff on an not existed pod
 	bpm.clearPodBackoff(ktypes.NamespacedName{Namespace: "ns", Name: "not-existed"})
 	// Backoff twice for pod foo
 	podID := ktypes.NamespacedName{Namespace: "ns", Name: "foo"}
-	bpm.BackoffPod(podID)
-	bpm.BackoffPod(podID)
+	bpm.BackoffPod(podID, podInfo1)
+	bpm.BackoffPod(podID, podInfo1)
 	if duration := bpm.calculateBackoffDuration(podID); duration != 2*time.Second {
 		t.Errorf("Expected backoff of 1s for pod %s, got %s", podID, duration.String())
 	}
 	// Clear backoff for pod foo
 	bpm.clearPodBackoff(podID)
 	// Backoff once for pod foo
-	bpm.BackoffPod(podID)
+	bpm.BackoffPod(podID, podInfo1)
 	if duration := bpm.calculateBackoffDuration(podID); duration != 1*time.Second {
 		t.Errorf("Expected backoff of 1s for pod %s, got %s", podID, duration.String())
 	}

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -276,13 +276,13 @@ func (p *PriorityQueue) isPodBackingOff(pod *v1.Pod) bool {
 
 // backoffPod checks if pod is currently undergoing backoff. If it is not it updates the backoff
 // timeout otherwise it does nothing.
-func (p *PriorityQueue) backoffPod(pod *v1.Pod) {
+func (p *PriorityQueue) backoffPod(podInfo *framework.PodInfo) {
 	p.podBackoff.CleanupPodsCompletesBackingoff()
 
-	podID := nsNameForPod(pod)
+	podID := nsNameForPod(podInfo.Pod)
 	boTime, found := p.podBackoff.GetBackoffTime(podID)
 	if !found || boTime.Before(p.clock.Now()) {
-		p.podBackoff.BackoffPod(podID)
+		p.podBackoff.BackoffPod(podID, podInfo)
 	}
 }
 
@@ -313,7 +313,7 @@ func (p *PriorityQueue) AddUnschedulableIfNotPresent(pod *v1.Pod, podSchedulingC
 	}
 
 	// Every unschedulable pod is subject to backoff timers.
-	p.backoffPod(pod)
+	p.backoffPod(pInfo)
 
 	// If a move request has been received, move it to the BackoffQ, otherwise move
 	// it to unschedulableQ.

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -1070,7 +1070,7 @@ var (
 		queue.MoveAllToActiveQueue()
 	}
 	backoffPod = func(queue *PriorityQueue, pInfo *framework.PodInfo) {
-		queue.backoffPod(pInfo.Pod)
+		queue.backoffPod(pInfo)
 	}
 	flushBackoffQ = func(queue *PriorityQueue, _ *framework.PodInfo) {
 		queue.clock.(*clock.FakeClock).Step(2 * time.Second)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Make pods in `podBackoffQ *util.Heap` and `podBackoff *PodBackoffMap` consistent.

**Which issue(s) this PR fixes**:
In our production cluster with k8s v1.14, we are seeing lots of error lines as below, which are caused by the pod exists in podBackoffQ but not exists in podBackoffMap. The error happens almost every day, and can happen hundreds of times per day.
```
E0527 23:40:31.348326    4896 scheduling_queue.go:468] Unable to find backoff value for pod xxx-ns/k8s-job-1558945756114-lm78s in backoffQ
E0527 23:40:32.348488    4896 scheduling_queue.go:468] Unable to find backoff value for pod xxx-ns/k8s-job-1558667108588-mgtsf in backoffQ
E0527 23:40:33.348862    4896 scheduling_queue.go:468] Unable to find backoff value for pod xxx-ns/k8s-job-1558953864326-l2m6g in backoffQ
E0527 23:40:33.348919    4896 scheduling_queue.go:468] Unable to find backoff value for pod xxx-ns/k8s-job-1558365432136-4tspp in backoffQ
E0527 23:40:33.348942    4896 scheduling_queue.go:468] Unable to find backoff value for pod xxx-ns/k8s-job-1558952765065-k7zpn in backoffQ
E0527 23:40:33.348964    4896 scheduling_queue.go:468] Unable to find backoff value for pod xxx-ns/k8s-job-1558952860732-lwxz4 in backoffQ
```
Fixes #

**Special notes for your reviewer**:
To clarify this change, the code i'm trying to change is to make the `podBackoffQ` and `podBackoff(Map)` consistent, i,e. the pod is either removed from both two data structures or none of them.

There are two places where we remove a pod from the `podBackoff *PodBackoffMap`, 1) `func Delete`, 2) `func backoffPod`, as below code shows. And in 2) `func backoffPod`, pod is only deleted from podBackoff(Map) instead of the `podBackoffQ`.
```
// Delete deletes the item from either of the two queues. It assumes the pod is
// only in one queue.
func (p *PriorityQueue) Delete(pod *v1.Pod) error {
	p.lock.Lock()
	defer p.lock.Unlock()
	p.nominatedPods.delete(pod)
	err := p.activeQ.Delete(newPodInfoNoTimestamp(pod))
	if err != nil { // The item was probably not found in the activeQ.
		p.clearPodBackoff(pod)
		p.podBackoffQ.Delete(newPodInfoNoTimestamp(pod))
		p.unschedulableQ.delete(pod)
	}
	return nil
}
```
```
// backoffPod checks if pod is currently undergoing backoff. If it is not it updates the backoff
// timeout otherwise it does nothing.
func (p *PriorityQueue) backoffPod(pod *v1.Pod) {
	p.podBackoff.CleanupPodsCompletesBackingoff() // this line only deletes pod from podBackoff(Map)

	podID := nsNameForPod(pod)
	boTime, found := p.podBackoff.GetBackoffTime(podID)
	if !found || boTime.Before(p.clock.Now()) {
		p.podBackoff.BackoffPod(podID)
	}
}
```





**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
