### PR TITLE
Use nettest v1.1 for e2e tests

### DIFF
--- a/test/images/nettest/rc.json
+++ b/test/images/nettest/rc.json
@@ -22,7 +22,7 @@
         "containers": [
           {
             "name": "webserver",
-            "image": "gcr.io/kubernetes-e2e-test-images/nettest-amd64:1.0",
+            "image": "gcr.io/kubernetes-e2e-test-images/nettest-amd64:1.1",
             "imagePullPolicy": "Always",
             "args": [
               "-service=nettest",

--- a/test/images/nettest/slow-pod.json
+++ b/test/images/nettest/slow-pod.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "webserver",
-        "image": "gcr.io/kubernetes-e2e-test-images/nettest-amd64:1.0",
+        "image": "gcr.io/kubernetes-e2e-test-images/nettest-amd64:1.1",
         "args": [
           "-service=nettest",
           "-delay-shutdown=10"

--- a/test/images/nettest/slow-rc.json
+++ b/test/images/nettest/slow-rc.json
@@ -23,7 +23,7 @@
         "containers": [
           {
             "name": "webserver",
-            "image": "gcr.io/kubernetes-e2e-test-images/nettest-amd64:1.0",
+            "image": "gcr.io/kubernetes-e2e-test-images/nettest-amd64:1.1",
             "args": [
               "-service=nettest",
               "-delay-shutdown=10"

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -229,7 +229,7 @@ func initImageConfigs() map[int]Config {
 	configs[Nautilus] = Config{e2eRegistry, "nautilus", "1.0"}
 	configs[Net] = Config{e2eRegistry, "net", "1.0"}
 	configs[Netexec] = Config{e2eRegistry, "netexec", "1.1"}
-	configs[Nettest] = Config{e2eRegistry, "nettest", "1.0"}
+	configs[Nettest] = Config{e2eRegistry, "nettest", "1.1"}
 	configs[Nginx] = Config{dockerLibraryRegistry, "nginx", "1.14-alpine"}
 	configs[NginxNew] = Config{dockerLibraryRegistry, "nginx", "1.15-alpine"}
 	configs[Nonewprivs] = Config{e2eRegistry, "nonewprivs", "1.0"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:

After adding dual stack support to the `nettest `image https://github.com/kubernetes/kubernetes/pull/75246 we need to configure the e2e tests to use it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

xref: https://github.com/kubernetes/kubernetes/issues/70248

The image has to be created and promoted to the container registry.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
