### PR TITLE
Update Cluster Autoscaler version to 1.15.0

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.15.0-beta.1",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.15.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Just a version update (no changes since 1.15.0-beta.1)
Changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.15.0

```release-note
Update Cluster Autoscaler to 1.15.0; changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.15.0
```
