### PR TITLE
fix stability level annotation for counter vec

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -86,6 +86,10 @@ type CounterVec struct {
 // However, the object returned will not measure anything unless the collector is first
 // registered, since the metric is lazily instantiated.
 func NewCounterVec(opts *CounterOpts, labels []string) *CounterVec {
+	// todo: handle defaulting better
+	if opts.StabilityLevel == "" {
+		opts.StabilityLevel = ALPHA
+	}
 	cv := &CounterVec{
 		CounterVec:     noopCounterVec,
 		CounterOpts:    opts,
@@ -104,6 +108,7 @@ func (v *CounterVec) DeprecatedVersion() *semver.Version {
 // initializeMetric invocation creates the actual underlying CounterVec. Until this method is called
 // the underlying counterVec is a no-op.
 func (v *CounterVec) initializeMetric() {
+	v.CounterOpts.annotateStabilityLevel()
 	v.CounterVec = prometheus.NewCounterVec(v.CounterOpts.toPromCounterOpts(), v.originalLabels)
 }
 

--- a/staging/src/k8s.io/component-base/metrics/counter_test.go
+++ b/staging/src/k8s.io/component-base/metrics/counter_test.go
@@ -143,7 +143,7 @@ func TestCounterVec(t *testing.T) {
 			},
 			labels:                    []string{"label_a", "label_b"},
 			expectedMetricFamilyCount: 1,
-			expectedHelp:              "counter help",
+			expectedHelp:              "[ALPHA] counter help",
 		},
 		{
 			desc: "Test deprecated",
@@ -156,7 +156,7 @@ func TestCounterVec(t *testing.T) {
 			},
 			labels:                    []string{"label_a", "label_b"},
 			expectedMetricFamilyCount: 1,
-			expectedHelp:              "(Deprecated since 1.15.0) counter help",
+			expectedHelp:              "[ALPHA] (Deprecated since 1.15.0) counter help",
 		},
 		{
 			desc: "Test hidden",
@@ -170,6 +170,19 @@ func TestCounterVec(t *testing.T) {
 			labels:                    []string{"label_a", "label_b"},
 			expectedMetricFamilyCount: 0,
 			expectedHelp:              "counter help",
+		},
+		{
+			desc: "Test alpha",
+			CounterOpts: &CounterOpts{
+				StabilityLevel: ALPHA,
+				Namespace:      "namespace",
+				Name:           "metric_test_name",
+				Subsystem:      "subsystem",
+				Help:           "counter help",
+			},
+			labels:                    []string{"label_a", "label_b"},
+			expectedMetricFamilyCount: 1,
+			expectedHelp:              "[ALPHA] counter help",
 		},
 	}
 


### PR DESCRIPTION
fix stability level annotation for counter vec and add corresponding test cases

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Counter vec does not currently correctly append stability level to counterVecs. This fixes that.

```release-note
NONE
```
/sig instrumentation
/assign @brancz