### PR TITLE
cache mutation detector: use correct diff function

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/mutation_detector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_detector.go
@@ -114,7 +114,7 @@ func (d *defaultCacheMutationDetector) CompareObjects() {
 	altered := false
 	for i, obj := range d.cachedObjs {
 		if !reflect.DeepEqual(obj.cached, obj.copied) {
-			fmt.Printf("CACHE %s[%d] ALTERED!\n%v\n", d.name, i, diff.ObjectDiff(obj.cached, obj.copied))
+			fmt.Printf("CACHE %s[%d] ALTERED!\n%v\n", d.name, i, diff.ObjectGoPrintSideBySide(obj.cached, obj.copied))
 			altered = true
 		}
 	}


### PR DESCRIPTION
The cache mutation detector must use a diff function that is designed to show differences that cause reflect.DeepEqual to return false.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/kind cleanup

```release-note
NONE
```
