### PR TITLE
Support IPv6 on e2e StatefulSet tests

### DIFF
--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -94,7 +94,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 
 	f = framework.NewDefaultFramework("daemonsets")
 
-	image := NginxImage
+	image := WebserverImage
 	dsName := "daemon-set"
 
 	var ns string

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -200,7 +200,7 @@ func testReplicationControllerConditionCheck(f *framework.Framework) {
 	framework.ExpectNoError(err)
 
 	ginkgo.By(fmt.Sprintf("Creating rc %q that asks for more than the allowed pod quota", name))
-	rc := newRC(name, 3, map[string]string{"name": name}, NginxImageName, NginxImage)
+	rc := newRC(name, 3, map[string]string{"name": name}, WebserverImageName, WebserverImage)
 	rc, err = c.CoreV1().ReplicationControllers(namespace).Create(rc)
 	framework.ExpectNoError(err)
 
@@ -270,7 +270,7 @@ func testRCAdoptMatchingOrphans(f *framework.Framework) {
 			Containers: []v1.Container{
 				{
 					Name:  name,
-					Image: NginxImage,
+					Image: WebserverImage,
 				},
 			},
 		},
@@ -278,7 +278,7 @@ func testRCAdoptMatchingOrphans(f *framework.Framework) {
 
 	ginkgo.By("When a replication controller with a matching selector is created")
 	replicas := int32(1)
-	rcSt := newRC(name, replicas, map[string]string{"name": name}, name, NginxImage)
+	rcSt := newRC(name, replicas, map[string]string{"name": name}, name, WebserverImage)
 	rcSt.Spec.Selector = map[string]string{"name": name}
 	rc, err := f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(rcSt)
 	framework.ExpectNoError(err)
@@ -307,7 +307,7 @@ func testRCReleaseControlledNotMatching(f *framework.Framework) {
 	name := "pod-release"
 	ginkgo.By("Given a ReplicationController is created")
 	replicas := int32(1)
-	rcSt := newRC(name, replicas, map[string]string{"name": name}, name, NginxImage)
+	rcSt := newRC(name, replicas, map[string]string{"name": name}, name, WebserverImage)
 	rcSt.Spec.Selector = map[string]string{"name": name}
 	rc, err := f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(rcSt)
 	framework.ExpectNoError(err)

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -202,7 +202,7 @@ func testReplicaSetConditionCheck(f *framework.Framework) {
 	framework.ExpectNoError(err)
 
 	ginkgo.By(fmt.Sprintf("Creating replica set %q that asks for more than the allowed pod quota", name))
-	rs := newRS(name, 3, map[string]string{"name": name}, NginxImageName, NginxImage)
+	rs := newRS(name, 3, map[string]string{"name": name}, WebserverImageName, WebserverImage)
 	rs, err = c.AppsV1().ReplicaSets(namespace).Create(rs)
 	framework.ExpectNoError(err)
 
@@ -273,7 +273,7 @@ func testRSAdoptMatchingAndReleaseNotMatching(f *framework.Framework) {
 			Containers: []v1.Container{
 				{
 					Name:  name,
-					Image: NginxImage,
+					Image: WebserverImage,
 				},
 			},
 		},
@@ -281,7 +281,7 @@ func testRSAdoptMatchingAndReleaseNotMatching(f *framework.Framework) {
 
 	ginkgo.By("When a replicaset with a matching selector is created")
 	replicas := int32(1)
-	rsSt := newRS(name, replicas, map[string]string{"name": name}, name, NginxImage)
+	rsSt := newRS(name, replicas, map[string]string{"name": name}, name, WebserverImage)
 	rsSt.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"name": name}}
 	rs, err := f.ClientSet.AppsV1().ReplicaSets(f.Namespace.Name).Create(rsSt)
 	framework.ExpectNoError(err)

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -312,7 +312,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 						pods.Items[i].Labels[appsv1.StatefulSetRevisionLabel],
 						currentRevision))
 			}
-			newImage := NewNginxImage
+			newImage := NewWebserverImage
 			oldImage := ss.Spec.Template.Spec.Containers[0].Image
 
 			ginkgo.By(fmt.Sprintf("Updating stateful set template: update image from %s to %s", oldImage, newImage))
@@ -532,7 +532,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 						pods.Items[i].Labels[appsv1.StatefulSetRevisionLabel],
 						currentRevision))
 			}
-			newImage := NewNginxImage
+			newImage := NewWebserverImage
 			oldImage := ss.Spec.Template.Spec.Containers[0].Image
 
 			ginkgo.By(fmt.Sprintf("Updating stateful set template: update image from %s to %s", oldImage, newImage))
@@ -720,8 +720,8 @@ var _ = SIGDescribe("StatefulSet", func() {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:  "nginx",
-							Image: imageutils.GetE2EImage(imageutils.Nginx),
+							Name:  "webserver",
+							Image: imageutils.GetE2EImage(imageutils.Httpd),
 							Ports: []v1.ContainerPort{conflictingPort},
 						},
 					},
@@ -1111,7 +1111,7 @@ func rollbackTest(c clientset.Interface, ns string, ss *appsv1.StatefulSet) {
 	err = sst.BreakPodHTTPProbe(ss, &pods.Items[1])
 	framework.ExpectNoError(err)
 	ss, pods = sst.WaitForPodNotReady(ss, pods.Items[1].Name)
-	newImage := NewNginxImage
+	newImage := NewWebserverImage
 	oldImage := ss.Spec.Template.Spec.Containers[0].Image
 
 	ginkgo.By(fmt.Sprintf("Updating StatefulSet template: update image from %s to %s", oldImage, newImage))

--- a/test/e2e/apps/types.go
+++ b/test/e2e/apps/types.go
@@ -23,8 +23,8 @@ import (
 
 // NOTE(claudiub): These constants should NOT be used as Pod Container Images.
 const (
-	NginxImageName = "nginx"
-	RedisImageName = "redis"
+	WebserverImageName = "httpd"
+	RedisImageName     = "redis"
 )
 
 var (
@@ -40,11 +40,11 @@ var (
 	// KittenImage is the fully qualified URI to the Kitten image
 	KittenImage = imageutils.GetE2EImage(imageutils.Kitten)
 
-	// NginxImage is the fully qualified URI to the Nginx image
-	NginxImage = imageutils.GetE2EImage(imageutils.Nginx)
+	// WebserverImage is the fully qualified URI to the Httpd image
+	WebserverImage = imageutils.GetE2EImage(imageutils.Httpd)
 
-	// NewNginxImage is the fully qualified URI to the NginxNew image
-	NewNginxImage = imageutils.GetE2EImage(imageutils.NginxNew)
+	// NewWebserverImage is the fully qualified URI to the HttpdNew image
+	NewWebserverImage = imageutils.GetE2EImage(imageutils.HttpdNew)
 
 	// RedisImage is the fully qualified URI to the Redis image
 	RedisImage = imageutils.GetE2EImage(imageutils.Redis)

--- a/test/e2e/framework/statefulset_utils.go
+++ b/test/e2e/framework/statefulset_utils.go
@@ -503,7 +503,7 @@ var httpProbe = &v1.Probe{
 	FailureThreshold: 1,
 }
 
-// SetHTTPProbe sets the pod template's ReadinessProbe for Nginx StatefulSet containers.
+// SetHTTPProbe sets the pod template's ReadinessProbe for Webserver StatefulSet containers.
 // This probe can then be controlled with BreakHTTPProbe() and RestoreHTTPProbe().
 // Note that this cannot be used together with PauseNewPods().
 func (s *StatefulSetTester) SetHTTPProbe(ss *appsv1.StatefulSet) {
@@ -517,7 +517,7 @@ func (s *StatefulSetTester) BreakHTTPProbe(ss *appsv1.StatefulSet) error {
 		return fmt.Errorf("Path expected to be not empty: %v", path)
 	}
 	// Ignore 'mv' errors to make this idempotent.
-	cmd := fmt.Sprintf("mv -v /usr/share/nginx/html%v /tmp/ || true", path)
+	cmd := fmt.Sprintf("mv -v /usr/local/apache2/htdocs%v /tmp/ || true", path)
 	return s.ExecInStatefulPods(ss, cmd)
 }
 
@@ -528,7 +528,7 @@ func (s *StatefulSetTester) BreakPodHTTPProbe(ss *appsv1.StatefulSet, pod *v1.Po
 		return fmt.Errorf("Path expected to be not empty: %v", path)
 	}
 	// Ignore 'mv' errors to make this idempotent.
-	cmd := fmt.Sprintf("mv -v /usr/share/nginx/html%v /tmp/ || true", path)
+	cmd := fmt.Sprintf("mv -v /usr/local/apache2/htdocs%v /tmp/ || true", path)
 	stdout, err := RunHostCmdWithRetries(pod.Namespace, pod.Name, cmd, StatefulSetPoll, StatefulPodTimeout)
 	e2elog.Logf("stdout of %v on %v: %v", cmd, pod.Name, stdout)
 	return err
@@ -541,7 +541,7 @@ func (s *StatefulSetTester) RestoreHTTPProbe(ss *appsv1.StatefulSet) error {
 		return fmt.Errorf("Path expected to be not empty: %v", path)
 	}
 	// Ignore 'mv' errors to make this idempotent.
-	cmd := fmt.Sprintf("mv -v /tmp%v /usr/share/nginx/html/ || true", path)
+	cmd := fmt.Sprintf("mv -v /tmp%v /usr/local/apache2/htdocs/ || true", path)
 	return s.ExecInStatefulPods(ss, cmd)
 }
 
@@ -552,7 +552,7 @@ func (s *StatefulSetTester) RestorePodHTTPProbe(ss *appsv1.StatefulSet, pod *v1.
 		return fmt.Errorf("Path expected to be not empty: %v", path)
 	}
 	// Ignore 'mv' errors to make this idempotent.
-	cmd := fmt.Sprintf("mv -v /tmp%v /usr/share/nginx/html/ || true", path)
+	cmd := fmt.Sprintf("mv -v /tmp%v /usr/local/apache2/htdocs/ || true", path)
 	stdout, err := RunHostCmdWithRetries(pod.Namespace, pod.Name, cmd, StatefulSetPoll, StatefulPodTimeout)
 	e2elog.Logf("stdout of %v on %v: %v", cmd, pod.Name, stdout)
 	return err
@@ -764,7 +764,7 @@ func NewStatefulSetPVC(name string) v1.PersistentVolumeClaim {
 	}
 }
 
-// NewStatefulSet creates a new NGINX StatefulSet for testing. The StatefulSet is named name, is in namespace ns,
+// NewStatefulSet creates a new Webserver StatefulSet for testing. The StatefulSet is named name, is in namespace ns,
 // statefulPodsMounts are the mounts that will be backed by PVs. podsMounts are the mounts that are mounted directly
 // to the Pod. labels are the labels that will be usd for the StatefulSet selector.
 func NewStatefulSet(name, ns, governingSvcName string, replicas int32, statefulPodMounts []v1.VolumeMount, podMounts []v1.VolumeMount, labels map[string]string) *appsv1.StatefulSet {
@@ -808,8 +808,8 @@ func NewStatefulSet(name, ns, governingSvcName string, replicas int32, statefulP
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:            "nginx",
-							Image:           imageutils.GetE2EImage(imageutils.Nginx),
+							Name:            "webserver",
+							Image:           imageutils.GetE2EImage(imageutils.Httpd),
 							VolumeMounts:    mounts,
 							SecurityContext: &v1.SecurityContext{},
 						},

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -141,6 +141,10 @@ const (
 	GBFrontend
 	// GBRedisSlave image
 	GBRedisSlave
+	// Httpd image
+	Httpd
+	// HttpdNew image
+	HttpdNew
 	// InClusterClient image
 	InClusterClient
 	// Invalid image
@@ -226,6 +230,8 @@ func initImageConfigs() map[int]Config {
 	configs[Etcd] = Config{gcRegistry, "etcd", "3.3.10"}
 	configs[GBFrontend] = Config{sampleRegistry, "gb-frontend", "v6"}
 	configs[GBRedisSlave] = Config{sampleRegistry, "gb-redisslave", "v3"}
+	configs[Httpd] = Config{dockerLibraryRegistry, "httpd", "2.4.38-alpine"}
+	configs[HttpdNew] = Config{dockerLibraryRegistry, "httpd", "2.4.39-alpine"}
 	configs[InClusterClient] = Config{e2eRegistry, "inclusterclient", "1.0"}
 	configs[Invalid] = Config{gcRegistry, "invalid-image", "invalid-tag"}
 	configs[InvalidRegistryImage] = Config{invalidRegistry, "alpine", "3.1"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:

It adds IPv6 support to the `[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]` tests

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Nginx official docker images only listen on IPv4 by default, however, Apache httpd listen in both IPv4 and IPv6 and offers the same functionality for the e2e tests.

xref https://github.com/kubernetes/kubernetes/issues/70248

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
