### PR TITLE
WIP: Add check_conformance_use_stable_apis_only.sh

### DIFF
--- a/cluster/images/conformance/check_conformance_use_stable_apis_only.sh
+++ b/cluster/images/conformance/check_conformance_use_stable_apis_only.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+E2ELOG=${1}
+errors_alpha=()
+errors_beta=()
+
+# e.g: I0531 22:41:04.314617      18 round_trippers.go:416] GET https://10.96.0.1:443/api/v1/nodes
+for line in $(egrep "(GET|POST|PUT|DELETE|HEAD) http" ${E2ELOG}| awk -F "] " '{print $2}'| sort| uniq| grep "alpha")
+do
+    errors_alpha+=( "${line}" )
+done
+
+for line in $(egrep "(GET|POST|PUT|DELETE|HEAD) http" ${E2ELOG}| awk -F "] " '{print $2}'| sort| uniq| grep "beta")
+do
+    errors_beta+=( "${line}" )
+done
+
+if [ ${#errors_beta[@]} -ne 0 ]; then
+  {
+    echo "Errors of Aplha APIs:"
+    for err in "${errors_alpha[@]}"; do
+      echo "$err"
+    done
+    echo "Errors of Beta APIs:"
+    for err in "${errors_beta[@]}"; do
+      echo "$err"
+    done
+    echo
+    echo 'The above Alpha/Beta APIs are called in conformance tests which should use stable APIs only'
+    echo
+  } >&2
+  exit 1
+fi
+

--- a/cluster/images/conformance/run_e2e.sh
+++ b/cluster/images/conformance/run_e2e.sh
@@ -64,4 +64,5 @@ set +x
 # $! is the pid of tee, not ginkgo
 wait "$(pgrep ginkgo)" && ret=0 || ret=$?
 saveResults
+check_conformance_use_stable_apis_only.sh "${RESULTS_DIR}"/e2e.log && ret=0 || ret=$?
 exit ${ret}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

One of the conformance requirements is `it tests only GA, non-optional features or APIs (e.g., no alpha or beta endpoints, no feature flags required, no deprecated features)` but it is hard to check all conformance tests use stable APIs only during the review process.
This PR adds the check script to verify stable APIs only are used in conformance tests.
If non stable APIs are used, `pull-kubernetes-conformance-image-test` job will be failed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #78613

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
