### PR TITLE
Add more backward compatible access mode logic to remove ReadOnlyMany access mode when ReadWriteOnce,ReadOnlyMany specified

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd_test.go
@@ -211,18 +211,16 @@ func TestBackwardCompatibleAccessModes(t *testing.T) {
 		expAccessModes []v1.PersistentVolumeAccessMode
 	}{
 		{
-			name: "multiple normals",
+			name: "ROX",
 			accessModes: []v1.PersistentVolumeAccessMode{
 				v1.ReadOnlyMany,
-				v1.ReadWriteOnce,
 			},
 			expAccessModes: []v1.PersistentVolumeAccessMode{
 				v1.ReadOnlyMany,
-				v1.ReadWriteOnce,
 			},
 		},
 		{
-			name: "one normal",
+			name: "RWO",
 			accessModes: []v1.PersistentVolumeAccessMode{
 				v1.ReadWriteOnce,
 			},
@@ -231,13 +229,52 @@ func TestBackwardCompatibleAccessModes(t *testing.T) {
 			},
 		},
 		{
-			name: "some readwritemany",
+			name: "RWX",
+			accessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteMany,
+			},
+			expAccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+		},
+		{
+			name: "RWO, ROX",
+			accessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadOnlyMany,
+				v1.ReadWriteOnce,
+			},
+			expAccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+		},
+		{
+			name: "RWO, RWX",
 			accessModes: []v1.PersistentVolumeAccessMode{
 				v1.ReadWriteOnce,
 				v1.ReadWriteMany,
 			},
 			expAccessModes: []v1.PersistentVolumeAccessMode{
 				v1.ReadWriteOnce,
+			},
+		},
+		{
+			name: "RWX, ROX",
+			accessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteMany,
+				v1.ReadOnlyMany,
+			},
+			expAccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+		},
+		{
+			name: "RWX, ROX, RWO",
+			accessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteMany,
+				v1.ReadWriteOnce,
+				v1.ReadOnlyMany,
+			},
+			expAccessModes: []v1.PersistentVolumeAccessMode{
 				v1.ReadWriteOnce,
 			},
 		},


### PR DESCRIPTION
Makes ReadWriteOnce,ReadOnlyMany access mode volumes backwards compatible for migration
stems from conversation here: https://github.com/kubernetes-csi/external-attacher/issues/153

/assign @jsafrane @msau42 

/kind bug
/sig storage
/priority important-soon


```release-note
NONE
```
