### PR TITLE
Kubectl user exec should accept zero-length environment values #652

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
@@ -250,8 +250,6 @@ func validateAuthInfo(authInfoName string, authInfo clientcmdapi.AuthInfo) []err
 		for _, v := range authInfo.Exec.Env {
 			if len(v.Name) == 0 {
 				validationErrors = append(validationErrors, fmt.Errorf("env variable name must be specified for %v to use exec authentication plugin", authInfoName))
-			} else if len(v.Value) == 0 {
-				validationErrors = append(validationErrors, fmt.Errorf("env variable %s value must be specified for %v to use exec authentication plugin", v.Name, authInfoName))
 			}
 		}
 	}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation_test.go
@@ -443,22 +443,19 @@ func TestValidateAuthInfoExecWithAuthProvider(t *testing.T) {
 	test.testConfig(t)
 }
 
-func TestValidateAuthInfoExecInvalidEnv(t *testing.T) {
+func TestValidateAuthInfoExecNoEnv(t *testing.T) {
 	config := clientcmdapi.NewConfig()
 	config.AuthInfos["user"] = &clientcmdapi.AuthInfo{
 		Exec: &clientcmdapi.ExecConfig{
 			Command:    "/bin/example",
 			APIVersion: "clientauthentication.k8s.io/v1alpha1",
 			Env: []clientcmdapi.ExecEnvVar{
-				{Name: "foo"}, // No value
+				{Name: "foo", Value: ""},
 			},
 		},
 	}
 	test := configValidationTest{
 		config: config,
-		expectedErrorSubstring: []string{
-			"env variable foo value must be specified for user to use exec authentication plugin",
-		},
 	}
 
 	test.testAuthInfo("user", t)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
**What this PR does / why we need it**:
Allow blank strings "" as values in `users.[].user.exec.env.[].value`
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/652
**Special notes for your reviewer**:
**Does this PR introduce a user-facing change?**:
```release-note
Users can now enter blank strings as values in the `users.[].user.exec.env.[].value` section of a kubeconfig file.
```
