### PR TITLE
vSphere: allow SAML token delegation

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
@@ -111,6 +111,7 @@ func (connection *VSphereConnection) Signer(ctx context.Context, client *vim25.C
 
 	req := sts.TokenRequest{
 		Certificate: &cert,
+		Delegatable: true,
 	}
 
 	signer, err := tokens.Issue(ctx, req)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

vSphere SAML token must be delegatable when used with the tags API for Zones support.
 
Issue #77360

**Which issue(s) this PR fixes**:

Fixes #77360

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
vSphere: allow SAML token delegation (required for Zones support)
```
