### PR TITLE
use noopRegistry for default global legacy prom registry, expose an http handler, introduce registerable interface

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Counter is our internal representation for our wrapping struct around prometheus
-// counters. Counter implements both KubeCollector and CounterMetric.
+// counters. Counter implements both kubeCollector and CounterMetric.
 type Counter struct {
 	CounterMetric
 	*CounterOpts
@@ -30,7 +30,7 @@ type Counter struct {
 	selfCollector
 }
 
-// NewCounter returns an object which satisfies the KubeCollector and CounterMetric interfaces.
+// NewCounter returns an object which satisfies the kubeCollector and CounterMetric interfaces.
 // However, the object returned will not measure anything unless the collector is first
 // registered, since the metric is lazily instantiated.
 func NewCounter(opts *CounterOpts) *Counter {
@@ -74,7 +74,7 @@ func (c *Counter) initializeDeprecatedMetric() {
 }
 
 // CounterVec is the internal representation of our wrapping struct around prometheus
-// counterVecs. CounterVec implements both KubeCollector and CounterVecMetric.
+// counterVecs. CounterVec implements both kubeCollector and CounterVecMetric.
 type CounterVec struct {
 	*prometheus.CounterVec
 	*CounterOpts
@@ -82,7 +82,7 @@ type CounterVec struct {
 	originalLabels []string
 }
 
-// NewCounterVec returns an object which satisfies the KubeCollector and CounterVecMetric interfaces.
+// NewCounterVec returns an object which satisfies the kubeCollector and CounterVecMetric interfaces.
 // However, the object returned will not measure anything unless the collector is first
 // registered, since the metric is lazily instantiated.
 func NewCounterVec(opts *CounterOpts, labels []string) *CounterVec {

--- a/staging/src/k8s.io/component-base/metrics/gauge.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Gauge is our internal representation for our wrapping struct around prometheus
-// gauges. kubeGauge implements both KubeCollector and KubeGauge.
+// gauges. kubeGauge implements both kubeCollector and KubeGauge.
 type Gauge struct {
 	GaugeMetric
 	*GaugeOpts
@@ -30,7 +30,7 @@ type Gauge struct {
 	selfCollector
 }
 
-// NewGauge returns an object which satisfies the KubeCollector and KubeGauge interfaces.
+// NewGauge returns an object which satisfies the kubeCollector and KubeGauge interfaces.
 // However, the object returned will not measure anything unless the collector is first
 // registered, since the metric is lazily instantiated.
 func NewGauge(opts *GaugeOpts) *Gauge {
@@ -74,7 +74,7 @@ func (g *Gauge) initializeDeprecatedMetric() {
 }
 
 // GaugeVec is the internal representation of our wrapping struct around prometheus
-// gaugeVecs. kubeGaugeVec implements both KubeCollector and KubeGaugeVec.
+// gaugeVecs. kubeGaugeVec implements both kubeCollector and KubeGaugeVec.
 type GaugeVec struct {
 	*prometheus.GaugeVec
 	*GaugeOpts
@@ -82,7 +82,7 @@ type GaugeVec struct {
 	originalLabels []string
 }
 
-// NewGaugeVec returns an object which satisfies the KubeCollector and KubeGaugeVec interfaces.
+// NewGaugeVec returns an object which satisfies the kubeCollector and KubeGaugeVec interfaces.
 // However, the object returned will not measure anything unless the collector is first
 // registered, since the metric is lazily instantiated.
 func NewGaugeVec(opts *GaugeOpts, labels []string) *GaugeVec {

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Histogram is our internal representation for our wrapping struct around prometheus
-// histograms. Summary implements both KubeCollector and ObserverMetric
+// histograms. Summary implements both kubeCollector and ObserverMetric
 type Histogram struct {
 	ObserverMetric
 	*HistogramOpts
@@ -82,7 +82,7 @@ type HistogramVec struct {
 	originalLabels []string
 }
 
-// NewHistogramVec returns an object which satisfies KubeCollector and wraps the
+// NewHistogramVec returns an object which satisfies kubeCollector and wraps the
 // prometheus.HistogramVec object. However, the object returned will not measure
 // anything unless the collector is first registered, since the metric is lazily instantiated.
 func NewHistogramVec(opts *HistogramOpts, labels []string) *HistogramVec {

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/BUILD
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/BUILD
@@ -11,6 +11,8 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -19,6 +19,7 @@ package legacyregistry
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -98,7 +99,7 @@ func Register(c metrics.KubeCollector) error {
 	globalRegistryFactory.registrationLock.Lock()
 	defer globalRegistryFactory.registrationLock.Unlock()
 
-	if globalRegistryFactory.globalRegistry == (noopRegistry{}) {
+	if reflect.DeepEqual(globalRegistryFactory.globalRegistry, noopRegistry{}) {
 		globalRegistryFactory.registerQueue = append(globalRegistryFactory.registerQueue, c)
 		return nil
 	}
@@ -113,7 +114,7 @@ func MustRegister(cs ...metrics.KubeCollector) {
 	globalRegistryFactory.registrationLock.Lock()
 	defer globalRegistryFactory.registrationLock.Unlock()
 
-	if globalRegistryFactory.globalRegistry == (noopRegistry{}) {
+	if reflect.DeepEqual(globalRegistryFactory.globalRegistry, noopRegistry{}) {
 		for _, c := range cs {
 			globalRegistryFactory.mustRegisterQueue = append(globalRegistryFactory.mustRegisterQueue, c)
 		}

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -32,25 +32,25 @@ import (
 
 var (
 	globalRegistryFactory = metricsRegistryFactory{
-		registerQueue:     make([]metrics.KubeCollector, 0),
-		mustRegisterQueue: make([]metrics.KubeCollector, 0),
+		registerQueue:     make([]metrics.Registerable, 0),
+		mustRegisterQueue: make([]metrics.Registerable, 0),
 		globalRegistry:    noopRegistry{},
 	}
 )
 
 type noopRegistry struct{}
 
-func (noopRegistry) Register(metrics.KubeCollector) error  { return nil }
-func (noopRegistry) MustRegister(...metrics.KubeCollector) {}
-func (noopRegistry) Unregister(metrics.KubeCollector) bool { return true }
-func (noopRegistry) Gather() ([]*dto.MetricFamily, error)  { return nil, nil }
+func (noopRegistry) Register(metrics.Registerable) error  { return nil }
+func (noopRegistry) MustRegister(...metrics.Registerable) {}
+func (noopRegistry) Unregister(metrics.Registerable) bool { return true }
+func (noopRegistry) Gather() ([]*dto.MetricFamily, error) { return nil, nil }
 
 type metricsRegistryFactory struct {
 	globalRegistry    metrics.KubeRegistry
 	kubeVersion       *apimachineryversion.Info
 	registrationLock  sync.Mutex
-	registerQueue     []metrics.KubeCollector
-	mustRegisterQueue []metrics.KubeCollector
+	registerQueue     []metrics.Registerable
+	mustRegisterQueue []metrics.Registerable
 }
 
 // HandlerForGlobalRegistry returns a http handler for the global registry. This
@@ -95,7 +95,7 @@ func SetRegistryFactoryVersion(ver apimachineryversion.Info) []error {
 
 // Register registers a collectable metric, but it uses a global registry. Registration is deferred
 // until the global registry has a version to use.
-func Register(c metrics.KubeCollector) error {
+func Register(c metrics.Registerable) error {
 	globalRegistryFactory.registrationLock.Lock()
 	defer globalRegistryFactory.registrationLock.Unlock()
 
@@ -110,7 +110,7 @@ func Register(c metrics.KubeCollector) error {
 // MustRegister works like Register but registers any number of
 // Collectors and panics upon the first registration that causes an
 // error. Registration is deferred  until the global registry has a version to use.
-func MustRegister(cs ...metrics.KubeCollector) {
+func MustRegister(cs ...metrics.Registerable) {
 	globalRegistryFactory.registrationLock.Lock()
 	defer globalRegistryFactory.registrationLock.Unlock()
 

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry_test.go
@@ -150,6 +150,7 @@ func TestDeferredRegister(t *testing.T) {
 	globalRegistryFactory = metricsRegistryFactory{
 		registerQueue:     make([]metrics.KubeCollector, 0),
 		mustRegisterQueue: make([]metrics.KubeCollector, 0),
+		globalRegistry:    noopRegistry{},
 	}
 	var err error
 	err = Register(alphaDeprecatedCounter)
@@ -179,6 +180,7 @@ func TestDeferredMustRegister(t *testing.T) {
 	globalRegistryFactory = metricsRegistryFactory{
 		registerQueue:     make([]metrics.KubeCollector, 0),
 		mustRegisterQueue: make([]metrics.KubeCollector, 0),
+		globalRegistry:    noopRegistry{},
 	}
 	MustRegister(alphaDeprecatedCounter)
 

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry_test.go
@@ -148,8 +148,8 @@ func TestMustRegister(t *testing.T) {
 func TestDeferredRegister(t *testing.T) {
 	// reset the global registry for this test.
 	globalRegistryFactory = metricsRegistryFactory{
-		registerQueue:     make([]metrics.KubeCollector, 0),
-		mustRegisterQueue: make([]metrics.KubeCollector, 0),
+		registerQueue:     make([]metrics.Registerable, 0),
+		mustRegisterQueue: make([]metrics.Registerable, 0),
 		globalRegistry:    noopRegistry{},
 	}
 	var err error
@@ -178,8 +178,8 @@ func TestDeferredRegister(t *testing.T) {
 func TestDeferredMustRegister(t *testing.T) {
 	// reset the global registry for this test.
 	globalRegistryFactory = metricsRegistryFactory{
-		registerQueue:     make([]metrics.KubeCollector, 0),
-		mustRegisterQueue: make([]metrics.KubeCollector, 0),
+		registerQueue:     make([]metrics.Registerable, 0),
+		mustRegisterQueue: make([]metrics.Registerable, 0),
 		globalRegistry:    noopRegistry{},
 	}
 	MustRegister(alphaDeprecatedCounter)
@@ -199,8 +199,8 @@ func TestDeferredMustRegister(t *testing.T) {
 func TestPreloadedMetrics(t *testing.T) {
 	// reset the global registry for this test.
 	globalRegistryFactory = metricsRegistryFactory{
-		registerQueue:     make([]metrics.KubeCollector, 0),
-		mustRegisterQueue: make([]metrics.KubeCollector, 0),
+		registerQueue:     make([]metrics.Registerable, 0),
+		mustRegisterQueue: make([]metrics.Registerable, 0),
 	}
 
 	SetRegistryFactoryVersion(apimachineryversion.Info{

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -25,12 +25,12 @@ import (
 )
 
 /*
-KubeCollector extends the prometheus.Collector interface to allow customization of the metric
+kubeCollector extends the prometheus.Collector interface to allow customization of the metric
 registration process. Defer metric initialization until Create() is called, which then
 delegates to the underlying metric's initializeMetric or initializeDeprecatedMetric
 method call depending on whether the metric is deprecated or not.
 */
-type KubeCollector interface {
+type kubeCollector interface {
 	Collector
 	lazyKubeMetric
 	DeprecatedVersion() *semver.Version
@@ -57,8 +57,8 @@ type lazyKubeMetric interface {
 /*
 lazyMetric implements lazyKubeMetric. A lazy metric is lazy because it waits until metric
 registration time before instantiation. Add it as an anonymous field to a struct that
-implements KubeCollector to get deferred registration behavior. You must call lazyInit
-with the KubeCollector itself as an argument.
+implements kubeCollector to get deferred registration behavior. You must call lazyInit
+with the kubeCollector itself as an argument.
 */
 type lazyMetric struct {
 	isDeprecated        bool
@@ -66,17 +66,17 @@ type lazyMetric struct {
 	isCreated           bool
 	markDeprecationOnce sync.Once
 	createOnce          sync.Once
-	self                KubeCollector
+	self                kubeCollector
 }
 
 func (r *lazyMetric) IsCreated() bool {
 	return r.isCreated
 }
 
-// lazyInit provides the lazyMetric with a reference to the KubeCollector it is supposed
+// lazyInit provides the lazyMetric with a reference to the kubeCollector it is supposed
 // to allow lazy initialization for. It should be invoked in the factory function which creates new
-// KubeCollector type objects.
-func (r *lazyMetric) lazyInit(self KubeCollector) {
+// kubeCollector type objects.
+func (r *lazyMetric) lazyInit(self kubeCollector) {
 	r.self = self
 }
 

--- a/staging/src/k8s.io/component-base/metrics/summary.go
+++ b/staging/src/k8s.io/component-base/metrics/summary.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Summary is our internal representation for our wrapping struct around prometheus
-// summaries. Summary implements both KubeCollector and ObserverMetric
+// summaries. Summary implements both kubeCollector and ObserverMetric
 //
 // DEPRECATED: as per the metrics overhaul KEP
 type Summary struct {
@@ -87,7 +87,7 @@ type SummaryVec struct {
 	originalLabels []string
 }
 
-// NewSummaryVec returns an object which satisfies KubeCollector and wraps the
+// NewSummaryVec returns an object which satisfies kubeCollector and wraps the
 // prometheus.SummaryVec object. However, the object returned will not measure
 // anything unless the collector is first registered, since the metric is lazily instantiated.
 //

--- a/staging/src/k8s.io/component-base/metrics/wrappers.go
+++ b/staging/src/k8s.io/component-base/metrics/wrappers.go
@@ -59,6 +59,8 @@ type CounterVecMetric interface {
 // GaugeMetric is an interface which defines a subset of the interface provided by prometheus.Gauge
 type GaugeMetric interface {
 	Set(float64)
+	Inc()
+	Dec()
 }
 
 // ObserverMetric captures individual observations.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR does 3 things:

1. Uses a noop factory for the global registry. This doesn't change anything functionally. However it does make noop'ing more explicit and it also brings things more in line with other pieces of the Kubernetes code base.
2. Expose http handler for registry. Traditionally prometheus exposes a global registry. Calls to MustRegister and Register act on this global registry. However, I have not exposed the legacyregistry (as of yet) and would prefer not to do so if it is possible. But in order to expose a prometheus endpoint, you need a handler for that registry. This PR exposes that.
3. Add interface for registerable metrics which does not have any private methods. 

```release-note
NONE
```
/sig instrumentation
/assign @brancz 