### PR TITLE
1.13: Fix incorrect procMount defaulting

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -286,12 +286,22 @@ func DropDisabledProcMountField(podSpec *api.PodSpec) {
 		defProcMount := api.DefaultProcMount
 		for i := range podSpec.Containers {
 			if podSpec.Containers[i].SecurityContext != nil {
-				podSpec.Containers[i].SecurityContext.ProcMount = &defProcMount
+				if podSpec.Containers[i].SecurityContext.ProcMount != nil {
+					// The ProcMount field was improperly forced to non-nil in 1.12.
+					// If the feature is disabled, and the ProcMount field is present in the incoming object, force to the default value.
+					// Note: we cannot force the field to nil when the feature is disabled because it causes a diff against previously persisted data.
+					podSpec.Containers[i].SecurityContext.ProcMount = &defProcMount
+				}
 			}
 		}
 		for i := range podSpec.InitContainers {
 			if podSpec.InitContainers[i].SecurityContext != nil {
-				podSpec.InitContainers[i].SecurityContext.ProcMount = &defProcMount
+				if podSpec.InitContainers[i].SecurityContext.ProcMount != nil {
+					// The ProcMount field was improperly forced to non-nil in 1.12.
+					// If the feature is disabled, and the ProcMount field is present in the incoming object, force to the default value.
+					// Note: we cannot force the field to nil when the feature is disabled because it causes a diff against previously persisted data.
+					podSpec.InitContainers[i].SecurityContext.ProcMount = &defProcMount
+				}
 			}
 		}
 	}

--- a/test/e2e/framework/deployment_util.go
+++ b/test/e2e/framework/deployment_util.go
@@ -107,8 +107,9 @@ func NewDeployment(deploymentName string, replicas int32, podLabels map[string]s
 					TerminationGracePeriodSeconds: &zero,
 					Containers: []v1.Container{
 						{
-							Name:  imageName,
-							Image: image,
+							Name:            imageName,
+							Image:           image,
+							SecurityContext: &v1.SecurityContext{},
 						},
 					},
 				},

--- a/test/e2e/framework/jobs_util.go
+++ b/test/e2e/framework/jobs_util.go
@@ -83,6 +83,7 @@ func NewTestJob(behavior, name string, rPol v1.RestartPolicy, parallelism, compl
 									Name:      "data",
 								},
 							},
+							SecurityContext: &v1.SecurityContext{},
 						},
 					},
 				},

--- a/test/e2e/framework/rs_util.go
+++ b/test/e2e/framework/rs_util.go
@@ -148,8 +148,9 @@ func NewReplicaSet(name, namespace string, replicas int32, podLabels map[string]
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:  imageName,
-							Image: image,
+							Name:            imageName,
+							Image:           image,
+							SecurityContext: &v1.SecurityContext{},
 						},
 					},
 				},

--- a/test/e2e/framework/statefulset_utils.go
+++ b/test/e2e/framework/statefulset_utils.go
@@ -809,9 +809,10 @@ func NewStatefulSet(name, ns, governingSvcName string, replicas int32, statefulP
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:         "nginx",
-							Image:        imageutils.GetE2EImage(imageutils.Nginx),
-							VolumeMounts: mounts,
+							Name:            "nginx",
+							Image:           imageutils.GetE2EImage(imageutils.Nginx),
+							VolumeMounts:    mounts,
+							SecurityContext: &v1.SecurityContext{},
 						},
 					},
 					Volumes: vols,

--- a/test/e2e/upgrades/apps/daemonsets.go
+++ b/test/e2e/upgrades/apps/daemonsets.go
@@ -60,9 +60,10 @@ func (t *DaemonSetUpgradeTest) Setup(f *framework.Framework) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:  daemonSetName,
-							Image: image,
-							Ports: []v1.ContainerPort{{ContainerPort: 9376}},
+							Name:            daemonSetName,
+							Image:           image,
+							Ports:           []v1.ContainerPort{{ContainerPort: 9376}},
+							SecurityContext: &v1.SecurityContext{},
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes incorrect forcing of the alpha procMount field to a non-nil value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #78633

See similar discussion around impact of defaulting fields within pod spec on workload controllers in #69988 and #69445.

**Special notes for your reviewer**:

This PR allows objects without the alpha field set to remain nil. This prevents unrelated updates to a workload object (like annotating it) from modifying the pod spec portion of the object and forcing a spurious rollout.

This also updates the fixtures used in the workload upgrade tests that would have caught this issue.
Similar changes are required in 1.12 and 1.14.

**Release note**:
```release-note
Resolves spurious rollouts of workload controllers when upgrading the API server due to incorrect defaulting of an alpha procMount field in pods
```

/sig apps
/cc @janetkuo @smarterclayton
/priority critical-urgent