### PR TITLE
1.15: Fix incorrect procMount defaulting

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -447,12 +447,22 @@ func dropDisabledProcMountField(podSpec, oldPodSpec *api.PodSpec) {
 		defaultProcMount := api.DefaultProcMount
 		for i := range podSpec.Containers {
 			if podSpec.Containers[i].SecurityContext != nil {
-				podSpec.Containers[i].SecurityContext.ProcMount = &defaultProcMount
+				if podSpec.Containers[i].SecurityContext.ProcMount != nil {
+					// The ProcMount field was improperly forced to non-nil in 1.12.
+					// If the feature is disabled, and the existing object is not using any non-default values, and the ProcMount field is present in the incoming object, force to the default value.
+					// Note: we cannot force the field to nil when the feature is disabled because it causes a diff against previously persisted data.
+					podSpec.Containers[i].SecurityContext.ProcMount = &defaultProcMount
+				}
 			}
 		}
 		for i := range podSpec.InitContainers {
 			if podSpec.InitContainers[i].SecurityContext != nil {
-				podSpec.InitContainers[i].SecurityContext.ProcMount = &defaultProcMount
+				if podSpec.InitContainers[i].SecurityContext.ProcMount != nil {
+					// The ProcMount field was improperly forced to non-nil in 1.12.
+					// If the feature is disabled, and the existing object is not using any non-default values, and the ProcMount field is present in the incoming object, force to the default value.
+					// Note: we cannot force the field to nil when the feature is disabled because it causes a diff against previously persisted data.
+					podSpec.InitContainers[i].SecurityContext.ProcMount = &defaultProcMount
+				}
 			}
 		}
 	}
@@ -514,7 +524,7 @@ func runtimeClassInUse(podSpec *api.PodSpec) bool {
 	return false
 }
 
-// procMountInUse returns true if the pod spec is non-nil and has a SecurityContext's ProcMount field set
+// procMountInUse returns true if the pod spec is non-nil and has a SecurityContext's ProcMount field set to a non-default value
 func procMountInUse(podSpec *api.PodSpec) bool {
 	if podSpec == nil {
 		return false

--- a/pkg/apis/apps/v1/zz_generated.defaults.go
+++ b/pkg/apis/apps/v1/zz_generated.defaults.go
@@ -136,9 +136,6 @@ func SetObjectDefaults_DaemonSet(in *v1.DaemonSet) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			corev1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -180,9 +177,6 @@ func SetObjectDefaults_DaemonSet(in *v1.DaemonSet) {
 					corev1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			corev1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -289,9 +283,6 @@ func SetObjectDefaults_Deployment(in *v1.Deployment) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			corev1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -333,9 +324,6 @@ func SetObjectDefaults_Deployment(in *v1.Deployment) {
 					corev1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			corev1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -442,9 +430,6 @@ func SetObjectDefaults_ReplicaSet(in *v1.ReplicaSet) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			corev1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -486,9 +471,6 @@ func SetObjectDefaults_ReplicaSet(in *v1.ReplicaSet) {
 					corev1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			corev1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -595,9 +577,6 @@ func SetObjectDefaults_StatefulSet(in *v1.StatefulSet) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			corev1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -639,9 +618,6 @@ func SetObjectDefaults_StatefulSet(in *v1.StatefulSet) {
 					corev1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			corev1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 	for i := range in.Spec.VolumeClaimTemplates {

--- a/pkg/apis/apps/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/apps/v1beta1/zz_generated.defaults.go
@@ -132,9 +132,6 @@ func SetObjectDefaults_Deployment(in *v1beta1.Deployment) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -176,9 +173,6 @@ func SetObjectDefaults_Deployment(in *v1beta1.Deployment) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -285,9 +279,6 @@ func SetObjectDefaults_StatefulSet(in *v1beta1.StatefulSet) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -329,9 +320,6 @@ func SetObjectDefaults_StatefulSet(in *v1beta1.StatefulSet) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 	for i := range in.Spec.VolumeClaimTemplates {

--- a/pkg/apis/apps/v1beta2/zz_generated.defaults.go
+++ b/pkg/apis/apps/v1beta2/zz_generated.defaults.go
@@ -136,9 +136,6 @@ func SetObjectDefaults_DaemonSet(in *v1beta2.DaemonSet) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -180,9 +177,6 @@ func SetObjectDefaults_DaemonSet(in *v1beta2.DaemonSet) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -289,9 +283,6 @@ func SetObjectDefaults_Deployment(in *v1beta2.Deployment) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -333,9 +324,6 @@ func SetObjectDefaults_Deployment(in *v1beta2.Deployment) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -442,9 +430,6 @@ func SetObjectDefaults_ReplicaSet(in *v1beta2.ReplicaSet) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -486,9 +471,6 @@ func SetObjectDefaults_ReplicaSet(in *v1beta2.ReplicaSet) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -595,9 +577,6 @@ func SetObjectDefaults_StatefulSet(in *v1beta2.StatefulSet) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -639,9 +618,6 @@ func SetObjectDefaults_StatefulSet(in *v1beta2.StatefulSet) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 	for i := range in.Spec.VolumeClaimTemplates {

--- a/pkg/apis/batch/v1/zz_generated.defaults.go
+++ b/pkg/apis/batch/v1/zz_generated.defaults.go
@@ -130,9 +130,6 @@ func SetObjectDefaults_Job(in *v1.Job) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			corev1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -174,9 +171,6 @@ func SetObjectDefaults_Job(in *v1.Job) {
 					corev1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			corev1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }

--- a/pkg/apis/batch/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/batch/v1beta1/zz_generated.defaults.go
@@ -131,9 +131,6 @@ func SetObjectDefaults_CronJob(in *v1beta1.CronJob) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.JobTemplate.Spec.Template.Spec.Containers {
 		a := &in.Spec.JobTemplate.Spec.Template.Spec.Containers[i]
@@ -175,9 +172,6 @@ func SetObjectDefaults_CronJob(in *v1beta1.CronJob) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -283,9 +277,6 @@ func SetObjectDefaults_JobTemplate(in *v1beta1.JobTemplate) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Template.Spec.Template.Spec.Containers {
 		a := &in.Template.Spec.Template.Spec.Containers[i]
@@ -327,9 +318,6 @@ func SetObjectDefaults_JobTemplate(in *v1beta1.JobTemplate) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }

--- a/pkg/apis/batch/v2alpha1/zz_generated.defaults.go
+++ b/pkg/apis/batch/v2alpha1/zz_generated.defaults.go
@@ -131,9 +131,6 @@ func SetObjectDefaults_CronJob(in *v2alpha1.CronJob) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.JobTemplate.Spec.Template.Spec.Containers {
 		a := &in.Spec.JobTemplate.Spec.Template.Spec.Containers[i]
@@ -175,9 +172,6 @@ func SetObjectDefaults_CronJob(in *v2alpha1.CronJob) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -283,9 +277,6 @@ func SetObjectDefaults_JobTemplate(in *v2alpha1.JobTemplate) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Template.Spec.Template.Spec.Containers {
 		a := &in.Template.Spec.Template.Spec.Containers[i]
@@ -327,9 +318,6 @@ func SetObjectDefaults_JobTemplate(in *v2alpha1.JobTemplate) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }

--- a/pkg/apis/core/fuzzer/fuzzer.go
+++ b/pkg/apis/core/fuzzer/fuzzer.go
@@ -354,10 +354,6 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 				c.Fuzz(&sc.Capabilities.Add)
 				c.Fuzz(&sc.Capabilities.Drop)
 			}
-			if sc.ProcMount == nil {
-				defProcMount := core.DefaultProcMount
-				sc.ProcMount = &defProcMount
-			}
 		},
 		func(s *core.Secret, c fuzz.Continue) {
 			c.FuzzNoCustom(s) // fuzz self without calling this function again

--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -421,10 +421,3 @@ func SetDefaults_HostPathVolumeSource(obj *v1.HostPathVolumeSource) {
 		obj.Type = &typeVol
 	}
 }
-
-func SetDefaults_SecurityContext(obj *v1.SecurityContext) {
-	if obj.ProcMount == nil {
-		defProcMount := v1.DefaultProcMount
-		obj.ProcMount = &defProcMount
-	}
-}

--- a/pkg/apis/core/v1/zz_generated.defaults.go
+++ b/pkg/apis/core/v1/zz_generated.defaults.go
@@ -263,9 +263,6 @@ func SetObjectDefaults_Pod(in *v1.Pod) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Containers {
 		a := &in.Spec.Containers[i]
@@ -307,9 +304,6 @@ func SetObjectDefaults_Pod(in *v1.Pod) {
 					SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -415,9 +409,6 @@ func SetObjectDefaults_PodTemplate(in *v1.PodTemplate) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Template.Spec.Containers {
 		a := &in.Template.Spec.Containers[i]
@@ -459,9 +450,6 @@ func SetObjectDefaults_PodTemplate(in *v1.PodTemplate) {
 					SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -569,9 +557,6 @@ func SetObjectDefaults_ReplicationController(in *v1.ReplicationController) {
 					}
 				}
 			}
-			if a.SecurityContext != nil {
-				SetDefaults_SecurityContext(a.SecurityContext)
-			}
 		}
 		for i := range in.Spec.Template.Spec.Containers {
 			a := &in.Spec.Template.Spec.Containers[i]
@@ -613,9 +598,6 @@ func SetObjectDefaults_ReplicationController(in *v1.ReplicationController) {
 						SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 					}
 				}
-			}
-			if a.SecurityContext != nil {
-				SetDefaults_SecurityContext(a.SecurityContext)
 			}
 		}
 	}

--- a/pkg/apis/extensions/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/extensions/v1beta1/zz_generated.defaults.go
@@ -138,9 +138,6 @@ func SetObjectDefaults_DaemonSet(in *v1beta1.DaemonSet) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -182,9 +179,6 @@ func SetObjectDefaults_DaemonSet(in *v1beta1.DaemonSet) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -291,9 +285,6 @@ func SetObjectDefaults_Deployment(in *v1beta1.Deployment) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -335,9 +326,6 @@ func SetObjectDefaults_Deployment(in *v1beta1.Deployment) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }
@@ -466,9 +454,6 @@ func SetObjectDefaults_ReplicaSet(in *v1beta1.ReplicaSet) {
 				}
 			}
 		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
-		}
 	}
 	for i := range in.Spec.Template.Spec.Containers {
 		a := &in.Spec.Template.Spec.Containers[i]
@@ -510,9 +495,6 @@ func SetObjectDefaults_ReplicaSet(in *v1beta1.ReplicaSet) {
 					v1.SetDefaults_HTTPGetAction(a.Lifecycle.PreStop.HTTPGet)
 				}
 			}
-		}
-		if a.SecurityContext != nil {
-			v1.SetDefaults_SecurityContext(a.SecurityContext)
 		}
 	}
 }

--- a/test/e2e/framework/deployment/fixtures.go
+++ b/test/e2e/framework/deployment/fixtures.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onsi/ginkgo"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -113,8 +113,9 @@ func NewDeployment(deploymentName string, replicas int32, podLabels map[string]s
 					TerminationGracePeriodSeconds: &zero,
 					Containers: []v1.Container{
 						{
-							Name:  imageName,
-							Image: image,
+							Name:            imageName,
+							Image:           image,
+							SecurityContext: &v1.SecurityContext{},
 						},
 					},
 				},

--- a/test/e2e/framework/job/fixtures.go
+++ b/test/e2e/framework/job/fixtures.go
@@ -69,6 +69,7 @@ func NewTestJob(behavior, name string, rPol v1.RestartPolicy, parallelism, compl
 									Name:      "data",
 								},
 							},
+							SecurityContext: &v1.SecurityContext{},
 						},
 					},
 				},

--- a/test/e2e/framework/replicaset/fixtures.go
+++ b/test/e2e/framework/replicaset/fixtures.go
@@ -18,7 +18,7 @@ package replicaset
 
 import (
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -45,8 +45,9 @@ func NewReplicaSet(name, namespace string, replicas int32, podLabels map[string]
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:  imageName,
-							Image: image,
+							Name:            imageName,
+							Image:           image,
+							SecurityContext: &v1.SecurityContext{},
 						},
 					},
 				},

--- a/test/e2e/framework/statefulset_utils.go
+++ b/test/e2e/framework/statefulset_utils.go
@@ -807,9 +807,10 @@ func NewStatefulSet(name, ns, governingSvcName string, replicas int32, statefulP
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:         "nginx",
-							Image:        imageutils.GetE2EImage(imageutils.Nginx),
-							VolumeMounts: mounts,
+							Name:            "nginx",
+							Image:           imageutils.GetE2EImage(imageutils.Nginx),
+							VolumeMounts:    mounts,
+							SecurityContext: &v1.SecurityContext{},
 						},
 					},
 					Volumes: vols,

--- a/test/e2e/upgrades/apps/daemonsets.go
+++ b/test/e2e/upgrades/apps/daemonsets.go
@@ -66,9 +66,10 @@ func (t *DaemonSetUpgradeTest) Setup(f *framework.Framework) {
 					},
 					Containers: []v1.Container{
 						{
-							Name:  daemonSetName,
-							Image: image,
-							Ports: []v1.ContainerPort{{ContainerPort: 9376}},
+							Name:            daemonSetName,
+							Image:           image,
+							Ports:           []v1.ContainerPort{{ContainerPort: 9376}},
+							SecurityContext: &v1.SecurityContext{},
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes incorrect forcing of the alpha procMount field to a non-nil value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #78633

See similar discussion in https://github.com/kubernetes/kubernetes/pull/69988 and https://github.com/kubernetes/kubernetes/issues/69445. The only reason upgrade tests didn't catch this is because the defaulting happened in a nested object that happened to be nil in the upgrade test fixtures.

**Special notes for your reviewer**:

This PR restores the behavior for this alpha field to the way it was in 1.12 and 1.13, with one change: objects without the alpha field set are allowed to remain nil. This prevents unrelated updates to a workload object (like annotating it) from modifying the pod spec portion of the object and forcing a spurious rollout.

This also updates the fixtures used in the workload upgrade tests that would have caught this issue.
Similar changes are required in 1.12-1.14.

**Release note**:
```release-note
Resolves spurious rollouts of workload controllers when upgrading the API server, due to incorrect defaulting of an alpha procMount field in pods
```

/sig apps
/cc @janetkuo @smarterclayton
/priority critical-urgent