### PR TITLE
Move test tool function to the test file

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1277,6 +1277,15 @@ func podWithUIDNameNsSpec(uid types.UID, name, namespace string, spec v1.PodSpec
 	return pod
 }
 
+// dirExists returns true if the path exists and represents a directory.
+func dirExists(path string) bool {
+	s, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return s.IsDir()
+}
+
 func TestDeletePodDirsForDeletedPods(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()

--- a/pkg/kubelet/util.go
+++ b/pkg/kubelet/util.go
@@ -16,18 +16,5 @@ limitations under the License.
 
 package kubelet
 
-import (
-	"os"
-)
-
-// dirExists returns true if the path exists and represents a directory.
-func dirExists(path string) bool {
-	s, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	return s.IsDir()
-}
-
 // empty is a placeholder type used to implement a set
 type empty struct{}


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
i notice the function “dirExists” have never been used in any files except the test files since it was created three years ago，so i think maybe moving it to test file is better.  

Which issue(s) this PR fixes:
Fixes #

/release-note-none
/priority backlog