### PR TITLE
Inverted error handling to ensure server-side apply does not fall bac…

### DIFF
--- a/pkg/kubectl/cmd/apply/apply.go
+++ b/pkg/kubectl/cmd/apply/apply.go
@@ -398,6 +398,7 @@ func (o *ApplyOptions) Run() error {
 			if err != nil {
 				return cmdutil.AddSourceToErr("serverside-apply", info.Source, err)
 			}
+			
 			options := metav1.PatchOptions{
 				Force:        &o.ForceConflicts,
 				FieldManager: o.FieldManager,
@@ -405,6 +406,7 @@ func (o *ApplyOptions) Run() error {
 			if o.ServerDryRun {
 				options.DryRun = []string{metav1.DryRunAll}
 			}
+
 			obj, err := resource.NewHelper(info.Client, info.Mapping).Patch(
 				info.Namespace,
 				info.Name,
@@ -412,29 +414,33 @@ func (o *ApplyOptions) Run() error {
 				data,
 				&options,
 			)
-			if err == nil {
-				info.Refresh(obj, true)
-				metadata, err := meta.Accessor(info.Object)
-				if err != nil {
-					return err
+			if err != nil {
+				if isIncompatibleServerError(err) {
+					klog.Warningf("serverside-apply incompatible server: %v", err)
 				}
-				visitedUids.Insert(string(metadata.GetUID()))
-				count++
-				if len(output) > 0 && !shortOutput {
-					objs = append(objs, info.Object)
-					return nil
-				}
-				printer, err := o.ToPrinter("serverside-applied")
-				if err != nil {
-					return err
-				}
-				return printer.PrintObj(info.Object, o.Out)
-			} else if !isIncompatibleServerError(err) {
+
 				return err
 			}
-			// If we're talking to a server which does not implement server-side apply,
-			// continue with the client side apply after this block.
-			klog.Warningf("serverside-apply incompatible server: %v", err)
+
+			info.Refresh(obj, true)
+			metadata, err := meta.Accessor(info.Object)
+			if err != nil {
+				return err
+			}
+
+			visitedUids.Insert(string(metadata.GetUID()))
+			count++
+			if len(output) > 0 && !shortOutput {
+				objs = append(objs, info.Object)
+				return nil
+			}
+			
+			printer, err := o.ToPrinter("serverside-applied")
+			if err != nil {
+				return err
+			}
+			
+			return printer.PrintObj(info.Object, o.Out)
 		}
 
 		// Get the modified configuration of the object. Embed the result

--- a/pkg/kubectl/cmd/apply/apply.go
+++ b/pkg/kubectl/cmd/apply/apply.go
@@ -434,12 +434,12 @@ func (o *ApplyOptions) Run() error {
 				objs = append(objs, info.Object)
 				return nil
 			}
-			
+
 			printer, err := o.ToPrinter("serverside-applied")
 			if err != nil {
 				return err
 			}
-			
+
 			return printer.PrintObj(info.Object, o.Out)
 		}
 

--- a/pkg/kubectl/cmd/apply/apply.go
+++ b/pkg/kubectl/cmd/apply/apply.go
@@ -398,7 +398,7 @@ func (o *ApplyOptions) Run() error {
 			if err != nil {
 				return cmdutil.AddSourceToErr("serverside-apply", info.Source, err)
 			}
-			
+
 			options := metav1.PatchOptions{
 				Force:        &o.ForceConflicts,
 				FieldManager: o.FieldManager,
@@ -416,7 +416,7 @@ func (o *ApplyOptions) Run() error {
 			)
 			if err != nil {
 				if isIncompatibleServerError(err) {
-					klog.Warningf("serverside-apply incompatible server: %v", err)
+					err = fmt.Errorf("Server-side apply not available on the server: (%v)", err)
 				}
 
 				return err


### PR DESCRIPTION
Inverted error handling to ensure server-side apply does not fall back on client-side apply when there is an error

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind feature

**What this PR does / why we need it**:
This PR is to prevent server-side apply from falling back on client-side apply when there is an error

**Which issue(s) this PR fixes**:
Part of issue 73723 is fixed (I dont want the issue to be linked/closed with this PR since it is a small part.

There does not appear to be an issue created just for this

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
