### PR TITLE
Return early when mount ref is determined

### DIFF
--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -313,13 +313,12 @@ func checkForNetDev(options []string) bool {
 // Plan to work on better approach to solve this issue.
 
 func HasMountRefs(mountPath string, mountRefs []string) bool {
-	count := 0
 	for _, ref := range mountRefs {
 		if !strings.Contains(ref, mountPath) {
-			count = count + 1
+			return true
 		}
 	}
-	return count > 0
+	return false
 }
 
 // PathWithinBase checks if give path is within given base directory.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In HasMountRefs, we use a counter to determine mount ref.

However, since the counter is only incremented, we can return early when counter is incremented.
The counter is actually not used (and dropped).

```release-note
NONE
```
