### PR TITLE
Automated cherry pick of #78876: vSphere: allow SAML token delegation

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vclib/connection.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/connection.go
@@ -111,6 +111,7 @@ func (connection *VSphereConnection) Signer(ctx context.Context, client *vim25.C
 
 	req := sts.TokenRequest{
 		Certificate: &cert,
+		Delegatable: true,
 	}
 
 	signer, err := tokens.Issue(ctx, req)


### PR DESCRIPTION
Cherry pick of #78876 on release-1.14.

#78876: vSphere: allow SAML token delegation