### PR TITLE
Rejecting valid Environment Variable Names #47

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -312,8 +312,8 @@ func IsHTTPHeaderName(value string) []string {
 	return nil
 }
 
-const envVarNameFmt = "[-._a-zA-Z][-._a-zA-Z0-9]*"
-const envVarNameFmtErrMsg string = "a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit"
+const envVarNameFmt = "[-._a-zA-Z][-._a-zA-Z0-9:]*"
+const envVarNameFmtErrMsg string = "a valid environment variable name must consist of alphabetic characters, digits, ':', '_', '-', or '.', and must not start with a digit"
 
 var envVarNameRegexp = regexp.MustCompile("^" + envVarNameFmt + "$")
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Allows using ':' chars in `kubectl --env`, e.g. `kubectl run myname --image=myimage:86 --port=80 --env="ConnectionStrings:DefaultConnection=Data Source=tcp:mySqlServer,1433;Initial Catalog=myDB;User Id=myUser;Password=mypassword;": `
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/47

**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
```release-note
Allows the use of ':' in environment names kubectl --env
```
