### PR TITLE
Do not add non-PersistentVolume to return value for pvAssumeCache#ListPVs

### DIFF
--- a/pkg/controller/volume/scheduling/scheduler_assume_cache.go
+++ b/pkg/controller/volume/scheduling/scheduler_assume_cache.go
@@ -396,6 +396,7 @@ func (c *pvAssumeCache) ListPVs(storageClassName string) []*v1.PersistentVolume 
 		pv, ok := obj.(*v1.PersistentVolume)
 		if !ok {
 			klog.Errorf("ListPVs: %v", &errWrongType{"v1.PersistentVolume", obj})
+			continue
 		}
 		pvs = append(pvs, pv)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently even if object retrieved from pvAssumeCache is not of *v1.PersistentVolume type, it is added to the end of pvs (and returned).

This PR fixes this bug by not adding such object.

```release-note
NONE
```
