### PR TITLE
Promote LimitRange e2e test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -203,6 +203,7 @@ test/e2e/node/events.go: "should be sent by kubelets and the scheduler about pod
 test/e2e/node/pods.go: "should be submitted and removed"
 test/e2e/node/pods.go: "should be submitted and removed"
 test/e2e/node/pre_stop.go: "should call prestop when killing a pod"
+test/e2e/scheduling/limit_range.go: "should create a LimitRange with defaults and ensure pod has those defaults applied"
 test/e2e/scheduling/predicates.go: "validates resource limits of pods that are allowed to run"
 test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if not matching"
 test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if matching"

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -44,7 +44,7 @@ var _ = SIGDescribe("LimitRange", func() {
 	/*
 		Release : v1.16
 		Testname: LimitRange: CRUD
-		Description: Ensure that LimitRange values are able to be applied, updated, deleted, and that this is observed by Pods.
+		Description: Create a LimitRange. Creation MUST be successful and creation of pods MUST respect set limits.
 	*/
 	framework.ConformanceIt("should create a LimitRange with defaults and ensure pod has those defaults applied", func() {
 		ginkgo.By("Creating a LimitRange")

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -46,7 +46,7 @@ var _ = SIGDescribe("LimitRange", func() {
 		Testname: LimitRange: CRUD
 		Description: Ensure that LimitRange values are able to be applied, updated, deleted, and that this is observed by Pods.
 	*/
-	framework.ConformanceIt("should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
+	framework.ConformanceIt("should create a LimitRange with defaults and ensure pod has those defaults applied", func() {
 		ginkgo.By("Creating a LimitRange")
 
 		min := getResourceList("50m", "100Mi", "100Gi")

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -41,7 +41,12 @@ const (
 var _ = SIGDescribe("LimitRange", func() {
 	f := framework.NewDefaultFramework("limitrange")
 
-	ginkgo.It("should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
+	/*
+		Release : v1.16
+		Testname: LimitRange: CRUD
+		Description: Ensure that LimitRange values are able to be applied, updated, deleted, and that this is observed by Pods.
+	*/
+	framework.ConformanceIt("should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
 		ginkgo.By("Creating a LimitRange")
 
 		min := getResourceList("50m", "100Mi", "100Gi")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Promotes the following E2E test to Conformance:
 `test/e2e/scheduling/limit_range.go: "should create a LimitRange with defaults and ensure pod has those defaults applied"`


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/78828

**Special notes for your reviewer**:

Part of Umbrella Issue https://github.com/kubernetes/kubernetes/issues/78748


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/area conformance
/area test

@kubernetes/sig-architecture-pr-reviews 
@kubernetes/cncf-conformance-wg
@kubernetes/sig-scheduling-pr-reviews


