### PR TITLE
Add ExpectEqual() to e2e framework

### DIFF
--- a/test/e2e/apimachinery/generated_clientset.go
+++ b/test/e2e/apimachinery/generated_clientset.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -115,7 +114,7 @@ var _ = SIGDescribe("Generated clientset", func() {
 		if err != nil {
 			framework.Failf("Failed to query for pods: %v", err)
 		}
-		gomega.Expect(len(pods.Items)).To(gomega.Equal(0))
+		framework.ExpectEqual(len(pods.Items), 0)
 		options = metav1.ListOptions{
 			LabelSelector:   selector,
 			ResourceVersion: pods.ListMeta.ResourceVersion,
@@ -140,7 +139,7 @@ var _ = SIGDescribe("Generated clientset", func() {
 		if err != nil {
 			framework.Failf("Failed to query for pods: %v", err)
 		}
-		gomega.Expect(len(pods.Items)).To(gomega.Equal(1))
+		framework.ExpectEqual(len(pods.Items), 1)
 
 		ginkgo.By("verifying pod creation was observed")
 		observeCreation(w)
@@ -231,7 +230,7 @@ var _ = SIGDescribe("Generated clientset", func() {
 		if err != nil {
 			framework.Failf("Failed to query for cronJobs: %v", err)
 		}
-		gomega.Expect(len(cronJobs.Items)).To(gomega.Equal(0))
+		framework.ExpectEqual(len(cronJobs.Items), 0)
 		options = metav1.ListOptions{
 			LabelSelector:   selector,
 			ResourceVersion: cronJobs.ListMeta.ResourceVersion,
@@ -256,7 +255,7 @@ var _ = SIGDescribe("Generated clientset", func() {
 		if err != nil {
 			framework.Failf("Failed to query for cronJobs: %v", err)
 		}
-		gomega.Expect(len(cronJobs.Items)).To(gomega.Equal(1))
+		framework.ExpectEqual(len(cronJobs.Items), 1)
 
 		ginkgo.By("verifying cronJob creation was observed")
 		observeCreation(w)
@@ -273,6 +272,6 @@ var _ = SIGDescribe("Generated clientset", func() {
 		if err != nil {
 			framework.Failf("Failed to list cronJobs to verify deletion: %v", err)
 		}
-		gomega.Expect(len(cronJobs.Items)).To(gomega.Equal(0))
+		framework.ExpectEqual(len(cronJobs.Items), 0)
 	})
 })

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1368,6 +1368,11 @@ func RandomSuffix() string {
 	return strconv.Itoa(r.Int() % 10000)
 }
 
+// ExpectEqual expects the specified two are the same, otherwise an exception raises
+func ExpectEqual(actual interface{}, extra interface{}, explain ...interface{}) {
+	gomega.Expect(actual).To(gomega.Equal(extra), explain...)
+}
+
 // ExpectError expects an error happens, otherwise an exception raises
 func ExpectError(err error, explain ...interface{}) {
 	gomega.Expect(err).To(gomega.HaveOccurred(), explain...)
@@ -2092,7 +2097,7 @@ func ExpectNodeHasLabel(c clientset.Interface, nodeName string, labelKey string,
 	ginkgo.By("verifying the node has the label " + labelKey + " " + labelValue)
 	node, err := c.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 	ExpectNoError(err)
-	gomega.Expect(node.Labels[labelKey]).To(gomega.Equal(labelValue))
+	ExpectEqual(node.Labels[labelKey], labelValue)
 }
 
 // RemoveTaintOffNode removes the given taint from the given node.


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Many e2e tests expect two values are the same, such check is one of
common things in tests. Now gomega.Expect(foo).To(gomega.Equal(bar))
is doing that, this adds ExpectEqual() for replacing the above call
for readable code.
In addition, this replaces under apimachinery/generated_clientset.go
as a sample.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
