### PR TITLE
fixing kubectl cp with wildcards

### DIFF
--- a/pkg/kubectl/cmd/cp/cp_test.go
+++ b/pkg/kubectl/cmd/cp/cp_test.go
@@ -258,11 +258,11 @@ func checkErr(t *testing.T, err error) {
 }
 
 func TestTarUntar(t *testing.T) {
-	dir, err := ioutil.TempDir("", "input")
+	dir, err := ioutil.TempDir(tmpDir(t), "input")
 	checkErr(t, err)
-	dir2, err := ioutil.TempDir("", "output")
+	dir2, err := ioutil.TempDir(tmpDir(t), "output")
 	checkErr(t, err)
-	dir3, err := ioutil.TempDir("", "dir")
+	dir3, err := ioutil.TempDir(tmpDir(t), "dir")
 	checkErr(t, err)
 
 	dir = dir + "/"
@@ -367,7 +367,7 @@ func TestTarUntar(t *testing.T) {
 	}
 
 	for _, file := range files {
-		absPath := filepath.Join(dir2, strings.TrimPrefix(dir, os.TempDir()))
+		absPath := filepath.Join(dir2, strings.TrimPrefix(dir, tmpDir(t)))
 		filePath := filepath.Join(absPath, file.name)
 
 		if file.fileType == RegularFile {
@@ -398,9 +398,9 @@ func TestTarUntar(t *testing.T) {
 }
 
 func TestTarUntarWrongPrefix(t *testing.T) {
-	dir, err := ioutil.TempDir("", "input")
+	dir, err := ioutil.TempDir(tmpDir(t), "input")
 	checkErr(t, err)
-	dir2, err := ioutil.TempDir("", "output")
+	dir2, err := ioutil.TempDir(tmpDir(t), "output")
 	checkErr(t, err)
 
 	dir = dir + "/"
@@ -432,8 +432,8 @@ func TestTarUntarWrongPrefix(t *testing.T) {
 }
 
 func TestTarDestinationName(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "input")
-	dir2, err2 := ioutil.TempDir(os.TempDir(), "output")
+	dir, err := ioutil.TempDir(tmpDir(t), "input")
+	dir2, err2 := ioutil.TempDir(tmpDir(t), "output")
 	if err != nil || err2 != nil {
 		t.Errorf("unexpected error: %v | %v", err, err2)
 		t.FailNow()
@@ -505,7 +505,7 @@ func TestTarDestinationName(t *testing.T) {
 }
 
 func TestBadTar(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "dest")
+	dir, err := ioutil.TempDir(tmpDir(t), "dest")
 	if err != nil {
 		t.Errorf("unexpected error: %v ", err)
 		t.FailNow()
@@ -574,7 +574,7 @@ func TestCopyToPod(t *testing.T) {
 
 	cmd := NewCmdCp(tf, ioStreams)
 
-	srcFile, err := ioutil.TempDir("", "test")
+	srcFile, err := ioutil.TempDir(tmpDir(t), "test")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 		t.FailNow()
@@ -644,7 +644,7 @@ func TestCopyToPodNoPreserve(t *testing.T) {
 
 	cmd := NewCmdCp(tf, ioStreams)
 
-	srcFile, err := ioutil.TempDir("", "test")
+	srcFile, err := ioutil.TempDir(tmpDir(t), "test")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 		t.FailNow()
@@ -720,7 +720,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestUntar(t *testing.T) {
-	testdir, err := ioutil.TempDir("", "test-untar")
+	testdir, err := ioutil.TempDir(tmpDir(t), "test-untar")
 	require.NoError(t, err)
 	defer os.RemoveAll(testdir)
 	t.Logf("Test base: %s", testdir)
@@ -936,4 +936,13 @@ type testWriter testing.T
 func (t *testWriter) Write(p []byte) (n int, err error) {
 	t.Logf(string(p))
 	return len(p), nil
+}
+
+func tmpDir(t *testing.T) string {
+	evaledTmpDir, err := filepath.EvalSymlinks(os.TempDir())
+	if err != nil {
+		t.Errorf("unexpected error: %v ", err)
+		t.FailNow()
+	}
+	return evaledTmpDir
 }

--- a/pkg/kubectl/cmd/cp/cp_test.go
+++ b/pkg/kubectl/cmd/cp/cp_test.go
@@ -355,7 +355,9 @@ func TestTarUntar(t *testing.T) {
 	opts := NewCopyOptions(genericclioptions.NewTestIOStreamsDiscard())
 
 	writer := &bytes.Buffer{}
-	if err := makeTar(dir, dir, writer); err != nil {
+	tarWriter := tar.NewWriter(writer)
+	defer tarWriter.Close()
+	if err := makeTar(dir, dir, tarWriter); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -416,7 +418,9 @@ func TestTarUntarWrongPrefix(t *testing.T) {
 	opts := NewCopyOptions(genericclioptions.NewTestIOStreamsDiscard())
 
 	writer := &bytes.Buffer{}
-	if err := makeTar(dir, dir, writer); err != nil {
+	tarWriter := tar.NewWriter(writer)
+	defer tarWriter.Close()
+	if err := makeTar(dir, dir, tarWriter); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -477,7 +481,9 @@ func TestTarDestinationName(t *testing.T) {
 
 	reader, writer := io.Pipe()
 	go func() {
-		if err := makeTar(dir, dir2, writer); err != nil {
+		tarWriter := tar.NewWriter(writer)
+		defer tarWriter.Close()
+		if err := makeTar(dir, dir2, tarWriter); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	}()

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1294,13 +1294,18 @@ metadata:
 		ginkgo.It("should copy a file from a running Pod", func() {
 			remoteContents := "foobar\n"
 			podSource := fmt.Sprintf("%s:/root/foo/bar/foo.bar", busyboxPodName)
-			tempDestination, err := ioutil.TempFile(os.TempDir(), "copy-foobar")
+			tmpDir, err := ioutil.TempDir(os.TempDir(), "copy-foobar")
+			if err != nil {
+				framework.Failf("Failed creating temporary destination dir: %v", err)
+			}
+
+			tempDestination, err := os.OpenFile(filepath.Join(tmpDir, "foo.bar"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 			if err != nil {
 				framework.Failf("Failed creating temporary destination file: %v", err)
 			}
 
 			ginkgo.By("specifying a remote filepath " + podSource + " on the pod")
-			framework.RunKubectlOrDie(ns, "cp", podSource, tempDestination.Name(), nsFlag)
+			framework.RunKubectlOrDie(ns, "cp", podSource, tmpDir, nsFlag)
 			ginkgo.By("verifying that the contents of the remote file " + podSource + " have been copied to a local file " + tempDestination.Name())
 			localData, err := ioutil.ReadAll(tempDestination)
 			if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/priority critical-urgent 

**What this PR does / why we need it**:
The wildcards will get expansion automatically by bash/sh.

The PR fixes,
* copyFromPod: use sh subcommand to avoid wildcards getting expansion;
* copyToPod: for command line, should use `'foo*'` instead of `foo*` to avoid getting expansion by shell automatically; 

**Which issue(s) this PR fixes**:
Fixes #78854

**Special notes for your reviewer**:
/cc @kubernetes/sig-cli-bugs 

This fix should get into 1.15 ASAP. 
This fix should be cherry-picked to release-1.14 as well.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fixing kubectl cp with wildcards, due to the files glob automatically made by sh/bash
```
