### PR TITLE
e2e: Support upgrade tests with the "local" cluster provider

### DIFF
--- a/test/e2e/framework/statefulset_utils.go
+++ b/test/e2e/framework/statefulset_utils.go
@@ -756,7 +756,7 @@ func NewStatefulSetPVC(name string) v1.PersistentVolumeClaim {
 			},
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
-					v1.ResourceStorage: *resource.NewQuantity(1, resource.BinarySI),
+					v1.ResourceStorage: resource.MustParse("1Gi"),
 				},
 			},
 		},

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -102,6 +102,7 @@ type TestContextType struct {
 	EtcdUpgradeStorage          string
 	EtcdUpgradeVersion          string
 	GCEUpgradeScript            string
+	LocalUpgradeScript          string
 	ContainerRuntime            string
 	ContainerRuntimeEndpoint    string
 	ContainerRuntimeProcessName string
@@ -319,6 +320,7 @@ func RegisterClusterFlags() {
 	flag.StringVar(&TestContext.EtcdUpgradeStorage, "etcd-upgrade-storage", "", "The storage version to upgrade to (either 'etcdv2' or 'etcdv3') if doing an etcd upgrade test.")
 	flag.StringVar(&TestContext.EtcdUpgradeVersion, "etcd-upgrade-version", "", "The etcd binary version to upgrade to (e.g., '3.0.14', '2.3.7') if doing an etcd upgrade test.")
 	flag.StringVar(&TestContext.GCEUpgradeScript, "gce-upgrade-script", "", "Script to use to upgrade a GCE cluster.")
+	flag.StringVar(&TestContext.LocalUpgradeScript, "local-upgrade-script", "", "Script to use to upgrade a local cluster.")
 	flag.BoolVar(&TestContext.CleanStart, "clean-start", false, "If true, purge all namespaces except default and system before running tests. This serves to Cleanup test namespaces from failed/interrupted e2e runs in a long-lived cluster.")
 
 	nodeKiller := &TestContext.NodeKiller

--- a/test/e2e/upgrades/storage/persistent_volumes.go
+++ b/test/e2e/upgrades/storage/persistent_volumes.go
@@ -51,9 +51,6 @@ func (t *PersistentVolumeUpgradeTest) deleteGCEVolume(pvSource *v1.PersistentVol
 func (t *PersistentVolumeUpgradeTest) Setup(f *framework.Framework) {
 
 	var err error
-	// TODO: generalize this to other providers
-	framework.SkipUnlessProviderIs("gce", "gke")
-
 	ns := f.Namespace.Name
 
 	ginkgo.By("Initializing PV source")
@@ -92,6 +89,12 @@ func (t *PersistentVolumeUpgradeTest) Teardown(f *framework.Framework) {
 	if len(errs) > 0 {
 		framework.Failf("Failed to delete 1 or more PVs/PVCs and/or the GCE volume. Errors: %v", utilerrors.NewAggregate(errs))
 	}
+}
+
+// Skip skips the test if running on a provider the test doesn't support.
+func (t *PersistentVolumeUpgradeTest) Skip(upgCtx upgrades.UpgradeContext) bool {
+	// TODO: generalize this to other providers
+	return !framework.ProviderIs("gce", "gke")
 }
 
 // testPod creates a pod that consumes a pv and prints it out. The output is then verified.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Allow upgrade tests to be run on local clusters by allowing callers to provide a script that will upgrade the cluster. Since every local cluster will be different we can't provide a default script, so the default is to throw an error - the current behavior when running upgrade tests on a local cluster. This will allow for running e2e tests against, e.g., managed kubernetes providers that support upgrades via an API.

Aside from adding the upgrade script option, I also needed to clean up one spot where the `Setup` function of an upgrade test was causing the entire suite to be skipped. Moving the skip condition to a `Skip` function solved the problem.

I've also included a change that was necessary to get these tests running on DigitalOcean Kubernetes: the PV tests were creating a 1-byte volume, which DO doesn't support. I've changed them to create a 1GiB volume, which is our minimum. I think 1GiB is a reasonable default that will work for other providers and isn't onerous, but we could parameterize this instead if anyone's concerned about the change.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig testing
/sig cluster-lifecycle