### PR TITLE
kubectl get --watch exits after ~90 seconds when getting CRDs

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -287,7 +287,7 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (r *crdHandler) serveResource(w http.ResponseWriter, req *http.Request, requestInfo *apirequest.RequestInfo, crdInfo *crdInfo, terminating bool, supportedTypes []string) http.HandlerFunc {
 	requestScope := crdInfo.requestScopes[requestInfo.APIVersion]
 	storage := crdInfo.storages[requestInfo.APIVersion].CustomResource
-	minRequestTimeout := 1 * time.Minute
+	minRequestTimeout := 1800 * time.Minute
 
 	switch requestInfo.Verb {
 	case "get":


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
Fixes https://github.com/kubernetes/kubectl/issues/668
**Special notes for your reviewer**:
1800 seconds may seem arbitrary but I just matched what I found in `staging/src/k8s.io/apiserver/pkg/server/config.go`
**Does this PR introduce a user-facing change?**:
```release-note
Fixes a bug where `kubectl --watch` times out after 1-2 minutes for CRD
```
