### PR TITLE
Fix failure in ciphersuites_flag_test

### DIFF
--- a/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go
+++ b/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go
@@ -77,6 +77,7 @@ var versions = map[string]uint16{
 	"VersionTLS10": tls.VersionTLS10,
 	"VersionTLS11": tls.VersionTLS11,
 	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
 }
 
 func TLSPossibleVersions() []string {


### PR DESCRIPTION
Change-Id: I5cd0d7f21cad13712c3ad22d433124532a837f37

first Failure reported in https://github.com/kubernetes/kubernetes/issues/78982#issue-455740280

```
go test ./vendor/k8s.io/component-base/cli/flag
--- FAIL: TestConstantMaps (0.01s)
    ciphersuites_flag_test.go:106: discovered version tls.VersionTLS13 not in version map
FAIL
FAIL	k8s.io/kubernetes/vendor/k8s.io/component-base/cli/flag	0.312s
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
