### PR TITLE
Reflector watchHandler: make 'The resourceVersion for ... watch is too old' log Info not Warning

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -299,7 +299,12 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 
 		if err := r.watchHandler(w, &resourceVersion, resyncerrc, stopCh); err != nil {
 			if err != errorStopRequested {
-				klog.Warningf("%s: watch of %v ended with: %v", r.name, r.expectedType, err)
+				switch {
+				case apierrs.IsResourceExpired(err):
+					klog.V(4).Infof("%s: watch of %v ended with: %v", r.name, r.expectedType, err)
+				default:
+					klog.Warningf("%s: watch of %v ended with: %v", r.name, r.expectedType, err)
+				}
 			}
 			return nil
 		}


### PR DESCRIPTION
**What type of PR is this?**
logging Warning to Info - not sure what /kind

**What this PR does / why we need it**:
This warning comes from Reflector watchHandler, from the apiserver error that indicates a watch was restarted.  This happens when etcd drops the connection and resources are relisted.  This informs the user that the watchers are operating properly, so should be logged as Info rather than Warning.

```release-note
Reflector watchHandler Warning log 'The resourceVersion for the provided watch is too old.' is now logged as Info. 
```