### PR TITLE
Increase load balancer timeout in test cases

### DIFF
--- a/test/e2e/upgrades/services.go
+++ b/test/e2e/upgrades/services.go
@@ -67,7 +67,11 @@ func (t *ServiceUpgradeTest) Setup(f *framework.Framework) {
 
 	// Hit it once before considering ourselves ready
 	ginkgo.By("hitting the pod through the service's LoadBalancer")
-	jig.TestReachableHTTP(tcpIngressIP, svcPort, framework.LoadBalancerLagTimeoutDefault)
+	timeout := framework.LoadBalancerLagTimeoutDefault
+	if framework.ProviderIs("aws") {
+		timeout = framework.LoadBalancerLagTimeoutAWS
+	}
+	jig.TestReachableHTTP(tcpIngressIP, svcPort, timeout)
 
 	t.jig = jig
 	t.tcpService = tcpService


### PR DESCRIPTION
In a heavily contested AWS account (that was close to rate limits)
it took more than 2m for the load balancer to begin accepting
requests. This increases the timeout to 3m to give upgrade tests
more of a chance to pass in a contentious environment.

```
Jun 13 08:25:31.210: Could not reach HTTP service through a7c23c3e48db411e9bc700ace239adbc-280006380.us-east-1.elb.amazonaws.com:80 after 2m0s

github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework.(*ServiceTestJig).TestReachableHTTPWithRetriableErrorCodes(0xc0010b0bc0, 0xc002bed180, 0x46, 0x50, 0xa30bb20, 0x0, 0x0, 0x1bf08eb000)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/service_util.go:915 +0x306
github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework.(*ServiceTestJig).TestReachableHTTP(...)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/service_util.go:897
github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/upgrades.(*ServiceUpgradeTest).Setup(0xc0020733e0, 0xc001e2d040)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/upgrades/services.go:70 +0x3c8
```

This was during setup in the upgrade test on 1.14

/kind bug

```release-note
NONE
```