### PR TITLE
Don't dereference nil pointer in apply conflicts

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/conflict.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/conflict.go
@@ -76,6 +76,9 @@ func printManager(manager string) string {
 		return fmt.Sprintf("%q", manager)
 	}
 	if encodedManager.Operation == metav1.ManagedFieldsOperationUpdate {
+		if encodedManager.Time == nil {
+			return fmt.Sprintf("%q using %v", encodedManager.Manager, encodedManager.APIVersion)
+		}
 		return fmt.Sprintf("%q using %v at %v", encodedManager.Manager, encodedManager.APIVersion, encodedManager.Time.UTC().Format(time.RFC3339))
 	}
 	return fmt.Sprintf("%q", encodedManager.Manager)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/cc @apelisse 

**What this PR does / why we need it**:
In case the managedFields entries get manually edited by a user to a state that would never occur otherwise, where an entry for an update doesn't have a timestamp, it shouldn't cause a panic.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
