### PR TITLE
ipvs: fix string check for IPVS protocol during graceful termination

### DIFF
--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -18,6 +18,7 @@ package ipvs
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -167,7 +168,7 @@ func (m *GracefulTerminationManager) deleteRsFunc(rsToDelete *listItem) (bool, e
 			// For UDP traffic, no graceful termination, we immediately delete the RS
 			//     (existing connections will be deleted on the next packet because sysctlExpireNoDestConn=1)
 			// For other protocols, don't delete until all connections have expired)
-			if rsToDelete.VirtualServer.Protocol != "udp" && rs.ActiveConn+rs.InactiveConn != 0 {
+			if strings.ToUpper(rsToDelete.VirtualServer.Protocol) != "UDP" && rs.ActiveConn+rs.InactiveConn != 0 {
 				klog.Infof("Not deleting, RS %v: %v ActiveConn, %v InactiveConn", rsToDelete.String(), rs.ActiveConn, rs.InactiveConn)
 				return false, nil
 			}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In https://github.com/kubernetes/kubernetes/pull/77802 we removed graceful termination for UDP (causes many issues when there are too many connections/real servers). It turns out that in `pkg/util/ipvs` we actually convert the protocol values from netlink to upper case strings ("TCP", "UDP", etc, see [protocolToString](https://github.com/kubernetes/kubernetes/blob/master/pkg/util/ipvs/ipvs_linux.go#L299-L309)) even though the string passed into `docker/libnetwork/ipvs` is lower case string (see [stringToProtocol](https://github.com/kubernetes/kubernetes/blob/master/pkg/util/ipvs/ipvs_linux.go#L285-L296)). 

This PR fixes this bug by always checking upper case values. As a follow-up we should consolidate the string casing for utils/ipvs to ensure this doesn't happen again. The PR for this will be larger so wanted to get the bug fix only change in before we cut v1.15 and for easier cherry-picking for previous versions. 

I'm missing context as to why we use lower case values for `stringToProtocol` and upper case values for `protocolToString`, would appreciate some background there @m1093782566  @lbernail. 

**Which issue(s) this PR fixes**:
Fixes #https://github.com/kubernetes/kubernetes/issues/78993

DNS service in the reported issue went down due to too many stale real server entries being held by graceful termination. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix a string comparison bug in IPVS graceful termination where UDP real servers are not deleted.
```
