### PR TITLE
kubectl config set hangs on some invalid property names #415

### DIFF
--- a/pkg/kubectl/cmd/config/navigation_step_parser.go
+++ b/pkg/kubectl/cmd/config/navigation_step_parser.go
@@ -76,6 +76,8 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			steps = append(steps, navigationStep{nextPart, fieldType})
 			currPartIndex += len(strings.Split(nextPart, "."))
 			currType = fieldType
+		default:
+			return nil, fmt.Errorf("unable to parse one or more field values of %v", path)
 		}
 	}
 

--- a/pkg/kubectl/cmd/config/navigation_step_parser_test.go
+++ b/pkg/kubectl/cmd/config/navigation_step_parser_test.go
@@ -72,6 +72,18 @@ func TestParseWithBadValue(t *testing.T) {
 	test.run(t)
 }
 
+func TestParseWithNoMatchingValue(t *testing.T) {
+	test := stepParserTest{
+		path: "users.jheiss.exec.command",
+		expectedNavigationSteps: navigationSteps{
+			steps: []navigationStep{},
+		},
+		expectedError: "unable to parse one or more field values of users.jheiss.exec",
+	}
+
+	test.run(t)
+}
+
 func (test stepParserTest) run(t *testing.T) {
 	actualSteps, err := newNavigationSteps(test.path)
 	if len(test.expectedError) != 0 {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
Fixes a bug where `kubectl set config` hangs and uses 100% CPU on some invalid property names 
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/415
**Special notes for your reviewer**:
**Does this PR introduce a user-facing change?**:
```release-note
Fixes a bug where `kubectl set config` hangs and uses 100% CPU on some invalid property names 
```
