### PR TITLE
Remove recursion in waitForVolumeDetachmentInternal

### DIFF
--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -894,11 +894,12 @@ func TestAttacherDetach(t *testing.T) {
 
 	nodeName := "test-node"
 	testCases := []struct {
-		name       string
-		volID      string
-		attachID   string
-		shouldFail bool
-		reactor    func(action core.Action) (handled bool, ret runtime.Object, err error)
+		name         string
+		volID        string
+		attachID     string
+		shouldFail   bool
+		watcherError bool
+		reactor      func(action core.Action) (handled bool, ret runtime.Object, err error)
 	}{
 		{name: "normal test", volID: "vol-001", attachID: getAttachmentName("vol-001", testDriver, nodeName)},
 		{name: "normal test 2", volID: "vol-002", attachID: getAttachmentName("vol-002", testDriver, nodeName)},
@@ -912,6 +913,19 @@ func TestAttacherDetach(t *testing.T) {
 				// return Forbidden to all DELETE requests
 				if action.Matches("delete", "volumeattachments") {
 					return true, nil, apierrs.NewForbidden(action.GetResource().GroupResource(), action.GetNamespace(), fmt.Errorf("mock error"))
+				}
+				return false, nil, nil
+			},
+		},
+		{
+			name:         "API watch error happen",
+			volID:        "vol-005",
+			attachID:     getAttachmentName("vol-005", testDriver, nodeName),
+			shouldFail:   true,
+			watcherError: true,
+			reactor: func(action core.Action) (handled bool, ret runtime.Object, err error) {
+				if action.Matches("get", "volumeattachments") {
+					return true, makeTestAttachment(getAttachmentName("vol-005", testDriver, nodeName), nodeName, "vol-005"), nil
 				}
 				return false, nil, nil
 			},
@@ -944,7 +958,14 @@ func TestAttacherDetach(t *testing.T) {
 			if err != nil {
 				t.Errorf("test case %s failed: %v", tc.name, err)
 			}
+			watchError := tc.watcherError
+			csiAttacher.waitSleepTime = 100 * time.Millisecond
 			go func() {
+				if watchError {
+					errStatus := apierrs.NewInternalError(fmt.Errorf("we got an error")).Status()
+					fakeWatcher.Error(&errStatus)
+					return
+				}
 				fakeWatcher.Delete(attachment)
 			}()
 			err = csiAttacher.Detach(volumeName, types.NodeName(nodeName))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When we receive ERROR from watcher, waitForVolumeDetachmentInternal is called recursively. https://github.com/kubernetes/kubernetes/pull/78826 has fixed the watch error happens when attaching. However, waitForVolumeDetachmentInternal has not been well solved.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #64952 

**Special notes for your reviewer**:
/cc @jingxu97 @tedyu 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
