### PR TITLE
Remove returned value of func handleCreateEvent

### DIFF
--- a/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
@@ -94,10 +94,7 @@ func (w *Watcher) Start(stopCh <-chan struct{}) error {
 						klog.Errorf("error %v when handling create event: %s", err, event)
 					}
 				} else if event.Op&fsnotify.Remove == fsnotify.Remove {
-					err := w.handleDeleteEvent(event)
-					if err != nil {
-						klog.Errorf("error %v when handling delete event: %s", err, event)
-					}
+					w.handleDeleteEvent(event)
 				}
 				continue
 			case err := <-fsWatcher.Errors:
@@ -219,14 +216,12 @@ func (w *Watcher) handlePluginRegistration(socketPath string) error {
 	return nil
 }
 
-func (w *Watcher) handleDeleteEvent(event fsnotify.Event) error {
+func (w *Watcher) handleDeleteEvent(event fsnotify.Event) {
 	klog.V(6).Infof("Handling delete event: %v", event)
 
 	socketPath := event.Name
 	klog.V(2).Infof("Removing socket path %s from desired state cache", socketPath)
 	w.desiredStateOfWorld.RemovePlugin(socketPath)
-
-	return nil
 }
 
 // While deprecated dir is supported, to add extra protection around #69015


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

Remove returned value of func handleCreateEvent and some dead codes

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
