### PR TITLE
Update node image names to use ID as fallback

### DIFF
--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -415,6 +415,10 @@ func Images(nodeStatusMaxImages int32,
 			if len(names) > MaxNamesPerImageInNodeStatus {
 				names = names[0:MaxNamesPerImageInNodeStatus]
 			}
+			// Use the image ID as fallback if no repo tag or digest exists
+			if len(names) == 0 {
+				names = []string{image.ID}
+			}
 			imagesOnNode = append(imagesOnNode, v1.ContainerImage{
 				Names:     names,
 				SizeBytes: image.Size,

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -1615,6 +1615,9 @@ func makeExpectedImageList(imageList []kubecontainer.Image, maxImages, maxNames 
 		if len(names) > int(maxNames) {
 			names = names[0:maxNames]
 		}
+		if len(names) == 0 {
+			names = []string{image.ID}
+		}
 		expectedImage.Names = names
 		expectedImage.SizeBytes = image.Size
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
If no repo tag or digest exist for the image, then we now fallback to
use the ID, which should always be set. This avoids having `null` within
the resulting node JSON which leads into an invalid manifest.

**Special notes for your reviewer**:

Another option would be to simply skip images without tag or digest.

**Does this PR introduce a user-facing change?**:
```release-note
Fix invalid node manifest when images contain no repo tag or digest
```
