### PR TITLE
link scripts in build/README.md

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -19,22 +19,22 @@ While it is possible to build Kubernetes using a local golang installation, we h
 
 ## Key scripts
 
-The following scripts are found in the `build/` directory. Note that all scripts must be run from the Kubernetes root directory.
+The following scripts are found in the [`build/`](.) directory. Note that all scripts must be run from the Kubernetes root directory.
 
-* `build/run.sh`: Run a command in a build docker container.  Common invocations:
+* [`build/run.sh`](run.sh): Run a command in a build docker container.  Common invocations:
   *  `build/run.sh make`: Build just linux binaries in the container.  Pass options and packages as necessary.
   *  `build/run.sh make cross`: Build all binaries for all platforms
   *  `build/run.sh make kubectl KUBE_BUILD_PLATFORMS=darwin/amd64`: Build the specific binary for the specific platform (`kubectl` and `darwin/amd64` respectively in this example)
   *  `build/run.sh make test`: Run all unit tests
   *  `build/run.sh make test-integration`: Run integration test
   *  `build/run.sh make test-cmd`: Run CLI tests
-* `build/copy-output.sh`: This will copy the contents of `_output/dockerized/bin` from the Docker container to the local `_output/dockerized/bin`. It will also copy out specific file patterns that are generated as part of the build process. This is run automatically as part of `build/run.sh`.
-* `build/make-clean.sh`: Clean out the contents of `_output`, remove any locally built container images and remove the data container.
-* `build/shell.sh`: Drop into a `bash` shell in a build container with a snapshot of the current repo code.
+* [`build/copy-output.sh`](copy-output.sh): This will copy the contents of `_output/dockerized/bin` from the Docker container to the local `_output/dockerized/bin`. It will also copy out specific file patterns that are generated as part of the build process. This is run automatically as part of `build/run.sh`.
+* [`build/make-clean.sh`](make-clean.sh): Clean out the contents of `_output`, remove any locally built container images and remove the data container.
+* [`build/shell.sh`](shell.sh): Drop into a `bash` shell in a build container with a snapshot of the current repo code.
 
 ## Basic Flow
 
-The scripts directly under `build/` are used to build and test.  They will ensure that the `kube-build` Docker image is built (based on `build/build-image/Dockerfile`) and then execute the appropriate command in that container.  These scripts will both ensure that the right data is cached from run to run for incremental builds and will copy the results back out of the container.
+The scripts directly under [`build/`](.) are used to build and test.  They will ensure that the `kube-build` Docker image is built (based on [`build/build-image/Dockerfile`](build-image/Dockerfile)) and then execute the appropriate command in that container.  These scripts will both ensure that the right data is cached from run to run for incremental builds and will copy the results back out of the container.
 
 The `kube-build` container image is built by first creating a "context" directory in `_output/images/build-image`.  It is done there instead of at the root of the Kubernetes repo to minimize the amount of data we need to package up when building the image.
 
@@ -93,7 +93,7 @@ Look at `docker-machine stop`, `docker-machine start` and `docker-machine rm` to
 
 ## Releasing
 
-The `build/release.sh` script will build a release.  It will build binaries, run tests, (optionally) build runtime Docker images.
+The [`build/release.sh`](release.sh) script will build a release.  It will build binaries, run tests, (optionally) build runtime Docker images.
 
 The main output is a tar file: `kubernetes.tar.gz`.  This includes:
 * Cross compiled client utilities.


### PR DESCRIPTION
This makes it easier to click through and learn what these do, for someone getting started browsing this developer doc.