### PR TITLE
Suppress irrelevant jq error message when propagating pinned dependencies

### DIFF
--- a/hack/pin-dependency.sh
+++ b/hack/pin-dependency.sh
@@ -92,7 +92,7 @@ go mod edit -replace "${dep}=${dep}@${rev}"
 # Propagate pinned version to staging repos that also have that dependency
 for repo in $(ls staging/src/k8s.io | sort); do
   pushd "staging/src/k8s.io/${repo}" >/dev/null 2>&1
-    if go mod edit -json | jq -e -r ".Require[] | select(.Path == \"${dep}\")" > /dev/null; then
+    if go mod edit -json | jq -e -r ".Require[] | select(.Path == \"${dep}\")" > /dev/null 2>&1; then
       go mod edit -require "${dep}@${rev}"
       go mod edit -replace "${dep}=${dep}@${rev}"
     fi


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Hides a misleading error message in the pin-dependency script


```release-note
NONE
```

/cc @dims