### PR TITLE
fix: disable cpu quota with guaranteed QoS when cpu manager enabled

### DIFF
--- a/pkg/kubelet/kuberuntime/BUILD
+++ b/pkg/kubelet/kuberuntime/BUILD
@@ -72,6 +72,7 @@ go_library(
         "//vendor/k8s.io/klog:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:linux": [
+            "//pkg/apis/core/v1/helper/qos:go_default_library",
             "//pkg/kubelet/qos:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:windows": [

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -21,9 +21,10 @@ package kuberuntime
 import (
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 )
@@ -74,6 +75,11 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerConfig(container *v1.C
 			cpuPeriod = int64(m.cpuCFSQuotaPeriod.Duration / time.Microsecond)
 		}
 		cpuQuota := milliCPUToQuota(cpuLimit.MilliValue(), cpuPeriod)
+		// if the pods are in Guaranteed QoS class and cpu manager is enabled, we should
+		// disable the use of of cfs quota.
+		if v1qos.GetPodQOS(pod) == v1.PodQOSGuaranteed && utilfeature.DefaultFeatureGate.Enabled(kubefeatures.CPUManager) {
+			cpuQuota = -1
+		}
 		lc.Resources.CpuQuota = cpuQuota
 		lc.Resources.CpuPeriod = cpuPeriod
 	}


### PR DESCRIPTION
/kind bug
/priority important-soon

**What this PR does / why we need it**:

Disable CFS CPU quota with guaranteed QoS pod when the CPU manager is enabled. The CFS bug could bring CPU throttle time which we don't expect.

**Which issue(s) this PR fixes**:

Fixes #70585

**Does this PR introduce a user-facing change?**:

```release-note
Disable CFS CPU quota with guaranteed QoS pod when the CPU manager is enabled.
```