### PR TITLE
Promote LocalStorageCapacityIsolationFSQuotaMonitoring to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -439,6 +439,7 @@ const (
 
 	// owner: @RobertKrawitz
 	// alpha: v1.15
+	// beta: v1.18
 	//
 	// Allow use of filesystems for ephemeral storage monitoring.
 	// Only applies if LocalStorageCapacityIsolation is set.
@@ -570,7 +571,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	WindowsGMSA:                    {Default: true, PreRelease: featuregate.Beta},
 	WindowsRunAsUserName:           {Default: false, PreRelease: featuregate.Alpha},
 	ServiceLoadBalancerFinalizer:   {Default: true, PreRelease: featuregate.Beta},
-	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Alpha},
+	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: true, PreRelease: featuregate.Beta},
 	NonPreemptingPriority:                          {Default: false, PreRelease: featuregate.Alpha},
 	VolumePVCDataSource:                            {Default: true, PreRelease: featuregate.Beta},
 	PodOverhead:                                    {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Graduate LocalStorageCapacityIsolationFSQuotaMonitoring to beta

**Which issue(s) this PR fixes**:

Fixes #79040

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: Yes
```release-note

Use of filesystem quotas to monitor consumption of EmptyDir volumes is graduating to beta.

`LocalStorageCapacityIsolationFSQuotaMonitoring`: When `LocalStorageCapacityIsolation` is enabled for [local ephemeral storage](/docs/concepts/configuration/manage-compute-resources-container/) and the backing filesystem for [emptyDir volumes](/docs/concepts/storage/volumes/#emptydir) supports project quotas and they are enabled, use project quotas to monitor [emptyDir volume](/docs/concepts/storage/volumes/#emptydir) storage consumption rather than filesystem walk for better performance and accuracy.
```
xref https://github.com/kubernetes/enhancements/issues/1029