### PR TITLE
kubelet_stats: fix potential e2e crash dereferencing ContainerStats.CPU

### DIFF
--- a/test/e2e/framework/kubelet_stats.go
+++ b/test/e2e/framework/kubelet_stats.go
@@ -598,6 +598,9 @@ func (r *resourceCollector) collectStats(oldStatsMap map[string]*stats.Container
 		}
 
 		if oldStats, ok := oldStatsMap[name]; ok {
+			if oldStats.CPU == nil || cStats.CPU == nil || oldStats.Memory == nil || cStats.Memory == nil {
+				continue
+			}
 			if oldStats.CPU.Time.Equal(&cStats.CPU.Time) {
 				// No change -> skip this stat.
 				continue


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
The kubelet's stats API can return nil within the CPU attribute of cadvisorapiv2.ContainerStats. This patch fixes the e2e test to check for nil CPU attributes before trying to dereference `oldStats.CPU` and `cStats.CPU`. We are seeing this flake currently within CI.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1679612
ref: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/stats/helper.go#L36-L40
ref: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/stats/helper.go#L77-L84

/cc @kubernetes/sig-node-pr-reviews @sjenning 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
