### PR TITLE
Check error return from MetaNamespaceKeyFunc

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -876,7 +876,11 @@ func (dsc *DaemonSetsController) podsShouldBeOnNode(
 	}
 
 	daemonPods, exists := nodeToDaemonPods[node.Name]
-	dsKey, _ := cache.MetaNamespaceKeyFunc(ds)
+	dsKey, err := cache.MetaNamespaceKeyFunc(ds)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
 
 	dsc.removeSuspendedDaemonPods(node.Name, dsKey)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently DaemonSetsController#podsShouldBeOnNode, the error return from MetaNamespaceKeyFunc is ignored.
If the error is related to lack of meta, the error shouldn't be ignored.

This PR makes the error handling in line with that from staging/src/k8s.io/sample-controller/controller.go

```release-note
NONE
```
