### PR TITLE
Kubectl completion zsh error #125

### DIFF
--- a/pkg/kubectl/cmd/completion/completion.go
+++ b/pkg/kubectl/cmd/completion/completion.go
@@ -270,6 +270,7 @@ __kubectl_quote() {
     fi
 }
 
+autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
 
 # use word boundary patterns for BSD or GNU sed


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
Fixes this error `zsh: command not found: compinit` when running `source <(kubectl completion zsh)` without before running `compinit` (this occurs on fresh MacOS installations).
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/125
**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
```release-note
Users of zsh no longer need to run `compinit` before running `source <(kubectl completion zsh)`
```
