### PR TITLE
 Fix update-codegen.sh for staging repos to not rely on scripts being executable

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/hack/update-codegen.sh
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/hack/update-codegen.sh
@@ -25,7 +25,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
-"${CODEGEN_PKG}/generate-groups.sh" all \
+bash "${CODEGEN_PKG}/generate-groups.sh" all \
   k8s.io/apiextensions-apiserver/examples/client-go/pkg/client k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis \
   cr:v1 \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../../.."

--- a/staging/src/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
+++ b/staging/src/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
@@ -27,7 +27,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
 CLIENTSET_NAME_VERSIONED=clientset \
 CLIENTSET_NAME_INTERNAL=internalclientset \
-"${CODEGEN_PKG}/generate-internal-groups.sh" all \
+bash "${CODEGEN_PKG}/generate-internal-groups.sh" all \
   k8s.io/apiextensions-apiserver/pkg/client k8s.io/apiextensions-apiserver/pkg/apis k8s.io/apiextensions-apiserver/pkg/apis \
   "apiextensions:v1beta1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \

--- a/staging/src/k8s.io/kube-aggregator/hack/update-codegen.sh
+++ b/staging/src/k8s.io/kube-aggregator/hack/update-codegen.sh
@@ -23,7 +23,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-
 
 CLIENTSET_NAME_VERSIONED=clientset \
 CLIENTSET_PKG_NAME=clientset_generated \
-"${CODEGEN_PKG}/generate-groups.sh" deepcopy,client,lister,informer \
+bash "${CODEGEN_PKG}/generate-groups.sh" deepcopy,client,lister,informer \
   k8s.io/kube-aggregator/pkg/client k8s.io/kube-aggregator/pkg/apis \
   "apiregistration:v1beta1,v1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
@@ -32,7 +32,7 @@ CLIENTSET_PKG_NAME=clientset_generated \
 CLIENTSET_NAME_VERSIONED=clientset \
 CLIENTSET_PKG_NAME=clientset_generated \
 CLIENTSET_NAME_INTERNAL=internalclientset \
-"${CODEGEN_PKG}/generate-internal-groups.sh" deepcopy,client,lister,informer,conversion \
+bash "${CODEGEN_PKG}/generate-internal-groups.sh" deepcopy,client,lister,informer,conversion \
   k8s.io/kube-aggregator/pkg/client k8s.io/kube-aggregator/pkg/apis k8s.io/kube-aggregator/pkg/apis \
   "apiregistration:v1beta1,v1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \

--- a/staging/src/k8s.io/metrics/hack/update-codegen.sh
+++ b/staging/src/k8s.io/metrics/hack/update-codegen.sh
@@ -28,12 +28,12 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-
 #
 # we skip informers and listers for metrics, because we don't quite support the requisite operations yet
 # we skip generating the internal clientset as it's not really needed
-"${CODEGEN_PKG}/generate-internal-groups.sh" deepcopy,conversion \
+bash "${CODEGEN_PKG}/generate-internal-groups.sh" deepcopy,conversion \
   k8s.io/metrics/pkg/client k8s.io/metrics/pkg/apis k8s.io/metrics/pkg/apis \
   "metrics:v1alpha1,v1beta1 custom_metrics:v1beta1 external_metrics:v1beta1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
   --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
-"${CODEGEN_PKG}/generate-groups.sh" client \
+bash "${CODEGEN_PKG}/generate-groups.sh" client \
   k8s.io/metrics/pkg/client k8s.io/metrics/pkg/apis \
   "metrics:v1alpha1,v1beta1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \

--- a/staging/src/k8s.io/node-api/hack/update-codegen.sh
+++ b/staging/src/k8s.io/node-api/hack/update-codegen.sh
@@ -25,7 +25,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
-"${CODEGEN_PKG}/generate-groups.sh" "deepcopy,client,informer,lister" \
+bash "${CODEGEN_PKG}/generate-groups.sh" "deepcopy,client,informer,lister" \
   k8s.io/node-api/pkg/client k8s.io/node-api/pkg/apis \
   "node:v1alpha1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \

--- a/staging/src/k8s.io/sample-apiserver/README.md
+++ b/staging/src/k8s.io/sample-apiserver/README.md
@@ -55,7 +55,7 @@ Note, however, that if you intend to
 [generate code](#changes-to-the-types) then you will also need the
 code-generator repo to exist in an old-style location.  One easy way
 to do this is to use the command `go mod vendor` to create and
-popdulate the `vendor` directory.
+populate the `vendor` directory.
 
 ### A Note on kubernetes/kubernetes
 

--- a/staging/src/k8s.io/sample-controller/README.md
+++ b/staging/src/k8s.io/sample-controller/README.md
@@ -31,6 +31,47 @@ The sample controller uses [client-go library](https://github.com/kubernetes/cli
 The details of interaction points of the sample controller with various mechanisms from this library are
 explained [here](docs/controller-client-go.md).
 
+## Fetch sample-controller and its dependencies
+
+Like the rest of Kubernetes, sample-controller has used
+[godep](https://github.com/tools/godep) and `$GOPATH` for years and is
+now adopting go 1.11 modules.  There are thus two alternative ways to
+go about fetching this demo and its dependencies.
+
+### Fetch with godep
+
+When NOT using go 1.11 modules, you can use the following commands.
+
+```sh
+go get -d k8s.io/sample-controller
+cd $GOPATH/src/k8s.io/sample-controller
+godep restore
+```
+
+### When using go 1.11 modules
+
+When using go 1.11 modules (`GO111MODULE=on`), issue the following
+commands --- starting in whatever working directory you like.
+
+```sh
+git clone https://github.com/kubernetes/sample-controller.git
+cd sample-controller
+```
+
+Note, however, that if you intend to
+[generate code](#changes-to-the-types) then you will also need the
+code-generator repo to exist in an old-style location.  One easy way
+to do this is to use the command `go mod vendor` to create and
+populate the `vendor` directory.
+
+### A Note on kubernetes/kubernetes
+
+If you are developing Kubernetes according to
+https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md
+then you already have a copy of this demo in
+`kubernetes/staging/src/k8s.io/sample-controller` and its dependencies
+--- including the code generator --- are in usable locations
+(valid for all Go versions).
 
 ## Purpose
 
@@ -42,8 +83,6 @@ This is an example of how to build a kube-like controller with a single type.
 
 ```sh
 # assumes you have a working kubeconfig, not required if operating in-cluster
-go get k8s.io/sample-controller
-cd $GOPATH/src/k8s.io/sample-controller
 go build -o sample-controller .
 ./sample-controller -kubeconfig=$HOME/.kube/config
 

--- a/staging/src/k8s.io/sample-controller/hack/update-codegen.sh
+++ b/staging/src/k8s.io/sample-controller/hack/update-codegen.sh
@@ -25,7 +25,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
-"${CODEGEN_PKG}"/generate-groups.sh "deepcopy,client,informer,lister" \
+bash "${CODEGEN_PKG}"/generate-groups.sh "deepcopy,client,informer,lister" \
   k8s.io/sample-controller/pkg/generated k8s.io/sample-controller/pkg/apis \
   samplecontroller:v1alpha1 \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \


### PR DESCRIPTION
Fixes https://github.com/kubernetes/sample-controller/issues/47
Fixes https://github.com/kubernetes/sample-controller/issues/51

If someone doesn't have code-generator in their GOPATH, they'll need to
run `go mod vendor` to populate the vendor directory with the code-generator
repo (it is required by `hack/tools.go`).

However, `go mod vendor` does not mark scripts as executable which leads to a
`Permission denied` error while trying to run `update-codegen.sh` in staging repos.
So fix scripts to not rely on codegen scripts being executable (similar to https://github.com/kubernetes/kubernetes/commit/18b7fda68d8102834ef0fe1b9d17dd40d6c00fec).

Also, add a note about how to fetch dependencies in the sample-controller README,
à la sample-apiserver.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @liggitt @sttts 
