### PR TITLE
Remove unused ServiceController.loadBalancerName method

### DIFF
--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -503,10 +503,6 @@ func (s *ServiceController) needsUpdate(oldService *v1.Service, newService *v1.S
 	return false
 }
 
-func (s *ServiceController) loadBalancerName(service *v1.Service) string {
-	return s.balancer.GetLoadBalancerName(context.TODO(), "", service)
-}
-
 func getPortsForLB(service *v1.Service) ([]*v1.ServicePort, error) {
 	var protocol v1.Protocol
 

--- a/pkg/controller/service/service_controller_test.go
+++ b/pkg/controller/service/service_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -360,7 +361,7 @@ func TestSyncLoadBalancerIfNeeded(t *testing.T) {
 				}
 				if balancer == nil {
 					t.Errorf("Got no load balancer, expected one to be created")
-				} else if balancer.Name != controller.loadBalancerName(tc.service) ||
+				} else if balancer.Name != controller.balancer.GetLoadBalancerName(context.Background(), "", tc.service) ||
 					balancer.Region != region ||
 					balancer.Ports[0].Port != tc.service.Spec.Ports[0].Port {
 					t.Errorf("Created load balancer has incorrect parameters: %v", balancer)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove unused `ServiceController.loadBalancerName` method

Its only caller lives in the corresponding test file. Hence, we move the method called by `loadBalancerName` over to the test and remove `loadBalancerName`.

**Does this PR introduce a user-facing change?**:
No.

```release-note
NONE
```

/sig cloud-provider