### PR TITLE
remove duplicate comment in e2e/common/sysctl.go

### DIFF
--- a/test/e2e/common/sysctl.go
+++ b/test/e2e/common/sysctl.go
@@ -94,7 +94,6 @@ var _ = framework.KubeDescribe("Sysctls [NodeFeature:Sysctls]", func() {
 		gomega.Expect(pod.Status.Phase).To(gomega.Equal(v1.PodSucceeded))
 
 		ginkgo.By("Getting logs from the pod")
-		ginkgo.By("Getting logs from the pod")
 		log, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
 		framework.ExpectNoError(err)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
e2e/common/sysctl.go has duplicate comment for test.
This PR removes the comment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
