### PR TITLE
Promote Service Controller e2e test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -38,6 +38,7 @@ test/e2e/apps/statefulset.go: "Burst scaling should run to completion even with 
 test/e2e/apps/statefulset.go: "Should recreate evicted statefulset"
 test/e2e/auth/service_accounts.go: "should mount an API token into pods"
 test/e2e/auth/service_accounts.go: "should allow opting out of API token automount"
+test/e2e/auth/service_accounts.go: "should ensure a single API token exists"
 test/e2e/common/configmap.go: "should be consumable via environment variable"
 test/e2e/common/configmap.go: "should be consumable via the environment"
 test/e2e/common/configmap.go: "should fail to create ConfigMap with empty key"

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -46,7 +46,15 @@ var inClusterClientImage = imageutils.GetE2EImage(imageutils.InClusterClient)
 var _ = SIGDescribe("ServiceAccounts", func() {
 	f := framework.NewDefaultFramework("svcaccounts")
 
-	ginkgo.It("should ensure a single API token exists", func() {
+
+	/*
+	   Release: v1.16
+	   Testname: Service Account: Single Secret Reference
+	   Description: Ensure that a given Service Account has a secret reference
+                    There MUST only be one secret reference. The reference MUST
+                    be able to be deleted, and a new reference added.
+	*/
+	framework.ConformanceIt("should ensure a single API token exists", func() {
 		// wait for the service account to reference a single secret
 		var secrets []v1.ObjectReference
 		framework.ExpectNoError(wait.Poll(time.Millisecond*500, time.Second*10, func() (bool, error) {

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -46,13 +46,12 @@ var inClusterClientImage = imageutils.GetE2EImage(imageutils.InClusterClient)
 var _ = SIGDescribe("ServiceAccounts", func() {
 	f := framework.NewDefaultFramework("svcaccounts")
 
-
 	/*
-	   Release: v1.16
-	   Testname: Service Account: Single Secret Reference
-	   Description: Ensure that a given Service Account has a secret reference
-                    There MUST only be one secret reference. The reference MUST
-                    be able to be deleted, and a new reference added.
+		   Release: v1.16
+		   Testname: Service Account: Single Secret Reference
+		   Description: Ensure that a given Service Account has a secret reference
+	                    There MUST only be one secret reference. The reference MUST
+	                    be able to be deleted, and a new reference added.
 	*/
 	framework.ConformanceIt("should ensure a single API token exists", func() {
 		// wait for the service account to reference a single secret


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Promotes the following E2E test to Conformance:
 `test/e2e/auth/service_accounts.go: "should ensure a single API token exists"`


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/78835

**Special notes for your reviewer**:

Part of Umbrella Issue https://github.com/kubernetes/kubernetes/issues/78748


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/area conformance
/area test

@kubernetes/sig-architecture-pr-reviews 
@kubernetes/cncf-conformance-wg
@kubernetes/sig-auth-pr-reviews