### PR TITLE
Fix golint failures of test/e2e/storage/testsuites

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -571,7 +571,6 @@ staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder
 test/e2e/common
 test/e2e/lifecycle/bootstrap
 test/e2e/scalability
-test/e2e/storage/testsuites
 test/e2e/storage/vsphere
 test/e2e_kubeadm
 test/e2e_node

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -574,15 +574,14 @@ func getMigrationVolumeOpCounts(cs clientset.Interface, pluginName string) (opCo
 			migratedOps = getVolumeOpCounts(cs, csiName)
 		}
 		return getVolumeOpCounts(cs, pluginName), migratedOps
-	} else {
-		// Not an in-tree driver
-		e2elog.Logf("Test running for native CSI Driver, not checking metrics")
-		return opCounts{}, opCounts{}
 	}
+	// Not an in-tree driver
+	e2elog.Logf("Test running for native CSI Driver, not checking metrics")
+	return opCounts{}, opCounts{}
 }
 
 func getTotOps(ops opCounts) int64 {
-	var tot int64 = 0
+	var tot = int64(0)
 	for _, count := range ops {
 		tot += count
 	}

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -439,6 +439,7 @@ func PVMultiNodeCheck(client clientset.Interface, claim *v1.PersistentVolumeClai
 	pod = nil
 }
 
+// TestBindingWaitForFirstConsumer tests the binding with WaitForFirstConsumer mode
 func (t StorageClassTest) TestBindingWaitForFirstConsumer(nodeSelector map[string]string, expectUnschedulable bool) (*v1.PersistentVolume, *v1.Node) {
 	pvs, node := t.TestBindingWaitForFirstConsumerMultiPVC([]*v1.PersistentVolumeClaim{t.Claim}, nodeSelector, expectUnschedulable)
 	if pvs == nil {
@@ -447,6 +448,7 @@ func (t StorageClassTest) TestBindingWaitForFirstConsumer(nodeSelector map[strin
 	return pvs[0], node
 }
 
+// TestBindingWaitForFirstConsumerMultiPVC tests the binding with WaitForFirstConsumer mode
 func (t StorageClassTest) TestBindingWaitForFirstConsumerMultiPVC(claims []*v1.PersistentVolumeClaim, nodeSelector map[string]string, expectUnschedulable bool) ([]*v1.PersistentVolume, *v1.Node) {
 	var err error
 	gomega.Expect(len(claims)).ToNot(gomega.Equal(0))

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -45,15 +45,6 @@ var (
 	snapshotContentGVR = schema.GroupVersionResource{Group: snapshotGroup, Version: "v1alpha1", Resource: "volumesnapshotcontents"}
 )
 
-type SnapshotClassTest struct {
-	Name           string
-	CloudProviders []string
-	Snapshotter    string
-	Parameters     map[string]string
-	NodeName       string
-	NodeSelector   map[string]string // NodeSelector for the pod
-}
-
 type snapshottableTestSuite struct {
 	tsInfo TestSuiteInfo
 }

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -112,6 +112,7 @@ type SnapshottableTestDriver interface {
 // Capability represents a feature that a volume plugin supports
 type Capability string
 
+// Constants related to capability
 const (
 	CapPersistence Capability = "persistence" // data is persisted across pod restarts
 	CapBlock       Capability = "block"       // raw block mode


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This fixes golint failures of the following file:
- test/e2e/storage/testsuites/base.go
- test/e2e/storage/testsuites/provisioning.go
- test/e2e/storage/testsuites/snapshottable.go
- test/e2e/storage/testsuites/testdriver.go

**Which issue(s) this PR fixes**:
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
