### PR TITLE
Add comment to ListOptions.LabelSelector field

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -1887,7 +1887,7 @@ func schema_pkg_apis_meta_v1_ListOptions(ref common.ReferenceCallback) common.Op
 					},
 					"labelSelector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+							Description: "A selector to restrict the list of returned objects by their labels. If you have a LabelSelector object and need to use it for this field, use FormatLabelSelector(selector) rather than selector.String() to create a string in the correct format. Defaults to everything.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -408,6 +408,9 @@ message ListMeta {
 // ListOptions is the query options to a standard REST list call.
 message ListOptions {
   // A selector to restrict the list of returned objects by their labels.
+  // If you have a LabelSelector object and need to use it for this field, use
+  // FormatLabelSelector(selector) rather than selector.String() to create a
+  // string in the correct format.
   // Defaults to everything.
   // +optional
   optional string labelSelector = 1;

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -343,6 +343,9 @@ type ListOptions struct {
 	TypeMeta `json:",inline"`
 
 	// A selector to restrict the list of returned objects by their labels.
+	// If you have a LabelSelector object and need to use it for this field, use
+	// FormatLabelSelector(selector) rather than selector.String() to create a
+	// string in the correct format.
 	// Defaults to everything.
 	// +optional
 	LabelSelector string `json:"labelSelector,omitempty" protobuf:"bytes,1,opt,name=labelSelector"`

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_swagger_doc_generated.go
@@ -210,7 +210,7 @@ func (ListMeta) SwaggerDoc() map[string]string {
 
 var map_ListOptions = map[string]string{
 	"":                    "ListOptions is the query options to a standard REST list call.",
-	"labelSelector":       "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+	"labelSelector":       "A selector to restrict the list of returned objects by their labels. If you have a LabelSelector object and need to use it for this field, use FormatLabelSelector(selector) rather than selector.String() to create a string in the correct format. Defaults to everything.",
 	"fieldSelector":       "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
 	"watch":               "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
 	"allowWatchBookmarks": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored. If the feature gate WatchBookmarks is not enabled in apiserver, this field is ignored.\n\nThis field is alpha and can be changed or removed without notice.",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Adds a comment to the `ListOptions.LabelSelector` field.

This comment explains how to use `metav1.LabelSelector` objects for the string value, as using `.String()` is a common error I've personally seen three times by now.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
