### PR TITLE
Promote AdmissionWebHook should be able to deny pod and configmap creation to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -14,6 +14,7 @@ test/e2e/apimachinery/watch.go: "should be able to start watching from a specifi
 test/e2e/apimachinery/watch.go: "should be able to restart watching from the last resource version observed by the previous watch"
 test/e2e/apimachinery/watch.go: "should observe an object deletion if it stops meeting the requirements of the selector"
 test/e2e/apimachinery/watch.go: "should receive events on concurrent watches in same order"
+test/e2e/apimachinery/webhook.go: "Should be able to deny pod and configmap creation"
 test/e2e/apps/daemon_set.go: "should run and stop simple daemon"
 test/e2e/apps/daemon_set.go: "should run and stop complex daemon"
 test/e2e/apps/daemon_set.go: "should retry creating failed daemon pods"

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -125,7 +125,12 @@ var _ = SIGDescribe("AdmissionWebhook", func() {
 		cleanWebhookTest(client, namespaceName)
 	})
 
-	ginkgo.It("Should be able to deny pod and configmap creation", func() {
+	/*
+		Release : v1.16
+		Testname: LimitRange: CRUD
+		Description: Ensure that AdmissionWebhook is able to deny pod and configmap creation
+	*/
+	framework.ConformanceIt("Should be able to deny pod and configmap creation", func() {
 		webhookCleanup := registerWebhook(f, context)
 		defer webhookCleanup()
 		testWebhook(f)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Promotes the following E2E test to Conformance:
```test/e2e/apimachinery/webhook.go: "Should be able to deny pod and configmap creation"```

**Which issue(s) this PR fixes**:

Fixes: #78832

**Special notes for your reviewer**:

Part of Umbrella Issue #78748

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/area conformance
/area test

@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg
@kubernetes/sig-api-machinery-pr-reviews 