### PR TITLE
Promote LimitRange CRUD to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -209,6 +209,7 @@ test/e2e/node/events.go: "should be sent by kubelets and the scheduler about pod
 test/e2e/node/pods.go: "should be submitted and removed"
 test/e2e/node/pods.go: "should be submitted and removed"
 test/e2e/node/pre_stop.go: "should call prestop when killing a pod"
+test/e2e/scheduling/limit_range.go: "should create a LimitRange with defaults and ensure pod has those defaults applied"
 test/e2e/scheduling/predicates.go: "validates resource limits of pods that are allowed to run"
 test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if not matching"
 test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if matching"

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -40,8 +40,12 @@ const (
 
 var _ = SIGDescribe("LimitRange", func() {
 	f := framework.NewDefaultFramework("limitrange")
-
-	ginkgo.It("should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
+	/*
+		Release: v1.16
+		Testname: LimitRange CRUD
+		Description: Create a LimitRange. Creation MUST be successful and creation of pods MUST respect set limits
+	*/
+	framework.ConformanceIt("should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
 		ginkgo.By("Creating a LimitRange")
 
 		min := getResourceList("50m", "100Mi", "100Gi")

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -45,7 +45,7 @@ var _ = SIGDescribe("LimitRange", func() {
 		Testname: LimitRange CRUD
 		Description: Create a LimitRange. Creation MUST be successful and creation of pods MUST respect set limits
 	*/
-	framework.ConformanceIt("should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
+	framework.ConformanceIt("should create a LimitRange with defaults and ensure pod has those defaults applied", func() {
 		ginkgo.By("Creating a LimitRange")
 
 		min := getResourceList("50m", "100Mi", "100Gi")


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

```
test/e2e/scheduling/limit_range.go: "should create a LimitRange with defaults and ensure pod has those defaults applied"
```

**Which issue(s) this PR fixes**:

Fixes #78831

**Special notes for your reviewer**:

Part of Umbrella Issue #78748

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/area conformance
/area test

@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg
@kubernetes/sig-scheduling-misc 