### PR TITLE
Redundant call to WithAll in NewWaitFlags

### DIFF
--- a/pkg/kubectl/cmd/wait/wait.go
+++ b/pkg/kubectl/cmd/wait/wait.go
@@ -93,7 +93,7 @@ func NewWaitFlags(restClientGetter genericclioptions.RESTClientGetter, streams g
 			WithFieldSelector("").
 			WithAll(false).
 			WithAllNamespaces(false).
-			WithAll(false).
+			WithLocal(false).
 			WithLatest(),
 
 		Timeout: 30 * time.Second,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In NewWaitFlags, WithAll is called twice.

If I read the code correctly, the redundant call should be replaced with WithLocal().

```release-note
NONE
```
