### PR TITLE
Promote test for scheduling the pod on a node it can tolerate to conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -215,6 +215,7 @@ test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if 
 test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if matching"
 test/e2e/scheduling/predicates.go: "validates that there is no conflict between pods with same hostPort but different hostIP and protocol"
 test/e2e/scheduling/predicates.go: "validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP"
+test/e2e/scheduling/priorities.go: "Pod should be preferably scheduled to nodes pod can tolerate"
 test/e2e/storage/empty_dir_wrapper.go: "should not conflict"
 test/e2e/storage/empty_dir_wrapper.go: "should not cause race condition when used for configmaps"
 test/e2e/storage/subpath.go: "should support subpaths with secret pod"

--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -217,7 +217,12 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 		}
 	})
 
-	ginkgo.It("Pod should be preferably scheduled to nodes pod can tolerate", func() {
+	/*
+		Release : v1.16
+		Testname: Scheduler, Pod Toleration
+		Description: Pod MUST be preferably scheduled onto the Node whose taint can be tolerated.
+	*/
+	framework.ConformanceIt("Pod should be preferably scheduled to nodes pod can tolerate", func() {
 		// make the nodes have balanced cpu,mem usage ratio
 		err := createBalancedPodForNodes(f, cs, ns, nodeList.Items, podRequestedResource, 0.5)
 		framework.ExpectNoError(err)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: This PR is a request to promote an existing E2E that verifies that the pod is scheduled only onto the node it can tolerate to conformance.

**Which issue(s) this PR fixes**: None, request for promotion of an existing E2E.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
1. The existing E2E takes around 100 seconds to complete its execution successfully.
2. The test is found to be non-disruptive and non-flaky as per the analysis.

**Does this PR introduce a user-facing change?**: NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

release-note-none

/area conformance
/sig scheduling

Copied to: @mgdevstack , @brahmaroutu 