### PR TITLE
Fix #79159: [cpumanager] AddContainer error: not enough cpus available to satisfy request

### DIFF
--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -94,7 +94,8 @@ type ContainerManager interface {
 	// any registered device plugin resource
 	UpdatePluginResources(*schedulernodeinfo.NodeInfo, *lifecycle.PodAdmitAttributes) error
 
-	InternalContainerLifecycle() InternalContainerLifecycle
+	// GetInternalContainerLifecycle returns InternalContainerLifecycle that handles container resource management
+	GetInternalContainerLifecycle() InternalContainerLifecycle
 
 	// GetPodCgroupRoot returns the cgroup which contains all pods.
 	GetPodCgroupRoot() string

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -136,6 +136,8 @@ type containerManagerImpl struct {
 	cpuManager cpumanager.Manager
 	// Interface for Topology resource co-ordination
 	topologyManager topologymanager.Manager
+	// Internal lifecycle event handlers for container resource management.
+	internalLifecycle InternalContainerLifecycle
 }
 
 type features struct {
@@ -331,6 +333,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 			return nil, err
 		}
 		cm.topologyManager.AddHintProvider(cm.cpuManager)
+		cm.internalLifecycle = &internalContainerLifecycleImpl{cm.cpuManager, cm.topologyManager}
 	}
 
 	return cm, nil
@@ -355,8 +358,8 @@ func (cm *containerManagerImpl) NewPodContainerManager() PodContainerManager {
 	}
 }
 
-func (cm *containerManagerImpl) InternalContainerLifecycle() InternalContainerLifecycle {
-	return &internalContainerLifecycleImpl{cm.cpuManager, cm.topologyManager}
+func (cm *containerManagerImpl) GetInternalContainerLifecycle() InternalContainerLifecycle {
+	return cm.internalLifecycle
 }
 
 // Create a cgroup container manager.

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -101,7 +101,7 @@ func (cm *containerManagerStub) UpdatePluginResources(*schedulernodeinfo.NodeInf
 	return nil
 }
 
-func (cm *containerManagerStub) InternalContainerLifecycle() InternalContainerLifecycle {
+func (cm *containerManagerStub) GetInternalContainerLifecycle() InternalContainerLifecycle {
 	return &internalContainerLifecycleImpl{cpumanager.NewFakeManager(), topologymanager.NewFakeManager()}
 }
 

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -52,6 +52,8 @@ type containerManagerImpl struct {
 	cadvisorInterface cadvisor.Interface
 	// Config of this node.
 	nodeConfig NodeConfig
+	// Internal lifecycle event handlers for container resource management.
+	internalLifecycle InternalContainerLifecycle
 }
 
 func (cm *containerManagerImpl) Start(node *v1.Node,
@@ -90,6 +92,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 		capacity:          capacity,
 		nodeConfig:        nodeConfig,
 		cadvisorInterface: cadvisorInterface,
+		internalLifecycle: &internalContainerLifecycleImpl{cpumanager.NewFakeManager(), topologymanager.NewFakeManager()},
 	}, nil
 }
 
@@ -162,8 +165,8 @@ func (cm *containerManagerImpl) UpdatePluginResources(*schedulernodeinfo.NodeInf
 	return nil
 }
 
-func (cm *containerManagerImpl) InternalContainerLifecycle() InternalContainerLifecycle {
-	return &internalContainerLifecycleImpl{cpumanager.NewFakeManager(), topologymanager.NewFakeManager()}
+func (cm *containerManagerImpl) GetInternalContainerLifecycle() InternalContainerLifecycle {
+	return cm.internalLifecycle
 }
 
 func (cm *containerManagerImpl) GetPodCgroupRoot() string {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2238,7 +2238,8 @@ func (kl *Kubelet) ListenAndServePodResources() {
 
 // Delete the eligible dead container instances in a pod. Depending on the configuration, the latest dead containers may be kept around.
 func (kl *Kubelet) cleanUpContainersInPod(podID types.UID, exitedContainerID string) {
-	// Handles container resource immediately.
+	// Handles container resource immediately, otherwise there will be a race condition,
+	// see https://github.com/kubernetes/kubernetes/issues/79159.
 	if err := kl.containerManager.GetInternalContainerLifecycle().PostStopContainer(exitedContainerID); err != nil {
 		klog.Errorf("Failed to post stop container %s: %v", exitedContainerID, err)
 	}


### PR DESCRIPTION
Co-authored-by: ddongchen@tencent.com

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Release container resource(cpu cores) immediately once it finishes

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79159

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Release container resource immediately once it finishes
```
