### PR TITLE
kubeadm: improve the kubeconfig file validation phase

### DIFF
--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -224,7 +224,13 @@ func validateKubeConfig(outDir, filename string, config *clientcmdapi.Config) er
 	expectedCtx := config.CurrentContext
 	expectedCluster := config.Contexts[expectedCtx].Cluster
 	currentCtx := currentConfig.CurrentContext
+	if currentConfig.Contexts[currentCtx] == nil {
+		return errors.Errorf("failed to find CurrentContext in Contexts of the kubeconfig file %s", kubeConfigFilePath)
+	}
 	currentCluster := currentConfig.Contexts[currentCtx].Cluster
+	if currentConfig.Clusters[currentCluster] == nil {
+		return errors.Errorf("failed to find the given CurrentContext Cluster in Clusters of the kubeconfig file %s", kubeConfigFilePath)
+	}
 
 	// If the current CA cert on disk doesn't match the expected CA cert, error out because we have a file, but it's stale
 	if !bytes.Equal(currentConfig.Clusters[currentCluster].CertificateAuthorityData, config.Clusters[expectedCluster].CertificateAuthorityData) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When a kubeconfig file is read from disk it may lack the
propper mapping between contexts and clusters.

In such a case the kubeconfig phase backend will panic,
without throwing a sensible error.

Add nil checks for a couple of map operations in
validateKubeConfig().

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79069
xref https://github.com/kubernetes/kubeadm/issues/1382

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: fix a potential panic if kubeadm discovers an invalid, existing kubeconfig file
```

/priority backlog
/assign @fabriziopandini @rosti 
/kind bug
@kubernetes/sig-cluster-lifecycle-pr-reviews 
/hold
