### PR TITLE
Move soltysh back to approvers

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -44,6 +44,7 @@ approvers:
   - shyamjvs
   - sig-testing-approvers
   - smarterclayton
+  - soltysh
   - sttts
   - timothysc
   - vishh
@@ -57,7 +58,6 @@ emeritus_approvers:
   - kow3ns
   - madhusudancs
   - marun
-  - soltysh
   - zmerlynn
   - MaciekPytel
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I've noticed I was removed from active approvers for tests in https://github.com/kubernetes/kubernetes/pull/77701 but as an active committer in both sig-cli and sig-apps this just blocked my abilities. I'm adding myself back to active approvers. 

**Special notes for your reviewer**:
/assign @spiffxp

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
