### PR TITLE
tests: Fixes Windows image pulling tests

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -90,6 +90,7 @@ var (
 	registry                = initReg()
 	dockerLibraryRegistry   = registry.DockerLibraryRegistry
 	e2eRegistry             = registry.E2eRegistry
+	e2eGcRegistry           = "gcr.io/kubernetes-e2e-test-images"
 	gcAuthenticatedRegistry = registry.GcAuthenticatedRegistry
 	gcRegistry              = registry.GcRegistry
 	googleContainerRegistry = registry.GoogleContainerRegistry
@@ -221,6 +222,7 @@ func initImageConfigs() map[int]Config {
 	configs[Agnhost] = Config{e2eRegistry, "agnhost", "2.0"}
 	configs[Alpine] = Config{dockerLibraryRegistry, "alpine", "3.7"}
 	configs[AuthenticatedAlpine] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
+	configs[AuthenticatedWindowsNanoServer] = Config{gcAuthenticatedRegistry, "windows-nanoserver", "v1"}
 	configs[APIServer] = Config{e2eRegistry, "sample-apiserver", "1.10"}
 	configs[AppArmorLoader] = Config{e2eRegistry, "apparmor-loader", "1.0"}
 	configs[AuditProxy] = Config{e2eRegistry, "audit-proxy", "1.0"}
@@ -269,7 +271,7 @@ func initImageConfigs() map[int]Config {
 	configs[VolumeISCSIServer] = Config{e2eRegistry, "volume/iscsi", "2.0"}
 	configs[VolumeGlusterServer] = Config{e2eRegistry, "volume/gluster", "1.0"}
 	configs[VolumeRBDServer] = Config{e2eRegistry, "volume/rbd", "1.0.1"}
-	configs[WindowsNanoServer] = Config{e2eRegistry, "windows-nanoserver", "v1"}
+	configs[WindowsNanoServer] = Config{e2eGcRegistry, "windows-nanoserver", "v1"}
 	return configs
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

/sig testing
/sig windows

/area conformance
/priority important-soon

**What this PR does / why we need it**:

A previous commit removed all hardcoded image names from the tests and centralized them into ``kubernetes/test/utils/image/manifest.go``, but it contained a few errors, which causes the image pulling tests to fail on Windows:

1. No entry was written for ``AuthenticatedWindowsNanoServer``, causing one of the tests to try to spawn a pod with the image name ``/``.
2. The registry set for ``WindowsNanoServer`` was ``e2eRegistry``, which is set to a dockerhub registry (``e2eteam``) in all sig-windows jobs, which is not the purpose of the test itself (the test tries to spawn a pod using an image from gcr.io). 

The reason why ``e2eRegistry`` is set to ``e2eteam`` is because that registry contains the Windows images needed for all the Kubernetes E2E tests.

This PR addresses this issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79171

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
