### PR TITLE
Add a 10s timeout to client-go examples

### DIFF
--- a/staging/src/k8s.io/client-go/examples/create-update-delete-deployment/main.go
+++ b/staging/src/k8s.io/client-go/examples/create-update-delete-deployment/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -55,6 +56,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	config.Timeout = 10 * time.Second
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		panic(err)

--- a/staging/src/k8s.io/client-go/examples/dynamic-create-update-delete-deployment/main.go
+++ b/staging/src/k8s.io/client-go/examples/dynamic-create-update-delete-deployment/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,6 +59,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	config.Timeout = 10 * time.Second
 	client, err := dynamic.NewForConfig(config)
 	if err != nil {
 		panic(err)

--- a/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/main.go
+++ b/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/main.go
@@ -42,6 +42,7 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
+	config.Timeout = 10 * time.Second
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/examples/leader-election/main.go
+++ b/staging/src/k8s.io/client-go/examples/leader-election/main.go
@@ -80,6 +80,7 @@ func main() {
 	if err != nil {
 		klog.Fatal(err)
 	}
+	config.Timeout = 10 * time.Second
 	client := clientset.NewForConfigOrDie(config)
 
 	// we use the Lease lock type since edits to Leases are less common

--- a/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go
@@ -53,6 +53,7 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
+	config.Timeout = 10 * time.Second
 
 	// create the clientset
 	clientset, err := kubernetes.NewForConfig(config)

--- a/staging/src/k8s.io/client-go/examples/workqueue/main.go
+++ b/staging/src/k8s.io/client-go/examples/workqueue/main.go
@@ -154,6 +154,7 @@ func main() {
 	if err != nil {
 		klog.Fatal(err)
 	}
+	config.Timeout = 10 * time.Second
 
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Adds a 10 second timeout to the examples in client-go.

I see too many instances of people using client-go with no timeout. The default is 0 or no timeout. We should encourage good practice of at least setting some sort of timeout in the example usage of client-go.

```release-note
NONE
```