### PR TITLE
Close auditStopCh if SecureServing encounters error

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -328,6 +328,7 @@ func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
 		stoppedCh, err = s.SecureServingInfo.Serve(s.Handler, s.ShutdownTimeout, internalStopCh)
 		if err != nil {
 			close(internalStopCh)
+			close(auditStopCh)
 			return err
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In preparedGenericAPIServer#NonBlockingRun, when SecureServingInfo.Serve encounters error, auditStopCh is left unclosed.

This PR closes auditStopCh in such scenario.

```release-note
NONE
```
