### PR TITLE
kubeadm: update OWNERS for 1.16

### DIFF
--- a/cmd/kubeadm/OWNERS
+++ b/cmd/kubeadm/OWNERS
@@ -6,20 +6,20 @@ approvers:
 - fabriziopandini
 - neolit123
 - rosti
+- ereslibre
 reviewers:
 - luxas
 - timothysc
 - fabriziopandini
 - neolit123
 - kad
-- liztio
-- chuckha
 - detiber
 - dixudx
 - rosti
 - yagonobre
-- ereslibre 
-# Might want to add @xiangpengzhao and @stealthybox back in the future
+- ereslibre
+- SataQiu
+# Might want to add @xiangpengzhao, @stealthybox, @liztio and @chuckha back in the future
 labels:
 - area/kubeadm
 - sig/cluster-lifecycle

--- a/test/e2e_kubeadm/OWNERS
+++ b/test/e2e_kubeadm/OWNERS
@@ -6,19 +6,19 @@ approvers:
 - fabriziopandini
 - neolit123
 - rosti
+- ereslibre
 reviewers:
 - luxas
 - timothysc
 - fabriziopandini
 - neolit123
 - kad
-- liztio
-- chuckha
 - detiber
 - dixudx
 - rosti
 - yagonobre
-- ereslibre 
+- ereslibre
+- SataQiu
 
 labels:
 - area/kubeadm


### PR DESCRIPTION
**What this PR does / why we need it**:
- comment out Liz and Chuck until further notice.
Feel free to come back to kubeadm!!
- Add SataQiu as reviewer. Welcome.
- Add ereslibre as approver. Congrats

SataQiu's PR to self promote.
https://github.com/kubernetes/kubernetes/pull/79167

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/hold
/assign @luxas @timothysc @fabriziopandini 
/kind cleanup
/priority important-soon
