### PR TITLE
kubeadm: Retire MarshalClusterConfigurationToBytes

### DIFF
--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -41,8 +41,6 @@ func MarshalKubeadmConfigObject(obj runtime.Object) ([]byte, error) {
 	switch internalcfg := obj.(type) {
 	case *kubeadmapi.InitConfiguration:
 		return MarshalInitConfigurationToBytes(internalcfg, kubeadmapiv1beta2.SchemeGroupVersion)
-	case *kubeadmapi.ClusterConfiguration:
-		return MarshalClusterConfigurationToBytes(internalcfg, kubeadmapiv1beta2.SchemeGroupVersion)
 	default:
 		return kubeadmutil.MarshalToYamlForCodecs(obj, kubeadmapiv1beta2.SchemeGroupVersion, kubeadmscheme.Codecs)
 	}

--- a/cmd/kubeadm/app/util/config/initconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration_test.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/pmezard/go-difflib/difflib"
@@ -198,95 +197,6 @@ func TestInitConfigurationMarshallingFromFile(t *testing.T) {
 	}
 }
 */
-
-func TestConsistentOrderByteSlice(t *testing.T) {
-	var (
-		aKind = "Akind"
-		aFile = []byte(`
-kind: Akind
-apiVersion: foo.k8s.io/v1
-`)
-		aaKind = "Aakind"
-		aaFile = []byte(`
-kind: Aakind
-apiVersion: foo.k8s.io/v1
-`)
-		abKind = "Abkind"
-		abFile = []byte(`
-kind: Abkind
-apiVersion: foo.k8s.io/v1
-`)
-	)
-	var tests = []struct {
-		name     string
-		in       map[string][]byte
-		expected [][]byte
-	}{
-		{
-			name: "a_aa_ab",
-			in: map[string][]byte{
-				aKind:  aFile,
-				aaKind: aaFile,
-				abKind: abFile,
-			},
-			expected: [][]byte{aaFile, abFile, aFile},
-		},
-		{
-			name: "a_ab_aa",
-			in: map[string][]byte{
-				aKind:  aFile,
-				abKind: abFile,
-				aaKind: aaFile,
-			},
-			expected: [][]byte{aaFile, abFile, aFile},
-		},
-		{
-			name: "aa_a_ab",
-			in: map[string][]byte{
-				aaKind: aaFile,
-				aKind:  aFile,
-				abKind: abFile,
-			},
-			expected: [][]byte{aaFile, abFile, aFile},
-		},
-		{
-			name: "aa_ab_a",
-			in: map[string][]byte{
-				aaKind: aaFile,
-				abKind: abFile,
-				aKind:  aFile,
-			},
-			expected: [][]byte{aaFile, abFile, aFile},
-		},
-		{
-			name: "ab_a_aa",
-			in: map[string][]byte{
-				abKind: abFile,
-				aKind:  aFile,
-				aaKind: aaFile,
-			},
-			expected: [][]byte{aaFile, abFile, aFile},
-		},
-		{
-			name: "ab_aa_a",
-			in: map[string][]byte{
-				abKind: abFile,
-				aaKind: aaFile,
-				aKind:  aFile,
-			},
-			expected: [][]byte{aaFile, abFile, aFile},
-		},
-	}
-
-	for _, rt := range tests {
-		t.Run(rt.name, func(t2 *testing.T) {
-			actual := consistentOrderByteSlice(rt.in)
-			if !reflect.DeepEqual(rt.expected, actual) {
-				t2.Errorf("the expected and actual output differs.\n\texpected: %s\n\tout: %s\n", rt.expected, actual)
-			}
-		})
-	}
-}
 
 func TestDefaultTaintsMarshaling(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:

MarshalClusterConfigurationToBytes has capabilities to output the component
configs, as separate YAML documents, besides the kubeadm ClusterConfiguration
kind. This is no longer necessary for the following reasons:

- All current use cases of this function require only the ClusterConfiguration.
- It will output component configs only if they are not the default ones. This
  can produce undeterministic output and, thus, cause potential problems.
- There are only hacky ways to dump the ClusterConfiguration only (without the
  component configs).

Hence, we simplify things by replacing the function with direct calls to the
underlaying MarshalToYamlForCodecs. Thus marshalling only ClusterConfiguration,
when needed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Although this change does not remove any dependencies, it's a necessary step to get kubeadm to use only versioned types for component configs (and not the internal types), which in turn does drop dependencies from `//pkg/...`.
Refs kubernetes/kubeadm#1600

**Special notes for your reviewer**:

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/priority important-soon
/assign @neolit123
/assign @fabriziopandini 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
