### PR TITLE
Support single logical operation in jsonpath

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/node.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/node.go
@@ -43,6 +43,7 @@ const (
 	NodeRecursive
 	NodeUnion
 	NodeBool
+	NodeLogical
 )
 
 var NodeTypeName = map[NodeType]string{
@@ -150,6 +151,26 @@ func newArray(params [3]ParamsEntry) *ArrayNode {
 
 func (a *ArrayNode) String() string {
 	return fmt.Sprintf("%s: %v", a.Type(), a.Params)
+}
+
+type LogicalNode struct {
+	NodeType
+	Left     *FilterNode
+	Right    *FilterNode
+	Operator string
+}
+
+func newLogical(left, right *FilterNode, operator string) *LogicalNode {
+	return &LogicalNode{
+		NodeType: NodeLogical,
+		Left:     left,
+		Right:    right,
+		Operator: operator,
+	}
+}
+
+func (l *LogicalNode) String() string {
+	return fmt.Sprintf("%s: %s %s %s", l.Type(), l.Left, l.Operator, l.Right)
 }
 
 // FilterNode holds operand and operator information for filter


### PR DESCRIPTION
Signed-off-by: Hannes Hörl <hhorl@pivotal.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR extends the jsonpath implementation in k/k to support a single logical (&& or ||) operation. Components that leverage that package (for example, kubectl) can then offer that to their users.

**Which issue(s) this PR fixes**:
It addresses part of https://github.com/kubernetes/kubernetes/issues/20352.

**Special notes for your reviewer**:
Opening this PR as WIP to start collecting feedback, however a few points remain to be completed:

Points to still cover as part of this PR
- [x] Support checking for field existence (not only field value equality) as part of the logical operation; i.e. support a syntax like`{.items[?(@.status.conditions[*].type == "Ready" && @.labels)].status.phase}`
- [x] Refactor duplication, particularly in `parser.go`
- [x] Test drive/cover any remaining error paths.
- [x] Add release note

Out of scope for this specific PR
* Support multiple chained logical operations

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubectl now supports a single logical expression (&& and ||) in any input offered in -o jsonpath={....}. For example, kubectl get pods  -o jsonpath='{.items[?(@.apiVersion == "v1" || @.apiVersion == "v2")].status.phase}' is now supported.
```
