### PR TITLE
Documentation on OutputFormatType references nonexistent file

### DIFF
--- a/pkg/printers/interface.go
+++ b/pkg/printers/interface.go
@@ -39,10 +39,6 @@ func (fn ResourcePrinterFunc) PrintObj(obj runtime.Object, w io.Writer) error {
 
 // PrintOptions struct defines a struct for various print options
 type PrintOptions struct {
-	// supported Format types can be found in pkg/printers/printers.go
-	OutputFormatType     string
-	OutputFormatArgument string
-
 	NoHeaders          bool
 	WithNamespace      bool
 	WithKind           bool


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Reviewing the PrintOptions in the printing package indicates more information can be found in `pkg/printers/printers.go`. This file was removed around the time of 1.10. The comment is no longer useful.

Fixes #

**Does this PR introduce a user-facing change?**:
NO

```release-note
NONE
```
