### PR TITLE
tests: Replaces images used with agnhost (part 3)

### DIFF
--- a/test/e2e/apimachinery/crd_conversion_webhook.go
+++ b/test/e2e/apimachinery/crd_conversion_webhook.go
@@ -134,7 +134,7 @@ var _ = SIGDescribe("CustomResourceConversionWebhook", func() {
 		context = setupServerCert(f.Namespace.Name, serviceCRDName)
 		createAuthReaderRoleBindingForCRDConversion(f, f.Namespace.Name)
 
-		deployCustomResourceWebhookAndService(f, imageutils.GetE2EImage(imageutils.CRDConversionWebhook), context)
+		deployCustomResourceWebhookAndService(f, imageutils.GetE2EImage(imageutils.Agnhost), context)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -269,11 +269,11 @@ func deployCustomResourceWebhookAndService(f *framework.Framework, image string,
 			Name:         "sample-crd-conversion-webhook",
 			VolumeMounts: mounts,
 			Args: []string{
+				"crd-conversion-webhook",
 				"--tls-cert-file=/webhook.local.config/certificates/tls.crt",
 				"--tls-private-key-file=/webhook.local.config/certificates/tls.key",
 				"--alsologtostderr",
 				"-v=4",
-				"2>&1",
 			},
 			Image: image,
 		},

--- a/test/e2e/apimachinery/table_conversion.go
+++ b/test/e2e/apimachinery/table_conversion.go
@@ -184,7 +184,8 @@ func newTablePod(podName string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  containerName,
-					Image: imageutils.GetE2EImage(imageutils.Porter),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"porter"},
 					Env:   []v1.EnvVar{{Name: fmt.Sprintf("SERVE_PORT_%d", port), Value: "foo"}},
 					Ports: []v1.ContainerPort{{ContainerPort: int32(port)}},
 				},

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -266,7 +266,7 @@ func testRollingUpdateDeployment(f *framework.Framework) {
 	rsRevision := "3546343826724305832"
 	annotations := make(map[string]string)
 	annotations[deploymentutil.RevisionAnnotation] = rsRevision
-	rs := newRS(rsName, replicas, rsPodLabels, WebserverImageName, WebserverImage)
+	rs := newRS(rsName, replicas, rsPodLabels, WebserverImageName, WebserverImage, nil)
 	rs.Annotations = annotations
 	e2elog.Logf("Creating replica set %q (going to be adopted)", rs.Name)
 	_, err := c.AppsV1().ReplicaSets(ns).Create(rs)
@@ -346,7 +346,7 @@ func testDeploymentCleanUpPolicy(f *framework.Framework) {
 	rsName := "test-cleanup-controller"
 	replicas := int32(1)
 	revisionHistoryLimit := utilpointer.Int32Ptr(0)
-	_, err := c.AppsV1().ReplicaSets(ns).Create(newRS(rsName, replicas, rsPodLabels, WebserverImageName, WebserverImage))
+	_, err := c.AppsV1().ReplicaSets(ns).Create(newRS(rsName, replicas, rsPodLabels, WebserverImageName, WebserverImage, nil))
 	framework.ExpectNoError(err)
 
 	// Verify that the required pods have come up.
@@ -417,7 +417,7 @@ func testRolloverDeployment(f *framework.Framework) {
 
 	rsName := "test-rollover-controller"
 	rsReplicas := int32(1)
-	_, err := c.AppsV1().ReplicaSets(ns).Create(newRS(rsName, rsReplicas, rsPodLabels, WebserverImageName, WebserverImage))
+	_, err := c.AppsV1().ReplicaSets(ns).Create(newRS(rsName, rsReplicas, rsPodLabels, WebserverImageName, WebserverImage, nil))
 	framework.ExpectNoError(err)
 	// Verify that the required pods have come up.
 	err = e2epod.VerifyPodsRunning(c, ns, podName, false, rsReplicas)

--- a/test/e2e/apps/network_partition.go
+++ b/test/e2e/apps/network_partition.go
@@ -87,6 +87,7 @@ func podOnNode(podName, nodeName string, image string) *v1.Pod {
 				{
 					Name:  podName,
 					Image: image,
+					Args:  []string{"serve-hostname"},
 					Ports: []v1.ContainerPort{{ContainerPort: 9376}},
 				},
 			},

--- a/test/e2e/auth/audit_dynamic.go
+++ b/test/e2e/auth/audit_dynamic.go
@@ -77,7 +77,8 @@ var _ = SIGDescribe("[Feature:DynamicAudit]", func() {
 				Containers: []v1.Container{
 					{
 						Name:  "proxy",
-						Image: imageutils.GetE2EImage(imageutils.AuditProxy),
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"audit-proxy"},
 						Ports: []v1.ContainerPort{
 							{
 								ContainerPort: 8080,

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -41,7 +41,6 @@ import (
 )
 
 var mountImage = imageutils.GetE2EImage(imageutils.Mounttest)
-var inClusterClientImage = imageutils.GetE2EImage(imageutils.InClusterClient)
 
 var _ = SIGDescribe("ServiceAccounts", func() {
 	f := framework.NewDefaultFramework("svcaccounts")
@@ -436,7 +435,8 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{{
 					Name:  "inclusterclient",
-					Image: inClusterClientImage,
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"inclusterclient"},
 					VolumeMounts: []v1.VolumeMount{{
 						MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
 						Name:      "kube-api-access-e2e",

--- a/test/e2e/common/docker_containers.go
+++ b/test/e2e/common/docker_containers.go
@@ -17,10 +17,13 @@ limitations under the License.
 package common
 
 import (
+	"github.com/onsi/gomega"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -33,9 +36,17 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 		Description: Default command and arguments from the docker image entrypoint MUST be used when Pod does not specify the container command
 	*/
 	framework.ConformanceIt("should use the image defaults if command and args are blank [NodeConformance]", func() {
-		f.TestContainerOutput("use defaults", entrypointTestPod(), 0, []string{
-			"[/ep default arguments]",
-		})
+		pod := f.PodClient().Create(entrypointTestPod())
+		err := e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+		framework.ExpectNoError(err, "Expected pod %q to be running, got error: %v", pod.Name, err)
+
+		pollLogs := func() (string, error) {
+			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, containerName)
+		}
+
+		// The agnhost's image default entrypoint / args are: "/agnhost pause"
+		// which will print out "Paused".
+		gomega.Eventually(pollLogs, 3, framework.Poll).Should(gomega.ContainSubstring("Paused"))
 	})
 
 	/*
@@ -45,10 +56,10 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 	*/
 	framework.ConformanceIt("should be able to override the image's default arguments (docker cmd) [NodeConformance]", func() {
 		pod := entrypointTestPod()
-		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
+		pod.Spec.Containers[0].Args = []string{"entrypoint-tester", "override", "arguments"}
 
 		f.TestContainerOutput("override arguments", pod, 0, []string{
-			"[/ep override arguments]",
+			"[/agnhost entrypoint-tester override arguments]",
 		})
 	})
 
@@ -61,10 +72,10 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 	*/
 	framework.ConformanceIt("should be able to override the image's default command (docker entrypoint) [NodeConformance]", func() {
 		pod := entrypointTestPod()
-		pod.Spec.Containers[0].Command = []string{"/ep-2"}
+		pod.Spec.Containers[0].Command = []string{"/agnhost-2", "entrypoint-tester"}
 
 		f.TestContainerOutput("override command", pod, 0, []string{
-			"[/ep-2]",
+			"[/agnhost-2 entrypoint-tester]",
 		})
 	})
 
@@ -75,11 +86,11 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 	*/
 	framework.ConformanceIt("should be able to override the image's default command and arguments [NodeConformance]", func() {
 		pod := entrypointTestPod()
-		pod.Spec.Containers[0].Command = []string{"/ep-2"}
-		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
+		pod.Spec.Containers[0].Command = []string{"/agnhost-2"}
+		pod.Spec.Containers[0].Args = []string{"entrypoint-tester", "override", "arguments"}
 
 		f.TestContainerOutput("override all", pod, 0, []string{
-			"[/ep-2 override arguments]",
+			"[/agnhost-2 entrypoint-tester override arguments]",
 		})
 	})
 })
@@ -99,7 +110,7 @@ func entrypointTestPod() *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  testContainerName,
-					Image: imageutils.GetE2EImage(imageutils.EntrypointTester),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 				},
 			},
 			RestartPolicy:                 v1.RestartPolicyNever,

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -54,14 +54,11 @@ var CurrentSuite Suite
 // TODO(random-liu): Change the image puller pod to use similar mechanism.
 var CommonImageWhiteList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.Agnhost),
-	imageutils.GetE2EImage(imageutils.AuditProxy),
 	imageutils.GetE2EImage(imageutils.BusyBox),
-	imageutils.GetE2EImage(imageutils.EntrypointTester),
 	imageutils.GetE2EImage(imageutils.IpcUtils),
 	imageutils.GetE2EImage(imageutils.Mounttest),
 	imageutils.GetE2EImage(imageutils.MounttestUser),
 	imageutils.GetE2EImage(imageutils.Nginx),
-	imageutils.GetE2EImage(imageutils.ServeHostname),
 	imageutils.GetE2EImage(imageutils.TestWebserver),
 	imageutils.GetE2EImage(imageutils.VolumeNFSServer),
 	imageutils.GetE2EImage(imageutils.VolumeGlusterServer),

--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -1236,6 +1236,7 @@ func StartServeHostnameService(c clientset.Interface, svc *v1.Service, ns string
 	config := testutils.RCConfig{
 		Client:               c,
 		Image:                ServeHostnameImage,
+		Command:              []string{"/agnhost", "serve-hostname"},
 		Name:                 name,
 		Namespace:            ns,
 		PollInterval:         3 * time.Second,

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -219,7 +219,7 @@ var (
 	}
 
 	// ServeHostnameImage is a serve hostname image name.
-	ServeHostnameImage = imageutils.GetE2EImage(imageutils.ServeHostname)
+	ServeHostnameImage = imageutils.GetE2EImage(imageutils.Agnhost)
 )
 
 // GetServicesProxyRequest returns a request for a service proxy.

--- a/test/e2e/lifecycle/addon_update.go
+++ b/test/e2e/lifecycle/addon_update.go
@@ -204,7 +204,7 @@ const (
 	addonNsName           = metav1.NamespaceSystem
 )
 
-var serveHostnameImage = imageutils.GetE2EImage(imageutils.ServeHostname)
+var serveHostnameImage = imageutils.GetE2EImage(imageutils.Agnhost)
 
 type stringPair struct {
 	data, fileName string

--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -640,7 +640,8 @@ func createServerPodAndService(f *framework.Framework, namespace *v1.Namespace, 
 		// Build the containers for the server pod.
 		containers = append(containers, v1.Container{
 			Name:  fmt.Sprintf("%s-container-%d", podName, port),
-			Image: imageutils.GetE2EImage(imageutils.Porter),
+			Image: imageutils.GetE2EImage(imageutils.Agnhost),
+			Args:  []string{"porter"},
 			Env: []v1.EnvVar{
 				{
 					Name:  fmt.Sprintf("SERVE_PORT_%d", port),

--- a/test/e2e/network/networking_perf.go
+++ b/test/e2e/network/networking_perf.go
@@ -69,7 +69,7 @@ func networkingIPerfTest(isIPv6 bool) {
 				return v1.PodSpec{
 					Containers: []v1.Container{{
 						Name:  "iperf-server",
-						Image: imageutils.GetE2EImage(imageutils.Iperf),
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
 						Args: []string{
 							"/bin/sh",
 							"-c",
@@ -97,7 +97,7 @@ func networkingIPerfTest(isIPv6 bool) {
 					Containers: []v1.Container{
 						{
 							Name:  "iperf-client",
-							Image: imageutils.GetE2EImage(imageutils.Iperf),
+							Image: imageutils.GetE2EImage(imageutils.Agnhost),
 							Args: []string{
 								"/bin/sh",
 								"-c",

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -125,7 +125,8 @@ var _ = SIGDescribe("Proxy", func() {
 			pods := []*v1.Pod{}
 			cfg := testutils.RCConfig{
 				Client:       f.ClientSet,
-				Image:        imageutils.GetE2EImage(imageutils.Porter),
+				Image:        imageutils.GetE2EImage(imageutils.Agnhost),
+				Command:      []string{"/agnhost", "porter"},
 				Name:         service.Name,
 				Namespace:    f.Namespace.Name,
 				Replicas:     1,

--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -61,6 +61,7 @@ var _ = SIGDescribe("Events", func() {
 					{
 						Name:  "p",
 						Image: framework.ServeHostnameImage,
+						Args:  []string{"serve-hostname"},
 						Ports: []v1.ContainerPort{{ContainerPort: 80}},
 					},
 				},

--- a/test/e2e/scalability/load.go
+++ b/test/e2e/scalability/load.go
@@ -176,24 +176,25 @@ var _ = SIGDescribe("Load capacity", func() {
 		quotas           bool
 	}
 
+	serveHostnameCmd := []string{"/agnhost", "serve-hostname"}
 	loadTests := []Load{
 		// The container will consume 1 cpu and 512mb of memory.
 		{podsPerNode: 3, image: "jess/stress", command: []string{"stress", "-c", "1", "-m", "2"}, kind: api.Kind("ReplicationController")},
-		{podsPerNode: 30, image: framework.ServeHostnameImage, kind: api.Kind("ReplicationController")},
+		{podsPerNode: 30, image: framework.ServeHostnameImage, command: serveHostnameCmd, kind: api.Kind("ReplicationController")},
 		// Tests for other resource types
-		{podsPerNode: 30, image: framework.ServeHostnameImage, kind: extensions.Kind("Deployment")},
-		{podsPerNode: 30, image: framework.ServeHostnameImage, kind: batch.Kind("Job")},
+		{podsPerNode: 30, image: framework.ServeHostnameImage, command: serveHostnameCmd, kind: extensions.Kind("Deployment")},
+		{podsPerNode: 30, image: framework.ServeHostnameImage, command: serveHostnameCmd, kind: batch.Kind("Job")},
 		// Test scheduling when daemons are preset
-		{podsPerNode: 30, image: framework.ServeHostnameImage, kind: api.Kind("ReplicationController"), daemonsPerNode: 2},
+		{podsPerNode: 30, image: framework.ServeHostnameImage, command: serveHostnameCmd, kind: api.Kind("ReplicationController"), daemonsPerNode: 2},
 		// Test with secrets
-		{podsPerNode: 30, image: framework.ServeHostnameImage, kind: extensions.Kind("Deployment"), secretsPerPod: 2},
+		{podsPerNode: 30, image: framework.ServeHostnameImage, command: serveHostnameCmd, kind: extensions.Kind("Deployment"), secretsPerPod: 2},
 		// Test with configmaps
-		{podsPerNode: 30, image: framework.ServeHostnameImage, kind: extensions.Kind("Deployment"), configMapsPerPod: 2},
+		{podsPerNode: 30, image: framework.ServeHostnameImage, command: serveHostnameCmd, kind: extensions.Kind("Deployment"), configMapsPerPod: 2},
 		// Special test case which randomizes created resources
-		{podsPerNode: 30, image: framework.ServeHostnameImage, kind: randomKind},
+		{podsPerNode: 30, image: framework.ServeHostnameImage, command: serveHostnameCmd, kind: randomKind},
 		// Test with quotas
-		{podsPerNode: 30, image: framework.ServeHostnameImage, kind: api.Kind("ReplicationController"), quotas: true},
-		{podsPerNode: 30, image: framework.ServeHostnameImage, kind: randomKind, quotas: true},
+		{podsPerNode: 30, image: framework.ServeHostnameImage, command: serveHostnameCmd, kind: api.Kind("ReplicationController"), quotas: true},
+		{podsPerNode: 30, image: framework.ServeHostnameImage, command: serveHostnameCmd, kind: randomKind, quotas: true},
 	}
 
 	isCanonical := func(test *Load) bool {

--- a/test/e2e/scheduling/ubernetes_lite.go
+++ b/test/e2e/scheduling/ubernetes_lite.go
@@ -56,7 +56,7 @@ var _ = SIGDescribe("Multi-AZ Clusters", func() {
 	})
 
 	ginkgo.It("should spread the pods of a replication controller across zones", func() {
-		SpreadRCOrFail(f, int32((2*zoneCount)+1), image)
+		SpreadRCOrFail(f, int32((2*zoneCount)+1), image, []string{"serve-hostname"})
 	})
 })
 
@@ -177,7 +177,7 @@ func checkZoneSpreading(c clientset.Interface, pods *v1.PodList, zoneNames []str
 
 // SpreadRCOrFail Check that the pods comprising a replication
 // controller get spread evenly across available zones
-func SpreadRCOrFail(f *framework.Framework, replicaCount int32, image string) {
+func SpreadRCOrFail(f *framework.Framework, replicaCount int32, image string, args []string) {
 	name := "ubelite-spread-rc-" + string(uuid.NewUUID())
 	ginkgo.By(fmt.Sprintf("Creating replication controller %s", name))
 	controller, err := f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(&v1.ReplicationController{
@@ -199,6 +199,7 @@ func SpreadRCOrFail(f *framework.Framework, replicaCount int32, image string) {
 						{
 							Name:  name,
 							Image: image,
+							Args:  args,
 							Ports: []v1.ContainerPort{{ContainerPort: 9376}},
 						},
 					},

--- a/test/e2e/upgrades/apps/daemonsets.go
+++ b/test/e2e/upgrades/apps/daemonsets.go
@@ -68,6 +68,7 @@ func (t *DaemonSetUpgradeTest) Setup(f *framework.Framework) {
 						{
 							Name:            daemonSetName,
 							Image:           image,
+							Args:            []string{"serve-hostname"},
 							Ports:           []v1.ContainerPort{{ContainerPort: 9376}},
 							SecurityContext: &v1.SecurityContext{},
 						},

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -44,13 +44,13 @@ const (
 // NodeImageWhiteList is a list of images used in node e2e test. These images will be prepulled
 // before test running so that the image pulling won't fail in actual test.
 var NodeImageWhiteList = sets.NewString(
+	imageutils.GetE2EImage(imageutils.Agnhost),
 	"google/cadvisor:latest",
 	"k8s.gcr.io/stress:v1",
 	busyboxImage,
 	"k8s.gcr.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff",
 	imageutils.GetE2EImage(imageutils.Nginx),
 	imageutils.GetE2EImage(imageutils.Perl),
-	imageutils.GetE2EImage(imageutils.ServeHostname),
 	imageutils.GetE2EImage(imageutils.Nonewprivs),
 	imageutils.GetPauseImageName(),
 	gpu.GetGPUDevicePluginImage(),

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -103,18 +103,14 @@ var (
 )
 
 const (
-	// CRDConversionWebhook image
-	CRDConversionWebhook = iota
 	// Agnhost image
-	Agnhost
+	Agnhost = iota
 	// Alpine image
 	Alpine
 	// APIServer image
 	APIServer
 	// AppArmorLoader image
 	AppArmorLoader
-	// AuditProxy image
-	AuditProxy
 	// AuthenticatedAlpine image
 	AuthenticatedAlpine
 	// AuthenticatedWindowsNanoServer image
@@ -133,8 +129,6 @@ const (
 	DebianBase
 	// EchoServer image
 	EchoServer
-	// EntrypointTester image
-	EntrypointTester
 	// Etcd image
 	Etcd
 	// GBFrontend image
@@ -145,16 +139,12 @@ const (
 	Httpd
 	// HttpdNew image
 	HttpdNew
-	// InClusterClient image
-	InClusterClient
 	// Invalid image
 	Invalid
 	// InvalidRegistryImage image
 	InvalidRegistryImage
 	// IpcUtils image
 	IpcUtils
-	// Iperf image
-	Iperf
 	// JessieDnsutils image
 	JessieDnsutils
 	// Kitten image
@@ -178,8 +168,6 @@ const (
 	Pause
 	// Perl image
 	Perl
-	// Porter image
-	Porter
 	// PrometheusDummyExporter image
 	PrometheusDummyExporter
 	// PrometheusToSd image
@@ -192,8 +180,6 @@ const (
 	ResourceController
 	// SdDummyExporter image
 	SdDummyExporter
-	// ServeHostname image
-	ServeHostname
 	// StartupScript image
 	StartupScript
 	// TestWebserver image
@@ -212,13 +198,11 @@ const (
 
 func initImageConfigs() map[int]Config {
 	configs := map[int]Config{}
-	configs[CRDConversionWebhook] = Config{e2eRegistry, "crd-conversion-webhook", "1.13rev2"}
-	configs[Agnhost] = Config{e2eRegistry, "agnhost", "2.1"}
+	configs[Agnhost] = Config{e2eRegistry, "agnhost", "2.2"}
 	configs[Alpine] = Config{dockerLibraryRegistry, "alpine", "3.7"}
 	configs[AuthenticatedAlpine] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[APIServer] = Config{e2eRegistry, "sample-apiserver", "1.10"}
 	configs[AppArmorLoader] = Config{e2eRegistry, "apparmor-loader", "1.0"}
-	configs[AuditProxy] = Config{e2eRegistry, "audit-proxy", "1.0"}
 	configs[BusyBox] = Config{dockerLibraryRegistry, "busybox", "1.29"}
 	configs[CheckMetadataConcealment] = Config{e2eRegistry, "metadata-concealment", "1.2"}
 	configs[CudaVectorAdd] = Config{e2eRegistry, "cuda-vector-add", "1.0"}
@@ -226,17 +210,14 @@ func initImageConfigs() map[int]Config {
 	configs[Dnsutils] = Config{e2eRegistry, "dnsutils", "1.1"}
 	configs[DebianBase] = Config{googleContainerRegistry, "debian-base", "0.4.1"}
 	configs[EchoServer] = Config{e2eRegistry, "echoserver", "2.2"}
-	configs[EntrypointTester] = Config{e2eRegistry, "entrypoint-tester", "1.0"}
 	configs[Etcd] = Config{gcRegistry, "etcd", "3.3.10"}
 	configs[GBFrontend] = Config{sampleRegistry, "gb-frontend", "v6"}
 	configs[GBRedisSlave] = Config{sampleRegistry, "gb-redisslave", "v3"}
 	configs[Httpd] = Config{dockerLibraryRegistry, "httpd", "2.4.38-alpine"}
 	configs[HttpdNew] = Config{dockerLibraryRegistry, "httpd", "2.4.39-alpine"}
-	configs[InClusterClient] = Config{e2eRegistry, "inclusterclient", "1.0"}
 	configs[Invalid] = Config{gcRegistry, "invalid-image", "invalid-tag"}
 	configs[InvalidRegistryImage] = Config{invalidRegistry, "alpine", "3.1"}
 	configs[IpcUtils] = Config{e2eRegistry, "ipc-utils", "1.0"}
-	configs[Iperf] = Config{e2eRegistry, "iperf", "1.0"}
 	configs[JessieDnsutils] = Config{e2eRegistry, "jessie-dnsutils", "1.0"}
 	configs[Kitten] = Config{e2eRegistry, "kitten", "1.0"}
 	configs[Mounttest] = Config{e2eRegistry, "mounttest", "1.0"}
@@ -249,14 +230,12 @@ func initImageConfigs() map[int]Config {
 	// Pause - when these values are updated, also update cmd/kubelet/app/options/container_runtime.go
 	configs[Pause] = Config{gcRegistry, "pause", "3.1"}
 	configs[Perl] = Config{dockerLibraryRegistry, "perl", "5.26"}
-	configs[Porter] = Config{e2eRegistry, "porter", "1.0"}
 	configs[PrometheusDummyExporter] = Config{e2eRegistry, "prometheus-dummy-exporter", "v0.1.0"}
 	configs[PrometheusToSd] = Config{e2eRegistry, "prometheus-to-sd", "v0.5.0"}
 	configs[Redis] = Config{e2eRegistry, "redis", "1.0"}
 	configs[ResourceConsumer] = Config{e2eRegistry, "resource-consumer", "1.5"}
 	configs[ResourceController] = Config{e2eRegistry, "resource-consumer-controller", "1.0"}
 	configs[SdDummyExporter] = Config{gcRegistry, "sd-dummy-exporter", "v0.2.0"}
-	configs[ServeHostname] = Config{e2eRegistry, "serve-hostname", "1.1"}
 	configs[StartupScript] = Config{googleContainerRegistry, "startup-script", "v1"}
 	configs[TestWebserver] = Config{e2eRegistry, "test-webserver", "1.0"}
 	configs[VolumeNFSServer] = Config{e2eRegistry, "volume/nfs", "1.0"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

/sig testing

**What this PR does / why we need it**:

Quite a few images are only used a few times in a few tests. Thus, the images are being centralized into the agnhost image, reducing the number of images that have to be pulled and used.

This PR replaces the usage of the following images with agnhost:

- audit-proxy
- crd-conversion-webhook
- entrypoint-tester
- inclusterclient
- iperf
- porter
- serve-hostname

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially Fixes #76342
Depends On: #79142

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE 
```
