### PR TITLE
default logging flags in scheduler_perf

### DIFF
--- a/test/integration/scheduler_perf/.gitignore
+++ b/test/integration/scheduler_perf/.gitignore
@@ -1,0 +1,2 @@
+# ignore log files
+scheduler_perf.test.*

--- a/test/integration/scheduler_perf/main_test.go
+++ b/test/integration/scheduler_perf/main_test.go
@@ -17,10 +17,19 @@ limitations under the License.
 package benchmark
 
 import (
+	"flag"
 	"testing"
 
 	"k8s.io/kubernetes/test/integration/framework"
 )
+
+func init() {
+	// default logging flags to more reasonable values for this test
+	flag.Set("v", "1")
+	flag.Set("logtostderr", "false")
+	flag.Set("log_dir", ".")
+	flag.Parse()
+}
 
 func TestMain(m *testing.M) {
 	framework.EtcdMain(m.Run)

--- a/test/integration/scheduler_perf/test-performance.sh
+++ b/test/integration/scheduler_perf/test-performance.sh
@@ -43,10 +43,10 @@ if ${RUN_BENCHMARK:-false}; then
   go test -c -o "perf.test"
 
   kube::log::status "performance test (benchmark) start"
-  "./perf.test" -test.bench=. -test.run=xxxx -test.cpuprofile=prof.out -test.short=false
+  "./perf.test" -test.bench=. -test.run=xxxx -test.cpuprofile=prof.out -test.short=false -args "$@"
   kube::log::status "...benchmark tests finished"
 fi
 # Running density tests. It might take a long time.
 kube::log::status "performance test (density) start"
-go test -test.run=. -test.timeout=60m -test.short=false
+go test -test.run=. -test.timeout=60m -test.short=false -args "$@"
 kube::log::status "...density tests finished"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: alternative to https://github.com/kubernetes/kubernetes/pull/78462

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
