### PR TITLE
Kubelet enabling to support pod-overhead

### DIFF
--- a/pkg/api/v1/resource/BUILD
+++ b/pkg/api/v1/resource/BUILD
@@ -11,8 +11,12 @@ go_test(
     srcs = ["helpers_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )
@@ -22,8 +26,10 @@ go_library(
     srcs = ["helpers.go"],
     importpath = "k8s.io/kubernetes/pkg/api/v1/resource",
     deps = [
+        "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/api/v1/resource/helpers_test.go
+++ b/pkg/api/v1/resource/helpers_test.go
@@ -71,12 +71,12 @@ func TestGetResourceRequest(t *testing.T) {
 		expectedError error
 	}{
 		{
-			pod:           getPod("foo", "9", "", "", ""),
+			pod:           getPod("foo", podResources{cpuRequest: "9"}),
 			res:           v1.ResourceCPU,
 			expectedValue: 9000,
 		},
 		{
-			pod:           getPod("foo", "", "", "90Mi", ""),
+			pod:           getPod("foo", podResources{memoryRequest: "90Mi"}),
 			res:           v1.ResourceMemory,
 			expectedValue: 94371840,
 		},
@@ -101,7 +101,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Resource: "limits.cpu",
 			},
 			cName:         "foo",
-			pod:           getPod("foo", "", "9", "", ""),
+			pod:           getPod("foo", podResources{cpuLimit: "9"}),
 			expectedValue: "9",
 		},
 		{
@@ -109,7 +109,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Resource: "requests.cpu",
 			},
 			cName:         "foo",
-			pod:           getPod("foo", "", "", "", ""),
+			pod:           getPod("foo", podResources{}),
 			expectedValue: "0",
 		},
 		{
@@ -117,7 +117,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Resource: "requests.cpu",
 			},
 			cName:         "foo",
-			pod:           getPod("foo", "8", "", "", ""),
+			pod:           getPod("foo", podResources{cpuRequest: "8"}),
 			expectedValue: "8",
 		},
 		{
@@ -125,7 +125,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Resource: "requests.cpu",
 			},
 			cName:         "foo",
-			pod:           getPod("foo", "100m", "", "", ""),
+			pod:           getPod("foo", podResources{cpuRequest: "100m"}),
 			expectedValue: "1",
 		},
 		{
@@ -134,7 +134,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Divisor:  resource.MustParse("100m"),
 			},
 			cName:         "foo",
-			pod:           getPod("foo", "1200m", "", "", ""),
+			pod:           getPod("foo", podResources{cpuRequest: "1200m"}),
 			expectedValue: "12",
 		},
 		{
@@ -142,7 +142,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Resource: "requests.memory",
 			},
 			cName:         "foo",
-			pod:           getPod("foo", "", "", "100Mi", ""),
+			pod:           getPod("foo", podResources{memoryRequest: "100Mi"}),
 			expectedValue: "104857600",
 		},
 		{
@@ -151,7 +151,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Divisor:  resource.MustParse("1Mi"),
 			},
 			cName:         "foo",
-			pod:           getPod("foo", "", "", "100Mi", "1Gi"),
+			pod:           getPod("foo", podResources{memoryRequest: "100Mi", memoryLimit: "1Gi"}),
 			expectedValue: "100",
 		},
 		{
@@ -159,7 +159,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Resource: "limits.memory",
 			},
 			cName:         "foo",
-			pod:           getPod("foo", "", "", "10Mi", "100Mi"),
+			pod:           getPod("foo", podResources{memoryRequest: "10Mi", memoryLimit: "100Mi"}),
 			expectedValue: "104857600",
 		},
 		{
@@ -167,7 +167,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Resource: "limits.cpu",
 			},
 			cName:         "init-foo",
-			pod:           getPod("foo", "", "9", "", ""),
+			pod:           getPod("foo", podResources{cpuLimit: "9"}),
 			expectedValue: "9",
 		},
 		{
@@ -175,7 +175,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Resource: "requests.cpu",
 			},
 			cName:         "init-foo",
-			pod:           getPod("foo", "", "", "", ""),
+			pod:           getPod("foo", podResources{}),
 			expectedValue: "0",
 		},
 		{
@@ -183,7 +183,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Resource: "requests.cpu",
 			},
 			cName:         "init-foo",
-			pod:           getPod("foo", "8", "", "", ""),
+			pod:           getPod("foo", podResources{cpuRequest: "8"}),
 			expectedValue: "8",
 		},
 		{
@@ -191,7 +191,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Resource: "requests.cpu",
 			},
 			cName:         "init-foo",
-			pod:           getPod("foo", "100m", "", "", ""),
+			pod:           getPod("foo", podResources{cpuRequest: "100m"}),
 			expectedValue: "1",
 		},
 		{
@@ -200,7 +200,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Divisor:  resource.MustParse("100m"),
 			},
 			cName:         "init-foo",
-			pod:           getPod("foo", "1200m", "", "", ""),
+			pod:           getPod("foo", podResources{cpuRequest: "1200m"}),
 			expectedValue: "12",
 		},
 		{
@@ -208,7 +208,7 @@ func TestExtractResourceValue(t *testing.T) {
 				Resource: "requests.memory",
 			},
 			cName:         "init-foo",
-			pod:           getPod("foo", "", "", "100Mi", ""),
+			pod:           getPod("foo", podResources{memoryRequest: "100Mi"}),
 			expectedValue: "104857600",
 		},
 		{
@@ -217,15 +217,16 @@ func TestExtractResourceValue(t *testing.T) {
 				Divisor:  resource.MustParse("1Mi"),
 			},
 			cName:         "init-foo",
-			pod:           getPod("foo", "", "", "100Mi", "1Gi"),
+			pod:           getPod("foo", podResources{memoryRequest: "100Mi", memoryLimit: "1Gi"}),
 			expectedValue: "100",
 		},
 		{
 			fs: &v1.ResourceFieldSelector{
 				Resource: "limits.memory",
 			},
-			cName:         "init-foo",
-			pod:           getPod("foo", "", "", "10Mi", "100Mi"),
+			cName: "init-foo",
+			pod:   getPod("foo", podResources{memoryRequest: "10Mi", memoryLimit: "100Mi"}),
+
 			expectedValue: "104857600",
 		},
 	}
@@ -241,35 +242,39 @@ func TestExtractResourceValue(t *testing.T) {
 	}
 }
 
-func getPod(cname, cpuRequest, cpuLimit, memoryRequest, memoryLimit string) *v1.Pod {
-	resources := v1.ResourceRequirements{
+type podResources struct {
+	cpuRequest, cpuLimit, memoryRequest, memoryLimit, cpuOverhead, memoryOverhead string
+}
+
+func getPod(cname string, resources podResources) *v1.Pod {
+	r := v1.ResourceRequirements{
 		Limits:   make(v1.ResourceList),
 		Requests: make(v1.ResourceList),
 	}
-	if cpuLimit != "" {
-		resources.Limits[v1.ResourceCPU] = resource.MustParse(cpuLimit)
+	if resources.cpuLimit != "" {
+		r.Limits[v1.ResourceCPU] = resource.MustParse(resources.cpuLimit)
 	}
-	if memoryLimit != "" {
-		resources.Limits[v1.ResourceMemory] = resource.MustParse(memoryLimit)
+	if resources.memoryLimit != "" {
+		r.Limits[v1.ResourceMemory] = resource.MustParse(resources.memoryLimit)
 	}
-	if cpuRequest != "" {
-		resources.Requests[v1.ResourceCPU] = resource.MustParse(cpuRequest)
+	if resources.cpuRequest != "" {
+		r.Requests[v1.ResourceCPU] = resource.MustParse(resources.cpuRequest)
 	}
-	if memoryRequest != "" {
-		resources.Requests[v1.ResourceMemory] = resource.MustParse(memoryRequest)
+	if resources.memoryRequest != "" {
+		r.Requests[v1.ResourceMemory] = resource.MustParse(resources.memoryRequest)
 	}
 	return &v1.Pod{
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
 					Name:      cname,
-					Resources: resources,
+					Resources: r,
 				},
 			},
 			InitContainers: []v1.Container{
 				{
 					Name:      "init-" + cname,
-					Resources: resources,
+					Resources: r,
 				},
 			},
 		},

--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -25,9 +25,8 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/features"
+	v1resource "k8s.io/kubernetes/pkg/api/v1/resource"
 	statsapi "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -536,8 +535,8 @@ func exceedMemoryRequests(stats statsFunc) cmpFunc {
 
 		p1Memory := memoryUsage(p1Stats.Memory)
 		p2Memory := memoryUsage(p2Stats.Memory)
-		p1ExceedsRequests := p1Memory.Cmp(podRequest(p1, v1.ResourceMemory)) == 1
-		p2ExceedsRequests := p2Memory.Cmp(podRequest(p2, v1.ResourceMemory)) == 1
+		p1ExceedsRequests := p1Memory.Cmp(v1resource.GetResourceRequestQuantity(p1, v1.ResourceMemory)) == 1
+		p2ExceedsRequests := p2Memory.Cmp(v1resource.GetResourceRequestQuantity(p2, v1.ResourceMemory)) == 1
 		// prioritize evicting the pod which exceeds its requests
 		return cmpBool(p1ExceedsRequests, p2ExceedsRequests)
 	}
@@ -555,51 +554,16 @@ func memory(stats statsFunc) cmpFunc {
 
 		// adjust p1, p2 usage relative to the request (if any)
 		p1Memory := memoryUsage(p1Stats.Memory)
-		p1Request := podRequest(p1, v1.ResourceMemory)
+		p1Request := v1resource.GetResourceRequestQuantity(p1, v1.ResourceMemory)
 		p1Memory.Sub(p1Request)
 
 		p2Memory := memoryUsage(p2Stats.Memory)
-		p2Request := podRequest(p2, v1.ResourceMemory)
+		p2Request := v1resource.GetResourceRequestQuantity(p2, v1.ResourceMemory)
 		p2Memory.Sub(p2Request)
 
 		// prioritize evicting the pod which has the larger consumption of memory
 		return p2Memory.Cmp(*p1Memory)
 	}
-}
-
-// podRequest returns the total resource request of a pod which is the
-// max(max of init container requests, sum of container requests)
-func podRequest(pod *v1.Pod, resourceName v1.ResourceName) resource.Quantity {
-	containerValue := resource.Quantity{Format: resource.BinarySI}
-	if resourceName == v1.ResourceEphemeralStorage && !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
-		// if the local storage capacity isolation feature gate is disabled, pods request 0 disk
-		return containerValue
-	}
-	for i := range pod.Spec.Containers {
-		switch resourceName {
-		case v1.ResourceMemory:
-			containerValue.Add(*pod.Spec.Containers[i].Resources.Requests.Memory())
-		case v1.ResourceEphemeralStorage:
-			containerValue.Add(*pod.Spec.Containers[i].Resources.Requests.StorageEphemeral())
-		}
-	}
-	initValue := resource.Quantity{Format: resource.BinarySI}
-	for i := range pod.Spec.InitContainers {
-		switch resourceName {
-		case v1.ResourceMemory:
-			if initValue.Cmp(*pod.Spec.InitContainers[i].Resources.Requests.Memory()) < 0 {
-				initValue = *pod.Spec.InitContainers[i].Resources.Requests.Memory()
-			}
-		case v1.ResourceEphemeralStorage:
-			if initValue.Cmp(*pod.Spec.InitContainers[i].Resources.Requests.StorageEphemeral()) < 0 {
-				initValue = *pod.Spec.InitContainers[i].Resources.Requests.StorageEphemeral()
-			}
-		}
-	}
-	if containerValue.Cmp(initValue) > 0 {
-		return containerValue
-	}
-	return initValue
 }
 
 // exceedDiskRequests compares whether or not pods' disk usage exceeds their requests
@@ -621,8 +585,8 @@ func exceedDiskRequests(stats statsFunc, fsStatsToMeasure []fsStatsType, diskRes
 
 		p1Disk := p1Usage[diskResource]
 		p2Disk := p2Usage[diskResource]
-		p1ExceedsRequests := p1Disk.Cmp(podRequest(p1, diskResource)) == 1
-		p2ExceedsRequests := p2Disk.Cmp(podRequest(p2, diskResource)) == 1
+		p1ExceedsRequests := p1Disk.Cmp(v1resource.GetResourceRequestQuantity(p1, diskResource)) == 1
+		p2ExceedsRequests := p2Disk.Cmp(v1resource.GetResourceRequestQuantity(p2, diskResource)) == 1
 		// prioritize evicting the pod which exceeds its requests
 		return cmpBool(p1ExceedsRequests, p2ExceedsRequests)
 	}
@@ -647,9 +611,9 @@ func disk(stats statsFunc, fsStatsToMeasure []fsStatsType, diskResource v1.Resou
 		// adjust p1, p2 usage relative to the request (if any)
 		p1Disk := p1Usage[diskResource]
 		p2Disk := p2Usage[diskResource]
-		p1Request := podRequest(p1, v1.ResourceEphemeralStorage)
+		p1Request := v1resource.GetResourceRequestQuantity(p1, v1.ResourceEphemeralStorage)
 		p1Disk.Sub(p1Request)
-		p2Request := podRequest(p2, v1.ResourceEphemeralStorage)
+		p2Request := v1resource.GetResourceRequestQuantity(p2, v1.ResourceEphemeralStorage)
 		p2Disk.Sub(p2Request)
 		// prioritize evicting the pod which has the larger consumption of disk
 		return p2Disk.Cmp(p1Disk)


### PR DESCRIPTION
Pod and burstable QoS cgroups should take overhead of running a sandbox
into account if the PodOverhead feature is enabled. Update helper
functions which are utilized by Kubelet for sizing the pod and burstable QoS
cgroups as well as for eviction and preemption handling.

While enabling PodOverhead support, refactored a couple of functions to remove duplicated logic and improve test coverage (ie, have eviction handling use the resources package).

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Pod and burstable QoS cgroups should take overhead of running a sandbox
into account if the PodOverhead feature is enabled. Similarly, pod overhead should be considered within the eviction handling in Kubernetes.  

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


```release-note
Introduce support for applying pod overhead to pod cgroups, if the PodOverhead feature is enabled.
```
