### PR TITLE
Remove redundant initilization for service controller

### DIFF
--- a/pkg/controller/service/service_controller_test.go
+++ b/pkg/controller/service/service_controller_test.go
@@ -82,7 +82,6 @@ func newController() (*ServiceController, *fakecloud.Cloud, *fake.Clientset) {
 	controller.serviceListerSynced = alwaysReady
 	controller.eventRecorder = record.NewFakeRecorder(100)
 
-	controller.init()
 	cloud.Calls = nil     // ignore any cloud calls made in init()
 	client.ClearActions() // ignore any client calls made in init()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Service controller no need to initilize again after itself be created by `New(...)`，as initilization has been done in `New(...)`。
https://github.com/kubernetes/kubernetes/blob/0f2b01ab3387c52fa60da2367b632805532e3553/pkg/controller/service/service_controller.go#L165-L169


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
