### PR TITLE
feat: remove several types in runtime serializer

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -268,7 +268,3 @@ func (f WithoutConversionCodecFactory) DecoderToVersion(serializer runtime.Decod
 		Decoder: serializer,
 	}
 }
-
-// DirectCodecFactory was renamed to WithoutConversionCodecFactory in 1.15.
-// TODO: remove in 1.16.
-type DirectCodecFactory = WithoutConversionCodecFactory

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -230,11 +230,3 @@ func (c *codec) Encode(obj runtime.Object, w io.Writer) error {
 	// Conversion is responsible for setting the proper group, version, and kind onto the outgoing object
 	return c.encoder.Encode(out, w)
 }
-
-// DirectEncoder was moved and renamed to runtime.WithVersionEncoder in 1.15.
-// TODO: remove in 1.16.
-type DirectEncoder = runtime.WithVersionEncoder
-
-// DirectDecoder was moved and renamed to runtime.WithoutVersionDecoder in 1.15.
-// TODO: remove in 1.16.
-type DirectDecoder = runtime.WithoutVersionDecoder


### PR DESCRIPTION
/kind cleanup
/priority backlog
/milestone 1.16

**What this PR does / why we need it**:

Remove several types in runtime serializer

```release-note
Remove DirectCodecFactory(replace with serializer.WithoutConversionCodecFactory), DirectEncoder(replace with runtime.WithVersionEncoder) and DirectDecoder(replace with runtime.WithoutVersionDecoder). action required
```
