### PR TITLE
Reload apiserver certificates from disk when they change

### DIFF
--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0
 	github.com/emicklei/go-restful v2.9.5+incompatible
 	github.com/evanphx/json-patch v4.2.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-openapi/spec v0.19.2
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d
 	github.com/google/go-cmp v0.3.0

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -112,6 +112,7 @@ go_library(
         "//vendor/github.com/coreos/go-systemd/daemon:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",
+        "//vendor/github.com/fsnotify/fsnotify:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/golang.org/x/net/http2:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback.go
@@ -71,7 +71,12 @@ func (s *SecureServingOptionsWithLoopback) ApplyTo(secureServingInfo **server.Se
 
 	default:
 		*loopbackClientConfig = secureLoopbackClientConfig
-		(*secureServingInfo).SNICerts[server.LoopbackClientServerNameOverride] = &tlsCert
+
+		// We write to the start of the SNICerts slice, so that we are guaranteed the `apiserver-loopback-client` map key
+		(*secureServingInfo).SNICerts = append([]server.CertKey{{
+			Names:  []string{server.LoopbackClientServerNameOverride},
+			Static: &tlsCert,
+		}}, (*secureServingInfo).SNICerts...)
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR is intended to allow apiserver serving certificates and client CA to be reloaded from disk. We do this based on a file watch. This will make it it easier to rotate these certificates without any downtime. 

1. Instead of reading cert files into `*tls.Certificate` objects, instead generate a `GetConfigForClient` function which reads config from an `atomic.Value`
2. Reload the `tls.Config` synchronously on first call, and then subsequently whenever a channel fires indicating that the config is stale, because of a filewatch update on any constituent file of the config.

**Which issue(s) this PR fixes**:
Fixes #66448

**Special notes for your reviewer**:
This approach was discussed briefly in the June 12th 2019 sig auth meeting - watching that could be useful context.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Reload apiserver serving certificates when they change on disk.
```