### PR TITLE
publishing: fix rules for kubectl

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -641,6 +641,6 @@ rules:
     go: 1.12.5
     dependencies:
       - repository: apimachinery
-        branch: master
+        branch: release-1.15
       - repository: client-go
-        branch: master
+        branch: release-12.0


### PR DESCRIPTION
`release-1.15` of kubectl should depend on `release-1.15` branch of it's dependencies, not master.

/assign @dims @sttts @soltysh @seans3 @monopole 
/priority critical-urgent
/kind bug
/sig cli

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
