### PR TITLE
Only delete the cache upon successful load balancer deletion

### DIFF
--- a/pkg/controller/service/service_controller_test.go
+++ b/pkg/controller/service/service_controller_test.go
@@ -317,7 +317,7 @@ func TestSyncLoadBalancerIfNeeded(t *testing.T) {
 			}
 			client.ClearActions()
 
-			op, err := controller.syncLoadBalancerIfNeeded(tc.service, key)
+			op, err, _ := controller.syncLoadBalancerIfNeeded(tc.service, key)
 			if err != nil {
 				t.Errorf("Got error: %v, want nil", err)
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In ServiceController#processServiceCreateOrUpdate, currently we remove load balancer from cache even if the load balancer is not deleted.

This PR makes the removal from cache conditional on the result of load balancer deletion.

```release-note
"NONE
```
