### PR TITLE
Use RWMutex to improve locking for serviceCache

### DIFF
--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -78,7 +78,7 @@ type cachedService struct {
 }
 
 type serviceCache struct {
-	mu         sync.Mutex // protects serviceMap
+	mu         sync.RWMutex // protects serviceMap
 	serviceMap map[string]*cachedService
 }
 
@@ -378,8 +378,8 @@ func (s *ServiceController) ensureLoadBalancer(service *v1.Service) (*v1.LoadBal
 // ListKeys implements the interface required by DeltaFIFO to list the keys we
 // already know about.
 func (s *serviceCache) ListKeys() []string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	keys := make([]string, 0, len(s.serviceMap))
 	for k := range s.serviceMap {
 		keys = append(keys, k)
@@ -389,8 +389,8 @@ func (s *serviceCache) ListKeys() []string {
 
 // GetByKey returns the value stored in the serviceMap under the given key
 func (s *serviceCache) GetByKey(key string) (interface{}, bool, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if v, ok := s.serviceMap[key]; ok {
 		return v, true, nil
 	}
@@ -400,8 +400,8 @@ func (s *serviceCache) GetByKey(key string) (interface{}, bool, error) {
 // ListKeys implements the interface required by DeltaFIFO to list the keys we
 // already know about.
 func (s *serviceCache) allServices() []*v1.Service {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	services := make([]*v1.Service, 0, len(s.serviceMap))
 	for _, v := range s.serviceMap {
 		services = append(services, v.state)
@@ -410,8 +410,8 @@ func (s *serviceCache) allServices() []*v1.Service {
 }
 
 func (s *serviceCache) get(serviceName string) (*cachedService, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	service, ok := s.serviceMap[serviceName]
 	return service, ok
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In serviceCache, we can utilize RWMutex to improve efficiency of locking.

```release-note
NONE
```
