### PR TITLE
Improve no resource found error messages for `get` command

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -570,7 +570,10 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 	w.Flush()
 	if trackingWriter.Written == 0 && !o.IgnoreNotFound && len(allErrs) == 0 {
 		// if we wrote no output, and had no errors, and are not ignoring NotFound, be sure we output something
-		fmt.Fprintln(o.ErrOut, "No resources found.")
+
+		resourceType := args[0]
+		fmt.Fprintf(o.ErrOut, "No %s found in namespace %s.\n", resourceType, o.Namespace)
+
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -570,10 +570,8 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 	w.Flush()
 	if trackingWriter.Written == 0 && !o.IgnoreNotFound && len(allErrs) == 0 {
 		// if we wrote no output, and had no errors, and are not ignoring NotFound, be sure we output something
-
 		resourceType := args[0]
 		fmt.Fprintf(o.ErrOut, "No %s found in namespace %s.\n", resourceType, o.Namespace)
-
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/get/get_test.go
+++ b/pkg/kubectl/cmd/get/get_test.go
@@ -357,12 +357,20 @@ func TestGetEmptyTable(t *testing.T) {
 		defaultNamespace string
 		expectedErr      string
 	}{
-		{cmdArg: "pods", defaultNamespace: "test", expectedErr: `No pods found in namespace test.
-`},
-		{cmdArg: "deployment", defaultNamespace: "anotherTestNamespace", expectedErr: `No deployment found in namespace anotherTestNamespace.
-`},
-		{cmdArg: "services", defaultNamespace: "anotherTestNamespace2", expectedErr: `No services found in namespace anotherTestNamespace2.
-`},
+		{
+			cmdArg:           "pods",
+			defaultNamespace: "test",
+			expectedErr:      "No pods found in namespace test.\n"},
+		{
+			cmdArg:           "deployment",
+			defaultNamespace: "anotherTestNamespace",
+			expectedErr:      "No deployment found in namespace anotherTestNamespace.\n",
+		},
+		{
+			cmdArg:           "services",
+			defaultNamespace: "anotherTestNamespace2",
+			expectedErr:      "No services found in namespace anotherTestNamespace2.\n",
+		},
 	}
 	for _, td := range testData {
 		testName := "No " + td.cmdArg + " in namespace " + td.defaultNamespace

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -77,16 +77,16 @@ run_kubectl_get_tests() {
   kube::test::if_has_not_string "${output_message}" 'No resources found'
   # Command
   output_message=$(kubectl get pods 2>&1 "${kube_flags[@]}")
-  # Post-condition: The text "No resources found" should be part of the output
-  kube::test::if_has_string "${output_message}" 'No resources found'
+  # Post-condition: The text "No pods found in namespace default" should be part of the output
+  kube::test::if_has_string "${output_message}" 'No pods found in namespace default'
   # Command
   output_message=$(kubectl get pods --ignore-not-found 2>&1 "${kube_flags[@]}")
   # Post-condition: The text "No resources found" should not be part of the output
   kube::test::if_has_not_string "${output_message}" 'No resources found'
   # Command
   output_message=$(kubectl get pods 2>&1 "${kube_flags[@]}" -o wide)
-  # Post-condition: The text "No resources found" should be part of the output
-  kube::test::if_has_string "${output_message}" 'No resources found'
+  # Post-condition: The text "No pods found in namespace default" should be part of the output
+  kube::test::if_has_string "${output_message}" 'No pods found in namespace default'
 
   ### Test retrieval of non-existing POD with json output flag specified
   # Pre-condition: no POD exists


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
explicit error message to make it easier to notice when the user is searching resources in the wrong place


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
"no resource found" error messages for `get` command now mention the kind of resource and the namespace in which the command looked for
```
