### PR TITLE
envar support for Master service of type ExternalName

### DIFF
--- a/pkg/kubelet/envvars/BUILD
+++ b/pkg/kubelet/envvars/BUILD
@@ -26,6 +26,7 @@ go_test(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -515,7 +515,7 @@ func (kl *Kubelet) getServiceEnvVarMap(ns string, enableServiceLinks bool) (map[
 		service := services[i]
 		// ignore services where ClusterIP is "None" or empty.
 		// Exception is made for the master service, which can be of type "ExternalName".
-		if !kl.filterService(service) {
+		if !kl.validateService(service) {
 			continue
 		}
 		serviceName := service.Name
@@ -549,11 +549,11 @@ func (kl *Kubelet) isMasterService(svc *v1.Service) bool {
 	return svc.Namespace == kl.masterServiceNamespace && masterService == svc.Name
 }
 
-// filterService returns true for a service if
+// validateService returns true for a service if
 // its ClusterIP is not "None" or empty
 // OR
 // it's the master service AND its ExternalName is not empty.
-func (kl *Kubelet) filterService(svc *v1.Service) bool {
+func (kl *Kubelet) validateService(svc *v1.Service) bool {
 	return v1helper.IsServiceIPSet(svc) ||
 		(kl.isMasterService(svc) && svc.Spec.Type == v1.ServiceTypeExternalName && svc.Spec.ExternalName != "")
 }

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -1798,7 +1798,7 @@ func TestIsMasterService(t *testing.T) {
 	}
 }
 
-func TestFilterService(t *testing.T) {
+func TestValidateService(t *testing.T) {
 	tcc := []struct {
 		testName      string
 		clusterIPSet  bool
@@ -1858,7 +1858,7 @@ func TestFilterService(t *testing.T) {
 			}
 
 			kl := Kubelet{masterServiceNamespace: masterNamespace}
-			isMaster := kl.filterService(svc)
+			isMaster := kl.validateService(svc)
 
 			assert.Equal(t, tc.expected, isMaster)
 		})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Allows cluster admins which disable the master endpoint reconciliation with `--endpoint-reconciler-type=none` to set `default/kubernetes` service of type `ExternalName`. Pods get the correct environment variables `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` set on them.

**Which issue(s) this PR fixes**:

Fixes #79280
Related issue https://github.com/kubernetes/kubernetes/issues/60535#issuecomment-375114468 

**Special notes for your reviewer**:

n/a

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix service environment variable injection into pods to allow for the master `default/kubernetes` service to be of type `ExternalName`. 
```

/sig node
