### PR TITLE
fix: Use correct function to remove etcd member

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember.go
@@ -36,7 +36,7 @@ func NewRemoveETCDMemberPhase() workflow.Phase {
 		Name:  "remove-etcd-member",
 		Short: "Remove a local etcd member.",
 		Long:  "Remove a local etcd member for a control plane node.",
-		Run:   runPreflight,
+		Run:   runRemoveETCDMemberPhase,
 		InheritFlags: []string{
 			options.KubeconfigPath,
 		},


### PR DESCRIPTION
Signed-off-by: Brad Beam <brad.beam@talos-systems.com>


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This uses the correct function name for removing the etcd member from the cluster during a kubeadm reset.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79324

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix remove the etcd member from the cluster during a kubeadm reset.
```