### PR TITLE
change the comment of the pid-pressure

### DIFF
--- a/pkg/scheduler/api/well_known_labels.go
+++ b/pkg/scheduler/api/well_known_labels.go
@@ -54,7 +54,7 @@ const (
 
 	// TaintNodePIDPressure will be added when node has pid pressure
 	// and feature-gate for TaintNodesByCondition flag is enabled,
-	// and removed when node has enough disk.
+	// and removed when pid number is less than the system limit.
 	TaintNodePIDPressure = "node.kubernetes.io/pid-pressure"
 
 	// TaintExternalCloudProvider sets this taint on a node to mark it as unusable,


### PR DESCRIPTION
What type of PR is this?
/kind bug

Does this PR introduce a user-facing change?:

```release-note
NONE
```

change the wrong comment of the pid-pressure.