### PR TITLE
Add support for max local retries for RestartOnFailure policy

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2242,6 +2242,14 @@ const (
 	RestartPolicyNever     RestartPolicy = "Never"
 )
 
+const (
+	// MaxRetriesAnnotation is an annotation used to specify max retry times
+	// when pod's RestartPolicy is OnFailure. Default value is MaxRetriesDefault,
+	// and negative value means always retry on failure.
+	MaxRetriesAnnotation = "kubernetes.io/maxRetriesForOnFailurePolicy"
+	MaxRetriesDefault    = -1
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PodList is a list of Pods.

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -397,6 +397,54 @@ func TestShouldContainerBeRestarted(t *testing.T) {
 	}
 }
 
+func TestExceedMaxRetries(t *testing.T) {
+	cases := []struct {
+		Name          string
+		MaxRetries    string
+		RestartCount  int
+		ExpectedValue bool
+	}{
+		{
+			Name:          "MaxRetriesTest1",
+			MaxRetries:    "",
+			RestartCount:  5,
+			ExpectedValue: false,
+		},
+		{
+			Name:          "MaxRetriesTest2",
+			MaxRetries:    "3",
+			RestartCount:  5,
+			ExpectedValue: true,
+		},
+		{
+			Name:          "MaxRetriesTest3",
+			MaxRetries:    "3",
+			RestartCount:  2,
+			ExpectedValue: false,
+		},
+		{
+			Name:          "MaxRetriesTest4",
+			MaxRetries:    "3",
+			RestartCount:  3,
+			ExpectedValue: true,
+		},
+		{
+			Name:          "MaxRetriesTest5",
+			MaxRetries:    "not a valid int",
+			RestartCount:  3,
+			ExpectedValue: false,
+		},
+	}
+	var pod v1.Pod
+	pod.Annotations = make(map[string]string)
+	for _, tc := range cases {
+		pod.Annotations[v1.MaxRetriesAnnotation] = tc.MaxRetries
+		if v := ExceedMaxRetries(&pod, tc.RestartCount); v != tc.ExpectedValue {
+			t.Errorf("%s expected %t, got %t", tc.Name, tc.ExpectedValue, v)
+		}
+	}
+}
+
 func TestHasPrivilegedContainer(t *testing.T) {
 	newBoolPtr := func(b bool) *bool {
 		return &b

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2473,6 +2473,14 @@ const (
 	RestartPolicyNever     RestartPolicy = "Never"
 )
 
+const (
+	// MaxRetriesAnnotation is an annotation used to specify max retry times
+	// when pod's RestartPolicy is OnFailure. Default value is MaxRetriesDefault,
+	// and negative value means always retry on failure.
+	MaxRetriesAnnotation = "kubernetes.io/maxRetriesForOnFailurePolicy"
+	MaxRetriesDefault    = -1
+)
+
 // DNSPolicy defines how a pod's DNS will be configured.
 type DNSPolicy string
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

If pod's restartPolicy is RestartPolicyOnFailure, its containers will be restarted constantly if they fail. However it might be meaningless if the failure is caused by system failure or some of user's program internal errors. It will fail even it retries a lot of time.

The PR adds a pod annotation `kubernetes.io/maxRetriesForOnFailurePolicy` to specify max retry times for pod when its restart policy is `OnFailure`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #65797

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for max local retries for RestartOnFailure policy
```
