### PR TITLE
Add Policy None for Topology Manager

### DIFF
--- a/pkg/kubelet/cm/topologymanager/BUILD
+++ b/pkg/kubelet/cm/topologymanager/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "policy.go",
+        "policy_none.go",
         "policy_preferred.go",
         "policy_strict.go",
         "topology_manager.go",
@@ -37,6 +38,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "policy_none_test.go",
         "policy_preferred_test.go",
         "policy_strict_test.go",
     ],

--- a/pkg/kubelet/cm/topologymanager/policy_none.go
+++ b/pkg/kubelet/cm/topologymanager/policy_none.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologymanager
+
+import (
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+)
+
+type nonePolicy struct{}
+
+var _ Policy = &nonePolicy{}
+
+// PolicyNone policy name.
+const PolicyNone string = "none"
+
+// NewNonePolicy returns none policy.
+func NewNonePolicy() Policy {
+	return &nonePolicy{}
+}
+
+func (p *nonePolicy) Name() string {
+	return string(PolicyNone)
+}
+
+func (p *nonePolicy) CanAdmitPodResult(admit bool) lifecycle.PodAdmitResult {
+	return lifecycle.PodAdmitResult{
+		Admit: true,
+	}
+}

--- a/pkg/kubelet/cm/topologymanager/policy_none_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_none_test.go
@@ -20,7 +20,25 @@ import (
 	"testing"
 )
 
-func TestPolicyPreferredCanAdmitPodResult(t *testing.T) {
+func TestName(t *testing.T) {
+	tcases := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     "New None Policy",
+			expected: "none",
+		},
+	}
+	for _, tc := range tcases {
+		policy := NewNonePolicy()
+		if policy.Name() != tc.expected {
+			t.Errorf("Expected Policy Name to be %s, got %s", tc.expected, policy.Name())
+		}
+	}
+}
+
+func TestPolicyNoneCanAdmitPodResult(t *testing.T) {
 	tcases := []struct {
 		name     string
 		admit    bool
@@ -39,7 +57,7 @@ func TestPolicyPreferredCanAdmitPodResult(t *testing.T) {
 	}
 
 	for _, tc := range tcases {
-		policy := NewPreferredPolicy()
+		policy := NewNonePolicy()
 		admit := tc.admit
 		result := policy.CanAdmitPodResult(admit)
 

--- a/pkg/kubelet/cm/topologymanager/policy_strict_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_strict_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestCanAdmitPodResult(t *testing.T) {
+func TestPolicyStrictCanAdmitPodResult(t *testing.T) {
 	tcases := []struct {
 		name     string
 		admit    bool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
>
 /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds 'None' policy for Topology Manager in addition to existing 'Preferred' and 'Strict' policies. 'None' policy will be enabled by default and will do nothing, ensuring current behavior is preserved even if topology manager feature gate is enabled. 
As discussed here https://github.com/kubernetes/kubernetes/pull/74411#discussion_r289436031

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```