### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,12 +15,13 @@ filters:
       - brendandburns
       - dchen1107
       - jbeda
-      - monopole # To move code per kubernetes/community#598
       - lavalamp
       - smarterclayton
       - thockin
       - wojtek-t
       - liggitt
+      # Emeritus
+      # - monopole # To move code per kubernetes/community#598
 
   # Bazel build infrastructure changes often touch files throughout the tree
   "\\.bzl$":


### PR DESCRIPTION
@seans3 has a way to split kubectl without top-level approvers.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
