### PR TITLE
reference paths to bump dependencies

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -1,0 +1,84 @@
+dependencies:
+  - name: "etcd"
+    version: 3.3.10
+    refPaths:
+    - path: cluster/gce/manifests/etcd.manifest
+      match: etcd_docker_tag|etcd_version      
+    - path: build/workspace.bzl
+      match: ETCD_VERSION 
+    - path: cluster/gce/manifests/etcd-empty-dir-cleanup.yaml
+      match: k8s.gcr.io/etcd-empty-dir-cleanup
+    - path: cluster/gce/upgrade-aliases.sh
+      match: ETCD_IMAGE|ETCD_VERSION
+    - path: cluster/images/etcd-empty-dir-cleanup/Makefile
+      match: ETCD_VERSION|TAG
+    - path: cluster/images/etcd/Makefile
+      match: BUNDLED_ETCD_VERSIONS\?|LATEST_ETCD_VERSION\?
+    - path: cluster/images/etcd/migrate-if-needed.sh
+      match: BUNDLED_VERSIONS=
+    - path: cmd/kubeadm/app/constants/constants.go
+    - path: hack/lib/etcd.sh
+      match: ETCD_VERSION=
+    - path: staging/src/k8s.io/sample-apiserver/artifacts/example/rc.yaml
+      match: quay.io/coreos/etcd
+    - path: test/e2e/framework/nodes_util.go
+      match: const etcdImage      
+
+  - name: "docker"
+    version: 18.09
+    refPaths:
+    - path: cmd/kubeadm/app/util/system/docker_validator.go
+      match: latestValidatedDockerVersion
+    - path: cmd/kubeadm/app/util/system/docker_validator_test.go
+      match: ServerVersion
+      
+
+  - name: "golang"
+    version: 1.12.6
+    refPaths:
+    - path: build/build-image/cross/Dockerfile
+      match: "golang:"
+    - path: build/build-image/cross/VERSION
+    - path: build/root/WORKSPACE
+      match: go_version
+    - path: test/images/Makefile
+      match: GOLANG_VERSION
+      
+
+  - name: "cni"
+    version: 0.7.5
+    refPaths:
+    - path: build/debian-hyperkube-base/Makefile
+      match: CNI_VERSION=
+    - path: build/rpms/kubeadm.spec
+      match: kubernetes-cni
+    - path: build/rpms/kubelet.spec
+      match: kubernetes-cni
+    - path: build/workspace.bzl
+      match: CNI_VERSION =
+    - path: cluster/gce/gci/configure.sh
+      match: DEFAULT_CNI_VERSION=
+    - path: test/e2e_node/remote/utils.go
+      match: cniVersion[\t\n\f\r ]*=
+      
+
+  - name: "coredns"
+    version: 1.3.1
+    refPaths:
+    - path: cluster/addons/dns/coredns/coredns.yaml.base
+      match: k8s.gcr.io/coredns
+    - path: cluster/addons/dns/coredns/coredns.yaml.in
+      match: k8s.gcr.io/coredns
+    - path: cluster/addons/dns/coredns/coredns.yaml.sed
+      match: k8s.gcr.io/coredns
+    - path: cmd/kubeadm/app/constants/constants.go
+      match: CoreDNSVersion =
+
+  - name: "crictl"
+    version: 1.14.0 
+    refPaths:
+    - path: build/workspace.bzl
+      match: CRI_TOOLS_VERSION =
+    - path: cluster/gce/gci/configure.sh
+      match: DEFAULT_CRICTL_VERSION=
+      

--- a/cmd/BUILD
+++ b/cmd/BUILD
@@ -32,6 +32,7 @@ filegroup(
         "//cmd/kubemark:all-srcs",
         "//cmd/linkcheck:all-srcs",
         "//cmd/preferredimports:all-srcs",
+        "//cmd/verifydependencies:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/cmd/verifydependencies/BUILD
+++ b/cmd/verifydependencies/BUILD
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["verifydependencies.go"],
+    importpath = "k8s.io/kubernetes/cmd/verifydependencies",
+    visibility = ["//visibility:private"],
+    deps = ["//vendor/gopkg.in/yaml.v2:go_default_library"],
+)
+
+go_binary(
+    name = "verifydependencies",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/verifydependencies/OWNERS
+++ b/cmd/verifydependencies/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- neolit123
+- justaugustus
+approvers:
+- yastij
+- dims

--- a/cmd/verifydependencies/verifydependencies.go
+++ b/cmd/verifydependencies/verifydependencies.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// verify that dependencies are up-to-date across different files
+package main
+
+import (
+	"flag"
+	"log"
+	"strings"
+
+	"bufio"
+	"io/ioutil"
+	"os"
+	"regexp"
+
+	"gopkg.in/yaml.v2"
+)
+
+type dependencies struct {
+	Dependencies []*dependency `yaml:"dependencies"`
+}
+
+type dependency struct {
+	Name     string     `yaml:"name"`
+	Version  string     `yaml:"version"`
+	RefPaths []*refPath `yaml:"refPaths"`
+}
+
+type refPath struct {
+	Path  string `yaml:"path"`
+	Match string `yaml:"match"`
+}
+
+func main() {
+
+	flag.Parse()
+
+	args := flag.Args()
+
+	if len(args) == 0 {
+		log.Fatalf("usage: verifydependency <file>")
+	}
+	externalDepsFilePath := args[0]
+	externalDepsFile, err := ioutil.ReadFile(externalDepsFilePath)
+	if err != nil {
+		panic(err)
+	}
+
+	externalDeps := &dependencies{}
+
+	err = yaml.Unmarshal(externalDepsFile, externalDeps)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, dep := range externalDeps.Dependencies {
+		for _, refPath := range dep.RefPaths {
+			file, err := os.Open(refPath.Path)
+			if err != nil {
+				log.Fatalf("error opening file %v : %v", refPath.Path, err)
+			}
+			matcher := regexp.MustCompile(refPath.Match)
+			depFileScanner := bufio.NewScanner(file)
+			var found bool
+			for depFileScanner.Scan() {
+				line := depFileScanner.Text()
+				if matcher.MatchString(line) && strings.Contains(line, dep.Version) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				log.Fatalf("%v dependency: file %v doesn't contain the expected version %v or matcher %v did change. check the %v file", dep.Name, refPath.Path, dep.Version, refPath.Match, externalDepsFilePath)
+			}
+		}
+	}
+
+}

--- a/hack/verify-external-dependencies-version.sh
+++ b/hack/verify-external-dependencies-version.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+kube::golang::verify_go_version
+
+cd "${KUBE_ROOT}"
+
+go run cmd/verifydependencies/verifydependencies.go "${KUBE_ROOT}"/build/dependencies.yaml


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What type of PR is this?**

/kind feature


**What this PR does / why we need it**: This PR introduces a yaml file that references all the paths needed to be updated in order to bump a dependency

**Which issue(s) this PR fixes**:  part of kubernetes/sig-release#601

**Special notes for your reviewer**:

for early feedback
This idea is to have a verify script that runs against this to make sure we don't forget something.

/assign @dims @liggitt 
/cc @tpepper 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
