### PR TITLE
Fix service load balancer may not be cleaned up on corner case of type change

### DIFF
--- a/pkg/controller/service/service_controller_test.go
+++ b/pkg/controller/service/service_controller_test.go
@@ -833,6 +833,16 @@ func TestProcessServiceDeletion(t *testing.T) {
 
 }
 
+// Test cases:
+// index    finalizer    timestamp    wantLB  |  clean-up
+//   0         0           0            0     |   false    (No finalizer, no clean up)
+//   1         0           0            1     |   false    (Ignored as same with case 0)
+//   2         0           1            0     |   false    (Ignored as same with case 0)
+//   3         0           1            1     |   false    (Ignored as same with case 0)
+//   4         1           0            0     |   true
+//   5         1           0            1     |   false
+//   6         1           1            0     |   true    (Service is deleted, needs clean up)
+//   7         1           1            1     |   true    (Ignored as same with case 6)
 func TestNeedsCleanup(t *testing.T) {
 	testCases := []struct {
 		desc               string
@@ -840,26 +850,30 @@ func TestNeedsCleanup(t *testing.T) {
 		expectNeedsCleanup bool
 	}{
 		{
-			desc:               "service without finalizer without timestamp",
+			desc:               "service without finalizer",
 			svc:                &v1.Service{},
 			expectNeedsCleanup: false,
 		},
 		{
-			desc: "service without finalizer with timestamp",
-			svc: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					DeletionTimestamp: &metav1.Time{
-						Time: time.Now(),
-					},
-				},
-			},
-			expectNeedsCleanup: false,
-		},
-		{
-			desc: "service with finalizer without timestamp",
+			desc: "service with finalizer without timestamp without LB",
 			svc: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Finalizers: []string{servicehelper.LoadBalancerCleanupFinalizer},
+				},
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeNodePort,
+				},
+			},
+			expectNeedsCleanup: true,
+		},
+		{
+			desc: "service with finalizer without timestamp with LB",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{servicehelper.LoadBalancerCleanupFinalizer},
+				},
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeLoadBalancer,
 				},
 			},
 			expectNeedsCleanup: false,
@@ -868,10 +882,10 @@ func TestNeedsCleanup(t *testing.T) {
 			desc: "service with finalizer with timestamp",
 			svc: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{servicehelper.LoadBalancerCleanupFinalizer},
 					DeletionTimestamp: &metav1.Time{
 						Time: time.Now(),
 					},
-					Finalizers: []string{servicehelper.LoadBalancerCleanupFinalizer, "unrelated"},
 				},
 			},
 			expectNeedsCleanup: true,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #78954 

**Special notes for your reviewer**:
For service that don't want loadBalancers but has finalizer means need to be cleaned up.
So, it should be include in function `needsCleanup(...)`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
