### PR TITLE
RateLimiter context aware and fix request may hang issue

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -172,6 +172,10 @@ func (t *fakeLimiter) QPS() float32 {
 	return t.FakeQPS
 }
 
+func (t *fakeLimiter) Wait(ctx context.Context) error {
+	return nil
+}
+
 func (t *fakeLimiter) Stop() {}
 
 func (t *fakeLimiter) Accept() {}

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -521,14 +521,24 @@ func (r Request) finalURLTemplate() url.URL {
 	return *url
 }
 
-func (r *Request) tryThrottle() {
+func (r *Request) tryThrottle() error {
+	if r.throttle == nil {
+		return nil
+	}
+
 	now := time.Now()
-	if r.throttle != nil {
+	var err error
+	if r.ctx != nil {
+		err = r.throttle.Wait(r.ctx)
+	} else {
 		r.throttle.Accept()
 	}
+
 	if latency := time.Since(now); latency > longThrottleLatency {
 		klog.V(4).Infof("Throttling request took %v, request: %s:%s", latency, r.verb, r.URL().String())
 	}
+
+	return err
 }
 
 // Watch attempts to begin watching the requested location.
@@ -630,7 +640,9 @@ func (r *Request) Stream() (io.ReadCloser, error) {
 		return nil, r.err
 	}
 
-	r.tryThrottle()
+	if err := r.tryThrottle(); err != nil {
+		return nil, err
+	}
 
 	url := r.URL().String()
 	req, err := http.NewRequest(r.verb, url, nil)
@@ -732,7 +744,9 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 			// We are retrying the request that we already send to apiserver
 			// at least once before.
 			// This request should also be throttled with the client-internal throttler.
-			r.tryThrottle()
+			if err := r.tryThrottle(); err != nil {
+				return err
+			}
 		}
 		resp, err := client.Do(req)
 		updateURLMetrics(r, resp, err)
@@ -803,7 +817,9 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 //  * If the server responds with a status: *errors.StatusError or *errors.UnexpectedObjectError
 //  * http.Client.Do errors are returned directly.
 func (r *Request) Do() Result {
-	r.tryThrottle()
+	if err := r.tryThrottle(); err != nil {
+		return Result{err: err}
+	}
 
 	var result Result
 	err := r.request(func(req *http.Request, resp *http.Response) {
@@ -817,7 +833,9 @@ func (r *Request) Do() Result {
 
 // DoRaw executes the request but does not process the response body.
 func (r *Request) DoRaw() ([]byte, error) {
-	r.tryThrottle()
+	if err := r.tryThrottle(); err != nil {
+		return nil, err
+	}
 
 	var result Result
 	err := r.request(func(req *http.Request, resp *http.Response) {

--- a/staging/src/k8s.io/client-go/util/flowcontrol/throttle_test.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/throttle_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package flowcontrol
 
 import (
+	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -149,5 +151,23 @@ func TestNeverFake(t *testing.T) {
 	wg.Wait()
 	if !finished {
 		t.Error("Stop should make Accept unblock in NeverFake.")
+	}
+}
+
+func TestWait(t *testing.T) {
+	r := NewTokenBucketRateLimiter(0.0001, 1)
+
+	ctx, cancelFn := context.WithTimeout(context.Background(), time.Second)
+	defer cancelFn()
+	if err := r.Wait(ctx); err != nil {
+		t.Errorf("unexpected wait failed, err: %v", err)
+	}
+
+	ctx2, cancelFn2 := context.WithTimeout(context.Background(), time.Second)
+	defer cancelFn2()
+	if err := r.Wait(ctx2); err == nil {
+		t.Errorf("unexpected wait success")
+	} else {
+		t.Log(fmt.Sprintf("wait err: %v", err))
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind feature

**What this PR does / why we need it**:

1. RateLimiter add a context-aware method which is really necessary in async scene
2. fix client-go request goruntine backlog in async scene

**Which issue(s) this PR fixes**:

Fixes #78766

**Special notes for your reviewer**:

The new method added in RateLimiter called `Wait`, it's context-aware, which is recommended to replace method `Accept` if the caller has context.

**Does this PR introduce a user-facing change?**:

Interface RateLimiter in `client-go/util/flowcontrol` package add a context-aware method called `Wait`.


```release-note
RateLimiter add a context-aware method, fix client-go request goruntine backlog in async timeout scene.
```
