### PR TITLE
Make Admission and Webhook context-aware

### DIFF
--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -68,7 +68,7 @@ func (p *Provision) Admit(a admission.Attributes, o admission.ObjectInterfaces) 
 		return nil
 	}
 	// we need to wait for our caches to warm
-	if !p.WaitForReady() {
+	if !p.WaitForReady(a.GetContext()) {
 		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
 	}
 

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -63,7 +63,7 @@ func (e *Exists) Validate(a admission.Attributes, o admission.ObjectInterfaces) 
 	}
 
 	// we need to wait for our caches to warm
-	if !e.WaitForReady() {
+	if !e.WaitForReady(a.GetContext()) {
 		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
 	}
 	_, err := e.namespaceLister.Get(a.GetNamespace())

--- a/plugin/pkg/admission/podnodeselector/admission.go
+++ b/plugin/pkg/admission/podnodeselector/admission.go
@@ -100,7 +100,7 @@ func (p *Plugin) Admit(a admission.Attributes, o admission.ObjectInterfaces) err
 	if shouldIgnore(a) {
 		return nil
 	}
-	if !p.WaitForReady() {
+	if !p.WaitForReady(a.GetContext()) {
 		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
 	}
 
@@ -127,7 +127,7 @@ func (p *Plugin) Validate(a admission.Attributes, o admission.ObjectInterfaces) 
 	if shouldIgnore(a) {
 		return nil
 	}
-	if !p.WaitForReady() {
+	if !p.WaitForReady(a.GetContext()) {
 		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
 	}
 

--- a/plugin/pkg/admission/podtolerationrestriction/admission.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission.go
@@ -78,7 +78,7 @@ func (p *Plugin) Admit(a admission.Attributes, o admission.ObjectInterfaces) err
 		return nil
 	}
 
-	if !p.WaitForReady() {
+	if !p.WaitForReady(a.GetContext()) {
 		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
 	}
 
@@ -136,7 +136,7 @@ func (p *Plugin) Validate(a admission.Attributes, o admission.ObjectInterfaces) 
 		return nil
 	}
 
-	if !p.WaitForReady() {
+	if !p.WaitForReady(a.GetContext()) {
 		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/interfaces.go
@@ -17,6 +17,7 @@ limitations under the License.
 package admission
 
 import (
+	"context"
 	"io"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -65,6 +66,9 @@ type Attributes interface {
 
 	// GetReinvocationContext tracks the admission request information relevant to the re-invocation policy.
 	GetReinvocationContext() ReinvocationContext
+
+	// GetContext returns the context associated with the request
+	GetContext() context.Context
 }
 
 // ObjectInterfaces is an interface used by AdmissionController to get object interfaces

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
@@ -107,7 +107,7 @@ func (l *Lifecycle) Admit(a admission.Attributes, o admission.ObjectInterfaces) 
 	}
 
 	// we need to wait for our caches to warm
-	if !l.WaitForReady() {
+	if !l.WaitForReady(a.GetContext()) {
 		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
@@ -17,7 +17,6 @@ limitations under the License.
 package generic
 
 import (
-	"context"
 	"fmt"
 	"io"
 
@@ -207,12 +206,10 @@ func (a *Webhook) Dispatch(attr admission.Attributes, o admission.ObjectInterfac
 	if rules.IsWebhookConfigurationResource(attr) {
 		return nil
 	}
-	if !a.WaitForReady() {
+	if !a.WaitForReady(attr.GetContext()) {
 		return admission.NewForbidden(attr, fmt.Errorf("not yet ready to handle request"))
 	}
 	hooks := a.hookSource.Webhooks()
-	// TODO: Figure out if adding one second timeout make sense here.
-	ctx := context.TODO()
 
-	return a.dispatcher.Dispatch(ctx, attr, o, hooks)
+	return a.dispatcher.Dispatch(attr.GetContext(), attr, o, hooks)
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -129,7 +129,7 @@ func createHandler(r rest.NamedCreater, scope *RequestScope, admit admission.Int
 		audit.LogRequestObject(ae, obj, scope.Resource, scope.Subresource, scope.Serializer)
 
 		userInfo, _ := request.UserFrom(ctx)
-		admissionAttributes := admission.NewAttributesRecord(obj, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Create, options, dryrun.IsDryRun(options.DryRun), userInfo)
+		admissionAttributes := admission.NewAttributesRecordWithContext(obj, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Create, options, dryrun.IsDryRun(options.DryRun), userInfo, req.Context())
 		if mutatingAdmission, ok := admit.(admission.MutationInterface); ok && mutatingAdmission.Handles(admission.Create) {
 			err = mutatingAdmission.Admit(admissionAttributes, scope)
 			if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
@@ -118,7 +118,7 @@ func DeleteResource(r rest.GracefulDeleter, allowsOptions bool, scope *RequestSc
 		trace.Step("About to delete object from database")
 		wasDeleted := true
 		userInfo, _ := request.UserFrom(ctx)
-		staticAdmissionAttrs := admission.NewAttributesRecord(nil, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Delete, options, dryrun.IsDryRun(options.DryRun), userInfo)
+		staticAdmissionAttrs := admission.NewAttributesRecordWithContext(nil, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Delete, options, dryrun.IsDryRun(options.DryRun), userInfo, req.Context())
 		result, err := finishRequest(timeout, func() (runtime.Object, error) {
 			obj, deleted, err := r.Delete(ctx, name, rest.AdmissionToValidateObjectDeleteFunc(admit, staticAdmissionAttrs, scope), options)
 			wasDeleted = deleted
@@ -253,7 +253,7 @@ func DeleteCollection(r rest.CollectionDeleter, checkBody bool, scope *RequestSc
 
 		admit = admission.WithAudit(admit, ae)
 		userInfo, _ := request.UserFrom(ctx)
-		staticAdmissionAttrs := admission.NewAttributesRecord(nil, nil, scope.Kind, namespace, "", scope.Resource, scope.Subresource, admission.Delete, options, dryrun.IsDryRun(options.DryRun), userInfo)
+		staticAdmissionAttrs := admission.NewAttributesRecordWithContext(nil, nil, scope.Kind, namespace, "", scope.Resource, scope.Subresource, admission.Delete, options, dryrun.IsDryRun(options.DryRun), userInfo, req.Context())
 		result, err := finishRequest(timeout, func() (runtime.Object, error) {
 			return r.DeleteCollection(ctx, rest.AdmissionToValidateObjectDeleteFunc(admit, staticAdmissionAttrs, scope), options, &listOptions)
 		})

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -143,7 +143,7 @@ func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interfac
 		)
 
 		userInfo, _ := request.UserFrom(ctx)
-		staticCreateAttributes := admission.NewAttributesRecord(
+		staticCreateAttributes := admission.NewAttributesRecordWithContext(
 			nil,
 			nil,
 			scope.Kind,
@@ -154,8 +154,9 @@ func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interfac
 			admission.Create,
 			patchToCreateOptions(options),
 			dryrun.IsDryRun(options.DryRun),
-			userInfo)
-		staticUpdateAttributes := admission.NewAttributesRecord(
+			userInfo,
+			req.Context())
+		staticUpdateAttributes := admission.NewAttributesRecordWithContext(
 			nil,
 			nil,
 			scope.Kind,
@@ -167,6 +168,7 @@ func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interfac
 			patchToUpdateOptions(options),
 			dryrun.IsDryRun(options.DryRun),
 			userInfo,
+			req.Context(),
 		)
 
 		mutatingAdmission, _ := admit.(admission.MutationInterface)
@@ -494,7 +496,7 @@ func (p *patcher) applyPatch(_ context.Context, _, currentObject runtime.Object)
 
 func (p *patcher) admissionAttributes(ctx context.Context, updatedObject runtime.Object, currentObject runtime.Object, operation admission.Operation, operationOptions runtime.Object) admission.Attributes {
 	userInfo, _ := request.UserFrom(ctx)
-	return admission.NewAttributesRecord(updatedObject, currentObject, p.kind, p.namespace, p.name, p.resource, p.subresource, operation, operationOptions, p.dryRun, userInfo)
+	return admission.NewAttributesRecordWithContext(updatedObject, currentObject, p.kind, p.namespace, p.name, p.resource, p.subresource, operation, operationOptions, p.dryRun, userInfo, ctx)
 }
 
 // applyAdmission is called every time GuaranteedUpdate asks for the updated object,

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -161,14 +161,14 @@ func ConnectResource(connecter rest.Connecter, scope *RequestScope, admit admiss
 			userInfo, _ := request.UserFrom(ctx)
 			// TODO: remove the mutating admission here as soon as we have ported all plugin that handle CONNECT
 			if mutatingAdmission, ok := admit.(admission.MutationInterface); ok {
-				err = mutatingAdmission.Admit(admission.NewAttributesRecord(opts, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Connect, nil, false, userInfo), scope)
+				err = mutatingAdmission.Admit(admission.NewAttributesRecordWithContext(opts, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Connect, nil, false, userInfo, req.Context()), scope)
 				if err != nil {
 					scope.err(err, w, req)
 					return
 				}
 			}
 			if validatingAdmission, ok := admit.(admission.ValidationInterface); ok {
-				err = validatingAdmission.Validate(admission.NewAttributesRecord(opts, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Connect, nil, false, userInfo), scope)
+				err = validatingAdmission.Validate(admission.NewAttributesRecordWithContext(opts, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Connect, nil, false, userInfo, req.Context()), scope)
 				if err != nil {
 					scope.err(err, w, req)
 					return

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
@@ -139,11 +139,11 @@ func UpdateResource(r rest.Updater, scope *RequestScope, admit admission.Interfa
 					return nil, fmt.Errorf("unexpected error when extracting UID from oldObj: %v", err.Error())
 				} else if !isNotZeroObject {
 					if mutatingAdmission.Handles(admission.Create) {
-						return newObj, mutatingAdmission.Admit(admission.NewAttributesRecord(newObj, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Create, updateToCreateOptions(options), dryrun.IsDryRun(options.DryRun), userInfo), scope)
+						return newObj, mutatingAdmission.Admit(admission.NewAttributesRecordWithContext(newObj, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Create, updateToCreateOptions(options), dryrun.IsDryRun(options.DryRun), userInfo, req.Context()), scope)
 					}
 				} else {
 					if mutatingAdmission.Handles(admission.Update) {
-						return newObj, mutatingAdmission.Admit(admission.NewAttributesRecord(newObj, oldObj, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Update, options, dryrun.IsDryRun(options.DryRun), userInfo), scope)
+						return newObj, mutatingAdmission.Admit(admission.NewAttributesRecordWithContext(newObj, oldObj, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Update, options, dryrun.IsDryRun(options.DryRun), userInfo, req.Context()), scope)
 					}
 				}
 				return newObj, nil
@@ -173,11 +173,11 @@ func UpdateResource(r rest.Updater, scope *RequestScope, admit admission.Interfa
 				rest.DefaultUpdatedObjectInfo(obj, transformers...),
 				withAuthorization(rest.AdmissionToValidateObjectFunc(
 					admit,
-					admission.NewAttributesRecord(nil, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Create, updateToCreateOptions(options), dryrun.IsDryRun(options.DryRun), userInfo), scope),
+					admission.NewAttributesRecordWithContext(nil, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Create, updateToCreateOptions(options), dryrun.IsDryRun(options.DryRun), userInfo, req.Context()), scope),
 					scope.Authorizer, createAuthorizerAttributes),
 				rest.AdmissionToValidateObjectUpdateFunc(
 					admit,
-					admission.NewAttributesRecord(nil, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Update, options, dryrun.IsDryRun(options.DryRun), userInfo), scope),
+					admission.NewAttributesRecordWithContext(nil, nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Update, options, dryrun.IsDryRun(options.DryRun), userInfo, req.Context()), scope),
 				false,
 				options,
 			)

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
@@ -166,7 +166,7 @@ func AdmissionToValidateObjectFunc(admit admission.Interface, staticAttributes a
 		return func(obj runtime.Object) error { return nil }
 	}
 	return func(obj runtime.Object) error {
-		finalAttributes := admission.NewAttributesRecord(
+		finalAttributes := admission.NewAttributesRecordWithContext(
 			obj,
 			staticAttributes.GetOldObject(),
 			staticAttributes.GetKind(),
@@ -178,6 +178,7 @@ func AdmissionToValidateObjectFunc(admit admission.Interface, staticAttributes a
 			staticAttributes.GetOperationOptions(),
 			staticAttributes.IsDryRun(),
 			staticAttributes.GetUserInfo(),
+			staticAttributes.GetContext(),
 		)
 		if !validatingAdmission.Handles(finalAttributes.GetOperation()) {
 			return nil

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/delete.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/delete.go
@@ -154,7 +154,7 @@ func AdmissionToValidateObjectDeleteFunc(admit admission.Interface, staticAttrib
 		if !mutating && !validating {
 			return nil
 		}
-		finalAttributes := admission.NewAttributesRecord(
+		finalAttributes := admission.NewAttributesRecordWithContext(
 			nil,
 			// Deep copy the object to avoid accidentally changing the object.
 			old.DeepCopyObject(),
@@ -167,6 +167,7 @@ func AdmissionToValidateObjectDeleteFunc(admit admission.Interface, staticAttrib
 			staticAttributes.GetOperationOptions(),
 			staticAttributes.IsDryRun(),
 			staticAttributes.GetUserInfo(),
+			staticAttributes.GetContext(),
 		)
 		if mutating {
 			if err := mutatingAdmission.Admit(finalAttributes, objInterfaces); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -262,7 +262,7 @@ func AdmissionToValidateObjectUpdateFunc(admit admission.Interface, staticAttrib
 		return func(obj, old runtime.Object) error { return nil }
 	}
 	return func(obj, old runtime.Object) error {
-		finalAttributes := admission.NewAttributesRecord(
+		finalAttributes := admission.NewAttributesRecordWithContext(
 			obj,
 			old,
 			staticAttributes.GetKind(),
@@ -274,6 +274,7 @@ func AdmissionToValidateObjectUpdateFunc(admit admission.Interface, staticAttrib
 			staticAttributes.GetOperationOptions(),
 			staticAttributes.IsDryRun(),
 			staticAttributes.GetUserInfo(),
+			staticAttributes.GetContext(),
 		)
 		if !validatingAdmission.Handles(finalAttributes.GetOperation()) {
 			return nil

--- a/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission.go
@@ -53,7 +53,7 @@ func (d *DisallowFlunder) Admit(a admission.Attributes, o admission.ObjectInterf
 		return nil
 	}
 
-	if !d.WaitForReady() {
+	if !d.WaitForReady(a.GetContext()) {
 		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add a method called `GetContext` which can get the request context in admission.Attributes. With this method, we can make Admission and Webhook context-aware to fix goruntine backlog in large-scale scene.

**Which issue(s) this PR fixes**:

Fixes #78783

**Special notes for your reviewer**:

Nothing yet.

**Does this PR introduce a user-facing change?**:

```release-note
Add a method called GetContext which can get the request context in admission.Attributes. With this method, we can make Admission and Webhook context-aware to fix goruntine backlog in large-scale scene.
```
