### PR TITLE
kubeadm: add property to define the DNS policy for the API Server

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -18,6 +18,7 @@ package fuzzer
 
 import (
 	fuzz "github.com/google/gofuzz"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -54,6 +55,7 @@ func fuzzInitConfiguration(obj *kubeadm.InitConfiguration, c fuzz.Continue) {
 			TimeoutForControlPlane: &metav1.Duration{
 				Duration: constants.DefaultControlPlaneTimeout,
 			},
+			DNSPolicy: v1.DNSClusterFirst,
 		},
 		DNS: kubeadm.DNS{
 			Type: kubeadm.CoreDNS,
@@ -107,6 +109,7 @@ func fuzzClusterConfiguration(obj *kubeadm.ClusterConfiguration, c fuzz.Continue
 	obj.APIServer.TimeoutForControlPlane = &metav1.Duration{
 		Duration: constants.DefaultControlPlaneTimeout,
 	}
+	obj.APIServer.DNSPolicy = v1.DNSClusterFirst
 }
 
 func fuzzDNS(obj *kubeadm.DNS, c fuzz.Continue) {

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -143,6 +143,9 @@ type APIServer struct {
 
 	// TimeoutForControlPlane controls the timeout that we use for API server to appear
 	TimeoutForControlPlane *metav1.Duration
+
+	// DNSPolicy sets a DNS policy for the API Server.
+	DNSPolicy v1.DNSPolicy
 }
 
 // DNSAddOnType defines string identifying DNS add-on types

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"time"
 
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -109,6 +110,9 @@ func SetDefaults_APIServer(obj *APIServer) {
 		obj.TimeoutForControlPlane = &metav1.Duration{
 			Duration: constants.DefaultControlPlaneTimeout,
 		}
+	}
+	if obj.DNSPolicy == "" {
+		obj.DNSPolicy = v1.DNSClusterFirst
 	}
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/doc.go
@@ -225,6 +225,7 @@ limitations under the License.
 // 	  - "10.100.1.1"
 // 	  - "ec2-10-100-0-1.compute-1.amazonaws.com"
 // 	  timeoutForControlPlane: 4m0s
+//    dnsPolicy: ClusterFirst
 // 	controllerManager:
 // 	  extraArgs:
 // 	    "node-cidr-mask-size": "20"

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/types.go
@@ -133,6 +133,9 @@ type APIServer struct {
 
 	// TimeoutForControlPlane controls the timeout that we use for API server to appear
 	TimeoutForControlPlane *metav1.Duration `json:"timeoutForControlPlane,omitempty"`
+
+	// DNSPolicy sets a DNS policy for the API Server.
+	DNSPolicy v1.DNSPolicy `json:"dnsPolicy,omitempty"`
 }
 
 // DNSAddOnType defines string identifying DNS add-on types

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/zz_generated.conversion.go
@@ -293,6 +293,7 @@ func autoConvert_v1beta1_APIServer_To_kubeadm_APIServer(in *APIServer, out *kube
 	}
 	out.CertSANs = *(*[]string)(unsafe.Pointer(&in.CertSANs))
 	out.TimeoutForControlPlane = (*v1.Duration)(unsafe.Pointer(in.TimeoutForControlPlane))
+	out.DNSPolicy = corev1.DNSPolicy(in.DNSPolicy)
 	return nil
 }
 
@@ -307,6 +308,7 @@ func autoConvert_kubeadm_APIServer_To_v1beta1_APIServer(in *kubeadm.APIServer, o
 	}
 	out.CertSANs = *(*[]string)(unsafe.Pointer(&in.CertSANs))
 	out.TimeoutForControlPlane = (*v1.Duration)(unsafe.Pointer(in.TimeoutForControlPlane))
+	out.DNSPolicy = corev1.DNSPolicy(in.DNSPolicy)
 	return nil
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/defaults.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"time"
 
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -108,6 +109,10 @@ func SetDefaults_APIServer(obj *APIServer) {
 		obj.TimeoutForControlPlane = &metav1.Duration{
 			Duration: constants.DefaultControlPlaneTimeout,
 		}
+	}
+
+	if obj.DNSPolicy == "" {
+		obj.DNSPolicy = v1.DNSClusterFirst
 	}
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
@@ -221,6 +221,7 @@ limitations under the License.
 // 	  - "10.100.1.1"
 // 	  - "ec2-10-100-0-1.compute-1.amazonaws.com"
 // 	  timeoutForControlPlane: 4m0s
+//    dnsPolicy: ClusterFirst
 // 	controllerManager:
 // 	  extraArgs:
 // 	    "node-cidr-mask-size": "20"

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/types.go
@@ -131,6 +131,9 @@ type APIServer struct {
 
 	// TimeoutForControlPlane controls the timeout that we use for API server to appear
 	TimeoutForControlPlane *metav1.Duration `json:"timeoutForControlPlane,omitempty"`
+
+	// DNSPolicy sets a DNS policy for the API Server.
+	DNSPolicy v1.DNSPolicy `json:"dnsPolicy,omitempty"`
 }
 
 // DNSAddOnType defines string identifying DNS add-on types

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/zz_generated.conversion.go
@@ -288,6 +288,7 @@ func autoConvert_v1beta2_APIServer_To_kubeadm_APIServer(in *APIServer, out *kube
 	}
 	out.CertSANs = *(*[]string)(unsafe.Pointer(&in.CertSANs))
 	out.TimeoutForControlPlane = (*v1.Duration)(unsafe.Pointer(in.TimeoutForControlPlane))
+	out.DNSPolicy = corev1.DNSPolicy(in.DNSPolicy)
 	return nil
 }
 
@@ -302,6 +303,7 @@ func autoConvert_kubeadm_APIServer_To_v1beta2_APIServer(in *kubeadm.APIServer, o
 	}
 	out.CertSANs = *(*[]string)(unsafe.Pointer(&in.CertSANs))
 	out.TimeoutForControlPlane = (*v1.Duration)(unsafe.Pointer(in.TimeoutForControlPlane))
+	out.DNSPolicy = corev1.DNSPolicy(in.DNSPolicy)
 	return nil
 }
 

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -64,21 +65,21 @@ var (
 		{{if .ControlPlaneEndpoint -}}
 		{{if .UploadCerts -}}
 		You can now join any number of the control-plane node running the following command on each as root:
-					  
+
 		  {{.joinControlPlaneCommand}}
-					
+
 		Please note that the certificate-key gives access to cluster sensitive data, keep it secret!
-		As a safeguard, uploaded-certs will be deleted in two hours; If necessary, you can use 
+		As a safeguard, uploaded-certs will be deleted in two hours; If necessary, you can use
 		"kubeadm init phase upload-certs --upload-certs" to reload certs afterward.
-		  
+
 		{{else -}}
-		You can now join any number of control-plane nodes by copying certificate authorities 
+		You can now join any number of control-plane nodes by copying certificate authorities
 		and service account keys on each node and then running the following as root:
-				  
-		  {{.joinControlPlaneCommand}}	  
-		  
+
+		  {{.joinControlPlaneCommand}}
+
 		{{end}}{{end}}Then you can join any number of worker nodes by running the following on each as root:
-						  
+
 		{{.joinWorkerCommand}}
 		`)))
 )
@@ -240,6 +241,13 @@ func AddClusterConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiv1beta2.Cluster
 		&cfg.APIServer.CertSANs, options.APIServerCertSANs, cfg.APIServer.CertSANs,
 		`Optional extra Subject Alternative Names (SANs) to use for the API Server serving certificate. Can be both IP addresses and DNS names.`,
 	)
+
+	var dnsPolicy string
+	flagSet.StringVar(
+		&dnsPolicy, "apiserver-dns-policy", string(v1.DNSClusterFirst), `Specify the DNS policy for the API Server.`,
+	)
+  cfg.APIServer.DNSPolicy = v1.DNSPolicy(dnsPolicy)
+
 	options.AddFeatureGatesStringFlag(flagSet, featureGatesString)
 }
 

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -61,7 +61,7 @@ func GetStaticPodSpecs(cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmap
 			LivenessProbe:   livenessProbe(staticpodutil.GetAPIServerProbeAddress(endpoint), int(endpoint.BindPort), v1.URISchemeHTTPS),
 			Resources:       staticpodutil.ComponentResources("250m"),
 			Env:             getProxyEnvVars(),
-		}, mounts.GetVolumes(kubeadmconstants.KubeAPIServer)),
+		}, mounts.GetVolumes(kubeadmconstants.KubeAPIServer), cfg.APIServer.DNSPolicy),
 		kubeadmconstants.KubeControllerManager: staticpodutil.ComponentPod(v1.Container{
 			Name:            kubeadmconstants.KubeControllerManager,
 			Image:           images.GetKubernetesImage(kubeadmconstants.KubeControllerManager, cfg),
@@ -71,7 +71,7 @@ func GetStaticPodSpecs(cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmap
 			LivenessProbe:   livenessProbe(staticpodutil.GetControllerManagerProbeAddress(cfg), kubeadmconstants.InsecureKubeControllerManagerPort, v1.URISchemeHTTP),
 			Resources:       staticpodutil.ComponentResources("200m"),
 			Env:             getProxyEnvVars(),
-		}, mounts.GetVolumes(kubeadmconstants.KubeControllerManager)),
+		}, mounts.GetVolumes(kubeadmconstants.KubeControllerManager), v1.DNSClusterFirst),
 		kubeadmconstants.KubeScheduler: staticpodutil.ComponentPod(v1.Container{
 			Name:            kubeadmconstants.KubeScheduler,
 			Image:           images.GetKubernetesImage(kubeadmconstants.KubeScheduler, cfg),
@@ -81,7 +81,7 @@ func GetStaticPodSpecs(cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmap
 			LivenessProbe:   livenessProbe(staticpodutil.GetSchedulerProbeAddress(cfg), kubeadmconstants.InsecureSchedulerPort, v1.URISchemeHTTP),
 			Resources:       staticpodutil.ComponentResources("100m"),
 			Env:             getProxyEnvVars(),
-		}, mounts.GetVolumes(kubeadmconstants.KubeScheduler)),
+		}, mounts.GetVolumes(kubeadmconstants.KubeScheduler), v1.DNSClusterFirst),
 	}
 	return staticPodSpecs
 }

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -172,7 +172,7 @@ func GetEtcdPodSpec(cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.A
 			&cfg.Etcd, kubeadmconstants.EtcdListenClientPort, cfg.CertificatesDir,
 			kubeadmconstants.EtcdCACertName, kubeadmconstants.EtcdHealthcheckClientCertName, kubeadmconstants.EtcdHealthcheckClientKeyName,
 		),
-	}, etcdMounts)
+	}, etcdMounts, v1.DNSClusterFirst)
 }
 
 // getEtcdCommand builds the right etcd command from the given config object

--- a/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/internal.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/internal.yaml
@@ -14,6 +14,7 @@ APIServer:
     PathType: ""
     ReadOnly: false
   TimeoutForControlPlane: 4m0s
+  DNSPolicy: ClusterFirst
 BootstrapTokens:
 - Description: ""
   Expires: null

--- a/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/internal_non_linux.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/internal_non_linux.yaml
@@ -14,6 +14,7 @@ APIServer:
     PathType: ""
     ReadOnly: false
   TimeoutForControlPlane: 4m0s
+  DNSPolicy: ClusterFirst
 BootstrapTokens:
 - Description: ""
   Expires: null

--- a/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/v1beta1.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/v1beta1.yaml
@@ -30,6 +30,7 @@ apiServer:
     mountPath: /mount/writable
     name: WritableVolume
   timeoutForControlPlane: 4m0s
+  dnsPolicy: ClusterFirst
 apiVersion: kubeadm.k8s.io/v1beta1
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes

--- a/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/v1beta1_non_linux.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/v1beta1_non_linux.yaml
@@ -30,6 +30,7 @@ apiServer:
     mountPath: /mount/writable
     name: WritableVolume
   timeoutForControlPlane: 4m0s
+  dnsPolicy: ClusterFirst
 apiVersion: kubeadm.k8s.io/v1beta1
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted.yaml
@@ -20,6 +20,7 @@ nodeRegistration:
 ---
 apiServer:
   timeoutForControlPlane: 4m0s
+  dnsPolicy: ClusterFirst
 apiVersion: kubeadm.k8s.io/v1beta1
 certificatesDir: /var/lib/kubernetes/pki
 clusterName: kubernetes

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted_non_linux.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted_non_linux.yaml
@@ -20,6 +20,7 @@ nodeRegistration:
 ---
 apiServer:
   timeoutForControlPlane: 4m0s
+  dnsPolicy: ClusterFirst
 apiVersion: kubeadm.k8s.io/v1beta1
 certificatesDir: /var/lib/kubernetes/pki
 clusterName: kubernetes

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -48,7 +48,7 @@ const (
 )
 
 // ComponentPod returns a Pod object from the container and volume specifications
-func ComponentPod(container v1.Container, volumes map[string]v1.Volume) v1.Pod {
+func ComponentPod(container v1.Container, volumes map[string]v1.Volume, dnsPolicy v1.DNSPolicy) v1.Pod {
 	return v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -66,6 +66,7 @@ func ComponentPod(container v1.Container, volumes map[string]v1.Volume) v1.Pod {
 			PriorityClassName: "system-cluster-critical",
 			HostNetwork:       true,
 			Volumes:           VolumeMapToSlice(volumes),
+			DNSPolicy:         dnsPolicy,
 		},
 	}
 }

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -267,6 +267,7 @@ func TestComponentPod(t *testing.T) {
 					PriorityClassName: "system-cluster-critical",
 					HostNetwork:       true,
 					Volumes:           []v1.Volume{},
+					DNSPolicy:         v1.DNSDefault,
 				},
 			},
 		},
@@ -275,7 +276,7 @@ func TestComponentPod(t *testing.T) {
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
 			c := v1.Container{Name: rt.name}
-			actual := ComponentPod(c, map[string]v1.Volume{})
+			actual := ComponentPod(c, map[string]v1.Volume{}, v1.DNSDefault)
 			if !reflect.DeepEqual(rt.expected, actual) {
 				t.Errorf(
 					"failed componentPod:\n\texpected: %v\n\t  actual: %v",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind feature


**What this PR does / why we need it**:

This PR adds a new flag and configuration property for `kubeadm` `ClusterConfiguration` to set the DNS policy for the API Server. Currently it isn't possible to set a specific DNS policy for that pod. 

Based on the environment or the infrastructure, it could become a requirement to set the DNS policy to `ClusterFirstWithHostNet` to resolve cluster internal addresses.

Consequently, we believe it'd be good to expose that option to be configured on demand.

/area kubeadm




