### PR TITLE
Add ipv6 support to the e2e guestbook test

### DIFF
--- a/test/e2e/testing-manifests/guestbook/legacy/redis-master-controller.yaml
+++ b/test/e2e/testing-manifests/guestbook/legacy/redis-master-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: k8s.gcr.io/redis:e2e  # or just image: redis
+        image: docker.io/library/redis:3.2.9-alpine
         resources:
           requests:
             cpu: 100m

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -252,7 +252,7 @@ func initImageConfigs() map[int]Config {
 	configs[Porter] = Config{e2eRegistry, "porter", "1.0"}
 	configs[PrometheusDummyExporter] = Config{e2eRegistry, "prometheus-dummy-exporter", "v0.1.0"}
 	configs[PrometheusToSd] = Config{e2eRegistry, "prometheus-to-sd", "v0.5.0"}
-	configs[Redis] = Config{e2eRegistry, "redis", "1.0"}
+	configs[Redis] = Config{dockerLibraryRegistry, "redis", "3.2.9-alpine"}
 	configs[ResourceConsumer] = Config{e2eRegistry, "resource-consumer", "1.5"}
 	configs[ResourceController] = Config{e2eRegistry, "resource-consumer-controller", "1.0"}
 	configs[SdDummyExporter] = Config{gcRegistry, "sd-dummy-exporter", "v0.2.0"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:

The e2e test `sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application [Conformance]` fails on IPv6 clusters because the redis image used is only bound to IPv4.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

xref: #70248

This PR changes the custom redis image used in the e2e tests by the official redis image. It has to use an older version (3.2.9) to keep compatibility with the redis-slave images.
If this works the redis image maintained in the kubernetes repo could be removed

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
