### PR TITLE
Fixing --show-kind functionality in get.go -o name

### DIFF
--- a/pkg/kubectl/cmd/get/get_flags.go
+++ b/pkg/kubectl/cmd/get/get_flags.go
@@ -117,6 +117,7 @@ func (f *PrintFlags) ToPrinter() (printers.ResourcePrinter, error) {
 	}
 	f.HumanReadableFlags.NoHeaders = noHeaders
 	f.CustomColumnsFlags.NoHeaders = noHeaders
+	f.NamePrintFlags.ShowKind = f.HumanReadableFlags.ShowKind
 
 	// for "get.go" we want to support a --template argument given, even when no --output format is provided
 	if f.TemplateFlags.TemplateArgument != nil && len(*f.TemplateFlags.TemplateArgument) > 0 && len(outputFormat) == 0 {

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags.go
@@ -33,6 +33,7 @@ type NamePrintFlags struct {
 	// took place on an object, to be included in the
 	// finalized "successful" message.
 	Operation string
+	ShowKind  *bool
 }
 
 func (f *NamePrintFlags) Complete(successTemplate string) error {
@@ -54,6 +55,7 @@ func (f *NamePrintFlags) AllowedFormats() []string {
 func (f *NamePrintFlags) ToPrinter(outputFormat string) (printers.ResourcePrinter, error) {
 	namePrinter := &printers.NamePrinter{
 		Operation: f.Operation,
+		ShowKind:  *f.ShowKind,
 	}
 
 	outputFormat = strings.ToLower(outputFormat)

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/name.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/name.go
@@ -36,6 +36,7 @@ type NamePrinter struct {
 	// Operation describes the name of the action that
 	// took place on an object, to be included in the
 	// finalized "successful" message.
+	ShowKind  bool
 	Operation string
 }
 
@@ -80,7 +81,7 @@ func (p *NamePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		}
 	}
 
-	return printObj(w, name, p.Operation, p.ShortOutput, GetObjectGroupKind(obj))
+	return printObj(w, name, p.Operation, p.ShortOutput, p.ShowKind, GetObjectGroupKind(obj))
 }
 
 func GetObjectGroupKind(obj runtime.Object) schema.GroupKind {
@@ -101,7 +102,7 @@ func GetObjectGroupKind(obj runtime.Object) schema.GroupKind {
 	return schema.GroupKind{Kind: "<unknown>"}
 }
 
-func printObj(w io.Writer, name string, operation string, shortOutput bool, groupKind schema.GroupKind) error {
+func printObj(w io.Writer, name string, operation string, shortOutput bool, showKind bool, groupKind schema.GroupKind) error {
 	if len(groupKind.Kind) == 0 {
 		return fmt.Errorf("missing kind for resource with name %v", name)
 	}
@@ -115,10 +116,18 @@ func printObj(w io.Writer, name string, operation string, shortOutput bool, grou
 	}
 
 	if len(groupKind.Group) == 0 {
-		fmt.Fprintf(w, "%s/%s%s\n", strings.ToLower(groupKind.Kind), name, operation)
+		if showKind {
+			fmt.Fprintf(w, "%s/%s%s\n", strings.ToLower(groupKind.Kind), name, operation)
+		} else {
+			fmt.Fprintf(w, "%s%s\n", name, operation)
+		}
 		return nil
 	}
 
-	fmt.Fprintf(w, "%s.%s/%s%s\n", strings.ToLower(groupKind.Kind), groupKind.Group, name, operation)
+	if showKind {
+		fmt.Fprintf(w, "%s.%s/%s%s\n", strings.ToLower(groupKind.Kind), groupKind.Group, name, operation)
+	} else {
+		fmt.Fprintf(w, "%s%s\n", name, operation)
+	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
--show-kind previously did not work with get.go. This PR fixes this
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/669
**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
```release-note
kubectl get po -o name --show-kind=false now omits the kind portion of the output
```
