### PR TITLE
fix inotify unused warning

### DIFF
--- a/cmd/kubelet/app/server_linux.go
+++ b/cmd/kubelet/app/server_linux.go
@@ -17,7 +17,7 @@ limitations under the License.
 package app
 
 import (
-	"github.com/sigma/go-inotify"
+	inotify "github.com/sigma/go-inotify"
 	"k8s.io/klog"
 )
 


### PR DESCRIPTION
some IDE warning for unused import, cuz there is no alias for import "github.com/sigma/go-inotify" 