### PR TITLE
clarify elasticsearch script as bash

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/run.sh
+++ b/cluster/addons/fluentd-elasticsearch/es-image/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2017 The Kubernetes Authors.
 #

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -1,6 +1,5 @@
 ./build/lib/release.sh
 ./cluster/addons/addon-manager/kube-addons.sh
-./cluster/addons/fluentd-elasticsearch/es-image/run.sh
 ./cluster/common.sh
 ./cluster/gce/config-common.sh
 ./cluster/gce/config-default.sh


### PR DESCRIPTION
**What this PR does / why we need it**: eliminates shellcheck failure in `cluster/addons/fluentd-elasticsearch/es-image/run.sh` by correcting the shebang to bash.

NOTE:
- The base image / existing published image are centos based with bash. `/bin/sh` is bash 4.2. This does not change what shell it actually runs under.
- `$HOSTNAME` is not POSIX, however it is set by bash.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
part of https://github.com/kubernetes/kubernetes/issues/72956

**Special notes for your reviewer**:

```
$ docker run --rm --entrypoint=/bin/sh gcr.io/fluentd-elasticsearch/elasticsearch:v6.7.2 --version
GNU bash, version 4.2.46(2)-release (x86_64-redhat-linux-gnu)
Copyright (C) 2011 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/kind cleanup
/sig cluster-lifecycle
/priority important-longterm