### PR TITLE
fix shellcheck failures in cluster/restore-from-backup.sh

### DIFF
--- a/cluster/restore-from-backup.sh
+++ b/cluster/restore-from-backup.sh
@@ -54,8 +54,8 @@ if [ ! -f "${VERSION_FILE}" ]; then
   echo "2.2.1/etcd2" > "${VERSION_FILE}"
 fi
 VERSION_CONTENTS="$(cat ${VERSION_FILE})"
-ETCD_VERSION="$(echo $VERSION_CONTENTS | cut -d '/' -f 1)"
-ETCD_API="$(echo $VERSION_CONTENTS | cut -d '/' -f 2)"
+ETCD_VERSION="$(echo "$VERSION_CONTENTS" | cut -d '/' -f 1)"
+ETCD_API="$(echo "$VERSION_CONTENTS" | cut -d '/' -f 2)"
 
 # Name is used only in case of etcd3 mode, to appropriate set the metadata
 # for the etcd data.
@@ -76,9 +76,9 @@ wait_for_etcd_up() {
   # {"health": "true"} on /health endpoint in healthy case.
   # However, we should come with a regex for it to avoid future break.
   health_ok="{\"health\": \"true\"}"
-  for i in $(seq 120); do
+  for _ in $(seq 120); do
     # TODO: Is it enough to look into /health endpoint?
-    health=$(curl --silent http://127.0.0.1:${port}/health)
+    health=$(curl --silent "http://127.0.0.1:${port}/health")
     if [ "${health}" == "${health_ok}" ]; then
       return 0
     fi
@@ -89,7 +89,7 @@ wait_for_etcd_up() {
 
 # Wait until apiserver is up.
 wait_for_cluster_healthy() {
-  for i in $(seq 120); do
+  for _ in $(seq 120); do
     cs_status=$(kubectl get componentstatuses -o template --template='{{range .items}}{{with index .conditions 0}}{{.type}}:{{.status}}{{end}}{{"\n"}}{{end}}') || true
     componentstatuses=$(echo "${cs_status}" | grep -c 'Healthy:') || true
     healthy=$(echo "${cs_status}" | grep -c 'Healthy:True') || true
@@ -103,13 +103,13 @@ wait_for_cluster_healthy() {
 
 # Wait until etcd and apiserver pods are down.
 wait_for_etcd_and_apiserver_down() {
-  for i in $(seq 120); do
-    etcd=$(docker ps | grep etcd-server | wc -l)
-    apiserver=$(docker ps | grep apiserver | wc -l)
+  for _ in $(seq 120); do
+    etcd=$(docker ps | grep -c etcd-server)
+    apiserver=$(docker ps | grep -c apiserver)
     # TODO: Theoretically it is possible, that apiserver and or etcd
     # are currently down, but Kubelet is now restarting them and they
     # will reappear again. We should avoid it.
-    if [ "${etcd}" -eq "0" -a "${apiserver}" -eq "0" ]; then
+    if [ "${etcd}" -eq "0" ] && [ "${apiserver}" -eq "0" ]; then
       return 0
     fi
     sleep 1
@@ -153,16 +153,15 @@ if [ "${ETCD_API}" == "etcd2" ]; then
   mkdir -p "${BACKUP_DIR}/member/snap"
   mkdir -p "${BACKUP_DIR}/member/wal"
   # If the cluster is relatively new, there can be no .snap file.
-  mv *.snap "${BACKUP_DIR}/member/snap/" || true
-  mv *.wal "${BACKUP_DIR}/member/wal/"
+  mv ./*.snap "${BACKUP_DIR}/member/snap/" || true
+  mv ./*.wal "${BACKUP_DIR}/member/wal/"
 
   # TODO(jsz): This won't work with HA setups (e.g. do we need to set --name flag)?
   echo "Starting etcd ${ETCD_VERSION} to restore data"
-  image=$(docker run -d -v ${BACKUP_DIR}:/var/etcd/data \
+  if ! image=$(docker run -d -v ${BACKUP_DIR}:/var/etcd/data \
     --net=host -p ${etcd_port}:${etcd_port} \
     "k8s.gcr.io/etcd:${ETCD_VERSION}" /bin/sh -c \
-    "/usr/local/bin/etcd --data-dir /var/etcd/data --force-new-cluster")
-  if [ "$?" -ne "0" ]; then
+    "/usr/local/bin/etcd --data-dir /var/etcd/data --force-new-cluster"); then
     echo "Docker container didn't started correctly"
     exit 1
   fi
@@ -185,15 +184,14 @@ elif [ "${ETCD_API}" == "etcd3" ]; then
     echo "Incorrect number of *.db files - expected 1"
     exit 1
   fi
-  mv *.db "${BACKUP_DIR}/"
+  mv ./*.db "${BACKUP_DIR}/"
   snapshot="$(ls ${BACKUP_DIR})"
 
   # Run etcdctl snapshot restore command and wait until it is finished.
   # setting with --name in the etcd manifest file and then it seems to work.
-  docker run -v ${BACKUP_DIR}:/var/tmp/backup --env ETCDCTL_API=3 \
+  if ! docker run -v ${BACKUP_DIR}:/var/tmp/backup --env ETCDCTL_API=3 \
     "k8s.gcr.io/etcd:${ETCD_VERSION}" /bin/sh -c \
-    "/usr/local/bin/etcdctl snapshot restore ${BACKUP_DIR}/${snapshot} --name ${NAME} --initial-cluster ${INITIAL_CLUSTER} --initial-advertise-peer-urls ${INITIAL_ADVERTISE_PEER_URLS}; mv /${NAME}.etcd/member /var/tmp/backup/"
-  if [ "$?" -ne "0" ]; then
+    "/usr/local/bin/etcdctl snapshot restore ${BACKUP_DIR}/${snapshot} --name ${NAME} --initial-cluster ${INITIAL_CLUSTER} --initial-advertise-peer-urls ${INITIAL_ADVERTISE_PEER_URLS}; mv /${NAME}.etcd/member /var/tmp/backup/"; then
     echo "Docker container didn't started correctly"
     exit 1
   fi

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -14,7 +14,6 @@
 ./cluster/gce/util.sh
 ./cluster/log-dump/log-dump.sh
 ./cluster/pre-existing/util.sh
-./cluster/restore-from-backup.sh
 ./cluster/test-e2e.sh
 ./cluster/validate-cluster.sh
 ./hack/lib/init.sh


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: fixes shellcheck failures in `cluster/restore-from-backup.sh`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/72956

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
