### PR TITLE
fix KubeletConfiguration apiVersion

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
@@ -54,7 +54,7 @@ limitations under the License.
 //     apiVersion: kubeadm.k8s.io/v1beta2
 //     kind: ClusterConfiguration
 //
-//     apiVersion: kubelet.config.k8s.io/v1beta2
+//     apiVersion: kubelet.config.k8s.io/v1beta1
 //     kind: KubeletConfiguration
 //
 //     apiVersion: kubeproxy.config.k8s.io/v1alpha1
@@ -139,14 +139,14 @@ limitations under the License.
 // See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ or https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration
 // for kube proxy official documentation.
 //
-//    apiVersion: kubelet.config.k8s.io/v1beta2
+//    apiVersion: kubelet.config.k8s.io/v1beta1
 //    kind: KubeletConfiguration
 //       ...
 //
 // The KubeletConfiguration type should be used to change the configurations that will be passed to all kubelet instances
 // deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
 //
-// See https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ or https://godoc.org/k8s.io/kubelet/config/v1beta2#KubeletConfiguration
+// See https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ or https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration
 // for kubelet official documentation.
 //
 // Here is a fully populated example of a single YAML file containing multiple
@@ -244,7 +244,7 @@ limitations under the License.
 // 	useHyperKubeImage: false
 // 	clusterName: "example-cluster"
 // 	---
-// 	apiVersion: kubelet.config.k8s.io/v1beta2
+// 	apiVersion: kubelet.config.k8s.io/v1beta1
 // 	kind: KubeletConfiguration
 // 	# kubelet specific options here
 // 	---


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: fixes the kubeadm docs, specifically corrects the KubeletConfig apiVersion from v1beta2 to v1beta1 (v1beta2 does not exist yet)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/79411

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig cluster-lifecycle
/priority important-soon
