### PR TITLE
add anti affinity pods for density e2e test

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -163,6 +163,8 @@ type TestContextType struct {
 
 	// The configration of NodeKiller.
 	NodeKiller NodeKillerConfig
+
+	PodAntiAffinity bool
 }
 
 // NodeKillerConfig describes configuration of NodeKiller -- a utility to
@@ -270,6 +272,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.KubernetesAnywherePath, "kubernetes-anywhere-path", "/workspace/k8s.io/kubernetes-anywhere", "Which directory kubernetes-anywhere is installed to.")
 
 	flag.BoolVar(&TestContext.ListImages, "list-images", false, "If true, will show list of images used for runnning tests.")
+	flag.BoolVar(&TestContext.PodAntiAffinity, "pod-anti-affinity", false, "If true will involve affinity pods into density test.")
 }
 
 // RegisterClusterFlags registers flags specific to the cluster e2e test suite.

--- a/test/e2e/scalability/density.go
+++ b/test/e2e/scalability/density.go
@@ -686,7 +686,7 @@ var _ = SIGDescribe("Density", func() {
 					Image:                          imageutils.GetPauseImageName(),
 					Name:                           name,
 					Namespace:                      nsName,
-					Labels:                         map[string]string{"type": "densityPod"},
+					Labels:                         map[string]string{"type": "densityPod", "app": name},
 					PollInterval:                   DensityPollInterval,
 					Timeout:                        timeout,
 					PodStatusFile:                  fileHndl,
@@ -713,6 +713,25 @@ var _ = SIGDescribe("Density", func() {
 						},
 					},
 				}
+
+				if framework.TestContext.PodAntiAffinity {
+					baseConfig.Affinity = &v1.Affinity{
+						PodAntiAffinity: &v1.PodAntiAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
+								{
+									Weight: 100,
+									PodAffinityTerm: v1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{"app": name},
+										},
+										TopologyKey: v1.LabelHostname,
+									},
+								},
+							},
+						},
+					}
+				}
+
 				switch itArg.kind {
 				case api.Kind("ReplicationController"):
 					configs[i] = baseConfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
>
> /kind api-change
> /kind design
> /kind feature
> /sig scheduling

**What this PR does / why we need it**:
Current e2e density test only runs some regular pod. It does not contain affinity pod. Which cannot measue the throughput of kube-scheduler for affinity pods. And affinity pod is a common strategy for production.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
