### PR TITLE
feat: use scheduler.New instead in daemonset integration test

### DIFF
--- a/test/integration/daemonset/BUILD
+++ b/test/integration/daemonset/BUILD
@@ -22,7 +22,6 @@ go_test(
         "//pkg/scheduler:go_default_library",
         "//pkg/scheduler/algorithmprovider:go_default_library",
         "//pkg/scheduler/api:go_default_library",
-        "//pkg/scheduler/factory:go_default_library",
         "//pkg/util/labels:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Use scheduler.New instead of factory.NewConfigFactory for scheduler initialization.

**Which issue(s) this PR fixes**:

ref: https://github.com/kubernetes/kubernetes/issues/71859

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
