### PR TITLE
Remove NodeInfo for csiNode from cache when there is no Pod scheduled

### DIFF
--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -606,8 +606,12 @@ func (cache *schedulerCache) RemoveCSINode(csiNode *storagev1beta1.CSINode) erro
 	if !ok {
 		return fmt.Errorf("node %v is not found", csiNode.Name)
 	}
-	n.info.SetCSINode(nil)
-	cache.moveNodeInfoToHead(csiNode.Name)
+	if len(n.info.Pods()) == 0 && n.info.Node() == nil {
+		cache.removeNodeInfoFromList(csiNode.Name)
+	} else {
+		n.info.SetCSINode(nil)
+		cache.moveNodeInfoToHead(csiNode.Name)
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This is related to #77595
In schedulerCache#RemoveCSINode, when there is no Pod on the node, we should remove the corresponding NodeInfo.
Without this removal, some NodeInfo's with nil CSINode may be stuck in the cache.

```release-note
NONE
```
