### PR TITLE
remove dead KUBE_TEST_API_VERSIONS from test-integration

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -20,15 +20,6 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
 source "${KUBE_ROOT}/hack/lib/init.sh"
-# Lists of API Versions of each groups that should be tested, groups are
-# separated by comma, lists are separated by semicolon. e.g.,
-# "v1,compute/v1alpha1,experimental/v1alpha2;v1,compute/v2,experimental/v1alpha3"
-# TODO: It's going to be:
-# KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1,extensions/v1beta1"}
-# FIXME: due to current implementation of a test client (see: pkg/api/testapi/testapi.go)
-# ONLY the last version is tested in each group.
-ALL_VERSIONS_CSV=$(IFS=',';echo "${KUBE_AVAILABLE_GROUP_VERSIONS[*]// /,}";IFS=$)
-KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS:-${ALL_VERSIONS_CSV}}"
 
 # Give integration tests longer to run by default.
 KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout=600s}
@@ -76,8 +67,7 @@ runTests() {
       GOFLAGS="${GOFLAGS:-}" \
       KUBE_TEST_ARGS="--alsologtostderr=true ${KUBE_TEST_ARGS:-} ${SHORT:--short=true} --vmodule=${KUBE_TEST_VMODULE}" \
       KUBE_RACE="" \
-      KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
-      KUBE_TEST_API_VERSIONS="$1"
+      KUBE_TIMEOUT="${KUBE_TIMEOUT}"
 
   cleanup
 }
@@ -96,8 +86,4 @@ checkEtcdOnPath
 # Run cleanup to stop etcd on interrupt or other kill signal.
 trap cleanup EXIT
 
-# Convert the CSV to an array of API versions to test
-IFS=';' read -ra apiVersions <<< "${KUBE_TEST_API_VERSIONS}"
-for apiVersion in "${apiVersions[@]}"; do
-  runTests "${apiVersion}"
-done
+runTests


### PR DESCRIPTION
This is just cruft from long ago

```release-note
NONE
```

/kind cleanup
/priority important-longterm
@kubernetes/sig-api-machinery-misc 