### PR TITLE
InstanceShutdownByProviderID should return true when instance is stopped or terminated in aws

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -1538,7 +1538,7 @@ func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID strin
 	return true, nil
 }
 
-// InstanceShutdownByProviderID returns true if the instance is in safe state to detach volumes
+// InstanceShutdownByProviderID returns true if the instance is shutdown in cloud provider
 func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
 	instanceID, err := KubernetesInstanceID(providerID).MapToAWSInstanceID()
 	if err != nil {
@@ -1567,7 +1567,8 @@ func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID str
 	if instance.State != nil {
 		state := aws.StringValue(instance.State.Name)
 		// valid state for detaching volumes
-		if state == ec2.InstanceStateNameStopped {
+		// In aws, instance shutdown means either stop (can be turned on again) or terminate (cannot be turned on again)
+		if state == ec2.InstanceStateNameStopped || state == ec2.InstanceStateNameTerminated {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig aws

**What this PR does / why we need it**:
Instance shutdown means terminated OR stopped in aws, return true only when instance is stopped will cause confusions:
1. The interface implies that it will return true if instance is "shutdown", i.e. the machine is not running, and a "terminated" ec2 instance will also fit in to this category
2. This will cause terminated node miss the shutdown taint, with only unreachable taint, daemonset will tolerate https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/daemon/util/daemonset_util.go#L49 , but adding a desired replica on terminated node does not make sense 

This PR checks terminated state for instance as well and added test for `InstanceShutdownByProviderID()`

**Which issue(s) this PR fixes**:
Fixes #79435

**Special notes for your reviewer**:
/cc @justinsb @jsafrane @micahhausler @gnufied 
/assign @mcrute

**TL;DR:** this fix does not change current behavior that after node is shutdown (stopped or terminated), we keep the `v1.Node` object in api server until the instance disappear from cloud provider, but just make node lifecycle controller to add a shutdown taint to the `v1.Node` object which makes it less confusing to other apps such as daemonset.


I'm aware that https://github.com/kubernetes/kubernetes/issues/69409 removed the "terminated" check, but with proper tainting (i.e. shutdown taint), node termination will result in the following behavior:

- node unreachable
- node marked as "shutdown" (add a shutdown taint, which no application is supposed to tolerate)
- node disappear in cloud provider (i.e. after an hour)
- v1.Node gets deleted from cloud provider

By leaving the v1.Node object hanging for an hour or so can assist debugging, the current behavior is to let the node hang after it gets terminated, but without a proper shutdown taint, and this change just made node lifecycle controller to add a shutdown taint to the terminated node.

**Does this PR introduce a user-facing change?**:
```release-note
InstanceShutdownByProviderID should return true when instance is stopped or terminated in aws
```
