### PR TITLE
Simplify checking in getMinTolerationTime

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/taint_manager.go
+++ b/pkg/controller/nodelifecycle/scheduler/taint_manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
+	"math"
 	"sync"
 	"time"
 
@@ -129,7 +130,7 @@ func getNoExecuteTaints(taints []v1.Taint) []v1.Taint {
 
 // getMinTolerationTime returns minimal toleration time from the given slice, or -1 if it's infinite.
 func getMinTolerationTime(tolerations []v1.Toleration) time.Duration {
-	minTolerationTime := int64(-1)
+	minTolerationTime := int64(math.MaxInt64)
 	if len(tolerations) == 0 {
 		return 0
 	}
@@ -139,12 +140,15 @@ func getMinTolerationTime(tolerations []v1.Toleration) time.Duration {
 			tolerationSeconds := *(tolerations[i].TolerationSeconds)
 			if tolerationSeconds <= 0 {
 				return 0
-			} else if tolerationSeconds < minTolerationTime || minTolerationTime == -1 {
+			} else if tolerationSeconds < minTolerationTime {
 				minTolerationTime = tolerationSeconds
 			}
 		}
 	}
 
+	if minTolerationTime == int64(math.MaxInt64) {
+		return -1
+	}
 	return time.Duration(minTolerationTime) * time.Second
 }
 

--- a/pkg/controller/nodelifecycle/scheduler/taint_manager_test.go
+++ b/pkg/controller/nodelifecycle/scheduler/taint_manager_test.go
@@ -617,6 +617,7 @@ func TestUpdateNodeWithMultiplePods(t *testing.T) {
 
 func TestGetMinTolerationTime(t *testing.T) {
 	one := int64(1)
+	two := int64(2)
 	oneSec := 1 * time.Second
 
 	tests := []struct {
@@ -627,6 +628,26 @@ func TestGetMinTolerationTime(t *testing.T) {
 			tolerations: []v1.Toleration{},
 			expected:    0,
 		},
+		{
+			tolerations: []v1.Toleration{
+				{
+					TolerationSeconds: nil,
+				},
+			},
+			expected: -1,
+		},
+		{
+			tolerations: []v1.Toleration{
+				{
+					TolerationSeconds: &one,
+				},
+				{
+					TolerationSeconds: &two,
+				},
+			},
+			expected: oneSec,
+		},
+
 		{
 			tolerations: []v1.Toleration{
 				{
@@ -662,7 +683,7 @@ func TestGetMinTolerationTime(t *testing.T) {
 // TestEventualConsistency verifies if getPodsAssignedToNode returns incomplete data
 // (e.g. due to watch latency), it will reconcile the remaining pods eventually.
 // This scenario is partially covered by TestUpdatePods, but given this is an important
-// property of TaitManager, it's better to have explicit test for this.
+// property of TaintManager, it's better to have explicit test for this.
 func TestEventualConsistency(t *testing.T) {
 	testCases := []struct {
 		description  string


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In getMinTolerationTime (taint_manager.go),
```
			} else if tolerationSeconds < minTolerationTime || minTolerationTime == -1 {
```
when tolerationSeconds >= minTolerationTime, even if minTolerationTime has been set in prior iteration (!= -1), the second clause would still be evaluated.

After my PR, the wasteful check doesn't exist.

```release-note
NONE
```
