### PR TITLE
Remove monopole from root OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,7 +15,6 @@ filters:
       - brendandburns
       - dchen1107
       - jbeda
-      - monopole # To move code per kubernetes/community#598
       - lavalamp
       - smarterclayton
       - thockin


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes @monopole from root OWNERS

**Special notes for your reviewer**:
https://github.com/kubernetes/community/pull/598 is closed, pointing to https://github.com/kubernetes/kubectl/pull/179, which is also closed and points nowhere

This leads me to believe @monopole doesn't need root OWNERS privileges
anymore

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```