### PR TITLE
Drop oldCSINode parameter from UpdateCSINode

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -171,7 +171,7 @@ func (sched *Scheduler) onCSINodeAdd(obj interface{}) {
 }
 
 func (sched *Scheduler) onCSINodeUpdate(oldObj, newObj interface{}) {
-	oldCSINode, ok := oldObj.(*storagev1beta1.CSINode)
+	_, ok := oldObj.(*storagev1beta1.CSINode)
 	if !ok {
 		klog.Errorf("cannot convert oldObj to *storagev1beta1.CSINode: %v", oldObj)
 		return
@@ -183,7 +183,7 @@ func (sched *Scheduler) onCSINodeUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	if err := sched.config.SchedulerCache.UpdateCSINode(oldCSINode, newCSINode); err != nil {
+	if err := sched.config.SchedulerCache.UpdateCSINode(newCSINode); err != nil {
 		klog.Errorf("scheduler cache UpdateCSINode failed: %v", err)
 	}
 

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -584,7 +584,7 @@ func (cache *schedulerCache) AddCSINode(csiNode *storagev1beta1.CSINode) error {
 	return nil
 }
 
-func (cache *schedulerCache) UpdateCSINode(oldCSINode, newCSINode *storagev1beta1.CSINode) error {
+func (cache *schedulerCache) UpdateCSINode(newCSINode *storagev1beta1.CSINode) error {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 

--- a/pkg/scheduler/internal/cache/fake/fake_cache.go
+++ b/pkg/scheduler/internal/cache/fake/fake_cache.go
@@ -79,7 +79,7 @@ func (c *Cache) RemoveNode(node *v1.Node) error { return nil }
 func (c *Cache) AddCSINode(csiNode *storagev1beta1.CSINode) error { return nil }
 
 // UpdateCSINode is a fake method for testing.
-func (c *Cache) UpdateCSINode(oldCSINode, newCSINode *storagev1beta1.CSINode) error { return nil }
+func (c *Cache) UpdateCSINode(newCSINode *storagev1beta1.CSINode) error { return nil }
 
 // RemoveCSINode is a fake method for testing.
 func (c *Cache) RemoveCSINode(csiNode *storagev1beta1.CSINode) error { return nil }

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -105,7 +105,7 @@ type Cache interface {
 	AddCSINode(csiNode *storagev1beta1.CSINode) error
 
 	// UpdateCSINode updates overall CSI-related information about node.
-	UpdateCSINode(oldCSINode, newCSINode *storagev1beta1.CSINode) error
+	UpdateCSINode(newCSINode *storagev1beta1.CSINode) error
 
 	// RemoveCSINode removes overall CSI-related information about node.
 	RemoveCSINode(csiNode *storagev1beta1.CSINode) error


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently in schedulerCache#UpdateCSINode, oldCSINode is not used.

This PR drops this parameter from the func.

```release-note
NONE
```
