### PR TITLE
Scheduler: reduce iteration and conversion to improve perfermance

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -29,7 +29,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -1236,10 +1235,7 @@ func (c *PodAffinityChecker) podMatchesPodAffinityTerms(pod, targetPod *v1.Pod, 
 	if len(terms) == 0 {
 		return false, false, fmt.Errorf("terms array is empty")
 	}
-	props, err := getAffinityTermProperties(pod, terms)
-	if err != nil {
-		return false, false, err
-	}
+	props := getAffinityTermProperties(pod, terms)
 	if !podMatchesAllAffinityTermProperties(targetPod, props) {
 		return false, false, nil
 	}
@@ -1298,12 +1294,8 @@ func getMatchingAntiAffinityTopologyPairsOfPod(newPod *v1.Pod, existingPod *v1.P
 
 	topologyMaps := newTopologyPairsMaps()
 	for _, term := range GetPodAntiAffinityTerms(affinity.PodAntiAffinity) {
-		selector, err := metav1.LabelSelectorAsSelector(term.LabelSelector)
-		if err != nil {
-			return nil, err
-		}
 		namespaces := priorityutil.GetNamespacesFromPodAffinityTerm(existingPod, &term)
-		if priorityutil.PodMatchesTermsNamespaceAndSelector(newPod, namespaces, selector) {
+		if priorityutil.PodMatchesTermsNamespaceAndSelector(newPod, namespaces, term.LabelSelector) {
 			if topologyValue, ok := node.Labels[term.TopologyKey]; ok {
 				pair := topologyPair{key: term.TopologyKey, value: topologyValue}
 				topologyMaps.addTopologyPair(pair, existingPod)

--- a/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
@@ -86,12 +85,7 @@ func (p *podAffinityPriorityMap) setError(err error) {
 
 func (p *podAffinityPriorityMap) processTerm(term *v1.PodAffinityTerm, podDefiningAffinityTerm, podToCheck *v1.Pod, fixedNode *v1.Node, weight int64) {
 	namespaces := priorityutil.GetNamespacesFromPodAffinityTerm(podDefiningAffinityTerm, term)
-	selector, err := metav1.LabelSelectorAsSelector(term.LabelSelector)
-	if err != nil {
-		p.setError(err)
-		return
-	}
-	match := priorityutil.PodMatchesTermsNamespaceAndSelector(podToCheck, namespaces, selector)
+	match := priorityutil.PodMatchesTermsNamespaceAndSelector(podToCheck, namespaces, term.LabelSelector)
 	if match {
 		for _, node := range p.nodes {
 			if priorityutil.NodesHaveSameTopologyKey(node, fixedNode, term.TopologyKey) {

--- a/pkg/scheduler/algorithm/priorities/util/BUILD
+++ b/pkg/scheduler/algorithm/priorities/util/BUILD
@@ -17,9 +17,6 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/selection:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )
@@ -33,8 +30,9 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util",
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/internal/queue/BUILD
+++ b/pkg/scheduler/internal/queue/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//pkg/scheduler/metrics:go_default_library",
         "//pkg/scheduler/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/klog"
 
 	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -567,11 +566,7 @@ func (p *PriorityQueue) getUnschedulablePodsWithMatchingAffinityTerm(pod *v1.Pod
 			terms := predicates.GetPodAffinityTerms(affinity.PodAffinity)
 			for _, term := range terms {
 				namespaces := priorityutil.GetNamespacesFromPodAffinityTerm(up, &term)
-				selector, err := metav1.LabelSelectorAsSelector(term.LabelSelector)
-				if err != nil {
-					klog.Errorf("Error getting label selectors for pod: %v.", up.Name)
-				}
-				if priorityutil.PodMatchesTermsNamespaceAndSelector(pod, namespaces, selector) {
+				if priorityutil.PodMatchesTermsNamespaceAndSelector(pod, namespaces, term.LabelSelector) {
 					podsToMove = append(podsToMove, pInfo)
 					break
 				}


### PR DESCRIPTION
rewrite two funcs:
1. GetNamespacesFromPodAffinityTerm func
2. PodMatchesTermsNamespaceAndSelector func

**What type of PR is this?**
/kind design
/sig scheduling

**What this PR does / why we need it**:
This PR tries to reduce iteration and remove affinity term namespaces  convert to map and labelSelector convert to selector, just use term namespaces and labelSelector to match pod namespace and labels. Which can improve the scheduler perfermance:

- Required PodAntiAffinity (2.4X perfermance improvement, as below)
  - Before
  ```
  BenchmarkSchedulingPodAntiAffinity/1000Nodes/1000Pods-4       10000	  24375155 ns/op
  ```
  - After
  ```
  BenchmarkSchedulingPodAntiAffinity/1000Nodes/1000Pods-4       10000	   9812070 ns/op
  ```
**Special notes for your reviewer**:
Above test result is run at a bm with 4 core cpus and 8GB memory.

**Does this PR introduce a user-facing change?**:
2.4X perfermance improvement on PodAntiAffinity
