### PR TITLE
Run sidecars for csi-mock as privileged

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-cluster-driver-registrar.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-cluster-driver-registrar.yaml
@@ -24,6 +24,8 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
           imagePullPolicy: Always
+          securityContext:
+            privileged: true
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
@@ -23,6 +23,8 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
           imagePullPolicy: Always
+          securityContext:
+            privileged: true
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
@@ -23,6 +23,8 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
           imagePullPolicy: Always
+          securityContext:
+            privileged: true
           volumeMounts:
           - mountPath: /csi
             name: socket-dir


### PR DESCRIPTION
The driver and provisioner runs as privileged, so make all the other sidecar containers privileged too.

This helps on system with SELinux, non-privileged container can't access socket of a privileged one.

AFAIK there is no canonical location of csi-mock yaml files, only this repo should be updated.

@pohly @msau42 PTAL.

This is the closest one, kubernetes tests are failing on RHEL:
/kind failing-test

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
