### PR TITLE
Removes test-cmd inappropriate dependency on kubectl

### DIFF
--- a/test/cmd/BUILD
+++ b/test/cmd/BUILD
@@ -1,7 +1,6 @@
 sh_library(
     name = "legacy-script",
     srcs = glob(["*.sh"]),
-    data = ["//pkg/kubectl/validation:testdata/v1/validPod.yaml"],
     visibility = ["//visibility:public"],
 )
 

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -438,7 +438,7 @@ run_pod_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'valid-pod:'
 
   ## Patch can modify a local object
-  kubectl patch --local -f pkg/kubectl/validation/testdata/v1/validPod.yaml --patch='{"spec": {"restartPolicy":"Never"}}' -o yaml | grep -q "Never"
+  kubectl patch --local -f test/fixtures/pkg/kubectl/cmd/patch/validPod.yaml --patch='{"spec": {"restartPolicy":"Never"}}' -o yaml | grep -q "Never"
 
   ## Patch fails with type restore error and exit code 1
   output_message=$(! kubectl patch "${kube_flags[@]}" pod valid-pod -p='{"metadata":{"labels":"invalid"}}' 2>&1)

--- a/test/fixtures/pkg/kubectl/cmd/patch/validPod.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/patch/validPod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: redis-master
+  name: name
+spec:
+  containers:
+  - args:
+    - this
+    - is
+    - an
+    - ok
+    - command
+    image: gcr.io/fake_project/fake_image:fake_tag
+    name: master


### PR DESCRIPTION
* Copies test file validPod.yaml to test/fixtures/pkg/kubectl
* Removes inappropriate dependency of test-cmd on kubectl

/sig cli
/area kubectl
/kind cleanup

```release-note
NONE
```
