### PR TITLE
Save docker tag for releases in tarfile archive

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -393,22 +393,21 @@ EOF
             docker_build_opts+=("--pull")
         fi
         "${DOCKER[@]}" build "${docker_build_opts[@]}" -q -t "${docker_image_tag}" "${docker_build_path}" >/dev/null
-        "${DOCKER[@]}" save "${docker_image_tag}" > "${binary_dir}/${binary_name}.tar"
+        # If we are building an official/alpha/beta release we want to keep
+        # docker images and tag them appropriately.
+        local release_docker_image_tag=""
+        if [[ -n "${KUBE_DOCKER_IMAGE_TAG-}" && -n "${KUBE_DOCKER_REGISTRY-}" && $docker_registry != $KUBE_DOCKER_REGISTRY ]]; then
+          release_docker_image_tag="${KUBE_DOCKER_REGISTRY}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG}"
+          kube::log::status "Tagging docker image ${docker_image_tag} as ${release_docker_image_tag}"
+          "${DOCKER[@]}" rmi "${release_docker_image_tag}" 2>/dev/null || true
+          "${DOCKER[@]}" tag "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
+        fi
+        "${DOCKER[@]}" save -o "${binary_dir}/${binary_name}.tar" "${docker_image_tag}" ${release_docker_image_tag}
         echo "${docker_tag}" > "${binary_dir}/${binary_name}.docker_tag"
         rm -rf "${docker_build_path}"
         ln "${binary_dir}/${binary_name}.tar" "${images_dir}/"
 
-        # If we are building an official/alpha/beta release we want to keep
-        # docker images and tag them appropriately.
-        if [[ -n "${KUBE_DOCKER_IMAGE_TAG-}" && -n "${KUBE_DOCKER_REGISTRY-}" ]]; then
-          local release_docker_image_tag="${KUBE_DOCKER_REGISTRY}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG}"
-          # Only rmi and tag if name is different
-          if [[ $docker_image_tag != $release_docker_image_tag ]]; then
-            kube::log::status "Tagging docker image ${docker_image_tag} as ${release_docker_image_tag}"
-            "${DOCKER[@]}" rmi "${release_docker_image_tag}" 2>/dev/null || true
-            "${DOCKER[@]}" tag "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
-          fi
-        else
+        if [[ -z "${KUBE_DOCKER_IMAGE_TAG-}" || -z "${KUBE_DOCKER_REGISTRY-}" ]]; then
           # not a release
           kube::log::status "Deleting docker image ${docker_image_tag}"
           "${DOCKER[@]}" rmi "${docker_image_tag}" &>/dev/null || true


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
When we release tarfiles, these only include the official "k8s.gcr.io" and "google_containers" tags, even if we specified a different registry using KUBE_DOCKER_REGISTRY.
We should save all the associated docker tags in the archive.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
