### PR TITLE
suppress libseccomp pkg-config errors

### DIFF
--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -62,11 +62,15 @@ for repo in "${staging_repos[@]}"; do
 done
 
 # Run gazelle to update Go rules in BUILD files.
+# filter out known pkg-config error (see buildozer workaround below)
+# NOTE: the `|| exit "${PIPESTATUS[0]}"` is to ignore grep errors 
+# while preserving the exit code of gazelle
 gazelle fix \
     -external=vendored \
     -mode=fix \
     -repo_root "${KUBE_ROOT}" \
-    "${KUBE_ROOT}"
+    "${KUBE_ROOT}" \
+    2>&1 | grep -Ev "vendor/github.com/seccomp/libseccomp-golang/seccomp(_internal)?.go: pkg-config not supported: #cgo pkg-config: libseccomp" || (exit "${PIPESTATUS[0]}")
 
 # Run kazel to update the pkg-srcs and all-srcs rules as well as handle
 # Kubernetes code generators.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Suppresses the following gazelle output in `hack/update-bazel.sh`

```
gazelle: /home/user/go/src/k8s.io/kubernetes/vendor/github.com/seccomp/libseccomp-golang/seccomp.go: error reading go file: /home/user/go/src/k8s.io/kubernetes/vendor/github.com/seccomp/libseccomp-golang/seccomp.go: pkg-config not supported: #cgo pkg-config: libseccomp
gazelle: /home/user/go/src/k8s.io/kubernetes/vendor/github.com/seccomp/libseccomp-golang/seccomp_internal.go: error reading go file: /home/user/go/src/k8s.io/kubernetes/vendor/github.com/seccomp/libseccomp-golang/seccomp_internal.go: pkg-config not supported: #cgo pkg-config: libseccomp
```

These errors are known, and we already worked around this in https://github.com/kubernetes/kubernetes/pull/79287

We do not expect the root cause to change in the forseeable future.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/79499

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
