### PR TITLE
add --advertise-port to kube-apiserver

### DIFF
--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -101,7 +101,7 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertion
 	config.GenericConfig.Version = &kubeVersion
 	config.ExtraConfig.StorageFactory = storageFactory
 	config.GenericConfig.LoopbackClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: legacyscheme.Codecs}}
-	config.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
+	config.GenericConfig.AdvertiseAddress = net.ParseIP("192.168.10.4")
 	config.GenericConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	config.ExtraConfig.KubeletClientConfig = kubeletclient.KubeletClientConfig{Port: 10250}
 	config.ExtraConfig.ProxyTransport = utilnet.SetTransportDefaults(&http.Transport{

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -194,10 +194,13 @@ type Config struct {
 	// values below here are targets for removal
 	//===========================================================================
 
-	// PublicAddress is the IP address where members of the cluster (kubelet,
+	// AdvertiseAddress is the IP address where members of the cluster (kubelet,
 	// kube-proxy, services, etc.) can reach the GenericAPIServer.
 	// If nil or 0.0.0.0, the host's default interface will be used.
-	PublicAddress net.IP
+	AdvertiseAddress net.IP
+	// AdvertisePort is the port on which to advertise the apiserver to members
+	// of the cluster.
+	AdvertisePort int
 
 	// EquivalentResourceRegistry provides information about resources equivalent to a given resource,
 	// and the kind associated with a given resource. As resources are installed, they are registered here.
@@ -372,8 +375,11 @@ type CompletedConfig struct {
 // Complete fills in any fields not set that are required to have valid data and can be derived
 // from other fields. If you're going to `ApplyOptions`, do that first. It's mutating the receiver.
 func (c *Config) Complete(informers informers.SharedInformerFactory) CompletedConfig {
-	if len(c.ExternalAddress) == 0 && c.PublicAddress != nil {
-		c.ExternalAddress = c.PublicAddress.String()
+	if len(c.ExternalAddress) == 0 && c.AdvertiseAddress != nil {
+		c.ExternalAddress = c.AdvertiseAddress.String()
+		if c.AdvertisePort != 0 {
+			c.ExternalAddress = net.JoinHostPort(c.AdvertiseAddress.String(), strconv.Itoa(c.AdvertisePort))
+		}
 	}
 
 	// if there is no port, and we listen on one securely, use that one

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -35,7 +35,7 @@ import (
 func TestNewWithDelegate(t *testing.T) {
 	delegateConfig := NewConfig(codecs)
 	delegateConfig.ExternalAddress = "192.168.10.4:443"
-	delegateConfig.PublicAddress = net.ParseIP("192.168.10.4")
+	delegateConfig.AdvertiseAddress = net.ParseIP("192.168.10.4")
 	delegateConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	delegateConfig.LoopbackClientConfig = &rest.Config{}
 	clientset := fake.NewSimpleClientset()
@@ -67,7 +67,7 @@ func TestNewWithDelegate(t *testing.T) {
 
 	wrappingConfig := NewConfig(codecs)
 	wrappingConfig.ExternalAddress = "192.168.10.4:443"
-	wrappingConfig.PublicAddress = net.ParseIP("192.168.10.4")
+	wrappingConfig.AdvertiseAddress = net.ParseIP("192.168.10.4")
 	wrappingConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	wrappingConfig.LoopbackClientConfig = &rest.Config{}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -126,7 +126,7 @@ func testGetOpenAPIDefinitions(_ kubeopenapi.ReferenceCallback) map[string]kubeo
 func setUp(t *testing.T) (Config, *assert.Assertions) {
 	config := NewConfig(codecs)
 	config.ExternalAddress = "192.168.10.4:443"
-	config.PublicAddress = net.ParseIP("192.168.10.4")
+	config.AdvertiseAddress = net.ParseIP("192.168.10.4")
 	config.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	config.LoopbackClientConfig = &restclient.Config{}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -35,6 +35,7 @@ import (
 // ServerRunOptions contains the options while running a generic api server.
 type ServerRunOptions struct {
 	AdvertiseAddress net.IP
+	AdvertisePort    int
 
 	CorsAllowedOriginList       []string
 	ExternalHost                string
@@ -79,7 +80,8 @@ func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
 	c.MinRequestTimeout = s.MinRequestTimeout
 	c.JSONPatchMaxCopyBytes = s.JSONPatchMaxCopyBytes
 	c.MaxRequestBodyBytes = s.MaxRequestBodyBytes
-	c.PublicAddress = s.AdvertiseAddress
+	c.AdvertiseAddress = s.AdvertiseAddress
+	c.AdvertisePort = s.AdvertisePort
 
 	return nil
 }
@@ -97,6 +99,10 @@ func (s *ServerRunOptions) DefaultAdvertiseAddress(secure *SecureServingOptions)
 				"Try to set the AdvertiseAddress directly or provide a valid BindAddress to fix this.", err)
 		}
 		s.AdvertiseAddress = hostIP
+	}
+
+	if s.AdvertisePort == 0 {
+		s.AdvertisePort = secure.BindPort
 	}
 
 	return nil
@@ -164,6 +170,10 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"address must be reachable by the rest of the cluster. If blank, the --bind-address "+
 		"will be used. If --bind-address is unspecified, the host's default interface will "+
 		"be used.")
+
+	fs.IntVar(&s.AdvertisePort, "advertise-port", s.AdvertisePort, ""+
+		"The port on which to advertise the apiserver to members of the cluster. If blank, "+
+		"the --secure-port will be used.")
 
 	fs.StringSliceVar(&s.CorsAllowedOriginList, "cors-allowed-origins", s.CorsAllowedOriginList, ""+
 		"List of allowed origins for CORS, comma separated.  An allowed origin can be a regular "+

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -165,6 +165,8 @@ func startMasterOrDie(masterConfig *master.Config, incomingServer *httptest.Serv
 		Groups: []string{user.SystemPrivilegedGroup},
 	}
 
+	masterConfig.GenericConfig.AdvertisePort = 443
+
 	tokenAuthenticator := authenticatorfactory.NewFromTokens(tokens)
 	if masterConfig.GenericConfig.Authentication.Authenticator == nil {
 		masterConfig.GenericConfig.Authentication.Authenticator = authenticatorunion.New(tokenAuthenticator, authauthenticator.RequestFunc(alwaysEmpty))
@@ -238,7 +240,7 @@ func NewIntegrationTestMasterConfig() *master.Config {
 // configured with the provided options.
 func NewIntegrationTestMasterConfigWithOptions(opts *MasterConfigOptions) *master.Config {
 	masterConfig := NewMasterConfigWithOptions(opts)
-	masterConfig.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
+	masterConfig.GenericConfig.AdvertiseAddress = net.ParseIP("192.168.10.4")
 	masterConfig.ExtraConfig.APIResourceConfigSource = master.DefaultAPIResourceConfigSource()
 
 	// TODO: get rid of these tests or port them to secure serving


### PR DESCRIPTION
To allow the kubernetes service port to be overriden. If you need to overwrite the public IP of the advertise address, you often need to override the port.