### PR TITLE
Automated cherry pick of #79514: Default resourceGroup should be used when value of annotation

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -1542,7 +1542,10 @@ func findSecurityRule(rules []network.SecurityRule, rule network.SecurityRule) b
 
 func (az *Cloud) getPublicIPAddressResourceGroup(service *v1.Service) string {
 	if resourceGroup, found := service.Annotations[ServiceAnnotationLoadBalancerResourceGroup]; found {
-		return resourceGroup
+		resourceGroupName := strings.TrimSpace(resourceGroup)
+		if len(resourceGroupName) > 0 {
+			return resourceGroupName
+		}
 	}
 
 	return az.ResourceGroup

--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer_test.go
@@ -303,3 +303,35 @@ func TestEnsureLoadBalancerDeleted(t *testing.T) {
 		assert.Equal(t, len(result), 0, "TestCase[%d]: %s", i, c.desc)
 	}
 }
+
+func TestGetPublicIPAddressResourceGroup(t *testing.T) {
+	az := getTestCloud()
+
+	for i, c := range []struct {
+		desc        string
+		annotations map[string]string
+		expected    string
+	}{
+		{
+			desc:     "no annotation",
+			expected: "rg",
+		},
+		{
+			desc:        "annoation with empty string resource group",
+			annotations: map[string]string{ServiceAnnotationLoadBalancerResourceGroup: ""},
+			expected:    "rg",
+		},
+		{
+			desc:        "annoation with non-empty resource group ",
+			annotations: map[string]string{ServiceAnnotationLoadBalancerResourceGroup: "rg2"},
+			expected:    "rg2",
+		},
+	} {
+		t.Run(c.desc, func(t *testing.T) {
+			s := &v1.Service{}
+			s.Annotations = c.annotations
+			real := az.getPublicIPAddressResourceGroup(s)
+			assert.Equal(t, c.expected, real, "TestCase[%d]: %s", i, c.desc)
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #79514 on release-1.13.

#79514: Default resourceGroup should be used when value of annotation