### PR TITLE
Remove dead metrics in etcd code

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/metrics/metrics.go
@@ -24,34 +24,6 @@ import (
 )
 
 var (
-	cacheHitCounterOpts = prometheus.CounterOpts{
-		Name: "etcd_helper_cache_hit_total",
-		Help: "Counter of etcd helper cache hits.",
-	}
-	cacheHitCounter      = prometheus.NewCounter(cacheHitCounterOpts)
-	cacheMissCounterOpts = prometheus.CounterOpts{
-		Name: "etcd_helper_cache_miss_total",
-		Help: "Counter of etcd helper cache miss.",
-	}
-	cacheMissCounter      = prometheus.NewCounter(cacheMissCounterOpts)
-	cacheEntryCounterOpts = prometheus.CounterOpts{
-		Name: "etcd_helper_cache_entry_total",
-		Help: "Counter of etcd helper cache entries. This can be different from etcd_helper_cache_miss_count " +
-			"because two concurrent threads can miss the cache and generate the same entry twice.",
-	}
-	cacheEntryCounter = prometheus.NewCounter(cacheEntryCounterOpts)
-	cacheGetLatency   = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Name: "etcd_request_cache_get_duration_seconds",
-			Help: "Latency in seconds of getting an object from etcd cache",
-		},
-	)
-	cacheAddLatency = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Name: "etcd_request_cache_add_duration_seconds",
-			Help: "Latency in seconds of adding an object to etcd cache",
-		},
-	)
 	etcdRequestLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "etcd_request_duration_seconds",
@@ -67,34 +39,6 @@ var (
 		[]string{"resource"},
 	)
 
-	deprecatedCacheHitCounterOpts = prometheus.CounterOpts{
-		Name: "etcd_helper_cache_hit_count",
-		Help: "(Deprecated) Counter of etcd helper cache hits.",
-	}
-	deprecatedCacheHitCounter      = prometheus.NewCounter(deprecatedCacheHitCounterOpts)
-	deprecatedCacheMissCounterOpts = prometheus.CounterOpts{
-		Name: "etcd_helper_cache_miss_count",
-		Help: "(Deprecated) Counter of etcd helper cache miss.",
-	}
-	deprecatedCacheMissCounter      = prometheus.NewCounter(deprecatedCacheMissCounterOpts)
-	deprecatedCacheEntryCounterOpts = prometheus.CounterOpts{
-		Name: "etcd_helper_cache_entry_count",
-		Help: "(Deprecated) Counter of etcd helper cache entries. This can be different from etcd_helper_cache_miss_count " +
-			"because two concurrent threads can miss the cache and generate the same entry twice.",
-	}
-	deprecatedCacheEntryCounter = prometheus.NewCounter(deprecatedCacheEntryCounterOpts)
-	deprecatedCacheGetLatency   = prometheus.NewSummary(
-		prometheus.SummaryOpts{
-			Name: "etcd_request_cache_get_latencies_summary",
-			Help: "(Deprecated) Latency in microseconds of getting an object from etcd cache",
-		},
-	)
-	deprecatedCacheAddLatency = prometheus.NewSummary(
-		prometheus.SummaryOpts{
-			Name: "etcd_request_cache_add_latencies_summary",
-			Help: "(Deprecated) Latency in microseconds of adding an object to etcd cache",
-		},
-	)
 	deprecatedEtcdRequestLatenciesSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name: "etcd_request_latencies_summary",
@@ -110,20 +54,10 @@ var registerMetrics sync.Once
 func Register() {
 	// Register the metrics.
 	registerMetrics.Do(func() {
-		prometheus.MustRegister(cacheHitCounter)
-		prometheus.MustRegister(cacheMissCounter)
-		prometheus.MustRegister(cacheEntryCounter)
-		prometheus.MustRegister(cacheAddLatency)
-		prometheus.MustRegister(cacheGetLatency)
 		prometheus.MustRegister(etcdRequestLatency)
 		prometheus.MustRegister(objectCounts)
 
 		// TODO(danielqsj): Remove the following metrics, they are deprecated
-		prometheus.MustRegister(deprecatedCacheHitCounter)
-		prometheus.MustRegister(deprecatedCacheMissCounter)
-		prometheus.MustRegister(deprecatedCacheEntryCounter)
-		prometheus.MustRegister(deprecatedCacheAddLatency)
-		prometheus.MustRegister(deprecatedCacheGetLatency)
 		prometheus.MustRegister(deprecatedEtcdRequestLatenciesSummary)
 	})
 }
@@ -137,42 +71,9 @@ func RecordEtcdRequestLatency(verb, resource string, startTime time.Time) {
 	deprecatedEtcdRequestLatenciesSummary.WithLabelValues(verb, resource).Observe(sinceInMicroseconds(startTime))
 }
 
-func ObserveGetCache(startTime time.Time) {
-	cacheGetLatency.Observe(sinceInSeconds(startTime))
-	deprecatedCacheGetLatency.Observe(sinceInMicroseconds(startTime))
-}
-
-func ObserveAddCache(startTime time.Time) {
-	cacheAddLatency.Observe(sinceInSeconds(startTime))
-	deprecatedCacheAddLatency.Observe(sinceInMicroseconds(startTime))
-}
-
-func ObserveCacheHit() {
-	cacheHitCounter.Inc()
-	deprecatedCacheHitCounter.Inc()
-}
-
-func ObserveCacheMiss() {
-	cacheMissCounter.Inc()
-	deprecatedCacheMissCounter.Inc()
-}
-
-func ObserveNewEntry() {
-	cacheEntryCounter.Inc()
-	deprecatedCacheEntryCounter.Inc()
-}
-
 func Reset() {
-	cacheHitCounter = prometheus.NewCounter(cacheHitCounterOpts)
-	cacheMissCounter = prometheus.NewCounter(cacheMissCounterOpts)
-	cacheEntryCounter = prometheus.NewCounter(cacheEntryCounterOpts)
-	// TODO: Reset cacheAddLatency.
-	// TODO: Reset cacheGetLatency.
 	etcdRequestLatency.Reset()
 
-	deprecatedCacheHitCounter = prometheus.NewCounter(deprecatedCacheHitCounterOpts)
-	deprecatedCacheMissCounter = prometheus.NewCounter(deprecatedCacheMissCounterOpts)
-	deprecatedCacheEntryCounter = prometheus.NewCounter(deprecatedCacheEntryCounterOpts)
 	deprecatedEtcdRequestLatenciesSummary.Reset()
 }
 


### PR DESCRIPTION
Those metrics are not propagated since we move to etcd v3, which is years ago.