### PR TITLE
Add missing CSINodeInformer when creating ConfigFactoryArgs

### DIFF
--- a/pkg/scheduler/api/compatibility/compatibility_test.go
+++ b/pkg/scheduler/api/compatibility/compatibility_test.go
@@ -1109,6 +1109,7 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			ServiceInformer:                informerFactory.Core().V1().Services(),
 			PdbInformer:                    informerFactory.Policy().V1beta1().PodDisruptionBudgets(),
 			StorageClassInformer:           informerFactory.Storage().V1().StorageClasses(),
+			CSINodeInformer:                informerFactory.Storage().V1beta1().CSINodes(),
 			HardPodAffinitySymmetricWeight: v1.DefaultHardPodAffinitySymmetricWeight,
 			DisablePreemption:              false,
 			PercentageOfNodesToScore:       schedulerapi.DefaultPercentageOfNodesToScore,

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -110,6 +110,7 @@ func setupScheduler(
 		ServiceInformer:                informerFactory.Core().V1().Services(),
 		PdbInformer:                    informerFactory.Policy().V1beta1().PodDisruptionBudgets(),
 		StorageClassInformer:           informerFactory.Storage().V1().StorageClasses(),
+		CSINodeInformer:                informerFactory.Storage().V1beta1().CSINodes(),
 		HardPodAffinitySymmetricWeight: v1.DefaultHardPodAffinitySymmetricWeight,
 		DisablePreemption:              false,
 		PercentageOfNodesToScore:       100,

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -97,6 +97,7 @@ func createConfiguratorWithPodInformer(
 		ServiceInformer:                informerFactory.Core().V1().Services(),
 		PdbInformer:                    informerFactory.Policy().V1beta1().PodDisruptionBudgets(),
 		StorageClassInformer:           informerFactory.Storage().V1().StorageClasses(),
+		CSINodeInformer:                informerFactory.Storage().V1beta1().CSINodes(),
 		Registry:                       pluginRegistry,
 		Plugins:                        plugins,
 		PluginConfig:                   pluginConfig,

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -120,6 +120,7 @@ func createSchedulerConfigurator(
 		ServiceInformer:                informerFactory.Core().V1().Services(),
 		PdbInformer:                    informerFactory.Policy().V1beta1().PodDisruptionBudgets(),
 		StorageClassInformer:           informerFactory.Storage().V1().StorageClasses(),
+		CSINodeInformer:                informerFactory.Storage().V1beta1().CSINodes(),
 		HardPodAffinitySymmetricWeight: v1.DefaultHardPodAffinitySymmetricWeight,
 		DisablePreemption:              false,
 		PercentageOfNodesToScore:       schedulerapi.DefaultPercentageOfNodesToScore,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

PR #77595 introduced the field [CSINodeInforme to factory.ConfigFactoryArgs](https://github.com/kubernetes/kubernetes/blob/dfc78caa2116acc94b40e8f8c5e584b1efe1cb65/pkg/scheduler/factory/factory.go#L244). However, this field was not initialized in all places where `ConfigFactoryArgs` is used. 

I believe this wasn't caught by any test because those non-initialized fields are not _currently_ used in any code path. However, they should be fixed to prevent potential future flakes.

```release-note
NONE
```
