### PR TITLE
Fix some golint failures of pkg/kubectl/cmd/logs golint

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -123,7 +123,6 @@ pkg/kubectl/cmd/explain
 pkg/kubectl/cmd/expose
 pkg/kubectl/cmd/get
 pkg/kubectl/cmd/label
-pkg/kubectl/cmd/logs
 pkg/kubectl/cmd/patch
 pkg/kubectl/cmd/plugin
 pkg/kubectl/cmd/portforward

--- a/pkg/kubectl/cmd/logs/logs.go
+++ b/pkg/kubectl/cmd/logs/logs.go
@@ -84,6 +84,7 @@ const (
 	defaultPodLogsTimeout = 20 * time.Second
 )
 
+// LogsOptions defines flags and other configuration parameters for the `logs` command
 type LogsOptions struct {
 	Namespace     string
 	ResourceArg   string
@@ -117,6 +118,7 @@ type LogsOptions struct {
 	genericclioptions.IOStreams
 }
 
+// NewLogsOptions creates new LogsOptions for the `logs` command
 func NewLogsOptions(streams genericclioptions.IOStreams, allContainers bool) *LogsOptions {
 	return &LogsOptions{
 		IOStreams:           streams,
@@ -164,6 +166,7 @@ func NewCmdLogs(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 	return cmd
 }
 
+// ToLogOptions convert PodLogOptions to LogOptions
 func (o *LogsOptions) ToLogOptions() (*corev1.PodLogOptions, error) {
 	logOptions := &corev1.PodLogOptions{
 		Container:  o.Container,
@@ -200,6 +203,7 @@ func (o *LogsOptions) ToLogOptions() (*corev1.PodLogOptions, error) {
 	return logOptions, nil
 }
 
+// Complete verifies if LogsOptions are valid and without conflicts.
 func (o *LogsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	o.ContainerNameSpecified = cmd.Flag("container").Changed
 	o.Resources = args
@@ -265,6 +269,7 @@ func (o *LogsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 	return nil
 }
 
+// Validate verifies if LogsOptions are valid.
 func (o LogsOptions) Validate() error {
 	if len(o.SinceTime) > 0 && o.SinceSeconds != 0 {
 		return fmt.Errorf("at most one of `sinceTime` or `sinceSeconds` may be specified")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Fix some golint failures of pkg/kubectl/cmd/logs

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #68026

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
