### PR TITLE
Allow unit test to pass on machines without ipv6

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config_selfclient_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_selfclient_test.go
@@ -59,7 +59,9 @@ func TestLoopbackHostPort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() || ip.To4() != nil {
+	if host == "localhost" {
+		// can happen on machines without IPv6
+	} else if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() || ip.To4() != nil {
 		t.Fatalf("expected IPv6 host to be loopback, got %q", host)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
The unit test assumes the local machine has IPv6 available. Allow the unit test to pass if the utility function fallback to localhost occurs.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
