### PR TITLE
Use feature gate to determine lock type

### DIFF
--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -209,9 +209,14 @@ func (cache *schedulerCache) Snapshot() *Snapshot {
 // This function tracks generation number of NodeInfo and updates only the
 // entries of an existing snapshot that have changed after the snapshot was taken.
 func (cache *schedulerCache) UpdateNodeInfoSnapshot(nodeSnapshot *NodeInfoSnapshot) error {
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
 	balancedVolumesEnabled := utilfeature.DefaultFeatureGate.Enabled(features.BalanceAttachedNodeVolumes)
+	if balancedVolumesEnabled {
+		cache.mu.Lock()
+		defer cache.mu.Unlock()
+	} else {
+		cache.mu.RLock()
+		defer cache.mu.RUnlock()
+	}
 
 	// Get the last generation of the the snapshot.
 	snapshotGeneration := nodeSnapshot.Generation


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In schedulerCache#UpdateNodeInfoSnapshot, feature gate check should be performed outside of cache lock.
If the feature gate is enabled, write lock should be acquired. Otherwise read lock suffices.
```
pkg/features/kube_features.go:
BalanceAttachedNodeVolumes:                  {Default: false, PreRelease: featuregate.Alpha},
```
For default value of the feature gate, the lock type is changed from write lock to read lock.

```release-note
NONE
```
