### PR TITLE
GCP config: gke-exec-auth-plugin for ValidatingAdmissionWebhook

### DIFF
--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -65,8 +65,7 @@
         {{webhook_authn_config_mount}}
         {{audit_policy_config_mount}}
         {{audit_webhook_config_mount}}
-        {{admission_controller_config_mount}}
-        {{image_policy_webhook_config_mount}}
+	{{webhook_exec_auth_plugin_mount}}
         { "name": "srvkube",
         "mountPath": "/etc/srv/kubernetes",
         "readOnly": true},
@@ -106,8 +105,7 @@
   {{webhook_authn_config_volume}}
   {{audit_policy_config_volume}}
   {{audit_webhook_config_volume}}
-  {{admission_controller_config_volume}}
-  {{image_policy_webhook_config_volume}}
+  {{webhook_exec_auth_plugin_volume}}
   { "name": "srvkube",
     "hostPath": {
         "path": "/etc/srv/kubernetes"}


### PR DESCRIPTION
This commit adds support for using `gke-exec-auth-plugin` for webhooks when calling endpoints matching `*.googleapis.com`, and integrates this support with ValidatingAdmissionWebhook.

To enable it, request ValidatingAdmissionWebhook with `ADMISSION_CONTROL=...,ValidatingAdmissionWebhook,...` (default) and opt in to `gke-exec-auth-plugin` using `WEBHOOK_GKE_EXEC_AUTH=true` during the configuration process.

If you don't opt-in, ValidatingAdmissionWebhook will be deployed as before.

Requesting `WEBHOOK_GKE_EXEC_AUTH=true` will fail if you have not provided other configuration variables:

  * `EXEC_AUTH_PLUGIN_URL`: controls whether `gke-exec-auth-plugin` is downloaded during the installation step.  A prerequisite for actually using the plugin.

  * `TOKEN_URL`, `TOKEN_BODY`, and `TOKEN_BODY_UNQUOTED`: configuration values used when calling the plugin.  `TOKEN_URL` and `TOKEN_BODY` have existing usage. 
 `TOKEN_BODY_UNQUOTED` is a new variable that is meant to sidestep the problem of inverting     `strconv.Quote` in Bash.

The existing configuration process for ImagePolicyWebhook has been reworked to make it play nicely with ValidatingAdmissionWebhook under `WEBHOOK_GKE_EXEC_AUTH=true`:

  * It originally placed the ImagePolicyWebhook configuration object at the top-level of the file specified by `--admission-control-config-file`.  I can't see why this worked; it must have been hitting some sort of lucky path through the various config file loading mechanisms.  Now, it places its configuration in a sub-field of that file, which is shared among all admission control plugins.

  * It mounted its various config files read-write.  I reviewed the code and couldn't see why it was necessary, so I moved the config files into the existing read-only mount at `/etc/srv/kubernetes`.

  * It now checks that all the configuration values it requires have been provided, rather than silently writing out a broken config.

/kind feature

```release-note
NONE
```
