### PR TITLE
when kubelet restarted, the status of the running pod would not set initialValue

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -247,6 +247,7 @@ func (m *manager) UpdatePodStatus(podUID types.UID, podStatus *v1.PodStatus) {
 				w, exists := m.getWorker(podUID, c.Name, readiness)
 				ready = !exists // no readinessProbe -> always ready
 				if exists {
+					m.statusManager.GetAPIContainerStatus(podUID, kubecontainer.ParseContainerID(c.ContainerID))
 					// Trigger an immediate run of the readinessProbe to update ready state
 					select {
 					case w.manualTriggerCh <- struct{}{}:

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -204,11 +204,16 @@ func (w *worker) doProbe() (keepGoing bool) {
 	}
 
 	if w.containerID.String() != c.ContainerID {
+		oldID := w.containerID
 		if !w.containerID.IsEmpty() {
 			w.resultsManager.Remove(w.containerID)
 		}
 		w.containerID = kubecontainer.ParseContainerID(c.ContainerID)
-		w.resultsManager.Set(w.containerID, w.initialValue, w.pod)
+		if oldID.IsEmpty() && w.probeType == readiness {
+
+		} else {
+			w.resultsManager.Set(w.containerID, w.initialValue, w.pod)
+		}
 		// We've got a new container; resume probing.
 		w.onHold = false
 	}

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -170,7 +170,7 @@ func TestInitialDelay(t *testing.T) {
 		case liveness:
 			expectResult(t, w, results.Success, "during initial delay")
 		case readiness:
-			expectResult(t, w, results.Failure, "during initial delay")
+			expectUnset(t, w, results.Failure, "during initial delay")
 		case startup:
 			expectResult(t, w, results.Unknown, "during initial delay")
 		}
@@ -184,6 +184,15 @@ func TestInitialDelay(t *testing.T) {
 		// Second call should succeed (already waited).
 		expectContinue(t, w, w.doProbe(), "after initial delay")
 		expectResult(t, w, results.Success, "after initial delay")
+	}
+}
+
+func expectUnset(t *testing.T, w *worker, expectedResult results.Result, msg string) {
+	result, ok := resultsManager(w.probeManager, w.probeType).Get(w.containerID)
+	if !ok {
+		t.Error("")
+	} else if result != expectedResult {
+		t.Error("")
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
if the kubelet is restart, the status of the pod in the node will be set to failure, and then set to ready. the pod will be remove from ep and than add to ep. If the number of the service is 1, the result is that the service can't connect by other service at that duration, but the pod is work. if lots of kubelet is restart, it will affect more services
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  #78733

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
