### PR TITLE
Automated cherry pick of #79094: fix kubelet can not delete orphaned pod directory when "/var/lib/kubelet/pods" directory symbolically links to another device's directory

### DIFF
--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -237,7 +237,7 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	if err != nil {
 		return true, err
 	}
-	rootStat, err := os.Lstat(filepath.Dir(strings.TrimSuffix(file, "/")))
+	rootStat, err := os.Stat(filepath.Dir(strings.TrimSuffix(file, "/")))
 	if err != nil {
 		return true, err
 	}


### PR DESCRIPTION
Cherry pick of #79094 on release-1.15.

#79094: fix kubelet can not delete orphaned pod directory when "/var/lib/kubelet/pods" directory symbolically links to another device's directory

```release-note
fix kubelet fail to delete orphaned pod directory when the kubelet's pods directory (default is "/var/lib/kubelet/pods") symbolically links to another disk device's directory
```