### PR TITLE
Allow unit test to pass on machines without ipv6

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config_selfclient_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_selfclient_test.go
@@ -59,7 +59,9 @@ func TestLoopbackHostPort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() || ip.To4() != nil {
+	if host == "localhost" {
+		// can happen on machines without IPv6
+	} else if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() || ip.To4() != nil {
 		t.Fatalf("expected IPv6 host to be loopback, got %q", host)
 	}
 


### PR DESCRIPTION
Fixes `pull-kubernetes-bazel-test`: https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/79182/pull-kubernetes-bazel-test/1145354074598674432/
Ref: https://github.com/kubernetes/kubernetes/pull/79182 

Like https://github.com/kubernetes/kubernetes/pull/79537, but for `release-1.14`.

/assign @liggitt 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
