### PR TITLE
kubelet: ensure stable order for images in node status

### DIFF
--- a/pkg/kubelet/util/sliceutils/sliceutils.go
+++ b/pkg/kubelet/util/sliceutils/sliceutils.go
@@ -53,6 +53,9 @@ func (s PodsByCreationTime) Less(i, j int) bool {
 type ByImageSize []kubecontainer.Image
 
 func (a ByImageSize) Less(i, j int) bool {
+	if a[i].Size == a[j].Size {
+		return a[i].ID > a[j].ID
+	}
 	return a[i].Size > a[j].Size
 }
 func (a ByImageSize) Len() int      { return len(a) }

--- a/pkg/kubelet/util/sliceutils/sliceutils_test.go
+++ b/pkg/kubelet/util/sliceutils/sliceutils_test.go
@@ -160,6 +160,12 @@ func buildByImageSize() ByImageSize {
 			RepoDigests: []string{"foo-rd31", "foo-rd32"},
 			Size:        3,
 		},
+		{
+			ID:          "4",
+			RepoTags:    []string{"foo-tag41", "foo-tag42"},
+			RepoDigests: []string{"foo-rd41", "foo-rd42"},
+			Size:        3,
+		},
 	}
 }
 
@@ -169,7 +175,7 @@ func TestByImageSizeLen(t *testing.T) {
 		el     int
 	}{
 		{[]kubecontainer.Image{}, 0},
-		{buildByImageSize(), 3},
+		{buildByImageSize(), 4},
 		{nil, 0},
 	}
 
@@ -211,6 +217,7 @@ func TestByImageSizeLess(t *testing.T) {
 		// descending order
 		{buildByImageSize(), 0, 2, false},
 		{buildByImageSize(), 1, 0, true},
+		{buildByImageSize(), 3, 2, true},
 	}
 
 	for _, fooTest := range fooTests {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR uses the image ID alongside the image size as part of the sort function to ensure a stable order for the `node.status.images` field even for images with the same size.

When two or more images on the same node have the same size, their order in the `node.status.images` field was not stable. As shown in #79577 a large number of nodes with this problem could become problematic to controllers due to apparent changes to the node.

**Which issue(s) this PR fixes**:
Fixes #79577

**Special notes for your reviewer**:

I wasn't sure about renaming the type from `ByImageSize` to something like `ByImageSizeAndID` in the end I left it as is. Please let me know if you think it would be better to rename it.

/sig node

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
