### PR TITLE
Perform store.Get for non-addition event type

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -236,15 +236,17 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 		w.Lock()
 		defer w.Unlock()
 
-		previous, exists, err := w.store.Get(elem)
-		if err != nil {
-			return err
-		}
-		if exists {
-			previousElem := previous.(*storeElement)
-			watchCacheEvent.PrevObject = previousElem.Object
-			watchCacheEvent.PrevObjLabels = previousElem.Labels
-			watchCacheEvent.PrevObjFields = previousElem.Fields
+		if event.Type != watch.Added {
+			previous, exists, err := w.store.Get(elem)
+			if err != nil {
+				return err
+			}
+			if exists {
+				previousElem := previous.(*storeElement)
+				watchCacheEvent.PrevObject = previousElem.Object
+				watchCacheEvent.PrevObjLabels = previousElem.Labels
+				watchCacheEvent.PrevObjFields = previousElem.Fields
+			}
 		}
 
 		w.updateCache(watchCacheEvent)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In watchCache#processEvent, the retrieval of previous store element should only be done for non-addition event type.

```release-note
NONE
```
