### PR TITLE
Clear valueWatchers instead of removing every entry using a loop

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -154,10 +154,10 @@ func (i *indexedWatchers) terminateAll(objectType reflect.Type, done func(*cache
 		klog.Warningf("Terminating all watchers from cacher %v", objectType)
 	}
 	i.allWatchers.terminateAll(done)
-	for index, watchers := range i.valueWatchers {
+	for _, watchers := range i.valueWatchers {
 		watchers.terminateAll(done)
-		delete(i.valueWatchers, index)
 	}
+	i.valueWatchers = map[string]watchersMap{}
 }
 
 // As we don't need a high precision here, we keep all watchers timeout within a


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In indexedWatchers#terminateAll, instead of removing every entry of valueWatchers we can clear the map at the end of the func.

```release-note
NONE
```
