### PR TITLE
Automated cherry pick of #79498: kubeadm: fix bug for --cri-socket flag processing logic

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -118,6 +118,9 @@ func newResetData(cmd *cobra.Command, options *resetOptions, in io.Reader, out i
 			return nil, err
 		}
 		klog.V(1).Infof("[reset] Detected and using CRI socket: %s", criSocketPath)
+	} else {
+		criSocketPath = options.criSocketPath
+		klog.V(1).Infof("[reset] Using specified CRI socket: %s", criSocketPath)
 	}
 
 	return &resetData{


### PR DESCRIPTION
Cherry pick of #79498 on release-1.15.

#79498: kubeadm: fix bug for --cri-socket flag processing logic

```release-note
kubeadm: fix the bug that "--cri-socket" flag does not work for `kubeadm reset`
```