### PR TITLE
quote container name in container already use error matching

### DIFF
--- a/pkg/kubelet/dockershim/docker_container_test.go
+++ b/pkg/kubelet/dockershim/docker_container_test.go
@@ -248,7 +248,7 @@ func TestContainerCreationConflict(t *testing.T) {
 	containerName := makeContainerName(sConfig, config)
 	const sandboxId = "sandboxid"
 	const containerId = "containerid"
-	conflictError := fmt.Errorf("Error response from daemon: Conflict. The name \"/%s\" is already in use by container %s. You have to remove (or rename) that container to be able to reuse that name.",
+	conflictError := fmt.Errorf("Error response from daemon: Conflict. The name \"/%s\" is already in use by container %q. You have to remove (or rename) that container to be able to reuse that name.",
 		containerName, containerId)
 	noContainerError := fmt.Errorf("Error response from daemon: No such container: %s", containerId)
 	randomError := fmt.Errorf("random error")

--- a/pkg/kubelet/dockershim/helpers.go
+++ b/pkg/kubelet/dockershim/helpers.go
@@ -43,7 +43,7 @@ const (
 )
 
 var (
-	conflictRE = regexp.MustCompile(`Conflict. (?:.)+ is already in use by container ([0-9a-z]+)`)
+	conflictRE = regexp.MustCompile(`Conflict. (?:.)+ is already in use by container \"?([0-9a-z]+)\"?`)
 
 	// this is hacky, but extremely common.
 	// if a container starts but the executable file is not found, runc gives a message that matches

--- a/pkg/kubelet/dockershim/helpers_test.go
+++ b/pkg/kubelet/dockershim/helpers_test.go
@@ -118,11 +118,16 @@ func TestGetUserFromImageUser(t *testing.T) {
 
 func TestParsingCreationConflictError(t *testing.T) {
 	// Expected error message from docker.
-	msg := "Conflict. The name \"/k8s_POD_pfpod_e2e-tests-port-forwarding-dlxt2_81a3469e-99e1-11e6-89f2-42010af00002_0\" is already in use by container 24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e. You have to remove (or rename) that container to be able to reuse that name."
+	msgs := []string{
+		"Conflict. The name \"/k8s_POD_pfpod_e2e-tests-port-forwarding-dlxt2_81a3469e-99e1-11e6-89f2-42010af00002_0\" is already in use by container 24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e. You have to remove (or rename) that container to be able to reuse that name.",
+		"Conflict. The name \"/k8s_POD_pfpod_e2e-tests-port-forwarding-dlxt2_81a3469e-99e1-11e6-89f2-42010af00002_0\" is already in use by container \"24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e\". You have to remove (or rename) that container to be able to reuse that name.",
+	}
 
-	matches := conflictRE.FindStringSubmatch(msg)
-	require.Len(t, matches, 2)
-	require.Equal(t, matches[1], "24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e")
+	for _, msg := range msgs {
+		matches := conflictRE.FindStringSubmatch(msg)
+		require.Len(t, matches, 2)
+		require.Equal(t, matches[1], "24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e")
+	}
 }
 
 func TestEnsureSandboxImageExists(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

https://github.com/kubernetes/kubernetes/pull/36768 introduced logic to detect and recover from a condition where a docker container exists with the same name as a container that the kubelet is attempting to create.  It does this by pattern matching against an error coming from Docker, however the format of the error changed in https://github.com/moby/moby/pull/27510 where the container id in the message became quoted.  That error message change appears to have been merged into Docker 17.04, which means that this recovery logic no longer works in modern versions of Docker.  In practice, I've found this to often cause DaemonSet pods to never recover after a host has been drained and rebooted.

Here's an example from Docker 18.06:
```
E0701 10:10:59.721422    1957 kuberuntime_manager.go:657] createPodSandbox for pod "kube-syslog-9qgqt_kube-system(462e3018-620b-11e9-8338-a0369f9437f4)" failed: rpc error: code = Unknown desc = failed to create a sandbox for pod "kube-syslog-9qgqt": Error response from daemon: Conflict. The container name "/k8s_POD_kube-syslog-9qgqt_kube-system_462e3018-620b-11e9-8338-a0369f9437f4_2" is already in use by container "223f81c54de6b6ad43cfa3bc0c1861dde6c2f10413f9ec37cada1de8715da0e0". You have to remove (or rename) that container to be able to reuse that name.
```

_This PR adds support to the regex matching to optionally match strings where the container ID is quoted._

 
**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
