### PR TITLE
Fixed a racing issue in scheduler UT

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -293,12 +293,12 @@ func TestPriorityQueue_AddUnschedulableIfNotPresent(t *testing.T) {
 	}
 }
 
-// TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff tests scenario when
-// AddUnschedulableIfNotPresent is called asynchronously pods in and before
-// current scheduling cycle will be put back to activeQueue if we were trying
-// to schedule them when we received move request.
+// TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff tests the scenarios when
+// AddUnschedulableIfNotPresent is called asynchronously.
+// Pods in and before current scheduling cycle will be put back to activeQueue
+// if we were trying to schedule them when we received move request.
 func TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff(t *testing.T) {
-	q := NewPriorityQueue(nil, nil)
+	q := NewPriorityQueueWithClock(nil, clock.NewFakeClock(time.Now()), nil)
 	totalNum := 10
 	expectedPods := make([]v1.Pod, 0, totalNum)
 	for i := 0; i < totalNum; i++ {
@@ -348,7 +348,9 @@ func TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff(t *testing.T) {
 			},
 		}
 
-		q.AddUnschedulableIfNotPresent(unschedulablePod, oldCycle)
+		if err := q.AddUnschedulableIfNotPresent(unschedulablePod, oldCycle); err != nil {
+			t.Errorf("Failed to call AddUnschedulableIfNotPresent(%v): %v", unschedulablePod.Name, err)
+		}
 	}
 
 	// Since there was a move request at the same cycle as "oldCycle", these pods


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind flake
/sig scheduling

**What this PR does / why we need it**:

scheduling_queue_test.go#TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff has racing issue.

```
⇒  go test k8s.io/kubernetes/pkg/scheduler/internal/queue -run=^TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff$ --race --count=10
PASS
==================
WARNING: DATA RACE
Write at 0x00c00032d620 by goroutine 23:
  runtime.mapdelete_faststr()
      /usr/local/Cellar/go/1.12.1/libexec/src/runtime/map_faststr.go:297 +0x0
  k8s.io/kubernetes/pkg/scheduler/util.(*heapData).Pop()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/util/heap.go:113 +0x203
  container/heap.Pop()
      /usr/local/Cellar/go/1.12.1/libexec/src/container/heap/heap.go:64 +0xb0
  k8s.io/kubernetes/pkg/scheduler/util.(*Heap).Pop()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/util/heap.go:200 +0x5b
  k8s.io/kubernetes/pkg/scheduler/internal/queue.(*PriorityQueue).flushBackoffQCompleted()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:356 +0x490
  k8s.io/kubernetes/pkg/scheduler/internal/queue.(*PriorityQueue).flushBackoffQCompleted-fm()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:334 +0x41
  k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x61
  k8s.io/apimachinery/pkg/util/wait.JitterUntil()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0x108
  k8s.io/apimachinery/pkg/util/wait.Until()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x5a

Previous read at 0x00c00032d620 by goroutine 22:
  runtime.mapaccess2_faststr()
      /usr/local/Cellar/go/1.12.1/libexec/src/runtime/map_faststr.go:107 +0x0
  k8s.io/kubernetes/pkg/scheduler/util.(*Heap).Get()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/util/heap.go:221 +0x11d
  k8s.io/kubernetes/pkg/scheduler/internal/queue.TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue_test.go:333 +0xa0a
  testing.tRunner()
      /usr/local/Cellar/go/1.12.1/libexec/src/testing/testing.go:865 +0x163

Goroutine 23 (running) created at:
  k8s.io/kubernetes/pkg/scheduler/internal/queue.(*PriorityQueue).run()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:200 +0xd0
  k8s.io/kubernetes/pkg/scheduler/internal/queue.NewPriorityQueueWithClock()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:193 +0x9af
  k8s.io/kubernetes/pkg/scheduler/internal/queue.TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:164 +0x70
  testing.tRunner()
      /usr/local/Cellar/go/1.12.1/libexec/src/testing/testing.go:865 +0x163

Goroutine 22 (finished) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.12.1/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go/1.12.1/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go/1.12.1/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go/1.12.1/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go/1.12.1/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:86 +0x222
==================
Found 1 data race(s)
FAIL	k8s.io/kubernetes/pkg/scheduler/internal/queue	1.173s
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

There is a background goroutine `flushBackoffQCompleted` manipulating the `podBackoffQ` every 1 second, and it's possible the logic goes to `p.podBackoffQ.Pop()`; at the same time, if we directly go accessing the heap data: `q.podBackoffQ.Get(XYZ)`, it will cause data race as the above log shows.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
