### PR TITLE
ImagePolicyWebhook: Correct misleading config docs

### DIFF
--- a/plugin/pkg/admission/imagepolicy/admission.go
+++ b/plugin/pkg/admission/imagepolicy/admission.go
@@ -206,9 +206,35 @@ func (a *Plugin) admitPod(pod *api.Pod, attributes admission.Attributes, review 
 	return nil
 }
 
-// NewImagePolicyWebhook a new ImagePolicyWebhook plugin from the provided config file.
-// The config file is specified by --admission-control-config-file and has the
-// following format for a webhook:
+// NewImagePolicyWebhook creates a new ImagePolicyWebhook plugin from the
+// provided config file.
+//
+// Like all plugins, the configuration can be provided in two ways:
+//
+//   1. Place the ImagePolicyWebhook configuration in its own file, and link the
+//      file from the shared admission control config specified by
+//      --admission-control-config-file:
+//
+//          # ...
+//          plugins:
+//          - name: ImagePolicyWebhook
+//            path: /path/to/config/file
+//
+//   2. Embed the ImagePolicyWebhook configuration in the shared admission
+//      control config file:
+//
+//          # ...
+//          plugins:
+//          - name: ImagePolicyWebhook
+//            configuration:
+//              imagePolicy:
+//                kubeConfigFile: path/to/kubeconfig
+//                allowTTL: 30
+//                denyTTL: 30
+//                retryBackoff: 500
+//                defaultAllow: true
+//
+//   The config file has the following schema:
 //
 //   {
 //     "imagePolicy": {


### PR DESCRIPTION
This commit changes the documentation for NewImagePolicyWebhook.

Previously, the documentation could be read to imply that the configuration values for ImagePolicyWebhook should be placed directly into the top level of the file specified by `--admission-control-config-file`.

This doesn't seem like it should work, contravenes the public documentation for ImagePolicyWebhook [1], and precludes configuring other admission control plugins at the same time as ImagePolicyWebhook.  This isn't just theoretical --- the GCP configure-helper.sh tried to use the flag in this way.

Now, the documentation explicitly states the two ways that the admission control plugin infrastructure seems to support --- linking to the plugin-specific configuration file, or directly embedding the plugin-specific configuration in the shared configuration file.

[1] https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#configuration-file-format

/kind documentation

```release-note
NONE
```
