### PR TITLE
Fix publishing x-kubernetes-preserve-unknown-fields working with kubectl

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder_test.go
@@ -59,6 +59,18 @@ func TestNewBuilder(t *testing.T) {
 			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
 			true,
 		},
+		{"preserve unknown at root v2",
+			`{"type":"object","x-kubernetes-preserve-unknown-fields":true}`,
+			`{"type":"object","x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
+			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
+			true,
+		},
+		{"preserve unknown at root v3",
+			`{"type":"object","x-kubernetes-preserve-unknown-fields":true}`,
+			`{"type":"object","x-kubernetes-preserve-unknown-fields":true,"properties":{"apiVersion":{"type":"string"},"kind":{"type":"string"},"metadata":{"$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"}},"x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
+			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
+			false,
+		},
 		{"with extensions",
 			`
 {
@@ -155,22 +167,7 @@ func TestNewBuilder(t *testing.T) {
     "embedded-object": {
       "x-kubernetes-embedded-resource": true,
       "x-kubernetes-preserve-unknown-fields": true,
-      "type": "object",
-      "required":["kind","apiVersion"],
-      "properties":{
-        "apiVersion":{
-          "description":"apiVersion defines the versioned schema of this representation of an object. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type":"string"
-        },
-        "kind":{
-          "description":"kind is a string value representing the type of this object. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type":"string"
-        },
-        "metadata":{
-          "description":"Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        }
-      }
+      "type":"object"
     }
   },
   "x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/conversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/conversion.go
@@ -65,6 +65,14 @@ func ToStructuralOpenAPIV2(in *structuralschema.Structural) *structuralschema.St
 				changed = true
 			}
 
+			if s.XPreserveUnknownFields {
+				// unknown fields break if items or properties are set in kubectl
+				s.Items = nil
+				s.Properties = nil
+
+				changed = true
+			}
+
 			return changed
 		},
 		// we drop all junctors above, and hence, never reach nested value validations


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes published openapi for CRDs with x-kubernetes-preserve-unknown-fields so that kubectl allows sending unknown fields, by dropping items/properties (including apiVersion/kind/metadata properties) from the published v2 schema.

Extracted from https://github.com/kubernetes/kubernetes/pull/79604 for separate merge and picking to 1.15

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a bug in openapi published for custom resources using x-kubernetes-preserve-unknown-fields extensions, so that kubectl will allow sending unknown fields for that portion of the object.
```

/sig api-machinery
/priority important-soon
/cc @sttts @roycaihw 