### PR TITLE
Omit obtaining the lock when adding Nodes in newNodeTree

### DIFF
--- a/pkg/scheduler/internal/cache/node_tree.go
+++ b/pkg/scheduler/internal/cache/node_tree.go
@@ -63,7 +63,7 @@ func newNodeTree(nodes []*v1.Node) *NodeTree {
 		tree: make(map[string]*nodeArray),
 	}
 	for _, n := range nodes {
-		nt.AddNode(n)
+		nt.addNode(n)
 	}
 	return nt
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In newNodeTree, we take lock, add a Node and release the lock.
This is repeated for every Node to be added.

This PR obtains lock and keeps the lock for all the Nodes added.

```release-note
NONE
```
