### PR TITLE
Utilize RWMutex for efficient backoff operations

### DIFF
--- a/staging/src/k8s.io/client-go/util/flowcontrol/backoff.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/backoff.go
@@ -30,7 +30,7 @@ type backoffEntry struct {
 }
 
 type Backoff struct {
-	sync.Mutex
+	sync.RWMutex
 	Clock           clock.Clock
 	defaultDuration time.Duration
 	maxDuration     time.Duration
@@ -57,8 +57,8 @@ func NewBackOff(initial, max time.Duration) *Backoff {
 
 // Get the current backoff Duration
 func (p *Backoff) Get(id string) time.Duration {
-	p.Lock()
-	defer p.Unlock()
+	p.RLock()
+	defer p.RUnlock()
 	var delay time.Duration
 	entry, ok := p.perItemBackoff[id]
 	if ok {
@@ -90,8 +90,8 @@ func (p *Backoff) Reset(id string) {
 
 // Returns True if the elapsed time since eventTime is smaller than the current backoff window
 func (p *Backoff) IsInBackOffSince(id string, eventTime time.Time) bool {
-	p.Lock()
-	defer p.Unlock()
+	p.RLock()
+	defer p.RUnlock()
 	entry, ok := p.perItemBackoff[id]
 	if !ok {
 		return false
@@ -104,8 +104,8 @@ func (p *Backoff) IsInBackOffSince(id string, eventTime time.Time) bool {
 
 // Returns True if time since lastupdate is less than the current backoff window.
 func (p *Backoff) IsInBackOffSinceUpdate(id string, eventTime time.Time) bool {
-	p.Lock()
-	defer p.Unlock()
+	p.RLock()
+	defer p.RUnlock()
 	entry, ok := p.perItemBackoff[id]
 	if !ok {
 		return false


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Quite a few Backoff operations, such as IsInBackOffSince, would benefit from taking read lock.

This PR changes the Mutex to RWMutex for Backoff.

```release-note
NONE
```
