### PR TITLE
Add public functions to define CSI external tests

### DIFF
--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -68,7 +68,14 @@ func (t testDriverParameter) String() string {
 }
 
 func (t testDriverParameter) Set(filename string) error {
-	driver, err := t.loadDriverDefinition(filename)
+	return AddDriverDefinition(filename)
+}
+
+// AddDriverDefinition defines ginkgo tests for CSI driver definition file.
+// Either --storage.testdriver cmdline argument or AddDriverDefinition can be used
+// to define the tests.
+func AddDriverDefinition(filename string) error {
+	driver, err := loadDriverDefinition(filename)
 	if err != nil {
 		return err
 	}
@@ -84,7 +91,7 @@ func (t testDriverParameter) Set(filename string) error {
 	return nil
 }
 
-func (t testDriverParameter) loadDriverDefinition(filename string) (*driverDefinition, error) {
+func loadDriverDefinition(filename string) (*driverDefinition, error) {
 	if filename == "" {
 		return nil, errors.New("missing file name")
 	}

--- a/test/e2e/storage/external/external_test.go
+++ b/test/e2e/storage/external/external_test.go
@@ -64,7 +64,7 @@ func TestDriverParameter(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		actual, err := testDriverParameter{}.loadDriverDefinition(testcase.filename)
+		actual, err := loadDriverDefinition(testcase.filename)
 		if testcase.err == "" {
 			assert.NoError(t, err, testcase.name)
 		} else {


### PR DESCRIPTION
3rd party test suites that want to include external CSI tests may not use "flags" for cmdline parsing.

We have a test suite that runs various Kubernetes e2e tests and I want CSI driver test included there. We do our own cmdline parsing and passing CSI driver definitions via `flag` package is really ugly. Therefore I propose a public function to set the driver definition file.

@pohly, PTAL

/kind cleanup
?

```release-note
NONE
```
