### PR TITLE
Ignore unschedulable pods

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	autoscaling "k8s.io/api/autoscaling/v2beta2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -365,11 +365,18 @@ func groupPods(pods []*v1.Pod, metrics metricsclient.PodMetricsInfo, resource v1
 		if pod.DeletionTimestamp != nil || pod.Status.Phase == v1.PodFailed {
 			continue
 		}
+		// Pending pods are ignored.
+		if pod.Status.Phase == v1.PodPending {
+			ignoredPods.Insert(pod.Name)
+			continue
+		}
+		// Pods missing metrics.
 		metric, found := metrics[pod.Name]
 		if !found {
 			missingPods.Insert(pod.Name)
 			continue
 		}
+		// Unready pods are ignored.
 		if resource == v1.ResourceCPU {
 			var ignorePod bool
 			_, condition := podutil.GetPodCondition(&pod.Status, v1.PodReady)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When the HPA decides which pods and metric values to take into account when scaling, it divides the pods into three disjoint subsets: 1) ready 2) missing metrics and 3) ignored.

https://github.com/kubernetes/kubernetes/blob/003c4e51555f6e9fce8b62ba6916d5b70b2f3010/pkg/controller/podautoscaler/replica_calculator.go#L361-L363

First the HPA selects pods which are missing metrics.  Then it selects pods should be ignored because they are not ready yet, or are still consuming CPU during initialization.  All the remaining pods go into the ready set.

After the HPA has decided what direction it wants to scale based on the ready pods, it considers what might have happened if it had the missing metrics.  It makes a conservative guess about what the missing metrics might have been, 0% if it wants to scale up--100% if it wants to scale down.

https://github.com/kubernetes/kubernetes/blob/003c4e51555f6e9fce8b62ba6916d5b70b2f3010/pkg/controller/podautoscaler/replica_calculator.go#L104-L116

This is a good thing when scaling up, because newly added pods will likely help reduce the usage ratio, even though their metrics are missing at the moment.  The HPA should wait to see the results of its previous scale decision before it makes another one.

However when scaling down, it means that many missing metrics can pin the HPA at high scale, even when load is completely removed.  In particular, when there are many unschedulable pods due to insufficient cluster capacity, the many missing metrics (assumed to be 100%) can cause the HPA to avoid scaling down indefinitely.

This change adding unschedulable pods to the ignored set **first** before selecting pods missing metrics.  Unschedulable pods are always ignored when calculating scale.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79158

**Special notes for your reviewer**:

This can be reproduced by using the [Kubernetes Horizontal Pod Autoscaler Walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/) and updating the Deployment while under load to a higher CPU request (e.g. 1700m).

![image](https://user-images.githubusercontent.com/1103629/60514740-630b4f80-9cda-11e9-9dab-dc2514abe73a.png)

I have tested this change (with #79035 patched) by deploying Kubernetes to GCE and running through the repro steps.  After removing load, the HPA scales down as expected, even with many unschedulable pending pods.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
