### PR TITLE
Test webhooks with and without watch cache enabled

### DIFF
--- a/test/integration/apiserver/admissionwebhook/admission_test.go
+++ b/test/integration/apiserver/admissionwebhook/admission_test.go
@@ -386,8 +386,18 @@ func (h *holder) verifyOptions(options runtime.Object) error {
 	return nil
 }
 
-// TestWebhookAdmission tests communication between API server and webhook process.
-func TestWebhookAdmission(t *testing.T) {
+// TestWebhookAdmissionWithWatchCache tests communication between API server and webhook process.
+func TestWebhookAdmissionWithWatchCache(t *testing.T) {
+	testWebhookAdmission(t, true)
+}
+
+// TestWebhookAdmissionWithoutWatchCache tests communication between API server and webhook process.
+func TestWebhookAdmissionWithoutWatchCache(t *testing.T) {
+	testWebhookAdmission(t, false)
+}
+
+// testWebhookAdmission tests communication between API server and webhook process.
+func testWebhookAdmission(t *testing.T, watchCache bool) {
 	// holder communicates expectations to webhooks, and results from webhooks
 	holder := &holder{
 		t:                 t,
@@ -428,6 +438,7 @@ func TestWebhookAdmission(t *testing.T) {
 	// start API server
 	etcdConfig := framework.SharedEtcd()
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		fmt.Sprintf("--watch-cache=%v", watchCache),
 		// turn off admission plugins that add finalizers
 		"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection",
 		// force enable all resources so we can check storage.

--- a/test/integration/apiserver/admissionwebhook/reinvocation_test.go
+++ b/test/integration/apiserver/admissionwebhook/reinvocation_test.go
@@ -49,8 +49,18 @@ const (
 	testReinvocationClientUsername = "webhook-reinvocation-integration-client"
 )
 
-// TestWebhookReinvocationPolicy ensures that the admission webhook reinvocation policy is applied correctly.
-func TestWebhookReinvocationPolicy(t *testing.T) {
+// TestWebhookReinvocationPolicyWithWatchCache ensures that the admission webhook reinvocation policy is applied correctly with the watch cache enabled.
+func TestWebhookReinvocationPolicyWithWatchCache(t *testing.T) {
+	testWebhookReinvocationPolicy(t, true)
+}
+
+// TestWebhookReinvocationPolicyWithoutWatchCache ensures that the admission webhook reinvocation policy is applied correctly without the watch cache enabled.
+func TestWebhookReinvocationPolicyWithoutWatchCache(t *testing.T) {
+	testWebhookReinvocationPolicy(t, false)
+}
+
+// testWebhookReinvocationPolicy ensures that the admission webhook reinvocation policy is applied correctly.
+func testWebhookReinvocationPolicy(t *testing.T, watchCache bool) {
 	reinvokeNever := registrationv1beta1.NeverReinvocationPolicy
 	reinvokeIfNeeded := registrationv1beta1.IfNeededReinvocationPolicy
 
@@ -175,6 +185,7 @@ func TestWebhookReinvocationPolicy(t *testing.T) {
 
 	s := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
 		"--disable-admission-plugins=ServiceAccount",
+		fmt.Sprintf("--watch-cache=%v", watchCache),
 	}, framework.SharedEtcd())
 	defer s.TearDownFn()
 


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Adds tests for admission webhooks with and without watch cache enabled

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery
/cc @sttts @jpbetz @roycaihw 