### PR TITLE
Cherry pick of #78495: Fix issues in kubelet for Aarch64 resulting in kubelet crashing on starup

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -51,7 +51,7 @@ const (
 
 // hugePageSizeList is useful for converting to the hugetlb canonical unit
 // which is what is expected when interacting with libcontainer
-var hugePageSizeList = []string{"B", "kB", "MB", "GB", "TB", "PB"}
+var hugePageSizeList = []string{"B", "KB", "MB", "GB", "TB", "PB"}
 
 var RootCgroupName = CgroupName([]string{})
 


### PR DESCRIPTION
**TL;DR**: This fixes issues in kubelet for AArch64 causing it to crash on startup. Without back porting this, the first working release for AArch64 running linux 5.0+ will land in september (v1.16.0).

When starting kubelet, it exits with 1 and prints:
```
Failed to start ContainerManager failed to initialize top level QOS containers: failed to update top level Burstable QOS cgroup : failed to set supported cgroup subsystems for cgroup [kubepods burstable]: Failed to set config for supported subsystems : failed to write 4611686018427387904 to hugetlb.64kB.limit_in_bytes: open /sys/fs/cgroup/hugetlb/kubepods/burstable/hugetlb.64kB.limit_in_bytes: permission denied
```

This is tested on `AArch64`, and works as expected: https://github.com/kubernetes/kubernetes/pull/79671#issuecomment-508585814

A bit unhappy with having to bump dependencies in a back port, but I do think it is required... This is a result of "wrong code" in k8s and runc, just something we haven't seen enabled by default before linux 5.0. :/

Just as @Pennyzct said in the original PR, #78495 (comment), the only way to run a working kubelet when running linux 5.0+ on AArch64 (The 64bits arm) is currently to compile your own version from master. No pervious releases will work (or i guess those pre hugetlb should work), and 1.16 (with the fix) will not land before mid september.

There are also people in k3s reporting this issue: rancher/k3s#474

Again, I am not a huge fan of this, and I think we at least should consider cherry picking it to 1.15, so that there is one supported version. It is also possible to back port even more, but I think doing only 1.15 is a valid choice in the middle.

For more background info, read through the (the whole discussion, not just the first post) original PR:  #78495 for all the background information.

--- 

Cherry pick of #78495 on release-1.15.

#78495: Update dependency opencontainer/runc