### PR TITLE
GCP config: vTPM helper LICENSE -> MERGED_LICENSES

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -303,7 +303,7 @@ function install-exec-auth-plugin {
   local -r license_url="${EXEC_AUTH_PLUGIN_LICENSE_URL}"
   echo "Downloading gke-exec-auth-plugin license"
   download-or-bust "" "${license_url}"
-  mv "${KUBE_HOME}/LICENSE" "${KUBE_BIN}/gke-exec-auth-plugin-license"
+  mv "${KUBE_HOME}/MERGED_LICENSES" "${KUBE_BIN}/gke-exec-auth-plugin-license"
 }
 
 function install-kube-manifests {


### PR DESCRIPTION
The license filename in the gke-exec-auth-plugin release bucket is MERGED_LICENSES.  A few releases have been manually modified to make a LICENSE file that's a copy of MERGED_LICENSES, but releases without this modification cause configure.sh to fail with an error:

```
mv: cannot stat '/home/kubernetes/LICENSE': No such file or directory
```
/kind bug

```release-note
NONE
```
