### PR TITLE
Making sure we handle error on http.NewRequest() in streamer

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer.go
@@ -19,6 +19,7 @@ package rest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -66,6 +67,9 @@ func (s *LocationStreamer) InputStream(ctx context.Context, apiVersion, acceptHe
 		CheckRedirect: s.RedirectChecker,
 	}
 	req, err := http.NewRequest("GET", s.Location.String(), nil)
+	if err != nil {
+		return nil, false, "", fmt.Errorf("failed to construct request for %s, got %v", s.Location.String(), err)
+	}
 	// Pass the parent context down to the request to ensure that the resources
 	// will be release properly.
 	req = req.WithContext(ctx)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
http.NewRequest can return an error. (Eg. error parsing url).
This will cause us to have a nil req object.
That in turn will become a SIGSEGV when we set the context.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
