### PR TITLE
Remove lazy provide from credential provider and kubelet

### DIFF
--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -80,12 +80,6 @@ func (p *ecrProvider) Enabled() bool {
 	return true
 }
 
-// LazyProvide is lazy
-// TODO: the LazyProvide methods will be removed in a future PR
-func (p *ecrProvider) LazyProvide(image string) *credentialprovider.DockerConfigEntry {
-	return nil
-}
-
 // Provide returns a DockerConfig with credentials from the cache if they are
 // found, or from ECR
 func (p *ecrProvider) Provide(image string) credentialprovider.DockerConfig {

--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -259,6 +259,3 @@ func parseACRLoginServerFromImage(image string) string {
 	}
 	return ""
 }
-func (a *acrProvider) LazyProvide(image string) *credentialprovider.DockerConfigEntry {
-	return nil
-}

--- a/pkg/credentialprovider/gcp/metadata.go
+++ b/pkg/credentialprovider/gcp/metadata.go
@@ -129,11 +129,6 @@ func (g *metadataProvider) Enabled() bool {
 	return onGCEVM()
 }
 
-// LazyProvide implements DockerConfigProvider. Should never be called.
-func (g *dockerConfigKeyProvider) LazyProvide(image string) *credentialprovider.DockerConfigEntry {
-	return nil
-}
-
 // Provide implements DockerConfigProvider
 func (g *dockerConfigKeyProvider) Provide(image string) credentialprovider.DockerConfig {
 	// Read the contents of the google-dockercfg metadata key and
@@ -145,11 +140,6 @@ func (g *dockerConfigKeyProvider) Provide(image string) credentialprovider.Docke
 	}
 
 	return credentialprovider.DockerConfig{}
-}
-
-// LazyProvide implements DockerConfigProvider. Should never be called.
-func (g *dockerConfigUrlKeyProvider) LazyProvide(image string) *credentialprovider.DockerConfigEntry {
-	return nil
 }
 
 // Provide implements DockerConfigProvider
@@ -255,11 +245,6 @@ func (g *containerRegistryProvider) Enabled() bool {
 // that is returned by GCE metadata.
 type tokenBlob struct {
 	AccessToken string `json:"access_token"`
-}
-
-// LazyProvide implements DockerConfigProvider. Should never be called.
-func (g *containerRegistryProvider) LazyProvide(image string) *credentialprovider.DockerConfigEntry {
-	return nil
 }
 
 // Provide implements DockerConfigProvider

--- a/pkg/credentialprovider/keyring.go
+++ b/pkg/credentialprovider/keyring.go
@@ -36,18 +36,18 @@ import (
 //   most specific match for a given image
 // - iterating a map does not yield predictable results
 type DockerKeyring interface {
-	Lookup(image string) ([]LazyAuthConfiguration, bool)
+	Lookup(image string) ([]AuthConfig, bool)
 }
 
 // BasicDockerKeyring is a trivial map-backed implementation of DockerKeyring
 type BasicDockerKeyring struct {
 	index []string
-	creds map[string][]LazyAuthConfiguration
+	creds map[string][]AuthConfig
 }
 
-// lazyDockerKeyring is an implementation of DockerKeyring that lazily
+// providersDockerKeyring is an implementation of DockerKeyring that
 // materializes its dockercfg based on a set of dockerConfigProviders.
-type lazyDockerKeyring struct {
+type providersDockerKeyring struct {
 	Providers []DockerConfigProvider
 }
 
@@ -73,38 +73,16 @@ type AuthConfig struct {
 	RegistryToken string `json:"registrytoken,omitempty"`
 }
 
-// LazyAuthConfiguration wraps dockertypes.AuthConfig, potentially deferring its
-// binding. If Provider is non-nil, it will be used to obtain new credentials
-// by calling LazyProvide() on it.
-type LazyAuthConfiguration struct {
-	AuthConfig
-	Provider DockerConfigProvider
-}
-
-func DockerConfigEntryToLazyAuthConfiguration(ident DockerConfigEntry) LazyAuthConfiguration {
-	return LazyAuthConfiguration{
-		AuthConfig: AuthConfig{
-			Username: ident.Username,
-			Password: ident.Password,
-			Email:    ident.Email,
-		},
-	}
-}
-
 func (dk *BasicDockerKeyring) Add(cfg DockerConfig) {
 	if dk.index == nil {
 		dk.index = make([]string, 0)
-		dk.creds = make(map[string][]LazyAuthConfiguration)
+		dk.creds = make(map[string][]AuthConfig)
 	}
 	for loc, ident := range cfg {
-
-		var creds LazyAuthConfiguration
-		if ident.Provider != nil {
-			creds = LazyAuthConfiguration{
-				Provider: ident.Provider,
-			}
-		} else {
-			creds = DockerConfigEntryToLazyAuthConfiguration(ident)
+		creds := AuthConfig{
+			Username: ident.Username,
+			Password: ident.Password,
+			Email:    ident.Email,
 		}
 
 		value := loc
@@ -255,9 +233,9 @@ func urlsMatch(globUrl *url.URL, targetUrl *url.URL) (bool, error) {
 // Lookup implements the DockerKeyring method for fetching credentials based on image name.
 // Multiple credentials may be returned if there are multiple potentially valid credentials
 // available.  This allows for rotation.
-func (dk *BasicDockerKeyring) Lookup(image string) ([]LazyAuthConfiguration, bool) {
+func (dk *BasicDockerKeyring) Lookup(image string) ([]AuthConfig, bool) {
 	// range over the index as iterating over a map does not provide a predictable ordering
-	ret := []LazyAuthConfiguration{}
+	ret := []AuthConfig{}
 	for _, k := range dk.index {
 		// both k and image are schemeless URLs because even though schemes are allowed
 		// in the credential configurations, we remove them in Add.
@@ -277,12 +255,12 @@ func (dk *BasicDockerKeyring) Lookup(image string) ([]LazyAuthConfiguration, boo
 		}
 	}
 
-	return []LazyAuthConfiguration{}, false
+	return []AuthConfig{}, false
 }
 
 // Lookup implements the DockerKeyring method for fetching credentials
 // based on image name.
-func (dk *lazyDockerKeyring) Lookup(image string) ([]LazyAuthConfiguration, bool) {
+func (dk *providersDockerKeyring) Lookup(image string) ([]AuthConfig, bool) {
 	keyring := &BasicDockerKeyring{}
 
 	for _, p := range dk.Providers {
@@ -293,19 +271,19 @@ func (dk *lazyDockerKeyring) Lookup(image string) ([]LazyAuthConfiguration, bool
 }
 
 type FakeKeyring struct {
-	auth []LazyAuthConfiguration
+	auth []AuthConfig
 	ok   bool
 }
 
-func (f *FakeKeyring) Lookup(image string) ([]LazyAuthConfiguration, bool) {
+func (f *FakeKeyring) Lookup(image string) ([]AuthConfig, bool) {
 	return f.auth, f.ok
 }
 
 // UnionDockerKeyring delegates to a set of keyrings.
 type UnionDockerKeyring []DockerKeyring
 
-func (k UnionDockerKeyring) Lookup(image string) ([]LazyAuthConfiguration, bool) {
-	authConfigs := []LazyAuthConfiguration{}
+func (k UnionDockerKeyring) Lookup(image string) ([]AuthConfig, bool) {
+	authConfigs := []AuthConfig{}
 	for _, subKeyring := range k {
 		if subKeyring == nil {
 			continue

--- a/pkg/credentialprovider/plugins.go
+++ b/pkg/credentialprovider/plugins.go
@@ -45,9 +45,9 @@ func RegisterCredentialProvider(name string, provider DockerConfigProvider) {
 }
 
 // NewDockerKeyring creates a DockerKeyring to use for resolving credentials,
-// which lazily draws from the set of registered credential providers.
+// which draws from the set of registered credential providers.
 func NewDockerKeyring() DockerKeyring {
-	keyring := &lazyDockerKeyring{
+	keyring := &providersDockerKeyring{
 		Providers: make([]DockerConfigProvider, 0),
 	}
 

--- a/pkg/credentialprovider/provider.go
+++ b/pkg/credentialprovider/provider.go
@@ -37,22 +37,6 @@ type DockerConfigProvider interface {
 	// implementation depends on information in the image name to return
 	// credentials; implementations are safe to ignore the image.
 	Provide(image string) DockerConfig
-	// LazyProvide gets called after URL matches have been
-	// performed, so the location used as the key in DockerConfig would be
-	// redundant.
-	// The image is passed in as context in the event that the
-	// implementation depends on information in the image name to return
-	// credentials; implementations are safe to ignore the image.
-	LazyProvide(image string) *DockerConfigEntry
-}
-
-//LazyProvide returns an Lazy AuthConfig
-func LazyProvide(creds LazyAuthConfiguration, image string) AuthConfig {
-	if creds.Provider != nil {
-		entry := *creds.Provider.LazyProvide(image)
-		return DockerConfigEntryToLazyAuthConfiguration(entry).AuthConfig
-	}
-	return creds.AuthConfig
 }
 
 // A DockerConfigProvider that simply reads the .dockercfg file
@@ -85,7 +69,7 @@ func (d *defaultDockerConfigProvider) Enabled() bool {
 	return true
 }
 
-// LazyProvide implements dockerConfigProvider
+// Provide implements dockerConfigProvider
 func (d *defaultDockerConfigProvider) Provide(image string) DockerConfig {
 	// Read the standard Docker credentials from .dockercfg
 	if cfg, err := ReadDockerConfigFile(); err == nil {
@@ -96,19 +80,9 @@ func (d *defaultDockerConfigProvider) Provide(image string) DockerConfig {
 	return DockerConfig{}
 }
 
-// LazyProvide implements dockerConfigProvider. Should never be called.
-func (d *defaultDockerConfigProvider) LazyProvide(image string) *DockerConfigEntry {
-	return nil
-}
-
 // Enabled implements dockerConfigProvider
 func (d *CachingDockerConfigProvider) Enabled() bool {
 	return d.Provider.Enabled()
-}
-
-// LazyProvide implements dockerConfigProvider. Should never be called.
-func (d *CachingDockerConfigProvider) LazyProvide(image string) *DockerConfigEntry {
-	return nil
 }
 
 // Provide implements dockerConfigProvider

--- a/pkg/kubelet/dockershim/helpers.go
+++ b/pkg/kubelet/dockershim/helpers.go
@@ -344,7 +344,7 @@ func ensureSandboxImageExists(client libdocker.Interface, image string) error {
 
 	var pullErrs []error
 	for _, currentCreds := range creds {
-		authConfig := dockertypes.AuthConfig(credentialprovider.LazyProvide(currentCreds, repoToPull))
+		authConfig := dockertypes.AuthConfig(currentCreds)
 		err := client.PullImage(image, authConfig, dockertypes.ImagePullOptions{})
 		// If there was no error, return success
 		if err == nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -21,7 +21,6 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/credentialprovider"
 	credentialprovidersecrets "k8s.io/kubernetes/pkg/credentialprovider/secrets"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/util/parsers"
@@ -57,14 +56,13 @@ func (m *kubeGenericRuntimeManager) PullImage(image kubecontainer.ImageSpec, pul
 
 	var pullErrs []error
 	for _, currentCreds := range creds {
-		authConfig := credentialprovider.LazyProvide(currentCreds, repoToPull)
 		auth := &runtimeapi.AuthConfig{
-			Username:      authConfig.Username,
-			Password:      authConfig.Password,
-			Auth:          authConfig.Auth,
-			ServerAddress: authConfig.ServerAddress,
-			IdentityToken: authConfig.IdentityToken,
-			RegistryToken: authConfig.RegistryToken,
+			Username:      currentCreds.Username,
+			Password:      currentCreds.Password,
+			Auth:          currentCreds.Auth,
+			ServerAddress: currentCreds.ServerAddress,
+			IdentityToken: currentCreds.IdentityToken,
+			RegistryToken: currentCreds.RegistryToken,
 		}
 
 		imageRef, err := m.imageService.PullImage(imgSpec, auth, podSandboxConfig)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR strips out LazyProvide from credential provider and kubelet. It was previously added in credential provider for AWS and after https://github.com/kubernetes/kubernetes/pull/75585 was merged, none of the providers use Lazy Provide. It is therefore unnecessary code.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/76465

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/sig aws
/sig cloud-provider
/sig node
/area cloudprovider
/area kubelet

/cc @mcrute @andrewsykim 
/assign @liggitt @justinsb