### PR TITLE
Promote Scheduler Preemption e2e test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -215,6 +215,7 @@ test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if 
 test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if matching"
 test/e2e/scheduling/predicates.go: "validates that there is no conflict between pods with same hostPort but different hostIP and protocol"
 test/e2e/scheduling/predicates.go: "validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP"
+test/e2e/scheduling/preemption.go: "runs ReplicaSets to verify preemption running path"
 test/e2e/storage/empty_dir_wrapper.go: "should not conflict"
 test/e2e/storage/empty_dir_wrapper.go: "should not cause race condition when used for configmaps"
 test/e2e/storage/subpath.go: "should support subpaths with secret pod"

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -467,7 +467,13 @@ var _ = SIGDescribe("PreemptionExecutionPath", func() {
 		}
 	})
 
-	ginkgo.It("runs ReplicaSets to verify preemption running path", func() {
+	/*
+	  Release : v1.16
+	  Testname: Scheduler: Preemption of ReplicaSet Pods
+	  Description: ReplicaSets MUST be scheduled within a reasonable
+	  amount of time. ReplicaSet pods MUST NOT be over-preempted.
+	*/
+	framework.ConformanceIt("runs ReplicaSets to verify preemption running path", func() {
 		podNamesSeen := make(map[string]struct{})
 		stopCh := make(chan struct{})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind cleanup

**Special notes to reviewer**

Part of Umbrella Issue #78748

**What this PR does / why we need it**:

Promotes the following E2E test to Conformance:
` test/e2e/scheduling/preemption.go: "runs ReplicaSets to verify preemption running path"`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/78833

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/area conformance
/area test

@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg
@kubernetes/sig-scheduling-pr-reviews