### PR TITLE
Use ExpectEqual under e2e/apimachinery

### DIFF
--- a/test/e2e/apimachinery/chunking.go
+++ b/test/e2e/apimachinery/chunking.go
@@ -94,7 +94,7 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 				if len(lastRV) == 0 {
 					lastRV = list.ResourceVersion
 				}
-				gomega.Expect(list.ResourceVersion).To(gomega.Equal(lastRV))
+				framework.ExpectEqual(list.ResourceVersion, lastRV)
 				if shouldCheckRemainingItem() {
 					if list.GetContinue() == "" {
 						gomega.Expect(list.GetRemainingItemCount()).To(gomega.BeNil())
@@ -104,7 +104,7 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 					}
 				}
 				for _, item := range list.Items {
-					gomega.Expect(item.Name).To(gomega.Equal(fmt.Sprintf("template-%04d", found)))
+					framework.ExpectEqual(item.Name, fmt.Sprintf("template-%04d", found))
 					found++
 				}
 				if len(list.Continue) == 0 {
@@ -187,7 +187,7 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 			}
 		}
 		for _, item := range list.Items {
-			gomega.Expect(item.Name).To(gomega.Equal(fmt.Sprintf("template-%04d", found)))
+			framework.ExpectEqual(item.Name, fmt.Sprintf("template-%04d", found))
 			found++
 		}
 
@@ -207,9 +207,9 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 			}
 			e2elog.Logf("Retrieved %d/%d results with rv %s and continue %s", len(list.Items), opts.Limit, list.ResourceVersion, list.Continue)
 			gomega.Expect(len(list.Items)).To(gomega.BeNumerically("<=", opts.Limit))
-			gomega.Expect(list.ResourceVersion).To(gomega.Equal(lastRV))
+			framework.ExpectEqual(list.ResourceVersion, lastRV)
 			for _, item := range list.Items {
-				gomega.Expect(item.Name).To(gomega.Equal(fmt.Sprintf("template-%04d", found)))
+				framework.ExpectEqual(item.Name, fmt.Sprintf("template-%04d", found))
 				found++
 			}
 			if len(list.Continue) == 0 {

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -33,7 +33,6 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 func extinguish(f *framework.Framework, totalNS int, maxAllowedAfterDel int, maxSeconds int) {
@@ -59,7 +58,7 @@ func extinguish(f *framework.Framework, totalNS int, maxAllowedAfterDel int, max
 	deleteFilter := []string{"nslifetest"}
 	deleted, err := framework.DeleteNamespaces(f.ClientSet, deleteFilter, nil /* skipFilter */)
 	framework.ExpectNoError(err, "failed to delete namespace(s) containing: %s", deleteFilter)
-	gomega.Expect(len(deleted)).To(gomega.Equal(totalNS))
+	framework.ExpectEqual(len(deleted), totalNS)
 
 	ginkgo.By("Waiting for namespaces to vanish")
 	//Now POLL until all namespaces have been eradicated.

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -38,7 +38,6 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 const (
@@ -770,22 +769,22 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		ginkgo.By("Getting a ResourceQuota")
 		resourceQuotaResult, err := client.CoreV1().ResourceQuotas(ns).Get(quotaName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
-		gomega.Expect(resourceQuotaResult.Spec.Hard[v1.ResourceCPU]).To(gomega.Equal(resource.MustParse("1")))
-		gomega.Expect(resourceQuotaResult.Spec.Hard[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("500Mi")))
+		framework.ExpectEqual(resourceQuotaResult.Spec.Hard[v1.ResourceCPU], resource.MustParse("1"))
+		framework.ExpectEqual(resourceQuotaResult.Spec.Hard[v1.ResourceMemory], resource.MustParse("500Mi"))
 
 		ginkgo.By("Updating a ResourceQuota")
 		resourceQuota.Spec.Hard[v1.ResourceCPU] = resource.MustParse("2")
 		resourceQuota.Spec.Hard[v1.ResourceMemory] = resource.MustParse("1Gi")
 		resourceQuotaResult, err = client.CoreV1().ResourceQuotas(ns).Update(resourceQuota)
 		framework.ExpectNoError(err)
-		gomega.Expect(resourceQuotaResult.Spec.Hard[v1.ResourceCPU]).To(gomega.Equal(resource.MustParse("2")))
-		gomega.Expect(resourceQuotaResult.Spec.Hard[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("1Gi")))
+		framework.ExpectEqual(resourceQuotaResult.Spec.Hard[v1.ResourceCPU], resource.MustParse("2"))
+		framework.ExpectEqual(resourceQuotaResult.Spec.Hard[v1.ResourceMemory], resource.MustParse("1Gi"))
 
 		ginkgo.By("Verifying a ResourceQuota was modified")
 		resourceQuotaResult, err = client.CoreV1().ResourceQuotas(ns).Get(quotaName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
-		gomega.Expect(resourceQuotaResult.Spec.Hard[v1.ResourceCPU]).To(gomega.Equal(resource.MustParse("2")))
-		gomega.Expect(resourceQuotaResult.Spec.Hard[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("1Gi")))
+		framework.ExpectEqual(resourceQuotaResult.Spec.Hard[v1.ResourceCPU], resource.MustParse("2"))
+		framework.ExpectEqual(resourceQuotaResult.Spec.Hard[v1.ResourceMemory], resource.MustParse("1Gi"))
 
 		ginkgo.By("Deleting a ResourceQuota")
 		err = deleteResourceQuota(client, ns, quotaName)
@@ -793,7 +792,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 
 		ginkgo.By("Verifying the deleted ResourceQuota")
 		_, err = client.CoreV1().ResourceQuotas(ns).Get(quotaName, metav1.GetOptions{})
-		gomega.Expect(errors.IsNotFound(err)).To(gomega.Equal(true))
+		framework.ExpectEqual(errors.IsNotFound(err), true)
 	})
 })
 
@@ -983,7 +982,7 @@ var _ = SIGDescribe("ResourceQuota [Feature:PodPriority]", func() {
 	ginkgo.It("should verify ResourceQuota's priority class scope (quota set to pod count: 1) against a pod with same priority class.", func() {
 
 		_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(&schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "pclass1"}, Value: int32(1000)})
-		gomega.Expect(err == nil || errors.IsAlreadyExists(err)).To(gomega.Equal(true))
+		framework.ExpectEqual(err == nil || errors.IsAlreadyExists(err), true)
 
 		hard := v1.ResourceList{}
 		hard[v1.ResourcePods] = resource.MustParse("1")
@@ -1022,7 +1021,7 @@ var _ = SIGDescribe("ResourceQuota [Feature:PodPriority]", func() {
 	ginkgo.It("should verify ResourceQuota's priority class scope (quota set to pod count: 1) against 2 pods with same priority class.", func() {
 
 		_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(&schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "pclass2"}, Value: int32(1000)})
-		gomega.Expect(err == nil || errors.IsAlreadyExists(err)).To(gomega.Equal(true))
+		framework.ExpectEqual(err == nil || errors.IsAlreadyExists(err), true)
 
 		hard := v1.ResourceList{}
 		hard[v1.ResourcePods] = resource.MustParse("1")
@@ -1067,7 +1066,7 @@ var _ = SIGDescribe("ResourceQuota [Feature:PodPriority]", func() {
 	ginkgo.It("should verify ResourceQuota's priority class scope (quota set to pod count: 1) against 2 pods with different priority class.", func() {
 
 		_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(&schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "pclass3"}, Value: int32(1000)})
-		gomega.Expect(err == nil || errors.IsAlreadyExists(err)).To(gomega.Equal(true))
+		framework.ExpectEqual(err == nil || errors.IsAlreadyExists(err), true)
 
 		hard := v1.ResourceList{}
 		hard[v1.ResourcePods] = resource.MustParse("1")
@@ -1113,10 +1112,10 @@ var _ = SIGDescribe("ResourceQuota [Feature:PodPriority]", func() {
 
 	ginkgo.It("should verify ResourceQuota's multiple priority class scope (quota set to pod count: 2) against 2 pods with same priority classes.", func() {
 		_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(&schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "pclass5"}, Value: int32(1000)})
-		gomega.Expect(err == nil || errors.IsAlreadyExists(err)).To(gomega.Equal(true))
+		framework.ExpectEqual(err == nil || errors.IsAlreadyExists(err), true)
 
 		_, err = f.ClientSet.SchedulingV1().PriorityClasses().Create(&schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "pclass6"}, Value: int32(1000)})
-		gomega.Expect(err == nil || errors.IsAlreadyExists(err)).To(gomega.Equal(true))
+		framework.ExpectEqual(err == nil || errors.IsAlreadyExists(err), true)
 
 		hard := v1.ResourceList{}
 		hard[v1.ResourcePods] = resource.MustParse("2")
@@ -1168,7 +1167,7 @@ var _ = SIGDescribe("ResourceQuota [Feature:PodPriority]", func() {
 	ginkgo.It("should verify ResourceQuota's priority class scope (quota set to pod count: 1) against a pod with different priority class (ScopeSelectorOpNotIn).", func() {
 
 		_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(&schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "pclass7"}, Value: int32(1000)})
-		gomega.Expect(err == nil || errors.IsAlreadyExists(err)).To(gomega.Equal(true))
+		framework.ExpectEqual(err == nil || errors.IsAlreadyExists(err), true)
 
 		hard := v1.ResourceList{}
 		hard[v1.ResourcePods] = resource.MustParse("1")
@@ -1202,7 +1201,7 @@ var _ = SIGDescribe("ResourceQuota [Feature:PodPriority]", func() {
 	ginkgo.It("should verify ResourceQuota's priority class scope (quota set to pod count: 1) against a pod with different priority class (ScopeSelectorOpExists).", func() {
 
 		_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(&schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "pclass8"}, Value: int32(1000)})
-		gomega.Expect(err == nil || errors.IsAlreadyExists(err)).To(gomega.Equal(true))
+		framework.ExpectEqual(err == nil || errors.IsAlreadyExists(err), true)
 
 		hard := v1.ResourceList{}
 		hard[v1.ResourcePods] = resource.MustParse("1")
@@ -1241,7 +1240,7 @@ var _ = SIGDescribe("ResourceQuota [Feature:PodPriority]", func() {
 	ginkgo.It("should verify ResourceQuota's priority class scope (cpu, memory quota set) against a pod with same priority class.", func() {
 
 		_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(&schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "pclass9"}, Value: int32(1000)})
-		gomega.Expect(err == nil || errors.IsAlreadyExists(err)).To(gomega.Equal(true))
+		framework.ExpectEqual(err == nil || errors.IsAlreadyExists(err), true)
 
 		hard := v1.ResourceList{}
 		hard[v1.ResourcePods] = resource.MustParse("1")

--- a/test/e2e/apimachinery/table_conversion.go
+++ b/test/e2e/apimachinery/table_conversion.go
@@ -64,10 +64,10 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		e2elog.Logf("Table: %#v", table)
 
 		gomega.Expect(len(table.ColumnDefinitions)).To(gomega.BeNumerically(">", 2))
-		gomega.Expect(len(table.Rows)).To(gomega.Equal(1))
-		gomega.Expect(len(table.Rows[0].Cells)).To(gomega.Equal(len(table.ColumnDefinitions)))
-		gomega.Expect(table.ColumnDefinitions[0].Name).To(gomega.Equal("Name"))
-		gomega.Expect(table.Rows[0].Cells[0]).To(gomega.Equal(podName))
+		framework.ExpectEqual(len(table.Rows), 1)
+		framework.ExpectEqual(len(table.Rows[0].Cells), len(table.ColumnDefinitions))
+		framework.ExpectEqual(table.ColumnDefinitions[0].Name, "Name")
+		framework.ExpectEqual(table.Rows[0].Cells[0], podName)
 
 		out := printTable(table)
 		gomega.Expect(out).To(gomega.MatchRegexp("^NAME\\s"))
@@ -109,12 +109,12 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 			SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").
 			Do().Into(pagedTable)
 		framework.ExpectNoError(err, "failed to get pod templates in Table form in namespace: %s", ns)
-		gomega.Expect(len(pagedTable.Rows)).To(gomega.Equal(2))
+		framework.ExpectEqual(len(pagedTable.Rows), 2)
 		gomega.Expect(pagedTable.ResourceVersion).ToNot(gomega.Equal(""))
 		gomega.Expect(pagedTable.SelfLink).ToNot(gomega.Equal(""))
 		gomega.Expect(pagedTable.Continue).ToNot(gomega.Equal(""))
-		gomega.Expect(pagedTable.Rows[0].Cells[0]).To(gomega.Equal("template-0000"))
-		gomega.Expect(pagedTable.Rows[1].Cells[0]).To(gomega.Equal("template-0001"))
+		framework.ExpectEqual(pagedTable.Rows[0].Cells[0], "template-0000")
+		framework.ExpectEqual(pagedTable.Rows[1].Cells[0], "template-0001")
 
 		err = c.CoreV1().RESTClient().Get().Namespace(ns).Resource("podtemplates").
 			VersionedParams(&metav1.ListOptions{Continue: pagedTable.Continue}, metav1.ParameterCodec).
@@ -122,7 +122,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 			Do().Into(pagedTable)
 		framework.ExpectNoError(err, "failed to get pod templates in Table form in namespace: %s", ns)
 		gomega.Expect(len(pagedTable.Rows)).To(gomega.BeNumerically(">", 0))
-		gomega.Expect(pagedTable.Rows[0].Cells[0]).To(gomega.Equal("template-0002"))
+		framework.ExpectEqual(pagedTable.Rows[0].Cells[0], "template-0002")
 	})
 
 	ginkgo.It("should return generic metadata details across all namespaces for nodes", func() {
@@ -135,8 +135,8 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 
 		gomega.Expect(len(table.ColumnDefinitions)).To(gomega.BeNumerically(">=", 2))
 		gomega.Expect(len(table.Rows)).To(gomega.BeNumerically(">=", 1))
-		gomega.Expect(len(table.Rows[0].Cells)).To(gomega.Equal(len(table.ColumnDefinitions)))
-		gomega.Expect(table.ColumnDefinitions[0].Name).To(gomega.Equal("Name"))
+		framework.ExpectEqual(len(table.Rows[0].Cells), len(table.ColumnDefinitions))
+		framework.ExpectEqual(table.ColumnDefinitions[0].Name, "Name")
 		gomega.Expect(table.ResourceVersion).ToNot(gomega.Equal(""))
 		gomega.Expect(table.SelfLink).ToNot(gomega.Equal(""))
 
@@ -159,7 +159,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		}
 		err := c.AuthorizationV1().RESTClient().Post().Resource("selfsubjectaccessreviews").SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").Body(sar).Do().Into(table)
 		framework.ExpectError(err, "failed to return error when posting self subject access review: %+v, to a backend that does not implement metadata", sar)
-		gomega.Expect(err.(errors.APIStatus).Status().Code).To(gomega.Equal(int32(406)))
+		framework.ExpectEqual(err.(errors.APIStatus).Status().Code, int32(406))
 	})
 })
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Since https://github.com/kubernetes/kubernetes/pull/78922 ExpectEqual() is implemented as test framework.
This makes e2e tests use the function under test/e2e/apimachinery.

Ref: https://github.com/kubernetes/kubernetes/issues/79686

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
