### PR TITLE
Utilize runtime cache when cleaning up orphaned pod dirs

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1035,20 +1035,14 @@ func (kl *Kubelet) HandlePodCleanups() error {
 
 	kl.removeOrphanedPodStatuses(allPods, mirrorPods)
 	// Note that we just killed the unwanted pods. This may not have reflected
-	// in the cache. We need to bypass the cache to get the latest set of
-	// running pods to clean up the volumes.
-	// TODO: Evaluate the performance impact of bypassing the runtime cache.
-	runningPods, err = kl.containerRuntime.GetPods(false)
-	if err != nil {
-		klog.Errorf("Error listing containers: %#v", err)
-		return err
-	}
+	// in the cache. Getting the latest set of running pods to clean up the volumes, considering the
+	// intersection with desired Pods.
 
 	// Remove any orphaned volumes.
 	// Note that we pass all pods (including terminated pods) to the function,
 	// so that we don't remove volumes associated with terminated but not yet
 	// deleted pods.
-	err = kl.cleanupOrphanedPodDirs(allPods, runningPods)
+	err = kl.cleanupOrphanedPodDirs(allPods, runningPods, desiredPods)
 	if err != nil {
 		// We want all cleanup tasks to be run even if one of them failed. So
 		// we just log an error here and continue other cleanup tasks.

--- a/pkg/kubelet/kubelet_volumes_linux_test.go
+++ b/pkg/kubelet/kubelet_volumes_linux_test.go
@@ -27,6 +27,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 )
@@ -137,7 +138,7 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				}
 			}
 
-			err := kubelet.cleanupOrphanedPodDirs(tc.pods, nil)
+			err := kubelet.cleanupOrphanedPodDirs(tc.pods, nil, map[types.UID]empty{})
 			if tc.expectErr && err == nil {
 				t.Errorf("%s failed: expected error, got success", name)
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In Kubelet#HandlePodCleanups, we call containerRuntime.GetPods because runtime cache hasn't reflected recent pod killings.

Since the selection of pods to kill is based on desiredPods, we don't need to call containerRuntime.GetPods.
Instead, we utilize desiredPods to establish the allPods set.

```release-note
NONE
```
