### PR TITLE
Add warning event to Pod stats: when duplicated env are defined in multiple Configmap/Secret

### DIFF
--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -1315,11 +1315,11 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 				Env: []v1.EnvVar{
 					{
 						Name:  "test1",
-						Value: "1234",
+						Value: "test",
 					},
 					{
 						Name:  "test4",
-						Value: "test-test",
+						Value: "test",
 					},
 				},
 				EnvFrom: []v1.EnvFromSource{
@@ -1340,7 +1340,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 				Data: map[string]string{
 					"test1": "abc",
 					"test2": "abc",
-					"test3": "abc",
+					"test5": "abc",
 				},
 			},
 			secret: &v1.Secret{
@@ -1349,29 +1349,34 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					Name:      "test-secret",
 				},
 				Data: map[string][]byte{
-					"test2": []byte("1234"),
-					"test3": []byte("5678"),
+					"test1": []byte("1234"),
+					"test3": []byte("1234"),
+					"test5": []byte("1234"),
 				},
 			},
 			expectedEnvs: []kubecontainer.EnvVar{
 				{
 					Name:  "test1",
-					Value: "1234",
+					Value: "test",
 				},
 				{
 					Name:  "test2",
-					Value: "1234",
+					Value: "abc",
 				},
 				{
 					Name:  "test3",
-					Value: "5678",
+					Value: "1234",
 				},
 				{
 					Name:  "test4",
-					Value: "test-test",
+					Value: "test",
+				},
+				{
+					Name:  "test5",
+					Value: "1234",
 				},
 			},
-			expectedEvent: "Warning DuplicatedEnvironmentVariableNames Keys [test1, test2, test3] were defined from multiple means.",
+			expectedEvent: "Warning DuplicatedEnvironmentVariableNames Keys [test1, test5] were defined from multiple means.",
 		},
 		{
 			name:               "secret",

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -1124,6 +1124,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					Value: "CONFIG_MAP",
 				},
 			},
+			expectedEvent: "Warning DuplicatedEnvironmentVariableNames Keys [DUPE_TEST] were defined from multiple means.",
 		},
 		{
 			name:               "configmap, service env vars",
@@ -1220,6 +1221,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					Value: "CONFIG_MAP",
 				},
 			},
+			expectedEvent: "Warning DuplicatedEnvironmentVariableNames Keys [DUPE_TEST] were defined from multiple means.",
 		},
 		{
 			name:               "configmap_missing",
@@ -1310,6 +1312,16 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			ns:                 "test",
 			enableServiceLinks: &falseValue,
 			container: &v1.Container{
+				Env: []v1.EnvVar{
+					{
+						Name:  "test1",
+						Value: "1234",
+					},
+					{
+						Name:  "test4",
+						Value: "test-test",
+					},
+				},
 				EnvFrom: []v1.EnvFromSource{
 					{
 						ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test-config-map"}},
@@ -1326,8 +1338,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					Name:      "test-configmap",
 				},
 				Data: map[string]string{
-					"test":  "abc",
-					"test2": "5678",
+					"test1": "abc",
+					"test2": "abc",
+					"test3": "abc",
 				},
 			},
 			secret: &v1.Secret{
@@ -1336,25 +1349,29 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					Name:      "test-secret",
 				},
 				Data: map[string][]byte{
-					"test":  []byte("1234"),
-					"test3": []byte("9012"),
+					"test2": []byte("1234"),
+					"test3": []byte("5678"),
 				},
 			},
 			expectedEnvs: []kubecontainer.EnvVar{
 				{
-					Name:  "test",
+					Name:  "test1",
 					Value: "1234",
 				},
 				{
 					Name:  "test2",
-					Value: "5678",
+					Value: "1234",
 				},
 				{
 					Name:  "test3",
-					Value: "9012",
+					Value: "5678",
+				},
+				{
+					Name:  "test4",
+					Value: "test-test",
 				},
 			},
-			expectedEvent: "Warning DuplicatedEnvironmentVariableNames Keys [test] were defined from multiple configMap/secret.",
+			expectedEvent: "Warning DuplicatedEnvironmentVariableNames Keys [test1, test2, test3] were defined from multiple means.",
 		},
 		{
 			name:               "secret",
@@ -1423,6 +1440,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					Value: "SECRET",
 				},
 			},
+			expectedEvent: "Warning DuplicatedEnvironmentVariableNames Keys [DUPE_TEST] were defined from multiple means.",
 		},
 		{
 			name:               "secret, service env vars",
@@ -1519,6 +1537,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					Value: "SECRET",
 				},
 			},
+			expectedEvent: "Warning DuplicatedEnvironmentVariableNames Keys [DUPE_TEST] were defined from multiple means.",
 		},
 		{
 			name:               "secret_missing",

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -1354,7 +1354,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					Value: "9012",
 				},
 			},
-			expectedEvent: "Warning DuplicatedEnvironmentVariableNames Keys [test] from the EnvFrom secret test/test-secret were already defined by other configMap or secret. Use test/test-secret.",
+			expectedEvent: "Warning DuplicatedEnvironmentVariableNames Keys [test] were defined from multiple configMap/secret.",
 		},
 		{
 			name:               "secret",

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -1324,7 +1324,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 				},
 				EnvFrom: []v1.EnvFromSource{
 					{
-						ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test-config-map"}},
+						ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test-configmap"}},
 					},
 					{
 						SecretRef: &v1.SecretEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test-secret"}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

Environment variables can be defined from both ConfigMap and Secret.
When environment variables are defined both of them, used last-evaluated secret .
I think it hard to find so I add a warning event to pod description.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add a event in the Pod description when environment variables are defined in multiple ConfigMap/Secret.
```