### PR TITLE
Make etcd world-executable in Docker image

### DIFF
--- a/cluster/images/etcd/Dockerfile
+++ b/cluster/images/etcd/Dockerfile
@@ -16,6 +16,4 @@ FROM BASEIMAGE
 
 EXPOSE 2379 2380 4001 7001
 COPY etcd* etcdctl* /usr/local/bin/
-RUN chmod +x /usr/local/bin/etcd* /usr/local/bin/etcdctl*
 COPY migrate-if-needed.sh migrate /usr/local/bin/
-RUN chmod +x /usr/local/bin/migrate-if-needed.sh /usr/local/bin/migrate

--- a/cluster/images/etcd/Dockerfile
+++ b/cluster/images/etcd/Dockerfile
@@ -16,4 +16,6 @@ FROM BASEIMAGE
 
 EXPOSE 2379 2380 4001 7001
 COPY etcd* etcdctl* /usr/local/bin/
+RUN chmod +x /usr/local/bin/etcd* /usr/local/bin/etcdctl*
 COPY migrate-if-needed.sh migrate /usr/local/bin/
+RUN chmod +x /usr/local/bin/migrate-if-needed.sh /usr/local/bin/migrate

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -49,10 +49,11 @@ PUSH_REGISTRY?=staging-k8s.gcr.io
 
 MANIFEST_IMAGE := $(PUSH_REGISTRY)/etcd
 
-SELINUX_ENABLED := $(shell cat /sys/fs/selinux/enforce 2> /dev/null || echo 0)
-
 # Install binaries matching base distro permissions
 BIN_INSTALL := install -m 0555
+
+# Hosts running SELinux need :z added to volume mounts
+SELINUX_ENABLED := $(shell cat /sys/fs/selinux/enforce 2> /dev/null || echo 0)
 
 ifeq ($(SELINUX_ENABLED),1)
   DOCKER_VOL_OPTS?=:z

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -51,6 +51,9 @@ MANIFEST_IMAGE := $(PUSH_REGISTRY)/etcd
 
 SELINUX_ENABLED := $(shell cat /sys/fs/selinux/enforce 2> /dev/null || echo 0)
 
+# Install binaries matching base distro permissions
+BIN_INSTALL := install -m 0555
+
 ifeq ($(SELINUX_ENABLED),1)
   DOCKER_VOL_OPTS?=:z
 endif
@@ -79,14 +82,15 @@ ifeq ($(ARCH),s390x)
 endif
 
 build:
-	# Copy the content in this dir to the temp dir,
-	# without copying the subdirectories.
-	find ./ -maxdepth 1 -type f | xargs -I {} cp {} $(TEMP_DIR)
+	# Explicitly copy files to the temp directory
+	$(BIN_INSTALL) migrate-if-needed.sh $(TEMP_DIR)
+	install Dockerfile $(TEMP_DIR)
 
 	# Compile migrate
-	docker run --interactive -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes$(DOCKER_VOL_OPTS) -v $(TEMP_DIR):/build$(DOCKER_VOL_OPTS) -e GOARCH=$(ARCH) golang:$(GOLANG_VERSION) \
-		/bin/bash -c "CGO_ENABLED=0 go build -o /build/migrate k8s.io/kubernetes/cluster/images/etcd/migrate"
-
+	migrate_tmp_dir=$(shell mktemp -d); \
+	docker run --interactive -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes$(DOCKER_VOL_OPTS) -v $${migrate_tmp_dir}:/build$(DOCKER_VOL_OPTS) -e GOARCH=$(ARCH) golang:$(GOLANG_VERSION) \
+		/bin/bash -c "CGO_ENABLED=0 go build -o /build/migrate k8s.io/kubernetes/cluster/images/etcd/migrate"; \
+	$(BIN_INSTALL) $${migrate_tmp_dir}/migrate $(TEMP_DIR)
 
 ifeq ($(ARCH),amd64)
 
@@ -95,10 +99,9 @@ ifeq ($(ARCH),amd64)
 	for version in $(BUNDLED_ETCD_VERSIONS); do \
 		etcd_release_tmp_dir=$(shell mktemp -d); \
 		curl -sSL --retry 5 https://github.com/coreos/etcd/releases/download/v$$version/etcd-v$$version-linux-amd64.tar.gz | tar -xz -C $$etcd_release_tmp_dir --strip-components=1; \
-		cp $$etcd_release_tmp_dir/etcd $$etcd_release_tmp_dir/etcdctl $(TEMP_DIR)/; \
-		cp $(TEMP_DIR)/etcd $(TEMP_DIR)/etcd-$$version; \
-		chmod +x $(TEMP_DIR)/etcd-$$version; \
-		cp $(TEMP_DIR)/etcdctl $(TEMP_DIR)/etcdctl-$$version; \
+		$(BIN_INSTALL) $$etcd_release_tmp_dir/etcd $$etcd_release_tmp_dir/etcdctl $(TEMP_DIR)/; \
+		$(BIN_INSTALL) $(TEMP_DIR)/etcd $(TEMP_DIR)/etcd-$$version; \
+		$(BIN_INSTALL) $(TEMP_DIR)/etcdctl $(TEMP_DIR)/etcdctl-$$version; \
 	done
 else
 
@@ -112,9 +115,9 @@ else
 			&& git checkout v$${version} \
 			&& GOARM=$(GOARM) GOARCH=$(ARCH) ./build \
 			&& cp -f bin/$(ARCH)/etcd* bin/etcd* /etcdbin; echo 'done'"; \
-		cp $$etcd_release_tmp_dir/etcd $$etcd_release_tmp_dir/etcdctl $(TEMP_DIR)/; \
-		cp $(TEMP_DIR)/etcd $(TEMP_DIR)/etcd-$$version; \
-		cp $(TEMP_DIR)/etcdctl $(TEMP_DIR)/etcdctl-$$version; \
+		$(BIN_INSTALL) $$etcd_release_tmp_dir/etcd $$etcd_release_tmp_dir/etcdctl $(TEMP_DIR)/; \
+		$(BIN_INSTALL) $(TEMP_DIR)/etcd $(TEMP_DIR)/etcd-$$version; \
+		$(BIN_INSTALL) $(TEMP_DIR)/etcdctl $(TEMP_DIR)/etcdctl-$$version; \
 	done
 
 	# Add this ENV variable in order to workaround an unsupported arch blocker

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -49,6 +49,12 @@ PUSH_REGISTRY?=staging-k8s.gcr.io
 
 MANIFEST_IMAGE := $(PUSH_REGISTRY)/etcd
 
+SELINUX_ENABLED := $(shell cat /sys/fs/selinux/enforce 2> /dev/null || echo 0)
+
+ifeq ($(SELINUX_ENABLED),1)
+  DOCKER_VOL_OPTS?=:z
+endif
+
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
 # golang version should match the golang version from https://github.com/coreos/etcd/releases for the current ETCD_VERSION.
@@ -78,7 +84,7 @@ build:
 	find ./ -maxdepth 1 -type f | xargs -I {} cp {} $(TEMP_DIR)
 
 	# Compile migrate
-	docker run --interactive -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes -v $(TEMP_DIR):/build -e GOARCH=$(ARCH) golang:$(GOLANG_VERSION) \
+	docker run --interactive -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes$(DOCKER_VOL_OPTS) -v $(TEMP_DIR):/build$(DOCKER_VOL_OPTS) -e GOARCH=$(ARCH) golang:$(GOLANG_VERSION) \
 		/bin/bash -c "CGO_ENABLED=0 go build -o /build/migrate k8s.io/kubernetes/cluster/images/etcd/migrate"
 
 
@@ -99,7 +105,7 @@ else
 	# For each release create a tmp dir 'etcd_release_tmp_dir' and unpack the release tar there.
 	for version in $(BUNDLED_ETCD_VERSIONS); do \
 		etcd_release_tmp_dir=$(shell mktemp -d); \
-		docker run --interactive -v $${etcd_release_tmp_dir}:/etcdbin golang:$(GOLANG_VERSION) /bin/bash -c \
+		docker run --interactive -v $${etcd_release_tmp_dir}:/etcdbin golang:$(GOLANG_VERSION)$(DOCKER_VOL_OPTS) /bin/bash -c \
 			"git clone https://github.com/coreos/etcd /go/src/github.com/coreos/etcd \
 			&& cd /go/src/github.com/coreos/etcd \
 			&& git checkout v$${version} \
@@ -145,7 +151,7 @@ push-manifest:
 	docker manifest push --purge ${MANIFEST_IMAGE}:${IMAGE_TAG}
 
 unit-test:
-	docker run --interactive -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes -e GOARCH=$(ARCH) golang:$(GOLANG_VERSION) \
+	docker run --interactive -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes$(DOCKER_VOL_OPTS) -e GOARCH=$(ARCH) golang:$(GOLANG_VERSION) \
 		/bin/bash -c "CGO_ENABLED=0 go test -v k8s.io/kubernetes/cluster/images/etcd/migrate"
 
 # Integration tests require both a golang build environment and all the etcd binaries from a `k8s.gcr.io/etcd` image (`/usr/local/bin/etcd-<version>`, ...).
@@ -158,7 +164,7 @@ build-integration-test-image: build
 	docker build --pull -t etcd-integration-test $(TEMP_DIR)_integration_test
 
 integration-test:
-	docker run --interactive -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes -e GOARCH=$(ARCH) etcd-integration-test \
+	docker run --interactive -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes$(DOCKER_VOL_OPTS) -e GOARCH=$(ARCH) etcd-integration-test \
 		/bin/bash -c "CGO_ENABLED=0 go test -tags=integration k8s.io/kubernetes/cluster/images/etcd/migrate -args -v 10 -logtostderr true"
 
 integration-build-test: build-integration-test-image integration-test

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -97,6 +97,7 @@ ifeq ($(ARCH),amd64)
 		curl -sSL --retry 5 https://github.com/coreos/etcd/releases/download/v$$version/etcd-v$$version-linux-amd64.tar.gz | tar -xz -C $$etcd_release_tmp_dir --strip-components=1; \
 		cp $$etcd_release_tmp_dir/etcd $$etcd_release_tmp_dir/etcdctl $(TEMP_DIR)/; \
 		cp $(TEMP_DIR)/etcd $(TEMP_DIR)/etcd-$$version; \
+		chmod +x $(TEMP_DIR)/etcd-$$version; \
 		cp $(TEMP_DIR)/etcdctl $(TEMP_DIR)/etcdctl-$$version; \
 	done
 else


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/area security
/sig release
/sig cluster-lifecycle

**What this PR does / why we need it**:
Makes the etcd binaries in the Docker image world-executable, which allows consumers to drop running the image as root.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79720 

**Special notes for your reviewer**:
Have added fixes to the Makefile to run on SELinux enabled systems.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
etcd Docker image can be run as non-root
```
