### PR TITLE
Output boolean for AllowPrivilegeEscalation

### DIFF
--- a/pkg/kubectl/describe/versioned/describe.go
+++ b/pkg/kubectl/describe/versioned/describe.go
@@ -3865,7 +3865,11 @@ func describePodSecurityPolicy(psp *policyv1beta1.PodSecurityPolicy) (string, er
 		w.Write(LEVEL_0, "\nSettings:\n")
 
 		w.Write(LEVEL_1, "Allow Privileged:\t%t\n", psp.Spec.Privileged)
-		w.Write(LEVEL_1, "Allow Privilege Escalation:\t%v\n", psp.Spec.AllowPrivilegeEscalation)
+		if psp.Spec.AllowPrivilegeEscalation != nil {
+			w.Write(LEVEL_1, "Allow Privilege Escalation:\t%t\n", *psp.Spec.AllowPrivilegeEscalation)
+		} else {
+			w.Write(LEVEL_1, "Allow Privilege Escalation:\t<unset>\n")
+		}
 		w.Write(LEVEL_1, "Default Add Capabilities:\t%v\n", capsToString(psp.Spec.DefaultAddCapabilities))
 		w.Write(LEVEL_1, "Required Drop Capabilities:\t%s\n", capsToString(psp.Spec.RequiredDropCapabilities))
 		w.Write(LEVEL_1, "Allowed Capabilities:\t%s\n", capsToString(psp.Spec.AllowedCapabilities))

--- a/pkg/kubectl/describe/versioned/describe_test.go
+++ b/pkg/kubectl/describe/versioned/describe_test.go
@@ -2683,6 +2683,7 @@ func TestDescribePodSecurityPolicy(t *testing.T) {
 	expected := []string{
 		"Name:\\s*mypsp",
 		"Allow Privileged:\\s*false",
+		"Allow Privilege Escalation:\\s*false",
 		"Default Add Capabilities:\\s*<none>",
 		"Required Drop Capabilities:\\s*<none>",
 		"Allowed Capabilities:\\s*<none>",
@@ -2704,13 +2705,15 @@ func TestDescribePodSecurityPolicy(t *testing.T) {
 		"Supplemental Groups Strategy: RunAsAny",
 	}
 
+	falseVal := false
 	fake := fake.NewSimpleClientset(&policyv1beta1.PodSecurityPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "mypsp",
 		},
 		Spec: policyv1beta1.PodSecurityPolicySpec{
-			AllowedUnsafeSysctls: []string{"kernel.*", "net.ipv4.ip_local_port_range"},
-			ForbiddenSysctls:     []string{"net.ipv4.ip_default_ttl"},
+			AllowPrivilegeEscalation: &falseVal,
+			AllowedUnsafeSysctls:     []string{"kernel.*", "net.ipv4.ip_local_port_range"},
+			ForbiddenSysctls:         []string{"net.ipv4.ip_default_ttl"},
 			SELinux: policyv1beta1.SELinuxStrategyOptions{
 				Rule: policyv1beta1.SELinuxStrategyRunAsAny,
 			},


### PR DESCRIPTION
`kubectl describe psp` was incorrectly outputting the hex-encoded value
of the pointer to bool AllowPrivilegeEscalation field of the
PodSecurityPolicySpec. This patch simply fixes the output to be a
stringified boolean value of the field.

Fixes Issue #79721

/sig cli
/kind bug