### PR TITLE
client-go: update installation instructions to reflect v12.0.0 release

### DIFF
--- a/staging/src/k8s.io/client-go/INSTALL.md
+++ b/staging/src/k8s.io/client-go/INSTALL.md
@@ -65,7 +65,7 @@ for each follows.
 ### Go modules
 
 Dependency management tools are built into go 1.11+ in the form of [go modules](https://github.com/golang/go/wiki/Modules).
-These are used by the main Kubernetes repo (>= 1.15) and `client-go` (on master, and v12.0.0+ once released) to manage dependencies.
+These are used by the main Kubernetes repo (>= 1.15) and `client-go` (on master, and v12.0.0+) to manage dependencies.
 When using `client-go` v12.0.0+ and go 1.11.4+, go modules are the recommended dependency management tool.
 
 If you are using go 1.11 or 1.12 and are working with a project located within `$GOPATH`,
@@ -83,10 +83,10 @@ go mod init
 ```
 
 Indicate which version of `client-go` your project requires.
-For `client-go` on master (and once version v12.0.0 is released), this is a single step:
+For `client-go` on v12.0.0 (and later), this is a single step:
 
 ```sh
-go get k8s.io/client-go@master # or v12.0.0+ once released
+go get k8s.io/client-go@v12.0.0
 ```
 
 For `client-go` prior to v12.0.0, you also need to indicate the required versions of `k8s.io/api` and `k8s.io/apimachinery`:
@@ -119,7 +119,7 @@ your project:
 package: ( your project's import path ) # e.g. github.com/foo/bar
 import:
 - package: k8s.io/client-go
-  version: v11.0.0 # replace v11.0.0 with the required version
+  version: v12.0.0 # replace v12.0.0 with the required version
 ```
 
 Second, add a Go file that imports `client-go` somewhere in your project,
@@ -152,7 +152,7 @@ requests can override the version manually in `glide.yaml`. For example:
 package: ( your project's import path ) # e.g. github.com/foo/bar
 import:
 - package: k8s.io/client-go
-  version: v11.0.0 # replace v11.0.0 with the required version
+  version: v12.0.0 # replace v12.0.0 with the required version
 # Use a newer version of go-spew even though client-go wants an old one.
 - package: github.com/davecgh/go-spew
   version: v1.1.0


### PR DESCRIPTION
https://github.com/kubernetes/client-go/releases/tag/v12.0.0

/assign @sttts 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
