### PR TITLE
Automated cherry pick of #79270: kubeadm: add --control-plane-endpoint flag

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/alpha/kubeconfig.go
@@ -100,7 +100,7 @@ func newCmdUserKubeConfig(out io.Writer) *cobra.Command {
 	// Add ClusterConfiguration backed flags to the command
 	cmd.Flags().StringVar(&clusterCfg.CertificatesDir, options.CertificatesDir, clusterCfg.CertificatesDir, "The path where certificates are stored")
 
-	// Add ClusterConfiguration backed flags to the command
+	// Add InitConfiguration backed flags to the command
 	cmd.Flags().StringVar(&initCfg.LocalAPIEndpoint.AdvertiseAddress, options.APIServerAdvertiseAddress, initCfg.LocalAPIEndpoint.AdvertiseAddress, "The IP address the API server is accessible on")
 	cmd.Flags().Int32Var(&initCfg.LocalAPIEndpoint.BindPort, options.APIServerBindPort, initCfg.LocalAPIEndpoint.BindPort, "The port the API server is accessible on")
 

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -230,6 +230,11 @@ func AddClusterConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiv1beta2.Cluster
 		`Use alternative domain for services, e.g. "myorg.internal".`,
 	)
 
+	flagSet.StringVar(
+		&cfg.ControlPlaneEndpoint, options.ControlPlaneEndpoint, cfg.ControlPlaneEndpoint,
+		`Specify a stable IP address or DNS name for the control plane.`,
+	)
+
 	options.AddKubernetesVersionFlag(flagSet, &cfg.KubernetesVersion)
 
 	flagSet.StringVar(

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -38,6 +38,9 @@ const (
 	// ControllerManagerExtraArgs flag sets extra flags to pass to the Controller Manager or override default ones in form of <flagname>=<value>.
 	ControllerManagerExtraArgs = "controller-manager-extra-args"
 
+	// ControlPlaneEndpoint flag sets a stable IP address or DNS name for the control plane.
+	ControlPlaneEndpoint = "control-plane-endpoint"
+
 	// DryRun flag instruct kubeadm to don't apply any changes; just output what would be done.
 	DryRun = "dry-run"
 

--- a/cmd/kubeadm/app/cmd/phases/init/addons.go
+++ b/cmd/kubeadm/app/cmd/phases/init/addons.go
@@ -112,6 +112,7 @@ func getAddonPhaseFlags(name string) []string {
 	if name == "all" || name == "kube-proxy" {
 		flags = append(flags,
 			options.APIServerAdvertiseAddress,
+			options.ControlPlaneEndpoint,
 			options.APIServerBindPort,
 			options.NetworkingPodSubnet,
 		)

--- a/cmd/kubeadm/app/cmd/phases/init/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs.go
@@ -139,6 +139,7 @@ func getCertPhaseFlags(name string) []string {
 	if name == "all" || name == "apiserver" {
 		flags = append(flags,
 			options.APIServerAdvertiseAddress,
+			options.ControlPlaneEndpoint,
 			options.APIServerCertSANs,
 			options.NetworkingDNSDomain,
 			options.NetworkingServiceSubnet,

--- a/cmd/kubeadm/app/cmd/phases/init/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/controlplane.go
@@ -105,6 +105,7 @@ func getControlPlanePhaseFlags(name string) []string {
 	if name == "all" || name == kubeadmconstants.KubeAPIServer {
 		flags = append(flags,
 			options.APIServerAdvertiseAddress,
+			options.ControlPlaneEndpoint,
 			options.APIServerBindPort,
 			options.APIServerExtraArgs,
 			options.FeatureGatesString,

--- a/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
@@ -97,6 +97,7 @@ func NewKubeConfigFilePhase(kubeConfigFileName string) workflow.Phase {
 func getKubeConfigPhaseFlags(name string) []string {
 	flags := []string{
 		options.APIServerAdvertiseAddress,
+		options.ControlPlaneEndpoint,
 		options.APIServerBindPort,
 		options.CertificatesDir,
 		options.CfgPath,


### PR DESCRIPTION
Cherry pick of #79270 on release-1.15.

#79270: kubeadm: add --control-plane-endpoint flag

```release-note
kubeadm: provide "--control-plane-endpoint" flag for `controlPlaneEndpoint`
```