### PR TITLE
Changed comment on ScaledValue

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -697,7 +697,7 @@ func (q *Quantity) MilliValue() int64 {
 	return q.ScaledValue(Milli)
 }
 
-// ScaledValue returns the value of ceil(q * 10^scale); this could overflow an int64.
+// ScaledValue returns the value of ceil(q / 10^scale); this could overflow an int64.
 // To detect overflow, call Value() first and verify the expected magnitude.
 func (q *Quantity) ScaledValue(scale Scale) int64 {
 	if q.d.Dec == nil {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -697,7 +697,9 @@ func (q *Quantity) MilliValue() int64 {
 	return q.ScaledValue(Milli)
 }
 
-// ScaledValue returns the value of ceil(q / 10^scale); this could overflow an int64.
+// ScaledValue returns the value of ceil(q / 10^scale).
+// For example, NewQuantity(1, DecimalSI).ScaledValue(Milli) returns 1000.
+// This could overflow an int64.
 // To detect overflow, call Value() first and verify the expected magnitude.
 func (q *Quantity) ScaledValue(scale Scale) int64 {
 	if q.d.Dec == nil {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1029,6 +1029,7 @@ func TestScaledValue(t *testing.T) {
 		{0, Micro, 1000 * 1000},
 		{0, Milli, 1000},
 		{0, 0, 1},
+		{2, -2, 100 * 100},
 	}
 
 	for _, item := range table {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**: Changes incorrect comment ```ScaledValue returns the value of ceil(q * 10^scale);``` to ```ScaledValue returns the value of ceil(q / 10^scale);```. Adds an additional test of ScaledValue outside of named special cases.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #50564

**Special notes for your reviewer**:

I tested the ScaledValue function with the following results to confirm the comment change:

With `q` as a `Quantity`, from `ScaledValueResult=q.ScaledValue(ScaledValueInput)` :
```
q.i.value=3,q.i.scale=-6,ScaleValueInput=-10,ScaledValueResult=30000
q.i.value=3,q.i.scale=-6,ScaleValueInput=-8,ScaledValueResult=300
q.i.value=3,q.i.scale=-6,ScaleValueInput=-6,ScaledValueResult=3
q.i.value=3,q.i.scale=-6,ScaleValueInput=-4,ScaledValueResult=1
q.i.value=3,q.i.scale=-6,ScaleValueInput=-2,ScaledValueResult=1
q.i.value=3,q.i.scale=-6,ScaleValueInput=0,ScaledValueResult=1
q.i.value=3,q.i.scale=0,ScaleValueInput=-4,ScaledValueResult=30000
q.i.value=3,q.i.scale=0,ScaleValueInput=-2,ScaledValueResult=300
q.i.value=3,q.i.scale=0,ScaleValueInput=0,ScaledValueResult=3
q.i.value=3,q.i.scale=0,ScaleValueInput=2,ScaledValueResult=1
q.i.value=3,q.i.scale=0,ScaleValueInput=4,ScaledValueResult=1
q.i.value=3,q.i.scale=0,ScaleValueInput=0,ScaledValueResult=3
```
**Does this PR introduce a user-facing change?**: NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
