### PR TITLE
Add IndexerInformerWatcher to watch limitRange creation

### DIFF
--- a/test/e2e/scheduling/BUILD
+++ b/test/e2e/scheduling/BUILD
@@ -42,6 +42,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
         "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/gpu:go_default_library",

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -19,14 +19,18 @@ package scheduling
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
@@ -41,21 +45,28 @@ const (
 var _ = SIGDescribe("LimitRange", func() {
 	f := framework.NewDefaultFramework("limitrange")
 
+	/*
+		Release : v1.15
+		Testname: LimitRange, resources
+		Description: Creating a Limitrange and verifying the creation of Limitrange, updating the Limitrange and validating the Limitrange. Creating Pods with resources and validate the pod resources are applied to the Limitrange
+	*/
+	//note: this test case can be promoted to conformance after verified the stability of the test case
 	ginkgo.It("should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
 		ginkgo.By("Creating a LimitRange")
-
 		min := getResourceList("50m", "100Mi", "100Gi")
 		max := getResourceList("500m", "500Mi", "500Gi")
 		defaultLimit := getResourceList("500m", "500Mi", "500Gi")
 		defaultRequest := getResourceList("100m", "200Mi", "200Gi")
 		maxLimitRequestRatio := v1.ResourceList{}
-		limitRange := newLimitRange("limit-range", v1.LimitTypeContainer,
+		value := strconv.Itoa(time.Now().Nanosecond())
+		limitRange := newLimitRange("limit-range", value, v1.LimitTypeContainer,
 			min, max,
 			defaultLimit, defaultRequest,
 			maxLimitRequestRatio)
 
 		ginkgo.By("Setting up watch")
-		selector := labels.SelectorFromSet(labels.Set(map[string]string{"name": limitRange.Name}))
+		selector := labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
+
 		options := metav1.ListOptions{LabelSelector: selector.String()}
 		limitRanges, err := f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).List(options)
 		framework.ExpectNoError(err, "failed to query for limitRanges")
@@ -64,8 +75,30 @@ var _ = SIGDescribe("LimitRange", func() {
 			LabelSelector:   selector.String(),
 			ResourceVersion: limitRanges.ListMeta.ResourceVersion,
 		}
-		w, err := f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Watch(metav1.ListOptions{})
-		framework.ExpectNoError(err, "failed to set up watch")
+
+		listCompleted := make(chan bool, 1)
+		lw := &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				options.LabelSelector = selector.String()
+				limitRanges, err := f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).List(options)
+				if err == nil {
+					select {
+					case listCompleted <- true:
+						e2elog.Logf("observed the limitRanges list")
+						return limitRanges, err
+					default:
+						e2elog.Logf("channel blocked")
+					}
+				}
+				return limitRanges, err
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.LabelSelector = selector.String()
+				return f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Watch(options)
+			},
+		}
+		_, _, w, _ := watchtools.NewIndexerInformerWatcher(lw, &v1.LimitRange{})
+		defer w.Stop()
 
 		ginkgo.By("Submitting a LimitRange")
 		limitRange, err = f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Create(limitRange)
@@ -73,12 +106,17 @@ var _ = SIGDescribe("LimitRange", func() {
 
 		ginkgo.By("Verifying LimitRange creation was observed")
 		select {
-		case event, _ := <-w.ResultChan():
-			if event.Type != watch.Added {
-				e2elog.Failf("Failed to observe pod creation: %v", event)
+		case <-listCompleted:
+			select {
+			case event, _ := <-w.ResultChan():
+				if event.Type != watch.Added {
+					e2elog.Failf("Failed to observe limitRange creation: %v", event)
+				}
+			case <-time.After(framework.ServiceRespondingTimeout):
+				e2elog.Failf("Timeout while waiting for LimitRange creation")
 			}
 		case <-time.After(framework.ServiceRespondingTimeout):
-			e2elog.Failf("Timeout while waiting for LimitRange creation")
+			e2elog.Failf("Timeout while waiting for LimitRange list complete")
 		}
 
 		ginkgo.By("Fetching the LimitRange to ensure it has proper values")
@@ -166,7 +204,7 @@ var _ = SIGDescribe("LimitRange", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Verifying the LimitRange was deleted")
-		err = wait.Poll(time.Second*5, time.Second*30, func() (bool, error) {
+		gomega.Expect(wait.Poll(time.Second*5, framework.ServiceRespondingTimeout, func() (bool, error) {
 			selector := labels.SelectorFromSet(labels.Set(map[string]string{"name": limitRange.Name}))
 			options := metav1.ListOptions{LabelSelector: selector.String()}
 			limitRanges, err := f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).List(options)
@@ -191,7 +229,8 @@ var _ = SIGDescribe("LimitRange", func() {
 
 			return false, nil
 
-		})
+		}))
+
 		framework.ExpectNoError(err, "kubelet never observed the termination notice")
 
 		ginkgo.By("Creating a Pod with more than former max resources")
@@ -242,13 +281,16 @@ func getResourceList(cpu, memory string, ephemeralStorage string) v1.ResourceLis
 }
 
 // newLimitRange returns a limit range with specified data
-func newLimitRange(name string, limitType v1.LimitType,
+func newLimitRange(name, value string, limitType v1.LimitType,
 	min, max,
 	defaultLimit, defaultRequest,
 	maxLimitRequestRatio v1.ResourceList) *v1.LimitRange {
 	return &v1.LimitRange{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			Labels: map[string]string{
+				"time": value,
+			},
 		},
 		Spec: v1.LimitRangeSpec{
 			Limits: []v1.LimitRangeItem{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This is continuation of #76328 fixing https://github.com/kubernetes/kubernetes/pull/76328#issuecomment-503591655 as @pontiyaraja is not active to contribute and it should close #76328

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
/area conformance
@kubernetes/cncf-conformance-wg
@kubernetes/sig-scheduling-pr-reviews
@kubernetes/sig-architecture-pr-reviews