### PR TITLE
[Failing Tests - GH-79533] use apps/v1 instead apps/v1beta1 since that is deprecated

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1581,7 +1581,7 @@ metadata:
 		*/
 		framework.ConformanceIt("should create a deployment from an image ", func() {
 			ginkgo.By("running the image " + nginxImage)
-			framework.RunKubectlOrDie("run", dName, "--image="+nginxImage, "--generator=deployment/v1beta1", nsFlag)
+			framework.RunKubectlOrDie("run", dName, "--image="+nginxImage, "--generator=deployment/apps.v1", nsFlag)
 			ginkgo.By("verifying the deployment " + dName + " was created")
 			d, err := c.AppsV1().Deployments(ns).Get(dName, metav1.GetOptions{})
 			if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
update tests to use apps/v1 for deployments instead of apps/v1beta1

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/79533

**Special notes for your reviewer**:
