### PR TITLE
feat: use framework.ExpectEqual in servicecatalog e2e test

### DIFF
--- a/test/e2e/servicecatalog/BUILD
+++ b/test/e2e/servicecatalog/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//test/e2e/framework/log:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
-        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )
 

--- a/test/e2e/servicecatalog/podpreset.go
+++ b/test/e2e/servicecatalog/podpreset.go
@@ -32,7 +32,6 @@ import (
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -115,7 +114,7 @@ var _ = SIGDescribe("[Feature:PodPreset] PodPreset", func() {
 		options := metav1.ListOptions{LabelSelector: selector.String()}
 		pods, err := podClient.List(options)
 		framework.ExpectNoError(err, "failed to query for pod")
-		gomega.Expect(len(pods.Items)).To(gomega.Equal(0))
+		framework.ExpectEqual(len(pods.Items), 0)
 		options = metav1.ListOptions{
 			LabelSelector:   selector.String(),
 			ResourceVersion: pods.ListMeta.ResourceVersion,
@@ -131,7 +130,7 @@ var _ = SIGDescribe("[Feature:PodPreset] PodPreset", func() {
 		options = metav1.ListOptions{LabelSelector: selector.String()}
 		pods, err = podClient.List(options)
 		framework.ExpectNoError(err, "failed to query for pod")
-		gomega.Expect(len(pods.Items)).To(gomega.Equal(1))
+		framework.ExpectEqual(len(pods.Items), 1)
 
 		ginkgo.By("verifying pod creation was observed")
 		select {
@@ -235,7 +234,7 @@ var _ = SIGDescribe("[Feature:PodPreset] PodPreset", func() {
 		options := metav1.ListOptions{LabelSelector: selector.String()}
 		pods, err := podClient.List(options)
 		framework.ExpectNoError(err, "failed to query for pod")
-		gomega.Expect(len(pods.Items)).To(gomega.Equal(0))
+		framework.ExpectEqual(len(pods.Items), 0)
 		options = metav1.ListOptions{
 			LabelSelector:   selector.String(),
 			ResourceVersion: pods.ListMeta.ResourceVersion,
@@ -251,7 +250,7 @@ var _ = SIGDescribe("[Feature:PodPreset] PodPreset", func() {
 		options = metav1.ListOptions{LabelSelector: selector.String()}
 		pods, err = podClient.List(options)
 		framework.ExpectNoError(err, "failed to query for pod")
-		gomega.Expect(len(pods.Items)).To(gomega.Equal(1))
+		framework.ExpectEqual(len(pods.Items), 1)
 
 		ginkgo.By("verifying pod creation was observed")
 		select {


### PR DESCRIPTION
/kind cleanup
/priority backlog
/assign @oomichi 

**What this PR does / why we need it**:

use framework.ExpectEqual in servicecatalog e2e test

**Which issue(s) this PR fixes**:

ref: https://github.com/kubernetes/kubernetes/issues/79686


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
