### PR TITLE
kubeadm: ignore the bind-address info stored in kubeadm-config ConfigMap for new joined control-plane node

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -508,5 +508,13 @@ func fetchInitConfiguration(tlsBootstrapCfg *clientcmdapi.Config) (*kubeadmapi.I
 		return nil, errors.Wrap(err, "unable to fetch the kubeadm-config ConfigMap")
 	}
 
+	// ignore the bind-address info in `kubeadm-config` ConfigMap for new joined control-plane node
+	delete(initConfiguration.ClusterConfiguration.APIServer.ExtraArgs, "advertise-address")
+	delete(initConfiguration.ClusterConfiguration.APIServer.ExtraArgs, "bind-address")
+	delete(initConfiguration.ClusterConfiguration.ControllerManager.ExtraArgs, "address")
+	delete(initConfiguration.ClusterConfiguration.ControllerManager.ExtraArgs, "bind-address")
+	delete(initConfiguration.ClusterConfiguration.Scheduler.ExtraArgs, "address")
+	delete(initConfiguration.ClusterConfiguration.Scheduler.ExtraArgs, "bind-address")
+
 	return initConfiguration, nil
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/kind design

**What this PR does / why we need it**:
kubeadm: ignore the bind-address info stored in kubeadm-config ConfigMap for new joined control-plane node
The bind-address information should be set dynamically at join time!


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref kubernetes/kubeadm#1647

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
