### PR TITLE
use expectEqual in framework

### DIFF
--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -672,13 +672,13 @@ func GetPodsScheduled(masterNodes sets.String, pods *v1.PodList) (scheduledPods,
 		if !masterNodes.Has(pod.Spec.NodeName) {
 			if pod.Spec.NodeName != "" {
 				_, scheduledCondition := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
-				gomega.Expect(scheduledCondition != nil).To(gomega.Equal(true))
-				gomega.Expect(scheduledCondition.Status).To(gomega.Equal(v1.ConditionTrue))
+				framework.ExpectEqual(scheduledCondition != nil, true)
+				framework.ExpectEqual(scheduledCondition.Status, v1.ConditionTrue)
 				scheduledPods = append(scheduledPods, pod)
 			} else {
 				_, scheduledCondition := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
-				gomega.Expect(scheduledCondition != nil).To(gomega.Equal(true))
-				gomega.Expect(scheduledCondition.Status).To(gomega.Equal(v1.ConditionFalse))
+				framework.ExpectEqual(scheduledCondition != nil, true)
+				framework.ExpectEqual(scheduledCondition.Status, v1.ConditionFalse)
 				if scheduledCondition.Reason == "Unschedulable" {
 
 					notScheduledPods = append(notScheduledPods, pod)

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -36,6 +36,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/client/conditions"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
+	e2efwk "k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -672,13 +673,13 @@ func GetPodsScheduled(masterNodes sets.String, pods *v1.PodList) (scheduledPods,
 		if !masterNodes.Has(pod.Spec.NodeName) {
 			if pod.Spec.NodeName != "" {
 				_, scheduledCondition := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
-				ExpectEqual(scheduledCondition != nil, true)
-				ExpectEqual(scheduledCondition.Status, v1.ConditionTrue)
+				e2efwk.ExpectEqual(scheduledCondition != nil, true)
+				e2efwk.ExpectEqual(scheduledCondition.Status, v1.ConditionTrue)
 				scheduledPods = append(scheduledPods, pod)
 			} else {
 				_, scheduledCondition := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
-				ExpectEqual(scheduledCondition != nil, true)
-				ExpectEqual(scheduledCondition.Status, v1.ConditionFalse)
+				e2efwk.ExpectEqual(scheduledCondition != nil, true)
+				e2efwk.ExpectEqual(scheduledCondition.Status, v1.ConditionFalse)
 				if scheduledCondition.Reason == "Unschedulable" {
 
 					notScheduledPods = append(notScheduledPods, pod)

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -36,6 +36,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/client/conditions"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
+	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -672,13 +673,13 @@ func GetPodsScheduled(masterNodes sets.String, pods *v1.PodList) (scheduledPods,
 		if !masterNodes.Has(pod.Spec.NodeName) {
 			if pod.Spec.NodeName != "" {
 				_, scheduledCondition := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
-				ExpectEqual(scheduledCondition != nil, true)
-				ExpectEqual(scheduledCondition.Status, v1.ConditionTrue)
+				framework.ExpectEqual(scheduledCondition != nil, true)
+				framework.ExpectEqual(scheduledCondition.Status, v1.ConditionTrue)
 				scheduledPods = append(scheduledPods, pod)
 			} else {
 				_, scheduledCondition := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
-				ExpectEqual(scheduledCondition != nil, true)
-				ExpectEqual(scheduledCondition.Status, v1.ConditionFalse)
+				framework.ExpectEqual(scheduledCondition != nil, true)
+				framework.ExpectEqual(scheduledCondition.Status, v1.ConditionFalse)
 				if scheduledCondition.Reason == "Unschedulable" {
 
 					notScheduledPods = append(notScheduledPods, pod)

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -672,13 +672,13 @@ func GetPodsScheduled(masterNodes sets.String, pods *v1.PodList) (scheduledPods,
 		if !masterNodes.Has(pod.Spec.NodeName) {
 			if pod.Spec.NodeName != "" {
 				_, scheduledCondition := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
-				framework.ExpectEqual(scheduledCondition != nil, true)
-				framework.ExpectEqual(scheduledCondition.Status, v1.ConditionTrue)
+				ExpectEqual(scheduledCondition != nil, true)
+				ExpectEqual(scheduledCondition.Status, v1.ConditionTrue)
 				scheduledPods = append(scheduledPods, pod)
 			} else {
 				_, scheduledCondition := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
-				framework.ExpectEqual(scheduledCondition != nil, true)
-				framework.ExpectEqual(scheduledCondition.Status, v1.ConditionFalse)
+				ExpectEqual(scheduledCondition != nil, true)
+				ExpectEqual(scheduledCondition.Status, v1.ConditionFalse)
 				if scheduledCondition.Reason == "Unschedulable" {
 
 					notScheduledPods = append(notScheduledPods, pod)

--- a/test/e2e/framework/timer/timer_test.go
+++ b/test/e2e/framework/timer/timer_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 var currentTime time.Time
@@ -64,7 +66,7 @@ func TestTimer(t *testing.T) {
 			}
 		]
 	}`))
-	ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 5.5s so far
+	framework.ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 5.5s so far
 Phase 033-two: 3.5s
 `)
 
@@ -86,7 +88,7 @@ Phase 033-two: 3.5s
 			}
 		]
 	}`))
-	ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 6.5s
+	framework.ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 6.5s
 Phase 033-two: 3.5s
 `)
 }

--- a/test/e2e/framework/timer/timer_test.go
+++ b/test/e2e/framework/timer/timer_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+
+	e2efwk "k8s.io/kubernetes/test/e2e/framework"
 )
 
 var currentTime time.Time
@@ -64,7 +66,7 @@ func TestTimer(t *testing.T) {
 			}
 		]
 	}`))
-	ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 5.5s so far
+	e2efwk.ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 5.5s so far
 Phase 033-two: 3.5s
 `)
 
@@ -86,7 +88,7 @@ Phase 033-two: 3.5s
 			}
 		]
 	}`))
-	ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 6.5s
+	e2efwk.ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 6.5s
 Phase 033-two: 3.5s
 `)
 }

--- a/test/e2e/framework/timer/timer_test.go
+++ b/test/e2e/framework/timer/timer_test.go
@@ -64,9 +64,9 @@ func TestTimer(t *testing.T) {
 			}
 		]
 	}`))
-	gomega.Expect(timer.PrintHumanReadable()).To(gomega.Equal(`Phase 001-one: 5.5s so far
+	framework.ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 5.5s so far
 Phase 033-two: 3.5s
-`))
+`)
 
 	setCurrentTimeSinceEpoch(7*time.Second + 500*time.Millisecond)
 	phaseOne.End()
@@ -86,7 +86,7 @@ Phase 033-two: 3.5s
 			}
 		]
 	}`))
-	gomega.Expect(timer.PrintHumanReadable()).To(gomega.Equal(`Phase 001-one: 6.5s
+	framework.ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 6.5s
 Phase 033-two: 3.5s
-`))
+`)
 }

--- a/test/e2e/framework/timer/timer_test.go
+++ b/test/e2e/framework/timer/timer_test.go
@@ -64,7 +64,7 @@ func TestTimer(t *testing.T) {
 			}
 		]
 	}`))
-	framework.ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 5.5s so far
+	ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 5.5s so far
 Phase 033-two: 3.5s
 `)
 
@@ -86,7 +86,7 @@ Phase 033-two: 3.5s
 			}
 		]
 	}`))
-	framework.ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 6.5s
+	ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 6.5s
 Phase 033-two: 3.5s
 `)
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1349,7 +1349,7 @@ func RandomSuffix() string {
 
 // ExpectEqual expects the specified two are the same, otherwise an exception raises
 func ExpectEqual(actual interface{}, extra interface{}, explain ...interface{}) {
-	framework.ExpectEqual(actual, extra, explain...)
+	gomega.Expect(actual).To(gomega.Equal(extra), explain...)
 }
 
 // ExpectError expects an error happens, otherwise an exception raises

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1349,7 +1349,7 @@ func RandomSuffix() string {
 
 // ExpectEqual expects the specified two are the same, otherwise an exception raises
 func ExpectEqual(actual interface{}, extra interface{}, explain ...interface{}) {
-	gomega.Expect(actual).To(gomega.Equal(extra), explain...)
+	framework.ExpectEqual(actual, extra, explain...)
 }
 
 // ExpectError expects an error happens, otherwise an exception raises


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Ref: #79686


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
