### PR TITLE
feat: use channel instead of mutex in scheduling predicates

### DIFF
--- a/pkg/scheduler/util/BUILD
+++ b/pkg/scheduler/util/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = [
+        "error_channel_test.go",
         "heap_test.go",
         "utils_test.go",
     ],
@@ -24,6 +25,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "clock.go",
+        "error_channel.go",
         "heap.go",
         "utils.go",
     ],

--- a/pkg/scheduler/util/error_channel.go
+++ b/pkg/scheduler/util/error_channel.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "context"
+
+// ErrorChannel supports non-blocking send and receive operation to capture error.
+// A maximum of one error is kept in the channel and the rest of the errors sent
+// are ignored, unless the existing error is received and the channel becomes empty
+// again.
+type ErrorChannel struct {
+	errCh chan error
+}
+
+// SendError sends an error without blocking the sender.
+func (e *ErrorChannel) SendError(err error) {
+	select {
+	case e.errCh <- err:
+	default:
+	}
+}
+
+// SendErrorWithCancel sends an error without blocking the sender and calls
+// cancel function.
+func (e *ErrorChannel) SendErrorWithCancel(err error, cancel context.CancelFunc) {
+	e.SendError(err)
+	cancel()
+}
+
+// ReceiveError receives an error from channel without blocking on the receiver.
+func (e *ErrorChannel) ReceiveError() error {
+	select {
+	case err := <-e.errCh:
+		return err
+	default:
+		return nil
+	}
+}
+
+// NewErrorChannel returns a new ErrorChannel.
+func NewErrorChannel() *ErrorChannel {
+	return &ErrorChannel{
+		errCh: make(chan error, 1),
+	}
+}

--- a/pkg/scheduler/util/error_channel_test.go
+++ b/pkg/scheduler/util/error_channel_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestErrorChannel(t *testing.T) {
+	errCh := NewErrorChannel()
+
+	if actualErr := errCh.ReceiveError(); actualErr != nil {
+		t.Errorf("expect nil from err channel, but got %v", actualErr)
+	}
+
+	err := errors.New("unknown error")
+	errCh.SendError(err)
+	if actualErr := errCh.ReceiveError(); actualErr != err {
+		t.Errorf("expect %v from err channel, but got %v", err, actualErr)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh.SendErrorWithCancel(err, cancel)
+	if actualErr := errCh.ReceiveError(); actualErr != err {
+		t.Errorf("expect %v from err channel, but got %v", err, actualErr)
+	}
+
+	if ctxErr := ctx.Err(); ctxErr != context.Canceled {
+		t.Errorf("expect context canceled, but got %v", ctxErr)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scheduling
/assign @Huang-Wei @bsalamat 

**What this PR does / why we need it**:

Use channel and select statement instead of mutex in scheduling predicates.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
