### PR TITLE
e2e: use framework.ExpectEqual() for test/e2e/network

### DIFF
--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -549,7 +549,7 @@ func assertFilesContain(fileNames []string, fileDir string, pod *v1.Pod, client 
 		e2elog.Logf("Lookups using %s/%s failed for: %v\n", pod.Namespace, pod.Name, failed)
 		return false, nil
 	}))
-	gomega.Expect(len(failed)).To(gomega.Equal(0))
+	framework.ExpectEqual(len(failed), 0)
 }
 
 func validateDNSResults(f *framework.Framework, pod *v1.Pod, fileNames []string) {

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/providers/gce"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 const (
@@ -341,7 +340,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 
 			// ClusterIP ServicePorts have no NodePort
 			for _, sp := range svcPorts {
-				gomega.Expect(sp.NodePort).To(gomega.Equal(int32(0)))
+				framework.ExpectEqual(sp.NodePort, int32(0))
 			}
 		})
 

--- a/test/e2e/network/network_tiers.go
+++ b/test/e2e/network/network_tiers.go
@@ -34,7 +34,6 @@ import (
 	gcecloud "k8s.io/legacy-cloud-providers/gce"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
@@ -80,7 +79,7 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 		// Verify that service has been updated properly.
 		svcTier, err := gcecloud.GetServiceNetworkTier(svc)
 		framework.ExpectNoError(err)
-		gomega.Expect(svcTier).To(gomega.Equal(cloud.NetworkTierStandard))
+		framework.ExpectEqual(svcTier, cloud.NetworkTierStandard)
 		// Record the LB name for test cleanup.
 		serviceLBNames = append(serviceLBNames, cloudprovider.DefaultLoadBalancerName(svc))
 
@@ -95,7 +94,7 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 		// Verify that service has been updated properly.
 		svcTier, err = gcecloud.GetServiceNetworkTier(svc)
 		framework.ExpectNoError(err)
-		gomega.Expect(svcTier).To(gomega.Equal(cloud.NetworkTierDefault))
+		framework.ExpectEqual(svcTier, cloud.NetworkTierDefault)
 
 		// Wait until the ingress IP changes. Each tier has its own pool of
 		// IPs, so changing tiers implies changing IPs.
@@ -125,10 +124,10 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 			setNetworkTier(svc, string(gcecloud.NetworkTierAnnotationStandard))
 		})
 		// Verify that service has been updated properly.
-		gomega.Expect(svc.Spec.LoadBalancerIP).To(gomega.Equal(requestedIP))
+		framework.ExpectEqual(svc.Spec.LoadBalancerIP, requestedIP)
 		svcTier, err = gcecloud.GetServiceNetworkTier(svc)
 		framework.ExpectNoError(err)
-		gomega.Expect(svcTier).To(gomega.Equal(cloud.NetworkTierStandard))
+		framework.ExpectEqual(svcTier, cloud.NetworkTierStandard)
 
 		// Wait until the ingress IP changes and verifies the LB.
 		ingressIP = waitAndVerifyLBWithTier(jig, ns, svcName, ingressIP, createTimeout, lagTimeout)
@@ -153,7 +152,7 @@ func waitAndVerifyLBWithTier(jig *framework.ServiceTestJig, ns, svcName, existin
 	ginkgo.By("running sanity and reachability checks")
 	if svc.Spec.LoadBalancerIP != "" {
 		// Verify that the new ingress IP is the requested IP if it's set.
-		gomega.Expect(ingressIP).To(gomega.Equal(svc.Spec.LoadBalancerIP))
+		framework.ExpectEqual(ingressIP, svc.Spec.LoadBalancerIP)
 	}
 	jig.SanityCheckService(svc, v1.ServiceTypeLoadBalancer)
 	// If the IP has been used by previous test, sometimes we get the lingering
@@ -166,7 +165,7 @@ func waitAndVerifyLBWithTier(jig *framework.ServiceTestJig, ns, svcName, existin
 	framework.ExpectNoError(err)
 	netTier, err := getLBNetworkTierByIP(ingressIP)
 	framework.ExpectNoError(err, "failed to get the network tier of the load balancer")
-	gomega.Expect(netTier).To(gomega.Equal(svcNetTier))
+	framework.ExpectEqual(netTier, svcNetTier)
 
 	return ingressIP
 }

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -312,7 +312,7 @@ func nodeProxyTest(f *framework.Framework, prefix, nodeDest string) {
 			serviceUnavailableErrors++
 		} else {
 			framework.ExpectNoError(err)
-			gomega.Expect(status).To(gomega.Equal(http.StatusOK))
+			framework.ExpectEqual(status, http.StatusOK)
 			gomega.Expect(d).To(gomega.BeNumerically("<", proxyHTTPCallTimeout))
 		}
 	}

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -317,12 +317,12 @@ var _ = SIGDescribe("Services", func() {
 		ginkgo.By("Retrieve sourceip from a pod on the same node")
 		sourceIP1, execPodIP1 := execSourceipTest(f, cs, ns, node1.Name, serviceIP, servicePort)
 		ginkgo.By("Verifying the preserved source ip")
-		gomega.Expect(sourceIP1).To(gomega.Equal(execPodIP1))
+		framework.ExpectEqual(sourceIP1, execPodIP1)
 
 		ginkgo.By("Retrieve sourceip from a pod on a different node")
 		sourceIP2, execPodIP2 := execSourceipTest(f, cs, ns, node2.Name, serviceIP, servicePort)
 		ginkgo.By("Verifying the preserved source ip")
-		gomega.Expect(sourceIP2).To(gomega.Equal(execPodIP2))
+		framework.ExpectEqual(sourceIP2, execPodIP2)
 	})
 
 	ginkgo.It("should be able to up and down services", func() {
@@ -1598,7 +1598,7 @@ var _ = SIGDescribe("Services", func() {
 			}
 			// should have the given static internal IP.
 			jig.SanityCheckService(svc, v1.ServiceTypeLoadBalancer)
-			gomega.Expect(framework.GetIngressPoint(lbIngress)).To(gomega.Equal(internalStaticIP))
+			framework.ExpectEqual(framework.GetIngressPoint(lbIngress), internalStaticIP)
 		}
 
 		ginkgo.By("switching to ClusterIP type to destroy loadbalancer")
@@ -1648,7 +1648,7 @@ var _ = SIGDescribe("Services", func() {
 		if err != nil {
 			e2elog.Failf("gceCloud.GetHttpHealthCheck(%q) = _, %v; want nil", hcName, err)
 		}
-		gomega.Expect(hc.CheckIntervalSec).To(gomega.Equal(gceHcCheckIntervalSeconds))
+		framework.ExpectEqual(hc.CheckIntervalSec, gceHcCheckIntervalSeconds)
 
 		ginkgo.By("modify the health check interval")
 		hc.CheckIntervalSec = gceHcCheckIntervalSeconds - 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
e2e: use framework.ExpectEqual() for test/e2e/network

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #79686

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
