### PR TITLE
e2e: use framework.ExpectEqual() for test/e2e/node

### DIFF
--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -30,7 +30,6 @@ import (
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 var _ = SIGDescribe("Events", func() {
@@ -83,7 +82,7 @@ var _ = SIGDescribe("Events", func() {
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
 		options := metav1.ListOptions{LabelSelector: selector.String()}
 		pods, err := podClient.List(options)
-		gomega.Expect(len(pods.Items)).To(gomega.Equal(1))
+		framework.ExpectEqual(len(pods.Items), 1)
 
 		ginkgo.By("retrieving the pod")
 		podWithUID, err := podClient.Get(pod.Name, metav1.GetOptions{})

--- a/test/e2e/node/mount_propagation.go
+++ b/test/e2e/node/mount_propagation.go
@@ -172,7 +172,7 @@ var _ = SIGDescribe("Mount propagation", func() {
 				shouldBeVisible := mounts.Has(mountName)
 				if shouldBeVisible {
 					framework.ExpectNoError(err, "%s: failed to run %q", msg, cmd)
-					gomega.Expect(stdout).To(gomega.Equal(mountName), msg)
+					framework.ExpectEqual(stdout, mountName, msg)
 				} else {
 					// We *expect* cat to return error here
 					framework.ExpectError(err, msg)

--- a/test/e2e/node/node_problem_detector.go
+++ b/test/e2e/node/node_problem_detector.go
@@ -67,7 +67,7 @@ var _ = SIGDescribe("NodeProblemDetector [DisabledForLargeClusters]", func() {
 				}
 			}
 		}
-		gomega.Expect(len(hosts)).To(gomega.Equal(len(nodes.Items)))
+		framework.ExpectEqual(len(hosts), len(nodes.Items))
 
 		isStandaloneMode := make(map[string]bool)
 		cpuUsageStats := make(map[string][]float64)

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -80,7 +80,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			options := metav1.ListOptions{LabelSelector: selector.String()}
 			pods, err := podClient.List(options)
 			framework.ExpectNoError(err, "failed to query for pod")
-			gomega.Expect(len(pods.Items)).To(gomega.Equal(0))
+			framework.ExpectEqual(len(pods.Items), 0)
 			options = metav1.ListOptions{
 				LabelSelector:   selector.String(),
 				ResourceVersion: pods.ListMeta.ResourceVersion,
@@ -94,7 +94,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			options = metav1.ListOptions{LabelSelector: selector.String()}
 			pods, err = podClient.List(options)
 			framework.ExpectNoError(err, "failed to query for pod")
-			gomega.Expect(len(pods.Items)).To(gomega.Equal(1))
+			framework.ExpectEqual(len(pods.Items), 1)
 
 			// We need to wait for the pod to be running, otherwise the deletion
 			// may be carried out immediately rather than gracefully.
@@ -117,7 +117,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			output := string(buf[:n])
 			proxyRegexp := regexp.MustCompile("Starting to serve on 127.0.0.1:([0-9]+)")
 			match := proxyRegexp.FindStringSubmatch(output)
-			gomega.Expect(len(match)).To(gomega.Equal(2))
+			framework.ExpectEqual(len(match), 2)
 			port, err := strconv.Atoi(match[1])
 			framework.ExpectNoError(err, "failed to convert port into string")
 
@@ -169,7 +169,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			options = metav1.ListOptions{LabelSelector: selector.String()}
 			pods, err = podClient.List(options)
 			framework.ExpectNoError(err, "failed to query for pods")
-			gomega.Expect(len(pods.Items)).To(gomega.Equal(0))
+			framework.ExpectEqual(len(pods.Items), 0)
 
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
e2e: use framework.ExpectEqual() for test/e2e/node

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #79686

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
