### PR TITLE
Use framework.ExpectEqual() for e2e/cloud tests

### DIFF
--- a/test/e2e/cloud/nodes.go
+++ b/test/e2e/cloud/nodes.go
@@ -57,7 +57,7 @@ var _ = SIGDescribe("[Feature:CloudProvider][Disruptive] Nodes", func() {
 
 		newNodes, err := e2enode.CheckReady(c, len(origNodes.Items)-1, 5*time.Minute)
 		gomega.Expect(err).To(gomega.BeNil())
-		gomega.Expect(len(newNodes)).To(gomega.Equal(len(origNodes.Items) - 1))
+		framework.ExpectEqual(len(newNodes), len(origNodes.Items)-1)
 
 		_, err = c.CoreV1().Nodes().Get(nodeToDelete.Name, metav1.GetOptions{})
 		if err == nil {


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

Since #78922 ExpectEqual() is implemented as test framework.
This makes e2e tests use the function under test/e2e/cloud.

Ref: #79686

Does this PR introduce a user-facing change?:

NONE


```release-note
NONE
```
