### PR TITLE
Populate DisruptedPods field for non-dry run

### DIFF
--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -206,13 +206,13 @@ func (r *EvictionREST) checkAndDecrement(namespace string, podName string, pdb p
 	}
 
 	pdb.Status.PodDisruptionsAllowed--
-	if pdb.Status.DisruptedPods == nil {
-		pdb.Status.DisruptedPods = make(map[string]metav1.Time)
-	}
-
 	// If this is a dry-run, we don't need to go any further than that.
 	if dryRun == true {
 		return nil
+	}
+
+	if pdb.Status.DisruptedPods == nil {
+		pdb.Status.DisruptedPods = make(map[string]metav1.Time)
 	}
 
 	// Eviction handler needs to inform the PDB controller that it is about to delete a pod


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In EvictionREST#checkAndDecrement, we should populate pdb.Status.DisruptedPods field when it is not dry-run.

```release-note
NONE
```
