### PR TITLE
Add e2e test for kubectl describe cronjob

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1112,6 +1112,42 @@ metadata:
 
 			// Quota and limitrange are skipped for now.
 		})
+
+		ginkgo.It("should check if kubectl describe prints relevant information for cronjob", func() {
+			ginkgo.By("creating a cronjob")
+			nsFlag := fmt.Sprintf("--namespace=%v", ns)
+			cronjobYaml := commonutils.SubstituteImageName(string(readTestFileOrDie("busybox-cronjob.yaml")))
+			framework.RunKubectlOrDieInput(cronjobYaml, "create", "-f", "-", nsFlag)
+
+			ginkgo.By("waiting for cronjob to start.")
+			err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+				cj, err := c.BatchV1beta1().CronJobs(ns).List(metav1.ListOptions{})
+				if err != nil {
+					return false, fmt.Errorf("Failed getting CronJob %s: %v", ns, err)
+				}
+				return len(cj.Items) > 0, nil
+			})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("verifying kubectl describe prints")
+			output := framework.RunKubectlOrDie("describe", "cronjob", "cronjob-test", nsFlag)
+			requiredStrings := [][]string{
+				{"Name:", "cronjob-test"},
+				{"Namespace:", ns},
+				{"Labels:"},
+				{"Annotations:"},
+				{"Schedule:", "*/1 * * * *"},
+				{"Concurrency Policy:", "Allow"},
+				{"Suspend:", "False"},
+				{"Successful Job History Limit:", "3"},
+				{"Failed Job History Limit:", "1"},
+				{"Starting Deadline Seconds:", "30s"},
+				{"Selector:"},
+				{"Parallelism:"},
+				{"Completions:"},
+			}
+			checkOutput(output, requiredStrings)
+		})
 	})
 
 	ginkgo.Describe("Kubectl expose", func() {

--- a/test/e2e/testing-manifests/kubectl/busybox-cronjob.yaml
+++ b/test/e2e/testing-manifests/kubectl/busybox-cronjob.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cronjob-test
+spec:
+  schedule: "*/1 * * * *"
+  concurrencyPolicy: Allow
+  suspend: false
+  startingDeadlineSeconds: 30
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: test
+            image: busybox
+            args:
+            - "/bin/true"
+          restartPolicy: OnFailure


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The issue which `kubectl describe cronjob` printed incorrect value was fixed in v1.15.
Ref: #77347

Current e2e test checks outputs of kubectl describe pod, rc and service, but not cronjob.
This PR adds a e2e test for `kubectl describe cronjob` to detect incorrect values like the above issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #77347

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/sig cli
/sig testing