### PR TITLE
fix HardPodAffinitySymmetricWeight typos

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -50,7 +50,7 @@ type KubeSchedulerConfiguration struct {
 	AlgorithmSource SchedulerAlgorithmSource
 	// RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
 	// corresponding to every RequiredDuringScheduling affinity rule.
-	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 0-100.
+	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 1-100.
 	HardPodAffinitySymmetricWeight int32
 
 	// LeaderElection defines the configuration of leader election client.

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -37,8 +37,8 @@ func ValidateKubeSchedulerConfiguration(cc *config.KubeSchedulerConfiguration) f
 	for _, msg := range validation.IsValidSocketAddr(cc.MetricsBindAddress) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metricsBindAddress"), cc.MetricsBindAddress, msg))
 	}
-	if cc.HardPodAffinitySymmetricWeight < 0 || cc.HardPodAffinitySymmetricWeight > 100 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("hardPodAffinitySymmetricWeight"), cc.HardPodAffinitySymmetricWeight, "not in valid range 0-100"))
+	if cc.HardPodAffinitySymmetricWeight < 1 || cc.HardPodAffinitySymmetricWeight > 100 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("hardPodAffinitySymmetricWeight"), cc.HardPodAffinitySymmetricWeight, "not in valid range 1-100"))
 	}
 	if cc.BindTimeoutSeconds == nil {
 		allErrs = append(allErrs, field.Required(field.NewPath("bindTimeoutSeconds"), ""))

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -205,7 +205,7 @@ type configFactory struct {
 
 	// RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
 	// corresponding to every RequiredDuringScheduling affinity rule.
-	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 0-100.
+	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 1-100.
 	hardPodAffinitySymmetricWeight int32
 
 	// Handles volume binding decisions

--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -453,12 +453,17 @@ func TestInvalidFactoryArgs(t *testing.T) {
 		{
 			name:                           "symmetric weight below range",
 			hardPodAffinitySymmetricWeight: -1,
-			expectErr:                      "invalid hardPodAffinitySymmetricWeight: -1, must be in the range 0-100",
+			expectErr:                      "invalid hardPodAffinitySymmetricWeight: -1, must be in the range 1-100",
+		},
+		{
+			name:                           "symmetric weight below range",
+			hardPodAffinitySymmetricWeight: 0,
+			expectErr:                      "invalid hardPodAffinitySymmetricWeight: 0, must be in the range 1-100",
 		},
 		{
 			name:                           "symmetric weight above range",
 			hardPodAffinitySymmetricWeight: 101,
-			expectErr:                      "invalid hardPodAffinitySymmetricWeight: 101, must be in the range 0-100",
+			expectErr:                      "invalid hardPodAffinitySymmetricWeight: 101, must be in the range 1-100",
 		},
 	}
 

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
@@ -46,7 +46,7 @@ type KubeSchedulerConfiguration struct {
 	AlgorithmSource SchedulerAlgorithmSource `json:"algorithmSource"`
 	// RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
 	// corresponding to every RequiredDuringScheduling affinity rule.
-	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 0-100.
+	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 1-100.
 	HardPodAffinitySymmetricWeight int32 `json:"hardPodAffinitySymmetricWeight"`
 
 	// LeaderElection defines the configuration of leader election client.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
/kind design

**What this PR does / why we need it**:
`HardPodAffinitySymmetricWeight` in kube-scheduler config, it's default value is `1` if not set,
if code related here https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/apis/config/v1alpha1/defaults.go#L47 

but In doc or config description, it's valid range is 0-100(somewhere 1-100), and code here:
https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/apis/config/validation/validation.go#L40
which validate it as `0-100`,



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix HardPodAffinitySymmetricWeight valid range to 1-100
```
