### PR TITLE
Make taint.ToString() consistent with the reverse parsing logic

### DIFF
--- a/pkg/apis/core/taint.go
+++ b/pkg/apis/core/taint.go
@@ -27,8 +27,14 @@ func (t *Taint) MatchTaint(taintToMatch Taint) bool {
 	return t.Key == taintToMatch.Key && t.Effect == taintToMatch.Effect
 }
 
-// taint.ToString() converts taint struct to string in format key=value:effect or key:effect.
+// taint.ToString() converts taint struct to string in format '<key>=<value>:<effect>', '<key>=<value>:', '<key>:<effect>', or '<key>'.
 func (t *Taint) ToString() string {
+	if len(t.Effect) == 0 {
+		if len(t.Value) == 0 {
+			return fmt.Sprintf("%v", t.Key)
+		}
+		return fmt.Sprintf("%v=%v:", t.Key, t.Value)
+	}
 	if len(t.Value) == 0 {
 		return fmt.Sprintf("%v:%v", t.Key, t.Effect)
 	}

--- a/pkg/apis/core/taint_test.go
+++ b/pkg/apis/core/taint_test.go
@@ -38,6 +38,19 @@ func TestTaintToString(t *testing.T) {
 			},
 			expectedString: "foo:NoSchedule",
 		},
+		{
+			taint: &Taint{
+				Key: "foo",
+			},
+			expectedString: "foo",
+		},
+		{
+			taint: &Taint{
+				Key:   "foo",
+				Value: "bar",
+			},
+			expectedString: "foo=bar:",
+		},
 	}
 
 	for i, tc := range testCases {

--- a/staging/src/k8s.io/api/core/v1/taint.go
+++ b/staging/src/k8s.io/api/core/v1/taint.go
@@ -24,8 +24,14 @@ func (t *Taint) MatchTaint(taintToMatch *Taint) bool {
 	return t.Key == taintToMatch.Key && t.Effect == taintToMatch.Effect
 }
 
-// taint.ToString() converts taint struct to string in format key=value:effect or key:effect.
+// taint.ToString() converts taint struct to string in format '<key>=<value>:<effect>', '<key>=<value>:', '<key>:<effect>', or '<key>'.
 func (t *Taint) ToString() string {
+	if len(t.Effect) == 0 {
+		if len(t.Value) == 0 {
+			return fmt.Sprintf("%v", t.Key)
+		}
+		return fmt.Sprintf("%v=%v:", t.Key, t.Value)
+	}
 	if len(t.Value) == 0 {
 		return fmt.Sprintf("%v:%v", t.Key, t.Effect)
 	}

--- a/staging/src/k8s.io/api/core/v1/taint_test.go
+++ b/staging/src/k8s.io/api/core/v1/taint_test.go
@@ -40,6 +40,19 @@ func TestTaintToString(t *testing.T) {
 			},
 			expectedString: "foo:NoSchedule",
 		},
+		{
+			taint: &Taint{
+				Key: "foo",
+			},
+			expectedString: "foo",
+		},
+		{
+			taint: &Taint{
+				Key:   "foo",
+				Value: "bar",
+			},
+			expectedString: "foo=bar:",
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
According to `pkg/util/taints/taints.go#parseTaint`, taint string format should be` '<key>=<value>:<effect>', '<key>:<effect>', or '<key>'`.
But `pkg/apis/core/taint.go#ToString` only support converting taint struct to string in format `<key>=<value>:<effect>` or `<key>:<effect>`.
This can cause kubelet to fail to start!
Ref: 
`parseTaint` logic: https://github.com/kubernetes/kubernetes/blob/master/pkg/util/taints/taints.go#L38-L81
`ToString` logic: https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/taint.go#L31
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref kubernetes/kubeadm#1655

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
