### PR TITLE
Fix golint failure in staging/src/k8s.io/apiextensions-apiserver/pkg/…

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -349,7 +349,6 @@ staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1
 staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver
-staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server
 staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer
 staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status
 staging/src/k8s.io/apiextensions-apiserver/pkg/features

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/server.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/server.go
@@ -25,7 +25,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 )
 
-func NewServerCommand(out, errOut io.Writer, stopCh <-chan struct{}) *cobra.Command {
+func newServerCommand(out, errOut io.Writer, stopCh <-chan struct{}) *cobra.Command {
 	o := options.NewCustomResourceDefinitionsServerOptions(out, errOut)
 
 	cmd := &cobra.Command{
@@ -38,7 +38,7 @@ func NewServerCommand(out, errOut io.Writer, stopCh <-chan struct{}) *cobra.Comm
 			if err := o.Validate(); err != nil {
 				return err
 			}
-			if err := Run(o, stopCh); err != nil {
+			if err := run(o, stopCh); err != nil {
 				return err
 			}
 			return nil
@@ -50,7 +50,7 @@ func NewServerCommand(out, errOut io.Writer, stopCh <-chan struct{}) *cobra.Comm
 	return cmd
 }
 
-func Run(o *options.CustomResourceDefinitionsServerOptions, stopCh <-chan struct{}) error {
+func run(o *options.CustomResourceDefinitionsServerOptions, stopCh <-chan struct{}) error {
 	config, err := o.Config()
 	if err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:
This fixes golint failures of the following file:

-  staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/server.go

**Which issue(s) this PR fixes**:
Ref [#68026] (https://github.com/kubernetes/kubernetes/issues/68026)
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```
None
```

