### PR TITLE
Use ExpectEqual in e2e/scalability

### DIFF
--- a/test/e2e/scalability/density.go
+++ b/test/e2e/scalability/density.go
@@ -265,8 +265,8 @@ func computeAverage(sample []float64) float64 {
 }
 
 func computeQuantile(sample []float64, quantile float64) float64 {
-	gomega.Expect(sort.Float64sAreSorted(sample)).To(gomega.Equal(true))
-	gomega.Expect(quantile >= 0.0 && quantile <= 1.0).To(gomega.Equal(true))
+	framework.ExpectEqual(sort.Float64sAreSorted(sample), true)
+	framework.ExpectEqual(quantile >= 0.0 && quantile <= 1.0, true)
 	index := int(quantile*float64(len(sample))) - 1
 	if index < 0 {
 		return math.NaN()
@@ -488,7 +488,7 @@ var _ = SIGDescribe("Density", func() {
 		// Fail if there were some high-latency requests.
 		gomega.Expect(highLatencyRequests).NotTo(gomega.BeNumerically(">", 0), "There should be no high-latency requests")
 		// Fail if more than the allowed threshold of measurements were missing in the latencyTest.
-		gomega.Expect(missingMeasurements <= MaxMissingPodStartupMeasurements).To(gomega.Equal(true))
+		framework.ExpectEqual(missingMeasurements <= MaxMissingPodStartupMeasurements, true)
 	})
 
 	options := framework.Options{
@@ -833,7 +833,7 @@ var _ = SIGDescribe("Density", func() {
 								if !ok {
 									e2elog.Logf("Failed to cast observed object to *v1.Pod.")
 								}
-								gomega.Expect(ok).To(gomega.Equal(true))
+								framework.ExpectEqual(ok, true)
 								go checkPod(p)
 							},
 							UpdateFunc: func(oldObj, newObj interface{}) {
@@ -841,7 +841,7 @@ var _ = SIGDescribe("Density", func() {
 								if !ok {
 									e2elog.Logf("Failed to cast observed object to *v1.Pod.")
 								}
-								gomega.Expect(ok).To(gomega.Equal(true))
+								framework.ExpectEqual(ok, true)
 								go checkPod(p)
 							},
 						},


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This makes e2e tests use ExpectEqual() under test/e2e/scalability.

**Which issue(s) this PR fixes**:
Fixes #79686

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE

```
