### PR TITLE
Provide resource version in error if available

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -124,6 +124,11 @@ func (s *store) Get(ctx context.Context, key string, resourceVersion string, out
 		if ignoreNotFound {
 			return runtime.SetZeroValue(out)
 		}
+		if len(resourceVersion) > 0 {
+			if rv, err := s.versioner.ParseResourceVersion(resourceVersion); err == nil {
+				return storage.NewKeyNotFoundError(key, int64(rv))
+			}
+		}
 		return storage.NewKeyNotFoundError(key, 0)
 	}
 	kv := getResp.Kvs[0]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In store#Get, when key is not found, the composition of KeyNotFoundError uses hardcoded value of 0 for resource version.
This PR parses resourceVersion and uses the parsed value for KeyNotFoundError if the parsing is successful.

```release-note
NONE
```
