### PR TITLE
Create OWNERS for ja

### DIFF
--- a/translations/kubectl/ja_JP/OWNERS
+++ b/translations/kubectl/ja_JP/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- nasa9084
+reviewers:
+- nasa9084


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

I'm an owner of kubernetes-docs-ja.
as described at https://github.com/kubernetes/kubernetes/issues/79770, I will manage translation file for Japanese. to managing, I want to take approver permission.

**Which issue(s) this PR fixes**:

no issue

**Special notes for your reviewer**:

in https://github.com/kubernetes/kubernetes/issues/79770, inductor and kakts are also mensioned.
however inductor is not a maintainer (he will be a reviewer of kubernetes/website next month, though) and kakts is not a member of kubernetes project yet.

I'm not sure this is good way to get the permission, if this is not good, please tell me how to do.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
