### PR TITLE
Fix nil pointer dereference error in volume_stat_calculator

### DIFF
--- a/pkg/volume/csi/csi_metrics.go
+++ b/pkg/volume/csi/csi_metrics.go
@@ -61,9 +61,11 @@ func (mc *metricsCsi) GetMetrics() (*volume.Metrics, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	// if plugin doesnot support volume status, return.
 	if !volumeStatsSet {
-		return nil, nil
+		return nil, volume.NewNotSupportedErrorWithDriverName(
+			string(mc.csiClientGetter.driverName))
 	}
 	// Get Volumestatus
 	metrics, err := csiClient.NodeGetVolumeStats(ctx, mc.volumeID, mc.targetPath)

--- a/pkg/volume/metrics_errors.go
+++ b/pkg/volume/metrics_errors.go
@@ -35,7 +35,16 @@ func NewNotSupportedError() *MetricsError {
 	}
 }
 
-// NewNoPathDefined creates a new MetricsError with code NoPathDefined.
+// NewNotSupportedErrorWithDriverName creates a new MetricsError with code NotSupported.
+// driver name is added to the error message.
+func NewNotSupportedErrorWithDriverName(name string) *MetricsError {
+	return &MetricsError{
+		Code: ErrCodeNotSupported,
+		Msg:  fmt.Sprintf("metrics are not supported for %s volumes", name),
+	}
+}
+
+// NewNoPathDefinedError creates a new MetricsError with code NoPathDefined.
 func NewNoPathDefinedError() *MetricsError {
 	return &MetricsError{
 		Code: ErrCodeNoPathDefined,


### PR DESCRIPTION
volume_stat_calculator expects GetMetrics function to return MetricsError error
with ErrCodeNotSupported code when driver for the volume
does not support metrics
Updated csi_metrics to return error when underlying csi
driver does not have GET_VOLUME_STATS capability

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> 
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

kubelet panics inside volume_stat_calculator since the function expects GetMetrics function to return non nil value for metrics when err is nil. However, csi_metrics returns nil for both metrics, and error when the driver does not support metrics.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79719

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a bug in the CSI metrics that does not return not supported error when a CSI driver does not support metrics.
```
