### PR TITLE
Remove unintended ampersand in front of in.Current.AverageValue

### DIFF
--- a/pkg/apis/autoscaling/v2beta1/conversion.go
+++ b/pkg/apis/autoscaling/v2beta1/conversion.go
@@ -212,9 +212,7 @@ func Convert_v2beta1_PodsMetricSource_To_autoscaling_PodsMetricSource(in *autosc
 }
 
 func Convert_autoscaling_ExternalMetricStatus_To_v2beta1_ExternalMetricStatus(in *autoscaling.ExternalMetricStatus, out *autoscalingv2beta1.ExternalMetricStatus, s conversion.Scope) error {
-	if &in.Current.AverageValue != nil {
-		out.CurrentAverageValue = in.Current.AverageValue
-	}
+	out.CurrentAverageValue = in.Current.AverageValue
 	out.MetricName = in.Metric.Name
 	if in.Current.Value != nil {
 		out.CurrentValue = *in.Current.Value


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The ampersand in front of in.Current.AverageValue would make the condition always true.

This PR removes the ampersand.

```release-note
NONE
```
