### PR TITLE
feat: use framework.ExpectEqual instead of should

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -297,7 +297,7 @@ func testRollingUpdateDeployment(f *framework.Framework) {
 	framework.ExpectNoError(err)
 	_, allOldRSs, err := deploymentutil.GetOldReplicaSets(deployment, c.AppsV1())
 	framework.ExpectNoError(err)
-	gomega.Expect(len(allOldRSs)).Should(gomega.Equal(1))
+	framework.ExpectEqual(len(allOldRSs), 1)
 }
 
 func testRecreateDeployment(f *framework.Framework) {
@@ -497,8 +497,8 @@ func testRolloverDeployment(f *framework.Framework) {
 }
 
 func ensureReplicas(rs *appsv1.ReplicaSet, replicas int32) {
-	gomega.Expect(*rs.Spec.Replicas).Should(gomega.Equal(replicas))
-	gomega.Expect(rs.Status.Replicas).Should(gomega.Equal(replicas))
+	framework.ExpectEqual(*rs.Spec.Replicas, replicas)
+	framework.ExpectEqual(rs.Status.Replicas, replicas)
 }
 
 func randomScale(d *appsv1.Deployment, i int) {
@@ -652,7 +652,7 @@ func testDeploymentsControllerRef(f *framework.Framework) {
 
 	e2elog.Logf("Verifying Deployment %q has only one ReplicaSet", deploymentName)
 	rsList := listDeploymentReplicaSets(c, ns, podLabels)
-	gomega.Expect(len(rsList.Items)).Should(gomega.Equal(1))
+	framework.ExpectEqual(len(rsList.Items), 1)
 
 	e2elog.Logf("Obtaining the ReplicaSet's UID")
 	orphanedRSUID := rsList.Items[0].UID
@@ -683,10 +683,10 @@ func testDeploymentsControllerRef(f *framework.Framework) {
 
 	e2elog.Logf("Verifying no extra ReplicaSet is created (Deployment %q still has only one ReplicaSet after adoption)", deploymentName)
 	rsList = listDeploymentReplicaSets(c, ns, podLabels)
-	gomega.Expect(len(rsList.Items)).Should(gomega.Equal(1))
+	framework.ExpectEqual(len(rsList.Items), 1)
 
 	e2elog.Logf("Verifying the ReplicaSet has the same UID as the orphaned ReplicaSet")
-	gomega.Expect(rsList.Items[0].UID).Should(gomega.Equal(orphanedRSUID))
+	framework.ExpectEqual(rsList.Items[0].UID, orphanedRSUID)
 }
 
 // testProportionalScalingDeployment tests that when a RollingUpdate Deployment is scaled in the middle
@@ -769,7 +769,7 @@ func testProportionalScalingDeployment(f *framework.Framework) {
 
 	// Second rollout's replicaset should have 0 available replicas.
 	e2elog.Logf("Verifying that the second rollout's replicaset has .status.availableReplicas = 0")
-	gomega.Expect(secondRS.Status.AvailableReplicas).Should(gomega.Equal(int32(0)))
+	framework.ExpectEqual(secondRS.Status.AvailableReplicas, int32(0))
 
 	// Second rollout's replicaset should have Deployment's (replicas + maxSurge - first RS's replicas) = 10 + 3 - 8 = 5 for .spec.replicas.
 	newReplicas := replicas + int32(maxSurge) - minAvailableReplicas

--- a/test/e2e/auth/node_authz.go
+++ b/test/e2e/auth/node_authz.go
@@ -74,17 +74,17 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 	})
 	ginkgo.It("Getting a non-existent secret should exit with the Forbidden error, not a NotFound error", func() {
 		_, err := c.CoreV1().Secrets(ns).Get("foo", metav1.GetOptions{})
-		gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.Equal(true))
+		framework.ExpectEqual(apierrors.IsForbidden(err), true)
 	})
 
 	ginkgo.It("Getting an existing secret should exit with the Forbidden error", func() {
 		_, err := c.CoreV1().Secrets(ns).Get(defaultSaSecret, metav1.GetOptions{})
-		gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.Equal(true))
+		framework.ExpectEqual(apierrors.IsForbidden(err), true)
 	})
 
 	ginkgo.It("Getting a non-existent configmap should exit with the Forbidden error, not a NotFound error", func() {
 		_, err := c.CoreV1().ConfigMaps(ns).Get("foo", metav1.GetOptions{})
-		gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.Equal(true))
+		framework.ExpectEqual(apierrors.IsForbidden(err), true)
 	})
 
 	ginkgo.It("Getting an existing configmap should exit with the Forbidden error", func() {
@@ -101,7 +101,7 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		_, err := f.ClientSet.CoreV1().ConfigMaps(ns).Create(configmap)
 		framework.ExpectNoError(err, "failed to create configmap (%s:%s) %+v", ns, configmap.Name, *configmap)
 		_, err = c.CoreV1().ConfigMaps(ns).Get(configmap.Name, metav1.GetOptions{})
-		gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.Equal(true))
+		framework.ExpectEqual(apierrors.IsForbidden(err), true)
 	})
 
 	ginkgo.It("Getting a secret for a workload the node has access to should succeed", func() {
@@ -120,7 +120,7 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 
 		ginkgo.By("Node should not get the secret")
 		_, err = c.CoreV1().Secrets(ns).Get(secret.Name, metav1.GetOptions{})
-		gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.Equal(true))
+		framework.ExpectEqual(apierrors.IsForbidden(err), true)
 
 		ginkgo.By("Create a pod that use the secret")
 		pod := &v1.Pod{
@@ -175,12 +175,12 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		}
 		ginkgo.By(fmt.Sprintf("Create node foo by user: %v", asUser))
 		_, err := c.CoreV1().Nodes().Create(node)
-		gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.Equal(true))
+		framework.ExpectEqual(apierrors.IsForbidden(err), true)
 	})
 
 	ginkgo.It("A node shouldn't be able to delete another node", func() {
 		ginkgo.By(fmt.Sprintf("Create node foo by user: %v", asUser))
 		err := c.CoreV1().Nodes().Delete("foo", &metav1.DeleteOptions{})
-		gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.Equal(true))
+		framework.ExpectEqual(apierrors.IsForbidden(err), true)
 	})
 })

--- a/test/e2e/autoscaling/cluster_autoscaler_scalability.go
+++ b/test/e2e/autoscaling/cluster_autoscaler_scalability.go
@@ -98,7 +98,7 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 		coresPerNode = int((&cpu).MilliValue() / 1000)
 		memCapacityMb = int((&mem).Value() / 1024 / 1024)
 
-		gomega.Expect(nodeCount).Should(gomega.Equal(sum))
+		framework.ExpectEqual(nodeCount, sum)
 
 		if framework.ProviderIs("gke") {
 			val, err := isAutoscalerEnabled(3)
@@ -326,7 +326,7 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 		ginkgo.By("Checking if the number of nodes is as expected")
 		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 		klog.Infof("Nodes: %v, expected: %v", len(nodes.Items), totalNodes)
-		gomega.Expect(len(nodes.Items)).Should(gomega.Equal(totalNodes))
+		framework.ExpectEqual(len(nodes.Items), totalNodes)
 	})
 
 	ginkgo.Specify("CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]", func() {

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -112,7 +112,9 @@ while true; do sleep 1; done
 					gomega.Eventually(terminateContainer.GetPhase, ContainerStatusRetryTimeout, ContainerStatusPollInterval).Should(gomega.Equal(testCase.Phase))
 
 					ginkgo.By(fmt.Sprintf("Container '%s': should get the expected 'Ready' condition", testContainer.Name))
-					gomega.Expect(terminateContainer.IsReady()).Should(gomega.Equal(testCase.Ready))
+					isReady, err := terminateContainer.IsReady()
+					framework.ExpectEqual(isReady, testCase.Ready)
+					framework.ExpectNoError(err)
 
 					status, err := terminateContainer.GetStatus()
 					framework.ExpectNoError(err)

--- a/test/e2e/lifecycle/bootstrap/BUILD
+++ b/test/e2e/lifecycle/bootstrap/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//test/e2e/framework/log:go_default_library",
         "//test/e2e/lifecycle:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
-        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )
 

--- a/test/e2e/lifecycle/bootstrap/bootstrap_signer.go
+++ b/test/e2e/lifecycle/bootstrap/bootstrap_signer.go
@@ -18,7 +18,6 @@ package bootstrap
 
 import (
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -78,7 +77,7 @@ var _ = lifecycle.SIGDescribe("[Feature:BootstrapTokens]", func() {
 		cfgMap, err := f.ClientSet.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		signedToken, ok := cfgMap.Data[bootstrapapi.JWSSignatureKeyPrefix+tokenId]
-		gomega.Expect(ok).Should(gomega.Equal(true))
+		framework.ExpectEqual(ok, true)
 
 		ginkgo.By("update the cluster-info ConfigMap")
 		originalData := cfgMap.Data[bootstrapapi.KubeConfigKey]

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -132,7 +132,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			ginkgo.By("deleting the pod gracefully")
 			rsp, err := client.Do(req)
 			framework.ExpectNoError(err, "failed to use http client to send delete")
-			gomega.Expect(rsp.StatusCode).Should(gomega.Equal(http.StatusOK), "failed to delete gracefully by client request")
+			framework.ExpectEqual(rsp.StatusCode, http.StatusOK, "failed to delete gracefully by client request")
 			var lastPod v1.Pod
 			err = json.NewDecoder(rsp.Body).Decode(&lastPod)
 			framework.ExpectNoError(err, "failed to decode graceful termination proxy response")


### PR DESCRIPTION
/kind cleanup
/sig testing
/assign @oomichi 

**What this PR does / why we need it**:

use framework.ExpectEqual instead of should in e2e test

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
