### PR TITLE
Skip processing pod if there is already an error in CalculateInterPodAffinityPriority

### DIFF
--- a/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -135,6 +135,9 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 	var maxCount, minCount int64
 
 	processPod := func(existingPod *v1.Pod) error {
+		if pm.firstError != nil {
+			return nil
+		}
 		existingPodNode, err := ipa.info.GetNodeInfo(existingPod.Spec.NodeName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In InterPodAffinity#CalculateInterPodAffinityPriority, processPod is called in parallel.
If one invocation of processPod sets firstError, there is no need to invoke subsequent processPod.

```release-note
NONE
```
