### PR TITLE
Promote return chunks of results for list calls to conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -1,4 +1,5 @@
 test/e2e/apimachinery/aggregator.go: "Should be able to support the 1.10 Sample API Server using the current Aggregator"
+test/e2e/apimachinery/chunking.go: "should return chunks of results for list calls"
 test/e2e/apimachinery/custom_resource_definition.go: "creating/deleting custom resource definition objects works"
 test/e2e/apimachinery/garbage_collector.go: "should delete pods created by rc when not orphaning"
 test/e2e/apimachinery/garbage_collector.go: "should orphan pods created by rc if delete options say so"

--- a/test/e2e/apimachinery/chunking.go
+++ b/test/e2e/apimachinery/chunking.go
@@ -75,7 +75,12 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 		})
 	})
 
-	ginkgo.It("should return chunks of results for list calls", func() {
+	/*
+		Release : v1.15
+		Testname: Return chunks of results for large numbers of objects
+		Description: List a large number of objects and verify the first three chunks
+	*/
+	framework.ConformanceIt("should return chunks of results for list calls", func() {
 		ns := f.Namespace.Name
 		c := f.ClientSet
 		client := c.CoreV1().PodTemplates(ns)

--- a/test/e2e/apimachinery/chunking.go
+++ b/test/e2e/apimachinery/chunking.go
@@ -76,9 +76,9 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 	})
 
 	/*
-		Release : v1.15
+		Release : v1.16
 		Testname: Return chunks of results for large numbers of objects
-		Description: List a large number of objects and verify the first three chunks
+		Description: Retrieve a large number of pre-generated objects, MUST return the first three chunks
 	*/
 	framework.ConformanceIt("should return chunks of results for list calls", func() {
 		ns := f.Namespace.Name


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E test to Conformance:  
`test/e2e/apimachinery/chunking.go: "should return chunks of results for list calls"`

**Which issue(s) this PR fixes**:
Fixes #79116

**Special notes for your reviewer**:
Part of Umbrella Issue #78748

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/area conformance
/area test
@kubernetes/sig-apimachinery-pr-reviews
@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg