### PR TITLE
Set runtimeState when RuntimeReady is not set or false

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2182,15 +2182,16 @@ func (kl *Kubelet) updateRuntimeUp() {
 		// Set nil if the container runtime network is ready.
 		kl.runtimeState.setNetworkState(nil)
 	}
-	// TODO(random-liu): Add runtime error in runtimeState, and update it
-	// when runtime is not ready, so that the information in RuntimeReady
-	// condition will be propagated to NodeReady condition.
+	// information in RuntimeReady condition will be propagated to NodeReady condition.
 	runtimeReady := s.GetRuntimeCondition(kubecontainer.RuntimeReady)
 	// If RuntimeReady is not set or is false, report an error.
 	if runtimeReady == nil || !runtimeReady.Status {
-		klog.Errorf("Container runtime not ready: %v", runtimeReady)
+		err := fmt.Errorf("Container runtime not ready: %v", runtimeReady)
+		klog.Error(err)
+		kl.runtimeState.setRuntimeState(err)
 		return
 	}
+	kl.runtimeState.setRuntimeState(nil)
 	kl.oneTimeInitializer.Do(kl.initializeRuntimeDependentModules)
 	kl.runtimeState.setRuntimeSync(kl.clock.Now())
 }

--- a/pkg/kubelet/runtime.go
+++ b/pkg/kubelet/runtime.go
@@ -30,6 +30,7 @@ type runtimeState struct {
 	lastBaseRuntimeSync      time.Time
 	baseRuntimeSyncThreshold time.Duration
 	networkError             error
+	runtimeError             error
 	storageError             error
 	cidr                     string
 	healthChecks             []*healthCheck
@@ -60,6 +61,12 @@ func (s *runtimeState) setNetworkState(err error) {
 	s.Lock()
 	defer s.Unlock()
 	s.networkError = err
+}
+
+func (s *runtimeState) setRuntimeState(err error) {
+	s.Lock()
+	defer s.Unlock()
+	s.runtimeError = err
 }
 
 func (s *runtimeState) setStorageState(err error) {
@@ -93,6 +100,9 @@ func (s *runtimeState) runtimeErrors() error {
 		if ok, err := hc.fn(); !ok {
 			errs = append(errs, fmt.Errorf("%s is not healthy: %v", hc.name, err))
 		}
+	}
+	if s.runtimeError != nil {
+		errs = append(errs, s.runtimeError)
 	}
 
 	return utilerrors.NewAggregate(errs)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In Kubelet#updateRuntimeUp, when RuntimeReady is not set or false, we set error for kl.runtimeState .

```release-note
NONE
```
