### PR TITLE
fix: use schedulerCache instead of podlister in config factory

### DIFF
--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -167,8 +167,6 @@ type configFactory struct {
 	client clientset.Interface
 	// a means to list all known scheduled pods.
 	scheduledPodLister corelisters.PodLister
-	// a means to list all known scheduled pods and pods assumed to have been scheduled.
-	podLister algorithm.PodLister
 	// a means to list all nodes
 	nodeLister corelisters.NodeLister
 	// a means to list all PersistentVolumes
@@ -279,7 +277,6 @@ func NewConfigFactory(args *ConfigFactoryArgs) Configurator {
 
 	c := &configFactory{
 		client:                         args.Client,
-		podLister:                      schedulerCache,
 		podQueue:                       internalqueue.NewSchedulingQueue(stopEverything, framework),
 		nodeLister:                     args.NodeInformer.Lister(),
 		pVLister:                       args.PvInformer.Lister(),
@@ -569,7 +566,7 @@ func (c *configFactory) GetPredicates(predicateKeys sets.String) (map[string]pre
 
 func (c *configFactory) getPluginArgs() (*PluginFactoryArgs, error) {
 	return &PluginFactoryArgs{
-		PodLister:                      c.podLister,
+		PodLister:                      c.schedulerCache,
 		ServiceLister:                  c.serviceLister,
 		ControllerLister:               c.controllerLister,
 		ReplicaSetLister:               c.replicaSetLister,


### PR DESCRIPTION
/kind cleanup
/priority important-soon
/assign @bsalamat 

**What this PR does / why we need it**:

Consider use schedulerCache to replace fields in PluginFactoryArgs 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79538

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```