### PR TITLE
kubeadm: move klog.InitFlags into app/kubeadm.go

### DIFF
--- a/cmd/kubeadm/BUILD
+++ b/cmd/kubeadm/BUILD
@@ -18,10 +18,7 @@ go_library(
     name = "go_default_library",
     srcs = ["kubeadm.go"],
     importpath = "k8s.io/kubernetes/cmd/kubeadm",
-    deps = [
-        "//cmd/kubeadm/app:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
-    ],
+    deps = ["//cmd/kubeadm/app:go_default_library"],
 )
 
 filegroup(

--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -22,8 +22,7 @@ import (
 
 	"github.com/spf13/pflag"
 
-	// ensure libs have a chance to globally register their flags
-	_ "k8s.io/klog"
+	"k8s.io/klog"
 
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd"
@@ -31,6 +30,7 @@ import (
 
 // Run creates and executes new kubeadm command
 func Run() error {
+	klog.InitFlags(nil)
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 

--- a/cmd/kubeadm/kubeadm.go
+++ b/cmd/kubeadm/kubeadm.go
@@ -19,12 +19,10 @@ package main
 import (
 	"os"
 
-	"k8s.io/klog"
 	"k8s.io/kubernetes/cmd/kubeadm/app"
 )
 
 func main() {
-	klog.InitFlags(nil)
 	if err := app.Run(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
kubeadm: move klog.InitFlags into app/kubeadm.go 
`klog` can be initialized in `cmd/kubeadm/app/kubeadm.go#Run` instead of `cmd/kubeadm/kubeadm.go#main`, as `cmd/kubeadm/app/kubeadm.go` already imports `k8s.io/klog`.

This PR makes our `main` function more clear.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
