### PR TITLE
Hollow-node should use separate client for heartbeats

### DIFF
--- a/cmd/kubemark/BUILD
+++ b/cmd/kubemark/BUILD
@@ -18,6 +18,7 @@ go_library(
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/client/metrics/prometheus:go_default_library",
+        "//pkg/features:go_default_library",
         "//pkg/kubelet/cadvisor/testing:go_default_library",
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/dockershim:go_default_library",
@@ -30,6 +31,7 @@ go_library(
         "//pkg/version/verflag:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -30,6 +30,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
+	"k8s.io/kubernetes/pkg/features"
 	cadvisortest "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim"
@@ -154,6 +156,23 @@ func run(config *hollowNodeConfig) {
 	}
 
 	if config.Morph == "kubelet" {
+		f, c := kubemark.GetHollowKubeletConfig(config.NodeName, config.KubeletPort, config.KubeletReadOnlyPort, maxPods, podsPerCore)
+
+		heartbeatClientConfig := *clientConfig
+		heartbeatClientConfig.Timeout = c.NodeStatusUpdateFrequency.Duration
+		// if the NodeLease feature is enabled, the timeout is the minimum of the lease duration and status update frequency
+		if utilfeature.DefaultFeatureGate.Enabled(features.NodeLease) {
+			leaseTimeout := time.Duration(c.NodeLeaseDurationSeconds) * time.Second
+			if heartbeatClientConfig.Timeout > leaseTimeout {
+				heartbeatClientConfig.Timeout = leaseTimeout
+			}
+		}
+		heartbeatClientConfig.QPS = float32(-1)
+		heartbeatClient, err := clientset.NewForConfig(&heartbeatClientConfig)
+		if err != nil {
+			klog.Fatalf("Failed to create a ClientSet: %v. Exiting.", err)
+		}
+
 		cadvisorInterface := &cadvisortest.Fake{
 			NodeName: config.NodeName,
 		}
@@ -166,15 +185,12 @@ func run(config *hollowNodeConfig) {
 		}
 
 		hollowKubelet := kubemark.NewHollowKubelet(
-			config.NodeName,
+			f, c,
 			client,
+			heartbeatClient,
 			cadvisorInterface,
 			fakeDockerClientConfig,
-			config.KubeletPort,
-			config.KubeletReadOnlyPort,
 			containerManager,
-			maxPods,
-			podsPerCore,
 		)
 		hollowKubelet.Run()
 	}

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -48,19 +48,13 @@ type HollowKubelet struct {
 }
 
 func NewHollowKubelet(
-	nodeName string,
+	flags *options.KubeletFlags,
+	config *kubeletconfig.KubeletConfiguration,
 	client *clientset.Clientset,
+	heartbeatClient *clientset.Clientset,
 	cadvisorInterface cadvisor.Interface,
 	dockerClientConfig *dockershim.ClientConfig,
-	kubeletPort, kubeletReadOnlyPort int,
-	containerManager cm.ContainerManager,
-	maxPods int, podsPerCore int,
-) *HollowKubelet {
-	// -----------------
-	// Static config
-	// -----------------
-	f, c := GetHollowKubeletConfig(nodeName, kubeletPort, kubeletReadOnlyPort, maxPods, podsPerCore)
-
+	containerManager cm.ContainerManager) *HollowKubelet {
 	// -----------------
 	// Injected objects
 	// -----------------
@@ -69,7 +63,7 @@ func NewHollowKubelet(
 	volumePlugins = append(volumePlugins, projected.ProbeVolumePlugins()...)
 	d := &kubelet.Dependencies{
 		KubeClient:         client,
-		HeartbeatClient:    client,
+		HeartbeatClient:    heartbeatClient,
 		DockerClientConfig: dockerClientConfig,
 		CAdvisorInterface:  cadvisorInterface,
 		Cloud:              nil,
@@ -84,8 +78,8 @@ func NewHollowKubelet(
 	}
 
 	return &HollowKubelet{
-		KubeletFlags:         f,
-		KubeletConfiguration: c,
+		KubeletFlags:         flags,
+		KubeletConfiguration: config,
 		KubeletDeps:          d,
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:

This is the way it works for normal kubelets: https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/server.go#L593 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
