### PR TITLE
update code docs around old todo that is not going to happen

### DIFF
--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -745,7 +745,7 @@ func TestReconcilePodStatus(t *testing.T) {
 	// If the pod status is the same, only the timestamp is in Rfc3339 format (lower precision without nanosecond),
 	// a reconciliation is not needed, syncBatch should do nothing.
 	// The StartTime should have been set in SetPodStatus().
-	// TODO(random-liu): Remove this later when api becomes consistent for timestamp.
+	// This test is done because the related issue #15262/PR #15263 to move apiserver to RFC339NANO is closed.
 	t.Logf("Syncbatch should do nothing, as a reconciliation is not required")
 	normalizedStartTime := testPod.Status.StartTime.Rfc3339Copy()
 	testPod.Status.StartTime = &normalizedStartTime


### PR DESCRIPTION
Going through old TODOs to clean up kubelet. I see there was a todo to remove normalization of cached timestamps when issue #15262 and pr #15263 merged, but they were closed 4years ago. Time to remove the TODO and update the code documentation to reflect.

@Random-Liu 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>

/kind cleanup

```release-note
na
```