### PR TITLE
apiaggregation available controller should only hit required endpoint

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -261,9 +261,11 @@ func (c *AvailableConditionController) sync(key string) error {
 					results <- err
 					return
 				}
+				discoveryURL.Path = "/apis/" + apiService.Spec.Group + "/" + apiService.Spec.Version
 
 				errCh := make(chan error)
 				go func() {
+					// be sure to check a URL that the aggregated API server is required to serve
 					newReq, err := http.NewRequest("GET", discoveryURL.String(), nil)
 					if err != nil {
 						errCh <- err

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller_test.go
@@ -90,6 +90,8 @@ func newRemoteAPIService(name string) *apiregistration.APIService {
 	return &apiregistration.APIService{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: apiregistration.APIServiceSpec{
+			Group:   strings.SplitN(name, ".", 2)[0],
+			Version: strings.SplitN(name, ".", 2)[1],
 			Service: &apiregistration.ServiceReference{
 				Namespace: "foo",
 				Name:      "bar",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/79838

We should only check for endpoints that aggregation is required to serve.  This updates the controller to hit `/apis/group/version` instead of `/`.


```release-note
Resolves an issue serving aggregated APIs backed by services that respond to requests to `/` with non-2xx HTTP responses
```

@kubernetes/sig-api-machinery-bugs 

@liggitt 