### PR TITLE
Refactor generate*-groups.sh

### DIFF
--- a/staging/src/k8s.io/code-generator/generate-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-groups.sh
@@ -50,7 +50,7 @@ shift 4
   # To support running this script from anywhere, we have to first cd into this directory
   # so we can install the tools.
   cd "$(dirname "${0}")"
-  go install ./cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+  go install ./cmd/{defaulter,client,lister,informer,deepcopy}-gen
 )
 # Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
 GOBIN="$(go env GOBIN)"
@@ -71,17 +71,28 @@ done
 
 if [ "${GENS}" = "all" ] || grep -qw "deepcopy" <<<"${GENS}"; then
   echo "Generating deepcopy funcs"
-  "${gobin}/deepcopy-gen" --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" -O zz_generated.deepcopy --bounding-dirs "${APIS_PKG}" "$@"
+  "${gobin}/deepcopy-gen" \
+      --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" \
+      --output-file-base zz_generated.deepcopy \
+      --bounding-dirs "${APIS_PKG}" \
+      "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "client" <<<"${GENS}"; then
   echo "Generating clientset for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}"
-  "${gobin}/client-gen" --clientset-name "${CLIENTSET_NAME_VERSIONED:-versioned}" --input-base "" --input "$(codegen::join , "${FQ_APIS[@]}")" --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}" "$@"
+  "${gobin}/client-gen" \
+      --clientset-name "${CLIENTSET_NAME_VERSIONED:-versioned}" \
+      --input-base "" --input "$(codegen::join , "${FQ_APIS[@]}")" \
+      --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}" \
+      "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "lister" <<<"${GENS}"; then
   echo "Generating listers for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/listers"
-  "${gobin}/lister-gen" --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" --output-package "${OUTPUT_PKG}/listers" "$@"
+  "${gobin}/lister-gen" \
+      --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" \
+      --output-package "${OUTPUT_PKG}/listers" \
+      "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "informer" <<<"${GENS}"; then

--- a/staging/src/k8s.io/code-generator/generate-internal-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-internal-groups.sh
@@ -47,8 +47,7 @@ EXT_APIS_PKG="$4"
 GROUPS_WITH_VERSIONS="$5"
 shift 5
 
-go install ./"$(dirname "${0}")"/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}
-
+go install ./"$(dirname "${0}")"/cmd/{defaulter,conversion,client,lister,informer,deepcopy,openapi}-gen
 function codegen::join() { local IFS="$1"; shift; echo "$*"; }
 
 # enumerate group versions
@@ -72,31 +71,52 @@ done
 
 if [ "${GENS}" = "all" ] || grep -qw "deepcopy" <<<"${GENS}"; then
   echo "Generating deepcopy funcs"
-  "${GOPATH}/bin/deepcopy-gen" --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" -O zz_generated.deepcopy --bounding-dirs "${INT_APIS_PKG},${EXT_APIS_PKG}" "$@"
+  "${GOPATH}/bin/deepcopy-gen" \
+      --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" \
+      --output-file-base zz_generated.deepcopy \
+      --bounding-dirs "${INT_APIS_PKG},${EXT_APIS_PKG}" \
+      "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "defaulter" <<<"${GENS}"; then
   echo "Generating defaulters"
-  "${GOPATH}/bin/defaulter-gen"  --input-dirs "$(codegen::join , "${EXT_FQ_APIS[@]}")" -O zz_generated.defaults "$@"
+  "${GOPATH}/bin/defaulter-gen" \
+      --input-dirs "$(codegen::join , "${EXT_FQ_APIS[@]}")" \
+      --output-file-base zz_generated.defaults \
+      "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "conversion" <<<"${GENS}"; then
   echo "Generating conversions"
-  "${GOPATH}/bin/conversion-gen" --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" -O zz_generated.conversion "$@"
+  "${GOPATH}/bin/conversion-gen" \
+      --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" \
+      --output-file-base zz_generated.conversion \
+      "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "client" <<<"${GENS}"; then
   echo "Generating clientset for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}"
   if [ -n "${INT_APIS_PKG}" ]; then
     IFS=" " read -r -a APIS <<< "$(printf '%s/ ' "${INT_FQ_APIS[@]}")"
-    "${GOPATH}/bin/client-gen" --clientset-name "${CLIENTSET_NAME_INTERNAL:-internalversion}" --input-base "" --input "$(codegen::join , "${APIS[@]}")" --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}" "$@"
+    "${GOPATH}/bin/client-gen" \
+        --clientset-name "${CLIENTSET_NAME_INTERNAL:-internalversion}" \
+        --input-base "" --input "$(codegen::join , "${APIS[@]}")" \
+        --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}" \
+        "$@"
   fi
-  "${GOPATH}/bin/client-gen" --clientset-name "${CLIENTSET_NAME_VERSIONED:-versioned}" --input-base "" --input "$(codegen::join , "${EXT_FQ_APIS[@]}")" --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}" "$@"
+  "${GOPATH}/bin/client-gen" \
+      --clientset-name "${CLIENTSET_NAME_VERSIONED:-versioned}" \
+      --input-base "" --input "$(codegen::join , "${EXT_FQ_APIS[@]}")" \
+      --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}" \
+      "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "lister" <<<"${GENS}"; then
   echo "Generating listers for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/listers"
-  "${GOPATH}/bin/lister-gen" --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" --output-package "${OUTPUT_PKG}/listers" "$@"
+  "${GOPATH}/bin/lister-gen" \
+      --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" \
+      --output-package "${OUTPUT_PKG}/listers" \
+      "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "informer" <<<"${GENS}"; then
@@ -117,6 +137,6 @@ if [ "${GENS}" = "all" ] || grep -qw "openapi" <<<"${GENS}"; then
            --input-dirs "$(codegen::join , "${EXT_FQ_APIS[@]}" "${OPENAPI_EXTRA_PACKAGES[@]}")" \
            --input-dirs "k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/runtime,k8s.io/apimachinery/pkg/version" \
            --output-package "${OUTPUT_PKG}/openapi" \
-           -O zz_generated.openapi \
+           --output-file-base zz_generated.openapi \
            "$@"
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The `generate-groups.sh` and `generate-internal-groups.sh` have really long lines, which makes them annoying to read on a small monitor or an editor with splits open.

This also should improve readability for github's code presentation, because you won't have to scroll as much to the side anymore.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
