### PR TITLE
update code documentation to reflect change in status

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -431,13 +431,10 @@ func (cm *containerManagerImpl) setupNode(activePods ActivePodsFunc) error {
 
 	systemContainers := []*systemContainer{}
 	if cm.ContainerRuntime == "docker" {
-		// With the docker-CRI integration, dockershim will manage the cgroups
+		// With the docker-CRI integration, dockershim manages the cgroups
 		// and oom score for the docker processes.
-		// In the future, NodeSpec should mandate the cgroup that the
-		// runtime processes need to be in. For now, we still check the
-		// cgroup for docker periodically, so that kubelet can recognize
-		// the cgroup for docker and serve stats for the runtime.
-		// TODO(#27097): Fix this after NodeSpec is clearly defined.
+		// Check the cgroup for docker periodically, so kubelet can serve stats for the docker runtime.
+		// TODO(KEP#866): remove special processing for CRI "docker" enablement
 		cm.periodicTasks = append(cm.periodicTasks, func() {
 			klog.V(4).Infof("[ContainerManager]: Adding periodic tasks for docker CRI integration")
 			cont, err := getContainerNameForProcess(dockerProcessName, dockerPidFile)


### PR DESCRIPTION
Going through old TODOs to clean up kubelet. I see there was a todo #27097 to specify how CRI runtime cgroups would be found/managed for cgroup stats collection. The issue has been closed / implemented since. But the Dockerisms todo still remains, there is a kep tracking said isms https://github.com/kubernetes/enhancements/pull/866

Updating the code docs to reflect this change in status.

@yujuhong 

Signed-off-by: Mike Brown brownwm@us.ibm.com

/kind cleanup