### PR TITLE
update todo to reflect current status

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -33,7 +33,7 @@ import (
 	_ "github.com/google/cadvisor/container/systemd/install"
 
 	// Register cloud info providers.
-	// TODO(#76660): Remove this once the cAdvisor endpoints are removed.
+	// TODO(#68522): Remove these package initializations when the cAdvisor endpoints are removed.
 	_ "github.com/google/cadvisor/utils/cloudinfo/aws"
 	_ "github.com/google/cadvisor/utils/cloudinfo/azure"
 	_ "github.com/google/cadvisor/utils/cloudinfo/gce"


### PR DESCRIPTION
Going through old TODOs to clean up kubelet. I see there is a todo issue #76660 for removing cadvisor package initializations when the cAdvisor endpoints are removed. That issue has been dup/closed. The new holding pen for this work is step [1.19] in issue #68522).

Updating the code docs to reflect this change in status.

Signed-off-by: Mike Brown brownwm@us.ibm.com

/kind cleanup