### PR TITLE
Replace KubeDescribe with ginkgo.Describe in e2e/kubectl

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -163,7 +163,7 @@ var _ = SIGDescribe("Kubectl alpha client", func() {
 		ns = f.Namespace.Name
 	})
 
-	framework.KubeDescribe("Kubectl run CronJob", func() {
+	ginkgo.Describe("Kubectl run CronJob", func() {
 		var nsFlag string
 		var cjName string
 
@@ -269,7 +269,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 		e2elog.Logf("scanned %s for discovery docs: %v", home, err)
 	}
 
-	framework.KubeDescribe("Update Demo", func() {
+	ginkgo.Describe("Update Demo", func() {
 		var nautilus, kitten string
 		ginkgo.BeforeEach(func() {
 			updateDemoRoot := "test/fixtures/doc-yaml/user-guide/update-demo"
@@ -327,7 +327,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 		})
 	})
 
-	framework.KubeDescribe("Guestbook application", func() {
+	ginkgo.Describe("Guestbook application", func() {
 		forEachGBFile := func(run func(s string)) {
 			guestbookRoot := "test/e2e/testing-manifests/guestbook"
 			for _, gbAppFile := range []string{
@@ -363,7 +363,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 		})
 	})
 
-	framework.KubeDescribe("Simple pod", func() {
+	ginkgo.Describe("Simple pod", func() {
 		var podYaml string
 		ginkgo.BeforeEach(func() {
 			ginkgo.By(fmt.Sprintf("creating the pod from %v", podYaml))
@@ -744,7 +744,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl api-versions", func() {
+	ginkgo.Describe("Kubectl api-versions", func() {
 		/*
 			Release : v1.9
 			Testname: Kubectl, check version v1
@@ -759,7 +759,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl get componentstatuses", func() {
+	ginkgo.Describe("Kubectl get componentstatuses", func() {
 		ginkgo.It("should get componentstatuses", func() {
 			ginkgo.By("getting list of componentstatuses")
 			output := framework.RunKubectlOrDie("get", "componentstatuses", "-o", "jsonpath={.items[*].metadata.name}")
@@ -772,7 +772,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl apply", func() {
+	ginkgo.Describe("Kubectl apply", func() {
 		ginkgo.It("should apply a new configuration to an existing RC", func() {
 			controllerJSON := commonutils.SubstituteImageName(string(readTestFileOrDie(redisControllerFilename)))
 
@@ -904,7 +904,7 @@ metadata:
 		return nil
 	}
 
-	framework.KubeDescribe("Kubectl client-side validation", func() {
+	ginkgo.Describe("Kubectl client-side validation", func() {
 		ginkgo.It("should create/apply a CR with unknown fields for CRD with no validation schema", func() {
 			ginkgo.By("create CRD with no validation schema")
 			crd, err := crd.CreateTestCRD(f)
@@ -991,7 +991,7 @@ metadata:
 
 	})
 
-	framework.KubeDescribe("Kubectl cluster-info", func() {
+	ginkgo.Describe("Kubectl cluster-info", func() {
 		/*
 			Release : v1.9
 			Testname: Kubectl, cluster info
@@ -1010,14 +1010,14 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl cluster-info dump", func() {
+	ginkgo.Describe("Kubectl cluster-info dump", func() {
 		ginkgo.It("should check if cluster-info dump succeeds", func() {
 			ginkgo.By("running cluster-info dump")
 			framework.RunKubectlOrDie("cluster-info", "dump")
 		})
 	})
 
-	framework.KubeDescribe("Kubectl describe", func() {
+	ginkgo.Describe("Kubectl describe", func() {
 		/*
 			Release : v1.9
 			Testname: Kubectl, describe pod or rc
@@ -1122,7 +1122,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl expose", func() {
+	ginkgo.Describe("Kubectl expose", func() {
 		/*
 			Release : v1.9
 			Testname: Kubectl, create service, replication controller
@@ -1206,7 +1206,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl label", func() {
+	ginkgo.Describe("Kubectl label", func() {
 		var podYaml string
 		var nsFlag string
 		ginkgo.BeforeEach(func() {
@@ -1247,7 +1247,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl copy", func() {
+	ginkgo.Describe("Kubectl copy", func() {
 		var podYaml string
 		var nsFlag string
 		ginkgo.BeforeEach(func() {
@@ -1287,7 +1287,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl logs", func() {
+	ginkgo.Describe("Kubectl logs", func() {
 		var nsFlag string
 		var rc string
 		containerName := "redis-master"
@@ -1362,7 +1362,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl patch", func() {
+	ginkgo.Describe("Kubectl patch", func() {
 		/*
 			Release : v1.9
 			Testname: Kubectl, patch to annotate
@@ -1396,7 +1396,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl version", func() {
+	ginkgo.Describe("Kubectl version", func() {
 		/*
 			Release : v1.9
 			Testname: Kubectl, version
@@ -1413,7 +1413,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl run default", func() {
+	ginkgo.Describe("Kubectl run default", func() {
 		var nsFlag string
 		var name string
 
@@ -1451,7 +1451,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl run rc", func() {
+	ginkgo.Describe("Kubectl run rc", func() {
 		var nsFlag string
 		var rcName string
 
@@ -1510,7 +1510,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl rolling-update", func() {
+	ginkgo.Describe("Kubectl rolling-update", func() {
 		var nsFlag string
 		var rcName string
 		var c clientset.Interface
@@ -1552,7 +1552,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl run deployment", func() {
+	ginkgo.Describe("Kubectl run deployment", func() {
 		var nsFlag string
 		var dName string
 
@@ -1607,7 +1607,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl run job", func() {
+	ginkgo.Describe("Kubectl run job", func() {
 		var nsFlag string
 		var jobName string
 
@@ -1643,7 +1643,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl run CronJob", func() {
+	ginkgo.Describe("Kubectl run CronJob", func() {
 		var nsFlag string
 		var cjName string
 
@@ -1680,7 +1680,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl run pod", func() {
+	ginkgo.Describe("Kubectl run pod", func() {
 		var nsFlag string
 		var podName string
 
@@ -1716,7 +1716,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl replace", func() {
+	ginkgo.Describe("Kubectl replace", func() {
 		var nsFlag string
 		var podName string
 
@@ -1767,7 +1767,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl run --rm job", func() {
+	ginkgo.Describe("Kubectl run --rm job", func() {
 		jobName := "e2e-test-rm-busybox-job"
 
 		/*
@@ -1798,7 +1798,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Proxy server", func() {
+	ginkgo.Describe("Proxy server", func() {
 		// TODO: test proxy options (static, prefix, etc)
 		/*
 			Release : v1.9
@@ -1861,7 +1861,7 @@ metadata:
 
 	// This test must run [Serial] because it modifies the node so it doesn't allow pods to execute on
 	// it, which will affect anything else running in parallel.
-	framework.KubeDescribe("Kubectl taint [Serial]", func() {
+	ginkgo.Describe("Kubectl taint [Serial]", func() {
 		ginkgo.It("should update the taint on a node", func() {
 			testTaint := v1.Taint{
 				Key:    fmt.Sprintf("kubernetes.io/e2e-taint-key-001-%s", string(uuid.NewUUID())),
@@ -1961,7 +1961,7 @@ metadata:
 		})
 	})
 
-	framework.KubeDescribe("Kubectl create quota", func() {
+	ginkgo.Describe("Kubectl create quota", func() {
 		ginkgo.It("should create a quota without scopes", func() {
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			quotaName := "million"

--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -438,8 +438,8 @@ func doTestOverWebSockets(bindAddress string, f *framework.Framework) {
 var _ = SIGDescribe("Kubectl Port forwarding", func() {
 	f := framework.NewDefaultFramework("port-forwarding")
 
-	framework.KubeDescribe("With a server listening on 0.0.0.0", func() {
-		framework.KubeDescribe("that expects a client request", func() {
+	ginkgo.Describe("With a server listening on 0.0.0.0", func() {
+		ginkgo.Describe("that expects a client request", func() {
 			ginkgo.It("should support a client that connects, sends NO DATA, and disconnects", func() {
 				doTestMustConnectSendNothing("0.0.0.0", f)
 			})
@@ -448,7 +448,7 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 			})
 		})
 
-		framework.KubeDescribe("that expects NO client request", func() {
+		ginkgo.Describe("that expects NO client request", func() {
 			ginkgo.It("should support a client that connects, sends DATA, and disconnects", func() {
 				doTestConnectSendDisconnect("0.0.0.0", f)
 			})
@@ -460,8 +460,8 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 	})
 
 	// kubectl port-forward may need elevated privileges to do its job.
-	framework.KubeDescribe("With a server listening on localhost", func() {
-		framework.KubeDescribe("that expects a client request", func() {
+	ginkgo.Describe("With a server listening on localhost", func() {
+		ginkgo.Describe("that expects a client request", func() {
 			ginkgo.It("should support a client that connects, sends NO DATA, and disconnects", func() {
 				doTestMustConnectSendNothing("localhost", f)
 			})
@@ -470,7 +470,7 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 			})
 		})
 
-		framework.KubeDescribe("that expects NO client request", func() {
+		ginkgo.Describe("that expects NO client request", func() {
 			ginkgo.It("should support a client that connects, sends DATA, and disconnects", func() {
 				doTestConnectSendDisconnect("localhost", f)
 			})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently, almost all e2e tests do not use `KubeDescribe` function but use `ginkgo.Describe` or `SIGDescribe`.
`KubeDescribe` adds [k8s.io] prefix, however the prefix is not necessary from modification of #50054.
Some e2e tests use `KubeDescribe`, that makes reader confusing why it uses `KubeDescribe` or other functions of description.

This PR replaces `KubeDescribe` with `ginkgo.Describe` in e2e/kubectl.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```