### PR TITLE
kube-cross makefile add REGISTRY

### DIFF
--- a/build/build-image/cross/Makefile
+++ b/build/build-image/cross/Makefile
@@ -14,14 +14,15 @@
 
 .PHONY:	build push
 
-IMAGE=kube-cross
+REGISTRY?=staging-k8s.gcr.io
+IMAGE=$(REGISTRY)/kube-cross
 TAG=$(shell cat VERSION)
 
 
 all: push
 
 build:
-	docker build --pull -t staging-k8s.gcr.io/$(IMAGE):$(TAG) .
+	docker build --pull -t $(IMAGE):$(TAG) .
 
 push: build
-	docker push staging-k8s.gcr.io/$(IMAGE):$(TAG)
+	docker push $(IMAGE):$(TAG)


### PR DESCRIPTION
Add REGISTRY var to the kube-cross makefile to allow building images for different registries.
This is related to https://github.com/kubernetes/k8s.io/pull/288

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
To be able to push kube-cross images into different registries, like gcr.io/k8s-staging-build-image


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
