### PR TITLE
Remove CSI Node related funcs from cache

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -157,58 +157,38 @@ func (sched *Scheduler) deleteNodeFromCache(obj interface{}) {
 }
 
 func (sched *Scheduler) onCSINodeAdd(obj interface{}) {
-	csiNode, ok := obj.(*storagev1beta1.CSINode)
+	_, ok := obj.(*storagev1beta1.CSINode)
 	if !ok {
 		klog.Errorf("cannot convert to *storagev1beta1.CSINode: %v", obj)
 		return
-	}
-
-	if err := sched.config.SchedulerCache.AddCSINode(csiNode); err != nil {
-		klog.Errorf("scheduler cache AddCSINode failed: %v", err)
 	}
 
 	sched.config.SchedulingQueue.MoveAllToActiveQueue()
 }
 
 func (sched *Scheduler) onCSINodeUpdate(oldObj, newObj interface{}) {
-	oldCSINode, ok := oldObj.(*storagev1beta1.CSINode)
+	_, ok := oldObj.(*storagev1beta1.CSINode)
 	if !ok {
 		klog.Errorf("cannot convert oldObj to *storagev1beta1.CSINode: %v", oldObj)
 		return
 	}
 
-	newCSINode, ok := newObj.(*storagev1beta1.CSINode)
+	_, ok = newObj.(*storagev1beta1.CSINode)
 	if !ok {
 		klog.Errorf("cannot convert newObj to *storagev1beta1.CSINode: %v", newObj)
 		return
-	}
-
-	if err := sched.config.SchedulerCache.UpdateCSINode(oldCSINode, newCSINode); err != nil {
-		klog.Errorf("scheduler cache UpdateCSINode failed: %v", err)
 	}
 
 	sched.config.SchedulingQueue.MoveAllToActiveQueue()
 }
 
 func (sched *Scheduler) onCSINodeDelete(obj interface{}) {
-	var csiNode *storagev1beta1.CSINode
 	switch t := obj.(type) {
 	case *storagev1beta1.CSINode:
-		csiNode = t
 	case cache.DeletedFinalStateUnknown:
-		var ok bool
-		csiNode, ok = t.Obj.(*storagev1beta1.CSINode)
-		if !ok {
-			klog.Errorf("cannot convert to *storagev1beta1.CSINode: %v", t.Obj)
-			return
-		}
 	default:
 		klog.Errorf("cannot convert to *storagev1beta1.CSINode: %v", t)
 		return
-	}
-
-	if err := sched.config.SchedulerCache.RemoveCSINode(csiNode); err != nil {
-		klog.Errorf("scheduler cache RemoveCSINode failed: %v", err)
 	}
 }
 

--- a/pkg/scheduler/internal/cache/BUILD
+++ b/pkg/scheduler/internal/cache/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/api/storage/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -567,47 +566,6 @@ func (cache *schedulerCache) RemoveNode(node *v1.Node) error {
 
 	cache.nodeTree.RemoveNode(node)
 	cache.removeNodeImageStates(node)
-	return nil
-}
-
-func (cache *schedulerCache) AddCSINode(csiNode *storagev1beta1.CSINode) error {
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
-
-	n, ok := cache.nodes[csiNode.Name]
-	if !ok {
-		n = newNodeInfoListItem(schedulernodeinfo.NewNodeInfo())
-		cache.nodes[csiNode.Name] = n
-	}
-	n.info.SetCSINode(csiNode)
-	cache.moveNodeInfoToHead(csiNode.Name)
-	return nil
-}
-
-func (cache *schedulerCache) UpdateCSINode(oldCSINode, newCSINode *storagev1beta1.CSINode) error {
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
-
-	n, ok := cache.nodes[newCSINode.Name]
-	if !ok {
-		n = newNodeInfoListItem(schedulernodeinfo.NewNodeInfo())
-		cache.nodes[newCSINode.Name] = n
-	}
-	n.info.SetCSINode(newCSINode)
-	cache.moveNodeInfoToHead(newCSINode.Name)
-	return nil
-}
-
-func (cache *schedulerCache) RemoveCSINode(csiNode *storagev1beta1.CSINode) error {
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
-
-	n, ok := cache.nodes[csiNode.Name]
-	if !ok {
-		return fmt.Errorf("node %v is not found", csiNode.Name)
-	}
-	n.info.SetCSINode(nil)
-	cache.moveNodeInfoToHead(csiNode.Name)
 	return nil
 }
 

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -18,7 +18,6 @@ package cache
 
 import (
 	v1 "k8s.io/api/core/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
@@ -100,15 +99,6 @@ type Cache interface {
 	// The node info contains aggregated information of pods scheduled (including assumed to be)
 	// on this node.
 	UpdateNodeInfoSnapshot(nodeSnapshot *NodeInfoSnapshot) error
-
-	// AddCSINode adds overall CSI-related information about node.
-	AddCSINode(csiNode *storagev1beta1.CSINode) error
-
-	// UpdateCSINode updates overall CSI-related information about node.
-	UpdateCSINode(oldCSINode, newCSINode *storagev1beta1.CSINode) error
-
-	// RemoveCSINode removes overall CSI-related information about node.
-	RemoveCSINode(csiNode *storagev1beta1.CSINode) error
 
 	// GetNodeInfo returns the node object with node string.
 	GetNodeInfo(nodeName string) (*v1.Node, error)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
From discussion in #79416, it seems determining the proper order of Node / CSINode addition / removal is non-trivial.

This PR removes CSI Node related funcs from cache.

```release-note
NONE
```
