### PR TITLE
Bugfix: csi plugin supporting raw block that does not need attach mounted failed

### DIFF
--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -104,9 +104,10 @@ func (m *csiBlockMapper) stageVolumeForBlock(
 		klog.Infof(log("blockMapper.stageVolumeForBlock STAGE_UNSTAGE_VOLUME capability not set. Skipping MountDevice..."))
 		return "", nil
 	}
-
-	publishVolumeInfo := attachment.Status.AttachmentMetadata
-
+	publishVolumeInfo := map[string]string{}
+	if attachment != nil {
+		publishVolumeInfo = attachment.Status.AttachmentMetadata
+	}
 	nodeStageSecrets := map[string]string{}
 	if csiSource.NodeStageSecretRef != nil {
 		nodeStageSecrets, err = getCredentialsFromSecret(m.k8s, csiSource.NodeStageSecretRef)
@@ -155,7 +156,10 @@ func (m *csiBlockMapper) publishVolumeForBlock(
 ) (string, error) {
 	klog.V(4).Infof(log("blockMapper.publishVolumeForBlock called"))
 
-	publishVolumeInfo := attachment.Status.AttachmentMetadata
+	publishVolumeInfo := map[string]string{}
+	if attachment != nil {
+		publishVolumeInfo = attachment.Status.AttachmentMetadata
+	}
 
 	nodePublishSecrets := map[string]string{}
 	var err error
@@ -223,18 +227,23 @@ func (m *csiBlockMapper) SetUpDevice() (string, error) {
 		return "", err
 	}
 
-	// Search for attachment by VolumeAttachment.Spec.Source.PersistentVolumeName
-	nodeName := string(m.plugin.host.GetNodeName())
-	attachID := getAttachmentName(csiSource.VolumeHandle, csiSource.Driver, nodeName)
-	attachment, err := m.k8s.StorageV1().VolumeAttachments().Get(attachID, meta.GetOptions{})
+	driverName := csiSource.Driver
+	skip, err := m.plugin.skipAttach(driverName)
 	if err != nil {
-		klog.Error(log("blockMapper.SetupDevice failed to get volume attachment [id=%v]: %v", attachID, err))
+		klog.Error(log("blockMapper.SetupDevice failed to check CSIDriver for %s: %v", driverName, err))
 		return "", err
 	}
 
-	if attachment == nil {
-		klog.Error(log("blockMapper.SetupDevice unable to find VolumeAttachment [id=%s]", attachID))
-		return "", errors.New("no existing VolumeAttachment found")
+	var attachment *storage.VolumeAttachment
+	if !skip {
+		// Search for attachment by VolumeAttachment.Spec.Source.PersistentVolumeName
+		nodeName := string(m.plugin.host.GetNodeName())
+		attachID := getAttachmentName(csiSource.VolumeHandle, csiSource.Driver, nodeName)
+		attachment, err = m.k8s.StorageV1().VolumeAttachments().Get(attachID, meta.GetOptions{})
+		if err != nil {
+			klog.Error(log("blockMapper.SetupDevice failed to get volume attachment [id=%v]: %v", attachID, err))
+			return "", err
+		}
 	}
 
 	//TODO (vladimirvivien) implement better AccessModes mapping between k8s and CSI


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

csi plugin supporting raw block that does not need attach mounted failed.
reason: for block device, csi_block.go always gets an attachment no matter if it supports attachment.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79884

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bugfix: csi plugin supporting raw block that does not need attach mounted failed
```
