### PR TITLE
kubectl book: added a leading slash to apis path

### DIFF
--- a/staging/src/k8s.io/kubectl/docs/book/pages/resource_printing/cluster_information.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/resource_printing/cluster_information.md
@@ -150,7 +150,7 @@ kubectl api-versions
 {% panel style="info", title="Discovery" %}
 The discovery information can be viewed at `127.0.0.1:8001/` by running
 `kubectl proxy`.  The Discovery for specific API can be found under either
-`/api/v1` or `apis/<group>/<version>`, depending on the API group -
+`/api/v1` or `/apis/<group>/<version>`, depending on the API group -
 e.g. `127.0.0.1:8001/apis/apps/v1`
 {% endpanel %}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

While `/api/v1` has a leading slash, `apis/<group>/<version>` doesn't have it in the following document. It's correct w/ a leading slash.
https://kubectl.docs.kubernetes.io/pages/resource_printing/cluster_information.html

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
