### PR TITLE
Avoid RbdDiskManager's DetachDisk function never be executed again

### DIFF
--- a/pkg/volume/rbd/attacher.go
+++ b/pkg/volume/rbd/attacher.go
@@ -216,18 +216,39 @@ func (detacher *rbdDetacher) UnmountDevice(deviceMountPath string) error {
 		return err
 	}
 	// Unmount the device from the device mount point.
-	klog.V(4).Infof("rbd: unmouting device mountpoint %s", deviceMountPath)
-	if err = detacher.mounter.Unmount(deviceMountPath); err != nil {
-		return err
-	}
-	klog.V(3).Infof("rbd: successfully umount device mountpath %s", deviceMountPath)
-
-	klog.V(4).Infof("rbd: detaching device %s", devicePath)
-	err = detacher.manager.DetachDisk(detacher.plugin, deviceMountPath, devicePath)
+	notMnt, err := detacher.mounter.IsLikelyNotMountPoint(deviceMountPath)
 	if err != nil {
 		return err
 	}
-	klog.V(3).Infof("rbd: successfully detach device %s", devicePath)
+	if !notMnt {
+		klog.V(4).Infof("rbd: unmouting device mountpoint %s", deviceMountPath)
+		if err = detacher.mounter.Unmount(deviceMountPath); err != nil {
+			return err
+		}
+		klog.V(3).Infof("rbd: successfully umount device mountpath %s", deviceMountPath)
+	}
+
+	// Get devicePath from deviceMountPath if devicePath is empty
+	if devicePath == "" {
+		rbdImageInfo, err := getRbdImageInfo(deviceMountPath)
+		if err != nil {
+			return err
+		}
+		found := false
+		devicePath, found = getRbdDevFromImageAndPool(rbdImageInfo.pool, rbdImageInfo.name)
+		if !found {
+			klog.Warningf("rbd: can't found devicePath for %v. Device is already unmounted, Image %v, Pool %v", deviceMountPath, rbdImageInfo.pool, rbdImageInfo.name)
+		}
+	}
+
+	if devicePath != "" {
+		klog.V(4).Infof("rbd: detaching device %s", devicePath)
+		err = detacher.manager.DetachDisk(detacher.plugin, deviceMountPath, devicePath)
+		if err != nil {
+			return err
+		}
+		klog.V(3).Infof("rbd: successfully detach device %s", devicePath)
+	}
 	err = os.Remove(deviceMountPath)
 	if err != nil {
 		return err

--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -707,3 +707,34 @@ func TestGetRbdImageSize(t *testing.T) {
 		}
 	}
 }
+
+func TestGetRbdImageInfo(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("rbd_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	for i, c := range []struct {
+		DeviceMountPath    string
+		TargetRbdImageInfo *rbdImageInfo
+	}{
+		{
+			DeviceMountPath:    fmt.Sprintf("%s/plugins/kubernetes.io/rbd/rbd/pool1-image-image1", tmpDir),
+			TargetRbdImageInfo: &rbdImageInfo{pool: "pool1", name: "image1"},
+		},
+		{
+			DeviceMountPath:    fmt.Sprintf("%s/plugins/kubernetes.io/rbd/mounts/pool2-image-image2", tmpDir),
+			TargetRbdImageInfo: &rbdImageInfo{pool: "pool2", name: "image2"},
+		},
+	} {
+		rbdImageInfo, err := getRbdImageInfo(c.DeviceMountPath)
+		if err != nil {
+			t.Errorf("Case %d: getRbdImageInfo failed: %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(rbdImageInfo, c.TargetRbdImageInfo) {
+			t.Errorf("Case %d: unexpected RbdImageInfo, wanted %v, got %v", i, c.TargetRbdImageInfo, rbdImageInfo)
+		}
+	}
+}

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -57,6 +57,12 @@ const (
 	rbdImageSizeUnitMiB      = 1024 * 1024
 )
 
+// A struct contains rbd image info.
+type rbdImageInfo struct {
+	pool string
+	name string
+}
+
 func getDevFromImageAndPool(pool, image string) (string, bool) {
 	device, found := getRbdDevFromImageAndPool(pool, image)
 	if found {
@@ -788,4 +794,16 @@ func (util *RBDUtil) rbdStatus(b *rbdMounter) (bool, string, error) {
 		klog.Warningf("rbd: no watchers on %s", b.Image)
 		return false, output, nil
 	}
+}
+
+// getRbdImageInfo try to get rbdImageInfo from deviceMountPath.
+func getRbdImageInfo(deviceMountPath string) (*rbdImageInfo, error) {
+	deviceMountedPathSeps := strings.Split(filepath.Base(deviceMountPath), "-image-")
+	if len(deviceMountedPathSeps) != 2 {
+		return nil, fmt.Errorf("Can't found devicePath for %s ", deviceMountPath)
+	}
+	return &rbdImageInfo{
+		pool: deviceMountedPathSeps[0],
+		name: deviceMountedPathSeps[1],
+	}, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
rbd volume will stuck when DetachDisk failed as Unmount will always returen not mounted， see [#54214](https://github.com/kubernetes/kubernetes/issues/54214#issuecomment-457082551)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #54214 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
