### PR TITLE
Ignore the error return from NewWriterLevel which is always nil

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -122,10 +122,7 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 
 var gzipPool = &sync.Pool{
 	New: func() interface{} {
-		gw, err := gzip.NewWriterLevel(nil, defaultGzipContentEncodingLevel)
-		if err != nil {
-			panic(err)
-		}
+		gw, _ := gzip.NewWriterLevel(nil, defaultGzipContentEncodingLevel)
 		return gw
 	},
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is related to #77449
The error return for the new response writer would only be nil (as @smarterclayton pointed out), the error can be ignored.

```release-note
NONE
```
