### PR TITLE
More consistent env var handling in vsphere e2e test

### DIFF
--- a/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
@@ -18,7 +18,6 @@ package vsphere
 
 import (
 	"context"
-	"os"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -45,9 +44,7 @@ var _ = utils.SIGDescribe("Node Unregister [Feature:vsphere] [Slow] [Disruptive]
 		namespace = f.Namespace.Name
 		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(client, framework.TestContext.NodeSchedulableTimeout))
 		framework.ExpectNoError(err)
-		workingDir = os.Getenv("VSPHERE_WORKING_DIR")
-		gomega.Expect(workingDir).NotTo(gomega.BeEmpty())
-
+		workingDir = GetAndExpectStringEnvVar("VSPHERE_WORKING_DIR")
 	})
 
 	ginkgo.It("node unregister", func() {
@@ -111,8 +108,7 @@ var _ = utils.SIGDescribe("Node Unregister [Feature:vsphere] [Slow] [Disruptive]
 		// Sanity test that pod provisioning works
 		ginkgo.By("Sanity check for volume lifecycle")
 		scParameters := make(map[string]string)
-		storagePolicy := os.Getenv("VSPHERE_SPBM_GOLD_POLICY")
-		gomega.Expect(storagePolicy).NotTo(gomega.BeEmpty(), "Please set VSPHERE_SPBM_GOLD_POLICY system environment")
+		storagePolicy := GetAndExpectStringEnvVar("VSPHERE_SPBM_GOLD_POLICY")
 		scParameters[SpbmStoragePolicy] = storagePolicy
 		invokeValidPolicyTest(f, client, namespace, scParameters)
 	})

--- a/test/e2e/storage/vsphere/vsphere_volume_ops_storm.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_ops_storm.go
@@ -64,8 +64,8 @@ var _ = utils.SIGDescribe("Volume Operations Storm [Feature:vsphere]", func() {
 		client = f.ClientSet
 		namespace = f.Namespace.Name
 		gomega.Expect(GetReadySchedulableNodeInfos()).NotTo(gomega.BeEmpty())
-		if os.Getenv("VOLUME_OPS_SCALE") != "" {
-			volume_ops_scale, err = strconv.Atoi(os.Getenv("VOLUME_OPS_SCALE"))
+		if scale := os.Getenv("VOLUME_OPS_SCALE"); scale != "" {
+			volume_ops_scale, err = strconv.Atoi(scale)
 			framework.ExpectNoError(err)
 		} else {
 			volume_ops_scale = DEFAULT_VOLUME_OPS_SCALE


### PR DESCRIPTION
This adds a useful error message when VSPHERE_WORKING_DIR is not set,
and replaces some explicit checks with the GetAndExpectStringEnvVar
helper.

**What type of PR is this?**
/kind cleanup
/sig storage
/sig vmware

**What this PR does / why we need it**:
Minor cleanup while trying to get vsphere E2E tests running.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
