### PR TITLE
Automated cherry pick of #79747: use apps/v1 instead apps/v1beta1 since that is deprecated -

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1547,7 +1547,7 @@ metadata:
 		*/
 		framework.ConformanceIt("should create a deployment from an image ", func() {
 			ginkgo.By("running the image " + nginxImage)
-			framework.RunKubectlOrDie("run", dName, "--image="+nginxImage, "--generator=deployment/v1beta1", nsFlag)
+			framework.RunKubectlOrDie("run", dName, "--image="+nginxImage, "--generator=deployment/apps.v1", nsFlag)
 			ginkgo.By("verifying the deployment " + dName + " was created")
 			d, err := c.AppsV1().Deployments(ns).Get(dName, metav1.GetOptions{})
 			if err != nil {


### PR DESCRIPTION
Cherry pick of #79747 on release-1.14.

#79747: use apps/v1 instead apps/v1beta1 since that is deprecated -

Fixes #79533