### PR TITLE
Promote pod autoscaling

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -38,7 +38,7 @@ test/e2e/apps/statefulset.go: "Burst scaling should run to completion even with 
 test/e2e/apps/statefulset.go: "Should recreate evicted statefulset"
 test/e2e/auth/service_accounts.go: "should mount an API token into pods"
 test/e2e/auth/service_accounts.go: "should allow opting out of API token automount"
-test/e2e/autoscaling/horizontal_pod_autoscaling.go: "Should scale from 1 pod to 2 pods"
+test/e2e/autoscaling/horizontal_pod_autoscaling.go: "should scale from 1 pod to 2 pods"
 test/e2e/common/configmap.go: "should be consumable via environment variable"
 test/e2e/common/configmap.go: "should be consumable via the environment"
 test/e2e/common/configmap.go: "should fail to create ConfigMap with empty key"

--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -38,6 +38,7 @@ test/e2e/apps/statefulset.go: "Burst scaling should run to completion even with 
 test/e2e/apps/statefulset.go: "Should recreate evicted statefulset"
 test/e2e/auth/service_accounts.go: "should mount an API token into pods"
 test/e2e/auth/service_accounts.go: "should allow opting out of API token automount"
+test/e2e/autoscaling/horizontal_pod_autoscaling.go: "Should scale from 1 pod to 2 pods"
 test/e2e/common/configmap.go: "should be consumable via environment variable"
 test/e2e/common/configmap.go: "should be consumable via the environment"
 test/e2e/common/configmap.go: "should fail to create ConfigMap with empty key"

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -70,11 +70,9 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", fu
 		/*
 		  Release : v1.16
 		  Testname: Horizontal Pod Autoscaling, CPU Target Utilization Scale
-		  Description: Given 1 Pod with 150mCPU usage
-		  And 200mCPU per Pod request
-		  And targeted CPU uitilzation is 50%
-		  Then the HP Autoscaler will create another pod
-		  And the 150mCPU usage will be spread across both Pods
+		  Description: Given 1 Pod with 150mCPU usage, 200mCPU per Pod request, and
+		  targeted CPU uitilzation of 50% the HP Autoscaler MUST create another pod,
+		  spreading the 150mCPU usage across both Pods.
 		*/
 		framework.ConformanceIt("Should scale from 1 pod to 2 pods", func() {
 			scaleTest := &HPAScaleTest{

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -69,10 +69,10 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", fu
 	SIGDescribe("ReplicationController light", func() {
 		/*
 		  Release : v1.16
-		  Testname: Horizontal Pod Autoscaling, CPU Request Scale
+		  Testname: Horizontal Pod Autoscaling, CPU Target Utilization Scale
 		  Description: Given 1 Pod with 150mCPU usage
 		  And 200mCPU per Pod request
-		  And targed CPU uitilzation is 50%
+		  And targeted CPU uitilzation is 50%
 		  Then the HP Autoscaler will create another pod
 		  And the 150mCPU usage will be spread across both Pods
 		*/

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -69,9 +69,12 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", fu
 	SIGDescribe("ReplicationController light", func() {
 		/*
 		  Release : v1.16
-		  Testname: Up-scale pod replicas and resources
-		  Description: Pod replicas MUST increase from 1 pod to 2 pods.
-		  Pod CPU request will increase to 50%.
+		  Testname: Horizontal Pod Autoscaling, CPU Request Scale
+		  Description: Given 1 Pod with 150mCPU usage
+		  And 200mCPU per Pod request
+		  And targed CPU uitilzation is 50%
+		  Then the HP Autoscaler will create another pod
+		  And the 150mCPU usage will be spread across both Pods
 		*/
 		framework.ConformanceIt("Should scale from 1 pod to 2 pods", func() {
 			scaleTest := &HPAScaleTest{

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -74,7 +74,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", fu
 		  targeted CPU uitilzation of 50% the HP Autoscaler MUST create another pod,
 		  spreading the 150mCPU usage across both Pods.
 		*/
-		framework.ConformanceIt("Should scale from 1 pod to 2 pods", func() {
+		framework.ConformanceIt("should scale from 1 pod to 2 pods", func() {
 			scaleTest := &HPAScaleTest{
 				initPods:                    1,
 				totalInitialCPUUsage:        150,

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -67,7 +67,13 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", fu
 	})
 
 	SIGDescribe("ReplicationController light", func() {
-		ginkgo.It("Should scale from 1 pod to 2 pods", func() {
+		/*
+		  Release : v1.16
+		  Testname: Up-scale pod replicas and resources
+		  Description: Pod replicas MUST increase from 1 pod to 2 pods.
+		  Pod CPU request will increase to 50%.
+		*/
+		framework.ConformanceIt("Should scale from 1 pod to 2 pods", func() {
 			scaleTest := &HPAScaleTest{
 				initPods:                    1,
 				totalInitialCPUUsage:        150,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E tests to Conformance:
test/e2e/autoscaling/horizontal_pod_autoscaling.go: "Should scale from 1 pod to 2 pods"

**Special notes for your reviewer**:
Part of Umbrella Issue #78747
[Test grid results](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=Should%20scale%20from%201%20pod%20to%202%20pods&graph-metrics=test-duration-minutes&width=5).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/area conformance
/area test
@kubernetes/sig-autoscaling-pr-reviews
@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg