### PR TITLE
Fix 'concurrency' logs typo

### DIFF
--- a/pkg/kubectl/cmd/logs/logs.go
+++ b/pkg/kubectl/cmd/logs/logs.go
@@ -107,7 +107,7 @@ type LogsOptions struct {
 	// whether or not a container name was given via --container
 	ContainerNameSpecified bool
 	Selector               string
-	MaxFollowConcurency    int
+	MaxFollowConcurrency   int
 
 	Object           runtime.Object
 	GetPodTimeout    time.Duration
@@ -121,10 +121,10 @@ type LogsOptions struct {
 
 func NewLogsOptions(streams genericclioptions.IOStreams, allContainers bool) *LogsOptions {
 	return &LogsOptions{
-		IOStreams:           streams,
-		AllContainers:       allContainers,
-		Tail:                -1,
-		MaxFollowConcurency: 5,
+		IOStreams:            streams,
+		AllContainers:        allContainers,
+		Tail:                 -1,
+		MaxFollowConcurrency: 5,
 	}
 }
 
@@ -162,7 +162,7 @@ func NewCmdLogs(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 	cmd.Flags().StringVarP(&o.Container, "container", "c", o.Container, "Print the logs of this container")
 	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodLogsTimeout)
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on.")
-	cmd.Flags().IntVar(&o.MaxFollowConcurency, "max-log-requests", o.MaxFollowConcurency, "Specify maximum number of concurrent logs to follow when using by a selector. Defaults to 5.")
+	cmd.Flags().IntVar(&o.MaxFollowConcurrency, "max-log-requests", o.MaxFollowConcurrency, "Specify maximum number of concurrent logs to follow when using by a selector. Defaults to 5.")
 	return cmd
 }
 
@@ -308,10 +308,10 @@ func (o LogsOptions) RunLogs() error {
 	}
 
 	if o.Follow && len(requests) > 1 {
-		if len(requests) > o.MaxFollowConcurency {
+		if len(requests) > o.MaxFollowConcurrency {
 			return fmt.Errorf(
-				"you are attempting to follow %d log streams, but maximum allowed concurency is %d, use --max-log-requests to increase the limit",
-				len(requests), o.MaxFollowConcurency,
+				"you are attempting to follow %d log streams, but maximum allowed concurrency is %d, use --max-log-requests to increase the limit",
+				len(requests), o.MaxFollowConcurrency,
 			)
 		}
 

--- a/pkg/kubectl/cmd/logs/logs_test.go
+++ b/pkg/kubectl/cmd/logs/logs_test.go
@@ -108,7 +108,7 @@ func TestLog(t *testing.T) {
 			},
 		},
 		{
-			name: "fail to follow logs from multiple requests when there are more logs sources then MaxFollowConcurency allows",
+			name: "fail to follow logs from multiple requests when there are more logs sources then MaxFollowConcurrency allows",
 			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
@@ -124,11 +124,11 @@ func TestLog(t *testing.T) {
 				o := NewLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
-				o.MaxFollowConcurency = 2
+				o.MaxFollowConcurrency = 2
 				o.Follow = true
 				return o
 			},
-			expectedErr: "you are attempting to follow 3 log streams, but maximum allowed concurency is 2, use --max-log-requests to increase the limit",
+			expectedErr: "you are attempting to follow 3 log streams, but maximum allowed concurrency is 2, use --max-log-requests to increase the limit",
 		},
 		{
 			name: "fail if LogsForObject fails",


### PR DESCRIPTION
Signed-off-by: John Harris <joharris@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Fix s/concurency/concurrency/g typos in kubectl logs pkg.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
