### PR TITLE
[WIP] Promote ReplicaSets preemption

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -209,6 +209,7 @@ test/e2e/node/events.go: "should be sent by kubelets and the scheduler about pod
 test/e2e/node/pods.go: "should be submitted and removed"
 test/e2e/node/pods.go: "should be set on Pods with matching resource requests and limits for memory and cpu"
 test/e2e/node/pre_stop.go: "should call prestop when killing a pod"
+test/e2e/scheduling/preemption.go: "runs ReplicaSets to verify preemption running path"
 test/e2e/scheduling/predicates.go: "validates resource limits of pods that are allowed to run"
 test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if not matching"
 test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if matching"

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+
 	// ensure libs have a chance to initialize
 	_ "github.com/stretchr/testify/assert"
 )
@@ -460,7 +461,12 @@ var _ = SIGDescribe("PreemptionExecutionPath", func() {
 		}
 	})
 
-	ginkgo.It("runs ReplicaSets to verify preemption running path", func() {
+	/*
+	   Release : v1.16
+	   Testname: Verify preemption of pod ReplicaSets
+	   Description: MUST create pods with ReplicaSets and verify pod's replica count
+	*/
+	framework.ConformanceIt("runs ReplicaSets to verify preemption running path", func() {
 		podNamesSeen := make(map[string]struct{})
 		stopCh := make(chan struct{})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E tests to Conformance:
test/e2e/scheduling/preemption.go: "runs ReplicaSets to verify preemption running path" 

**Special notes for your reviewer**:
Part of Umbrella Issue #78747
[Test grid results](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=runs%20ReplicaSets%20to%20verify%20preemption%20running%20path&width=5).
Endpoint(s):
- [sig-scheduling] PreemptionExecutionPath runs ReplicaSets to verify preemption running path

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/area conformance
/area test
@kubernetes/sig-scheduling-pr-reviews
@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg
/assign @hh 