### PR TITLE
throw an error if extra invalid args are found in the command

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -413,6 +414,8 @@ func HandlePluginCommand(pluginHandler PluginHandler, cmdArgs []string) error {
 
 	if len(foundBinaryPath) == 0 {
 		return nil
+	} else if len(remainingArgs) > 0 {
+		return errors.New("extra invalid args found in the command")
 	}
 
 	// invoke cmd binary relaying the current environment and args given


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind feature

**What this PR does / why we need it**:
`$ kubectl version somerandom arg`
Instead of showing an error/warning for the above command, this works perfectly alright as the present Implementation looks for the longest prefix match. So, we need to throw an error `if len(binaryPath) > 0` and `if len(remainingArgs) > 0`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79688

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
