### PR TITLE
add QPS and Burst limits flags to auth options

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -123,12 +123,6 @@ type DelegatingAuthenticationOptions struct {
 	// TolerateInClusterLookupFailure indicates failures to look up authentication configuration from the cluster configmap should not be fatal.
 	// Setting this can result in an authenticator that will reject all requests.
 	TolerateInClusterLookupFailure bool
-
-	// AuthQPS is the QPS limit to send authentication requests to the core kubernetes server.
-	AuthQPS float32
-
-	// AuthBurst is the Burst limit to send authentication requests to the core kubernetes server.
-	AuthBurst int
 }
 
 func NewDelegatingAuthenticationOptions() *DelegatingAuthenticationOptions {
@@ -141,8 +135,6 @@ func NewDelegatingAuthenticationOptions() *DelegatingAuthenticationOptions {
 			GroupHeaders:        []string{"x-remote-group"},
 			ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 		},
-		AuthQPS:   200,
-		AuthBurst: 400,
 	}
 }
 
@@ -176,12 +168,6 @@ func (s *DelegatingAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.TolerateInClusterLookupFailure, "authentication-tolerate-lookup-failure", s.TolerateInClusterLookupFailure, ""+
 		"If true, failures to look up missing authentication configuration from the cluster are not considered fatal. "+
 		"Note that this can result in authentication that treats all requests as anonymous.")
-
-	fs.Float32Var(&s.AuthQPS, "authentication-request-qps", s.AuthQPS,
-		"QPS limit to send authentication requests to the 'core' kubernetes server.")
-
-	fs.IntVar(&s.AuthBurst, "authentication-request-burst", s.AuthBurst,
-		"Burst limit to send authentication requests to the 'core' kubernetes server.")
 }
 
 func (s *DelegatingAuthenticationOptions) ApplyTo(c *server.AuthenticationInfo, servingInfo *server.SecureServingInfo, openAPIConfig *openapicommon.Config) error {
@@ -408,8 +394,8 @@ func (s *DelegatingAuthenticationOptions) getClient() (kubernetes.Interface, err
 	}
 
 	// set high qps/burst limits since this will effectively limit API server responsiveness
-	clientConfig.QPS = s.AuthQPS
-	clientConfig.Burst = s.AuthBurst
+	clientConfig.QPS = 200
+	clientConfig.Burst = 400
 
 	return kubernetes.NewForConfig(clientConfig)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -123,6 +123,12 @@ type DelegatingAuthenticationOptions struct {
 	// TolerateInClusterLookupFailure indicates failures to look up authentication configuration from the cluster configmap should not be fatal.
 	// Setting this can result in an authenticator that will reject all requests.
 	TolerateInClusterLookupFailure bool
+
+	// AuthQPS is the QPS limit to send authentication requests to the core kubernetes server.
+	AuthQPS float32
+
+	// AuthBurst is the Burst limit to send authentication requests to the core kubernetes server.
+	AuthBurst int
 }
 
 func NewDelegatingAuthenticationOptions() *DelegatingAuthenticationOptions {
@@ -135,6 +141,8 @@ func NewDelegatingAuthenticationOptions() *DelegatingAuthenticationOptions {
 			GroupHeaders:        []string{"x-remote-group"},
 			ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 		},
+		AuthQPS:   200,
+		AuthBurst: 400,
 	}
 }
 
@@ -168,6 +176,12 @@ func (s *DelegatingAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.TolerateInClusterLookupFailure, "authentication-tolerate-lookup-failure", s.TolerateInClusterLookupFailure, ""+
 		"If true, failures to look up missing authentication configuration from the cluster are not considered fatal. "+
 		"Note that this can result in authentication that treats all requests as anonymous.")
+
+	fs.Float32Var(&s.AuthQPS, "authentication-request-qps", s.AuthQPS,
+		"QPS limit to send authentication requests to the 'core' kubernetes server.")
+
+	fs.IntVar(&s.AuthBurst, "authentication-request-burst", s.AuthBurst,
+		"Burst limit to send authentication requests to the 'core' kubernetes server.")
 }
 
 func (s *DelegatingAuthenticationOptions) ApplyTo(c *server.AuthenticationInfo, servingInfo *server.SecureServingInfo, openAPIConfig *openapicommon.Config) error {
@@ -394,8 +408,8 @@ func (s *DelegatingAuthenticationOptions) getClient() (kubernetes.Interface, err
 	}
 
 	// set high qps/burst limits since this will effectively limit API server responsiveness
-	clientConfig.QPS = 200
-	clientConfig.Burst = 400
+	clientConfig.QPS = s.AuthQPS
+	clientConfig.Burst = s.AuthBurst
 
 	return kubernetes.NewForConfig(clientConfig)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -59,12 +59,6 @@ type DelegatingAuthorizationOptions struct {
 
 	// AlwaysAllowGroups are groups which are allowed to take any actions.  In kube, this is system:masters.
 	AlwaysAllowGroups []string
-
-	// AuthQPS is the QPS limit to send authorization requests to the core kubernetes server.
-	AuthQPS float32
-
-	// AuthBurst is the Burst limit to send authorization requests to the core kubernetes server.
-	AuthBurst int
 }
 
 func NewDelegatingAuthorizationOptions() *DelegatingAuthorizationOptions {
@@ -72,8 +66,6 @@ func NewDelegatingAuthorizationOptions() *DelegatingAuthorizationOptions {
 		// very low for responsiveness, but high enough to handle storms
 		AllowCacheTTL: 10 * time.Second,
 		DenyCacheTTL:  10 * time.Second,
-		AuthQPS:       200,
-		AuthBurst:     400,
 	}
 }
 
@@ -118,12 +110,6 @@ func (s *DelegatingAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&s.AlwaysAllowPaths, "authorization-always-allow-paths", s.AlwaysAllowPaths,
 		"A list of HTTP paths to skip during authorization, i.e. these are authorized without "+
 			"contacting the 'core' kubernetes server.")
-
-	fs.Float32Var(&s.AuthQPS, "authorization-request-qps", s.AuthQPS,
-		"QPS limit to send authorization requests to the 'core' kubernetes server.")
-
-	fs.IntVar(&s.AuthBurst, "authorization-request-burst", s.AuthBurst,
-		"Burst limit to send authorization requests to the 'core' kubernetes server.")
 }
 
 func (s *DelegatingAuthorizationOptions) ApplyTo(c *server.AuthorizationInfo) error {
@@ -198,8 +184,8 @@ func (s *DelegatingAuthorizationOptions) getClient() (kubernetes.Interface, erro
 	}
 
 	// set high qps/burst limits since this will effectively limit API server responsiveness
-	clientConfig.QPS = s.AuthQPS
-	clientConfig.Burst = s.AuthBurst
+	clientConfig.QPS = 200
+	clientConfig.Burst = 400
 
 	return kubernetes.NewForConfig(clientConfig)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind feature


**What this PR does / why we need it**:

the QPS and Burst of client config should be added to `DelegatingAuthorizationOptions` and `DelegatingAuthenticationOptions` as flags. The users can configure the values in this high concurrent scenario.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#79939](https://github.com/kubernetes/kubernetes/issues/79939)

**Special notes for your reviewer**:
nothing yet

**Does this PR introduce a user-facing change?**:
NONE

```release-note

```
