### PR TITLE
Add the Sysdig Platform provider to the list of Custom Metrics Providers

### DIFF
--- a/staging/src/k8s.io/metrics/IMPLEMENTATIONS.md
+++ b/staging/src/k8s.io/metrics/IMPLEMENTATIONS.md
@@ -25,6 +25,8 @@ They are listed here for convenience.***
 - [Google Stackdriver (coming
   soon)](https://github.com/GoogleCloudPlatform/k8s-stackdriver)
 
+- [Sysdig Platform Adapter](https://github.com/draios/kubernetes-sysdig-metrics-apiserver). An implementation of the Custom Metrics API using the Official Custom Metrics Adapter Server Framework and Sysdig Monitor.
+
 - [Datadog Cluster Agent](https://github.com/DataDog/datadog-agent/blob/c4f38af1897bac294d8fed6285098b14aafa6178/docs/cluster-agent/CUSTOM_METRICS_SERVER.md).
   Implementation of the external metrics provider, using Datadog as a backend for the metrics.
   Coming soon: Implementation of the custom metrics provider to support in-cluster metrics collected by the Datadog Agents.


### PR DESCRIPTION

**What this PR does / why we need it**:

Hi everyone, I would like to add the Sysdig Platform provider to the list of implementations for the Custom/External Metrics Provider.

We created a blog post about how to build a Kubernetes Horizontal Pod Autoscaler using custom metrics and our provider if you need more information: 
https://sysdig.com/blog/kubernetes-scaler/

**Does this PR introduce a user-facing change?**:
NONE

/kind documentation