### PR TITLE
[kube-proxy/ipvs] Add flag to disable ipvs for external ip

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -186,6 +186,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.config.UDPIdleTimeout.Duration, "udp-timeout", o.config.UDPIdleTimeout.Duration, "How long an idle UDP connection will be kept open (e.g. '250ms', '2s').  Must be greater than 0. Only applicable for proxy-mode=userspace")
 
 	fs.BoolVar(&o.config.IPVS.StrictARP, "ipvs-strict-arp", o.config.IPVS.StrictARP, "Enable strict ARP by setting arp_ignore to 1 and arp_announce to 2")
+	fs.BoolVar(&o.config.IPVS.ExcludeExternalIP, "ipvs-exclude-external-ip", o.config.IPVS.ExcludeExternalIP, "If true disable the ipvs forwarding for both ExternalIPs and LoadBalancerIPs, used in scenarios where it is expected that the traffic from pod to LB should leave the host to reach LB and then route back to a host instead of being forwarded directly to the pod by ipvs.")
 	fs.BoolVar(&o.config.IPTables.MasqueradeAll, "masquerade-all", o.config.IPTables.MasqueradeAll, "If using the pure iptables proxy, SNAT all traffic sent via Service cluster IPs (this not commonly needed)")
 	fs.BoolVar(&o.config.EnableProfiling, "profiling", o.config.EnableProfiling, "If true enables profiling via web interface on /debug/pprof handler.")
 

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -178,6 +178,7 @@ func newProxyServer(
 			config.IPVS.MinSyncPeriod.Duration,
 			config.IPVS.ExcludeCIDRs,
 			config.IPVS.StrictARP,
+			config.IPVS.ExcludeExternalIP,
 			config.IPTables.MasqueradeAll,
 			int(*config.IPTables.MasqueradeBit),
 			config.ClusterCIDR,

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -58,6 +58,8 @@ type KubeProxyIPVSConfiguration struct {
 	// strict ARP configure arp_ignore and arp_announce to avoid answering ARP queries
 	// from kube-ipvs0 interface
 	StrictARP bool
+	// excludeExternalIP disable the ipvs forwarding from pod to both ExternalIPs and LoadBalancerIPs
+	ExcludeExternalIP bool
 }
 
 // KubeProxyConntrackConfiguration contains conntrack settings for

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -223,6 +223,7 @@ func autoConvert_v1alpha1_KubeProxyIPVSConfiguration_To_config_KubeProxyIPVSConf
 	out.Scheduler = in.Scheduler
 	out.ExcludeCIDRs = *(*[]string)(unsafe.Pointer(&in.ExcludeCIDRs))
 	out.StrictARP = in.StrictARP
+	out.ExcludeExternalIP = in.ExcludeExternalIP
 	return nil
 }
 
@@ -237,6 +238,7 @@ func autoConvert_config_KubeProxyIPVSConfiguration_To_v1alpha1_KubeProxyIPVSConf
 	out.Scheduler = in.Scheduler
 	out.ExcludeCIDRs = *(*[]string)(unsafe.Pointer(&in.ExcludeCIDRs))
 	out.StrictARP = in.StrictARP
+	out.ExcludeExternalIP = in.ExcludeExternalIP
 	return nil
 }
 

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -54,6 +54,8 @@ type KubeProxyIPVSConfiguration struct {
 	// strict ARP configure arp_ignore and arp_announce to avoid answering ARP queries
 	// from kube-ipvs0 interface
 	StrictARP bool `json:"strictARP"`
+	// excludeExternalIP disable the ipvs forwarding from pod to both ExternalIPs and LoadBalancerIPs
+	ExcludeExternalIP bool `json:"excludeExternalIP"`
 }
 
 // KubeProxyConntrackConfiguration contains conntrack settings for


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Not exactly a bug but a regression for some users which use LoadBalancer not compatible with [this change](https://github.com/kubernetes/kubernetes/pull/63066). This change bind LB IP to `kube-ipvs0`, so packet from LB to NodePort will never reach the pod, cuz linux will ignore the packets which source ip is a local ip (kernel will treat LB IP as a local ip, cuz it's been bounded to `kube-ipvs0`), and if we enable kernel param `accept_local`, pod can receive packets, but the reply packet will also cannot reach the client, cuz destination ip is LB IP, which is a local ip, so the packet cannot go out, this caused some problems, for instance:
1.  If LoadBalancer SNAT packet to its own IP (`EXTERNAL-IP`), the packet will never reach the pod
2. If LoadBalancer not do SNAT, but it uses its own IP as probe packet and send to NodePort for health check, it will also never reach the pod, so LB will think the NodePort is unhealthy

**Which issue(s) this PR fixes**:

Fixes #79783

**Does this PR introduce a user-facing change?**:

```release-note
[IPVS] Introduces flag ipvs-exclude-external-ip to disable the ipvs forwarding for both ExternalIPs and LoadBalancerIPs, used in scenarios where it is expected that the traffic from pod to LB should leave the host to reach LB and then route back to a host instead of being forwarded directly to the pod by ipvs, defaulting to false to preserve existing behaviors. 
```
