### PR TITLE
Fix iSCSI storage plugin cleanup in block volumes

### DIFF
--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -280,6 +280,7 @@ type iscsiDisk struct {
 	Portals       []string
 	Iqn           string
 	Lun           string
+	InitIface     string
 	Iface         string
 	chapDiscovery bool
 	chapSession   bool
@@ -551,12 +552,18 @@ func createISCSIDisk(spec *volume.Spec, podUID types.UID, plugin *iscsiPlugin, m
 		return nil, err
 	}
 
+	initIface := iface
+	if initiatorName != "" {
+		iface = bkportal[0] + ":" + spec.Name()
+	}
+
 	return &iscsiDisk{
 		podUID:        podUID,
 		VolName:       spec.Name(),
 		Portals:       bkportal,
 		Iqn:           iqn,
 		Lun:           lun,
+		InitIface:     initIface,
 		Iface:         iface,
 		chapDiscovery: chapDiscovery,
 		chapSession:   chapSession,

--- a/pkg/volume/iscsi/iscsi_util_test.go
+++ b/pkg/volume/iscsi/iscsi_util_test.go
@@ -276,11 +276,11 @@ func TestClonedIface(t *testing.T) {
 	plugin := plugins[0]
 	fakeMounter := iscsiDiskMounter{
 		iscsiDisk: &iscsiDisk{
+			Iface:  "192.168.1.10:pv0001",
 			plugin: plugin.(*iscsiPlugin)},
 		exec: fakeExec,
 	}
-	newIface := "192.168.1.10:pv0001"
-	cloneIface(fakeMounter, newIface)
+	cloneIface(fakeMounter)
 	if cmdCount != 4 {
 		t.Errorf("expected 4 CombinedOutput() calls, got %d", cmdCount)
 	}
@@ -305,11 +305,11 @@ func TestClonedIfaceShowError(t *testing.T) {
 	plugin := plugins[0]
 	fakeMounter := iscsiDiskMounter{
 		iscsiDisk: &iscsiDisk{
+			Iface:  "192.168.1.10:pv0001",
 			plugin: plugin.(*iscsiPlugin)},
 		exec: fakeExec,
 	}
-	newIface := "192.168.1.10:pv0001"
-	cloneIface(fakeMounter, newIface)
+	cloneIface(fakeMounter)
 	if cmdCount != 1 {
 		t.Errorf("expected 1 CombinedOutput() calls, got %d", cmdCount)
 	}
@@ -350,11 +350,11 @@ func TestClonedIfaceUpdateError(t *testing.T) {
 	plugin := plugins[0]
 	fakeMounter := iscsiDiskMounter{
 		iscsiDisk: &iscsiDisk{
+			Iface:  "192.168.1.10:pv0001",
 			plugin: plugin.(*iscsiPlugin)},
 		exec: fakeExec,
 	}
-	newIface := "192.168.1.10:pv0001"
-	cloneIface(fakeMounter, newIface)
+	cloneIface(fakeMounter)
 	if cmdCount != 5 {
 		t.Errorf("expected 5 CombinedOutput() calls, got %d", cmdCount)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

During the attach of a block volume, the function [makeVDPDNameInternal](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/iscsi/iscsi_util.go#L195) is called twice in order to return a string like the one below. Note that the iface name is part of the path:

`/var/lib/kubelet/plugins/kubernetes.io/iscsi/volumeDevices/iface_name/portal-some_iqn-lun-lun_id`

On the first call, the iSCSI iface used is typically the default one. Later on, **if there's an initiator set in the PV**, we create [a new iface and overwrite the default one](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/iscsi/iscsi_util.go#L309-L320). Then, the next call to `makeVDPDNameInternal` will return a different path because the iface is different.

This patch sets the correct iface during the iSCSI disk initialization, so we always get the correct path.

**Which issue(s) this PR fixes**:

Fixes #79973

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig storage
/assign @bswartz @jsafrane @j-griffith 
