### PR TITLE
Fix CSI volume reconstruction

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -387,7 +387,7 @@ func (rc *reconciler) syncStates() {
 			if volumeInDSW {
 				// Some pod needs the volume, don't clean it up and hope that
 				// reconcile() calls SetUp and reconstructs the volume in ASW.
-				klog.V(4).Infof("Volume exists in desired state (volume.SpecName %s, pod.UID %s), skip cleaning up mounts", volume.volumeSpecName, volume.podName)
+				klog.V(4).Infof("Could not construct volume information for (volume.SpecName %s, pod.UID %s), skipping cleaning up mounts: %s", volume.volumeSpecName, volume.podName, err)
 				continue
 			}
 			// No pod needs the volume.

--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -507,16 +507,6 @@ func (rc *reconciler) reconstructVolume(volume podVolume) (*reconstructedVolume,
 			newMounterErr)
 	}
 
-	// Check existence of mount point for filesystem volume or symbolic link for block volume
-	isExist, checkErr := rc.operationExecutor.CheckVolumeExistenceOperation(volumeSpec, volumeMounter.GetPath(), volumeSpec.Name(), rc.mounter, uniqueVolumeName, volume.podName, pod.UID, attachablePlugin)
-	if checkErr != nil {
-		return nil, checkErr
-	}
-	// If mount or symlink doesn't exist, volume reconstruction should be failed
-	if !isExist {
-		return nil, fmt.Errorf("Volume: %q is not mounted", uniqueVolumeName)
-	}
-
 	// TODO: remove feature gate check after no longer needed
 	var volumeMapper volumepkg.BlockVolumeMapper
 	if utilfeature.DefaultFeatureGate.Enabled(features.BlockVolume) && volume.volumeMode == v1.PersistentVolumeBlock {


### PR DESCRIPTION
CSI volumes are not mounted into directory `/var/lib/kubelet/pods/<podUID>/volumes/<plugin name>/<volume name>`, they're either not mounted at all or they are mounted in `mount/` subdirectory there.
    
Therefore don't expect that all volumes are mounts and reconstruct the volume only from presence of the <volume name> directory. The reconstructed volume is either added to Actual State of World (=it will be torn down) or it already is in Desired State of World (=it will be set-up to make sure that volume set up is complete).
    
In both cases, SetUp / TearDown of all volume plugins should be idempotent and either VolumeManager fixes any broken mounts / clears unneeded volume or does nothing when the volume is already set up / torn down correctly.

/kind bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79980

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed cleanup of orphaned CSI volumes after kubelet restart.
```

/sig storage
cc @jingxu97 @msau42 @gnufied @vladimirvivien 