### PR TITLE
Code cleanup and condition changes for score calculations in balanced…

### DIFF
--- a/pkg/scheduler/algorithm/priorities/balanced_resource_allocation.go
+++ b/pkg/scheduler/algorithm/priorities/balanced_resource_allocation.go
@@ -41,10 +41,16 @@ var (
 func balancedResourceScorer(requested, allocable *schedulernodeinfo.Resource, includeVolumes bool, requestedVolumes int, allocatableVolumes int) int64 {
 	cpuFraction := fractionOfCapacity(requested.MilliCPU, allocable.MilliCPU)
 	memoryFraction := fractionOfCapacity(requested.Memory, allocable.Memory)
+
+	if cpuFraction >= 1 || memoryFraction >= 1 {
+		// if requested >= capacity, the corresponding host should never be preferred.
+		return 0
+	}
+
 	// This to find a node which has most balanced CPU, memory and volume usage.
 	if includeVolumes && utilfeature.DefaultFeatureGate.Enabled(features.BalanceAttachedNodeVolumes) && allocatableVolumes > 0 {
 		volumeFraction := float64(requestedVolumes) / float64(allocatableVolumes)
-		if cpuFraction >= 1 || memoryFraction >= 1 || volumeFraction >= 1 {
+		if volumeFraction >= 1 {
 			// if requested >= capacity, the corresponding host should never be preferred.
 			return 0
 		}
@@ -57,10 +63,6 @@ func balancedResourceScorer(requested, allocable *schedulernodeinfo.Resource, in
 		return int64((1 - variance) * float64(schedulerapi.MaxPriority))
 	}
 
-	if cpuFraction >= 1 || memoryFraction >= 1 {
-		// if requested >= capacity, the corresponding host should never be preferred.
-		return 0
-	}
 	// Upper and lower boundary of difference between cpuFraction and memoryFraction are -1 and 1
 	// respectively. Multiplying the absolute value of the difference by 10 scales the value to
 	// 0-10 with 0 representing well balanced allocation and 10 poorly balanced. Subtracting it from


### PR DESCRIPTION
…ResourceScorer, pkg/scheduler

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
this PR changes following (code cleanup, code logic change for early termination and score checks.)
1.  Early termination when the cpuFraction and memoryFraction is >=1
2. Removal of redundant check of cpufraction and memoryfraction when the volumeFraction is >=1
3. Removal of redundant check of cpufraction and memoryfraction when volumeFraction is not included in score calculation

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Please check the conditions(volume>=1.0 and cpu>=1.0) for early termination of score, condition for score caluclation when volume is included and the final condition when the volume is not included.

**Does this PR introduce a user-facing change?**:


```release-note

```
