### PR TITLE
Deprecate CSIVolumeSource.FSType

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -1627,6 +1627,9 @@ type CSIVolumeSource struct {
 	// +optional
 	ReadOnly *bool
 
+	// DEPRECATED. Kubernetes cannot translate FSType into something that the driver's
+	// NodePublishVolume understands.
+	//
 	// Filesystem type to mount. Ex. "ext4", "xfs", "ntfs".
 	// If not provided, the empty value is passed to the associated CSI driver
 	// which will determine the default filesystem to apply.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
CSIVolumeSource.FSType is deprecated due to the fact that volume creation is left entirely to the driver.

**Which issue(s) this PR fixes**:
Fixes #79986

```release-note
NONE
```
