### PR TITLE
Revert cancel process node when error occurs

### DIFF
--- a/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/pkg/scheduler/algorithm/predicates/metadata.go
@@ -397,7 +397,6 @@ func getTPMapMatchingExistingAntiAffinity(pod *v1.Pod, nodeInfoMap map[string]*s
 		node := nodeInfo.Node()
 		if node == nil {
 			catchError(fmt.Errorf("node %q not found", allNodeNames[i]))
-			cancel()
 			return
 		}
 		for _, existingPod := range nodeInfo.PodsWithAffinity() {
@@ -466,7 +465,6 @@ func getTPMapMatchingIncomingAffinityAntiAffinity(pod *v1.Pod, nodeInfoMap map[s
 		node := nodeInfo.Node()
 		if node == nil {
 			catchError(fmt.Errorf("node %q not found", allNodeNames[i]))
-			cancel()
 			return
 		}
 		nodeTopologyPairsAffinityPodsMaps := newTopologyPairsMaps()


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This revert of #79774 is due to the comment from @bsalamat :
Node being nil is a recoverable error. We shouldn't cancel processing the rest of the nodes.

Since it is night time for @snowplayfire , I put this PR forward.

```release-note
NONE
```
