### PR TITLE
Populate API version in synthetic authorization requests

### DIFF
--- a/pkg/registry/rbac/escalation_check.go
+++ b/pkg/registry/rbac/escalation_check.go
@@ -80,6 +80,7 @@ func RoleEscalationAuthorized(ctx context.Context, a authorizer.Authorizer) bool
 		User:            user,
 		Verb:            "escalate",
 		APIGroup:        requestInfo.APIGroup,
+		APIVersion:      "*",
 		Resource:        requestInfo.Resource,
 		Name:            requestInfo.Name,
 		Namespace:       requestInfo.Namespace,
@@ -122,10 +123,12 @@ func BindingAuthorized(ctx context.Context, roleRef rbac.RoleRef, bindingNamespa
 	switch roleRef.Kind {
 	case "ClusterRole":
 		attrs.APIGroup = roleRef.APIGroup
+		attrs.APIVersion = "*"
 		attrs.Resource = "clusterroles"
 		attrs.Name = roleRef.Name
 	case "Role":
 		attrs.APIGroup = roleRef.APIGroup
+		attrs.APIVersion = "*"
 		attrs.Resource = "roles"
 		attrs.Name = roleRef.Name
 	default:

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -373,6 +373,7 @@ func buildAttributes(info user.Info, namespace, policyName, apiGroupName string)
 		Namespace:       namespace,
 		Name:            policyName,
 		APIGroup:        apiGroupName,
+		APIVersion:      "*",
 		Resource:        "podsecuritypolicies",
 		ResourceRequest: true,
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
@@ -68,16 +68,18 @@ func WithImpersonation(handler http.Handler, a authorizer.Authorizer, s runtime.
 		groups := []string{}
 		userExtra := map[string][]string{}
 		for _, impersonationRequest := range impersonationRequests {
+			gvk := impersonationRequest.GetObjectKind().GroupVersionKind()
 			actingAsAttributes := &authorizer.AttributesRecord{
 				User:            requestor,
 				Verb:            "impersonate",
-				APIGroup:        impersonationRequest.GetObjectKind().GroupVersionKind().Group,
+				APIGroup:        gvk.Group,
+				APIVersion:      gvk.Version,
 				Namespace:       impersonationRequest.Namespace,
 				Name:            impersonationRequest.Name,
 				ResourceRequest: true,
 			}
 
-			switch impersonationRequest.GetObjectKind().GroupVersionKind().GroupKind() {
+			switch gvk.GroupKind() {
 			case v1.SchemeGroupVersion.WithKind("ServiceAccount").GroupKind():
 				actingAsAttributes.Resource = "serviceaccounts"
 				username = serviceaccount.MakeUsername(impersonationRequest.Namespace, impersonationRequest.Name)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Populates the APIVersion field in synthetic authorization checks. All REST requests populate this, and most synthetic authorization checks already populated this, but a few did not.

None of the in-tree authorizers make use of the version field, but external authorizers could.

**Does this PR introduce a user-facing change?**:
```release-note
SubjectAccessReview requests sent for RBAC escalation, impersonation, and pod security policy authorization checks now populate the version attribute.
```

/sig auth
/cc @enj
/priority backlog