### PR TITLE
Speed up WaitAndVerifyBinds when PVs number exceeds PVCs number

### DIFF
--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -248,7 +248,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 
 			// Create 4 PVs and 2 PVCs.
 			// Note: PVs are created before claims and no pre-binding.
-			ginkgo.It("should create 4 PVs and 2 PVCs: test write access [Slow]", func() {
+			ginkgo.It("should create 4 PVs and 2 PVCs: test write access", func() {
 				numPVs, numPVCs := 4, 2
 				pvols, claims, err = framework.CreatePVsPVCs(numPVs, numPVCs, c, ns, pvConfig, pvcConfig)
 				framework.ExpectNoError(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
When the number of PVs exceeds the number of PVCs, the max binding wait time (3 minutes) will occur for each PV in excess.

Instead of always checking PV phase, we check PVC phase when PV number exceeds PVC number, and check PV phase when PV number does not exceeds PVC number.

```release-note
NONE
```
/kind cleanup
