### PR TITLE
Remove make-symlinks flag and corresponding code

### DIFF
--- a/cmd/hyperkube/main.go
+++ b/cmd/hyperkube/main.go
@@ -20,12 +20,9 @@ limitations under the License.
 package main
 
 import (
-	"errors"
 	goflag "flag"
-	"fmt"
 	"math/rand"
 	"os"
-	"path"
 	"path/filepath"
 	"time"
 
@@ -103,53 +100,21 @@ func NewHyperKubeCommand() (*cobra.Command, []func() *cobra.Command) {
 		cloudController,
 	}
 
-	makeSymlinksFlag := false
 	cmd := &cobra.Command{
 		Use:   "hyperkube",
 		Short: "Request a new project",
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 0 || !makeSymlinksFlag {
+			if len(args) != 0 {
 				cmd.Help()
 				os.Exit(1)
 			}
 
-			if err := makeSymlinks(os.Args[0], commandFns); err != nil {
-				fmt.Fprintf(os.Stderr, "%v\n", err.Error())
-			}
 		},
 	}
-	cmd.Flags().BoolVar(&makeSymlinksFlag, "make-symlinks", makeSymlinksFlag, "create a symlink for each server in current directory")
-	cmd.Flags().MarkHidden("make-symlinks") // hide this flag from appearing in servers' usage output
-	cmd.Flags().MarkDeprecated("make-symlinks", "This feature will be removed in a later release.")
 
 	for i := range commandFns {
 		cmd.AddCommand(commandFns[i]())
 	}
 
 	return cmd, commandFns
-}
-
-// makeSymlinks will create a symlink for each command in the local directory.
-func makeSymlinks(targetName string, commandFns []func() *cobra.Command) error {
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	var errs bool
-	for _, commandFn := range commandFns {
-		command := commandFn()
-		link := path.Join(wd, command.Name())
-
-		err := os.Symlink(targetName, link)
-		if err != nil {
-			errs = true
-			fmt.Println(err)
-		}
-	}
-
-	if errs {
-		return errors.New("Error creating one or more symlinks")
-	}
-	return nil
 }


### PR DESCRIPTION
Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
`make-symlinks` flag in HyperKube has been deprecated for a while, this PR removes the flag completely along with the corresponding code.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #75491 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
hyperkube: the `--make-symlinks` flag, deprecated in v1.14, has been removed.
```
@dims 