### PR TITLE
Add GetKubernetesHandler for FrameworkHandle

### DIFF
--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -259,7 +259,9 @@ func NewConfigFactory(args *ConfigFactoryArgs) Configurator {
 	}
 	schedulerCache := internalcache.New(30*time.Second, stopEverything)
 
-	framework, err := framework.NewFramework(args.Registry, args.Plugins, args.PluginConfig)
+	kubernetesHandler := getKubernetesHandler(args)
+	framework, err := framework.NewFramework(args.Registry, args.Plugins, args.PluginConfig,
+		framework.WithKubernetesHandler(kubernetesHandler))
 	if err != nil {
 		klog.Fatalf("error initializing the scheduling framework: %v", err)
 	}
@@ -580,6 +582,23 @@ func (c *configFactory) getPluginArgs() (*PluginFactoryArgs, error) {
 		VolumeBinder:                   c.volumeBinder,
 		HardPodAffinitySymmetricWeight: c.hardPodAffinitySymmetricWeight,
 	}, nil
+}
+
+func getKubernetesHandler(args *ConfigFactoryArgs) *framework.KubernetesHandler {
+	return &framework.KubernetesHandler{
+		Client:                        args.Client,
+		PodInformer:                   args.PodInformer,
+		NodeInformer:                  args.NodeInformer,
+		PvInformer:                    args.PvInformer,
+		PvcInformer:                   args.PvcInformer,
+		ServiceInformer:               args.ServiceInformer,
+		ReplicationControllerInformer: args.ReplicationControllerInformer,
+		ReplicaSetInformer:            args.ReplicaSetInformer,
+		StatefulSetInformer:           args.StatefulSetInformer,
+		PdbInformer:                   args.PdbInformer,
+		StorageClassInformer:          args.StorageClassInformer,
+		CSINodeInformer:               args.CSINodeInformer,
+	}
 }
 
 // assignedPodLister filters the pods returned from a PodLister to

--- a/pkg/scheduler/framework/v1alpha1/BUILD
+++ b/pkg/scheduler/framework/v1alpha1/BUILD
@@ -17,6 +17,12 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/client-go/informers/apps/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/informers/policy/v1beta1:go_default_library",
+        "//staging/src/k8s.io/client-go/informers/storage/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/informers/storage/v1beta1:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -24,6 +24,12 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	appsinformers "k8s.io/client-go/informers/apps/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	policyinformers "k8s.io/client-go/informers/policy/v1beta1"
+	storageinformersv1 "k8s.io/client-go/informers/storage/v1"
+	storageinformersv1beta1 "k8s.io/client-go/informers/storage/v1beta1"
+	clientset "k8s.io/client-go/kubernetes"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
 
@@ -233,6 +239,34 @@ type Framework interface {
 	RunPermitPlugins(pc *PluginContext, pod *v1.Pod, nodeName string) *Status
 }
 
+// KubernetesHandler contains a kubernetes client and a set of resource informers.
+type KubernetesHandler struct {
+	// Client is a kubernetes client set
+	Client clientset.Interface
+	// NodeInformer is a node informer
+	NodeInformer coreinformers.NodeInformer
+	// PodInformer is a pod informer
+	PodInformer coreinformers.PodInformer
+	// PvInformer is a pv informer
+	PvInformer coreinformers.PersistentVolumeInformer
+	// PvcInformer is a pvc informer
+	PvcInformer coreinformers.PersistentVolumeClaimInformer
+	// ReplicationControllerInformer is a ReplicationController informer
+	ReplicationControllerInformer coreinformers.ReplicationControllerInformer
+	// ReplicaSetInformer is a ReplicaSet informer
+	ReplicaSetInformer appsinformers.ReplicaSetInformer
+	// StatefulSetInformer is a StatefulSet informer
+	StatefulSetInformer appsinformers.StatefulSetInformer
+	// ServiceInformer is a service informer
+	ServiceInformer coreinformers.ServiceInformer
+	// PdbInformer is a pdb informer
+	PdbInformer policyinformers.PodDisruptionBudgetInformer
+	// StorageClassInformer is a StorageClass informer
+	StorageClassInformer storageinformersv1.StorageClassInformer
+	// CSINodeInformer is a CSINode informer
+	CSINodeInformer storageinformersv1beta1.CSINodeInformer
+}
+
 // FrameworkHandle provides data and some tools that plugins can use. It is
 // passed to the plugin factories at the time of plugin initialization. Plugins
 // must store and use this handle to call framework functions.
@@ -248,4 +282,7 @@ type FrameworkHandle interface {
 
 	// GetWaitingPod returns a waiting pod given its UID.
 	GetWaitingPod(uid types.UID) WaitingPod
+
+	// GetKubernetesHandler returns a KubernetesHandler
+	GetKubernetesHandler() *KubernetesHandler
 }

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -193,6 +193,10 @@ func (*fakeFramework) GetWaitingPod(uid types.UID) framework.WaitingPod {
 	return nil
 }
 
+func (f *fakeFramework) GetKubernetesHandler() *framework.KubernetesHandler {
+	return nil
+}
+
 func TestPriorityQueue_AddWithReversePriorityLessFunc(t *testing.T) {
 	q := NewPriorityQueue(nil, &fakeFramework{})
 	if err := q.Add(&medPriorityPod); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

Add `GetKubernetesHandler` for `FrameworkHandle` to get kubernetes client and a set of informers.

At first glance, [PluginFactoryArgs](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/factory/plugins.go#L37) is appropriate for getting kubernetes resource list. However there is some cons:

* It does not contains kubenetes client that is useful.
* It is a little confusing used for this new scheduler framework(e.g. the name `PluginFactoryArgs` is confusing), it has some useless filed(e.g. `HardPodAffinitySymmetricWeight`)

So I add a new struct `KubernetesHandler`. It contains a client set and a set of resource informers that plugins could use directly. These informers are same as scheduler's informers. Plugins could use them to add event handler or get resource lister.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79972 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add `GetKubernetesHandler` for `FrameworkHandle` to get kubernetes client and a set of informers.
```
