### PR TITLE
feat: use nodeInfo.Pods to get pods in predicates

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -1346,14 +1346,9 @@ func (c *PodAffinityChecker) satisfiesExistingPodsAntiAffinity(pod *v1.Pod, meta
 	if predicateMeta, ok := meta.(*predicateMetadata); ok {
 		topologyMaps = predicateMeta.topologyPairsAntiAffinityPodsMap
 	} else {
-		// Filter out pods whose nodeName is equal to nodeInfo.node.Name, but are not
-		// present in nodeInfo. Pods on other nodes pass the filter.
-		filteredPods, err := c.podLister.FilteredList(nodeInfo.Filter, labels.Everything())
-		if err != nil {
-			errMessage := fmt.Sprintf("Failed to get all pods: %v", err)
-			klog.Error(errMessage)
-			return ErrExistingPodsAntiAffinityRulesNotMatch, errors.New(errMessage)
-		}
+		filteredPods := nodeInfo.Pods()
+
+		var err error
 		if topologyMaps, err = c.getMatchingAntiAffinityTopologyPairsOfPods(pod, filteredPods); err != nil {
 			errMessage := fmt.Sprintf("Failed to get all terms that match pod %s: %v", podName(pod), err)
 			klog.Error(errMessage)


### PR DESCRIPTION
/kind cleanup
/assign @bsalamat @Huang-Wei 
/sig scheduling

**What this PR does / why we need it**:

Use the function nodeInfo.Pods() to get the pods' info.

**Which issue(s) this PR fixes**:

Fixes #79930

**Special notes for your reviewer**:

I'm not sure whether it is legit to use `nodeInfo.Pods`, I dug around and found the comments here:

```go
// Pods return all pods scheduled (including assumed to be) on this node.
func (n *NodeInfo) Pods() []*v1.Pod {
	if n == nil {
		return nil
	}
	return n.pods
}
```

And it seems like we could call `nodeInfo.Pods` directly to get all pods scheduled or assumed to be scheduled on this node. Given that, we could use `nodeInfo.Pods` instead of calling `FilteredList` which costs a lot of time.

```go
func (cache *schedulerCache) FilteredList(podFilter algorithm.PodFilter, selector labels.Selector) ([]*v1.Pod, error) {
	cache.mu.RLock()
	defer cache.mu.RUnlock()
	// podFilter is expected to return true for most or all of the pods. We
	// can avoid expensive array growth without wasting too much memory by
	// pre-allocating capacity.
	maxSize := 0
	for _, n := range cache.nodes {
		maxSize += len(n.info.Pods())
	}
	pods := make([]*v1.Pod, 0, maxSize)
	for _, n := range cache.nodes {
		for _, pod := range n.info.Pods() {
			if podFilter(pod) && selector.Matches(labels.Set(pod.Labels)) {
				pods = append(pods, pod)
			}
		}
	}
	return pods, nil
}
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```