### PR TITLE
fix IsMasterNode func

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -713,7 +713,7 @@ func (nc *Controller) monitorNodeHealth() error {
 		}
 
 		// We do not treat a master node as a part of the cluster for network disruption checking.
-		if !system.IsMasterNode(node.Name) {
+		if !system.IsMasterNode(node) {
 			zoneToNodeConditions[utilnode.GetZoneKey(node)] = append(zoneToNodeConditions[utilnode.GetZoneKey(node)], currentReadyCondition)
 		}
 

--- a/pkg/util/system/system_utils.go
+++ b/pkg/util/system/system_utils.go
@@ -17,21 +17,16 @@ limitations under the License.
 package system
 
 import (
-	"strings"
+	"k8s.io/api/core/v1"
 )
 
+const LabelNodeRoleMaster = "node-role.kubernetes.io/master"
+
 // IsMasterNode returns true if given node is a registered master.
-// TODO: find a better way of figuring out if given node is a registered master.
-func IsMasterNode(nodeName string) bool {
-	// We are trying to capture "master(-...)?$" regexp.
-	// However, using regexp.MatchString() results even in more than 35%
-	// of all space allocations in ControllerManager spent in this function.
-	// That's why we are trying to be a bit smarter.
-	if strings.HasSuffix(nodeName, "master") {
+// use node-role.kubernetes.io/master label to figure out if given node is a registered master.
+func IsMasterNode(node *v1.Node) bool {
+	if _, ok := node.Labels[LabelNodeRoleMaster]; ok {
 		return true
-	}
-	if len(nodeName) >= 10 {
-		return strings.HasSuffix(nodeName[:len(nodeName)-3], "master-")
 	}
 	return false
 }

--- a/pkg/util/system/system_utils_test.go
+++ b/pkg/util/system/system_utils_test.go
@@ -24,24 +24,22 @@ import (
 )
 
 func TestIsMasterNode(t *testing.T) {
+	label1 := map[string]string{"foo": "bar"}
+	label2 := map[string]string{"foo": "bar", LabelNodeRoleMaster: ""}
+	label3 := map[string]string{"foo": "bar", "node-role.kubernetes.io/node": ""}
 	testCases := []struct {
-		input  string
+		node   *v1.Node
 		result bool
 	}{
-		{"foo-master", true},
-		{"foo-master-", false},
-		{"foo-master-a", false},
-		{"foo-master-ab", false},
-		{"foo-master-abc", true},
-		{"foo-master-abdc", false},
-		{"foo-bar", false},
+		{&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: label1}}, false},
+		{&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: label2}}, true},
+		{&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: label3}}, false},
 	}
 
 	for _, tc := range testCases {
-		node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: tc.input}}
-		res := IsMasterNode(node.Name)
+		res := IsMasterNode(tc.node)
 		if res != tc.result {
-			t.Errorf("case \"%s\": expected %t, got %t", tc.input, tc.result, res)
+			t.Errorf("case \"%s\": expected %t, got %t", tc.node.Name, tc.result, res)
 		}
 	}
 }

--- a/test/e2e/framework/metrics/metrics_grabber.go
+++ b/test/e2e/framework/metrics/metrics_grabber.go
@@ -63,7 +63,7 @@ func NewMetricsGrabber(c clientset.Interface, ec clientset.Interface, kubelets b
 		klog.Warning("Can't find any Nodes in the API server to grab metrics from")
 	}
 	for _, node := range nodeList.Items {
-		if system.IsMasterNode(node.Name) {
+		if system.IsMasterNode(&node) {
 			registeredMaster = true
 			masterName = node.Name
 			break

--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -629,7 +629,7 @@ func sendRestRequestToScheduler(c clientset.Interface, op string) (string, error
 
 	var masterRegistered = false
 	for _, node := range nodes.Items {
-		if system.IsMasterNode(node.Name) {
+		if system.IsMasterNode(&node) {
 			masterRegistered = true
 		}
 	}

--- a/test/e2e/framework/node/wait.go
+++ b/test/e2e/framework/node/wait.go
@@ -83,7 +83,7 @@ func WaitForTotalHealthy(c clientset.Interface, timeout time.Duration) error {
 		}
 		missingPodsPerNode = make(map[string][]string)
 		for _, node := range nodes.Items {
-			if !system.IsMasterNode(node.Name) {
+			if !system.IsMasterNode(&node) {
 				for _, requiredPod := range requiredPerNodePods {
 					foundRequired := false
 					for _, presentPod := range systemPodsPerNode[node.Name] {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3048,7 +3048,7 @@ func GetMasterAndWorkerNodesOrDie(c clientset.Interface) (sets.String, *v1.NodeL
 	all, err := c.CoreV1().Nodes().List(metav1.ListOptions{})
 	ExpectNoError(err)
 	for _, n := range all.Items {
-		if system.IsMasterNode(n.Name) {
+		if system.IsMasterNode(&n) {
 			masters.Insert(n.Name)
 		} else if isNodeSchedulable(&n) && isNodeUntainted(&n) {
 			nodes.Items = append(nodes.Items, n)


### PR DESCRIPTION
**What type of PR is this?**
>
> /kind bug

**What this PR does / why we need it**:
Current IsMasterNode check nodeName's length and whether match "master". It is not a good way. This PR use "node-role.kubernetes.io/master" label to figure out if given node is a registered master.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
