### PR TITLE
kubeadm should always fall back to client version when there is any internet issue

### DIFF
--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -96,10 +96,6 @@ func kubernetesReleaseVersion(version string, fetcher func(string, time.Duration
 		url := fmt.Sprintf("%s/%s.txt", bucketURL, versionLabel)
 		body, err := fetcher(url, getReleaseVersionTimeout)
 		if err != nil {
-			// If the network operaton was successful but the server did not reply with StatusOK
-			if body != "" {
-				return "", err
-			}
 			if clientVersionErr == nil {
 				// Handle air-gapped environments by falling back to the client version.
 				klog.Warningf("could not fetch a Kubernetes version from the internet: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #79997 
Fixes https://github.com/kubernetes/kubeadm/issues/1662

**Special notes for your reviewer**:
Please help to check if more test case needed. 
I think it's enough to check the return value of the function `fetcher`.

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: fall back to client version in case of certain HTTP errors
```
