### PR TITLE
kubeadm: support fetching configuration from the original cluster for 'upgrade diff'

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -26,12 +26,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 )
 
 type diffFlags struct {
@@ -40,6 +43,7 @@ type diffFlags struct {
 	schedulerManifestPath         string
 	newK8sVersionStr              string
 	contextLines                  int
+	kubeConfigPath                string
 	cfgPath                       string
 	out                           io.Writer
 }
@@ -53,7 +57,8 @@ var (
 // NewCmdDiff returns the cobra command for `kubeadm upgrade diff`
 func NewCmdDiff(out io.Writer) *cobra.Command {
 	flags := &diffFlags{
-		out: out,
+		kubeConfigPath: kubeadmconstants.GetAdminKubeConfigPath(),
+		out:            out,
 	}
 
 	cmd := &cobra.Command{
@@ -65,6 +70,7 @@ func NewCmdDiff(out io.Writer) *cobra.Command {
 		},
 	}
 
+	options.AddKubeConfigFlag(cmd.Flags(), &flags.kubeConfigPath)
 	options.AddConfigFlag(cmd.Flags(), &flags.cfgPath)
 	cmd.Flags().StringVar(&flags.apiServerManifestPath, "api-server-manifest", defaultAPIServerManifestPath, "path to API server manifest")
 	cmd.Flags().StringVar(&flags.controllerManagerManifestPath, "controller-manager-manifest", defaultControllerManagerManifestPath, "path to controller manifest")
@@ -75,13 +81,22 @@ func NewCmdDiff(out io.Writer) *cobra.Command {
 }
 
 func runDiff(flags *diffFlags, args []string) error {
-
-	// If the version is specified in config file, pick up that value.
-	cfg, err := configutil.LoadInitConfigurationFromFile(flags.cfgPath)
+	var err error
+	var cfg *kubeadmapi.InitConfiguration
+	if flags.cfgPath != "" {
+		cfg, err = configutil.LoadInitConfigurationFromFile(flags.cfgPath)
+	} else {
+		client, err := kubeconfigutil.ClientSetFromFile(flags.kubeConfigPath)
+		if err != nil {
+			return errors.Wrapf(err, "couldn't create a Kubernetes client from file %q", flags.kubeConfigPath)
+		}
+		cfg, err = configutil.FetchInitConfigurationFromCluster(client, flags.out, "upgrade/diff", false)
+	}
 	if err != nil {
 		return err
 	}
 
+	// If the version is specified in config file, pick up that value.
 	if cfg.KubernetesVersion != "" {
 		flags.newK8sVersionStr = cfg.KubernetesVersion
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/diff_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff_test.go
@@ -32,6 +32,7 @@ func TestRunDiff(t *testing.T) {
 		out:     ioutil.Discard,
 	}
 
+	// TODO: Add test cases for empty cfgPath, it should automatically fetch cfg from cluster
 	testCases := []struct {
 		name            string
 		args            []string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind cleanup
/kind feature

**What this PR does / why we need it**:
kubeadm: support fetching configuration from the original cluster for 'upgrade diff'

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: support fetching configuration from the original cluster for 'upgrade diff'
```
