### PR TITLE
Add support for HA kubemark

### DIFF
--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -35,11 +35,15 @@ function create-kubemark-master {
   # We intentionally override env vars in subshell to preserve original values.
   # shellcheck disable=SC2030,SC2031
   (
+    # All calls to e2e-grow-cluster must share temp dir with initial e2e-up.sh.
+    kube::util::ensure-temp-dir
+    export KUBE_TEMP="${KUBE_TEMP}"
+
     export KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark"
     export CLUSTER_NAME="${CLUSTER_NAME}-kubemark"
     export KUBE_CREATE_NODES=false
     export KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-kubemark"
-    
+
     # Even if the "real cluster" is private, we shouldn't manage cloud nat.
     export KUBE_GCE_PRIVATE_CLUSTER=false
 
@@ -47,7 +51,7 @@ function create-kubemark-master {
     # cloud routes and RangeAllocator to assign cidrs by kube-controller-manager.
     export KUBE_GCE_ENABLE_IP_ALIASES=true
     export KUBE_GCE_NODE_IPAM_MODE=RangeAllocator
-    
+
     # Disable all addons. They are running outside of the kubemark cluster.
     export KUBE_ENABLE_CLUSTER_AUTOSCALER=false
     export KUBE_ENABLE_CLUSTER_DNS=false
@@ -56,12 +60,12 @@ function create-kubemark-master {
     export KUBE_ENABLE_CLUSTER_MONITORING="none"
     export KUBE_ENABLE_L7_LOADBALANCING="none"
 
-    # Unset env variables set by kubetest for 'root cluster'. We need recompute them 
+    # Unset env variables set by kubetest for 'root cluster'. We need recompute them
     # for kubemark master.
     # TODO(mborsz): Figure out some better way to filter out such env variables than
     # listing them here.
     unset MASTER_SIZE MASTER_DISK_SIZE MASTER_ROOT_DISK_SIZE
-    
+
     # Set kubemark-specific overrides:
     # for each defined env KUBEMARK_X=Y call export X=Y.
     for var in ${!KUBEMARK_*}; do
@@ -70,21 +74,36 @@ function create-kubemark-master {
       echo "Setting ${dst_var} to '${val}'"
       export "${dst_var}"="${val}"
     done
-    
+
     "${KUBE_ROOT}/hack/e2e-internal/e2e-up.sh"
+
+    if [[ "${KUBEMARK_HA_MASTER:-}" == "true" && -n "${KUBEMARK_MASTER_ADDITIONAL_ZONES:-}" ]]; then
+        for KUBE_GCE_ZONE in ${KUBEMARK_MASTER_ADDITIONAL_ZONES}; do
+          KUBE_GCE_ZONE="${KUBE_GCE_ZONE}" KUBE_REPLICATE_EXISTING_MASTER=true \
+            "${KUBE_ROOT}/hack/e2e-internal/e2e-grow-cluster.sh"
+        done
+    fi
     )
 }
 
 function delete-kubemark-master {
   # We intentionally override env vars in subshell to preserve original values.
   # shellcheck disable=SC2030,SC2031
-  ( 
+  (
     export CLUSTER_NAME="${CLUSTER_NAME}-kubemark"
     export KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-kubemark"
 
     export KUBE_DELETE_NETWORK=false
     # Even if the "real cluster" is private, we shouldn't manage cloud nat.
     export KUBE_GCE_PRIVATE_CLUSTER=false
+
+    if [[ "${KUBEMARK_HA_MASTER:-}" == "true" && -n "${KUBEMARK_MASTER_ADDITIONAL_ZONES:-}" ]]; then
+      for KUBE_GCE_ZONE in ${KUBEMARK_MASTER_ADDITIONAL_ZONES}; do
+        KUBE_GCE_ZONE="${KUBE_GCE_ZONE}" KUBE_REPLICATE_EXISTING_MASTER=true \
+          "${KUBE_ROOT}/hack/e2e-internal/e2e-shrink-cluster.sh"
+      done
+    fi
+
     "${KUBE_ROOT}/hack/e2e-internal/e2e-down.sh"
   )
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds a way to start GCE kubemark with multiple masters. To use set few env variables:

```bash
export KUBE_GCE_ZONE=us-central1-a
export KUBEMARK_HA_MASTER=true
export KUBEMARK_MASTER_ADDITIONAL_ZONES="us-central1-b us-central1-c"
```

This will create 3-master kubemark with masters in us-central1-a, us-central1-b and us-central1-c.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @wojtek-t 
