### PR TITLE
mark dashboard tests [Feature:Dashboard]

### DIFF
--- a/test/e2e/ui/dashboard.go
+++ b/test/e2e/ui/dashboard.go
@@ -32,7 +32,7 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
-var _ = SIGDescribe("Kubernetes Dashboard", func() {
+var _ = SIGDescribe("Kubernetes Dashboard [Feature:Dashboard]", func() {
 	ginkgo.BeforeEach(func() {
 		// TODO(kubernetes/kubernetes#61559): Enable dashboard here rather than skip the test.
 		framework.SkipIfProviderIs("gke")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Marks the dashboard e2e tests as `[Feature:Dashboard]` so they are skipped by `[Feature:.*]` skip regex or can be specifically skipped. The dashboard is not installed by default in EG kubeadm clusters and is a feature similar to `[Feature:PrometheusMonitoring]` or `[Feature:StackdriverLogging]`.

I thought we'd done this already, but apparently the PR never happened. I've spoken to the SIG about this in the past.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**: This will prevent obvious failures in new CI bringup, many possible deployment tools don't deploy this by default. IMHO for most of them we should just not run this test, as it is from a time when we expected all clusters to deploy this.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig ui
cc @jeefy