### PR TITLE
Avoid truncating long messages in docker test logs

### DIFF
--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -204,7 +204,7 @@ function save-logs() {
 function export-windows-docker-event-log() {
     local -r node="${1}"
 
-    local -r powershell_cmd="powershell.exe -Command \"\$logs=\$(Get-EventLog -LogName Application -Source Docker | Select-Object -Property TimeGenerated, EntryType, Message); \$logs | Out-File -FilePath '${WINDOWS_LOGS_DIR}\\docker.log'\""
+    local -r powershell_cmd="powershell.exe -Command \"\$logs=\$(Get-EventLog -LogName Application -Source Docker | Format-Table -Property TimeGenerated, EntryType, Message -Wrap); \$logs | Out-File -FilePath '${WINDOWS_LOGS_DIR}\\docker.log'\""
 
     # Retry up to 3 times to allow ssh keys to be properly propagated and
     # stored.


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:
Long log messages are truncated with `Select-Object` in #79949 , changed to use `Format-Table -Wrap` to avoid truncating them. 