### PR TITLE
[kubeadm] Adds json struct tags to exposed API types

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/bootstraptokenstring.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/bootstraptokenstring.go
@@ -31,8 +31,8 @@ import (
 // of view and as an authentication method for the node in the bootstrap phase of
 // "kubeadm join". This token is and should be short-lived
 type BootstrapTokenString struct {
-	ID     string
-	Secret string
+	ID     string `json:"-"`
+	Secret string `json:"-"`
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/bootstraptokenstring.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/bootstraptokenstring.go
@@ -31,8 +31,8 @@ import (
 // of view and as an authentication method for the node in the bootstrap phase of
 // "kubeadm join". This token is and should be short-lived
 type BootstrapTokenString struct {
-	ID     string
-	Secret string
+	ID     string `json:"-"`
+	Secret string `json:"-"`
 }
 
 // MarshalJSON implements the json.Marshaler interface.


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds json tags to all exposed kubeadm api types

**Which issue(s) this PR fixes**:
Fixes kubernetes/kubeadm#1663

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```