### PR TITLE
tests: Fixes jessie-dnsutils image build

### DIFF
--- a/test/images/jessie-dnsutils/fixup-apt-list.sh
+++ b/test/images/jessie-dnsutils/fixup-apt-list.sh
@@ -22,8 +22,11 @@ DEB_ARCH=$(dpkg --print-architecture)
 
 case ${DEB_ARCH} in
     s390x|arm64|ppc64el)
-        sed -i '/debian-security/d' /etc/apt/sources.list
-        ;;
+        # we have to use the archive mirrors.
+        # See: https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
+        echo "deb http://archive.debian.org/debian/ jessie main contrib non-free" | tee /etc/apt/sources.list
+        echo "deb-src http://archive.debian.org/debian/ jessie main contrib non-free" | tee -a /etc/apt/sources.list
+       ;;
 esac
 
 exit 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

/sig testing
/area conformance

/priority important-soon

**What this PR does / why we need it**:

Currently, the jessie-dnsutils image cannot be built for arm64, ppc64le, s390x, as its mirrors has been moved to the archive.

This PR will replace its regular mirrors with the archive ones.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #80052

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
