### PR TITLE
cluster: configure: load images and add tags with no arch

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -381,6 +381,15 @@ function load-docker-images {
   else
     try-load-docker-image "${img_dir}/kube-proxy.tar"
   fi
+  # When we load from a docker archive, the image is tagged with the arch, we don't have docker manifests here.
+  # The resource manifest is expecting something like 'registry/kube-controller-manager:v1.2.3', no arch specified.
+  local -r images=$(docker images --format "{{.Repository}}:{{.Tag}}" | egrep 'kube-apiserver|kube-controller-manager|kube-scheduler|kube-proxy' | grep amd64)
+  for image in $images ; do
+    local -r manifest_name="${image/-amd64/}"
+    if ! docker images --format "{{.Repository}}:{{.Tag}}" | grep -q ${manifest_name} ; then
+      docker tag $image $manifest_name
+    fi
+  done
 }
 
 # Downloads kubernetes binaries and kube-system manifest tarball, unpacks them,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In GCE, when loading docker images from tar files, docker images should not include the 'amd64' suffix in the name.
The resource manifest (like kube-controller-manager.manifest) is expecting an image called like "registry/kube-controller-manager:v1.2.3", which is provided by the docker manifest, but GCI is not using.

**Special notes for your reviewer**:
Due to this change https://github.com/kubernetes/kubernetes/pull/80047, archive images will be named with the arch 'amd64'.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
