### PR TITLE
Automated cherry pick of #78874: Fix the creation of load balancer policy for the NodeIp when

### DIFF
--- a/pkg/proxy/winkernel/hnsV1.go
+++ b/pkg/proxy/winkernel/hnsV1.go
@@ -172,6 +172,8 @@ func (hns hnsV1) getLoadBalancer(endpoints []endpointsInfo, flags loadBalancerFl
 				if len(elbPolicy.VIPs) == 0 || elbPolicy.VIPs[0] != vip {
 					continue
 				}
+			} else if len(elbPolicy.VIPs) != 0 {
+				continue
 			}
 			LogJson(plist, "Found existing Hns loadbalancer policy resource", 1)
 			return &loadBalancerInfo{

--- a/pkg/proxy/winkernel/hnsV2.go
+++ b/pkg/proxy/winkernel/hnsV2.go
@@ -186,6 +186,8 @@ func (hns hnsV2) getLoadBalancer(endpoints []endpointsInfo, flags loadBalancerFl
 				if len(plist.FrontendVIPs) == 0 || plist.FrontendVIPs[0] != vip {
 					continue
 				}
+			} else if len(plist.FrontendVIPs) != 0 {
+				continue
 			}
 			LogJson(plist, "Found existing Hns loadbalancer policy resource", 1)
 			return &loadBalancerInfo{


### PR DESCRIPTION
Cherry pick of #78874 on release-1.15.

#78874: Fix the creation of load balancer policy for the NodeIp when

```release-note
NONE
```