### PR TITLE
bandwidth: handle new 'chain X' output from 'tc filter show dev XYZ'

### DIFF
--- a/pkg/util/bandwidth/linux.go
+++ b/pkg/util/bandwidth/linux.go
@@ -153,13 +153,20 @@ func (t *tcShaper) findCIDRClass(cidr string) (classAndHandleList [][]string, fo
 			continue
 		}
 		if strings.Contains(line, spec) {
+			var resultTmp []string
+
 			parts := strings.Split(filter, " ")
-			// expected tc line:
-			// filter parent 1: protocol ip pref 1 u32 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:1
-			if len(parts) != 19 {
+			if len(parts) == 19 {
+				// expected tc line:
+				// filter parent 1: protocol ip pref 1 u32 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:1
+				resultTmp = []string{parts[18], parts[9]}
+			} else if len(parts) == 21 {
+				// expected tc line:
+				// filter parent 1: protocol ip pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:1
+				resultTmp = []string{parts[20], parts[11]}
+			} else {
 				return classAndHandleList, false, fmt.Errorf("unexpected output from tc: %s %d (%v)", filter, len(parts), parts)
 			}
-			resultTmp := []string{parts[18], parts[9]}
 			classAndHandleList = append(classAndHandleList, resultTmp)
 		}
 	}

--- a/pkg/util/bandwidth/linux_test.go
+++ b/pkg/util/bandwidth/linux_test.go
@@ -213,6 +213,14 @@ filter parent 1: protocol ip pref 1 u32 fh 800::801 order 2049 key ht 800 bkt 0 
   match 01020000/ffff0000 at 16
 `
 
+var tcFilterOutputNew = `filter parent 1: protocol ip pref 1 u32
+filter parent 1: protocol ip pref 1 u32 chain 0 fh 800: ht divisor 1
+filter parent 1: protocol ip pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:1
+  match ac110002/ffffffff at 16
+filter parent 1: protocol ip pref 1 u32 chain 0 fh 800::801 order 2049 key ht 800 bkt 0 flowid 1:2
+  match 01020000/ffff0000 at 16
+`
+
 func TestFindCIDRClass(t *testing.T) {
 	tests := []struct {
 		cidr           string
@@ -238,6 +246,23 @@ func TestFindCIDRClass(t *testing.T) {
 		{
 			cidr:           "2.2.3.4/16",
 			output:         tcFilterOutput,
+			expectNotFound: true,
+		},
+		{
+			cidr:           "172.17.0.2/32",
+			output:         tcFilterOutputNew,
+			expectedClass:  "1:1",
+			expectedHandle: "800::800",
+		},
+		{
+			cidr:           "1.2.3.4/16",
+			output:         tcFilterOutputNew,
+			expectedClass:  "1:2",
+			expectedHandle: "800::801",
+		},
+		{
+			cidr:           "2.2.3.4/16",
+			output:         tcFilterOutputNew,
 			expectNotFound: true,
 		},
 		{


### PR DESCRIPTION
tc started adding 'chain 0' into the output of 'tc filter show dev eth0' as of iproute2 commit 732f03461bc48cf94946ee3cc92ab5832862b989 and that confuses the bandwidth code.

Related: https://github.com/kubernetes/kubernetes/issues/76064

/kind bug
```release-note
NONE
```
@cadmuxe