### PR TITLE
kubeadm: mount K8s certs dir into scheduler pods

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -307,6 +307,24 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 		},
 	}
 	volMap[kubeadmconstants.KubeScheduler] = map[string]v1.Volume{}
+	volMap[kubeadmconstants.KubeScheduler]["k8s-certs"] = v1.Volume{
+		Name: "k8s-certs",
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: testCertsDir,
+				Type: &hostPathDirectoryOrCreate,
+			},
+		},
+	}
+	volMap[kubeadmconstants.KubeScheduler]["ca-certs"] = v1.Volume{
+		Name: "ca-certs",
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: "/etc/ssl/certs",
+				Type: &hostPathDirectoryOrCreate,
+			},
+		},
+	}
 	volMap[kubeadmconstants.KubeScheduler]["kubeconfig"] = v1.Volume{
 		Name: "kubeconfig",
 		VolumeSource: v1.VolumeSource{
@@ -345,6 +363,16 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 		ReadOnly:  true,
 	}
 	volMountMap[kubeadmconstants.KubeScheduler] = map[string]v1.VolumeMount{}
+	volMountMap[kubeadmconstants.KubeScheduler]["k8s-certs"] = v1.VolumeMount{
+		Name:      "k8s-certs",
+		MountPath: testCertsDir,
+		ReadOnly:  true,
+	}
+	volMountMap[kubeadmconstants.KubeScheduler]["ca-certs"] = v1.VolumeMount{
+		Name:      "ca-certs",
+		MountPath: "/etc/ssl/certs",
+		ReadOnly:  true,
+	}
 	volMountMap[kubeadmconstants.KubeScheduler]["kubeconfig"] = v1.VolumeMount{
 		Name:      "kubeconfig",
 		MountPath: "/etc/kubernetes/scheduler.conf",
@@ -418,6 +446,24 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 		},
 	}
 	volMap2[kubeadmconstants.KubeScheduler] = map[string]v1.Volume{}
+	volMap2[kubeadmconstants.KubeScheduler]["k8s-certs"] = v1.Volume{
+		Name: "k8s-certs",
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: testCertsDir,
+				Type: &hostPathDirectoryOrCreate,
+			},
+		},
+	}
+	volMap2[kubeadmconstants.KubeScheduler]["ca-certs"] = v1.Volume{
+		Name: "ca-certs",
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: "/etc/ssl/certs",
+				Type: &hostPathDirectoryOrCreate,
+			},
+		},
+	}
 	volMap2[kubeadmconstants.KubeScheduler]["kubeconfig"] = v1.Volume{
 		Name: "kubeconfig",
 		VolumeSource: v1.VolumeSource{
@@ -466,6 +512,16 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 		ReadOnly:  true,
 	}
 	volMountMap2[kubeadmconstants.KubeScheduler] = map[string]v1.VolumeMount{}
+	volMountMap2[kubeadmconstants.KubeScheduler]["k8s-certs"] = v1.VolumeMount{
+		Name:      "k8s-certs",
+		MountPath: testCertsDir,
+		ReadOnly:  true,
+	}
+	volMountMap2[kubeadmconstants.KubeScheduler]["ca-certs"] = v1.VolumeMount{
+		Name:      "ca-certs",
+		MountPath: "/etc/ssl/certs",
+		ReadOnly:  true,
+	}
 	volMountMap2[kubeadmconstants.KubeScheduler]["kubeconfig"] = v1.VolumeMount{
 		Name:      "kubeconfig",
 		MountPath: "/etc/kubernetes/scheduler.conf",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR add mounting K8s Certificates directory `/etc/kubernetes/pki` into `kube-scheduler` pods, so it becomes possible to use `--tls-cert-file`/`--tls-private-key-file` args for them with cert/key files from the k8s certs dir.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #80063

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`kube-scheduler` pods mount K8s Certificates directory
```
