### PR TITLE
Add josephburnett to podautoscaler OWNERS.

### DIFF
--- a/pkg/controller/podautoscaler/OWNERS
+++ b/pkg/controller/podautoscaler/OWNERS
@@ -1,15 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- mwielgus
-- piosz
-- jszczepkowski
 - fgrzadkowski
-- MaciekPytel
-approvers:
-- mwielgus
-- piosz
+- josephburnet
 - jszczepkowski
 - MaciekPytel
+- mwielgus
+- piosz
+approvers:
+- josephburnett
+- jszczepkowski
+- MaciekPytel
+- mwielgus
+- piosz
 labels:
 - sig/autoscaling


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/sig autoscaling

**What this PR does / why we need it**:

This adds `josephburnett` to `pkg/controller/podautoscaler/OWNERS`. I have been the most active HPA contributor lately (e.g https://github.com/kubernetes/kubernetes/pull/79035 and https://github.com/kubernetes/kubernetes/pull/79657).

Also alphabetizes the lists.

```release-note
NONE
```
