### PR TITLE
Add label "configuration_name" for admission webhook metric, fix #79832

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
@@ -93,7 +93,7 @@ func mergeMutatingWebhookConfigurations(configurations []*v1beta1.MutatingWebhoo
 			n := c.Webhooks[i].Name
 			uid := fmt.Sprintf("%s/%s/%d", c.Name, n, names[n])
 			names[n]++
-			accessors = append(accessors, webhook.NewMutatingWebhookAccessor(uid, &c.Webhooks[i]))
+			accessors = append(accessors, webhook.NewMutatingWebhookAccessor(uid, c.Name, &c.Webhooks[i]))
 		}
 	}
 	return accessors

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
@@ -91,7 +91,7 @@ func mergeValidatingWebhookConfigurations(configurations []*v1beta1.ValidatingWe
 			n := c.Webhooks[i].Name
 			uid := fmt.Sprintf("%s/%s/%d", c.Name, n, names[n])
 			names[n]++
-			accessors = append(accessors, webhook.NewValidatingWebhookAccessor(uid, &c.Webhooks[i]))
+			accessors = append(accessors, webhook.NewValidatingWebhookAccessor(uid, c.Name, &c.Webhooks[i]))
 		}
 	}
 	return accessors

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -122,7 +122,7 @@ func newAdmissionMetrics() *AdmissionMetrics {
 
 	// Admission webhook metrics. Each webhook is identified by name.
 	webhook := newMetricSet("webhook",
-		[]string{"name", "type", "operation", "rejected"},
+		[]string{"name", "configuration_name", "type", "operation", "rejected"},
 		"Admission webhook %s, identified by name and broken out for each operation and API resource and type (validate or admit).", false)
 
 	step.mustRegister()

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -70,12 +70,13 @@ func TestObserveAdmissionController(t *testing.T) {
 
 func TestObserveWebhook(t *testing.T) {
 	Metrics.reset()
-	Metrics.ObserveWebhook(2*time.Second, false, attr, stepAdmit, "x")
+	Metrics.ObserveWebhook(2*time.Second, false, attr, stepAdmit, "x", "test.configuration.admission")
 	wantLabels := map[string]string{
-		"name":      "x",
-		"operation": string(admission.Create),
-		"type":      "admit",
-		"rejected":  "false",
+		"name":               "x",
+		"configuration_name": "test.configuration.admission",
+		"operation":          string(admission.Create),
+		"type":               "admit",
+		"rejected":           "false",
 	}
 	expectHistogramCountTotal(t, "apiserver_admission_webhook_admission_duration_seconds", wantLabels, 1)
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
@@ -23,6 +23,9 @@ import (
 
 // WebhookAccessor provides a common interface to both mutating and validating webhook types.
 type WebhookAccessor interface {
+	// GetConfigurationName gets the configuration name of the webhook.
+	GetConfigurationName() string
+
 	// GetUID gets a string that uniquely identifies the webhook.
 	GetUID() string
 
@@ -56,15 +59,19 @@ type WebhookAccessor interface {
 }
 
 // NewMutatingWebhookAccessor creates an accessor for a MutatingWebhook.
-func NewMutatingWebhookAccessor(uid string, h *v1beta1.MutatingWebhook) WebhookAccessor {
-	return mutatingWebhookAccessor{uid: uid, MutatingWebhook: h}
+func NewMutatingWebhookAccessor(uid string, configurationName string, h *v1beta1.MutatingWebhook) WebhookAccessor {
+	return mutatingWebhookAccessor{uid: uid, configurationName: configurationName, MutatingWebhook: h}
 }
 
 type mutatingWebhookAccessor struct {
 	*v1beta1.MutatingWebhook
-	uid string
+	configurationName string
+	uid               string
 }
 
+func (m mutatingWebhookAccessor) GetConfigurationName() string {
+	return m.configurationName
+}
 func (m mutatingWebhookAccessor) GetUID() string {
 	return m.uid
 }
@@ -108,15 +115,19 @@ func (m mutatingWebhookAccessor) GetValidatingWebhook() (*v1beta1.ValidatingWebh
 }
 
 // NewValidatingWebhookAccessor creates an accessor for a ValidatingWebhook.
-func NewValidatingWebhookAccessor(uid string, h *v1beta1.ValidatingWebhook) WebhookAccessor {
-	return validatingWebhookAccessor{uid: uid, ValidatingWebhook: h}
+func NewValidatingWebhookAccessor(uid, configurationName string, h *v1beta1.ValidatingWebhook) WebhookAccessor {
+	return validatingWebhookAccessor{uid: uid, configurationName: configurationName, ValidatingWebhook: h}
 }
 
 type validatingWebhookAccessor struct {
 	*v1beta1.ValidatingWebhook
-	uid string
+	configurationName string
+	uid               string
 }
 
+func (v validatingWebhookAccessor) GetConfigurationName() string {
+	return v.configurationName
+}
 func (v validatingWebhookAccessor) GetUID() string {
 	return v.uid
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors_test.go
@@ -36,10 +36,14 @@ func TestMutatingWebhookAccessor(t *testing.T) {
 			// zero out any accessor type specific fields not included in the accessor
 			orig.ReinvocationPolicy = nil
 
-			uid := fmt.Sprintf("test.configuration.admission/%s/0", orig.Name)
-			accessor := NewMutatingWebhookAccessor(uid, orig)
+			configurationName := "test.configuration.admission"
+			uid := fmt.Sprintf("%s/%s/0", configurationName, orig.Name)
+			accessor := NewMutatingWebhookAccessor(uid, configurationName, orig)
 			if uid != accessor.GetUID() {
 				t.Errorf("expected GetUID to return %s, but got %s", accessor.GetUID(), uid)
+			}
+			if configurationName != accessor.GetConfigurationName() {
+				t.Errorf("expected GetConfigurationName to return %s, but got %s", accessor.GetConfigurationName(), configurationName)
 			}
 			m, ok := accessor.GetMutatingWebhook()
 			if !ok {
@@ -76,10 +80,14 @@ func TestValidatingWebhookAccessor(t *testing.T) {
 		t.Run(fmt.Sprintf("Run %d/100", i), func(t *testing.T) {
 			orig := &v1beta1.ValidatingWebhook{}
 			f.Fuzz(orig)
-			uid := fmt.Sprintf("test.configuration.admission/%s/0", orig.Name)
-			accessor := NewValidatingWebhookAccessor(uid, orig)
+			configurationName := "test.configuration.admission"
+			uid := fmt.Sprintf("%s/%s/0", configurationName, orig.Name)
+			accessor := NewValidatingWebhookAccessor(uid, configurationName, orig)
 			if uid != accessor.GetUID() {
 				t.Errorf("expected GetUID to return %s, but got %s", accessor.GetUID(), uid)
+			}
+			if configurationName != accessor.GetConfigurationName() {
+				t.Errorf("expected GetConfigurationName to return %s, but got %s", accessor.GetConfigurationName(), configurationName)
 			}
 			m, ok := accessor.GetValidatingWebhook()
 			if !ok {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook_test.go
@@ -293,7 +293,7 @@ func TestShouldCallHook(t *testing.T) {
 
 	for i, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-			invocation, err := a.ShouldCallHook(webhook.NewValidatingWebhookAccessor(fmt.Sprintf("webhook-%d", i), testcase.webhook), testcase.attrs, interfaces)
+			invocation, err := a.ShouldCallHook(webhook.NewValidatingWebhookAccessor(fmt.Sprintf("webhook-%d", i), "test.configuration.admission", testcase.webhook), testcase.attrs, interfaces)
 			if err != nil {
 				if len(testcase.expectErr) == 0 {
 					t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -117,7 +117,8 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr admission.Attrib
 		t := time.Now()
 
 		changed, err := a.callAttrMutatingHook(ctx, hook, invocation, versionedAttr, o)
-		admissionmetrics.Metrics.ObserveWebhook(time.Since(t), err != nil, versionedAttr.Attributes, "admit", hook.Name)
+		configurationName := invocation.Webhook.GetConfigurationName()
+		admissionmetrics.Metrics.ObserveWebhook(time.Since(t), err != nil, versionedAttr.Attributes, "admit", hook.Name, configurationName)
 		if changed {
 			// Patch had changed the object. Prepare to reinvoke all previous webhooks that are eligible for re-invocation.
 			webhookReinvokeCtx.RequireReinvokingPreviouslyInvokedPlugins()

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/namespace/matcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/namespace/matcher_test.go
@@ -120,7 +120,7 @@ func TestNotExemptClusterScopedResource(t *testing.T) {
 	}
 	attr := admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{}, "", "mock-name", schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, "", admission.Create, &metav1.CreateOptions{}, false, nil)
 	matcher := Matcher{}
-	matches, err := matcher.MatchNamespaceSelector(webhook.NewValidatingWebhookAccessor("mock-hook", hook), attr)
+	matches, err := matcher.MatchNamespaceSelector(webhook.NewValidatingWebhookAccessor("mock-hook", "test.configuration.admission", hook), attr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/object/matcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/object/matcher_test.go
@@ -115,7 +115,7 @@ func TestObjectSelector(t *testing.T) {
 			}}}
 
 		t.Run(testcase.name, func(t *testing.T) {
-			match, err := matcher.MatchObjectSelector(webhook.NewValidatingWebhookAccessor("mock-hook", hook), testcase.attrs)
+			match, err := matcher.MatchObjectSelector(webhook.NewValidatingWebhookAccessor("mock-hook", "test.configuration.admission", hook), testcase.attrs)
 			if err != nil {
 				t.Error(err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -94,7 +94,8 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr admission.Attr
 			versionedAttr := versionedAttrs[invocation.Kind]
 			t := time.Now()
 			err := d.callHook(ctx, hook, invocation, versionedAttr)
-			admissionmetrics.Metrics.ObserveWebhook(time.Since(t), err != nil, versionedAttr.Attributes, "validating", hook.Name)
+			configurationName := invocation.Webhook.GetConfigurationName()
+			admissionmetrics.Metrics.ObserveWebhook(time.Since(t), err != nil, versionedAttr.Attributes, "validating", hook.Name, configurationName)
 			if err == nil {
 				return
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
According to the issue #79832, added the label "configuration_name" for admission webhook metric first.

**Which issue(s) this PR fixes**:
Fixes #79832

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add the label "configuration_name" for admission webhook metric.
```
