### PR TITLE
Make service "no endpoints" test use agnhost connect

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -199,7 +199,7 @@ const (
 
 func initImageConfigs() map[int]Config {
 	configs := map[int]Config{}
-	configs[Agnhost] = Config{e2eRegistry, "agnhost", "2.2"}
+	configs[Agnhost] = Config{e2eRegistry, "agnhost", "2.4"}
 	configs[Alpine] = Config{dockerLibraryRegistry, "alpine", "3.7"}
 	configs[AuthenticatedAlpine] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[AuthenticatedWindowsNanoServer] = Config{gcAuthenticatedRegistry, "windows-nanoserver", "v1"}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Completing #79012 / #79423, this makes the networking `"should be rejected when no endpoints exist"` test use the new `agnhost connect` command rather than relying on `wget` to output a specific error message.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @mgdevstack @johnSchnake @spiffxp 