### PR TITLE
Register WatchEvents metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -170,6 +170,7 @@ var (
 		DroppedRequests,
 		DeprecatedDroppedRequests,
 		RegisteredWatchers,
+		WatchEvents,
 		currentInflightRequests,
 	}
 )


### PR DESCRIPTION
In the https://github.com/kubernetes/kubernetes/pull/78732 PR I forgot the most important part: registering the metric.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/assign @wojtek-t 
