### PR TITLE
Improve readability for image manager tests

### DIFF
--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -145,8 +145,9 @@ func TestParallelPuller(t *testing.T) {
 
 	cases := pullerTestCases()
 
+	useSerializedEnv := false
 	for i, c := range cases {
-		puller, fakeClock, fakeRuntime, container := pullerTestEnv(c, false)
+		puller, fakeClock, fakeRuntime, container := pullerTestEnv(c, useSerializedEnv)
 
 		for tick, expected := range c.expected {
 			fakeRuntime.CalledFunctions = nil
@@ -170,8 +171,9 @@ func TestSerializedPuller(t *testing.T) {
 
 	cases := pullerTestCases()
 
+	useSerializedEnv := true
 	for i, c := range cases {
-		puller, fakeClock, fakeRuntime, container := pullerTestEnv(c, true)
+		puller, fakeClock, fakeRuntime, container := pullerTestEnv(c, useSerializedEnv)
 
 		for tick, expected := range c.expected {
 			fakeRuntime.CalledFunctions = nil


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Create wrapper methods for `pullerTestEnv` so that the method name (i.e.
`parallelPullerTestEnv`) indicates whether the environment is parallel or
serialized. The descriptive method name is more readable than a boolean
argument, especially given Go doesn't support named keyword arguments.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
