### PR TITLE
Add e2e tests for CSI PVCDataSources

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -87,8 +87,9 @@ var _ testsuites.SnapshottableTestDriver = &hostpathCSIDriver{}
 // InitHostPathCSIDriver returns hostpathCSIDriver that implements TestDriver interface
 func InitHostPathCSIDriver() testsuites.TestDriver {
 	return initHostPathCSIDriver("csi-hostpath",
-		map[testsuites.Capability]bool{testsuites.CapPersistence: true, testsuites.CapDataSource: true,
-			testsuites.CapMultiPODs: true, testsuites.CapBlock: true},
+		map[testsuites.Capability]bool{testsuites.CapPersistence: true, testsuites.CapSnapshotDataSource: true,
+			testsuites.CapMultiPODs: true, testsuites.CapBlock: true,
+			testsuites.CapPVCDataSource: true},
 		"test/e2e/testing-manifests/storage-csi/driver-registrar/rbac.yaml",
 		"test/e2e/testing-manifests/storage-csi/external-attacher/rbac.yaml",
 		"test/e2e/testing-manifests/storage-csi/external-provisioner/rbac.yaml",

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -78,7 +78,7 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 		dInfo := driver.GetDriverInfo()
 		ok := false
 		sDriver, ok = driver.(SnapshottableTestDriver)
-		if !dInfo.Capabilities[CapDataSource] || !ok {
+		if !dInfo.Capabilities[CapSnapshotDataSource] || !ok {
 			framework.Skipf("Driver %q does not support snapshots - skipping", dInfo.Name)
 		}
 		dDriver, ok = driver.(DynamicPVTestDriver)

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -131,11 +131,12 @@ type Capability string
 
 // Constants related to capability
 const (
-	CapPersistence Capability = "persistence" // data is persisted across pod restarts
-	CapBlock       Capability = "block"       // raw block mode
-	CapFsGroup     Capability = "fsGroup"     // volume ownership via fsGroup
-	CapExec        Capability = "exec"        // exec a file in the volume
-	CapDataSource  Capability = "dataSource"  // support populate data from snapshot
+	CapPersistence        Capability = "persistence"        // data is persisted across pod restarts
+	CapBlock              Capability = "block"              // raw block mode
+	CapFsGroup            Capability = "fsGroup"            // volume ownership via fsGroup
+	CapExec               Capability = "exec"               // exec a file in the volume
+	CapSnapshotDataSource Capability = "snapshotDataSource" // support populate data from snapshot
+	CapPVCDataSource      Capability = "pvcDataSource"      // support populate data from pvc
 
 	// multiple pods on a node can use the same volume concurrently;
 	// for CSI, see:


### PR DESCRIPTION
/kind cleanup


**What this PR does / why we need it**:

Add an e2e test for the VolumePVCDataSource feature, test against the CSI Hostpath driver.

```release-note
None
```
