### PR TITLE
Automated cherry pick of #79245: kunsupported cgroup setup causes kubelet to emit a warning

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -625,17 +625,15 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 	cgroupRoots = append(cgroupRoots, cm.NodeAllocatableRoot(s.CgroupRoot, s.CgroupDriver))
 	kubeletCgroup, err := cm.GetKubeletContainer(s.KubeletCgroups)
 	if err != nil {
-		return fmt.Errorf("failed to get the kubelet's cgroup: %v", err)
-	}
-	if kubeletCgroup != "" {
+		klog.Warningf("failed to get the kubelet's cgroup: %v.  Kubelet system container metrics may be missing.", err)
+	} else if kubeletCgroup != "" {
 		cgroupRoots = append(cgroupRoots, kubeletCgroup)
 	}
 
 	runtimeCgroup, err := cm.GetRuntimeContainer(s.ContainerRuntime, s.RuntimeCgroups)
 	if err != nil {
-		return fmt.Errorf("failed to get the container runtime's cgroup: %v", err)
-	}
-	if runtimeCgroup != "" {
+		klog.Warningf("failed to get the container runtime's cgroup: %v. Runtime system container metrics may be missing.", err)
+	} else if runtimeCgroup != "" {
 		// RuntimeCgroups is optional, so ignore if it isn't specified
 		cgroupRoots = append(cgroupRoots, runtimeCgroup)
 	}


### PR DESCRIPTION
Cherry pick of #79245 on release-1.15.

#79245: kunsupported cgroup setup causes kubelet to emit a warning

#### Release note
```release-note
Fixed possible kubelet stop because of non unified CPU and memory cgroup hierarchy.
```