### PR TITLE
bazel: add openapi generation for non-main spec and fix main spec

### DIFF
--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -30,7 +30,7 @@ fi
 
 # Remove generated files prior to running kazel.
 # TODO(spxtr): Remove this line once Bazel is the only way to build.
-rm -f "${KUBE_ROOT}/pkg/generated/openapi/zz_generated.openapi.go"
+rm -f "${KUBE_ROOT}/{pkg/generated,staging/src/k8s.io/apiextensions-apiserver/pkg/client,staging/src/k8s.io/kube-aggregator/pkg/client}/openapi/zz_generated.openapi.go"
 
 _tmpdir="$(kube::realpath "$(mktemp -d -t verify-bazel.XXXXXX)")"
 kube::util::trap_add "rm -rf ${_tmpdir}" EXIT

--- a/pkg/generated/openapi/BUILD
+++ b/pkg/generated/openapi/BUILD
@@ -5,6 +5,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 gen_openapi(
     outs = ["zz_generated.openapi.go"],
+    exclude_pkgs = [
+        "staging/src/k8s.io/code-generator",
+        "staging/src/k8s.io/sample-apiserver",
+    ],
     output_pkg = "k8s.io/kubernetes/pkg/generated/openapi",
 )
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/BUILD
@@ -1,4 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//build:code_generation.bzl", "gen_openapi", "openapi_deps")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+gen_openapi(
+    outs = ["zz_generated.openapi.go"],
+    include_pkgs = [
+        "staging/src/k8s.io/apimachinery/pkg/apis/meta/v1",
+        "staging/src/k8s.io/apimachinery/pkg/runtime",
+        "staging/src/k8s.io/apimachinery/pkg/version",
+        "staging/src/k8s.io/sample-apiserver",
+    ],
+    output_pkg = "k8s.io/sample-apiserver/pkg/generated/openapi",
+)
 
 go_library(
     name = "go_default_library",
@@ -6,11 +20,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/sample-apiserver/pkg/generated/openapi",
     importpath = "k8s.io/sample-apiserver/pkg/generated/openapi",
     visibility = ["//visibility:public"],
-    deps = [
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/github.com/go-openapi/spec:go_default_library",
-        "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
-    ],
+    deps = openapi_deps(),  # keep
 )
 
 filegroup(


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/kubernetes/pull/79843.

/kind bug

```release-note
NONE
```