### PR TITLE
Use docker official redis images

### DIFF
--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -65,17 +65,16 @@ var CommonImageWhiteList = sets.NewString(
 )
 
 type testImagesStruct struct {
-	AgnhostImage      string
-	BusyBoxImage      string
-	GBFrontendImage   string
-	GBRedisSlaveImage string
-	KittenImage       string
-	MounttestImage    string
-	NautilusImage     string
-	NginxImage        string
-	NginxNewImage     string
-	PauseImage        string
-	RedisImage        string
+	AgnhostImage    string
+	BusyBoxImage    string
+	GBFrontendImage string
+	KittenImage     string
+	MounttestImage  string
+	NautilusImage   string
+	NginxImage      string
+	NginxNewImage   string
+	PauseImage      string
+	RedisImage      string
 }
 
 var testImages testImagesStruct
@@ -85,7 +84,6 @@ func init() {
 		imageutils.GetE2EImage(imageutils.Agnhost),
 		imageutils.GetE2EImage(imageutils.BusyBox),
 		imageutils.GetE2EImage(imageutils.GBFrontend),
-		imageutils.GetE2EImage(imageutils.GBRedisSlave),
 		imageutils.GetE2EImage(imageutils.Kitten),
 		imageutils.GetE2EImage(imageutils.Mounttest),
 		imageutils.GetE2EImage(imageutils.Nautilus),

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1144,7 +1144,7 @@ metadata:
 			waitForOrFailWithDebug(1)
 			forEachPod(func(pod v1.Pod) {
 				e2elog.Logf("wait on redis-master startup in %v ", ns)
-				framework.LookForStringInLog(ns, pod.Name, "redis-master", "The server is now ready to accept connections", framework.PodStartTimeout)
+				framework.LookForStringInLog(ns, pod.Name, "redis-master", "Ready to accept connections", framework.PodStartTimeout)
 			})
 			validateService := func(name string, servicePort int, timeout time.Duration) {
 				err := wait.Poll(framework.Poll, timeout, func() (bool, error) {
@@ -1323,7 +1323,7 @@ metadata:
 			waitForOrFailWithDebug(1)
 			forEachPod(func(pod v1.Pod) {
 				ginkgo.By("checking for a matching strings")
-				_, err := framework.LookForStringInLog(ns, pod.Name, containerName, "The server is now ready to accept connections", framework.PodStartTimeout)
+				_, err := framework.LookForStringInLog(ns, pod.Name, containerName, "Ready to accept connections", framework.PodStartTimeout)
 				framework.ExpectNoError(err)
 
 				ginkgo.By("limiting log lines")

--- a/test/e2e/testing-manifests/guestbook/legacy/redis-master-controller.yaml
+++ b/test/e2e/testing-manifests/guestbook/legacy/redis-master-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: docker.io/library/redis:3.2.9-alpine
+        image: docker.io/library/redis:5.0.5-alpine
         resources:
           requests:
             cpu: 100m

--- a/test/e2e/testing-manifests/guestbook/legacy/redis-slave-controller.yaml
+++ b/test/e2e/testing-manifests/guestbook/legacy/redis-slave-controller.yaml
@@ -17,7 +17,10 @@ spec:
     spec:
       containers:
       - name: slave
-        image: gcr.io/google_samples/gb-redisslave:v1
+        image: docker.io/library/redis:5.0.5-alpine
+        # We are only implementing the dns option of:
+        # https://github.com/kubernetes/examples/blob/97c7ed0eb6555a4b667d2877f965d392e00abc45/guestbook/redis-slave/run.sh
+        command: [ "redis-server", "--slaveof", "redis-master", "6379" ]
         resources:
           requests:
             cpu: 100m

--- a/test/e2e/testing-manifests/guestbook/redis-slave-deployment.yaml.in
+++ b/test/e2e/testing-manifests/guestbook/redis-slave-deployment.yaml.in
@@ -18,7 +18,10 @@ spec:
     spec:
       containers:
       - name: slave
-        image: {{.GBRedisSlaveImage}}
+        image: {{.RedisImage}}
+        # We are only implementing the dns option of:
+        # https://github.com/kubernetes/examples/blob/97c7ed0eb6555a4b667d2877f965d392e00abc45/guestbook/redis-slave/run.sh
+        command: [ "redis-server", "--slaveof", "redis-master", "6379" ]
         resources:
           requests:
             cpu: 100m

--- a/test/fixtures/doc-yaml/user-guide/replicaset/redis-slave.yaml
+++ b/test/fixtures/doc-yaml/user-guide/replicaset/redis-slave.yaml
@@ -24,7 +24,10 @@ spec:
     spec:
       containers:
       - name: slave
-        image: gcr.io/google-samples/gb-redisslave:v3
+        image: docker.io/library/redis:5.0.5-alpine
+        # We are only implementing the dns option of:
+        # https://github.com/kubernetes/examples/blob/97c7ed0eb6555a4b667d2877f965d392e00abc45/guestbook/redis-slave/run.sh
+        command: [ "redis-server", "--slaveof", "redis-master", "6379" ]
         resources:
           requests:
             cpu: 100m

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -134,8 +134,6 @@ const (
 	Etcd
 	// GBFrontend image
 	GBFrontend
-	// GBRedisSlave image
-	GBRedisSlave
 	// Httpd image
 	Httpd
 	// HttpdNew image
@@ -214,7 +212,6 @@ func initImageConfigs() map[int]Config {
 	configs[EchoServer] = Config{e2eRegistry, "echoserver", "2.2"}
 	configs[Etcd] = Config{gcRegistry, "etcd", "3.3.10"}
 	configs[GBFrontend] = Config{sampleRegistry, "gb-frontend", "v6"}
-	configs[GBRedisSlave] = Config{sampleRegistry, "gb-redisslave", "v3"}
 	configs[Httpd] = Config{dockerLibraryRegistry, "httpd", "2.4.38-alpine"}
 	configs[HttpdNew] = Config{dockerLibraryRegistry, "httpd", "2.4.39-alpine"}
 	configs[Invalid] = Config{gcRegistry, "invalid-image", "invalid-tag"}

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -234,7 +234,7 @@ func initImageConfigs() map[int]Config {
 	configs[Perl] = Config{dockerLibraryRegistry, "perl", "5.26"}
 	configs[PrometheusDummyExporter] = Config{e2eRegistry, "prometheus-dummy-exporter", "v0.1.0"}
 	configs[PrometheusToSd] = Config{e2eRegistry, "prometheus-to-sd", "v0.5.0"}
-	configs[Redis] = Config{dockerLibraryRegistry, "redis", "3.2.9-alpine"}
+	configs[Redis] = Config{dockerLibraryRegistry, "redis", "5.0.5-alpine"}
 	configs[ResourceConsumer] = Config{e2eRegistry, "resource-consumer", "1.5"}
 	configs[ResourceController] = Config{e2eRegistry, "resource-consumer-controller", "1.0"}
 	configs[SdDummyExporter] = Config{gcRegistry, "sd-dummy-exporter", "v0.2.0"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:

It fixes the regression introduced in https://github.com/kubernetes/kubernetes/pull/79388
breaking the CI for non-amd64 platforms when IPv6 support was added

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This PR replaces current redis images used in e2e tests by the docker official images that have multi-platform support, reducing the cost of supporting custom images for e2e testing

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
