### PR TITLE
Obtain lock after apiService is copied in addAPIServiceToSync

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller.go
@@ -304,14 +304,14 @@ func (c *autoRegisterController) AddAPIServiceToSync(in *apiregistration.APIServ
 }
 
 func (c *autoRegisterController) addAPIServiceToSync(in *apiregistration.APIService, syncType string) {
-	c.apiServicesToSyncLock.Lock()
-	defer c.apiServicesToSyncLock.Unlock()
-
 	apiService := in.DeepCopy()
 	if apiService.Labels == nil {
 		apiService.Labels = map[string]string{}
 	}
 	apiService.Labels[AutoRegisterManagedLabel] = syncType
+
+	c.apiServicesToSyncLock.Lock()
+	defer c.apiServicesToSyncLock.Unlock()
 
 	c.apiServicesToSync[apiService.Name] = apiService
 	c.queue.Add(apiService.Name)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In autoRegisterController#addAPIServiceToSync, a copy of APIService parameter is made.

This PR moves the acquisition of lock to after the copy is made and initialized.

```release-note
NONE
```
