### PR TITLE
fix: rename RegisterPriorityFunction2 to RegisterPriorityMapReduceFunction

### DIFF
--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -90,9 +90,9 @@ func ApplyFeatureGates() {
 	// Prioritizes nodes that satisfy pod's resource limits
 	if utilfeature.DefaultFeatureGate.Enabled(features.ResourceLimitsPriorityFunction) {
 		klog.Infof("Registering resourcelimits priority function")
-		factory.RegisterPriorityFunction2(priorities.ResourceLimitsPriority, priorities.ResourceLimitsPriorityMap, nil, 1)
+		factory.RegisterPriorityMapReduceFunction(priorities.ResourceLimitsPriority, priorities.ResourceLimitsPriorityMap, nil, 1)
 		// Register the priority function to specific provider too.
-		factory.InsertPriorityKeyToAlgorithmProviderMap(factory.RegisterPriorityFunction2(priorities.ResourceLimitsPriority, priorities.ResourceLimitsPriorityMap, nil, 1))
+		factory.InsertPriorityKeyToAlgorithmProviderMap(factory.RegisterPriorityMapReduceFunction(priorities.ResourceLimitsPriority, priorities.ResourceLimitsPriorityMap, nil, 1))
 	}
 }
 

--- a/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
@@ -46,10 +46,10 @@ func init() {
 	// EqualPriority is a prioritizer function that gives an equal weight of one to all nodes
 	// Register the priority function so that its available
 	// but do not include it as part of the default priorities
-	factory.RegisterPriorityFunction2(priorities.EqualPriority, core.EqualPriorityMap, nil, 1)
+	factory.RegisterPriorityMapReduceFunction(priorities.EqualPriority, core.EqualPriorityMap, nil, 1)
 	// Optional, cluster-autoscaler friendly priority function - give used nodes higher priority.
-	factory.RegisterPriorityFunction2(priorities.MostRequestedPriority, priorities.MostRequestedPriorityMap, nil, 1)
-	factory.RegisterPriorityFunction2(
+	factory.RegisterPriorityMapReduceFunction(priorities.MostRequestedPriority, priorities.MostRequestedPriorityMap, nil, 1)
+	factory.RegisterPriorityMapReduceFunction(
 		priorities.RequestedToCapacityRatioPriority,
 		priorities.RequestedToCapacityRatioResourceAllocationPriorityDefault().PriorityMap,
 		nil,
@@ -77,21 +77,21 @@ func init() {
 	)
 
 	// Prioritize nodes by least requested utilization.
-	factory.RegisterPriorityFunction2(priorities.LeastRequestedPriority, priorities.LeastRequestedPriorityMap, nil, 1)
+	factory.RegisterPriorityMapReduceFunction(priorities.LeastRequestedPriority, priorities.LeastRequestedPriorityMap, nil, 1)
 
 	// Prioritizes nodes to help achieve balanced resource usage
-	factory.RegisterPriorityFunction2(priorities.BalancedResourceAllocation, priorities.BalancedResourceAllocationMap, nil, 1)
+	factory.RegisterPriorityMapReduceFunction(priorities.BalancedResourceAllocation, priorities.BalancedResourceAllocationMap, nil, 1)
 
 	// Set this weight large enough to override all other priority functions.
 	// TODO: Figure out a better way to do this, maybe at same time as fixing #24720.
-	factory.RegisterPriorityFunction2(priorities.NodePreferAvoidPodsPriority, priorities.CalculateNodePreferAvoidPodsPriorityMap, nil, 10000)
+	factory.RegisterPriorityMapReduceFunction(priorities.NodePreferAvoidPodsPriority, priorities.CalculateNodePreferAvoidPodsPriorityMap, nil, 10000)
 
 	// Prioritizes nodes that have labels matching NodeAffinity
-	factory.RegisterPriorityFunction2(priorities.NodeAffinityPriority, priorities.CalculateNodeAffinityPriorityMap, priorities.CalculateNodeAffinityPriorityReduce, 1)
+	factory.RegisterPriorityMapReduceFunction(priorities.NodeAffinityPriority, priorities.CalculateNodeAffinityPriorityMap, priorities.CalculateNodeAffinityPriorityReduce, 1)
 
 	// Prioritizes nodes that marked with taint which pod can tolerate.
-	factory.RegisterPriorityFunction2(priorities.TaintTolerationPriority, priorities.ComputeTaintTolerationPriorityMap, priorities.ComputeTaintTolerationPriorityReduce, 1)
+	factory.RegisterPriorityMapReduceFunction(priorities.TaintTolerationPriority, priorities.ComputeTaintTolerationPriorityMap, priorities.ComputeTaintTolerationPriorityReduce, 1)
 
 	// ImageLocalityPriority prioritizes nodes that have images requested by the pod present.
-	factory.RegisterPriorityFunction2(priorities.ImageLocalityPriority, priorities.ImageLocalityPriorityMap, nil, 1)
+	factory.RegisterPriorityMapReduceFunction(priorities.ImageLocalityPriority, priorities.ImageLocalityPriorityMap, nil, 1)
 }

--- a/pkg/scheduler/factory/plugins.go
+++ b/pkg/scheduler/factory/plugins.go
@@ -278,10 +278,9 @@ func RegisterPriorityFunction(name string, function priorities.PriorityFunction,
 	})
 }
 
-// RegisterPriorityFunction2 registers a priority function with the algorithm registry. Returns the name,
+// RegisterPriorityMapReduceFunction registers a priority function with the algorithm registry. Returns the name,
 // with which the function was registered.
-// FIXME: Rename to PriorityFunctionFactory.
-func RegisterPriorityFunction2(
+func RegisterPriorityMapReduceFunction(
 	name string,
 	mapFunction priorities.PriorityMapFunction,
 	reduceFunction priorities.PriorityReduceFunction,


### PR DESCRIPTION
/kind cleanup
/sig scheduling
/priority backlog

Rename RegisterPriorityFunction2 to RegisterPriorityMapReduceFunction followed @Huang-Wei 's advice.

```release-note
NONE
```
