### PR TITLE
Adds kubeadm feature-gate for dual-stack (IPv6DualStack)

### DIFF
--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -31,6 +31,8 @@ const (
 
 	// CoreDNS is GA in v1.11
 	CoreDNS = "CoreDNS"
+	// IPv6DualStack is expected to be alpha in v1.16
+	IPv6DualStack = "IPv6DualStack"
 )
 
 var coreDNSMessage = "featureGates:CoreDNS has been removed in v1.13\n" +
@@ -38,7 +40,8 @@ var coreDNSMessage = "featureGates:CoreDNS has been removed in v1.13\n" +
 
 // InitFeatureGates are the default feature gates for the init command
 var InitFeatureGates = FeatureList{
-	CoreDNS: {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Deprecated}, HiddenInHelpText: true, DeprecationMessage: coreDNSMessage},
+	CoreDNS:       {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Deprecated}, HiddenInHelpText: true, DeprecationMessage: coreDNSMessage},
+	IPv6DualStack: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 }
 
 // Feature represents a feature being gated


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR adds the dual-stack feature gate to kubeadm. We need to isolate the forthcoming dual-stack related changes to kubeadm.

**Special notes for your reviewer**:
This is the first of several PRs that will bring dual-stack specific changes to kubeadm. For a complete list of kubeadm changes, see the tracking issue: https://github.com/kubernetes/kubeadm/issues/1612

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm ClusterConfiguration now supports featureGates: IPv6DualStack: true
```

@neolit123 @yastij @fabriziopandini @aojea 