### PR TITLE
Promote ReplicaSet Pod quota limit

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -33,6 +33,7 @@ test/e2e/apps/rc.go: "should surface a failure condition on a common issue like 
 test/e2e/apps/rc.go: "should adopt matching pods on creation"
 test/e2e/apps/rc.go: "should release no longer matching pods"
 test/e2e/apps/replica_set.go: "should serve a basic image on each replica with a public image"
+test/e2e/apps/replica_set.go: "should surface a failure condition on a common issue like exceeded quota"
 test/e2e/apps/replica_set.go: "should adopt matching pods on creation and release no longer matching pods"
 test/e2e/apps/statefulset.go: "should perform rolling updates and roll backs of template modifications"
 test/e2e/apps/statefulset.go: "should perform canary updates and phased rolling updates of template modifications"

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -229,7 +229,7 @@ func testReplicaSetConditionCheck(f *framework.Framework) {
 		conditions = rs.Status.Conditions
 
 		cond := replicaset.GetCondition(rs.Status, appsv1.ReplicaSetReplicaFailure)
-		return cond != nil, nil
+		return cond.Status == "True", nil
 
 	})
 	if err == wait.ErrWaitTimeout {

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -102,7 +102,14 @@ var _ = SIGDescribe("ReplicaSet", func() {
 		testReplicaSetServeImageOrFail(f, "private", privateimage.GetE2EImage())
 	})
 
-	ginkgo.It("should surface a failure condition on a common issue like exceeded quota", func() {
+	/*
+	   Release : v1.16
+	   Testname: Validate ReplicaSet pod limit restrictions
+	   Description: Apply quota to the namespace, prohibiting more than two pods.
+	   When creating a ReplicaSet of 3 of a pod, ReplicaSetConditions MUST include the failure of creating more than the quota allows.
+	   Replicas of pods will be scaled down to two MUST succeed, as the quota allows this amount of replicas to exist.
+	*/
+	framework.ConformanceIt("should surface a failure condition on a common issue like exceeded quota", func() {
 		testReplicaSetConditionCheck(f)
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E test to Conformance:
test/e2e/apps/replica_set.go: "should surface a failure condition on a common issue like exceeded quota"

**Special notes for your reviewer**:
Part of Umbrella Issue #78747.  
[Testgrid results](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=should%20surface%20a%20failure%20condition%20on%20a%20common%20issue%20like%20exceeded%20quota&include-filter-by-regex=ReplicaSet%20should%20surface%20a%20failure%20condition%20on%20a%20common%20issue%20like%20exceeded%20quota&width=5).  
Test(s):
- [sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota

Endpoint(s):
- replaceAppsV1NamespacedReplicaSet

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/area conformance
/area test
@kubernetes/sig-apps-pr-reviews
@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg