### PR TITLE
Promote StatefulSet Replica scaling

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -36,6 +36,7 @@ test/e2e/apps/statefulset.go: "should perform canary updates and phased rolling 
 test/e2e/apps/statefulset.go: "Scaling should happen in predictable order and halt if any stateful pod is unhealthy"
 test/e2e/apps/statefulset.go: "Burst scaling should run to completion even with unhealthy pods"
 test/e2e/apps/statefulset.go: "Should recreate evicted statefulset"
+test/e2e/apps/statefulset.go: "should have a working scale subresource"
 test/e2e/auth/service_accounts.go: "should mount an API token into pods"
 test/e2e/auth/service_accounts.go: "should allow opting out of API token automount"
 test/e2e/common/configmap.go: "should be consumable via environment variable"

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -762,7 +762,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 			}, e2esset.StatefulPodTimeout, 2*time.Second).Should(gomega.BeNil())
 		})
 
-		ginkgo.It("should have a working scale subresource", func() {
+		/*
+						Release : v1.16
+						Testname: StatefulSet resource Replica scaling
+						Description: Create a StatefulSet resource.
+			            Newly created StatefulSet resource MUST have a scale of one.
+			            Bring the scale of the StatefulSet resource up to two. StatefulSet scale MUST be at two replicas.
+		*/
+		framework.ConformanceIt("should have a working scale subresource", func() {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			ss := e2esset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, labels)
 			e2esset.SetHTTPProbe(ss)

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -763,11 +763,11 @@ var _ = SIGDescribe("StatefulSet", func() {
 		})
 
 		/*
-						Release : v1.16
-						Testname: StatefulSet resource Replica scaling
-						Description: Create a StatefulSet resource.
-			            Newly created StatefulSet resource MUST have a scale of one.
-			            Bring the scale of the StatefulSet resource up to two. StatefulSet scale MUST be at two replicas.
+			Release : v1.16
+			Testname: StatefulSet resource Replica scaling
+			Description: Create a StatefulSet resource.
+			Newly created StatefulSet resource MUST have a scale of one.
+			Bring the scale of the StatefulSet resource up to two. StatefulSet scale MUST be at two replicas.
 		*/
 		framework.ConformanceIt("should have a working scale subresource", func() {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E test to Conformance:
test/e2e/apps/statefulset.go: "should have a working scale subresource"

**Special notes for your reviewer**:
Part of Umbrella Issue #78747.
[Testgrid results](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=should%20surface%20a%20failure%20condition%20on%20a%20common%20issue%20like%20exceeded%20quota&include-filter-by-regex=ReplicaSet%20should%20surface%20a%20failure%20condition%20on%20a%20common%20issue%20like%20exceeded%20quota&width=5&include-filter-by-regex=%5Bsig-apps%5D%20StatefulSet%20%5Bk8s.io%5D%20Basic%20StatefulSet%20functionality%20%5BStatefulSetBasic%5D%20should%20have%20a%20working%20scale%20subresource).
Test(s):
- [sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should have a working scale subresource  

Endpoint(s):
- replaceAppsV1NamespacedStatefulSetScale
- readAppsV1NamespacedStatefulSetScale

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/area conformance
/area test
@kubernetes/sig-apps-pr-reviews
@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg