### PR TITLE
publishing: bump go versions for 1.13 and 1.14

### DIFF
--- a/staging/publishing/rules-godeps.yaml
+++ b/staging/publishing/rules-godeps.yaml
@@ -16,7 +16,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/code-generator
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
   - source:
       branch: release-1.14
       dir: staging/src/k8s.io/code-generator
@@ -34,7 +34,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/apimachinery
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
   - source:
       branch: release-1.14
       dir: staging/src/k8s.io/apimachinery
@@ -55,7 +55,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/api
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -84,7 +84,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/client-go
     name: release-10.0
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -134,7 +134,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/apiserver
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -176,7 +176,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -226,7 +226,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -290,7 +290,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/sample-controller
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -353,7 +353,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -406,7 +406,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/metrics
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -447,7 +447,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/csi-api
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -490,7 +490,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: api
       branch: release-1.13
@@ -531,7 +531,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: api
       branch: release-1.13
@@ -572,7 +572,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -603,7 +603,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/kubelet
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -638,7 +638,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -673,7 +673,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -698,7 +698,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: apimachinery
       branch: release-1.13
@@ -721,7 +721,7 @@ rules:
       branch: release-1.13
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.13
-    go: 1.11.2
+    go: 1.11.5
     dependencies:
     - repository: api
       branch: release-1.13

--- a/staging/publishing/rules-godeps.yaml
+++ b/staging/publishing/rules-godeps.yaml
@@ -21,7 +21,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/code-generator
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
 - destination: apimachinery
   library: true
   branches:
@@ -39,7 +39,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/apimachinery
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
 - destination: api
   library: true
   branches:
@@ -63,7 +63,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/api
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -94,7 +94,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/client-go
     name: release-11.0
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -111,7 +111,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/component-base
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -146,7 +146,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/apiserver
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -190,7 +190,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -244,7 +244,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -306,7 +306,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/sample-controller
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -371,7 +371,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -418,7 +418,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/metrics
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -461,7 +461,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/csi-api
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -502,7 +502,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: api
         branch: release-1.14
@@ -545,7 +545,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: api
         branch: release-1.14
@@ -580,7 +580,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -613,7 +613,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/kubelet
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -648,7 +648,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -683,7 +683,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -708,7 +708,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: apimachinery
         branch: release-1.14
@@ -733,7 +733,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: api
         branch: release-1.14
@@ -750,7 +750,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/node-api
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: api
         branch: release-1.14
@@ -765,7 +765,7 @@ rules:
       branch: release-1.14
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.14
-    go: 1.12
+    go: 1.12.5
     dependencies:
       - repository: api
         branch: release-1.14


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/80134#discussion_r303265612

This PR has the following changes:

- Bump Go version for `release-1.13` to 1.11.5. ([Ref](https://github.com/kubernetes/kubernetes/blob/release-1.13/build/build-image/cross/VERSION))

- Bump Go version for `release-1.14` to 1.12.5. ([Ref](https://github.com/kubernetes/kubernetes/blob/release-1.13/build/build-image/cross/VERSION))

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/hold
@feiskyer can you confirm that it's fine to remove rules for `release-1.12` for the publishing-bot? are any more patch releases expected for this branch?

/cc @sttts @dims 
