### PR TITLE
cleanup: remove useless code

### DIFF
--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -500,10 +500,6 @@ func registerWebhookForAttachingPod(f *framework.Framework, context *certContext
 
 	namespace := f.Namespace.Name
 	configName := attachingPodWebhookConfigName
-	// A webhook that cannot talk to server, with fail-open policy
-	failOpenHook := failingWebhook(namespace, "fail-open.k8s.io")
-	policyIgnore := admissionregistrationv1beta1.Ignore
-	failOpenHook.FailurePolicy = &policyIgnore
 
 	_, err := client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Create(&admissionregistrationv1beta1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
`failOpenHook` is validate against `configmaps`, it has nothing to
do with pod attaching.

Signed-off-by: Dave Chen <dave.chen@arm.com>


**What type of PR is this?**
 /kind cleanup


```release-note
NONE
```
