### PR TITLE
Automated cherry pick of #80048: Fixes mount/unmount paths for migrated inline volumes. Some

### DIFF
--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -764,6 +764,12 @@ func (og *operationGenerator) resizeFileSystem(volumeToMount VolumeToMount, rsOp
 		return true, nil
 	}
 
+	if volumeToMount.VolumeSpec != nil &&
+		volumeToMount.VolumeSpec.InlineVolumeSpecForCSIMigration {
+		klog.V(4).Infof("This volume %s is a migrated inline volume and is not resizable", volumeToMount.VolumeName)
+		return true, nil
+	}
+
 	// Get expander, if possible
 	expandableVolumePlugin, _ :=
 		og.volumePluginMgr.FindNodeExpandablePluginBySpec(volumeToMount.VolumeSpec)

--- a/staging/src/k8s.io/csi-translation-lib/plugins/BUILD
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/BUILD
@@ -16,6 +16,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/storage/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/cloud-provider/volume:go_default_library",
     ],

--- a/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -57,6 +58,10 @@ func (t *awsElasticBlockStoreCSITranslator) TranslateInTreeInlineVolumeToCSI(vol
 	}
 	ebsSource := volume.AWSElasticBlockStore
 	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			// A.K.A InnerVolumeSpecName required to match for Unmount
+			Name: volume.Name,
+		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -67,6 +68,10 @@ func (t *azureDiskCSITranslator) TranslateInTreeInlineVolumeToCSI(volume *v1.Vol
 
 	azureSource := volume.AzureDisk
 	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			// A.K.A InnerVolumeSpecName required to match for Unmount
+			Name: volume.Name,
+		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -63,6 +64,10 @@ func (t *azureFileCSITranslator) TranslateInTreeInlineVolumeToCSI(volume *v1.Vol
 	azureSource := volume.AzureFile
 
 	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			// A.K.A InnerVolumeSpecName required to match for Unmount
+			Name: volume.Name,
+		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{

--- a/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudvolume "k8s.io/cloud-provider/volume"
 )
@@ -172,6 +173,10 @@ func (g *gcePersistentDiskCSITranslator) TranslateInTreeInlineVolumeToCSI(volume
 	}
 
 	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			// A.K.A InnerVolumeSpecName required to match for Unmount
+			Name: volume.Name,
+		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{

--- a/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -54,6 +55,10 @@ func (t *osCinderCSITranslator) TranslateInTreeInlineVolumeToCSI(volume *v1.Volu
 
 	cinderSource := volume.Cinder
 	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			// A.K.A InnerVolumeSpecName required to match for Unmount
+			Name: volume.Name,
+		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{

--- a/staging/src/k8s.io/csi-translation-lib/translate.go
+++ b/staging/src/k8s.io/csi-translation-lib/translate.go
@@ -125,8 +125,12 @@ func GetInTreePluginNameFromSpec(pv *v1.PersistentVolume, vol *v1.Volume) (strin
 		}
 		return "", fmt.Errorf("could not find in-tree plugin name from persistent volume %v", pv)
 	} else if vol != nil {
-		// TODO(dyzz): Implement inline volume migration support
-		return "", errors.New("inline volume migration not yet supported")
+		for _, curPlugin := range inTreePlugins {
+			if curPlugin.CanSupportInline(vol) {
+				return curPlugin.GetInTreePluginName(), nil
+			}
+		}
+		return "", fmt.Errorf("could not find in-tree plugin name from volume %v", vol)
 	} else {
 		return "", errors.New("both persistent volume and volume are nil")
 	}


### PR DESCRIPTION
Cherry pick of #80048 on release-1.15.

Migrated inline volumes were not working. The Mount/Unmount paths were broken because the translation lib was throwing a not implemented error, the resize pathway was trying to check for volume resize on inline volumes, and the PV name (A.K.A InnerVolumeSpec) was not populated for any volume types, I've resolved it for all existing translation lib volumes (other cloud providers may also have to resolve this).

Needs to be cherry-picked to `1.15`

/assign @msau42 @ddebroy 
/cc @leakingtapan @andyzhangx @adisky 

/kind bug
/sig storage
/priority important-soon

```release-note
NONE
```