### PR TITLE
release: accept empty KUBE_DOCKER_IMAGE_TAG

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -385,9 +385,8 @@ EOF
         "${DOCKER[@]}" build "${docker_build_opts[@]}" -q -t "${docker_image_tag}" "${docker_build_path}" >/dev/null
         # If we are building an official/alpha/beta release we want to keep
         # docker images and tag them appropriately.
-        local release_docker_image_tag=""
-        if [[ -n "${KUBE_DOCKER_IMAGE_TAG-}" || -n "${KUBE_DOCKER_REGISTRY-}" ]]; then
-          release_docker_image_tag="${KUBE_DOCKER_REGISTRY-$docker_registry}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG-$docker_tag}"
+        local -r release_docker_image_tag="${KUBE_DOCKER_REGISTRY-$docker_registry}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG-$docker_tag}"
+        if [[ "${release_docker_image_tag}" != "${docker_image_tag}" ]]; then
           kube::log::status "Tagging docker image ${docker_image_tag} as ${release_docker_image_tag}"
           "${DOCKER[@]}" rmi "${release_docker_image_tag}" 2>/dev/null || true
           "${DOCKER[@]}" tag "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
@@ -397,11 +396,8 @@ EOF
         rm -rf "${docker_build_path}"
         ln "${binary_dir}/${binary_name}.tar" "${images_dir}/"
 
-        if [[ -z "${KUBE_DOCKER_IMAGE_TAG-}" || -z "${KUBE_DOCKER_REGISTRY-}" ]]; then
-          # not a release
-          kube::log::status "Deleting docker image ${docker_image_tag}"
-          "${DOCKER[@]}" rmi "${docker_image_tag}" &>/dev/null || true
-        fi
+        kube::log::status "Deleting docker image ${docker_image_tag}"
+        "${DOCKER[@]}" rmi "${docker_image_tag}" &>/dev/null || true
       ) &
     done
 

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -386,8 +386,8 @@ EOF
         # If we are building an official/alpha/beta release we want to keep
         # docker images and tag them appropriately.
         local release_docker_image_tag=""
-        if [[ -n "${KUBE_DOCKER_IMAGE_TAG-}" && -n "${KUBE_DOCKER_REGISTRY-}" && $docker_registry != $KUBE_DOCKER_REGISTRY ]]; then
-          release_docker_image_tag="${KUBE_DOCKER_REGISTRY}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG}"
+        if [[ -n "${KUBE_DOCKER_IMAGE_TAG-}" || -n "${KUBE_DOCKER_REGISTRY-}" ]]; then
+          release_docker_image_tag="${KUBE_DOCKER_REGISTRY-$docker_registry}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG-$docker_tag}"
           kube::log::status "Tagging docker image ${docker_image_tag} as ${release_docker_image_tag}"
           "${DOCKER[@]}" rmi "${release_docker_image_tag}" 2>/dev/null || true
           "${DOCKER[@]}" tag "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When we build CI releases, they need to use the same docker tag for 'k8s.gcr.io' and for KUBE_DOCKER_REGISTRY. If we leave KUBE_DOCKER_IMAGE_TAG empty, it will use the same docker tag.

See https://github.com/kubernetes/kubernetes/issues/80184

**Special notes for your reviewer**:
If only KUBE_DOCKER_IMAGE_TAG is defined, and for some reason the value is the same as '$docker_tag', it will work because we can tag the image with the same name. The only difference, the image will be preserved at the end of the execution.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
