### PR TITLE
Fix error shadowing error for createPDWithRetry so failures return actual error

### DIFF
--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -647,8 +647,9 @@ func MakePersistentVolumeClaim(cfg PersistentVolumeClaimConfig, ns string) *v1.P
 
 func createPDWithRetry(zone string) (string, error) {
 	var err error
+	var newDiskName string
 	for start := time.Now(); time.Since(start) < pdRetryTimeout; time.Sleep(pdRetryPollTime) {
-		newDiskName, err := createPD(zone)
+		newDiskName, err = createPD(zone)
 		if err != nil {
 			e2elog.Logf("Couldn't create a new PD, sleeping 5 seconds: %v", err)
 			continue


### PR DESCRIPTION
When PD creation fails we actually returned empty string and empty error. It's masking things and causing failures later in a test

/sig storage
/kind bug
/kind failing-test

/assign @msau42 


```release-note
NONE
```