### PR TITLE
kubeadm: get rid of dependency on pkg/util/node

### DIFF
--- a/cmd/kubeadm/.import-restrictions
+++ b/cmd/kubeadm/.import-restrictions
@@ -82,7 +82,6 @@
 				"k8s.io/kubernetes/pkg/util/iptables",
 				"k8s.io/kubernetes/pkg/util/ipvs",
 				"k8s.io/kubernetes/pkg/util/metrics",
-				"k8s.io/kubernetes/pkg/util/node",
 				"k8s.io/kubernetes/pkg/util/parsers",
 				"k8s.io/kubernetes/pkg/util/procfs",
 				"k8s.io/kubernetes/pkg/util/sysctl",

--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//cmd/kubeadm/app/util/initsystem:go_default_library",
         "//pkg/kubelet/apis/config:go_default_library",
-        "//pkg/util/node:go_default_library",
         "//pkg/util/procfs:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
-	nodeutil "k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/util/procfs"
 	utilsexec "k8s.io/utils/exec"
 )
@@ -47,10 +46,11 @@ type kubeletFlagsOpts struct {
 // WriteKubeletDynamicEnvFile writes an environment file with dynamic flags to the kubelet.
 // Used at "kubeadm init" and "kubeadm join" time.
 func WriteKubeletDynamicEnvFile(cfg *kubeadmapi.ClusterConfiguration, nodeReg *kubeadmapi.NodeRegistrationOptions, registerTaintsUsingFlags bool, kubeletDir string) error {
-	hostName, err := nodeutil.GetHostname("")
+	hostName, err := os.Hostname()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "couldn't determine hostname")
 	}
+	hostName = strings.ToLower(hostName)
 
 	flagOpts := kubeletFlagsOpts{
 		nodeRegOpts:              nodeReg,

--- a/cmd/kubeadm/app/phases/markcontrolplane/BUILD
+++ b/cmd/kubeadm/app/phases/markcontrolplane/BUILD
@@ -12,7 +12,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/constants:go_default_library",
-        "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane_test.go
+++ b/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane_test.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -29,7 +31,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/pkg/util/node"
 )
 
 func TestMarkControlPlane(t *testing.T) {
@@ -108,10 +109,12 @@ func TestMarkControlPlane(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			hostname, err := node.GetHostname("")
+			hostname, err := os.Hostname()
 			if err != nil {
-				t.Fatalf("MarkControlPlane(%s): unexpected error: %v", tc.name, err)
+				t.Fatalf("MarkControlPlane(%s): couldn't determine hostname: %v", tc.name, err)
 			}
+			hostname = strings.ToLower(hostname)
+
 			controlPlaneNode := &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: hostname,

--- a/cmd/kubeadm/app/util/config/BUILD
+++ b/cmd/kubeadm/app/util/config/BUILD
@@ -26,7 +26,6 @@ go_library(
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//cmd/kubeadm/app/util/config/strict:go_default_library",
         "//cmd/kubeadm/app/util/runtime:go_default_library",
-        "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Replaced GetHostname calls with os.Hostname + a bit of logic
from the GetHostname API.

**Which issue(s) this PR fixes**:

Refs kubernetes/kubeadm#1600

**Special notes for your reviewer**:

This is a replacement of [this](https://github.com/kubernetes/kubernetes/pull/79477) and [this](https://github.com/kubernetes/utils/pull/103) as both were pushed back for various reasons.

```release-note
NONE
```