### PR TITLE
Use scheduler cache in affinity priority functions

### DIFF
--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -79,7 +79,6 @@ go_test(
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
-        "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/tools/events:go_default_library",
     ],

--- a/pkg/scheduler/algorithm/types.go
+++ b/pkg/scheduler/algorithm/types.go
@@ -34,7 +34,7 @@ var NodeFieldSelectorKeys = map[string]func(*v1.Node) string{
 type NodeLister interface {
 	// We explicitly return []*v1.Node, instead of v1.NodeList, to avoid
 	// performing expensive copies that are unneeded.
-	List() ([]*v1.Node, error)
+	ListNodes() []*v1.Node
 }
 
 // PodFilter is a function to filter a pod. If pod passed return true else return false.

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -195,7 +195,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 		return result, prefilterStatus.AsError()
 	}
 
-	nodes, err := nodeLister.List()
+	nodes := nodeLister.ListNodes()
 	if err != nil {
 		return result, err
 	}
@@ -324,10 +324,7 @@ func (g *genericScheduler) Preempt(pod *v1.Pod, nodeLister algorithm.NodeLister,
 		klog.V(5).Infof("Pod %v/%v is not eligible for more preemption.", pod.Namespace, pod.Name)
 		return nil, nil, nil, nil
 	}
-	allNodes, err := nodeLister.List()
-	if err != nil {
-		return nil, nil, nil, err
-	}
+	allNodes := nodeLister.ListNodes()
 	if len(allNodes) == 0 {
 		return nil, nil, nil, ErrNoNodesAvailable
 	}

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -715,8 +715,24 @@ func (cache *schedulerCache) GetNodeInfo(nodeName string) (*v1.Node, error) {
 
 	n, ok := cache.nodes[nodeName]
 	if !ok {
-		return nil, fmt.Errorf("error retrieving node '%v' from cache", nodeName)
+		return nil, fmt.Errorf("node %q not found in cache", nodeName)
 	}
 
 	return n.info.Node(), nil
+}
+
+// ListNodes returns the cached list of nodes.
+func (cache *schedulerCache) ListNodes() []*v1.Node {
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+
+	nodes := make([]*v1.Node, 0, len(cache.nodes))
+	for _, node := range cache.nodes {
+		// Node info is sometimes not removed immediately. See schedulerCache.RemoveNode.
+		n := node.info.Node()
+		if n != nil {
+			nodes = append(nodes, n)
+		}
+	}
+	return nodes
 }

--- a/pkg/scheduler/internal/cache/fake/fake_cache.go
+++ b/pkg/scheduler/internal/cache/fake/fake_cache.go
@@ -109,3 +109,8 @@ func (c *Cache) NodeTree() *internalcache.NodeTree { return nil }
 func (c *Cache) GetNodeInfo(nodeName string) (*v1.Node, error) {
 	return nil, nil
 }
+
+// ListNodes is a fake method for testing.
+func (c *Cache) ListNodes() []*v1.Node {
+	return nil
+}

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -17,9 +17,8 @@ limitations under the License.
 package cache
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
@@ -59,6 +58,9 @@ import (
 // - Both "Expired" and "Deleted" are valid end states. In case of some problems, e.g. network issue,
 //   a pod might have changed its state (e.g. added and deleted) without delivering notification to the cache.
 type Cache interface {
+	algorithm.PodLister
+	algorithm.NodeLister
+
 	// AssumePod assumes a pod scheduled and aggregates the pod's information into its node.
 	// The implementation also decides the policy to expire pod before being confirmed (receiving Add event).
 	// After expiration, its information would be subtracted.
@@ -112,12 +114,6 @@ type Cache interface {
 
 	// GetNodeInfo returns the node object with node string.
 	GetNodeInfo(nodeName string) (*v1.Node, error)
-
-	// List lists all cached pods (including assumed ones).
-	List(labels.Selector) ([]*v1.Pod, error)
-
-	// FilteredList returns all cached pods that pass the filter.
-	FilteredList(filter algorithm.PodFilter, selector labels.Selector) ([]*v1.Pod, error)
 
 	// Snapshot takes a snapshot on current cache
 	Snapshot() *Snapshot

--- a/pkg/scheduler/testing/fake_lister.go
+++ b/pkg/scheduler/testing/fake_lister.go
@@ -33,9 +33,9 @@ var _ algorithm.NodeLister = &FakeNodeLister{}
 // FakeNodeLister implements NodeLister on a []string for test purposes.
 type FakeNodeLister []*v1.Node
 
-// List returns nodes as a []string.
-func (f FakeNodeLister) List() ([]*v1.Node, error) {
-	return f, nil
+// ListNodes returns nodes as a []*v1.Node.
+func (f FakeNodeLister) ListNodes() []*v1.Node {
+	return f
 }
 
 var _ algorithm.PodLister = &FakePodLister{}


### PR DESCRIPTION
Make the cache implement NodeLister and expose it to the priority
functions. This way, the priority functions make use of a single cache,
the scheduler's, instead of mixing it with the lister's caches.

Fixes #79629

/kind cleanup

```release-note
NONE
```