### PR TITLE
gce: configure: use 'amd64' in kube core images manifest

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -381,15 +381,6 @@ function load-docker-images {
   else
     try-load-docker-image "${img_dir}/kube-proxy.tar"
   fi
-  # When we load from a docker archive, the image is tagged with the arch, we don't have docker manifests here.
-  # The resource manifest is expecting something like 'registry/kube-controller-manager:v1.2.3', no arch specified.
-  local -r images=$(docker images --format "{{.Repository}}:{{.Tag}}" | egrep 'kube-apiserver|kube-controller-manager|kube-scheduler|kube-proxy' | grep amd64)
-  for image in $images ; do
-    local manifest_name="${image/-amd64/}"
-    if ! docker images --format "{{.Repository}}:{{.Tag}}" | grep -q ${manifest_name} ; then
-      docker tag $image $manifest_name
-    fi
-  done
 }
 
 # Downloads kubernetes binaries and kube-system manifest tarball, unpacks them,

--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -18,7 +18,7 @@
 "containers":[
     {
     "name": "kube-apiserver",
-    "image": "{{pillar['kube_docker_registry']}}/kube-apiserver:{{pillar['kube-apiserver_docker_tag']}}",
+    "image": "{{pillar['kube_docker_registry']}}/kube-apiserver-amd64:{{pillar['kube-apiserver_docker_tag']}}",
     "resources": {
       "requests": {
         "cpu": "250m"

--- a/cluster/gce/manifests/kube-controller-manager.manifest
+++ b/cluster/gce/manifests/kube-controller-manager.manifest
@@ -18,7 +18,7 @@
 "containers":[
     {
     "name": "kube-controller-manager",
-    "image": "{{pillar['kube_docker_registry']}}/kube-controller-manager:{{pillar['kube-controller-manager_docker_tag']}}",
+    "image": "{{pillar['kube_docker_registry']}}/kube-controller-manager-amd64:{{pillar['kube-controller-manager_docker_tag']}}",
     "resources": {
       "requests": {
         "cpu": "{{cpurequest}}"

--- a/cluster/gce/manifests/kube-proxy.manifest
+++ b/cluster/gce/manifests/kube-proxy.manifest
@@ -16,7 +16,7 @@ spec:
     effect: "NoSchedule"
   containers:
   - name: kube-proxy
-    image: {{pillar['kube_docker_registry']}}/kube-proxy:{{pillar['kube-proxy_docker_tag']}}
+    image: {{pillar['kube_docker_registry']}}/kube-proxy-amd64:{{pillar['kube-proxy_docker_tag']}}
     resources:
       requests:
         cpu: {{ cpurequest }}

--- a/cluster/gce/manifests/kube-scheduler.manifest
+++ b/cluster/gce/manifests/kube-scheduler.manifest
@@ -18,7 +18,7 @@
 "containers":[
     {
     "name": "kube-scheduler",
-    "image": "{{pillar['kube_docker_registry']}}/kube-scheduler:{{pillar['kube-scheduler_docker_tag']}}",
+    "image": "{{pillar['kube_docker_registry']}}/kube-scheduler-amd64:{{pillar['kube-scheduler_docker_tag']}}",
     "resources": {
       "requests": {
         "cpu": "{{cpurequest}}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Instead of using docker tag to tag core images without the arch in the name, like 'kube-apiserver-amd64' as 'kube-apiserver', we should update the configuration script for GCE to setup the resource manifest to point to 'kube-apiserver-amd64'.

Alternative: adding a tag into containerd is not trivial as using docker tag.
The workflow looks like:
1. import image into docker (docker load)
2. docker tag with the name 'kube-apiserver'
3. export image (docker save) with the names 'kube-apiserver' and 'kube-apiserver-amd64'
4. import image into containerd (ctr cri load)

**Special notes for your reviewer**:
Previous changed assumed container images were available in docker, which is not true.
I'm reverting this logic.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
