### PR TITLE
 Remove NodeLister from Scheduler Configurator

### DIFF
--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -153,8 +153,6 @@ type Configurator interface {
 	GetClient() clientset.Interface
 
 	// TODO(#80216): Remove these methods from the interface.
-	// Needs to be exposed for things like integration tests where we want to make fake nodes.
-	GetNodeLister() corelisters.NodeLister
 	// Exposed for testing
 	GetScheduledPodLister() corelisters.PodLister
 
@@ -170,8 +168,6 @@ type configFactory struct {
 	client clientset.Interface
 	// a means to list all known scheduled pods.
 	scheduledPodLister corelisters.PodLister
-	// a means to list all nodes
-	nodeLister corelisters.NodeLister
 	// a means to list all PersistentVolumes
 	pVLister corelisters.PersistentVolumeLister
 	// a means to list all PersistentVolumeClaims
@@ -281,7 +277,6 @@ func NewConfigFactory(args *ConfigFactoryArgs) Configurator {
 	c := &configFactory{
 		client:                         args.Client,
 		podQueue:                       internalqueue.NewSchedulingQueue(stopEverything, framework),
-		nodeLister:                     args.NodeInformer.Lister(),
 		pVLister:                       args.PvInformer.Lister(),
 		pVCLister:                      args.PvcInformer.Lister(),
 		serviceLister:                  args.ServiceInformer.Lister(),
@@ -322,11 +317,6 @@ func NewConfigFactory(args *ConfigFactoryArgs) Configurator {
 		c.podQueue.Close()
 	}()
 	return c
-}
-
-// GetNodeStore provides the cache to the nodes, mostly internal use, but may also be called by mock-tests.
-func (c *configFactory) GetNodeLister() corelisters.NodeLister {
-	return c.nodeLister
 }
 
 func (c *configFactory) GetHardPodAffinitySymmetricWeight() int32 {

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -152,7 +152,7 @@ type Configurator interface {
 	// Exposed for testing
 	GetClient() clientset.Interface
 
-	// TODO(#80216): Remove these methods from the interface.
+	// TODO(#80216): Remove GetScheduledPodLister from the interface.
 	// Exposed for testing
 	GetScheduledPodLister() corelisters.PodLister
 
@@ -163,7 +163,7 @@ type Configurator interface {
 }
 
 // configFactory is the default implementation of the scheduler.Configurator interface.
-// TODO(#80216): Remove pod and node listers.
+// TODO(#80216): Remove pod lister.
 type configFactory struct {
 	client clientset.Interface
 	// a means to list all known scheduled pods.

--- a/pkg/scheduler/testutil.go
+++ b/pkg/scheduler/testutil.go
@@ -56,11 +56,6 @@ func (fc *FakeConfigurator) MakeDefaultErrorFunc(backoff *internalqueue.PodBacko
 	return nil
 }
 
-// GetNodeLister is not implemented yet.
-func (fc *FakeConfigurator) GetNodeLister() corelisters.NodeLister {
-	return nil
-}
-
 // GetClient is not implemented yet.
 func (fc *FakeConfigurator) GetClient() clientset.Interface {
 	return nil

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -354,7 +354,7 @@ func TestUnschedulableNodes(t *testing.T) {
 	context := initTest(t, "unschedulable-nodes")
 	defer cleanupTest(t, context)
 
-	nodeLister := context.schedulerConfig.NodeLister
+	nodeLister := context.schedulerConfigArgs.NodeInformer.Lister()
 	// NOTE: This test cannot run in parallel, because it is creating and deleting
 	// non-namespaced objects (Nodes).
 	defer context.clientSet.CoreV1().Nodes().DeleteCollection(nil, metav1.ListOptions{})
@@ -605,8 +605,8 @@ func TestMultiScheduler(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	schedulerConfigFactory2 := createConfiguratorWithPodInformer(fooScheduler, clientSet2, podInformer2, informerFactory2, schedulerframework.NewRegistry(),
-		nil, []kubeschedulerconfig.PluginConfig{}, stopCh)
+	schedulerConfigFactory2 := factory.NewConfigFactory(createConfiguratorArgsWithPodInformer(fooScheduler, clientSet2, podInformer2, informerFactory2, schedulerframework.NewRegistry(),
+		nil, []kubeschedulerconfig.PluginConfig{}, stopCh))
 	schedulerConfig2, err := schedulerConfigFactory2.Create()
 	if err != nil {
 		t.Errorf("Couldn't create scheduler config: %v", err)

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -354,7 +354,7 @@ func TestUnschedulableNodes(t *testing.T) {
 	context := initTest(t, "unschedulable-nodes")
 	defer cleanupTest(t, context)
 
-	nodeLister := context.schedulerConfigFactory.GetNodeLister()
+	nodeLister := context.schedulerConfig.NodeLister
 	// NOTE: This test cannot run in parallel, because it is creating and deleting
 	// non-namespaced objects (Nodes).
 	defer context.clientSet.CoreV1().Nodes().DeleteCollection(nil, metav1.ListOptions{})

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -61,19 +61,19 @@ import (
 )
 
 type testContext struct {
-	closeFn                framework.CloseFunc
-	httpServer             *httptest.Server
-	ns                     *v1.Namespace
-	clientSet              *clientset.Clientset
-	informerFactory        informers.SharedInformerFactory
-	schedulerConfigFactory factory.Configurator
-	schedulerConfig        *factory.Config
-	scheduler              *scheduler.Scheduler
-	stopCh                 chan struct{}
+	closeFn             framework.CloseFunc
+	httpServer          *httptest.Server
+	ns                  *v1.Namespace
+	clientSet           *clientset.Clientset
+	informerFactory     informers.SharedInformerFactory
+	schedulerConfigArgs *factory.ConfigFactoryArgs
+	schedulerConfig     *factory.Config
+	scheduler           *scheduler.Scheduler
+	stopCh              chan struct{}
 }
 
 // createConfiguratorWithPodInformer creates a configurator for scheduler.
-func createConfiguratorWithPodInformer(
+func createConfiguratorArgsWithPodInformer(
 	schedulerName string,
 	clientSet clientset.Interface,
 	podInformer coreinformers.PodInformer,
@@ -82,8 +82,8 @@ func createConfiguratorWithPodInformer(
 	plugins *schedulerconfig.Plugins,
 	pluginConfig []schedulerconfig.PluginConfig,
 	stopCh <-chan struct{},
-) factory.Configurator {
-	return factory.NewConfigFactory(&factory.ConfigFactoryArgs{
+) *factory.ConfigFactoryArgs {
+	return &factory.ConfigFactoryArgs{
 		SchedulerName:                  schedulerName,
 		Client:                         clientSet,
 		NodeInformer:                   informerFactory.Core().V1().Nodes(),
@@ -105,7 +105,7 @@ func createConfiguratorWithPodInformer(
 		PercentageOfNodesToScore:       schedulerapi.DefaultPercentageOfNodesToScore,
 		BindTimeoutSeconds:             600,
 		StopCh:                         stopCh,
-	})
+	}
 }
 
 // initTestMasterAndScheduler initializes a test environment and creates a master with default
@@ -186,16 +186,17 @@ func initTestSchedulerWithOptions(
 		podInformer = context.informerFactory.Core().V1().Pods()
 	}
 
-	context.schedulerConfigFactory = createConfiguratorWithPodInformer(
+	context.schedulerConfigArgs = createConfiguratorArgsWithPodInformer(
 		v1.DefaultSchedulerName, context.clientSet, podInformer, context.informerFactory, pluginRegistry, plugins,
 		pluginConfig, context.stopCh)
+	configFactory := factory.NewConfigFactory(context.schedulerConfigArgs)
 
 	var err error
 
 	if policy != nil {
-		context.schedulerConfig, err = context.schedulerConfigFactory.CreateFromConfig(*policy)
+		context.schedulerConfig, err = configFactory.CreateFromConfig(*policy)
 	} else {
-		context.schedulerConfig, err = context.schedulerConfigFactory.Create()
+		context.schedulerConfig, err = configFactory.Create()
 	}
 
 	if err != nil {


### PR DESCRIPTION
/kind cleanup

The NodeLister from the Configurator is no longer used in runtime code, so tests shouldn't use it either. Use the lister from Config instead

**Which issue(s) this PR fixes**:
First tackle on #80216

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```