### PR TITLE
Add OWNERS for generated openapi spec package

### DIFF
--- a/pkg/generated/openapi/OWNERS
+++ b/pkg/generated/openapi/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- sttts
+- roycaihw
+- liggitt
+reviewers:
+- sttts
+- roycaihw
+- liggitt
+labels:
+- sig/api-machinery
+- area/code-generation


### PR DESCRIPTION
This package needed pkg top-level approval, but should be owned by people responsible for the openapi spec. The BUILD file contains special logic for the openapi spec generation.

```docs
NONE
```