### PR TITLE
Update deprecated diff.ObjectGoPrintDiff method

### DIFF
--- a/staging/src/k8s.io/sample-controller/controller_test.go
+++ b/staging/src/k8s.io/sample-controller/controller_test.go
@@ -182,7 +182,7 @@ func checkAction(expected, actual core.Action, t *testing.T) {
 
 		if !reflect.DeepEqual(expObject, object) {
 			t.Errorf("Action %s %s has wrong object\nDiff:\n %s",
-				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintDiff(expObject, object))
+				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintSideBySide(expObject, object))
 		}
 	case core.UpdateAction:
 		e, _ := expected.(core.UpdateAction)
@@ -191,7 +191,7 @@ func checkAction(expected, actual core.Action, t *testing.T) {
 
 		if !reflect.DeepEqual(expObject, object) {
 			t.Errorf("Action %s %s has wrong object\nDiff:\n %s",
-				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintDiff(expObject, object))
+				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintSideBySide(expObject, object))
 		}
 	case core.PatchAction:
 		e, _ := expected.(core.PatchAction)
@@ -200,7 +200,7 @@ func checkAction(expected, actual core.Action, t *testing.T) {
 
 		if !reflect.DeepEqual(expPatch, patch) {
 			t.Errorf("Action %s %s has wrong patch\nDiff:\n %s",
-				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintDiff(expPatch, patch))
+				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintSideBySide(expPatch, patch))
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup  

**What this PR does / why we need it**:
Use `diff.ObjectGoPrintSideBySide` to print the difference.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
