### PR TITLE
fix panic in ResourceLocation in case of empty pod ip list

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -239,6 +239,18 @@ func getPod(getter ResourceGetter, ctx context.Context, name string) (*api.Pod, 
 	return pod, nil
 }
 
+// returns primary IP for a Pod
+func getPodIP(pod *api.Pod) string {
+	if pod == nil {
+		return ""
+	}
+	if len(pod.Status.PodIPs) > 0 {
+		return pod.Status.PodIPs[0].IP
+	}
+
+	return ""
+}
+
 // ResourceLocation returns a URL to which one can send traffic for the specified pod.
 func ResourceLocation(getter ResourceGetter, rt http.RoundTripper, ctx context.Context, id string) (*url.URL, http.RoundTripper, error) {
 	// Allow ID as "podname" or "podname:port" or "scheme:podname:port".
@@ -262,8 +274,8 @@ func ResourceLocation(getter ResourceGetter, rt http.RoundTripper, ctx context.C
 			}
 		}
 	}
-
-	if err := proxyutil.IsProxyableIP(pod.Status.PodIPs[0].IP); err != nil {
+	podIP := getPodIP(pod)
+	if err := proxyutil.IsProxyableIP(podIP); err != nil {
 		return nil, nil, errors.NewBadRequest(err.Error())
 	}
 
@@ -271,9 +283,9 @@ func ResourceLocation(getter ResourceGetter, rt http.RoundTripper, ctx context.C
 		Scheme: scheme,
 	}
 	if port == "" {
-		loc.Host = pod.Status.PodIPs[0].IP
+		loc.Host = podIP
 	} else {
-		loc.Host = net.JoinHostPort(pod.Status.PodIPs[0].IP, port)
+		loc.Host = net.JoinHostPort(podIP, port)
 	}
 	return loc, rt, nil
 }

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -487,3 +487,80 @@ func TestPortForwardLocation(t *testing.T) {
 		}
 	}
 }
+
+func TestGetPodIP(t *testing.T) {
+	testCases := []struct {
+		name       string
+		pod        *api.Pod
+		expectedIP string
+	}{
+		{
+			name:       "nil pod",
+			pod:        nil,
+			expectedIP: "",
+		},
+		{
+			name: "no status object",
+			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod1"},
+				Spec:       api.PodSpec{},
+			},
+			expectedIP: "",
+		},
+		{
+			name: "no pod ips",
+			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod1"},
+				Spec:       api.PodSpec{},
+				Status:     api.PodStatus{},
+			},
+			expectedIP: "",
+		},
+		{
+			name: "empty list",
+			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod1"},
+				Spec:       api.PodSpec{},
+				Status: api.PodStatus{
+					PodIPs: []api.PodIP{},
+				},
+			},
+			expectedIP: "",
+		},
+		{
+			name: "1 ip",
+			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod1"},
+				Spec:       api.PodSpec{},
+				Status: api.PodStatus{
+					PodIPs: []api.PodIP{
+						{IP: "10.0.0.10"},
+					},
+				},
+			},
+			expectedIP: "10.0.0.10",
+		},
+		{
+			name: "multiple ips",
+			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod1"},
+				Spec:       api.PodSpec{},
+				Status: api.PodStatus{
+					PodIPs: []api.PodIP{
+						{IP: "10.0.0.10"},
+						{IP: "10.0.0.20"},
+					},
+				},
+			},
+			expectedIP: "10.0.0.10",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			podIP := getPodIP(tc.pod)
+			if podIP != tc.expectedIP {
+				t.Errorf("expected pod ip:%v does not match actual %v", tc.expectedIP, podIP)
+			}
+		})
+	}
+}


### PR DESCRIPTION

**What type of PR is this?**
/kind api-change
 /kind bug
/kind cleanup
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/commit/54d42e6a658f84ea66593d3107f41db6931a5fbf#r34326319 (cc @liggitt )

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
NONE
```release-note
N/A
```

@kubernetes/sig-network-misc 
