### PR TITLE
build: bazel: release tars should use arch in the name

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -52,14 +52,8 @@ DOCKERIZED_BINARIES = {
     },
 }
 
-# In the bash-based build (build/lib/release.sh), the images built for amd64 do not use
-# an arch in their name (but other arches do), and the GCE cluster scripts
-# (which sideload the images via tarfiles) expect there not to be an arch.
 # When pushing to gcr.io, we want to use an arch, since the archless name is now used for a
 # manifest list. Bazel doesn't support manifest lists (yet), so we can't do that either.
-# For now, we use the archless name for the image tars saved in the server tarball,
-# to satisfy GCE and other similar providers. (If one were to pull the images via the manifest
-# list, the arch wouldn't appear in the name either.)
 [multi_arch_container(
     name = binary,
     architectures = SERVER_PLATFORMS["linux"],
@@ -71,10 +65,8 @@ DOCKERIZED_BINARIES = {
     )),
     # Since the multi_arch_container macro replaces the {ARCH} format string,
     # we need to escape the stamping vars.
-    # Also see comment above about why the push tags use ARCH while the
-    # non-push tags do not.
     docker_push_tags = ["{{STABLE_DOCKER_PUSH_REGISTRY}}/%s-{ARCH}:{{STABLE_DOCKER_TAG}}" % binary],
-    docker_tags = ["{{STABLE_DOCKER_REGISTRY}}/%s:{{STABLE_DOCKER_TAG}}" % binary],
+    docker_tags = ["{{STABLE_DOCKER_REGISTRY}}/%s-{ARCH}:{{STABLE_DOCKER_TAG}}" % binary],
     stamp = True,
     symlinks = {
         # Some cluster startup scripts expect to find the binaries in /usr/local/bin,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Build release-tars with bazel and use the arch in the docker tag name.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/80262

**Special notes for your reviewer**:
This replicate the logic for make build in https://github.com/kubernetes/kubernetes/pull/80047

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ACTION REQUIRED: container images tar files for 'amd64' will now contain the architecture in the RepoTags manifest.json section.
If you are using docker manifests there are not visible changes.
```

