### PR TITLE
Add calling binary envvar to kubectl plugin

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -422,8 +423,12 @@ func HandlePluginCommand(pluginHandler PluginHandler, cmdArgs []string) error {
 		return nil
 	}
 
+	// add KUBECTL_BINARY environment variable, so that downstream plugins can use this for help/examples
+	pluginEnvironment := os.Environ()
+	pluginEnvironment = append(pluginEnvironment, fmt.Sprintf("KUBECTL_BINARY=%s", filepath.Base(os.Args[0])))
+
 	// invoke cmd binary relaying the current environment and args given
-	if err := pluginHandler.Execute(foundBinaryPath, cmdArgs[len(remainingArgs):], os.Environ()); err != nil {
+	if err := pluginHandler.Execute(foundBinaryPath, cmdArgs[len(remainingArgs):], pluginEnvironment); err != nil {
 		return err
 	}
 

--- a/test/cmd/plugins.sh
+++ b/test/cmd/plugins.sh
@@ -48,6 +48,10 @@ run_plugins_tests() {
   output_message=$(PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/bar" kubectl bar arg1)
   kube::test::if_has_string "${output_message}" 'test/fixtures/pkg/kubectl/plugins/bar/kubectl-bar arg1'
 
+  # check that plugin can identify the calling binary via an environment variable
+  output_message=$(PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/bar" kubectl bar)
+  kube::test::if_has_string "${output_message}" 'You can execute me with kubectl bar'
+
   # ensure that a kubectl command supersedes a plugin that overshadows it
   output_message=$(PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/version" kubectl version)
   kube::test::if_has_string "${output_message}" 'Client Version'

--- a/test/fixtures/pkg/kubectl/plugins/bar/kubectl-bar
+++ b/test/fixtures/pkg/kubectl/plugins/bar/kubectl-bar
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 echo "I am plugin bar called with args $0 $@"
+echo "You can execute me with ${KUBECTL_BINARY} bar"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add an environment variable to kubectl plugin calls that names the calling binary. This allows plugins to know the name of the calling kubectl binary, so that they can use this in help and examples.

**Special notes for your reviewer**:
This is useful in the context of distributions that use a custom kubectl binary (such as `oc`), but still support plugins. Plugins would then be able to consume this information when displaying help/examples.

**Does this PR introduce a user-facing change?**:
```release-note
Add KUBECTL_BINARY environment variable to the environment passed to kubectl plugins.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
