### PR TITLE
Check InitContainerStatuses in Kubelet#syncPod

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1594,8 +1594,9 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 		// should be killed intermittently and brought back up
 		// under the qos cgroup hierarchy.
 		// Check if this is the pod's first sync
+		// The application of resource parameters should affect init containers as well.
 		firstSync := true
-		for _, containerStatus := range apiPodStatus.ContainerStatuses {
+		for _, containerStatus := range append(apiPodStatus.InitContainerStatuses, apiPodStatus.ContainerStatuses...) {
 			if containerStatus.State.Running != nil {
 				firstSync = false
 				break


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds check for InitContainerStatuses in deciding whether this is the first sync.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
