### PR TITLE
Don't expect pod to stay up during node upgrade

### DIFF
--- a/test/e2e/upgrades/apparmor.go
+++ b/test/e2e/upgrades/apparmor.go
@@ -69,7 +69,7 @@ func (t *AppArmorUpgradeTest) Setup(f *framework.Framework) {
 // pod can still consume the secret.
 func (t *AppArmorUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade UpgradeType) {
 	<-done
-	if upgrade == MasterUpgrade || upgrade == ClusterUpgrade {
+	if upgrade == MasterUpgrade {
 		t.verifyPodStillUp(f)
 	}
 	t.verifyNodesAppArmorEnabled(f)


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

Fix failing apparmor upgrade test in 1.13->1.14 (needs cherrypick).
I can't find any dashboards for this test? It's failing on our internal dashboard though.

The test verifies that a pod is still running, but that check is only valid if nodes aren't upgraded. This change reverts part of https://github.com/kubernetes/kubernetes/pull/73903 which added verification that the pod is still running for ClusterUpgrade tests.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/priority important-soon
/assign @smarterclayton 