### PR TITLE
Update the cpumanager and topologymanager to error out if an invalid policy is given

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -132,8 +132,7 @@ func NewManager(cpuPolicyName string, reconcilePeriod time.Duration, machineInfo
 		policy = NewStaticPolicy(topo, numReservedCPUs)
 
 	default:
-		klog.Errorf("[cpumanager] Unknown policy \"%s\", falling back to default policy \"%s\"", cpuPolicyName, PolicyNone)
-		policy = NewNonePolicy()
+		return nil, fmt.Errorf("unknown policy: \"%s\"", cpuPolicyName)
 	}
 
 	stateImpl, err := state.NewCheckpointState(stateFileDirectory, cpuManagerStateFileName, policy.Name())

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -232,7 +232,7 @@ func TestCPUManagerGenerate(t *testing.T) {
 			description:                "invalid policy name",
 			cpuPolicyName:              "invalid",
 			nodeAllocatableReservation: nil,
-			expectedPolicy:             "none",
+			expectedError:              fmt.Errorf("unknown policy: \"invalid\""),
 		},
 		{
 			description:                "static policy",

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -17,6 +17,8 @@ limitations under the License.
 package topologymanager
 
 import (
+	"fmt"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/socketmask"
@@ -71,7 +73,7 @@ type TopologyHint struct {
 var _ Manager = &manager{}
 
 //NewManager creates a new TopologyManager based on provided policy
-func NewManager(topologyPolicyName string) Manager {
+func NewManager(topologyPolicyName string) (Manager, error) {
 	klog.Infof("[topologymanager] Creating topology manager with %s policy", topologyPolicyName)
 	var policy Policy
 
@@ -87,8 +89,7 @@ func NewManager(topologyPolicyName string) Manager {
 		policy = NewStrictPolicy()
 
 	default:
-		klog.Errorf("[topologymanager] Unknown policy %s, using default policy %s", topologyPolicyName, PolicyNone)
-		policy = NewNonePolicy()
+		return nil, fmt.Errorf("unknown policy: \"%s\"", topologyPolicyName)
 	}
 
 	var hp []HintProvider
@@ -101,7 +102,7 @@ func NewManager(topologyPolicyName string) Manager {
 		policy:           policy,
 	}
 
-	return manager
+	return manager, nil
 }
 
 func (m *manager) GetAffinity(podUID string, containerName string) TopologyHint {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR updates the `cpumanager` and the `topologymanager` to error out if an invalid policy is specified for either of them.

Previously, these components would simply fall back to their respective None() policies if an invalid policy was specified. This PR updates these components to return an error when an invalid policy is passed to them, forcing the kubelet to fail fast when this occurs.

These semantics should be preferable because an invalid policy likely indicates operator error in setting the policy flag on the kubelet correctly (e.g. misspelling 'static' as 'statiic' or 'strict' as 'striict'). 

In this case it is better to fail fast so the operator can detect this and correct the mistake, than to mask the error and essentially disable the `cpumanager` or the `topologymanager` unexpectedly.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Passing an invalid policy name in the `--cpu-manager-policy` flag will now cause the kubelet to fail instead of simply ignoring the flag and running the `cpumanager`s default policy instead.
```