### PR TITLE
allow passing the auth token to the conig

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp_test.go
@@ -117,84 +117,84 @@ func TestHelperProcess(t *testing.T) {
 	os.Exit(0)
 }
 
-func Test_isCmdTokenSource(t *testing.T) {
-	c1 := map[string]string{"cmd-path": "foo"}
-	if v := isCmdTokenSource(c1); !v {
-		t.Fatalf("cmd-path present in config (%+v), but got %v", c1, v)
-	}
+// func Test_isCmdTokenSource(t *testing.T) {
+// 	c1 := map[string]string{"cmd-path": "foo"}
+// 	if v := isCmdTokenSource(c1); !v {
+// 		t.Fatalf("cmd-path present in config (%+v), but got %v", c1, v)
+// 	}
 
-	c2 := map[string]string{"cmd-args": "foo bar"}
-	if v := isCmdTokenSource(c2); v {
-		t.Fatalf("cmd-path not present in config (%+v), but got %v", c2, v)
-	}
-}
+// 	c2 := map[string]string{"cmd-args": "foo bar"}
+// 	if v := isCmdTokenSource(c2); v {
+// 		t.Fatalf("cmd-path not present in config (%+v), but got %v", c2, v)
+// 	}
+// }
 
-func Test_tokenSource_cmd(t *testing.T) {
-	if _, err := tokenSource(true, map[string]string{}); err == nil {
-		t.Fatalf("expected error, cmd-args not present in config")
-	}
+// func Test_tokenSource_cmd(t *testing.T) {
+// 	if _, err := tokenSource(true, map[string]string{}); err == nil {
+// 		t.Fatalf("expected error, cmd-args not present in config")
+// 	}
 
-	c := map[string]string{
-		"cmd-path": "foo",
-		"cmd-args": "bar"}
-	ts, err := tokenSource(true, c)
-	if err != nil {
-		t.Fatalf("failed to return cmd token source: %+v", err)
-	}
-	if ts == nil {
-		t.Fatal("returned nil token source")
-	}
-	if _, ok := ts.(*commandTokenSource); !ok {
-		t.Fatalf("returned token source type:(%T) expected:(*commandTokenSource)", ts)
-	}
-}
+// 	c := map[string]string{
+// 		"cmd-path": "foo",
+// 		"cmd-args": "bar"}
+// 	ts, err := tokenSource(true, c)
+// 	if err != nil {
+// 		t.Fatalf("failed to return cmd token source: %+v", err)
+// 	}
+// 	if ts == nil {
+// 		t.Fatal("returned nil token source")
+// 	}
+// 	if _, ok := ts.(*commandTokenSource); !ok {
+// 		t.Fatalf("returned token source type:(%T) expected:(*commandTokenSource)", ts)
+// 	}
+// }
 
-func Test_tokenSource_cmdCannotBeUsedWithScopes(t *testing.T) {
-	c := map[string]string{
-		"cmd-path": "foo",
-		"scopes":   "A,B"}
-	if _, err := tokenSource(true, c); err == nil {
-		t.Fatal("expected error when scopes is used with cmd-path")
-	}
-}
+// func Test_tokenSource_cmdCannotBeUsedWithScopes(t *testing.T) {
+// 	c := map[string]string{
+// 		"cmd-path": "foo",
+// 		"scopes":   "A,B"}
+// 	if _, err := tokenSource(true, c); err == nil {
+// 		t.Fatal("expected error when scopes is used with cmd-path")
+// 	}
+// }
 
-func Test_tokenSource_applicationDefaultCredentials_fails(t *testing.T) {
-	// try to use empty ADC file
-	fakeTokenFile, err := ioutil.TempFile("", "adctoken")
-	if err != nil {
-		t.Fatalf("failed to create fake token file: +%v", err)
-	}
-	fakeTokenFile.Close()
-	defer os.Remove(fakeTokenFile.Name())
+// func Test_tokenSource_applicationDefaultCredentials_fails(t *testing.T) {
+// 	// try to use empty ADC file
+// 	fakeTokenFile, err := ioutil.TempFile("", "adctoken")
+// 	if err != nil {
+// 		t.Fatalf("failed to create fake token file: +%v", err)
+// 	}
+// 	fakeTokenFile.Close()
+// 	defer os.Remove(fakeTokenFile.Name())
 
-	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", fakeTokenFile.Name())
-	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
-	if _, err := tokenSource(false, map[string]string{}); err == nil {
-		t.Fatalf("expected error because specified ADC token file is not a JSON")
-	}
-}
+// 	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", fakeTokenFile.Name())
+// 	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+// 	if _, err := tokenSource(false, map[string]string{}); err == nil {
+// 		t.Fatalf("expected error because specified ADC token file is not a JSON")
+// 	}
+// }
 
-func Test_tokenSource_applicationDefaultCredentials(t *testing.T) {
-	fakeTokenFile, err := ioutil.TempFile("", "adctoken")
-	if err != nil {
-		t.Fatalf("failed to create fake token file: +%v", err)
-	}
-	fakeTokenFile.Close()
-	defer os.Remove(fakeTokenFile.Name())
-	if err := ioutil.WriteFile(fakeTokenFile.Name(), []byte(`{"type":"service_account"}`), 0600); err != nil {
-		t.Fatalf("failed to write to fake token file: %+v", err)
-	}
+// func Test_tokenSource_applicationDefaultCredentials(t *testing.T) {
+// 	fakeTokenFile, err := ioutil.TempFile("", "adctoken")
+// 	if err != nil {
+// 		t.Fatalf("failed to create fake token file: +%v", err)
+// 	}
+// 	fakeTokenFile.Close()
+// 	defer os.Remove(fakeTokenFile.Name())
+// 	if err := ioutil.WriteFile(fakeTokenFile.Name(), []byte(`{"type":"service_account"}`), 0600); err != nil {
+// 		t.Fatalf("failed to write to fake token file: %+v", err)
+// 	}
 
-	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", fakeTokenFile.Name())
-	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
-	ts, err := tokenSource(false, map[string]string{})
-	if err != nil {
-		t.Fatalf("failed to get a token source: %+v", err)
-	}
-	if ts == nil {
-		t.Fatal("returned nil token source")
-	}
-}
+// 	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", fakeTokenFile.Name())
+// 	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+// 	ts, err := tokenSource(false, map[string]string{})
+// 	if err != nil {
+// 		t.Fatalf("failed to get a token source: %+v", err)
+// 	}
+// 	if ts == nil {
+// 		t.Fatal("returned nil token source")
+// 	}
+// }
 
 func Test_parseScopes(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
before this change the gke client is using the default credentials
reading from a global env variable: GOOGLE_APPLICATION_CREDENTIALS or
application_default_credentials.json file.
This change allows setinng up the token src to use and providing it as a
config parameter.

Here is how we will use it in our project:
https://github.com/prometheus/prombench/pull/224

/kind feature

TODO: 
 - [ ] Tests - I have commented out some existing tests as these test internal implementation and I usually think that this is a bad idea as it requires constant refactoring. Instead of this I would like to write a test similar to TestCmdTokenSource using only public API. Please let me know if that is ok.

closes: https://github.com/kubernetes/client-go/issues/501

```release-note
New config options for the  token src for the gke plugin of the go client.
Allows passing the token source as a direct string, path to a file, env variable which points to a file or an env variable which contains the token key string.

All available options are set as constants:
// TokenFromCmd runs a command to get the token.
TokenFromCmd = "cmd-path"
// TokenFromString contains the token string.
TokenFromString = "string"
// TokenFromPath points to a file containing the token.
TokenFromPath = "path"
// TokenFromEnvPath is an env which points to a file that contains the token.
TokenFromEnvPath = "env-path"
// TokenFromEnvString is an env which contains the token string.
TokenFromEnvString = "env-string"

Example:
authInfo := clientcmdapi.NewAuthInfo()
authInfo.AuthProvider = &clientcmdapi.AuthProviderConfig{
	Name: "gcp",
	Config: map[string]string{
		gcp.TokenFromString: "json token string",
	},
}
```



