### PR TITLE
Precheck score plugins' weight when initializing

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -93,9 +93,8 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 
 		// A weight of zero is not permitted, plugins can be disabled explicitly
 		// when configured.
-		f.pluginNameToWeightMap[name] = int(pg[name].Weight)
-		if f.pluginNameToWeightMap[name] == 0 {
-			f.pluginNameToWeightMap[name] = 1
+		if pg[name].Weight != 0 {
+			f.pluginNameToWeightMap[name] = int(pg[name].Weight)
 		}
 	}
 
@@ -121,6 +120,9 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 					return nil, fmt.Errorf("plugin %v does not extend score plugin", sc.Name)
 				}
 				f.scorePlugins = append(f.scorePlugins, p)
+				if _, exists := f.pluginNameToWeightMap[p.Name()]; !exists {
+					return nil, fmt.Errorf("score plugin %v is not configured with weight", sc.Name)
+				}
 			} else {
 				return nil, fmt.Errorf("score plugin %v does not exist", sc.Name)
 			}
@@ -276,12 +278,8 @@ func (f *framework) RunScorePlugins(pc *PluginContext, pod *v1.Pod, nodes []*v1.
 	errCh := schedutil.NewErrorChannel()
 	workqueue.ParallelizeUntil(ctx, 16, len(nodes), func(index int) {
 		for _, pl := range f.scorePlugins {
-			weight, weightExists := f.pluginNameToWeightMap[pl.Name()]
-			if !weightExists {
-				err := fmt.Errorf("weight does not exist for plugin %v", pl.Name())
-				errCh.SendErrorWithCancel(err, cancel)
-				return
-			}
+			// Score plugins' weight has been checked when they are initialized.
+			weight, _ := f.pluginNameToWeightMap[pl.Name()]
 			score, status := pl.Score(pc, pod, nodes[index].Name)
 			if !status.IsSuccess() {
 				errCh.SendErrorWithCancel(fmt.Errorf(status.Message()), cancel)

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -456,6 +456,7 @@ func TestScorePlugin(t *testing.T) {
 			Enabled: []schedulerconfig.Plugin{
 				{
 					Name: scorePluginName,
+					Weight: 1,
 				},
 			},
 		},

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -456,7 +456,6 @@ func TestScorePlugin(t *testing.T) {
 			Enabled: []schedulerconfig.Plugin{
 				{
 					Name: scorePluginName,
-					Weight: 1,
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Precheck score plugins' weight when initializing. And it checks that users must configure weight for score plugins. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig scheduling