### PR TITLE
Cleanup the TopologyManager socketmask abstraction

### DIFF
--- a/pkg/kubelet/cm/topologymanager/socketmask/socketmask.go
+++ b/pkg/kubelet/cm/topologymanager/socketmask/socketmask.go
@@ -39,6 +39,12 @@ type SocketMask interface {
 
 type socketMask uint64
 
+//NewEmptySocketMask creates a new, empty SocketMask
+func NewEmptySocketMask() SocketMask {
+	s := socketMask(0)
+	return &s
+}
+
 //NewSocketMask creates a new SocketMask
 func NewSocketMask(sockets ...int) (SocketMask, error) {
 	s := socketMask(0)

--- a/pkg/kubelet/cm/topologymanager/socketmask/socketmask.go
+++ b/pkg/kubelet/cm/topologymanager/socketmask/socketmask.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 )
 
-//SocketMask interface allows hint providers to create SocketMasks for TopologyHints
+// SocketMask interface allows hint providers to create SocketMasks for TopologyHints
 type SocketMask interface {
 	Add(sockets ...int) error
 	Remove(sockets ...int) error
@@ -39,13 +39,13 @@ type SocketMask interface {
 
 type socketMask uint64
 
-//NewEmptySocketMask creates a new, empty SocketMask
+// NewEmptySocketMask creates a new, empty SocketMask
 func NewEmptySocketMask() SocketMask {
 	s := socketMask(0)
 	return &s
 }
 
-//NewSocketMask creates a new SocketMask
+// NewSocketMask creates a new SocketMask
 func NewSocketMask(sockets ...int) (SocketMask, error) {
 	s := socketMask(0)
 	err := (&s).Add(sockets...)
@@ -55,7 +55,7 @@ func NewSocketMask(sockets ...int) (SocketMask, error) {
 	return &s, nil
 }
 
-//Add adds the sockets with topology affinity to the SocketMask
+// Add adds the sockets with topology affinity to the SocketMask
 func (s *socketMask) Add(sockets ...int) error {
 	mask := *s
 	for _, i := range sockets {
@@ -68,7 +68,7 @@ func (s *socketMask) Add(sockets ...int) error {
 	return nil
 }
 
-//Remove removes specified sockets from SocketMask
+// Remove removes specified sockets from SocketMask
 func (s *socketMask) Remove(sockets ...int) error {
 	mask := *s
 	for _, i := range sockets {
@@ -81,36 +81,36 @@ func (s *socketMask) Remove(sockets ...int) error {
 	return nil
 }
 
-//And performs and operation on all bits in masks
+// And performs and operation on all bits in masks
 func (s *socketMask) And(masks ...SocketMask) {
 	for _, m := range masks {
 		*s &= *m.(*socketMask)
 	}
 }
 
-//Or performs or operation on all bits in masks
+// Or performs or operation on all bits in masks
 func (s *socketMask) Or(masks ...SocketMask) {
 	for _, m := range masks {
 		*s |= *m.(*socketMask)
 	}
 }
 
-//Clear resets all bits in mask to zero
+// Clear resets all bits in mask to zero
 func (s *socketMask) Clear() {
 	*s = 0
 }
 
-//Fill sets all bits in mask to one
+// Fill sets all bits in mask to one
 func (s *socketMask) Fill() {
 	*s = socketMask(^uint64(0))
 }
 
-//IsEmpty checks mask to see if all bits are zero
+// IsEmpty checks mask to see if all bits are zero
 func (s *socketMask) IsEmpty() bool {
 	return *s == 0
 }
 
-//IsSet checks socket in mask to see if bit is set to one
+// IsSet checks socket in mask to see if bit is set to one
 func (s *socketMask) IsSet(socket int) bool {
 	if socket < 0 || socket >= 64 {
 		return false
@@ -118,7 +118,7 @@ func (s *socketMask) IsSet(socket int) bool {
 	return (*s & (1 << uint64(socket))) > 0
 }
 
-//IsEqual checks if masks are equal
+// IsEqual checks if masks are equal
 func (s *socketMask) IsEqual(mask SocketMask) bool {
 	return *s == *mask.(*socketMask)
 }
@@ -137,7 +137,7 @@ func (s *socketMask) IsNarrowerThan(mask SocketMask) bool {
 	return s.Count() < mask.Count()
 }
 
-//String converts mask to string
+// String converts mask to string
 func (s *socketMask) String() string {
 	str := ""
 	for i := uint64(0); i < 64; i++ {
@@ -150,7 +150,7 @@ func (s *socketMask) String() string {
 	return str
 }
 
-//Count counts number of bits in mask set to one
+// Count counts number of bits in mask set to one
 func (s *socketMask) Count() int {
 	count := 0
 	for i := uint64(0); i < 64; i++ {
@@ -161,7 +161,7 @@ func (s *socketMask) Count() int {
 	return count
 }
 
-//GetSockets returns each socket number with bits set to one
+// GetSockets returns each socket number with bits set to one
 func (s *socketMask) GetSockets() []int {
 	var sockets []int
 	for i := uint64(0); i < 64; i++ {
@@ -172,14 +172,14 @@ func (s *socketMask) GetSockets() []int {
 	return sockets
 }
 
-//And is a package level implementation of 'and' between first and masks
+// And is a package level implementation of 'and' between first and masks
 func And(first SocketMask, masks ...SocketMask) SocketMask {
 	s := *first.(*socketMask)
 	s.And(masks...)
 	return &s
 }
 
-//Or is a package level implementation of 'or' between first and masks
+// Or is a package level implementation of 'or' between first and masks
 func Or(first SocketMask, masks ...SocketMask) SocketMask {
 	s := *first.(*socketMask)
 	s.Or(masks...)

--- a/pkg/kubelet/cm/topologymanager/socketmask/socketmask.go
+++ b/pkg/kubelet/cm/topologymanager/socketmask/socketmask.go
@@ -171,3 +171,17 @@ func (s *socketMask) GetSockets() []int {
 	}
 	return sockets
 }
+
+//And is a package level implementation of 'and' between first and masks
+func And(first SocketMask, masks ...SocketMask) SocketMask {
+	s := *first.(*socketMask)
+	s.And(masks...)
+	return &s
+}
+
+//Or is a package level implementation of 'or' between first and masks
+func Or(first SocketMask, masks ...SocketMask) SocketMask {
+	s := *first.(*socketMask)
+	s.Or(masks...)
+	return &s
+}

--- a/pkg/kubelet/cm/topologymanager/socketmask/socketmask_test.go
+++ b/pkg/kubelet/cm/topologymanager/socketmask/socketmask_test.go
@@ -106,6 +106,12 @@ func TestAnd(t *testing.T) {
 	for _, tc := range tcases {
 		firstMask, _ := NewSocketMask(tc.firstMaskBit)
 		secondMask, _ := NewSocketMask(tc.secondMaskBit)
+
+		result := And(firstMask, secondMask)
+		if result.String() != string(tc.andMask) {
+			t.Errorf("Expected mask to be %v, got %v", tc.andMask, result)
+		}
+
 		firstMask.And(secondMask)
 		if firstMask.String() != string(tc.andMask) {
 			t.Errorf("Expected mask to be %v, got %v", tc.andMask, firstMask)
@@ -130,6 +136,12 @@ func TestOr(t *testing.T) {
 	for _, tc := range tcases {
 		firstMask, _ := NewSocketMask(tc.firstMaskBit)
 		secondMask, _ := NewSocketMask(tc.secondMaskBit)
+
+		result := Or(firstMask, secondMask)
+		if result.String() != string(tc.orMask) {
+			t.Errorf("Expected mask to be %v, got %v", tc.orMask, result)
+		}
+
 		firstMask.Or(secondMask)
 		if firstMask.String() != string(tc.orMask) {
 			t.Errorf("Expected mask to be %v, got %v", tc.orMask, firstMask)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds package level commands for `And` and `Or` to the `TopologyManager`  `socketmask` abstraction. It also adds a new `NewEmtpySocketMask()` call to the API, so we can create empty socket masks that don't return an `error`. Finally, it cleans up the comments to make them more in line with go conventions.

The combination of the package level `And` and `Or` calls, together with the `NewEmtpySocketMask()` call will help to cleanup some of the code in the places where these socket masks are used.

Follow-up PRs will be created to address these. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```