### PR TITLE
Register Kubelet server metrics

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -80,6 +80,7 @@ go_library(
         "//pkg/kubelet/runtimeclass:go_default_library",
         "//pkg/kubelet/secret:go_default_library",
         "//pkg/kubelet/server:go_default_library",
+        "//pkg/kubelet/server/metrics:go_default_library",
         "//pkg/kubelet/server/portforward:go_default_library",
         "//pkg/kubelet/server/remotecommand:go_default_library",
         "//pkg/kubelet/server/stats:go_default_library",

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -92,6 +92,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/runtimeclass"
 	"k8s.io/kubernetes/pkg/kubelet/secret"
 	"k8s.io/kubernetes/pkg/kubelet/server"
+	servermetrics "k8s.io/kubernetes/pkg/kubelet/server/metrics"
 	serverstats "k8s.io/kubernetes/pkg/kubelet/server/stats"
 	"k8s.io/kubernetes/pkg/kubelet/server/streaming"
 	"k8s.io/kubernetes/pkg/kubelet/stats"
@@ -1318,6 +1319,7 @@ func (kl *Kubelet) initializeModules() error {
 		collectors.NewLogMetricsCollector(kl.StatsProvider.ListPodStats),
 	)
 	metrics.SetNodeName(kl.nodeName)
+	servermetrics.Register()
 
 	// Setup filesystem directories.
 	if err := kl.setupDataDirs(); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Follow up to https://github.com/kubernetes/kubernetes/pull/75228, which forgot to register the new metrics.

**Which issue(s) this PR fixes**:
For https://github.com/kubernetes/kubernetes/issues/75060

**Special notes for your reviewer**:

I'm going to propose cherry-picking this into 1.15, since the metrics were added without being registered.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig node
/priority important-soon
/assign @haiyanmeng 