### PR TITLE
Update misleading comemnts for HandleCrash

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
@@ -40,11 +40,7 @@ var PanicHandlers = []func(interface{}){logPanic}
 // called in case of panic.  HandleCrash actually crashes, after calling the
 // handlers and logging the panic message.
 //
-// TODO: remove this function. We are switching to a world where it's safe for
-// apiserver to panic, since it will be restarted by kubelet. At the beginning
-// of the Kubernetes project, nothing was going to restart apiserver and so
-// catching panics was important. But it's actually much simpler for monitoring
-// software if we just exit when an unexpected panic happens.
+// E.g., you can provide one or more additional handlers for something like shutting down go routines gracefully.
 func HandleCrash(additionalHandlers ...func(interface{})) {
 	if r := recover(); r != nil {
 		for _, fn := range PanicHandlers {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The comment is misleading, actually, it's a good idea for functions to defer HandleCrash.

https://github.com/kubernetes/kubernetes/blob/15ade86935561c92cabfdd60342fe2e22e9dfed9/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go#L38-L61

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Please correct me directly if the description is not correct.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
