### PR TITLE
Update kube-state-metrics cluster role & remove addon-resizer

### DIFF
--- a/cluster/addons/prometheus/kube-state-metrics-deployment.yaml
+++ b/cluster/addons/prometheus/kube-state-metrics-deployment.yaml
@@ -7,18 +7,18 @@ metadata:
     k8s-app: kube-state-metrics
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.3.0
+    version: v1.7.1
 spec:
   selector:
     matchLabels:
       k8s-app: kube-state-metrics
-      version: v1.3.0
+      version: v1.7.1
   replicas: 1
   template:
     metadata:
       labels:
         k8s-app: kube-state-metrics
-        version: v1.3.0
+        version: v1.7.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.0
+        image: quay.io/coreos/kube-state-metrics:v1.7.1
         ports:
         - name: http-metrics
           containerPort: 8080
@@ -38,54 +38,3 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           timeoutSeconds: 5
-      - name: addon-resizer
-        image: k8s.gcr.io/addon-resizer:1.8.5
-        resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 100m
-            memory: 30Mi
-        env:
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        volumeMounts:
-          - name: config-volume
-            mountPath: /etc/config
-        command:
-          - /pod_nanny
-          - --config-dir=/etc/config
-          - --container=kube-state-metrics
-          - --cpu=100m
-          - --extra-cpu=1m
-          - --memory=100Mi
-          - --extra-memory=2Mi
-          - --threshold=5
-          - --deployment=kube-state-metrics
-      volumes:
-        - name: config-volume
-          configMap:
-            name: kube-state-metrics-config
----
-# Config map for resource configuration.
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kube-state-metrics-config
-  namespace: kube-system
-  labels:
-    k8s-app: kube-state-metrics
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-data:
-  NannyConfiguration: |-
-    apiVersion: nannyconfig/v1alpha1
-    kind: NannyConfiguration
-

--- a/cluster/addons/prometheus/kube-state-metrics-rbac.yaml
+++ b/cluster/addons/prometheus/kube-state-metrics-rbac.yaml
@@ -35,9 +35,13 @@ rules:
   - daemonsets
   - deployments
   - replicasets
+  - ingresses
   verbs: ["list", "watch"]
 - apiGroups: ["apps"]
   resources:
+  - daemonsets
+  - deployments
+  - replicasets
   - statefulsets
   verbs: ["list", "watch"]
 - apiGroups: ["batch"]
@@ -49,25 +53,22 @@ rules:
   resources:
   - horizontalpodautoscalers
   verbs: ["list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: kube-state-metrics-resizer
-  namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-rules:
-- apiGroups: [""]
+- apiGroups: ["policy"]
   resources:
-  - pods
-  verbs: ["get"]
-- apiGroups: ["extensions"]
+  - poddisruptionbudgets
+  verbs: ["list", "watch"]
+- apiGroups: ["certificates.k8s.io"]
   resources:
-  - deployments
-  resourceNames: ["kube-state-metrics"]
-  verbs: ["get", "update"]
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources:
+  - storageclasses
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling.k8s.io"]
+  resources:
+  - verticalpodautoscalers
+  verbs: ["list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -80,23 +81,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kube-state-metrics
-subjects:
-- kind: ServiceAccount
-  name: kube-state-metrics
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: kube-state-metrics
-  namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: kube-state-metrics-resizer
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind feature

**What this PR does / why we need it**:
• Bump `kube-state-metrics` to `1.7.1`
• Update `kube-state-metrics` cluster role `resources` and `apiGroups`
• Remove `addon-resizer` sidecar which was causing issues with the autoscalling

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Deployed and works as expected.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
```