### PR TITLE
fix kubectl cp escape when destdir relative

### DIFF
--- a/pkg/kubectl/cmd/cp/cp.go
+++ b/pkg/kubectl/cmd/cp/cp.go
@@ -416,6 +416,12 @@ func recursiveTar(srcBase, srcFile, destBase, destFile string, tw *tar.Writer) e
 func (o *CopyOptions) untarAll(reader io.Reader, destDir, prefix string) error {
 	// TODO: use compression here?
 	tarReader := tar.NewReader(reader)
+	
+	destDir, err := filepath.Abs(destDir)
+	if err != nil {
+		return fmt.Errorf("relative path to absolute path error")
+	}
+	
 	for {
 		header, err := tarReader.Next()
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR cleans up the tar code used in `kubectl cp`.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
`Clean links handling in cp's tar code`


