### PR TITLE
Don't count unrelated volumes in scheduler predicate

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -422,9 +422,9 @@ func (c *MaxPDVolumeCountChecker) filterVolumes(volumes []v1.Volume, namespace s
 
 			pvc, err := c.pvcInfo.GetPersistentVolumeClaimInfo(namespace, pvcName)
 			if err != nil || pvc == nil {
-				// if the PVC is not found, log the error and count the PV towards the PV limit
-				klog.V(4).Infof("Unable to look up PVC info for %s/%s, assuming PVC matches predicate when counting limits: %v", namespace, pvcName, err)
-				filteredVolumes[pvID] = true
+				// If the PVC is invalid, we don't count the volume because
+				// there's no guarantee that it belongs to the running predicate.
+				klog.V(4).Infof("Unable to look up PVC info for %s/%s, assuming PVC doesn't match predicate when counting limits: %v", namespace, pvcName, err)
 				continue
 			}
 

--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -287,6 +287,7 @@ type MaxPDVolumeCountChecker struct {
 	maxVolumeFunc  func(node *v1.Node) int
 	pvInfo         PersistentVolumeInfo
 	pvcInfo        PersistentVolumeClaimInfo
+	scInfo         StorageClassInfo
 
 	// The string below is generated randomly during the struct's initialization.
 	// It is used to prefix volumeID generated inside the predicate() method to
@@ -299,6 +300,8 @@ type VolumeFilter struct {
 	// Filter normal volumes
 	FilterVolume           func(vol *v1.Volume) (id string, relevant bool)
 	FilterPersistentVolume func(pv *v1.PersistentVolume) (id string, relevant bool)
+	// MatchProvisioner evaluates if the StorageClass provisioner matches the running predicate
+	MatchProvisioner func(sc *storagev1.StorageClass) (relevant bool)
 	// IsMigrated returns a boolean specifying whether the plugin is migrated to a CSI driver
 	IsMigrated func(csiNode *storagev1beta1.CSINode) bool
 }
@@ -314,7 +317,7 @@ type VolumeFilter struct {
 // types, counts the number of unique volumes, and rejects the new pod if it would place the total count over
 // the maximum.
 func NewMaxPDVolumeCountPredicate(
-	filterName string, pvInfo PersistentVolumeInfo, pvcInfo PersistentVolumeClaimInfo) FitPredicate {
+	filterName string, scInfo StorageClassInfo, pvInfo PersistentVolumeInfo, pvcInfo PersistentVolumeClaimInfo) FitPredicate {
 	var filter VolumeFilter
 	var volumeLimitKey v1.ResourceName
 
@@ -344,6 +347,7 @@ func NewMaxPDVolumeCountPredicate(
 		maxVolumeFunc:        getMaxVolumeFunc(filterName),
 		pvInfo:               pvInfo,
 		pvcInfo:              pvcInfo,
+		scInfo:               scInfo,
 		randomVolumeIDPrefix: rand.String(32),
 	}
 
@@ -428,19 +432,23 @@ func (c *MaxPDVolumeCountChecker) filterVolumes(volumes []v1.Volume, namespace s
 			if pvName == "" {
 				// PVC is not bound. It was either deleted and created again or
 				// it was forcefully unbound by admin. The pod can still use the
-				// original PV where it was bound to -> log the error and count
-				// the PV towards the PV limit
-				klog.V(4).Infof("PVC %s/%s is not bound, assuming PVC matches predicate when counting limits", namespace, pvcName)
-				filteredVolumes[pvID] = true
+				// original PV where it was bound to, so we count the volume if
+				// it belongs to the running predicate.
+				if c.matchProvisioner(pvc) {
+					klog.V(4).Infof("PVC %s/%s is not bound, assuming PVC matches predicate when counting limits", namespace, pvcName)
+					filteredVolumes[pvID] = true
+				}
 				continue
 			}
 
 			pv, err := c.pvInfo.GetPersistentVolumeInfo(pvName)
 			if err != nil || pv == nil {
-				// if the PV is not found, log the error
-				// and count the PV towards the PV limit
-				klog.V(4).Infof("Unable to look up PV info for %s/%s/%s, assuming PV matches predicate when counting limits: %v", namespace, pvcName, pvName, err)
-				filteredVolumes[pvID] = true
+				// If the PV is invalid and PVC belongs to the running predicate,
+				// log the error and count the PV towards the PV limit.
+				if c.matchProvisioner(pvc) {
+					klog.V(4).Infof("Unable to look up PV info for %s/%s/%s, assuming PV matches predicate when counting limits: %v", namespace, pvcName, pvName, err)
+					filteredVolumes[pvID] = true
+				}
 				continue
 			}
 
@@ -451,6 +459,20 @@ func (c *MaxPDVolumeCountChecker) filterVolumes(volumes []v1.Volume, namespace s
 	}
 
 	return nil
+}
+
+// matchProvisioner helps identify if the given PVC belongs to the running predicate.
+func (c *MaxPDVolumeCountChecker) matchProvisioner(pvc *v1.PersistentVolumeClaim) bool {
+	if pvc.Spec.StorageClassName == nil {
+		return false
+	}
+
+	storageClass, err := c.scInfo.GetStorageClassInfo(*pvc.Spec.StorageClassName)
+	if err != nil || storageClass == nil {
+		return false
+	}
+
+	return c.filter.MatchProvisioner(storageClass)
 }
 
 func (c *MaxPDVolumeCountChecker) predicate(pod *v1.Pod, meta PredicateMetadata, nodeInfo *schedulernodeinfo.NodeInfo) (bool, []PredicateFailureReason, error) {
@@ -530,6 +552,13 @@ var EBSVolumeFilter = VolumeFilter{
 		return "", false
 	},
 
+	MatchProvisioner: func(sc *storagev1.StorageClass) (relevant bool) {
+		if sc.Provisioner == csilibplugins.AWSEBSInTreePluginName {
+			return true
+		}
+		return false
+	},
+
 	IsMigrated: func(csiNode *storagev1beta1.CSINode) bool {
 		return isCSIMigrationOn(csiNode, csilibplugins.AWSEBSInTreePluginName)
 	},
@@ -549,6 +578,13 @@ var GCEPDVolumeFilter = VolumeFilter{
 			return pv.Spec.GCEPersistentDisk.PDName, true
 		}
 		return "", false
+	},
+
+	MatchProvisioner: func(sc *storagev1.StorageClass) (relevant bool) {
+		if sc.Provisioner == csilibplugins.GCEPDInTreePluginName {
+			return true
+		}
+		return false
 	},
 
 	IsMigrated: func(csiNode *storagev1beta1.CSINode) bool {
@@ -572,6 +608,13 @@ var AzureDiskVolumeFilter = VolumeFilter{
 		return "", false
 	},
 
+	MatchProvisioner: func(sc *storagev1.StorageClass) (relevant bool) {
+		if sc.Provisioner == csilibplugins.AzureDiskInTreePluginName {
+			return true
+		}
+		return false
+	},
+
 	IsMigrated: func(csiNode *storagev1beta1.CSINode) bool {
 		return isCSIMigrationOn(csiNode, csilibplugins.AzureDiskInTreePluginName)
 	},
@@ -592,6 +635,13 @@ var CinderVolumeFilter = VolumeFilter{
 			return pv.Spec.Cinder.VolumeID, true
 		}
 		return "", false
+	},
+
+	MatchProvisioner: func(sc *storagev1.StorageClass) (relevant bool) {
+		if sc.Provisioner == csilibplugins.CinderInTreePluginName {
+			return true
+		}
+		return false
 	},
 
 	IsMigrated: func(csiNode *storagev1beta1.CSINode) bool {

--- a/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
@@ -61,21 +61,21 @@ func init() {
 	factory.RegisterFitPredicateFactory(
 		predicates.MaxEBSVolumeCountPred,
 		func(args factory.PluginFactoryArgs) predicates.FitPredicate {
-			return predicates.NewMaxPDVolumeCountPredicate(predicates.EBSVolumeFilterType, args.PVInfo, args.PVCInfo)
+			return predicates.NewMaxPDVolumeCountPredicate(predicates.EBSVolumeFilterType, args.StorageClassInfo, args.PVInfo, args.PVCInfo)
 		},
 	)
 	// Fit is determined by whether or not there would be too many GCE PD volumes attached to the node
 	factory.RegisterFitPredicateFactory(
 		predicates.MaxGCEPDVolumeCountPred,
 		func(args factory.PluginFactoryArgs) predicates.FitPredicate {
-			return predicates.NewMaxPDVolumeCountPredicate(predicates.GCEPDVolumeFilterType, args.PVInfo, args.PVCInfo)
+			return predicates.NewMaxPDVolumeCountPredicate(predicates.GCEPDVolumeFilterType, args.StorageClassInfo, args.PVInfo, args.PVCInfo)
 		},
 	)
 	// Fit is determined by whether or not there would be too many Azure Disk volumes attached to the node
 	factory.RegisterFitPredicateFactory(
 		predicates.MaxAzureDiskVolumeCountPred,
 		func(args factory.PluginFactoryArgs) predicates.FitPredicate {
-			return predicates.NewMaxPDVolumeCountPredicate(predicates.AzureDiskVolumeFilterType, args.PVInfo, args.PVCInfo)
+			return predicates.NewMaxPDVolumeCountPredicate(predicates.AzureDiskVolumeFilterType, args.StorageClassInfo, args.PVInfo, args.PVCInfo)
 		},
 	)
 	factory.RegisterFitPredicateFactory(
@@ -87,7 +87,7 @@ func init() {
 	factory.RegisterFitPredicateFactory(
 		predicates.MaxCinderVolumeCountPred,
 		func(args factory.PluginFactoryArgs) predicates.FitPredicate {
-			return predicates.NewMaxPDVolumeCountPredicate(predicates.CinderVolumeFilterType, args.PVInfo, args.PVCInfo)
+			return predicates.NewMaxPDVolumeCountPredicate(predicates.CinderVolumeFilterType, args.StorageClassInfo, args.PVInfo, args.PVCInfo)
 		},
 	)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR changes the old volume limits predicates (now deprecated) so they don't count unrelated volumes.

**Which issue(s) this PR fixes**:

Fixes #80352

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig storage