### PR TITLE
iptables feature detection improvements

### DIFF
--- a/cmd/kube-proxy/app/BUILD
+++ b/cmd/kube-proxy/app/BUILD
@@ -172,43 +172,33 @@ go_test(
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
             "//pkg/proxy/ipvs:go_default_library",
-            "//pkg/util/iptables:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "//pkg/proxy/ipvs:go_default_library",
-            "//pkg/util/iptables:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly": [
             "//pkg/proxy/ipvs:go_default_library",
-            "//pkg/util/iptables:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
             "//pkg/proxy/ipvs:go_default_library",
-            "//pkg/util/iptables:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/proxy/ipvs:go_default_library",
-            "//pkg/util/iptables:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:nacl": [
             "//pkg/proxy/ipvs:go_default_library",
-            "//pkg/util/iptables:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//pkg/proxy/ipvs:go_default_library",
-            "//pkg/util/iptables:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:openbsd": [
             "//pkg/proxy/ipvs:go_default_library",
-            "//pkg/util/iptables:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:plan9": [
             "//pkg/proxy/ipvs:go_default_library",
-            "//pkg/util/iptables:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:solaris": [
             "//pkg/proxy/ipvs:go_default_library",
-            "//pkg/util/iptables:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -23,68 +23,75 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/proxy/ipvs"
-	"k8s.io/kubernetes/pkg/util/iptables"
 )
+
+type fakeIPSetVersioner struct {
+	version string // what to return
+	err     error  // what to return
+}
+
+func (fake *fakeIPSetVersioner) GetVersion() (string, error) {
+	return fake.version, fake.err
+}
+
+type fakeKernelCompatTester struct {
+	ok bool
+}
+
+func (fake *fakeKernelCompatTester) IsCompatible() error {
+	if !fake.ok {
+		return fmt.Errorf("error")
+	}
+	return nil
+}
+
+// fakeKernelHandler implements KernelHandler.
+type fakeKernelHandler struct {
+	modules       []string
+	kernelVersion string
+}
+
+func (fake *fakeKernelHandler) GetModules() ([]string, error) {
+	return fake.modules, nil
+}
+
+func (fake *fakeKernelHandler) GetKernelVersion() (string, error) {
+	return fake.kernelVersion, nil
+}
 
 func Test_getProxyMode(t *testing.T) {
 	var cases = []struct {
-		flag            string
-		iptablesVersion string
-		ipsetVersion    string
-		kmods           []string
-		kernelVersion   string
-		kernelCompat    bool
-		iptablesError   error
-		ipsetError      error
-		expected        string
+		flag          string
+		ipsetVersion  string
+		kmods         []string
+		kernelVersion string
+		kernelCompat  bool
+		ipsetError    error
+		expected      string
 	}{
 		{ // flag says userspace
 			flag:     "userspace",
 			expected: proxyModeUserspace,
 		},
-		{ // flag says iptables, error detecting version
-			flag:          "iptables",
-			iptablesError: fmt.Errorf("flag says iptables, error detecting version"),
-			expected:      proxyModeUserspace,
+		{ // flag says iptables, kernel not compatible
+			flag:         "iptables",
+			kernelCompat: false,
+			expected:     proxyModeUserspace,
 		},
-		{ // flag says iptables, version too low
-			flag:            "iptables",
-			iptablesVersion: "0.0.0",
-			expected:        proxyModeUserspace,
+		{ // flag says iptables, kernel is compatible
+			flag:         "iptables",
+			kernelCompat: true,
+			expected:     proxyModeIPTables,
 		},
-		{ // flag says iptables, version ok, kernel not compatible
-			flag:            "iptables",
-			iptablesVersion: iptables.MinCheckVersion,
-			kernelCompat:    false,
-			expected:        proxyModeUserspace,
+		{ // detect, kernel not compatible
+			flag:         "",
+			kernelCompat: false,
+			expected:     proxyModeUserspace,
 		},
-		{ // flag says iptables, version ok, kernel is compatible
-			flag:            "iptables",
-			iptablesVersion: iptables.MinCheckVersion,
-			kernelCompat:    true,
-			expected:        proxyModeIPTables,
-		},
-		{ // detect, error
-			flag:          "",
-			iptablesError: fmt.Errorf("oops"),
-			expected:      proxyModeUserspace,
-		},
-		{ // detect, version too low
-			flag:            "",
-			iptablesVersion: "0.0.0",
-			expected:        proxyModeUserspace,
-		},
-		{ // detect, version ok, kernel not compatible
-			flag:            "",
-			iptablesVersion: iptables.MinCheckVersion,
-			kernelCompat:    false,
-			expected:        proxyModeUserspace,
-		},
-		{ // detect, version ok, kernel is compatible
-			flag:            "",
-			iptablesVersion: iptables.MinCheckVersion,
-			kernelCompat:    true,
-			expected:        proxyModeIPTables,
+		{ // detect, kernel is compatible
+			flag:         "",
+			kernelCompat: true,
+			expected:     proxyModeIPTables,
 		},
 		{ // flag says ipvs, ipset version ok, kernel modules installed for linux kernel before 4.19
 			flag:          "ipvs",
@@ -101,69 +108,38 @@ func Test_getProxyMode(t *testing.T) {
 			expected:      proxyModeIPVS,
 		},
 		{ // flag says ipvs, ipset version too low, fallback on iptables mode
-			flag:            "ipvs",
-			kmods:           []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack"},
-			kernelVersion:   "4.19",
-			ipsetVersion:    "0.0",
-			iptablesVersion: iptables.MinCheckVersion,
-			kernelCompat:    true,
-			expected:        proxyModeIPTables,
+			flag:          "ipvs",
+			kmods:         []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack"},
+			kernelVersion: "4.19",
+			ipsetVersion:  "0.0",
+			kernelCompat:  true,
+			expected:      proxyModeIPTables,
 		},
 		{ // flag says ipvs, bad ipset version, fallback on iptables mode
-			flag:            "ipvs",
-			kmods:           []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack"},
-			kernelVersion:   "4.19",
-			ipsetVersion:    "a.b.c",
-			iptablesVersion: iptables.MinCheckVersion,
-			kernelCompat:    true,
-			expected:        proxyModeIPTables,
+			flag:          "ipvs",
+			kmods:         []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack"},
+			kernelVersion: "4.19",
+			ipsetVersion:  "a.b.c",
+			kernelCompat:  true,
+			expected:      proxyModeIPTables,
 		},
 		{ // flag says ipvs, required kernel modules are not installed, fallback on iptables mode
-			flag:            "ipvs",
-			kmods:           []string{"foo", "bar", "baz"},
-			kernelVersion:   "4.19",
-			ipsetVersion:    ipvs.MinIPSetCheckVersion,
-			iptablesVersion: iptables.MinCheckVersion,
-			kernelCompat:    true,
-			expected:        proxyModeIPTables,
-		},
-		{ // flag says ipvs, required kernel modules are not installed, iptables version too old, fallback on userspace mode
-			flag:            "ipvs",
-			kmods:           []string{"foo", "bar", "baz"},
-			kernelVersion:   "4.19",
-			ipsetVersion:    ipvs.MinIPSetCheckVersion,
-			iptablesVersion: "0.0.0",
-			kernelCompat:    true,
-			expected:        proxyModeUserspace,
-		},
-		{ // flag says ipvs, required kernel modules are not installed, iptables version too old, fallback on userspace mode
-			flag:            "ipvs",
-			kmods:           []string{"foo", "bar", "baz"},
-			kernelVersion:   "4.19",
-			ipsetVersion:    ipvs.MinIPSetCheckVersion,
-			iptablesVersion: "0.0.0",
-			kernelCompat:    true,
-			expected:        proxyModeUserspace,
-		},
-		{ // flag says ipvs, ipset version too low, iptables version too old, kernel not compatible, fallback on userspace mode
-			flag:            "ipvs",
-			kmods:           []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack"},
-			kernelVersion:   "4.19",
-			ipsetVersion:    "0.0",
-			iptablesVersion: iptables.MinCheckVersion,
-			kernelCompat:    false,
-			expected:        proxyModeUserspace,
+			flag:          "ipvs",
+			kmods:         []string{"foo", "bar", "baz"},
+			kernelVersion: "4.19",
+			ipsetVersion:  ipvs.MinIPSetCheckVersion,
+			kernelCompat:  true,
+			expected:      proxyModeIPTables,
 		},
 	}
 	for i, c := range cases {
-		versioner := &fakeIPTablesVersioner{c.iptablesVersion, c.iptablesError}
 		kcompater := &fakeKernelCompatTester{c.kernelCompat}
 		ipsetver := &fakeIPSetVersioner{c.ipsetVersion, c.ipsetError}
 		khandler := &fakeKernelHandler{
 			modules:       c.kmods,
 			kernelVersion: c.kernelVersion,
 		}
-		r := getProxyMode(c.flag, versioner, khandler, ipsetver, kcompater)
+		r := getProxyMode(c.flag, khandler, ipsetver, kcompater)
 		if r != c.expected {
 			t.Errorf("Case[%d] Expected %q, got %q", i, c.expected, r)
 		}

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -38,53 +38,6 @@ import (
 	utilpointer "k8s.io/utils/pointer"
 )
 
-type fakeIPTablesVersioner struct {
-	version string // what to return
-	err     error  // what to return
-}
-
-func (fake *fakeIPTablesVersioner) GetVersion() (string, error) {
-	return fake.version, fake.err
-}
-
-func (fake *fakeIPTablesVersioner) IsCompatible() error {
-	return fake.err
-}
-
-type fakeIPSetVersioner struct {
-	version string // what to return
-	err     error  // what to return
-}
-
-func (fake *fakeIPSetVersioner) GetVersion() (string, error) {
-	return fake.version, fake.err
-}
-
-type fakeKernelCompatTester struct {
-	ok bool
-}
-
-func (fake *fakeKernelCompatTester) IsCompatible() error {
-	if !fake.ok {
-		return fmt.Errorf("error")
-	}
-	return nil
-}
-
-// fakeKernelHandler implements KernelHandler.
-type fakeKernelHandler struct {
-	modules       []string
-	kernelVersion string
-}
-
-func (fake *fakeKernelHandler) GetModules() ([]string, error) {
-	return fake.modules, nil
-}
-
-func (fake *fakeKernelHandler) GetKernelVersion() (string, error) {
-	return fake.kernelVersion, nil
-}
-
 // This test verifies that NewProxyServer does not crash when CleanupAndExit is true.
 func TestProxyServerWithCleanupAndExit(t *testing.T) {
 	// Each bind address below is a separate test case

--- a/pkg/kubelet/dockershim/network/hostport/fake_iptables.go
+++ b/pkg/kubelet/dockershim/network/hostport/fake_iptables.go
@@ -52,10 +52,6 @@ func NewFakeIPTables() *fakeIPTables {
 	}
 }
 
-func (f *fakeIPTables) GetVersion() (string, error) {
-	return "1.4.21", nil
-}
-
 func (f *fakeIPTables) getTable(tableName utiliptables.Table) (*fakeTable, error) {
 	table, ok := f.tables[string(tableName)]
 	if !ok {

--- a/pkg/proxy/iptables/BUILD
+++ b/pkg/proxy/iptables/BUILD
@@ -21,7 +21,6 @@ go_library(
         "//pkg/util/sysctl:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -36,7 +36,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/proxy"
@@ -52,15 +51,6 @@ import (
 )
 
 const (
-	// iptablesMinVersion is the minimum version of iptables for which we will use the Proxier
-	// from this package instead of the userspace Proxier.  While most of the
-	// features we need were available earlier, the '-C' flag was added more
-	// recently.  We use that indirectly in Ensure* functions, and if we don't
-	// have it, we have to be extra careful about the exact args we feed in being
-	// the same as the args we read back (iptables itself normalizes some args).
-	// This is the "new" Proxier, so we require "new" versions of tools.
-	iptablesMinVersion = utiliptables.MinCheckVersion
-
 	// the services chain
 	kubeServicesChain utiliptables.Chain = "KUBE-SERVICES"
 
@@ -83,12 +73,6 @@ const (
 	kubeForwardChain utiliptables.Chain = "KUBE-FORWARD"
 )
 
-// Versioner can query the current iptables version.
-type Versioner interface {
-	// returns "X.Y.Z"
-	GetVersion() (string, error)
-}
-
 // KernelCompatTester tests whether the required kernel capabilities are
 // present to run the iptables proxier.
 type KernelCompatTester interface {
@@ -96,28 +80,8 @@ type KernelCompatTester interface {
 }
 
 // CanUseIPTablesProxier returns true if we should use the iptables Proxier
-// instead of the "classic" userspace Proxier.  This is determined by checking
-// the iptables version and for the existence of kernel features. It may return
-// an error if it fails to get the iptables version without error, in which
-// case it will also return false.
-func CanUseIPTablesProxier(iptver Versioner, kcompat KernelCompatTester) (bool, error) {
-	minVersion, err := utilversion.ParseGeneric(iptablesMinVersion)
-	if err != nil {
-		return false, err
-	}
-	versionString, err := iptver.GetVersion()
-	if err != nil {
-		return false, err
-	}
-	version, err := utilversion.ParseGeneric(versionString)
-	if err != nil {
-		return false, err
-	}
-	if version.LessThan(minVersion) {
-		return false, nil
-	}
-
-	// Check that the kernel supports what we need.
+// instead of the "classic" userspace Proxier.
+func CanUseIPTablesProxier(kcompat KernelCompatTester) (bool, error) {
 	if err := kcompat.IsCompatible(); err != nil {
 		return false, err
 	}
@@ -131,7 +95,6 @@ type LinuxKernelCompatTester struct{}
 // that it exists.  If this Proxier is chosen, we'll initialize it as we
 // need.
 func (lkct LinuxKernelCompatTester) IsCompatible() error {
-
 	_, err := utilsysctl.New().GetSysctl(sysctlRouteLocalnet)
 	return err
 }

--- a/pkg/util/iptables/BUILD
+++ b/pkg/util/iptables/BUILD
@@ -45,6 +45,7 @@ go_test(
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/util/dbus:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+            "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
             "//vendor/k8s.io/utils/exec:go_default_library",
             "//vendor/k8s.io/utils/exec/testing:go_default_library",
         ],

--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -43,8 +43,6 @@ const (
 
 // An injectable interface for running iptables commands.  Implementations must be goroutine-safe.
 type Interface interface {
-	// GetVersion returns the "X.Y.Z" version string for iptables.
-	GetVersion() (string, error)
 	// EnsureChain checks if the specified chain exists and, if not, creates it.  If the chain existed, return true.
 	EnsureChain(table Table, chain Chain) (bool, error)
 	// FlushChain clears the specified chain.  If the chain did not exist, return error.
@@ -121,12 +119,13 @@ const NoFlushTables FlushFlag = false
 
 // Versions of iptables less than this do not support the -C / --check flag
 // (test whether a rule exists).
-const MinCheckVersion = "1.4.11"
+var MinCheckVersion = utilversion.MustParseGeneric("1.4.11")
 
 // Minimum iptables versions supporting the -w and -w<seconds> flags
-const WaitMinVersion = "1.4.20"
-const WaitSecondsMinVersion = "1.4.22"
-const WaitRestoreMinVersion = "1.6.2"
+var WaitMinVersion = utilversion.MustParseGeneric("1.4.20")
+var WaitSecondsMinVersion = utilversion.MustParseGeneric("1.4.22")
+var WaitRestoreMinVersion = utilversion.MustParseGeneric("1.6.2")
+
 const WaitString = "-w"
 const WaitSecondsValue = "5"
 
@@ -151,10 +150,10 @@ type runner struct {
 // newInternal returns a new Interface which will exec iptables, and allows the
 // caller to change the iptables-restore lockfile path
 func newInternal(exec utilexec.Interface, dbus utildbus.Interface, protocol Protocol, lockfilePath string) Interface {
-	vstring, err := getIPTablesVersionString(exec, protocol)
+	version, err := getIPTablesVersion(exec, protocol)
 	if err != nil {
 		klog.Warningf("Error checking iptables version, assuming version at least %s: %v", MinCheckVersion, err)
-		vstring = MinCheckVersion
+		version = MinCheckVersion
 	}
 
 	if lockfilePath == "" {
@@ -165,10 +164,10 @@ func newInternal(exec utilexec.Interface, dbus utildbus.Interface, protocol Prot
 		exec:            exec,
 		dbus:            dbus,
 		protocol:        protocol,
-		hasCheck:        getIPTablesHasCheckCommand(vstring),
+		hasCheck:        version.AtLeast(MinCheckVersion),
 		hasListener:     false,
-		waitFlag:        getIPTablesWaitFlag(vstring),
-		restoreWaitFlag: getIPTablesRestoreWaitFlag(vstring),
+		waitFlag:        getIPTablesWaitFlag(version),
+		restoreWaitFlag: getIPTablesRestoreWaitFlag(version),
 		lockfilePath:    lockfilePath,
 	}
 	return runner
@@ -213,11 +212,6 @@ func (runner *runner) connectToFirewallD() {
 	bus.Signal(runner.signal)
 
 	go runner.dbusSignalHandler(bus)
-}
-
-// GetVersion returns the version string.
-func (runner *runner) GetVersion() (string, error) {
-	return getIPTablesVersionString(runner.exec, runner.protocol)
 }
 
 // EnsureChain is part of Interface.
@@ -540,83 +534,46 @@ func makeFullArgs(table Table, chain Chain, args ...string) []string {
 	return append([]string{string(chain), "-t", string(table)}, args...)
 }
 
-// Checks if iptables has the "-C" flag
-func getIPTablesHasCheckCommand(vstring string) bool {
-	minVersion, err := utilversion.ParseGeneric(MinCheckVersion)
-	if err != nil {
-		klog.Errorf("MinCheckVersion (%s) is not a valid version string: %v", MinCheckVersion, err)
-		return true
-	}
-	version, err := utilversion.ParseGeneric(vstring)
-	if err != nil {
-		klog.Errorf("vstring (%s) is not a valid version string: %v", vstring, err)
-		return true
-	}
-	return version.AtLeast(minVersion)
-}
-
-// Checks if iptables version has a "wait" flag
-func getIPTablesWaitFlag(vstring string) []string {
-	version, err := utilversion.ParseGeneric(vstring)
-	if err != nil {
-		klog.Errorf("vstring (%s) is not a valid version string: %v", vstring, err)
-		return nil
-	}
-
-	minVersion, err := utilversion.ParseGeneric(WaitMinVersion)
-	if err != nil {
-		klog.Errorf("WaitMinVersion (%s) is not a valid version string: %v", WaitMinVersion, err)
-		return nil
-	}
-	if version.LessThan(minVersion) {
-		return nil
-	}
-
-	minVersion, err = utilversion.ParseGeneric(WaitSecondsMinVersion)
-	if err != nil {
-		klog.Errorf("WaitSecondsMinVersion (%s) is not a valid version string: %v", WaitSecondsMinVersion, err)
-		return nil
-	}
-	if version.LessThan(minVersion) {
-		return []string{WaitString}
-	}
-	return []string{WaitString, WaitSecondsValue}
-}
-
-// getIPTablesVersionString runs "iptables --version" to get the version string
-// in the form "X.X.X"
-func getIPTablesVersionString(exec utilexec.Interface, protocol Protocol) (string, error) {
+// getIPTablesVersion runs "iptables --version" and parses the returned version
+func getIPTablesVersion(exec utilexec.Interface, protocol Protocol) (*utilversion.Version, error) {
 	// this doesn't access mutable state so we don't need to use the interface / runner
 	iptablesCmd := iptablesCommand(protocol)
 	bytes, err := exec.Command(iptablesCmd, "--version").CombinedOutput()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	versionMatcher := regexp.MustCompile("v([0-9]+(\\.[0-9]+)+)")
 	match := versionMatcher.FindStringSubmatch(string(bytes))
 	if match == nil {
-		return "", fmt.Errorf("no iptables version found in string: %s", bytes)
+		return nil, fmt.Errorf("no iptables version found in string: %s", bytes)
 	}
-	return match[1], nil
+	version, err := utilversion.ParseGeneric(match[1])
+	if err != nil {
+		return nil, fmt.Errorf("iptables version %q is not a valid version string: %v", match[1], err)
+	}
+
+	return version, nil
+}
+
+// Checks if iptables version has a "wait" flag
+func getIPTablesWaitFlag(version *utilversion.Version) []string {
+	switch {
+	case version.AtLeast(WaitSecondsMinVersion):
+		return []string{WaitString, WaitSecondsValue}
+	case version.AtLeast(WaitMinVersion):
+		return []string{WaitString}
+	default:
+		return nil
+	}
 }
 
 // Checks if iptables-restore has a "wait" flag
-func getIPTablesRestoreWaitFlag(vstring string) []string {
-	version, err := utilversion.ParseGeneric(vstring)
-	if err != nil {
-		klog.Errorf("vstring (%s) is not a valid version string: %v", vstring, err)
+func getIPTablesRestoreWaitFlag(version *utilversion.Version) []string {
+	if version.AtLeast(WaitRestoreMinVersion) {
+		return []string{WaitString, WaitSecondsValue}
+	} else {
 		return nil
 	}
-
-	minVersion, err := utilversion.ParseGeneric(WaitRestoreMinVersion)
-	if err != nil {
-		klog.Errorf("WaitRestoreMinVersion (%s) is not a valid version string: %v", WaitRestoreMinVersion, err)
-		return nil
-	}
-	if version.LessThan(minVersion) {
-		return nil
-	}
-	return []string{WaitString, WaitSecondsValue}
 }
 
 // goroutine to listen for D-Bus signals

--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -126,6 +126,7 @@ const MinCheckVersion = "1.4.11"
 // Minimum iptables versions supporting the -w and -w<seconds> flags
 const WaitMinVersion = "1.4.20"
 const WaitSecondsMinVersion = "1.4.22"
+const WaitRestoreMinVersion = "1.6.2"
 const WaitString = "-w"
 const WaitSecondsValue = "5"
 
@@ -167,7 +168,7 @@ func newInternal(exec utilexec.Interface, dbus utildbus.Interface, protocol Prot
 		hasCheck:        getIPTablesHasCheckCommand(vstring),
 		hasListener:     false,
 		waitFlag:        getIPTablesWaitFlag(vstring),
-		restoreWaitFlag: getIPTablesRestoreWaitFlag(exec, protocol),
+		restoreWaitFlag: getIPTablesRestoreWaitFlag(vstring),
 		lockfilePath:    lockfilePath,
 	}
 	return runner
@@ -580,7 +581,6 @@ func getIPTablesWaitFlag(vstring string) []string {
 		return []string{WaitString}
 	}
 	return []string{WaitString, WaitSecondsValue}
-
 }
 
 // getIPTablesVersionString runs "iptables --version" to get the version string
@@ -601,44 +601,22 @@ func getIPTablesVersionString(exec utilexec.Interface, protocol Protocol) (strin
 }
 
 // Checks if iptables-restore has a "wait" flag
-// --wait support landed in v1.6.1+ right before --version support, so
-// any version of iptables-restore that supports --version will also
-// support --wait
-func getIPTablesRestoreWaitFlag(exec utilexec.Interface, protocol Protocol) []string {
-	vstring, err := getIPTablesRestoreVersionString(exec, protocol)
-	if err != nil || vstring == "" {
-		klog.V(3).Infof("couldn't get iptables-restore version; assuming it doesn't support --wait")
-		return nil
-	}
-	if _, err := utilversion.ParseGeneric(vstring); err != nil {
-		klog.V(3).Infof("couldn't parse iptables-restore version; assuming it doesn't support --wait")
-		return nil
-	}
-
-	return []string{WaitString, WaitSecondsValue}
-}
-
-// getIPTablesRestoreVersionString runs "iptables-restore --version" to get the version string
-// in the form "X.X.X"
-func getIPTablesRestoreVersionString(exec utilexec.Interface, protocol Protocol) (string, error) {
-	// this doesn't access mutable state so we don't need to use the interface / runner
-
-	// iptables-restore hasn't always had --version, and worse complains
-	// about unrecognized commands but doesn't exit when it gets them.
-	// Work around that by setting stdin to nothing so it exits immediately.
-	iptablesRestoreCmd := iptablesRestoreCommand(protocol)
-	cmd := exec.Command(iptablesRestoreCmd, "--version")
-	cmd.SetStdin(bytes.NewReader([]byte{}))
-	bytes, err := cmd.CombinedOutput()
+func getIPTablesRestoreWaitFlag(vstring string) []string {
+	version, err := utilversion.ParseGeneric(vstring)
 	if err != nil {
-		return "", err
+		klog.Errorf("vstring (%s) is not a valid version string: %v", vstring, err)
+		return nil
 	}
-	versionMatcher := regexp.MustCompile("v([0-9]+(\\.[0-9]+)+)")
-	match := versionMatcher.FindStringSubmatch(string(bytes))
-	if match == nil {
-		return "", fmt.Errorf("no iptables version found in string: %s", bytes)
+
+	minVersion, err := utilversion.ParseGeneric(WaitRestoreMinVersion)
+	if err != nil {
+		klog.Errorf("WaitRestoreMinVersion (%s) is not a valid version string: %v", WaitRestoreMinVersion, err)
+		return nil
 	}
-	return match[1], nil
+	if version.LessThan(minVersion) {
+		return nil
+	}
+	return []string{WaitString, WaitSecondsValue}
 }
 
 // goroutine to listen for D-Bus signals

--- a/pkg/util/iptables/testing/fake.go
+++ b/pkg/util/iptables/testing/fake.go
@@ -48,10 +48,6 @@ func NewFake() *FakeIPTables {
 	return &FakeIPTables{}
 }
 
-func (*FakeIPTables) GetVersion() (string, error) {
-	return "0.0.0", nil
-}
-
 func (*FakeIPTables) EnsureChain(table iptables.Table, chain iptables.Chain) (bool, error) {
 	return true, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The iptables code was doing version detection on the `iptables` binary but feature detection on the `iptables-restore` binary, to try to support the version of iptables in RHEL 7, which claims to be 1.4.21 but has certain features from iptables 1.6.

The problem is that this particular set of versions and checks resulted in the code passing "`-w`" ("wait forever for the lock") to `iptables`, but "`-w 5`" ("wait at most 5 seconds for the lock") to `iptables-restore`. On systems with very very many iptables rules, this could result in the kubelet periodic resyncs (which use "`iptables`") blocking kube-proxy (which uses "`iptables-restore`") and causing it to time out.

We already have code to grab the lock file by hand when using a version of `iptables-restore` that doesn't support "`-w`", and it works fine. So just use that instead, and only pass "`-w 5`" to `iptables-restore` when `iptables` reports a version that actually supports it.

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a problem with the iptables proxy mode that could result in long delays
updating Service/Endpoints IPs in very large clusters on RHEL/CentOS 7.
```

/assign @dcbw 