### PR TITLE
Propagate errors from DSW to pod events

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1673,8 +1673,8 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 	if !kl.podIsTerminated(pod) {
 		// Wait for volumes to attach/mount
 		if err := kl.volumeManager.WaitForAttachAndMount(pod); err != nil {
-			kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedMountVolume, "Unable to mount volumes for pod %q: %v", format.Pod(pod), err)
-			klog.Errorf("Unable to mount volumes for pod %q: %v; skipping pod", format.Pod(pod), err)
+			kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedMountVolume, "Unable to attach or mount volumes: %v", err)
+			klog.Errorf("Unable to attach or mount volumes for pod %q: %v; skipping pod", format.Pod(pod), err)
 			return err
 		}
 	}

--- a/pkg/kubelet/volumemanager/BUILD
+++ b/pkg/kubelet/volumemanager/BUILD
@@ -61,6 +61,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",

--- a/pkg/kubelet/volumemanager/cache/BUILD
+++ b/pkg/kubelet/volumemanager/cache/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -24,8 +24,9 @@ import (
 	"fmt"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 	apiv1resource "k8s.io/kubernetes/pkg/api/v1/resource"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
@@ -107,6 +108,18 @@ type DesiredStateOfWorld interface {
 	// If a pod with the same name does not exist under the specified
 	// volume, false is returned.
 	VolumeExistsWithSpecName(podName types.UniquePodName, volumeSpecName string) bool
+
+	// AddErrorToPod adds the given error to the given pod in the cache.
+	// It will be returned by subsequent GetPodErrors().
+	// Each error string is stored only once.
+	AddErrorToPod(podName types.UniquePodName, err string)
+
+	// PopPodErrors returns accumulated errors on a given pod and clears
+	// them.
+	PopPodErrors(podName types.UniquePodName) []string
+
+	// GetPodsWithErrors returns names of pods that have stored errors.
+	GetPodsWithErrors() []types.UniquePodName
 }
 
 // VolumeToMount represents a volume that is attached to this node and needs to
@@ -120,6 +133,7 @@ func NewDesiredStateOfWorld(volumePluginMgr *volume.VolumePluginMgr) DesiredStat
 	return &desiredStateOfWorld{
 		volumesToMount:  make(map[v1.UniqueVolumeName]volumeToMount),
 		volumePluginMgr: volumePluginMgr,
+		podErrors:       make(map[types.UniquePodName]sets.String),
 	}
 }
 
@@ -132,6 +146,8 @@ type desiredStateOfWorld struct {
 	// volumePluginMgr is the volume plugin manager used to create volume
 	// plugin objects.
 	volumePluginMgr *volume.VolumePluginMgr
+	// podErrors are errors caught by desiredStateOfWorldPopulator about volumes for a given pod.
+	podErrors map[types.UniquePodName]sets.String
 
 	sync.RWMutex
 }
@@ -293,6 +309,8 @@ func (dsw *desiredStateOfWorld) DeletePodFromVolume(
 	dsw.Lock()
 	defer dsw.Unlock()
 
+	delete(dsw.podErrors, podName)
+
 	volumeObj, volumeExists := dsw.volumesToMount[volumeName]
 	if !volumeExists {
 		return
@@ -411,4 +429,37 @@ func (dsw *desiredStateOfWorld) isDeviceMountableVolume(volumeSpec *volume.Spec)
 	}
 
 	return false
+}
+
+func (dsw *desiredStateOfWorld) AddErrorToPod(podName types.UniquePodName, err string) {
+	dsw.Lock()
+	defer dsw.Unlock()
+
+	if errs, found := dsw.podErrors[podName]; found {
+		errs.Insert(err)
+		return
+	}
+	dsw.podErrors[podName] = sets.NewString(err)
+}
+
+func (dsw *desiredStateOfWorld) PopPodErrors(podName types.UniquePodName) []string {
+	dsw.Lock()
+	defer dsw.Unlock()
+
+	if errs, found := dsw.podErrors[podName]; found {
+		delete(dsw.podErrors, podName)
+		return errs.List()
+	}
+	return []string{}
+}
+
+func (dsw *desiredStateOfWorld) GetPodsWithErrors() []types.UniquePodName {
+	dsw.RLock()
+	defer dsw.RUnlock()
+
+	pods := make([]types.UniquePodName, 0, len(dsw.podErrors))
+	for podName := range dsw.podErrors {
+		pods = append(pods, podName)
+	}
+	return pods
 }

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -376,12 +376,10 @@ func (vm *volumeManager) WaitForAttachAndMount(pod *v1.Pod) error {
 		}
 
 		return fmt.Errorf(
-			"failed to attach or mount for pod %q/%q: %s. List of unmounted volumes=%v, list of unattached volumes=%v.",
-			pod.Namespace,
-			pod.Name,
-			err,
+			"unmounted volumes=%v, unattached volumes=%v: %s",
 			unmountedVolumes,
-			unattachedVolumes)
+			unattachedVolumes,
+			err)
 	}
 
 	klog.V(3).Infof("All volumes are attached and mounted for pod %q", format.Pod(pod))

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -17,12 +17,14 @@ limitations under the License.
 package volumemanager
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -363,7 +365,6 @@ func (vm *volumeManager) WaitForAttachAndMount(pod *v1.Pod) error {
 		vm.verifyVolumesMountedFunc(uniquePodName, expectedVolumes))
 
 	if err != nil {
-		// Timeout expired
 		unmountedVolumes :=
 			vm.getUnmountedVolumes(uniquePodName, expectedVolumes)
 		// Also get unattached volumes for error message
@@ -375,9 +376,10 @@ func (vm *volumeManager) WaitForAttachAndMount(pod *v1.Pod) error {
 		}
 
 		return fmt.Errorf(
-			"timeout expired waiting for volumes to attach or mount for pod %q/%q. list of unmounted volumes=%v. list of unattached volumes=%v",
+			"failed to attach or mount for pod %q/%q: %s. List of unmounted volumes=%v, list of unattached volumes=%v.",
 			pod.Namespace,
 			pod.Name,
+			err,
 			unmountedVolumes,
 			unattachedVolumes)
 	}
@@ -402,6 +404,9 @@ func (vm *volumeManager) getUnattachedVolumes(expectedVolumes []string) []string
 // volumes are mounted.
 func (vm *volumeManager) verifyVolumesMountedFunc(podName types.UniquePodName, expectedVolumes []string) wait.ConditionFunc {
 	return func() (done bool, err error) {
+		if errs := vm.desiredStateOfWorld.PopPodErrors(podName); len(errs) > 0 {
+			return true, errors.New(strings.Join(errs, "; "))
+		}
 		return len(vm.getUnmountedVolumes(podName, expectedVolumes)) == 0, nil
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Goal: tell users that pod cannot run because:
 - PVC does not exist
 - PVC is not bound
 - PVC uses a different volumeMode than the pod expects.
 - ...

The first two bullets are checked also by scheduler, but kubelet should report errors here too, in case a pod runs with a different scheduler or was scheduled manually.

I added list of errors for each pod to DesiredStateOfWorld (DSW), where DSW populator (DSWP) stores them and kubelet picks them up via `WaitForAttachAndMount` and creates pod event(s) from them.

I did not want to add errors to `dsw.volumesToMount`, because that would create `volumesToMount` entries with incomplete / erroneous volumes (e.g. PVC was not bound yet and we don't know unique volume name).

I hope I got the cleaning right - DSWP periodically checks all stored errors and removes those for deleted pods.

I cleaned some error messages on the way, so the events are nice and tidy (well, at least they're better than before, see below).

Natural extension would be to report also mount / set up errors from reconciler ((not part of this PR). By placing the list of errors to DSW, there is no way to pass errors from unmount / teardown (there is no entry in DSW for pods that are being torn down).

**Examples** (simulating narrow terminal window):

* PVC does not exist:

  ```
  Type     Reason       Age   From                Message
  ----     ------       ----  ----                -------
  Warning  FailedMount  9s    kubelet, 127.0.0.1  Unable to attach or mount volumes:
  error processing PVC default/myclaim: failed to fetch PVC from API server:
  persistentvolumeclaims "myclaim" not found. List of unmounted volumes=[vol]. List 
  of unattached volumes=[vol default-token-4pt45].
  ```

* PVC is not bound:
  ```
  Type     Reason       Age   From                Message
  ----     ------       ----  ----                -------
  Warning  FailedMount  4s    kubelet, 127.0.0.1  Unable to attach or mount volumes:
  error processing PVC default/myclaim: PVC is not bound. List of unmounted volumes=
  [vol]. List of unattached volumes=[vol default-token-4pt45]. 
  ```

* Wrong mode:
  ```
  Type     Reason                  Age   From                     Message
  ----     ------                  ----  ----                     -------
  Normal   SuccessfulAttachVolume  4s    attachdetach-controller  AttachVolume.Attach 
  succeeded for volume "mypv"
  Warning  FailedMount             4s    kubelet, 127.0.0.1       Unable to attach or
  mount volumes: volume vol has volumeMode Filesystem, but is specified in 
  volumeDevices. List of unmounted volumes=[vol default-token-4pt45]. List of 
  unattached volumes=[vol default-token-4pt45].
  ```

* Multiple errors:
  ```
  Type     Reason       Age   From                Message
  ----     ------       ----  ----                -------
  Warning  FailedMount  1s    kubelet, 127.0.0.1  Unable to attach or mount volumes: 
  error processing PVC default/myclaim2: failed to fetch PVC from API server: 
  persistentvolumeclaims "myclaim2" not found; error processing PVC default/myclaim: 
  failed to fetch PVC from API server: persistentvolumeclaims "myclaim" not found. 
  List of unmounted volumes=[vol vol2 default-token-5jpm2]. List of unattached 
  volumes=[vol vol2 default-token-5jpm2].
  ```

I might send every error as a separate event. Would it be too many events? Does 
`List of unmounted volumes=[vol vol2 default-token-5jpm2]. List of unattached 
  volumes=[vol vol2 default-token-5jpm2].` have any value?


**Which issue(s) this PR fixes**:
Fixes #79794
 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Errors from pod volume set up are now propagated as pod events.
```

/kind bug
/sig storage

@msau42 @jingxu97 @gnufied, PTAL

@mkimuram, I am afraid that checking for events in #79796 is the best we can do here.