### PR TITLE
Propagate errors when getting annotations

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -59,6 +59,25 @@ func (obj *Unstructured) IsList() bool {
 	_, ok = field.([]interface{})
 	return ok
 }
+
+func (u *Unstructured) Validate() error {
+	obj, found, _ := NestedFieldNoCopy(u.Object, "metadata", "annotations")
+	if found && obj != nil {
+		if _, _, err := NestedStringMap(u.Object, "metadata", "annotations"); err != nil {
+			return err
+		}
+	}
+
+	obj, found, _ = NestedFieldNoCopy(u.Object, "metadata", "labels")
+	if found && obj != nil {
+		if _, _, err := NestedStringMap(u.Object, "metadata", "labels"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (obj *Unstructured) ToList() (*UnstructuredList, error) {
 	if !obj.IsList() {
 		// return an empty list back
@@ -392,7 +411,10 @@ func (u *Unstructured) SetDeletionGracePeriodSeconds(deletionGracePeriodSeconds 
 }
 
 func (u *Unstructured) GetLabels() map[string]string {
-	m, _, _ := NestedStringMap(u.Object, "metadata", "labels")
+	m, _, err := NestedStringMap(u.Object, "metadata", "labels")
+	if err != nil {
+		utilruntime.HandleError(err)
+	}
 	return m
 }
 
@@ -405,7 +427,11 @@ func (u *Unstructured) SetLabels(labels map[string]string) {
 }
 
 func (u *Unstructured) GetAnnotations() map[string]string {
-	m, _, _ := NestedStringMap(u.Object, "metadata", "annotations")
+	m, _, err := NestedStringMap(u.Object, "metadata", "annotations")
+	if err != nil {
+		utilruntime.HandleError(err)
+	}
+
 	return m
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -377,6 +377,12 @@ func (o *ApplyOptions) Run() error {
 			return err
 		}
 
+		if un, ok := info.Object.(*unstructured.Unstructured); ok {
+			if err := un.Validate(); err != nil {
+				return err
+			}
+		}
+
 		// If server-dry-run is requested but the type doesn't support it, fail right away.
 		if o.ServerDryRun {
 			if err := dryRunVerifier.HasSupport(info.Mapping.GroupVersionKind); err != nil {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
~~This PR propagates errors from the [Object interface](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go#L33)'s `GetAnnotations` function. This allows the functions that `GetAnnotations` calls to pass their errors down the call stack, fixing a bug where annotations are silently dropped when the type of the annotation is something other than string.~~

~~Specifically this PR adds the `GetAnnotationsSafely() (map[string]string, error)` prototype that sends the error down the call stack. It also adds a call to `utilruntime.HandleError` in `GetAnnotations` if there is an error.~~

This PR adds a validate function to the Unstructured type and a check in the apply subcommand for each object.

More details about possible solutions and the direct cause are in the Github issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/59113

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required: NONE
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
