### PR TITLE
Drop deprecated cadvisor metric labels

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -932,10 +932,8 @@ func containerPrometheusLabelsFunc(s stats.Provider) metrics.ContainerLabelsFunc
 			metrics.LabelID:    c.Name,
 			metrics.LabelName:  name,
 			metrics.LabelImage: image,
-			"pod_name":         podName,
 			"pod":              podName,
 			"namespace":        namespace,
-			"container_name":   containerName,
 			"container":        containerName,
 		}
 		return set

--- a/test/e2e/instrumentation/monitoring/prometheus.go
+++ b/test/e2e/instrumentation/monitoring/prometheus.go
@@ -92,7 +92,7 @@ var _ = instrumentation.SIGDescribe("[Feature:PrometheusMonitoring] Prometheus",
 })
 
 func prometheusCPUQuery(namespace, podNamePrefix string, rate time.Duration) string {
-	return fmt.Sprintf(`sum(irate(container_cpu_usage_seconds_total{namespace="%v",pod_name=~"%v.*",image!=""}[%vm]))`,
+	return fmt.Sprintf(`sum(irate(container_cpu_usage_seconds_total{namespace="%v",pod=~"%v.*",image!=""}[%vm]))`,
 		namespace, podNamePrefix, int64(rate.Minutes()))
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind api-change
/kind cleanup

**What this PR does / why we need it**:

Updates exported cadvisor metric labels to match the [Kubernetes instrumentation guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/instrumentation.md#normalization). Duplicate labels were included in the 1.14 and 1.15 releases; for 1.16, I'd like to drop the deprecated labels.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Addresses #66790.

**Special notes for your reviewer**:

See also #69099 which introduced the duplicate labels.

/sig instrumentation
/sig node
/cc @brancz 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Removed cadvisor metric labels `pod_name` and `container_name` to match instrumentation guidelines.

Action required: any Prometheus queries that match `pod_name` and `container_name` labels (e.g. cadvisor or kubelet probe metrics) must be updated to use `pod` and `container` instead.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: https://github.com/kubernetes/enhancements/blob/28d0f41a30b32bceb01e0d4ae338f91ede195005/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md#cadvisor-instrumentation-changes
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/28d0f41a30b32bceb01e0d4ae338f91ede195005/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md#cadvisor-instrumentation-changes
```
