### PR TITLE
Change default PVC AccessModes to RWO in test framework

### DIFF
--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -621,8 +621,8 @@ func MakePersistentVolumeClaim(cfg PersistentVolumeClaimConfig, ns string) *v1.P
 	// Specs are expected to match this test's PersistentVolume
 
 	if len(cfg.AccessModes) == 0 {
-		e2elog.Logf("AccessModes unspecified, default: all modes (RWO, RWX, ROX).")
-		cfg.AccessModes = append(cfg.AccessModes, v1.ReadWriteOnce, v1.ReadOnlyMany, v1.ReadOnlyMany)
+		e2elog.Logf("AccessModes unspecified, default: ReadWriteOnce (RWO).")
+		cfg.AccessModes = append(cfg.AccessModes, v1.ReadWriteOnce)
 	}
 
 	return &v1.PersistentVolumeClaim{


### PR DESCRIPTION
AccessModes on the PVC specify the *union* of all modes the volume provisioned in the PV must support. This means the default request for `PVC` is requesting a volume with all `RWO, ROX, RWX` which is not supported by many volumes so does not seem like a sensible default.

Changing it to `RWO`, a minimal, standard access mode required for the provisioner to satisfy seems like a more sensible default. If the plugin/driver wants to test specifically setting more/different access modes they can pass in a config.


Since this is changing defaulting behavior this might affect tests. This might break some NFS tests but it's my assertion that if that happens it is a bug in the NFS provisioner code not the fault of the defaulting since the access modes specified in this change is a *strict subset* of the old *union* of accessmodes.

/kind bug
/kind failing-test
/sig storage
/priority important-soon
/assign @msau42 @jsafrane 
/cc @mkimuram

```release-note
NONE
```