### PR TITLE
Add a field 'RequiredAccessModes' to the driver info object that is propagated to pvc creation

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -41,6 +41,7 @@ import (
 	"strconv"
 
 	"github.com/onsi/ginkgo"
+	"k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -354,6 +355,7 @@ func InitGcePDCSIDriver() testsuites.TestDriver {
 				testsuites.CapExec:        true,
 				testsuites.CapMultiPODs:   true,
 			},
+			RequiredAccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 		},
 	}
 }

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -160,11 +160,19 @@ type DriverInfo struct {
 	InTreePluginName string
 	FeatureTag       string // FeatureTag for the driver
 
-	MaxFileSize          int64               // Max file size to be tested for this driver
-	SupportedFsType      sets.String         // Map of string for supported fs type
-	SupportedMountOption sets.String         // Map of string for supported mount option
-	RequiredMountOption  sets.String         // Map of string for required mount option (Optional)
-	Capabilities         map[Capability]bool // Map that represents plugin capabilities
+	// Max file size to be tested for this driver
+	MaxFileSize int64
+	// Map of string for supported fs type
+	SupportedFsType sets.String
+	// Map of string for supported mount option
+	SupportedMountOption sets.String
+	// [Optional] Map of string for required mount option
+	RequiredMountOption sets.String
+	// Map that represents plugin capabilities
+	Capabilities map[Capability]bool
+	// [Optional] List of access modes required for provisioning, defaults to
+	// RWO if unset
+	RequiredAccessModes []v1.PersistentVolumeAccessMode
 }
 
 // PerTestConfig represents parameters that control test execution.


### PR DESCRIPTION
Let driver's specify their required access modes for creation of PVC and PV.

/kind cleanup
/sig storage
/assign @mkimuram @msau42 


```release-note
NONE
```