### PR TITLE
Update fsType to ntfs for Windows node

### DIFF
--- a/pkg/volume/gcepd/gce_pd.go
+++ b/pkg/volume/gcepd/gce_pd.go
@@ -492,9 +492,13 @@ func (c *gcePersistentDiskProvisioner) Provision(selectedNode *v1.Node, allowedT
 	}
 
 	if fstype == "" {
-		fstype = "ext4"
+		if runtime.GOOS == "windows" {
+			fstype = "ntfs"
+		} else {
+			fstype = "ext4"
+		}
 	}
-
+	
 	var volumeMode *v1.PersistentVolumeMode
 	if utilfeature.DefaultFeatureGate.Enabled(features.BlockVolume) {
 		volumeMode = c.options.PVC.Spec.VolumeMode

--- a/pkg/volume/gcepd/gce_pd_test.go
+++ b/pkg/volume/gcepd/gce_pd_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"testing"
 
@@ -187,6 +188,16 @@ func TestPlugin(t *testing.T) {
 	if persistentSpec.Spec.PersistentVolumeSource.GCEPersistentDisk.PDName != "test-gce-volume-name" {
 		t.Errorf("Provision() returned unexpected volume ID: %s", persistentSpec.Spec.PersistentVolumeSource.GCEPersistentDisk.PDName)
 	}
+	var fstype string
+	if runtime.GOOS == "windows" {
+		fstype = "ntfs"
+	} else {
+		fstype = "ext4"
+	}
+	if persistentSpec.Spec.PersistentVolumeSource.GCEPersistentDisk.FSType != fstype {
+		t.Errorf("Provision() returned unexpected fsType: %s", persistentSpec.Spec.PersistentVolumeSource.GCEPersistentDisk.FSType)
+	}
+
 	cap := persistentSpec.Spec.Capacity[v1.ResourceStorage]
 	size := cap.Value()
 	if size != 100*volumehelpers.GiB {


### PR DESCRIPTION
This fix is to update fsType to default ntfs during volume provision on
windows node. If node is linux, it will default to linux

Change-Id: Icbbdef5e392012f881029aac6df8ea0f18b53ad6
