### PR TITLE
Add NormalizeScore extension point for scheduler framework.

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -780,6 +780,18 @@ func PrioritizeNodes(
 		return schedulerapi.HostPriorityList{}, scoreStatus.AsError()
 	}
 
+	// Run the Normalize Score plugins.
+	status := framework.RunNormalizeScorePlugins(pluginContext, pod, scoresMap)
+	if !status.IsSuccess() {
+		return schedulerapi.HostPriorityList{}, status.AsError()
+	}
+
+	// Apply weights for scores.
+	status = framework.ApplyScoreWeights(pluginContext, pod, scoresMap)
+	if !status.IsSuccess() {
+		return schedulerapi.HostPriorityList{}, status.AsError()
+	}
+
 	// Summarize all scores.
 	result := make(schedulerapi.HostPriorityList, 0, len(nodes))
 

--- a/pkg/scheduler/framework/v1alpha1/BUILD
+++ b/pkg/scheduler/framework/v1alpha1/BUILD
@@ -39,6 +39,14 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["interface_test.go"],
+    srcs = [
+        "framework_test.go",
+        "interface_test.go",
+    ],
     embed = [":go_default_library"],
+    deps = [
+        "//pkg/scheduler/apis/config:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
 )

--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -1,0 +1,434 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+)
+
+const (
+	scorePlugin1               = "score-plugin-1"
+	scorePlugin2               = "score-plugin-2"
+	scorePlugin3               = "score-plugin-3"
+	pluginNotImplementingScore = "plugin-not-implementing-score"
+	weight1                    = 2
+	weight2                    = 3
+	weight3                    = 4
+)
+
+// TestScorePlugin1 and 2 implements ScoreWithNormalizePlugin interface,
+// TestScorePlugin3 only implements ScorePlugin interface.
+var _ = ScoreWithNormalizePlugin(&TestScorePlugin1{})
+var _ = ScoreWithNormalizePlugin(&TestScorePlugin2{})
+var _ = ScorePlugin(&TestScorePlugin3{})
+
+type TestScorePlugin1 struct {
+	// If fail is true, NormalizeScore will return error status.
+	fail bool
+}
+
+// NewScorePlugin1 is the factory for NormalizeScore plugin 1.
+func NewScorePlugin1(_ *runtime.Unknown, _ FrameworkHandle) (Plugin, error) {
+	return &TestScorePlugin1{}, nil
+}
+
+// NewScorePlugin1InjectFailure creates a new TestScorePlugin1 which will
+// return an error status for NormalizeScore.
+func NewScorePlugin1InjectFailure(_ *runtime.Unknown, _ FrameworkHandle) (Plugin, error) {
+	return &TestScorePlugin1{fail: true}, nil
+}
+
+func (pl *TestScorePlugin1) Name() string {
+	return scorePlugin1
+}
+
+func (pl *TestScorePlugin1) NormalizeScore(pc *PluginContext, pod *v1.Pod, scores NodeScoreList) *Status {
+	if pl.fail {
+		return NewStatus(Error, "injecting failure.")
+	}
+	// Simply decrease each node score by 1.
+	for i := range scores {
+		scores[i] = scores[i] - 1
+	}
+	return nil
+}
+
+func (pl *TestScorePlugin1) Score(pc *PluginContext, p *v1.Pod, nodeName string) (int, *Status) {
+	// Score is currently not used in the tests so just return some dummy value.
+	return 0, nil
+}
+
+type TestScorePlugin2 struct{}
+
+// NewScorePlugin2 is the factory for NormalizeScore plugin 2.
+func NewScorePlugin2(_ *runtime.Unknown, _ FrameworkHandle) (Plugin, error) {
+	return &TestScorePlugin2{}, nil
+}
+
+func (pl *TestScorePlugin2) Name() string {
+	return scorePlugin2
+}
+
+func (pl *TestScorePlugin2) NormalizeScore(pc *PluginContext, pod *v1.Pod, scores NodeScoreList) *Status {
+	// Simply force each node score to 5.
+	for i := range scores {
+		scores[i] = 5
+	}
+	return nil
+}
+
+func (pl *TestScorePlugin2) Score(pc *PluginContext, p *v1.Pod, nodeName string) (int, *Status) {
+	// Score is currently not used in the tests so just return some dummy value.
+	return 0, nil
+}
+
+// TestScorePlugin3 only implements ScorePlugin interface.
+type TestScorePlugin3 struct{}
+
+// NewScorePlugin3 is the factory for Score plugin 3.
+func NewScorePlugin3(_ *runtime.Unknown, _ FrameworkHandle) (Plugin, error) {
+	return &TestScorePlugin3{}, nil
+}
+
+func (pl *TestScorePlugin3) Name() string {
+	return scorePlugin3
+}
+
+func (pl *TestScorePlugin3) Score(pc *PluginContext, p *v1.Pod, nodeName string) (int, *Status) {
+	// Score is currently not used in the tests so just return some dummy value.
+	return 0, nil
+}
+
+// PluginNotImplementingScore doesn't implement the ScorePlugin interface.
+type PluginNotImplementingScore struct{}
+
+// NewPluginNotImplementingScore is the factory for PluginNotImplementingScore.
+func NewPluginNotImplementingScore(_ *runtime.Unknown, _ FrameworkHandle) (Plugin, error) {
+	return &PluginNotImplementingScore{}, nil
+}
+
+func (pl *PluginNotImplementingScore) Name() string {
+	return pluginNotImplementingScore
+}
+
+var registry = Registry{
+	scorePlugin1:               NewScorePlugin1,
+	scorePlugin2:               NewScorePlugin2,
+	scorePlugin3:               NewScorePlugin3,
+	pluginNotImplementingScore: NewPluginNotImplementingScore,
+}
+
+var plugin1 = &config.Plugins{
+	Score: &config.PluginSet{
+		Enabled: []config.Plugin{
+			{Name: scorePlugin1, Weight: weight1},
+		},
+	},
+}
+var plugin3 = &config.Plugins{
+	Score: &config.PluginSet{
+		Enabled: []config.Plugin{
+			{Name: scorePlugin3, Weight: weight3},
+		},
+	},
+}
+var plugin1And2 = &config.Plugins{
+	Score: &config.PluginSet{
+		Enabled: []config.Plugin{
+			{Name: scorePlugin1, Weight: weight1},
+			{Name: scorePlugin2, Weight: weight2},
+		},
+	},
+}
+var plugin1And3 = &config.Plugins{
+	Score: &config.PluginSet{
+		Enabled: []config.Plugin{
+			{Name: scorePlugin1, Weight: weight1},
+			{Name: scorePlugin3, Weight: weight3},
+		},
+	},
+}
+
+// No specific config required.
+var args = []config.PluginConfig{}
+var pc = &PluginContext{}
+
+// Pod is only used for logging errors.
+var pod = &v1.Pod{}
+
+func TestInitFrameworkWithScorePlugins(t *testing.T) {
+	tests := []struct {
+		name    string
+		plugins *config.Plugins
+		// If initErr is true, we expect framework initialization to fail.
+		initErr bool
+	}{
+		{
+			name: "enabled Score plugin doesn't exist in registry",
+			plugins: &config.Plugins{
+				Score: &config.PluginSet{
+					Enabled: []config.Plugin{
+						{Name: "notExist"},
+					},
+				},
+			},
+			initErr: true,
+		},
+		{
+			name: "enabled Score plugin doesn't extend the ScorePlugin interface",
+			plugins: &config.Plugins{
+				Score: &config.PluginSet{
+					Enabled: []config.Plugin{
+						{Name: pluginNotImplementingScore},
+					},
+				},
+			},
+			initErr: true,
+		},
+		{
+			name:    "Score plugins are nil",
+			plugins: &config.Plugins{Score: nil},
+		},
+		{
+			name: "enabled Score plugin list is empty",
+			plugins: &config.Plugins{
+				Score: &config.PluginSet{
+					Enabled: []config.Plugin{},
+				},
+			},
+		},
+		{
+			name: "enabled plugin only implements ScorePlugin interface",
+			plugins: &config.Plugins{
+				Score: &config.PluginSet{
+					Enabled: []config.Plugin{
+						{Name: scorePlugin3},
+					},
+				},
+			},
+		},
+		{
+			name: "enabled plugin implements ScoreWithNormalizePlugin interface",
+			plugins: &config.Plugins{
+				Score: &config.PluginSet{
+					Enabled: []config.Plugin{
+						{Name: scorePlugin1},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewFramework(registry, tt.plugins, args)
+			if tt.initErr && err == nil {
+				t.Fatal("Framework initialization should fail")
+			}
+			if !tt.initErr && err != nil {
+				t.Fatalf("Failed to create framework for testing: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunNormalizeScorePlugins(t *testing.T) {
+	tests := []struct {
+		name     string
+		registry Registry
+		plugins  *config.Plugins
+		input    PluginToNodeScoreMap
+		want     PluginToNodeScoreMap
+		// If err is true, we expect RunNormalizeScorePlugin to fail.
+		err bool
+	}{
+		{
+			name:     "no NormalizeScore plugins",
+			plugins:  plugin3,
+			registry: registry,
+			input: PluginToNodeScoreMap{
+				scorePlugin1: {2, 3},
+			},
+			// No NormalizeScore plugin, map should be untouched.
+			want: PluginToNodeScoreMap{
+				scorePlugin1: {2, 3},
+			},
+		},
+		{
+			name:     "single Score plugin, single NormalizeScore plugin",
+			registry: registry,
+			plugins:  plugin1,
+			input: PluginToNodeScoreMap{
+				scorePlugin1: {2, 3},
+			},
+			want: PluginToNodeScoreMap{
+				// For plugin1, want=input-1.
+				scorePlugin1: {1, 2},
+			},
+		},
+		{
+			name:     "2 Score plugins, 2 NormalizeScore plugins",
+			registry: registry,
+			plugins:  plugin1And2,
+			input: PluginToNodeScoreMap{
+				scorePlugin1: {2, 3},
+				scorePlugin2: {2, 4},
+			},
+			want: PluginToNodeScoreMap{
+				// For plugin1, want=input-1.
+				scorePlugin1: {1, 2},
+				// For plugin2, want=5.
+				scorePlugin2: {5, 5},
+			},
+		},
+		{
+			name:     "2 Score plugins, 1 NormalizeScore plugin",
+			registry: registry,
+			plugins:  plugin1And3,
+			input: PluginToNodeScoreMap{
+				scorePlugin1: {2, 3},
+				scorePlugin3: {2, 4},
+			},
+			want: PluginToNodeScoreMap{
+				// For plugin1, want=input-1.
+				scorePlugin1: {1, 2},
+				// No NormalizeScore for plugin 3. The node scores are untouched.
+				scorePlugin3: {2, 4},
+			},
+		},
+		{
+			name: "score map contains both test plugin 1 and 2 but plugin 1 fails",
+			registry: Registry{
+				scorePlugin1: NewScorePlugin1InjectFailure,
+				scorePlugin2: NewScorePlugin2,
+			},
+			plugins: plugin1And2,
+			input: PluginToNodeScoreMap{
+				scorePlugin1: {2, 3},
+				scorePlugin2: {2, 4},
+			},
+			err: true,
+		},
+		{
+			name:     "2 plugins but score map only contains plugin1",
+			registry: registry,
+			plugins:  plugin1And2,
+			input: PluginToNodeScoreMap{
+				scorePlugin1: {2, 3},
+			},
+			err: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := NewFramework(tt.registry, tt.plugins, args)
+			if err != nil {
+				t.Fatalf("Failed to create framework for testing: %v", err)
+			}
+
+			status := f.RunNormalizeScorePlugins(pc, pod, tt.input)
+
+			if tt.err {
+				if status.IsSuccess() {
+					t.Errorf("Expected status to be non-success.")
+				}
+			} else {
+				if !status.IsSuccess() {
+					t.Errorf("Expected status to be success.")
+				}
+				if !reflect.DeepEqual(tt.input, tt.want) {
+					t.Errorf("Score map after RunNormalizeScorePlugin: %+v, want: %+v.", tt.input, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyScoreWeights(t *testing.T) {
+	tests := []struct {
+		name    string
+		plugins *config.Plugins
+		input   PluginToNodeScoreMap
+		want    PluginToNodeScoreMap
+		// If err is true, we expect ApplyScoreWeights to fail.
+		err bool
+	}{
+		{
+			name:    "single Score plugin, single nodeScoreList",
+			plugins: plugin1,
+			input: PluginToNodeScoreMap{
+				scorePlugin1: {2, 3},
+			},
+			want: PluginToNodeScoreMap{
+				// For plugin1, want=input*weight1.
+				scorePlugin1: {4, 6},
+			},
+		},
+		{
+			name:    "2 Score plugins, 2 nodeScoreLists in scoreMap",
+			plugins: plugin1And2,
+			input: PluginToNodeScoreMap{
+				scorePlugin1: {2, 3},
+				scorePlugin2: {2, 4},
+			},
+			want: PluginToNodeScoreMap{
+				// For plugin1, want=input*weight1.
+				scorePlugin1: {4, 6},
+				// For plugin2, want=input*weight2.
+				scorePlugin2: {6, 12},
+			},
+		},
+		{
+			name:    "2 Score plugins, 1 without corresponding nodeScoreList in the score map",
+			plugins: plugin1And2,
+			input: PluginToNodeScoreMap{
+				scorePlugin1: {2, 3},
+			},
+			err: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := NewFramework(registry, tt.plugins, args)
+			if err != nil {
+				t.Fatalf("Failed to create framework for testing: %v", err)
+			}
+
+			status := f.ApplyScoreWeights(pc, pod, tt.input)
+
+			if tt.err {
+				if status.IsSuccess() {
+					t.Errorf("Expected status to be non-success.")
+				}
+			} else {
+				if !status.IsSuccess() {
+					t.Errorf("Expected status to be success.")
+				}
+				if !reflect.DeepEqual(tt.input, tt.want) {
+					t.Errorf("Score map after RunNormalizeScorePlugin: %+v, want: %+v.", tt.input, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -179,6 +179,14 @@ func (*fakeFramework) RunScorePlugins(pc *framework.PluginContext, pod *v1.Pod, 
 	return nil, nil
 }
 
+func (*fakeFramework) RunNormalizeScorePlugins(pc *framework.PluginContext, pod *v1.Pod, scores framework.PluginToNodeScoreMap) *framework.Status {
+	return nil
+}
+
+func (*fakeFramework) ApplyScoreWeights(pc *framework.PluginContext, pod *v1.Pod, scores framework.PluginToNodeScoreMap) *framework.Status {
+	return nil
+}
+
 func (*fakeFramework) RunPrebindPlugins(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Implement normalize plugin extension point so that normalize plugin can be used.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79901
Also helps with #80272

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Implement normalize plugin extension point for the scheduler framework.

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

[Scheduler Framework](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/20180409-scheduling-framework.md)

