### PR TITLE
kubectl explain displays path of kind instead of "Object"

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/explain/fields_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/fields_printer_test.go
@@ -33,7 +33,7 @@ func TestFields(t *testing.T) {
 		t.Fatal("Couldn't find schema v1.OneKind")
 	}
 
-	want := `field1	<Object> -required-
+	want := `field1	<OtherKind> -required-
   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ut lacus ac
   enim vulputate imperdiet ac accumsan risus. Integer vel accumsan lectus.
   Praesent tempus nulla id tortor luctus, quis varius nulla laoreet. Ut orci

--- a/staging/src/k8s.io/kubectl/pkg/explain/model_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/model_printer_test.go
@@ -46,7 +46,7 @@ DESCRIPTION:
      OneKind has a short description
 
 FIELDS:
-   field1	<Object> -required-
+   field1	<OtherKind> -required-
      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ut lacus ac
      enim vulputate imperdiet ac accumsan risus. Integer vel accumsan lectus.
      Praesent tempus nulla id tortor luctus, quis varius nulla laoreet. Ut orci
@@ -65,7 +65,7 @@ FIELDS:
 			want: `KIND:     OneKind
 VERSION:  v1
 
-RESOURCE: field1 <Object>
+RESOURCE: field1 <OtherKind>
 
 DESCRIPTION:
      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ut lacus ac

--- a/staging/src/k8s.io/kubectl/pkg/explain/recursive_fields_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/recursive_fields_printer_test.go
@@ -34,7 +34,7 @@ func TestRecursiveFields(t *testing.T) {
 		t.Fatal("Couldn't find schema v1.OneKind")
 	}
 
-	want := `field1	<Object>
+	want := `field1	<OtherKind>
    array	<[]integer>
    int	<integer>
    object	<map[string]string>
@@ -72,13 +72,13 @@ func TestRecursiveFieldsWithSelfReferenceObjects(t *testing.T) {
 		t.Fatal("Couldn't find schema v2.OneKind")
 	}
 
-	want := `field1	<Object>
-   referencefield	<Object>
-   referencesarray	<[]Object>
-field2	<Object>
-   reference	<Object>
-      referencefield	<Object>
-      referencesarray	<[]Object>
+	want := `field1	<ReferenceKind>
+   referencefield	<ReferenceKind>
+   referencesarray	<[]ReferenceKind>
+field2	<OtherKind>
+   reference	<ReferenceKind>
+      referencefield	<ReferenceKind>
+      referencesarray	<[]ReferenceKind>
    string	<string>
 `
 

--- a/staging/src/k8s.io/kubectl/pkg/explain/typename.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/typename.go
@@ -36,9 +36,9 @@ func (t *typeName) VisitArray(a *proto.Array) {
 	t.Name = fmt.Sprintf("[]%s", s.Name)
 }
 
-// VisitKind just returns "Object".
+// VisitKind returns the path of the kind.
 func (t *typeName) VisitKind(k *proto.Kind) {
-	t.Name = "Object"
+	t.Name = k.GetPath().String()
 }
 
 // VisitMap adds the map[string] prefix and recurses.

--- a/staging/src/k8s.io/kubectl/pkg/explain/typename_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/typename_test.go
@@ -44,13 +44,13 @@ func TestReferenceTypename(t *testing.T) {
 			// Kind is "Object"
 			name:     "test1",
 			path:     []string{},
-			expected: "Object",
+			expected: "OneKind",
 		},
 		{
 			// Reference is equal to pointed type "Object"
 			name:     "test2",
 			path:     []string{"field1"},
-			expected: "Object",
+			expected: "OtherKind",
 		},
 		{
 			// Reference is equal to pointed type "string"

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -104,7 +104,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		}
 
 		ginkgo.By("kubectl explain works to explain CR properties")
-		if err := verifyKubectlExplain(crd.Crd.Spec.Names.Plural, `(?s)DESCRIPTION:.*Foo CRD for Testing.*FIELDS:.*apiVersion.*<string>.*APIVersion defines.*spec.*<Object>.*Specification of Foo`); err != nil {
+		if err := verifyKubectlExplain(crd.Crd.Spec.Names.Plural, `(?s)DESCRIPTION:.*Foo CRD for Testing.*FIELDS:.*apiVersion.*<string>.*APIVersion defines.*spec.*<com\.example\.crd-publish-openapi-test-foo\.v1\.E2e-test-crd-publish-openapi-[0-9]+-crd\.spec>.*Specification of Foo`); err != nil {
 			framework.Failf("%v", err)
 		}
 
@@ -112,10 +112,10 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		if err := verifyKubectlExplain(crd.Crd.Spec.Names.Plural+".metadata", `(?s)DESCRIPTION:.*Standard object's metadata.*FIELDS:.*creationTimestamp.*<string>.*CreationTimestamp is a timestamp`); err != nil {
 			framework.Failf("%v", err)
 		}
-		if err := verifyKubectlExplain(crd.Crd.Spec.Names.Plural+".spec", `(?s)DESCRIPTION:.*Specification of Foo.*FIELDS:.*bars.*<\[\]Object>.*List of Bars and their specs`); err != nil {
+		if err := verifyKubectlExplain(crd.Crd.Spec.Names.Plural+".spec", `(?s)DESCRIPTION:.*Specification of Foo.*FIELDS:.*bars.*<\[\]com\.example\.crd-publish-openapi-test-foo\.v1\.E2e-test-crd-publish-openapi-[0-9]+-crd\.spec\.bars>.*List of Bars and their specs`); err != nil {
 			framework.Failf("%v", err)
 		}
-		if err := verifyKubectlExplain(crd.Crd.Spec.Names.Plural+".spec.bars", `(?s)RESOURCE:.*bars.*<\[\]Object>.*DESCRIPTION:.*List of Bars and their specs.*FIELDS:.*bazs.*<\[\]string>.*List of Bazs.*name.*<string>.*Name of Bar`); err != nil {
+		if err := verifyKubectlExplain(crd.Crd.Spec.Names.Plural+".spec.bars", `(?s)RESOURCE:.*bars.*<\[\]com\.example\.crd-publish-openapi-test-foo\.v1\.E2e-test-crd-publish-openapi-[0-9]+-crd\.spec\.bars>.*DESCRIPTION:.*List of Bars and their specs.*FIELDS:.*bazs.*<\[\]string>.*List of Bazs.*name.*<string>.*Name of Bar`); err != nil {
 			framework.Failf("%v", err)
 		}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The "kubectl explain" command displays "Object" for non primitive fields, and it's not usable when using the output of explain to write Go code.

I propose to display the full path of the field, so the Go developer can use it to find the Go import and the name of the structure.

Example:

```
$ kubectl explain pod.spec

KIND:     Pod
VERSION:  v1

RESOURCE: spec <io.k8s.api.core.v1.PodSpec>
[...]
   dnsConfig    <io.k8s.api.core.v1.PodDNSConfig>
     Specifies the DNS parameters of a pod. Parameters specified here will be
     merged to the generated DNS configuration based on DNSPolicy.
```

With this output, the developer can easily find the import "k8s.io/api/core/v1" and the name of the structs PodSpec and PodDNSConfig.

**Which issue(s) this PR fixes**:
Fixes #80386

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubectl explain displays path of kind instead of "Object"
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
