### PR TITLE
Check whether metricObj can be converted to *v1beta2.MetricValueList

### DIFF
--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/versioned_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/versioned_client.go
@@ -18,11 +18,12 @@ package custom_metrics
 
 import (
 	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 
@@ -122,7 +123,11 @@ func (m *rootScopedMetrics) getForNamespace(namespace string, metricName string,
 		return nil, err
 	}
 
-	res := metricObj.(*v1beta2.MetricValueList)
+	var res *v1beta2.MetricValueList
+	var ok bool
+	if res, ok = metricObj.(*v1beta2.MetricValueList); !ok {
+		return nil, fmt.Errorf("the custom metrics API server didn't return MetricValueList, the type is %v", reflect.TypeOf(metricObj))
+	}
 	if len(res.Items) != 1 {
 		return nil, fmt.Errorf("the custom metrics API server returned %v results when we asked for exactly one", len(res.Items))
 	}
@@ -160,7 +165,11 @@ func (m *rootScopedMetrics) GetForObject(groupKind schema.GroupKind, name string
 		return nil, err
 	}
 
-	res := metricObj.(*v1beta2.MetricValueList)
+	var res *v1beta2.MetricValueList
+	var ok bool
+	if res, ok = metricObj.(*v1beta2.MetricValueList); !ok {
+		return nil, fmt.Errorf("the custom metrics API server didn't return MetricValueList, the type is %v", reflect.TypeOf(metricObj))
+	}
 	if len(res.Items) != 1 {
 		return nil, fmt.Errorf("the custom metrics API server returned %v results when we asked for exactly one", len(res.Items))
 	}
@@ -199,7 +208,11 @@ func (m *rootScopedMetrics) GetForObjects(groupKind schema.GroupKind, selector l
 		return nil, err
 	}
 
-	res := metricObj.(*v1beta2.MetricValueList)
+	var res *v1beta2.MetricValueList
+	var ok bool
+	if res, ok = metricObj.(*v1beta2.MetricValueList); !ok {
+		return nil, fmt.Errorf("the custom metrics API server didn't return MetricValueList, the type is %v", reflect.TypeOf(metricObj))
+	}
 	return res, nil
 }
 
@@ -234,7 +247,11 @@ func (m *namespacedMetrics) GetForObject(groupKind schema.GroupKind, name string
 		return nil, err
 	}
 
-	res := metricObj.(*v1beta2.MetricValueList)
+	var res *v1beta2.MetricValueList
+	var ok bool
+	if res, ok = metricObj.(*v1beta2.MetricValueList); !ok {
+		return nil, fmt.Errorf("the custom metrics API server didn't return MetricValueList, the type is %v", reflect.TypeOf(metricObj))
+	}
 	if len(res.Items) != 1 {
 		return nil, fmt.Errorf("the custom metrics API server returned %v results when we asked for exactly one", len(res.Items))
 	}
@@ -269,6 +286,10 @@ func (m *namespacedMetrics) GetForObjects(groupKind schema.GroupKind, selector l
 		return nil, err
 	}
 
-	res := metricObj.(*v1beta2.MetricValueList)
+	var res *v1beta2.MetricValueList
+	var ok bool
+	if res, ok = metricObj.(*v1beta2.MetricValueList); !ok {
+		return nil, fmt.Errorf("the custom metrics API server didn't return MetricValueList, the type is %v", reflect.TypeOf(metricObj))
+	}
 	return res, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As #80390 mentioned, namespacedMetrics#GetForObject doesn't check whether metricObj can be converted to *v1beta2.MetricValueList .

this PR adds the check to avoid potential panic.

**Which issue(s) this PR fixes**:
Fixes #80390

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
