### PR TITLE
Pod e2e for reading last line can flake if pod runs to completion

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -594,7 +594,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			ginkgo.By("executing a command with run")
 			framework.RunKubectlOrDie("run", podName, "--generator=run-pod/v1", "--image="+busyboxImage, "--restart=OnFailure", nsFlag, "--", "sh", "-c", "sleep 10; seq 100 | while read i; do echo $i; sleep 0.01; done; echo EOF")
 
-			if !e2epod.CheckPodsRunningReady(c, ns, []string{podName}, framework.PodStartTimeout) {
+			if !e2epod.CheckPodsRunningReadyOrSucceeded(c, ns, []string{podName}, framework.PodStartTimeout) {
 				e2elog.Failf("Pod for run-log-test was not ready")
 			}
 


### PR DESCRIPTION
Pod completes so fast the current check fails:

```
Jul 18 07:09:24.858: INFO: Running '/usr/bin/kubectl --server=https://api.ci-op-ziq360tf-12fbf.origin-ci-int-aws.dev.rhcloud.com:6443 --kubeconfig=/tmp/admin.kubeconfig run run-log-test --generator=run-pod/v1 --image=docker.io/library/busybox:1.29 --restart=OnFailure --namespace=e2e-tests-kubectl-nxzxx -- sh -c sleep 10; seq 100 | while read i; do echo $i; sleep 0.01; done; echo EOF'
...
Jul 18 07:09:25.116: INFO: Waiting up to 5m0s for pod "run-log-test" in namespace "e2e-tests-kubectl-nxzxx" to be "running and ready"
Jul 18 07:09:25.135: INFO: Pod "run-log-test": Phase="Pending", Reason="", readiness=false. Elapsed: 19.221661ms
...
Jul 18 07:09:57.456: INFO: Pod "run-log-test": Phase="Pending", Reason="", readiness=false. Elapsed: 32.339426605s
Jul 18 07:09:59.477: INFO: Pod "run-log-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 34.360446811s
...
Jul 18 07:14:24.023: INFO: Pod "run-log-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4m58.906706065s
Jul 18 07:14:26.023: INFO: Pod run-log-test failed to be running and ready.
```

The test should be reporting running and ready or succeeded.

/kind flake

```release-note
NONE
```
```docs
```