### PR TITLE
Disable JSON Patch negative indices to be compliant with RFC 6902

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/jsonmergepatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/jsonmergepatch/patch.go
@@ -20,10 +20,15 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/mergepatch"
 )
+
+func init() {
+	// Disable negative indices to be compliant with RFC6902.
+	jsonpatch.SupportNegativeIndices = false
+}
 
 // Create a 3-way merge patch based-on JSON merge patch.
 // Calculate addition-and-change patch between current and modified.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -55,6 +55,11 @@ const (
 	maxJSONPatchOperations = 10000
 )
 
+func init() {
+	// Disable negative indices to be compliant with RFC6902.
+	jsonpatch.SupportNegativeIndices = false
+}
+
 // PatchResource returns a function that will handle a resource patch.
 func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interface, patchTypes []string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {

--- a/staging/src/k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/patch/patch.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/patch/patch.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -38,6 +38,11 @@ type patchTransformer struct {
 }
 
 var _ transformers.Transformer = &patchTransformer{}
+
+func init() {
+	// Disable negative indices to be compliant with RFC6902.
+	jsonpatch.SupportNegativeIndices = false
+}
 
 // NewPatchTransformer constructs a patchTransformer.
 func NewPatchTransformer(

--- a/staging/src/k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/patch/patchconflictdetector.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/patch/patchconflictdetector.go
@@ -19,7 +19,7 @@ package patch
 import (
 	"encoding/json"
 
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/mergepatch"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -37,6 +37,11 @@ type jsonMergePatch struct {
 }
 
 var _ conflictDetector = &jsonMergePatch{}
+
+func init() {
+	// Disable negative indices to be compliant with RFC6902.
+	jsonpatch.SupportNegativeIndices = false
+}
 
 func newJMPConflictDetector(rf *resource.Factory) conflictDetector {
 	return &jsonMergePatch{rf: rf}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -92,6 +92,11 @@ var (
 		kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path": "/spec/containers/0/image", "value":"new image"}]'`))
 )
 
+func init() {
+	// Disable negative indices to be compliant with RFC6902.
+	jsonpatch.SupportNegativeIndices = false
+}
+
 func NewPatchOptions(ioStreams genericclioptions.IOStreams) *PatchOptions {
 	return &PatchOptions{
 		RecordFlags: genericclioptions.NewRecordFlags(),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -53,6 +53,11 @@ const (
 
 type debugError interface {
 	DebugError() (msg string, args []interface{})
+}
+
+func init() {
+	// Disable negative indices to be compliant with RFC6902.
+	jsonpatch.SupportNegativeIndices = false
 }
 
 // AddSourceToErr adds handleResourcePrefix and source string to error message.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Disable JSON Patch negative indices to be compliant with RFC 6902

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #68578

**Special notes for your reviewer**:

- Please see https://github.com/kubernetes/kubernetes/issues/68578#issuecomment-513656352 for why I fixed these 6 sources and not others.

- I used `init` funcs spread across sources to set the global flag as required by the evanphx/json-patch, as it seemed like the only way to achieve this. Please see https://github.com/kubernetes/kubernetes/issues/68578#issuecomment-438145280 for more context on this.

- My understanding is that this affects patches on local `kubectl patch --local` and remote(apiserver). To verify this locally, I've run the following commands:
  ```console
  $ for kubectl in kubectl ./_output/local/bin/darwin/amd64/kubectl; do $kubectl patch -f pod.yaml --type=json -p '[{"op":"add","path":"/spec/containers/-1","value":{"foo":"bar"}}]' --local; done
  # kubectl without this fix treat -1 as the last index
  pod/icy-lion-envoy-67f47967c-vjc5b patched
  # kubectl with this fix treat it as-is and evanphx/json-patch has no index bound check, that results in...
  panic: runtime error: slice bounds out of range
  
  goroutine 1 [running]:
  k8s.io/kubernetes/vendor/github.com/evanphx/json-patch.(*partialArray).add(0xc0008a0460, 0xc0004742d2, 0x2, 0xc0008a06f0, 0xc000847d08, 0xc000474201)
  #snip
  ```

- Although this bug fix can be considered a "breaking" change in case anyone was relying on this "bug". But the risk should be relatively small as this affects JSON patches with `add` ops on arrays only, and not others. See the fix on `evanphx/json-patch` for why this affects `add` only: https://github.com/evanphx/json-patch/commit/fcd53eccb4f88d7e54b742358017d72c9b34ae44

**Does this PR introduce a user-facing change?**:

```release-note
ACTION Required: negative indices in JSON patches with `add` operations are now rejected by `kubectl patch --type=json` and `apiserver`. JSON patches with other ops(replace, remove, set, etc.), and strategic-merge patches are not affected.
```
