### PR TITLE
Fix es initial cluster formation & update es to 7.2.0

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
@@ -17,7 +17,7 @@ COPY elasticsearch_logging_discovery.go go.mod go.sum /
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -ldflags "-w" -o /elasticsearch_logging_discovery /elasticsearch_logging_discovery.go
 
 
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.1.1
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.2.0
 
 VOLUME ["/data"]
 EXPOSE 9200 9300

--- a/cluster/addons/fluentd-elasticsearch/es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Makefile
@@ -16,11 +16,12 @@
 
 PREFIX = quay.io/fluentd_elasticsearch
 IMAGE = elasticsearch
-TAG = v7.1.1
+TAG = v7.2.0
 
 build:
-	docker build  --tag ${PREFIX}/${IMAGE}:${TAG} .
+	docker build --tag ${PREFIX}/${IMAGE}:${TAG} .
+	docker build --tag ${PREFIX}/${IMAGE}:latest .
 
 push:
-    docker push ${PREFIX}/${IMAGE}:${TAG}
+	docker push ${PREFIX}/${IMAGE}:${TAG}
 	docker push ${PREFIX}/${IMAGE}:latest

--- a/cluster/addons/fluentd-elasticsearch/es-image/config/elasticsearch.yml
+++ b/cluster/addons/fluentd-elasticsearch/es-image/config/elasticsearch.yml
@@ -4,11 +4,9 @@ node.name: ${NODE_NAME}
 node.master: ${NODE_MASTER}
 node.data: ${NODE_DATA}
 
-transport.tcp.port: ${TRANSPORT_PORT}
+transport.profiles.default.port: ${TRANSPORT_PORT}
 http.port: ${HTTP_PORT}
 
 path.data: /data
 
 network.host: 0.0.0.0
-
-discovery.zen.minimum_master_nodes: ${MINIMUM_MASTER_NODES}

--- a/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go
+++ b/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go
@@ -124,5 +124,6 @@ func main() {
 	}
 
 	klog.Infof("Endpoints = %s", addrs)
-	fmt.Printf("discovery.zen.ping.unicast.hosts: [%s]\n", strings.Join(addrs, ", "))
+	fmt.Printf("discovery.seed_hosts: [%s]\n", strings.Join(addrs, ", "))
+	fmt.Printf("cluster.initial_master_nodes: [%s]\n", strings.Join(addrs, ", "))
 }

--- a/cluster/addons/fluentd-elasticsearch/es-image/go.mod
+++ b/cluster/addons/fluentd-elasticsearch/es-image/go.mod
@@ -23,7 +23,7 @@ require (
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
-	k8s.io/api v0.0.0-20190111032252-67edc246be36 // indirect
+	k8s.io/api v0.0.0-20190111032252-67edc246be36
 	k8s.io/apiextensions-apiserver v0.0.0-20190111034747-7d26de67f177 // indirect
 	k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93
 	k8s.io/apiserver v0.0.0-20190111033246-d50e9ac5404f // indirect

--- a/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
@@ -51,7 +51,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: elasticsearch-logging
-    version: v7.1.1
+    version: v7.2.0
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   serviceName: elasticsearch-logging
@@ -59,17 +59,18 @@ spec:
   selector:
     matchLabels:
       k8s-app: elasticsearch-logging
-      version: v7.1.1
+      version: v7.2.0
   template:
     metadata:
       labels:
         k8s-app: elasticsearch-logging
-        version: v7.1.1
+        version: v7.2.0
     spec:
       serviceAccountName: elasticsearch-logging
       containers:
-      - image: quay.io/fluentd_elasticsearch/elasticsearch:v7.1.1
+      - image: quay.io/fluentd_elasticsearch/elasticsearch:v7.2.0
         name: elasticsearch-logging
+        imagePullPolicy: Always
         resources:
           # need more cpu upon initialization, therefore burstable class
           limits:

--- a/cluster/addons/fluentd-elasticsearch/kibana-deployment.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: docker.elastic.co/kibana/kibana-oss:7.1.1
+        image: docker.elastic.co/kibana/kibana-oss:7.2.0
         resources:
           # need more cpu upon initialization, therefore burstable class
           limits:
@@ -28,10 +28,14 @@ spec:
           requests:
             cpu: 100m
         env:
-          - name: ELASTICSEARCH_URL
+          - name: ELASTICSEARCH_HOSTS
             value: http://elasticsearch-logging:9200
+          - name: SERVER_NAME
+            value: kibana-logging
           - name: SERVER_BASEPATH
             value: /api/v1/namespaces/kube-system/services/kibana-logging/proxy
+          - name: SERVER_REWRITEBASEPATH
+            value: "false"
         ports:
         - containerPort: 5601
           name: ui


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind feature

**What this PR does / why we need it**:
• Fix `elasticseatch` broken service discovery `7.1.1` upgrade
• Bump `elasticsearch` / `kibana` to latest stable (`7.2.0`)
• Fix makefile indentation

**Which issue(s) this PR fixes**:
Fixes #80282

**Special notes for your reviewer**:
• Changes to be pushed on`quay.io/fluentd_elasticsearch/elasticsearch` before merging.
• Both `7.1.1` and `7.2.0` were built and tested with [lostick/fluentd-elasticsearch](https://cloud.docker.com/repository/docker/lostick/fluentd-elasticsearch) image.
```bash
# elasticsearch health endpoint
$ curl -s  http://elasticsearch-logging:9200/_cluster/health | jq .
{
  "cluster_name": "kubernetes-logging",
  "status": "green",
  "timed_out": false,
  "number_of_nodes": 2,
  "number_of_data_nodes": 2,
  "active_primary_shards": 4,
  "active_shards": 8,
  "relocating_shards": 0,
  "initializing_shards": 0,
  "unassigned_shards": 0,
  "delayed_unassigned_shards": 0,
  "number_of_pending_tasks": 0,
  "number_of_in_flight_fetch": 0,
  "task_max_waiting_in_queue_millis": 0,
  "active_shards_percent_as_number": 100
}

# kibana health endpoint
$ curl -s http://kibana-logging:5601/api/status | jq .status.overall
{
  "state": "green",
  "title": "Green",
  "nickname": "Looking good",
  "icon": "success",
  "uiColor": "secondary",
  "since": "2019-07-22T09:25:01.239Z"
}
```

**Does this PR introduce a user-facing change?**:
```release-note
Kibana has been slightly revamped/improved in the latest version
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
```
