### PR TITLE
kubelet: change node-lease-renew-interval to 0.25 of lease-renew-duration

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -872,7 +872,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.softAdmitHandlers.AddPodAdmitHandler(lifecycle.NewNoNewPrivsAdmitHandler(klet.containerRuntime))
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.NodeLease) {
-		klet.nodeLeaseController = nodelease.NewController(klet.clock, klet.heartbeatClient, string(klet.nodeName), kubeCfg.NodeLeaseDurationSeconds, kubeCfg.NodeStatusUpdateFrequency.Duration, klet.onRepeatedHeartbeatFailure)
+		klet.nodeLeaseController = nodelease.NewController(klet.clock, klet.heartbeatClient, string(klet.nodeName), kubeCfg.NodeLeaseDurationSeconds, klet.onRepeatedHeartbeatFailure)
 	}
 
 	klet.softAdmitHandlers.AddPodAdmitHandler(lifecycle.NewProcMountAdmitHandler(klet.containerRuntime))

--- a/pkg/kubelet/nodelease/controller.go
+++ b/pkg/kubelet/nodelease/controller.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	// defaultRenewInterval is the default interval at which the lease is renewed
-	defaultRenewInterval = 10 * time.Second
+	// renewIntervalFraction is the fraction of lease duration to renew the lease
+	renewIntervalFraction = 0.25
 	// maxUpdateRetries is the number of immediate, successive retries the Kubelet will attempt
 	// when renewing the lease before it waits for the renewal interval before trying again,
 	// similar to what we do for node status retries
@@ -60,27 +60,18 @@ type controller struct {
 }
 
 // NewController constructs and returns a controller
-func NewController(clock clock.Clock, client clientset.Interface, holderIdentity string, leaseDurationSeconds int32, nodeStatusUpdateFrequency time.Duration, onRepeatedHeartbeatFailure func()) Controller {
+func NewController(clock clock.Clock, client clientset.Interface, holderIdentity string, leaseDurationSeconds int32, onRepeatedHeartbeatFailure func()) Controller {
 	var leaseClient coordclientset.LeaseInterface
 	if client != nil {
 		leaseClient = client.CoordinationV1().Leases(corev1.NamespaceNodeLease)
 	}
-	renewInterval := defaultRenewInterval
-	// Users are able to decrease the timeout after which nodes are being
-	// marked as "Ready: Unknown" by NodeLifecycleController to values
-	// smaller than defaultRenewInterval. Until the knob to configure
-	// lease renew interval is exposed to user, we temporarily decrease
-	// renewInterval based on the NodeStatusUpdateFrequency.
-	if renewInterval > nodeStatusUpdateFrequency {
-		renewInterval = nodeStatusUpdateFrequency
-	}
-
+	leaseDuration := time.Duration(leaseDurationSeconds) * time.Second
 	return &controller{
 		client:                     client,
 		leaseClient:                leaseClient,
 		holderIdentity:             holderIdentity,
 		leaseDurationSeconds:       leaseDurationSeconds,
-		renewInterval:              renewInterval,
+		renewInterval:              time.Duration(float64(leaseDuration) * renewIntervalFraction),
 		clock:                      clock,
 		onRepeatedHeartbeatFailure: onRepeatedHeartbeatFailure,
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

Ref: https://github.com/kubernetes/enhancements/issues/589

**What this PR does / why we need it**:
change node-lease-renew-interval to 0.25 of lease-renew-duration instead of hardcoded `10s` 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubelet: change node-lease-renew-interval to 0.25 of lease-renew-duration
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

@wojtek-t @liggitt @wangzhen127 @mtaufen 