### PR TITLE
Set enableTcpReset of load balancer rules to true for Azure Standard Load Balancer

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -967,6 +967,7 @@ func (az *Cloud) reconcileLoadBalancerRule(
 					BackendPort:         to.Int32Ptr(port.Port),
 					EnableFloatingIP:    to.BoolPtr(true),
 					DisableOutboundSnat: to.BoolPtr(az.disableLoadBalancerOutboundSNAT()),
+					EnableTCPReset:      to.BoolPtr(az.useStandardLoadBalancer()),
 				},
 			}
 			if protocol == v1.ProtocolTCP {
@@ -1496,7 +1497,9 @@ func equalLoadBalancingRulePropertiesFormat(s *network.LoadBalancingRuleProperti
 		reflect.DeepEqual(s.LoadDistribution, t.LoadDistribution) &&
 		reflect.DeepEqual(s.FrontendPort, t.FrontendPort) &&
 		reflect.DeepEqual(s.BackendPort, t.BackendPort) &&
-		reflect.DeepEqual(s.EnableFloatingIP, t.EnableFloatingIP)
+		reflect.DeepEqual(s.EnableFloatingIP, t.EnableFloatingIP) &&
+		reflect.DeepEqual(s.EnableTCPReset, t.EnableTCPReset) &&
+		reflect.DeepEqual(s.DisableOutboundSnat, t.DisableOutboundSnat)
 
 	if wantLB {
 		return properties && reflect.DeepEqual(s.IdleTimeoutInMinutes, t.IdleTimeoutInMinutes)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
@@ -1038,7 +1038,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/" +
 								"Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-80"),
 						},
-						EnableTCPReset: nil,
+						EnableTCPReset: to.BoolPtr(false),
 					},
 				},
 			},

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -120,7 +120,7 @@ func TestParseConfig(t *testing.T) {
 
 // Test flipServiceInternalAnnotation
 func TestFlipServiceInternalAnnotation(t *testing.T) {
-	svc := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	svcUpdated := flipServiceInternalAnnotation(&svc)
 	if !requiresInternalLoadBalancer(svcUpdated) {
 		t.Errorf("Expected svc to be an internal service")
@@ -145,7 +145,7 @@ func TestFlipServiceInternalAnnotation(t *testing.T) {
 // Test additional of a new service/port.
 func TestAddPort(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	clusterResources := getClusterResources(az, 1, 1)
 
 	svc.Spec.Ports = append(svc.Spec.Ports, v1.ServicePort{
@@ -200,7 +200,7 @@ func testLoadBalancerServiceDefaultModeSelection(t *testing.T, isInternal bool) 
 			svc = getInternalTestService(svcName, 8081)
 			addTestSubnet(t, az, &svc)
 		} else {
-			svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+			svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 		}
 
 		lbStatus, err := az.EnsureLoadBalancer(context.TODO(), testClusterName, &svc, clusterResources.nodes)
@@ -255,7 +255,7 @@ func testLoadBalancerServiceAutoModeSelection(t *testing.T, isInternal bool) {
 			svc = getInternalTestService(svcName, 8081)
 			addTestSubnet(t, az, &svc)
 		} else {
-			svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+			svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 		}
 		setLoadBalancerAutoModeAnnotation(&svc)
 		lbStatus, err := az.EnsureLoadBalancer(context.TODO(), testClusterName, &svc, clusterResources.nodes)
@@ -318,7 +318,7 @@ func testLoadBalancerServicesSpecifiedSelection(t *testing.T, isInternal bool) {
 			svc = getInternalTestService(svcName, 8081)
 			addTestSubnet(t, az, &svc)
 		} else {
-			svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+			svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 		}
 		lbMode := fmt.Sprintf("%s,%s", selectedAvailabilitySetName1, selectedAvailabilitySetName2)
 		setLoadBalancerModeAnnotation(&svc, lbMode)
@@ -360,7 +360,7 @@ func testLoadBalancerMaxRulesServices(t *testing.T, isInternal bool) {
 			svc = getInternalTestService(svcName, 8081)
 			addTestSubnet(t, az, &svc)
 		} else {
-			svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+			svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 		}
 
 		lbStatus, err := az.EnsureLoadBalancer(context.TODO(), testClusterName, &svc, clusterResources.nodes)
@@ -389,7 +389,7 @@ func testLoadBalancerMaxRulesServices(t *testing.T, isInternal bool) {
 		svc = getInternalTestService(svcName, 8081)
 		addTestSubnet(t, az, &svc)
 	} else {
-		svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+		svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 	}
 	_, err := az.EnsureLoadBalancer(context.TODO(), testClusterName, &svc, clusterResources.nodes)
 	if err == nil {
@@ -419,7 +419,7 @@ func testLoadBalancerServiceAutoModeDeleteSelection(t *testing.T, isInternal boo
 			svc = getInternalTestService(svcName, 8081)
 			addTestSubnet(t, az, &svc)
 		} else {
-			svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+			svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 		}
 		setLoadBalancerAutoModeAnnotation(&svc)
 		lbStatus, err := az.EnsureLoadBalancer(context.TODO(), testClusterName, &svc, clusterResources.nodes)
@@ -438,7 +438,7 @@ func testLoadBalancerServiceAutoModeDeleteSelection(t *testing.T, isInternal boo
 			svc = getInternalTestService(svcName, 8081)
 			addTestSubnet(t, az, &svc)
 		} else {
-			svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+			svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 		}
 
 		setLoadBalancerAutoModeAnnotation(&svc)
@@ -482,7 +482,7 @@ func TestReconcileLoadBalancerAddServiceOnInternalSubnet(t *testing.T) {
 
 func TestReconcileSecurityGroupFromAnyDestinationAddressPrefixToLoadBalancerIP(t *testing.T) {
 	az := getTestCloud()
-	svc1 := getTestService("serviceea", v1.ProtocolTCP, 80)
+	svc1 := getTestService("serviceea", v1.ProtocolTCP, nil, 80)
 	svc1.Spec.LoadBalancerIP = "192.168.0.0"
 	sg := getTestSecurityGroup(az)
 	// Simulate a pre-Kubernetes 1.8 NSG, where we do not specify the destination address prefix
@@ -499,7 +499,7 @@ func TestReconcileSecurityGroupFromAnyDestinationAddressPrefixToLoadBalancerIP(t
 
 func TestReconcileSecurityGroupDynamicLoadBalancerIP(t *testing.T) {
 	az := getTestCloud()
-	svc1 := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc1 := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	svc1.Spec.LoadBalancerIP = ""
 	sg := getTestSecurityGroup(az)
 	dynamicallyAssignedIP := "192.168.0.0"
@@ -514,7 +514,7 @@ func TestReconcileSecurityGroupDynamicLoadBalancerIP(t *testing.T) {
 func TestReconcileLoadBalancerAddServicesOnMultipleSubnets(t *testing.T) {
 	az := getTestCloud()
 	clusterResources := getClusterResources(az, 1, 1)
-	svc1 := getTestService("service1", v1.ProtocolTCP, 8081)
+	svc1 := getTestService("service1", v1.ProtocolTCP, nil, 8081)
 	svc2 := getInternalTestService("service2", 8081)
 
 	// Internal and External service cannot reside on the same LB resource
@@ -580,7 +580,7 @@ func TestReconcileLoadBalancerEditServiceSubnet(t *testing.T) {
 func TestReconcileLoadBalancerNodeHealth(t *testing.T) {
 	az := getTestCloud()
 	clusterResources := getClusterResources(az, 1, 1)
-	svc := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 	svc.Spec.HealthCheckNodePort = int32(32456)
 
@@ -601,7 +601,7 @@ func TestReconcileLoadBalancerNodeHealth(t *testing.T) {
 func TestReconcileLoadBalancerRemoveService(t *testing.T) {
 	az := getTestCloud()
 	clusterResources := getClusterResources(az, 1, 1)
-	svc := getTestService("servicea", v1.ProtocolTCP, 80, 443)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
 
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
 	if err != nil {
@@ -625,7 +625,7 @@ func TestReconcileLoadBalancerRemoveService(t *testing.T) {
 func TestReconcileLoadBalancerRemoveAllPortsRemovesFrontendConfig(t *testing.T) {
 	az := getTestCloud()
 	clusterResources := getClusterResources(az, 1, 1)
-	svc := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
 	if err != nil {
@@ -633,7 +633,7 @@ func TestReconcileLoadBalancerRemoveAllPortsRemovesFrontendConfig(t *testing.T) 
 	}
 	validateLoadBalancer(t, lb, svc)
 
-	svcUpdated := getTestService("servicea", v1.ProtocolTCP)
+	svcUpdated := getTestService("servicea", v1.ProtocolTCP, nil)
 	lb, err = az.reconcileLoadBalancer(testClusterName, &svcUpdated, clusterResources.nodes, false /* wantLb*/)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
@@ -652,13 +652,13 @@ func TestReconcileLoadBalancerRemovesPort(t *testing.T) {
 	az := getTestCloud()
 	clusterResources := getClusterResources(az, 1, 1)
 
-	svc := getTestService("servicea", v1.ProtocolTCP, 80, 443)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
 
-	svcUpdated := getTestService("servicea", v1.ProtocolTCP, 80)
+	svcUpdated := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	lb, err = az.reconcileLoadBalancer(testClusterName, &svcUpdated, clusterResources.nodes, true /* wantLb */)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
@@ -671,8 +671,8 @@ func TestReconcileLoadBalancerRemovesPort(t *testing.T) {
 func TestReconcileLoadBalancerMultipleServices(t *testing.T) {
 	az := getTestCloud()
 	clusterResources := getClusterResources(az, 1, 1)
-	svc1 := getTestService("servicea", v1.ProtocolTCP, 80, 443)
-	svc2 := getTestService("serviceb", v1.ProtocolTCP, 80)
+	svc1 := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
+	svc2 := getTestService("serviceb", v1.ProtocolTCP, nil, 80)
 
 	updatedLoadBalancer, err := az.reconcileLoadBalancer(testClusterName, &svc1, clusterResources.nodes, true /* wantLb */)
 	if err != nil {
@@ -698,7 +698,7 @@ func findLBRuleForPort(lbRules []network.LoadBalancingRule, port int32) (network
 
 func TestServiceDefaultsToNoSessionPersistence(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("service-sa-omitted", v1.ProtocolTCP, 7170)
+	svc := getTestService("service-sa-omitted", v1.ProtocolTCP, nil, 7170)
 	clusterResources := getClusterResources(az, 1, 1)
 
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
@@ -718,7 +718,7 @@ func TestServiceDefaultsToNoSessionPersistence(t *testing.T) {
 
 func TestServiceRespectsNoSessionAffinity(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("service-sa-none", v1.ProtocolTCP, 7170)
+	svc := getTestService("service-sa-none", v1.ProtocolTCP, nil, 7170)
 	svc.Spec.SessionAffinity = v1.ServiceAffinityNone
 	clusterResources := getClusterResources(az, 1, 1)
 
@@ -741,7 +741,7 @@ func TestServiceRespectsNoSessionAffinity(t *testing.T) {
 
 func TestServiceRespectsClientIPSessionAffinity(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("service-sa-clientip", v1.ProtocolTCP, 7170)
+	svc := getTestService("service-sa-clientip", v1.ProtocolTCP, nil, 7170)
 	svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
 	clusterResources := getClusterResources(az, 1, 1)
 
@@ -765,7 +765,7 @@ func TestServiceRespectsClientIPSessionAffinity(t *testing.T) {
 func TestReconcileSecurityGroupNewServiceAddsPort(t *testing.T) {
 	az := getTestCloud()
 	getTestSecurityGroup(az)
-	svc1 := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc1 := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	clusterResources := getClusterResources(az, 1, 1)
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc1, clusterResources.nodes, true)
 	lbStatus, _ := az.getServiceLoadBalancerStatus(&svc1, lb)
@@ -797,8 +797,8 @@ func TestReconcileSecurityGroupNewInternalServiceAddsPort(t *testing.T) {
 
 func TestReconcileSecurityGroupRemoveService(t *testing.T) {
 	az := getTestCloud()
-	service1 := getTestService("servicea", v1.ProtocolTCP, 81)
-	service2 := getTestService("serviceb", v1.ProtocolTCP, 82)
+	service1 := getTestService("servicea", v1.ProtocolTCP, nil, 81)
+	service2 := getTestService("serviceb", v1.ProtocolTCP, nil, 82)
 	clusterResources := getClusterResources(az, 1, 1)
 
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &service1, clusterResources.nodes, true)
@@ -819,11 +819,11 @@ func TestReconcileSecurityGroupRemoveService(t *testing.T) {
 
 func TestReconcileSecurityGroupRemoveServiceRemovesPort(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicea", v1.ProtocolTCP, 80, 443)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
 	clusterResources := getClusterResources(az, 1, 1)
 
 	sg := getTestSecurityGroup(az, svc)
-	svcUpdated := getTestService("servicea", v1.ProtocolTCP, 80)
+	svcUpdated := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true)
 	lbStatus, _ := az.getServiceLoadBalancerStatus(&svc, lb)
 
@@ -837,7 +837,7 @@ func TestReconcileSecurityGroupRemoveServiceRemovesPort(t *testing.T) {
 
 func TestReconcileSecurityWithSourceRanges(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicea", v1.ProtocolTCP, 80, 443)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
 	svc.Spec.LoadBalancerSourceRanges = []string{
 		"192.168.0.0/24",
 		"10.0.0.0/32",
@@ -864,7 +864,7 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 	cachedSG.Etag = to.StringPtr("1111111-0000-0000-0000-000000000000")
 	az.nsgCache.Set(to.String(sg.Name), &cachedSG)
 
-	svc1 := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc1 := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	clusterResources := getClusterResources(az, 1, 1)
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc1, clusterResources.nodes, true)
 	lbStatus, _ := az.getServiceLoadBalancerStatus(&svc1, lb)
@@ -877,7 +877,7 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 
 func TestReconcilePublicIPWithNewService(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicea", v1.ProtocolTCP, 80, 443)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
 
 	pip, err := az.reconcilePublicIP(testClusterName, &svc, "", true /* wantLb*/)
 	if err != nil {
@@ -898,7 +898,7 @@ func TestReconcilePublicIPWithNewService(t *testing.T) {
 
 func TestReconcilePublicIPRemoveService(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicea", v1.ProtocolTCP, 80, 443)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
 
 	pip, err := az.reconcilePublicIP(testClusterName, &svc, "", true /* wantLb*/)
 	if err != nil {
@@ -939,7 +939,7 @@ func TestReconcilePublicIPWithExternalAndInternalSwitch(t *testing.T) {
 	validatePublicIP(t, pip, &svc, true)
 
 	// Update to external service
-	svcUpdated := getTestService("servicea", v1.ProtocolTCP, 80)
+	svcUpdated := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	pip, err = az.reconcilePublicIP(testClusterName, &svcUpdated, "", true /* wantLb*/)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
@@ -1131,7 +1131,7 @@ func getBackendPort(port int32) int32 {
 	return port + 10000
 }
 
-func getTestService(identifier string, proto v1.Protocol, requestedPorts ...int32) v1.Service {
+func getTestService(identifier string, proto v1.Protocol, annotations map[string]string, requestedPorts ...int32) v1.Service {
 	ports := []v1.ServicePort{}
 	for _, port := range requestedPorts {
 		ports = append(ports, v1.ServicePort{
@@ -1151,19 +1151,23 @@ func getTestService(identifier string, proto v1.Protocol, requestedPorts ...int3
 	svc.Name = identifier
 	svc.Namespace = "default"
 	svc.UID = types.UID(identifier)
-	svc.Annotations = make(map[string]string)
+	if annotations == nil {
+		svc.Annotations = make(map[string]string)
+	} else {
+		svc.Annotations = annotations
+	}
 
 	return svc
 }
 
 func getInternalTestService(identifier string, requestedPorts ...int32) v1.Service {
-	svc := getTestService(identifier, v1.ProtocolTCP, requestedPorts...)
+	svc := getTestService(identifier, v1.ProtocolTCP, nil, requestedPorts...)
 	svc.Annotations[ServiceAnnotationLoadBalancerInternal] = "true"
 	return svc
 }
 
 func getResourceGroupTestService(identifier, resourceGroup, loadBalancerIP string, requestedPorts ...int32) v1.Service {
-	svc := getTestService(identifier, v1.ProtocolTCP, requestedPorts...)
+	svc := getTestService(identifier, v1.ProtocolTCP, nil, requestedPorts...)
 	svc.Spec.LoadBalancerIP = loadBalancerIP
 	svc.Annotations[ServiceAnnotationLoadBalancerResourceGroup] = resourceGroup
 	return svc
@@ -1869,7 +1873,7 @@ func addTestSubnet(t *testing.T, az *Cloud, svc *v1.Service) {
 
 func TestIfServiceSpecifiesSharedRuleAndRuleDoesNotExistItIsCreated(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicesr", v1.ProtocolTCP, 80)
+	svc := getTestService("servicesr", v1.ProtocolTCP, nil, 80)
 	svc.Spec.LoadBalancerIP = "192.168.77.88"
 	svc.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -1908,7 +1912,7 @@ func TestIfServiceSpecifiesSharedRuleAndRuleDoesNotExistItIsCreated(t *testing.T
 
 func TestIfServiceSpecifiesSharedRuleAndRuleExistsThenTheServicesPortAndAddressAreAdded(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicesr", v1.ProtocolTCP, 80)
+	svc := getTestService("servicesr", v1.ProtocolTCP, nil, 80)
 	svc.Spec.LoadBalancerIP = "192.168.77.88"
 	svc.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -1961,11 +1965,11 @@ func TestIfServiceSpecifiesSharedRuleAndRuleExistsThenTheServicesPortAndAddressA
 func TestIfServicesSpecifySharedRuleButDifferentPortsThenSeparateRulesAreCreated(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 4444)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 4444)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 8888)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 8888)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -2030,11 +2034,11 @@ func TestIfServicesSpecifySharedRuleButDifferentPortsThenSeparateRulesAreCreated
 func TestIfServicesSpecifySharedRuleButDifferentProtocolsThenSeparateRulesAreCreated(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 4444)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 4444)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolUDP, 4444)
+	svc2 := getTestService("servicesr2", v1.ProtocolUDP, nil, 4444)
 	svc2.Spec.LoadBalancerIP = "192.168.77.88"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -2097,12 +2101,12 @@ func TestIfServicesSpecifySharedRuleButDifferentProtocolsThenSeparateRulesAreCre
 func TestIfServicesSpecifySharedRuleButDifferentSourceAddressesThenSeparateRulesAreCreated(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 80)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 80)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Spec.LoadBalancerSourceRanges = []string{"192.168.12.0/24"}
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 80)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 80)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Spec.LoadBalancerSourceRanges = []string{"192.168.34.0/24"}
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
@@ -2168,15 +2172,15 @@ func TestIfServicesSpecifySharedRuleButDifferentSourceAddressesThenSeparateRules
 func TestIfServicesSpecifySharedRuleButSomeAreOnDifferentPortsThenRulesAreSeparatedOrConsoliatedByPort(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 4444)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 4444)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 8888)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 8888)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc3 := getTestService("servicesr3", v1.ProtocolTCP, 4444)
+	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, 4444)
 	svc3.Spec.LoadBalancerIP = "192.168.99.11"
 	svc3.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -2268,11 +2272,11 @@ func TestIfServicesSpecifySharedRuleButSomeAreOnDifferentPortsThenRulesAreSepara
 func TestIfServiceSpecifiesSharedRuleAndServiceIsDeletedThenTheServicesPortAndAddressAreRemoved(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 80)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 80)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 80)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 80)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -2323,15 +2327,15 @@ func TestIfServiceSpecifiesSharedRuleAndServiceIsDeletedThenTheServicesPortAndAd
 func TestIfSomeServicesShareARuleAndOneIsDeletedItIsRemovedFromTheRightRule(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 4444)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 4444)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 8888)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 8888)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc3 := getTestService("servicesr3", v1.ProtocolTCP, 4444)
+	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, 4444)
 	svc3.Spec.LoadBalancerIP = "192.168.99.11"
 	svc3.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -2430,15 +2434,15 @@ func TestIfSomeServicesShareARuleAndOneIsDeletedItIsRemovedFromTheRightRule(t *t
 func TestIfServiceSpecifiesSharedRuleAndLastServiceIsDeletedThenRuleIsDeleted(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 4444)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 4444)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 8888)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 8888)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc3 := getTestService("servicesr3", v1.ProtocolTCP, 4444)
+	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, 4444)
 	svc3.Spec.LoadBalancerIP = "192.168.99.11"
 	svc3.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -2510,23 +2514,23 @@ func TestIfServiceSpecifiesSharedRuleAndLastServiceIsDeletedThenRuleIsDeleted(t 
 func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 4444)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 4444)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 8888)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 8888)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc3 := getTestService("servicesr3", v1.ProtocolTCP, 4444)
+	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, 4444)
 	svc3.Spec.LoadBalancerIP = "192.168.99.11"
 	svc3.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc4 := getTestService("servicesr4", v1.ProtocolTCP, 4444)
+	svc4 := getTestService("servicesr4", v1.ProtocolTCP, nil, 4444)
 	svc4.Spec.LoadBalancerIP = "192.168.22.33"
 	svc4.Annotations[ServiceAnnotationSharedSecurityRule] = "false"
 
-	svc5 := getTestService("servicesr5", v1.ProtocolTCP, 8888)
+	svc5 := getTestService("servicesr5", v1.ProtocolTCP, nil, 8888)
 	svc5.Spec.LoadBalancerIP = "192.168.22.33"
 	svc5.Annotations[ServiceAnnotationSharedSecurityRule] = "false"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> 
kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
When using Azure Standard Load Balancer backed K8S cluster, previously K8S cloud provider will not set the EnableTCPReset to true in new load balancer rules added to a Standard Load Balancer. This change fixes the issue and always set the value to true as that's one of the benefits of Azure Standard Load Blancer over Basic Load Balancer.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #80442

**Special notes for your reviewer**:
Should cherry pick to 1.13, 1.14 and 1.15.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
When using Azure Standard Load Balancer backed K8S cluster, previously K8S cloud provider will not set the EnableTCPReset to true in new load balancer rules added to a Standard Load Balancer. This change fixes the issue and always set the value to true as that's one of the benefits of Azure Standard Load Blancer over Basic Load Balancer.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig azure