### PR TITLE
Add migration shim for verifyvolumeattachment and bulk verify

### DIFF
--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/csi"
 	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
@@ -635,17 +636,46 @@ func (oe *operationExecutor) VerifyVolumesAreAttached(
 				klog.Errorf("VerifyVolumesAreAttached: nil spec for volume %s", volumeAttached.VolumeName)
 				continue
 			}
-			volumePlugin, err :=
-				oe.operationGenerator.GetVolumePluginMgr().FindPluginBySpec(volumeAttached.VolumeSpec)
 
-			if err != nil || volumePlugin == nil {
-				klog.Errorf(
-					"VolumesAreAttached.FindPluginBySpec failed for volume %q (spec.Name: %q) on node %q with error: %v",
-					volumeAttached.VolumeName,
-					volumeAttached.VolumeSpec.Name(),
-					volumeAttached.NodeName,
-					err)
+			// Migration: Must also check the Node since Attach would have been done with in-tree if node is not using Migration
+			nu, err := nodeUsingCSIPlugin(oe.operationGenerator, volumeAttached.VolumeSpec, node)
+			if err != nil {
+				klog.Errorf(volumeAttached.GenerateErrorDetailed("VolumesAreAttached.NodeUsingCSIPlugin failed", err).Error())
 				continue
+			}
+
+			var volumePlugin volume.VolumePlugin
+			if useCSIPlugin(oe.operationGenerator.GetVolumePluginMgr(), volumeAttached.VolumeSpec) && nu {
+				// The volume represented by this spec is CSI and thus should be migrated
+				volumePlugin, err = oe.operationGenerator.GetVolumePluginMgr().FindPluginByName(csi.CSIPluginName)
+				if err != nil || volumePlugin == nil {
+					klog.Errorf(
+						"VolumesAreAttached.Name failed for volume %q (spec.Name: %q) on node %q with error: %v",
+						volumeAttached.VolumeName,
+						volumeAttached.VolumeSpec.Name(),
+						volumeAttached.NodeName,
+						err)
+					continue
+				}
+
+				csiSpec, err := translateSpec(volumeAttached.VolumeSpec)
+				if err != nil {
+					klog.Errorf(volumeAttached.GenerateErrorDetailed("VolumesAreAttached.TranslateSpec failed", err).Error())
+					continue
+				}
+				volumeAttached.VolumeSpec = csiSpec
+			} else {
+				volumePlugin, err =
+					oe.operationGenerator.GetVolumePluginMgr().FindPluginBySpec(volumeAttached.VolumeSpec)
+				if err != nil || volumePlugin == nil {
+					klog.Errorf(
+						"VolumesAreAttached.FindPluginBySpec failed for volume %q (spec.Name: %q) on node %q with error: %v",
+						volumeAttached.VolumeName,
+						volumeAttached.VolumeSpec.Name(),
+						volumeAttached.NodeName,
+						err)
+					continue
+				}
 			}
 
 			pluginName := volumePlugin.GetPluginName()


### PR DESCRIPTION
`VerifyVolumesAreAttached` and `BulkVolumeVerify` were not shimmed to CSI when migration was enabled for the verification plugin. This implements the shim layer for those functions. 

However, `VerifyVolumesAreAttached` for CSI is broken since it checks the `VolumeAttachment` object which is not currently necessarily representative of what's attached in the backend (if something was detached out of band VolumeAttachment wont see that). and `BulkVolumeVerify` is not implemented for CSI.

Those are separate issues that can be worked on after this PR. 

/kind feature
/sig storage
/assign @msau42 @ddebroy @leakingtapan @saad-ali 
/cc @gnufied @jsafrane @andrewsykim @adisky @andyzhangx

```release-note
Add CSI Migration Shim for VerifyVolumesAreAttached and BulkVolumeVerify
```