### PR TITLE
Update github.com/robfig/cron to tagged version v1.0.0-53...

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2983,7 +2983,7 @@
 		},
 		{
 			"ImportPath": "github.com/robfig/cron",
-			"Comment": "v1-53-gdf38d32658d878",
+			"Comment": "v1.0.0-53-gdf38d32658d878",
 			"Rev": "df38d32658d8788cd446ba74db4bb5375c4b0cb3"
 		},
 		{


### PR DESCRIPTION
All changes to k8s/k8s/release-1.13 are failing tests because of the deps error of this package comment being wrong

/assign @tpepper @aleksandra-malinowska 

/kind bug
/kind cleanup
/kind failing-test

```release-note
NONE
```