### PR TITLE
Check error return from GetPodKey

### DIFF
--- a/pkg/scheduler/nodeinfo/node_info.go
+++ b/pkg/scheduler/nodeinfo/node_info.go
@@ -712,7 +712,10 @@ func (n *NodeInfo) FilterOutPods(pods []*v1.Pod) []*v1.Pod {
 			continue
 		}
 		// If pod is on the given node, add it to 'filtered' only if it is present in nodeInfo.
-		podKey, _ := GetPodKey(p)
+		podKey, err := GetPodKey(p)
+		if err != nil {
+			continue
+		}
 		for _, np := range n.Pods() {
 			npodkey, _ := GetPodKey(np)
 			if npodkey == podKey {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In NodeInfo#FilterOutPods, the error return from GetPodKey is ignored.

This PR adds check of the error return.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
