### PR TITLE
Fix informer-gen to honor nonNamespaced tag

### DIFF
--- a/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example2/types.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example2/types.go
@@ -20,7 +20,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
+// +genclient:nonNamespaced
 // TestType is a top-level type. A client is created for it.
 type TestType struct {
 	metav1.TypeMeta

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/example2_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/example2_client.go
@@ -33,8 +33,8 @@ type SecondExampleClient struct {
 	restClient rest.Interface
 }
 
-func (c *SecondExampleClient) TestTypes(namespace string) TestTypeInterface {
-	return newTestTypes(c, namespace)
+func (c *SecondExampleClient) TestTypes() TestTypeInterface {
+	return newTestTypes(c)
 }
 
 // NewForConfig creates a new SecondExampleClient for the given config.

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/fake/fake_example2_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/fake/fake_example2_client.go
@@ -28,8 +28,8 @@ type FakeSecondExample struct {
 	*testing.Fake
 }
 
-func (c *FakeSecondExample) TestTypes(namespace string) internalversion.TestTypeInterface {
-	return &FakeTestTypes{c, namespace}
+func (c *FakeSecondExample) TestTypes() internalversion.TestTypeInterface {
+	return &FakeTestTypes{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/fake/fake_testtype.go
@@ -31,7 +31,6 @@ import (
 // FakeTestTypes implements TestTypeInterface
 type FakeTestTypes struct {
 	Fake *FakeSecondExample
-	ns   string
 }
 
 var testtypesResource = schema.GroupVersionResource{Group: "example.test.apiserver.code-generator.k8s.io", Version: "", Resource: "testtypes"}
@@ -41,8 +40,7 @@ var testtypesKind = schema.GroupVersionKind{Group: "example.test.apiserver.code-
 // Get takes name of the testType, and returns the corresponding testType object, and an error if there is any.
 func (c *FakeTestTypes) Get(name string, options v1.GetOptions) (result *example2.TestType, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(testtypesResource, c.ns, name), &example2.TestType{})
-
+		Invokes(testing.NewRootGetAction(testtypesResource, name), &example2.TestType{})
 	if obj == nil {
 		return nil, err
 	}
@@ -52,8 +50,7 @@ func (c *FakeTestTypes) Get(name string, options v1.GetOptions) (result *example
 // List takes label and field selectors, and returns the list of TestTypes that match those selectors.
 func (c *FakeTestTypes) List(opts v1.ListOptions) (result *example2.TestTypeList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(testtypesResource, testtypesKind, c.ns, opts), &example2.TestTypeList{})
-
+		Invokes(testing.NewRootListAction(testtypesResource, testtypesKind, opts), &example2.TestTypeList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,15 +71,13 @@ func (c *FakeTestTypes) List(opts v1.ListOptions) (result *example2.TestTypeList
 // Watch returns a watch.Interface that watches the requested testTypes.
 func (c *FakeTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(testtypesResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(testtypesResource, opts))
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
 func (c *FakeTestTypes) Create(testType *example2.TestType) (result *example2.TestType, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(testtypesResource, c.ns, testType), &example2.TestType{})
-
+		Invokes(testing.NewRootCreateAction(testtypesResource, testType), &example2.TestType{})
 	if obj == nil {
 		return nil, err
 	}
@@ -92,8 +87,7 @@ func (c *FakeTestTypes) Create(testType *example2.TestType) (result *example2.Te
 // Update takes the representation of a testType and updates it. Returns the server's representation of the testType, and an error, if there is any.
 func (c *FakeTestTypes) Update(testType *example2.TestType) (result *example2.TestType, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(testtypesResource, c.ns, testType), &example2.TestType{})
-
+		Invokes(testing.NewRootUpdateAction(testtypesResource, testType), &example2.TestType{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,8 +98,7 @@ func (c *FakeTestTypes) Update(testType *example2.TestType) (result *example2.Te
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeTestTypes) UpdateStatus(testType *example2.TestType) (*example2.TestType, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(testtypesResource, "status", c.ns, testType), &example2.TestType{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(testtypesResource, "status", testType), &example2.TestType{})
 	if obj == nil {
 		return nil, err
 	}
@@ -115,14 +108,13 @@ func (c *FakeTestTypes) UpdateStatus(testType *example2.TestType) (*example2.Tes
 // Delete takes name of the testType and deletes it. Returns an error if one occurs.
 func (c *FakeTestTypes) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(testtypesResource, c.ns, name), &example2.TestType{})
-
+		Invokes(testing.NewRootDeleteAction(testtypesResource, name), &example2.TestType{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeTestTypes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(testtypesResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(testtypesResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &example2.TestTypeList{})
 	return err
@@ -131,8 +123,7 @@ func (c *FakeTestTypes) DeleteCollection(options *v1.DeleteOptions, listOptions 
 // Patch applies the patch and returns the patched testType.
 func (c *FakeTestTypes) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *example2.TestType, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(testtypesResource, c.ns, name, pt, data, subresources...), &example2.TestType{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(testtypesResource, name, pt, data, subresources...), &example2.TestType{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
@@ -32,7 +32,7 @@ import (
 // TestTypesGetter has a method to return a TestTypeInterface.
 // A group's client should implement this interface.
 type TestTypesGetter interface {
-	TestTypes(namespace string) TestTypeInterface
+	TestTypes() TestTypeInterface
 }
 
 // TestTypeInterface has methods to work with TestType resources.
@@ -52,14 +52,12 @@ type TestTypeInterface interface {
 // testTypes implements TestTypeInterface
 type testTypes struct {
 	client rest.Interface
-	ns     string
 }
 
 // newTestTypes returns a TestTypes
-func newTestTypes(c *SecondExampleClient, namespace string) *testTypes {
+func newTestTypes(c *SecondExampleClient) *testTypes {
 	return &testTypes{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -67,7 +65,6 @@ func newTestTypes(c *SecondExampleClient, namespace string) *testTypes {
 func (c *testTypes) Get(name string, options v1.GetOptions) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -84,7 +81,6 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example2.TestTypeList, er
 	}
 	result = &example2.TestTypeList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,7 +97,6 @@ func (c *testTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -112,7 +107,6 @@ func (c *testTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *testTypes) Create(testType *example2.TestType) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
 		Do().
@@ -124,7 +118,6 @@ func (c *testTypes) Create(testType *example2.TestType) (result *example2.TestTy
 func (c *testTypes) Update(testType *example2.TestType) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).
 		Body(testType).
@@ -139,7 +132,6 @@ func (c *testTypes) Update(testType *example2.TestType) (result *example2.TestTy
 func (c *testTypes) UpdateStatus(testType *example2.TestType) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).
 		SubResource("status").
@@ -152,7 +144,6 @@ func (c *testTypes) UpdateStatus(testType *example2.TestType) (result *example2.
 // Delete takes name of the testType and deletes it. Returns an error if one occurs.
 func (c *testTypes) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("testtypes").
 		Name(name).
 		Body(options).
@@ -167,7 +158,6 @@ func (c *testTypes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("testtypes").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -180,7 +170,6 @@ func (c *testTypes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 func (c *testTypes) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("testtypes").
 		SubResource(subresources...).
 		Name(name).

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/example2/internalversion/interface.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/example2/internalversion/interface.go
@@ -41,5 +41,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // TestTypes returns a TestTypeInformer.
 func (v *version) TestTypes() TestTypeInformer {
-	return &testTypeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &testTypeInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/example2/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/example2/internalversion/testtype.go
@@ -41,33 +41,32 @@ type TestTypeInformer interface {
 type testTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredTestTypeInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewTestTypeInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredTestTypeInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SecondExample().TestTypes(namespace).List(options)
+				return client.SecondExample().TestTypes().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SecondExample().TestTypes(namespace).Watch(options)
+				return client.SecondExample().TestTypes().Watch(options)
 			},
 		},
 		&example2.TestType{},
@@ -77,7 +76,7 @@ func NewFilteredTestTypeInformer(client clientsetinternalversion.Interface, name
 }
 
 func (f *testTypeInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredTestTypeInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredTestTypeInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example2/internalversion/expansion_generated.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example2/internalversion/expansion_generated.go
@@ -21,7 +21,3 @@ package internalversion
 // TestTypeListerExpansion allows custom methods to be added to
 // TestTypeLister.
 type TestTypeListerExpansion interface{}
-
-// TestTypeNamespaceListerExpansion allows custom methods to be added to
-// TestTypeNamespaceLister.
-type TestTypeNamespaceListerExpansion interface{}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example2/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example2/internalversion/testtype.go
@@ -29,8 +29,8 @@ import (
 type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	List(selector labels.Selector) (ret []*example2.TestType, err error)
-	// TestTypes returns an object that can list and get TestTypes.
-	TestTypes(namespace string) TestTypeNamespaceLister
+	// Get retrieves the TestType from the index for a given name.
+	Get(name string) (*example2.TestType, error)
 	TestTypeListerExpansion
 }
 
@@ -52,38 +52,9 @@ func (s *testTypeLister) List(selector labels.Selector) (ret []*example2.TestTyp
 	return ret, err
 }
 
-// TestTypes returns an object that can list and get TestTypes.
-func (s *testTypeLister) TestTypes(namespace string) TestTypeNamespaceLister {
-	return testTypeNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// TestTypeNamespaceLister helps list and get TestTypes.
-type TestTypeNamespaceLister interface {
-	// List lists all TestTypes in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*example2.TestType, err error)
-	// Get retrieves the TestType from the indexer for a given namespace and name.
-	Get(name string) (*example2.TestType, error)
-	TestTypeNamespaceListerExpansion
-}
-
-// testTypeNamespaceLister implements the TestTypeNamespaceLister
-// interface.
-type testTypeNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all TestTypes in the indexer for a given namespace.
-func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*example2.TestType, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*example2.TestType))
-	})
-	return ret, err
-}
-
-// Get retrieves the TestType from the indexer for a given namespace and name.
-func (s testTypeNamespaceLister) Get(name string) (*example2.TestType, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the TestType from the index for a given name.
+func (s *testTypeLister) Get(name string) (*example2.TestType, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/versioninterface.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/versioninterface.go
@@ -68,7 +68,7 @@ func (g *versionInterfaceGenerator) GenerateType(c *generator.Context, t *types.
 
 	sw.Do(versionTemplate, m)
 	for _, typeDef := range g.types {
-		tags, err := util.ParseClientGenTags(typeDef.SecondClosestCommentLines)
+		tags, err := util.ParseClientGenTags(append(typeDef.SecondClosestCommentLines, typeDef.CommentLines...))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR fixes #80457 so that informer-gen produces correct code for a type with nonNamespaced tag.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #80457

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes the bug in informer-gen that it produces incorrect code if a type has nonNamespaced tag set.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
