### PR TITLE
Fix symlinks in bazel-release

### DIFF
--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -305,6 +305,11 @@ pkg_tar(
     extension = "tar.gz",
     package_dir = "kubernetes",
     strip_prefix = "//",
+    symlinks = {
+        "kubernetes/cluster/gce/cos/": "gci",
+        "kubernetes/cluster/gce/custom/": "gci",
+        "kubernetes/cluster/gce/ubuntu/": "gci",
+    },
     tags = ["no-cache"],
     deps = [
         ":_full_server",

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -37,9 +37,9 @@ versions.check(minimum_bazel_version = "0.23.0")
 
 http_archive(
     name = "io_k8s_repo_infra",
-    sha256 = "462dcc769f29e9eee16499edb818e2fc2ffc24efea28300d53bbc098d27d322c",
-    strip_prefix = "repo-infra-f85734f673056977d8ba04b0386394b684ca2acb",
-    urls = mirror("https://github.com/kubernetes/repo-infra/archive/f85734f673056977d8ba04b0386394b684ca2acb.tar.gz"),
+    sha256 = "f6d65480241ec0fd7a0d01f432938b97d7395aeb8eefbe859bb877c9b4eafa56",
+    strip_prefix = "repo-infra-9f4571ad7242bf3ec4b47365062498c2528f9a5f",
+    urls = mirror("https://github.com/kubernetes/repo-infra/archive/9f4571ad7242bf3ec4b47365062498c2528f9a5f.tar.gz"),
 )
 
 http_archive(


### PR DESCRIPTION
kubernetes.tar.gz produced by `make bazel-release` should contain all symlinks that are in `cluster/` subdirectory. These symlinks are present in kubernetes.tar.gz created by `make quick-release`.

/kind bug
Fixes: #78940

```release-note
NONE
```