### PR TITLE
remove apiserver loopback client QPS limit

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config_selfclient.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_selfclient.go
@@ -38,12 +38,9 @@ func (s *SecureServingInfo) NewClientConfig(caCert []byte) (*restclient.Config, 
 	}
 
 	return &restclient.Config{
-		// Increase QPS limits. The client is currently passed to all admission plugins,
-		// and those can be throttled in case of higher load on apiserver - see #22340 and #22422
-		// for more details. Once #22422 is fixed, we may want to remove it.
-		QPS:   50,
-		Burst: 100,
-		Host:  "https://" + net.JoinHostPort(host, port),
+		// Do not limit loopback client QPS.
+		QPS:  -1,
+		Host: "https://" + net.JoinHostPort(host, port),
 		// override the ServerName to select our loopback certificate via SNI. This name is also
 		// used by the client to compare the returns server certificate against.
 		TLSClientConfig: restclient.TLSClientConfig{


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

The loopback QPS limit will influence API Server performance, we need to remove limit.

**Which issue(s) this PR fixes**:

related to #78766

**Special notes for your reviewer**:

The loopback QPS limit will influence API Server performance, we need to remove limit.

**Does this PR introduce a user-facing change?**:

```release-note
Resolves bottleneck in internal API server communication that can cause increased goroutines and degrade API Server performance
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

None