### PR TITLE
fix: return empty string when status is nil

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/BUILD
+++ b/pkg/scheduler/framework/v1alpha1/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -35,4 +35,10 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["interface_test.go"],
+    embed = [":go_default_library"],
 )

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -71,15 +71,15 @@ func (s *Status) Code() Code {
 
 // Message returns message of the Status.
 func (s *Status) Message() string {
+	if s == nil {
+		return ""
+	}
 	return s.message
 }
 
 // IsSuccess returns true if and only if "Status" is nil or Code is "Success".
 func (s *Status) IsSuccess() bool {
-	if s == nil || s.code == Success {
-		return true
-	}
-	return false
+	return s.Code() == Success
 }
 
 // AsError returns an "error" object with the same message as that of the Status.

--- a/pkg/scheduler/framework/v1alpha1/interface_test.go
+++ b/pkg/scheduler/framework/v1alpha1/interface_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		status            *Status
+		expectedCode      Code
+		expectedMessage   string
+		expectedIsSuccess bool
+		expectedAsError   error
+	}{
+		{
+			status:            NewStatus(Success, ""),
+			expectedCode:      Success,
+			expectedMessage:   "",
+			expectedIsSuccess: true,
+			expectedAsError:   nil,
+		},
+		{
+			status:            NewStatus(Error, "unknown error"),
+			expectedCode:      Error,
+			expectedMessage:   "unknown error",
+			expectedIsSuccess: false,
+			expectedAsError:   errors.New("unknown error"),
+		},
+		{
+			status:            nil,
+			expectedCode:      Success,
+			expectedMessage:   "",
+			expectedIsSuccess: true,
+			expectedAsError:   nil,
+		},
+	}
+
+	for i, test := range tests {
+		if test.status.Code() != test.expectedCode {
+			t.Errorf("test #%v, expect status.Code() returns %v, but %v", i, test.expectedCode, test.status.Code())
+		}
+
+		if test.status.Message() != test.expectedMessage {
+			t.Errorf("test #%v, expect status.Message() returns %v, but %v", i, test.expectedMessage, test.status.Message())
+		}
+
+		if test.status.IsSuccess() != test.expectedIsSuccess {
+			t.Errorf("test #%v, expect status.IsSuccess() returns %v, but %v", i, test.expectedIsSuccess, test.status.IsSuccess())
+		}
+
+		if test.status.AsError() == test.expectedAsError {
+			continue
+		}
+
+		if test.status.AsError().Error() != test.expectedAsError.Error() {
+			t.Errorf("test #%v, expect status.AsError() returns %v, but %v", i, test.expectedAsError, test.status.AsError())
+		}
+	}
+}


### PR DESCRIPTION
/kind cleanup
/sig scheduling
/priority backlog

**What this PR does / why we need it**:

Add unit tests for framework status and fix a bug when calling status.Message() with nil status.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
