### PR TITLE
Make namespace controller aware of implicit finalizer on pods

### DIFF
--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -471,6 +471,13 @@ func (d *namespacedResourcesDeleter) deleteAllContentForGroupVersionResource(
 				return finalizerEstimateSeconds, nil
 			}
 		}
+
+		if gvr.GroupResource() == (schema.GroupResource{Group: "", Resource: "pods"}) {
+			klog.V(5).Infof("namespace controller - deleteAllContentForGroupVersionResource - some pods are pending deletion from kubelet - namespace: %s, gvr: %v", namespace, gvr)
+			// Pods have implicit finalizer and are only deleted by kubelet (unless force deleted).
+			return finalizerEstimateSeconds, nil
+		}
+
 		// nothing reported a finalizer, so something was unexpected as it should have been deleted.
 		return estimate, fmt.Errorf("unexpected items still remain in namespace: %s for gvr: %v", namespace, gvr)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Namespace controller gets into a backoff if there are items remaining in the namespace without finalizer. Yet pods are deleted asynchronously by kubelet - an implicit finalizer. (This changed somewhere around 3.6 I think.) When controller saw pods still remaining in the namespace it return an error and started a backoff. When a pod was deleted after a while, namespace controller was already in high backoff and took too long to delete the namespace so e2e timed out.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
