### PR TITLE
Azure support for dualstack LB services

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -35,6 +35,9 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	servicehelpers "k8s.io/cloud-provider/service/helpers"
 	"k8s.io/klog"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	utilnet "k8s.io/utils/net"
 )
 
 const (
@@ -536,6 +539,23 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 		}
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(IPv6DualStack) {
+		// TODO: (khenidak) if we ever enable IPv6 single stack, then we should
+		// not wrap the following in a feature gate
+		ipv6 := utilnet.IsIPv6String(service.Spec.ClusterIP)
+		if ipv6 {
+			pip.PublicIPAddressVersion = network.IPv6
+			klog.V(2).Infof("service(%s): pip(%s) - creating as ipv6 for clusterIP:%v", serviceName, *pip.Name, service.Spec.ClusterIP)
+			// static allocation on IPv6 on Azure is not allowed
+			pip.PublicIPAddressPropertiesFormat.PublicIPAllocationMethod = network.Dynamic
+		} else {
+			pip.PublicIPAddressVersion = network.IPv4
+			klog.V(2).Infof("service(%s): pip(%s) - creating as ipv4 for clusterIP:%v", serviceName, *pip.Name, service.Spec.ClusterIP)
+		}
+	}
+
+	klog.V(2).Infof("ensurePublicIPExists for service(%s): pip(%s) - creating", serviceName, *pip.Name)
+
 	klog.V(10).Infof("CreateOrUpdatePIP(%s, %q): start", pipResourceGroup, *pip.Name)
 	err = az.CreateOrUpdatePIP(service, pipResourceGroup, pip)
 	if err != nil {
@@ -649,7 +669,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	klog.V(2).Infof("reconcileLoadBalancer for service(%s): lb(%s) wantLb(%t) resolved load balancer name", serviceName, lbName, wantLb)
 	lbFrontendIPConfigName := az.getFrontendIPConfigName(service, subnet(service))
 	lbFrontendIPConfigID := az.getFrontendIPConfigID(lbName, lbFrontendIPConfigName)
-	lbBackendPoolName := getBackendPoolName(clusterName)
+	lbBackendPoolName := getBackendPoolName(clusterName, service)
 	lbBackendPoolID := az.getBackendPoolID(lbName, lbBackendPoolName)
 
 	lbIdleTimeout, err := getIdleTimeout(service)
@@ -727,6 +747,13 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 			// construct FrontendIPConfigurationPropertiesFormat
 			var fipConfigurationProperties *network.FrontendIPConfigurationPropertiesFormat
 			if isInternal {
+				// azure does not support ILB for IPv6 yet.
+				// TODO: remove this check when ILB supports IPv6 *and* the SDK
+				// have been rev'ed to 2019* version
+				if utilnet.IsIPv6String(service.Spec.ClusterIP) {
+					return nil, fmt.Errorf("ensure(%s): lb(%s) - internal load balancers does not support IPv6", serviceName, lbName)
+				}
+
 				subnetName := subnet(service)
 				if subnetName == nil {
 					subnetName = &az.SubnetName
@@ -1025,11 +1052,18 @@ func (az *Cloud) reconcileLoadBalancerRule(
 					LoadDistribution:    loadDistribution,
 					FrontendPort:        to.Int32Ptr(port.Port),
 					BackendPort:         to.Int32Ptr(port.Port),
-					EnableFloatingIP:    to.BoolPtr(true),
 					DisableOutboundSnat: to.BoolPtr(az.disableLoadBalancerOutboundSNAT()),
 					EnableTCPReset:      enableTCPReset,
 				},
 			}
+			// LB does not support floating IPs for IPV6 rules
+			if utilnet.IsIPv6String(service.Spec.ClusterIP) {
+				expectedRule.BackendPort = to.Int32Ptr(port.NodePort)
+				expectedRule.EnableFloatingIP = to.BoolPtr(false)
+			} else {
+				expectedRule.EnableFloatingIP = to.BoolPtr(true)
+			}
+
 			if protocol == v1.ProtocolTCP {
 				expectedRule.LoadBalancingRulePropertiesFormat.IdleTimeoutInMinutes = lbIdleTimeout
 			}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes.go
@@ -34,15 +34,13 @@ import (
 	// Azure route controller changes behavior if ipv6dual stack feature is turned on
 	// remove this once the feature graduates
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/component-base/featuregate"
 )
 
 // copied to minimize the number of cross reference
 // and exceptions in publishing and allowed imports.
 const (
-	IPv6DualStack      featuregate.Feature = "IPv6DualStack"
-	routeNameFmt                           = "%s____%s"
-	routeNameSeparator                     = "____"
+	routeNameFmt       = "%s____%s"
+	routeNameSeparator = "____"
 )
 
 // ListRoutes lists all managed routes that belong to the specified clusterName


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
Add azure support for dual stack services. IPv4 and IPv6 ingress. CANNOT be merged UNTIL https://github.com/kubernetes/kubernetes/pull/79386 (dual stack phase 2: services endpoints) and https://github.com/kubernetes/kubernetes/pull/79576  (dual stack phase 2: kube-proxy)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Please review, but don't approve until dep PRs are merged. **only last (Azure) commit needs a review**. the rest of commits are part of the dep PR.

**Does this PR introduce a user-facing change?**:
```release-note
Azure supports IPv6 only on ELB not ILB. The cloud provider will return an error if the service is internal and is IPv6.

Notes on LB name:
to ensure backword and forward compat:
- SingleStack -v4 (pre v1.16) => BackendPool name == clusterName
- SingleStack -v6 => BackendPool name == clusterName (all cluster bootstrap uses this name)
DualStack:
=> IPv4 BackendPool name == clusterName
=> IPv6 BackendPool name == <clusterName>-IPv6
This result into:
- clusters moving from IPv4 to duakstack will require no changes
- clusters moving from IPv6 (while not seen in the wild, we can not rule out thier existance) to dualstack will require deleting backend pools (the reconciler will take care of creating correct backendpools)
```


@feiskyer  @kubernetes/sig-azure 