### PR TITLE
Fix shellcheck failures in hack/verify-test-featuregates.sh

### DIFF
--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -17,5 +17,4 @@
 ./cluster/validate-cluster.sh
 ./hack/lib/test.sh
 ./hack/test-integration.sh
-./hack/verify-test-featuregates.sh
 ./test/images/image-util.sh

--- a/hack/verify-test-featuregates.sh
+++ b/hack/verify-test-featuregates.sh
@@ -26,7 +26,7 @@ cd "${KUBE_ROOT}"
 rc=0
 
 # find test files accessing the mutable global feature gate or interface
-direct_sets=$(grep -n --include '*_test.go' -R 'MutableFeatureGate' . 2>/dev/null) || true
+direct_sets=$(find -L . -name '*_test.go' -exec grep -Hn 'MutableFeatureGate' {} \; 2>/dev/null) || true
 if [[ -n "${direct_sets}" ]]; then
   echo "Test files may not access mutable global feature gates directly:" >&2
   echo "${direct_sets}" >&2
@@ -38,7 +38,7 @@ if [[ -n "${direct_sets}" ]]; then
 fi
 
 # find test files calling SetFeatureGateDuringTest and not calling the result
-missing_defers=$(grep -n --include '*_test.go' -R 'SetFeatureGateDuringTest' . 2>/dev/null | grep -E -v "defer .*\\)\\(\\)$") || true
+missing_defers=$(find -L . -name '*_test.go' -exec grep -Hn 'SetFeatureGateDuringTest' {} \; 2>/dev/null | grep -E -v "defer .*\\)\\(\\)$") || true
 if [[ -n "${missing_defers}" ]]; then
   echo "Invalid invocations of featuregatetesting.SetFeatureGateDuringTest():" >&2
   echo "${missing_defers}" >&2


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix shellcheck failures of hack/verify-test-featuregates.sh

shellcheck says these errors.
```
In ./hack/verify-test-featuregates.sh line 29:
direct_sets=$(grep -n --include '*_test.go' -R 'MutableFeatureGate' . 2>/dev/null) || true
                                ^---------^ SC2063: Grep uses regex, but this looks like a glob.


In ./hack/verify-test-featuregates.sh line 41:
missing_defers=$(grep -n --include '*_test.go' -R 'SetFeatureGateDuringTest' . 2>/dev/null | grep -E -v "defer .*\\)\\(\\)$") || true
                                   ^---------^ SC2063: Grep uses regex, but this looks like a glob.
```
However, grep's include parameter cannot use regex instead of glob. See #76855.
Therefore, grep is changed to find command in this PR.

**Which issue(s) this PR fixes**:
Ref #72956

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig testing
/priority backlog