### PR TITLE
Fix detachment of deleted volumes

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -41,7 +41,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/gcfg.v1"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	netutil "k8s.io/apimachinery/pkg/util/net"


### PR DESCRIPTION
/kind bug
/sig storage
/sig openstack

**What this PR does / why we need it**:
Volumes that were attached to nodes and were forcefully deleted by admin should be considered as detached.

Before this PR, error was returned from `Detach()` and A/D controller would retry detaching the volume indefinitely.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed detachment of deleted volumes on OpenStack / Cinder.
```

cc: @gnufied @kubernetes/sig-openstack-pr-reviews 