### PR TITLE
Allow customize base image and released image registry

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -40,6 +40,9 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 readonly KUBE_BUILD_IMAGE_REPO=kube-build
 readonly KUBE_BUILD_IMAGE_CROSS_TAG="$(cat "${KUBE_ROOT}/build/build-image/cross/VERSION")"
 
+readonly KUBE_DOCKER_REGISTRY="${KUBE_DOCKER_REGISTRY:-k8s.gcr.io}"
+readonly KUBE_BASE_IMAGE_REGISTRY="${KUBE_BASE_IMAGE_REGISTRY:-k8s.gcr.io}"
+
 # This version number is used to cause everyone to rebuild their data containers
 # and build image.  This is especially useful for automated build systems like
 # Jenkins.
@@ -94,11 +97,11 @@ kube::build::get_docker_wrapped_binaries() {
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets
   local targets=(
-    cloud-controller-manager,"k8s.gcr.io/debian-base-${arch}:${debian_base_version}"
-    kube-apiserver,"k8s.gcr.io/debian-base-${arch}:${debian_base_version}"
-    kube-controller-manager,"k8s.gcr.io/debian-base-${arch}:${debian_base_version}"
-    kube-scheduler,"k8s.gcr.io/debian-base-${arch}:${debian_base_version}"
-    kube-proxy,"k8s.gcr.io/debian-iptables-${arch}:${debian_iptables_version}"
+    cloud-controller-manager,"${KUBE_BASE_IMAGE_REGISTRY}/debian-base-${arch}:${debian_base_version}"
+    kube-apiserver,"${KUBE_BASE_IMAGE_REGISTRY}/debian-base-${arch}:${debian_base_version}"
+    kube-controller-manager,"${KUBE_BASE_IMAGE_REGISTRY}/debian-base-${arch}:${debian_base_version}"
+    kube-scheduler,"${KUBE_BASE_IMAGE_REGISTRY}/debian-base-${arch}:${debian_base_version}"
+    kube-proxy,"${KUBE_BASE_IMAGE_REGISTRY}/debian-iptables-${arch}:${debian_iptables_version}"
   )
 
   echo "${targets[@]}"

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -337,7 +337,7 @@ function kube::release::create_docker_images_for_server() {
     local images_dir="${RELEASE_IMAGES}/${arch}"
     mkdir -p "${images_dir}"
 
-    local -r docker_registry="k8s.gcr.io"
+    local -r docker_registry="${KUBE_DOCKER_REGISTRY}"
     # Docker tags cannot contain '+'
     local docker_tag="${KUBE_GIT_VERSION/+/_}"
     if [[ -z "${docker_tag}" ]]; then

--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -445,6 +445,8 @@ define RELEASE_SKIP_TESTS_HELP_INFO
 # Args:
 #   KUBE_RELEASE_RUN_TESTS: Whether to run tests. Set to 'y' to run tests anyways.
 #   KUBE_FASTBUILD: Whether to cross-compile for other architectures. Set to 'false' to do so.
+#   KUBE_DOCKER_REGISTRY: Registry of released images, default to k8s.gcr.io
+#   KUBE_BASE_IMAGE_REGISTRY: Registry of base images for controlplane binaries, default to k8s.gcr.io
 #
 # Example:
 #   make release-skip-tests


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind feature

**What this PR does / why we need it**:
There are two type of images during build:
base images: consumed by build process to create released image
released images: the output container images (will tag with registry and name by default), for example: kube-api-server:###, tag with k8s.gcr.io/kube-api-server:###.

default behavior does not change, the default registry for those type of images is k8s.gcr.io, but they can be customized if needed.

more specifically, BASE_IMAGE_REGISTRY is for customize base image at:
https://github.com/kubernetes/kubernetes/blob/master/build/lib/release.sh#L370

KUBE_DOCKER_REGISTRY is for customize released image tag.

**Which issue(s) this PR fixes**:
Fixes # N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
yes, it allows user to run build with customized base image registry by running:
```KUBE_DOCKER_REGISTRY=### BASE_IMAGE_REGISTRY=### make quick-release```


```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```

/sig release