### PR TITLE
kubeadm: add forgotten error check

### DIFF
--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -438,7 +438,8 @@ func NewCmdConfigImagesPull() *cobra.Command {
 			kubeadmutil.CheckErr(err)
 			containerRuntime, err := utilruntime.NewContainerRuntime(utilsexec.New(), internalcfg.NodeRegistration.CRISocket)
 			kubeadmutil.CheckErr(err)
-			PullControlPlaneImages(containerRuntime, &internalcfg.ClusterConfiguration)
+			err = PullControlPlaneImages(containerRuntime, &internalcfg.ClusterConfiguration)
+			kubeadmutil.CheckErr(err)
 		},
 	}
 	AddImagesCommonConfigFlags(cmd.PersistentFlags(), externalClusterCfg, &cfgPath, &featureGatesString)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

```kubeadm config images pull``` command ignores image pulling errors due to forgotten error check.

This PR adds the check to correctly output errors if they occur.

**Does this PR introduce a user-facing change?**:

```release-note
kubeadm: fixed ignoring errors when pulling control plane images
```