### PR TITLE
Query nodes in Schedule only when there are no predicates

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -195,11 +195,8 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 		return result, prefilterStatus.AsError()
 	}
 
-	nodes := nodeLister.ListNodes()
-	if err != nil {
-		return result, err
-	}
-	if len(nodes) == 0 {
+	numNodes := g.cache.NodeTree().NumNodes()
+	if numNodes == 0 {
 		return result, ErrNoNodesAvailable
 	}
 
@@ -209,7 +206,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 
 	trace.Step("Basic checks done")
 	startPredicateEvalTime := time.Now()
-	filteredNodes, failedPredicateMap, err := g.findNodesThatFit(pluginContext, pod, nodes)
+	filteredNodes, failedPredicateMap, err := g.findNodesThatFit(pluginContext, pod, nodeLister)
 	if err != nil {
 		return result, err
 	}
@@ -217,7 +214,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 	if len(filteredNodes) == 0 {
 		return result, &FitError{
 			Pod:              pod,
-			NumAllNodes:      len(nodes),
+			NumAllNodes:      numNodes,
 			FailedPredicates: failedPredicateMap,
 		}
 	}
@@ -457,12 +454,12 @@ func (g *genericScheduler) numFeasibleNodesToFind(numAllNodes int32) (numNodes i
 
 // Filters the nodes to find the ones that fit based on the given predicate functions
 // Each node is passed through the predicate functions to determine if it is a fit
-func (g *genericScheduler) findNodesThatFit(pluginContext *framework.PluginContext, pod *v1.Pod, nodes []*v1.Node) ([]*v1.Node, FailedPredicateMap, error) {
+func (g *genericScheduler) findNodesThatFit(pluginContext *framework.PluginContext, pod *v1.Pod, nodeLister algorithm.NodeLister) ([]*v1.Node, FailedPredicateMap, error) {
 	var filtered []*v1.Node
 	failedPredicateMap := FailedPredicateMap{}
 
 	if len(g.predicates) == 0 {
-		filtered = nodes
+		filtered = nodeLister.ListNodes()
 	} else {
 		allNodes := int32(g.cache.NodeTree().NumNodes())
 		numNodesToFind := g.numFeasibleNodesToFind(allNodes)

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -506,7 +506,7 @@ func TestFindFitAllError(t *testing.T) {
 	nodes := makeNodeList([]string{"3", "2", "1"})
 	scheduler := makeScheduler(predicates, nodes)
 
-	_, predicateMap, err := scheduler.findNodesThatFit(nil, &v1.Pod{}, nodes)
+	_, predicateMap, err := scheduler.findNodesThatFit(nil, &v1.Pod{}, schedulertesting.FakeNodeLister(nodes))
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -536,7 +536,7 @@ func TestFindFitSomeError(t *testing.T) {
 	scheduler := makeScheduler(predicates, nodes)
 
 	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "1", UID: types.UID("1")}}
-	_, predicateMap, err := scheduler.findNodesThatFit(nil, pod, nodes)
+	_, predicateMap, err := scheduler.findNodesThatFit(nil, pod, schedulertesting.FakeNodeLister(nodes))
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

This is a small optimization. The list of nodes is only needed in `findNodesThatFit` when there are no predicates.

**Which issue(s) this PR fixes**:

Fixes #80322 

**Special notes for your reviewer**:

Depends on PR #80220. Review only latest commit.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```