### PR TITLE
Promote SchedulerPreemption e2e tests to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1914,6 +1914,22 @@
     number of Replicas.
   release: v1.19
   file: test/e2e/scheduling/preemption.go
+- testname: Scheduler, Basic Preemption
+  codename: '[sig-scheduling] SchedulerPreemption [Serial] validates basic preemption
+    works [Conformance]'
+  description: When a higher priority pod is created and no node with enough resources
+    is found, the scheduler MUST preempt a lower priority pod and schedule the high
+    priority pod.
+  release: v1.19
+  file: test/e2e/scheduling/preemption.go
+- testname: Scheduler, Preemption for critical pod
+  codename: '[sig-scheduling] SchedulerPreemption [Serial] validates lower priority
+    pod preemption by critical pod [Conformance]'
+  description: When a critical pod is created and no node with enough resources is
+    found, the scheduler MUST preempt a lower priority pod to schedule the critical
+    pod.
+  release: v1.19
+  file: test/e2e/scheduling/preemption.go
 - testname: ConfigMap Volume, text data, binary data
   codename: '[sig-storage] ConfigMap binary data should be reflected in volume [NodeConformance]
     [Conformance]'

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -103,10 +103,14 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		framework.ExpectNoError(err)
 	})
 
-	// This test verifies that when a higher priority pod is created and no node with
-	// enough resources is found, scheduler preempts a lower priority pod to schedule
-	// the high priority pod.
-	ginkgo.It("validates basic preemption works", func() {
+	/*
+		Release : v1.19
+		Testname: Scheduler, Basic Preemption
+		Description: When a higher priority pod is created and no node with enough
+		resources is found, the scheduler MUST preempt a lower priority pod and
+		schedule the high priority pod.
+	*/
+	framework.ConformanceIt("validates basic preemption works", func() {
 		var podRes v1.ResourceList
 
 		// Create one pod per node that uses a lot of the node's resources.
@@ -186,10 +190,14 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		framework.ExpectEqual(podPreempted, true)
 	})
 
-	// This test verifies that when a critical pod is created and no node with
-	// enough resources is found, scheduler preempts a lower priority pod to schedule
-	// this critical pod.
-	ginkgo.It("validates lower priority pod preemption by critical pod", func() {
+	/*
+		Release : v1.19
+		Testname: Scheduler, Preemption for critical pod
+		Description: When a critical pod is created and no node with enough
+		resources is found, the scheduler MUST preempt a lower priority pod to
+		schedule the critical pod.
+	*/
+	framework.ConformanceIt("validates lower priority pod preemption by critical pod", func() {
 		var podRes v1.ResourceList
 
 		ginkgo.By("Create pods that use 2/3 of node resources.")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Promotes the following tests to Conformance:
- `[sig-scheduling] SchedulerPreemption [Serial] validates basic preemption works`
- `[sig-scheduling] SchedulerPreemption [Serial] validates lower priority pod preemption by critical pod`

**Special notes for your reviewer**:

Supercedes https://github.com/kubernetes/kubernetes/pull/78364 which can't merge due to CLA issues

It looked good to myself and other reviewers, I was going to seek `/approve` for this once a rebase had been taken care of (which I'm doing here)

```release-note
NONE
```

/cc @johnbelamaric @bsalamat