### PR TITLE
Log when plugins' weight is zero

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -96,6 +96,7 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 		// when configured.
 		f.pluginNameToWeightMap[name] = int(pg[name].Weight)
 		if f.pluginNameToWeightMap[name] == 0 {
+			klog.V(4).Infof("plugin %v is not configured with weight, weight set to 1", name)
 			f.pluginNameToWeightMap[name] = 1
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In NewFramework, we should check that plugins' weight is not zero which is not permitted value.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
