### PR TITLE
Promote job completion after failure e2e test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -25,6 +25,7 @@ test/e2e/apps/deployment.go: "RecreateDeployment should delete old pods and crea
 test/e2e/apps/deployment.go: "deployment should delete old replica sets"
 test/e2e/apps/deployment.go: "deployment should support rollover"
 test/e2e/apps/deployment.go: "deployment should support proportional scaling"
+test/e2e/apps/job.go: "should run a job to completion when tasks sometimes fail and are locally restarted"
 test/e2e/apps/job.go: "should delete a job"
 test/e2e/apps/rc.go: "should serve a basic image on each replica with a public image"
 test/e2e/apps/rc.go: "should surface a failure condition on a common issue like exceeded quota"

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -83,8 +83,13 @@ var _ = SIGDescribe("Job", func() {
 		framework.ExpectNoError(err, "failed to get PodList for job %s in namespace: %s", job.Name, f.Namespace.Name)
 	})
 
-	// Pods sometimes fail, but eventually succeed.
-	ginkgo.It("should run a job to completion when tasks sometimes fail and are locally restarted", func() {
+	/*
+		Release : v1.16
+		Testname: Jobs, completion after task failure
+		Description: Explicitly cause the tasks to fail once initially. After restarting, the Job MUST
+		execute to completion.
+	*/
+	framework.ConformanceIt("should run a job to completion when tasks sometimes fail and are locally restarted", func() {
 		ginkgo.By("Creating a job")
 		// One failure, then a success, local restarts.
 		// We can't use the random failure approach used by the


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Promotes `[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted` to Conformance

**Special notes for your reviewer**:

This PR supercedes https://github.com/kubernetes/kubernetes/pull/76423
which can't be merged due to CLA issues

It looked good to me, I think this is good for an /approve

```release-note
NONE
```

/cc @johnbelamaric @mgdevstack
reviewers on the original PR