### PR TITLE
Validate that storage is of TableConvertor type

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -376,7 +376,10 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		resourceKind = kind
 	}
 
-	tableProvider, _ := storage.(rest.TableConvertor)
+	var tableProvider rest.TableConvertor
+	if tableProvider, ok = storage.(rest.TableConvertor); !ok {
+		return nil, fmt.Errorf("%q  must implement TableConvertor", storage)
+	}
 
 	var apiResource metav1.APIResource
 	if utilfeature.DefaultFeatureGate.Enabled(features.StorageVersionHash) &&


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In APIInstaller#registerResourceHandlers, we cast storage to TableConvertor type without checking whether the cast is effective.

this PR adds check against the casting.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
