### PR TITLE
Update GetTopologyHints() for TopologyManager Hint Providers to return a map

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -68,7 +68,7 @@ type Manager interface {
 
 	// GetTopologyHints implements the Topology Manager Interface and is
 	// consulted to make Topology aware resource alignments
-	GetTopologyHints(pod v1.Pod, container v1.Container) []topologymanager.TopologyHint
+	GetTopologyHints(pod v1.Pod, container v1.Container) map[string][]topologymanager.TopologyHint
 }
 
 type manager struct {

--- a/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
@@ -47,9 +47,9 @@ func (m *fakeManager) RemoveContainer(containerID string) error {
 	return nil
 }
 
-func (m *fakeManager) GetTopologyHints(pod v1.Pod, container v1.Container) []topologymanager.TopologyHint {
+func (m *fakeManager) GetTopologyHints(pod v1.Pod, container v1.Container) map[string][]topologymanager.TopologyHint {
 	klog.Infof("[fake cpumanager] Get Topology Hints")
-	return []topologymanager.TopologyHint{}
+	return map[string][]topologymanager.TopologyHint{}
 }
 
 func (m *fakeManager) State() state.Reader {

--- a/pkg/kubelet/cm/cpumanager/topology_hints.go
+++ b/pkg/kubelet/cm/cpumanager/topology_hints.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/socketmask"
 )
 
-func (m *manager) GetTopologyHints(pod v1.Pod, container v1.Container) []topologymanager.TopologyHint {
+func (m *manager) GetTopologyHints(pod v1.Pod, container v1.Container) map[string][]topologymanager.TopologyHint {
 	// The 'none' policy does not generate topology hints.
 	if m.policy.Name() == string(PolicyNone) {
 		return nil
@@ -60,7 +60,9 @@ func (m *manager) GetTopologyHints(pod v1.Pod, container v1.Container) []topolog
 	cpuHints := m.generateCPUTopologyHints(available, requested)
 	klog.Infof("[cpumanager] TopologyHints generated for pod '%v', container '%v': %v", pod.Name, container.Name, cpuHints)
 
-	return cpuHints
+	return map[string][]topologymanager.TopologyHint{
+		string(v1.ResourceCPU): cpuHints,
+	}
 }
 
 // generateCPUtopologyHints generates a set of TopologyHints given the set of

--- a/pkg/kubelet/cm/cpumanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology_hints_test.go
@@ -130,11 +130,11 @@ func TestGetTopologyHints(t *testing.T) {
 			name:          "Request 11 CPUs, 4 available on Socket 0, 6 available on Socket 1",
 			pod:           *testPod4,
 			container:     *testContainer4,
-			expectedHints: []topologymanager.TopologyHint{},
+			expectedHints: nil,
 		},
 	}
 	for _, tc := range tcases {
-		hints := m.GetTopologyHints(tc.pod, tc.container)
+		hints := m.GetTopologyHints(tc.pod, tc.container)[string(v1.ResourceCPU)]
 		if len(tc.expectedHints) == 0 && len(hints) == 0 {
 			continue
 		}
@@ -147,6 +147,5 @@ func TestGetTopologyHints(t *testing.T) {
 		if !reflect.DeepEqual(tc.expectedHints, hints) {
 			t.Errorf("Expected in result to be %v , got %v", tc.expectedHints, hints)
 		}
-
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind api-change

> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
```
    At present, there is no way for a hint provider to return distinct hints
    for different resource types via a call to GetTopologyHints(). This
    means that hint providers that govern multiple resource types (e.g. the
    devicemanager) must do some sort of "pre-merge" on the hints it
    generates for each resource type before passing them back to the
    TopologyManager.

    This seems counter-intuitive, since there is no practical reason that a
    "pre-merge" should be necessary -- it just happens to be necessary
    because of the way the current interface is designed.

    It would be better to allow a hint provider to pass back raw hints for
    each resource type, and allow the TopologyManager to merge them using
    a single unified strategy.

    This patch makes a simple change to the GetTopologyHints() interface
    to allow this to occur.

    Moreover, this change allows the TopologyManager to recognize which
    resource type a set of hints originated from, should this information
    become useful in the future.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

This implements the change proposed in https://github.com/kubernetes/enhancements/pull/1131