### PR TITLE
kubeadm: handle ResetClusterStatusForNode errors

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/reset/updateclusterstatus.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/updateclusterstatus.go
@@ -44,7 +44,9 @@ func runUpdateClusterStatus(c workflow.RunData) error {
 	// Reset the ClusterStatus for a given control-plane node.
 	cfg := r.Cfg()
 	if isControlPlane() && cfg != nil {
-		uploadconfig.ResetClusterStatusForNode(cfg.NodeRegistration.Name, r.Client())
+		if err := uploadconfig.ResetClusterStatusForNode(cfg.NodeRegistration.Name, r.Client()); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Handled errors returned by ResetClusterStatusForNode function when
resetting cluster status for a control-plane node.

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: produce errors if they occur when resetting cluster status for a control-plane node
```