### PR TITLE
Fix leader election in kube-addon manager

### DIFF
--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -194,7 +194,7 @@ function is_leader() {
     log INFO "Leader election disabled."
     return 0;
   fi
-  KUBE_CONTROLLER_MANAGER_LEADER=`${KUBECTL} -n kube-system get ep kube-controller-manager \
+  KUBE_CONTROLLER_MANAGER_LEADER=`${KUBECTL} ${KUBECTL_OPTS} -n kube-system get ep kube-controller-manager \
     -o go-template=$'{{index .metadata.annotations "control-plane.alpha.kubernetes.io/leader"}}' \
     | sed 's/^.*"holderIdentity":"\([^"]*\)".*/\1/' | awk -F'_' '{print $1}'`
   # If there was any problem with getting the leader election results, var will


### PR DESCRIPTION
kube-addon-manager doesn't implement it's own leader election logic -- it rather tries to follow kube-controller-manager.

Apparently, it fails to do so, as in logs I see:

```
INFO: == Kubernetes addon reconcile completed at 2019-07-25T11:55:26+00:00 ==
The connection to the server localhost:8080 was refused - did you specify the right host or port?
INFO: Leader is 
```

This is caused by lack of ${KUBECTL_OPTS} opts in kubectl call, which makes it tries to reach localhost:8080 instead of the endpoint set in kubeconfig:
https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/manifests/kube-addon-manager.yaml#L40

Given that the default localhost:8080 port is disabled in 1.15, I think we should consider cherry-picking this PR to that branch as well.

/assign @wojtek-t 

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a bug in kube-addon-manager's leader election logic that made all replicas active.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
