### PR TITLE
[WIP] Kubeadm kustomize

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -437,6 +437,7 @@ func isAllowedFlag(flagName string) bool {
 		kubeadmcmdoptions.NodeCRISocket,
 		kubeadmcmdoptions.KubeconfigDir,
 		kubeadmcmdoptions.UploadCerts,
+		kubeadmcmdoptions.KustomizePods,
 		"print-join-command", "rootfs", "v")
 	if knownFlags.Has(flagName) {
 		return true

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -99,6 +99,7 @@ type initOptions struct {
 	externalClusterCfg      *kubeadmapiv1beta2.ClusterConfiguration
 	uploadCerts             bool
 	skipCertificateKeyPrint bool
+	kustomizeDir            string
 }
 
 // compile-time assert that the local data object satisfies the phases data interface.
@@ -120,6 +121,7 @@ type initData struct {
 	outputWriter            io.Writer
 	uploadCerts             bool
 	skipCertificateKeyPrint bool
+	kustomizeDir            string
 }
 
 // NewCmdInit returns "kubeadm init" command.
@@ -272,6 +274,7 @@ func AddInitOtherFlags(flagSet *flag.FlagSet, initOptions *initOptions) {
 		&initOptions.skipCertificateKeyPrint, options.SkipCertificateKeyPrint, initOptions.skipCertificateKeyPrint,
 		"Don't print the key used to encrypt the control-plane certificates.",
 	)
+	options.AddKustomizePodsFlag(flagSet, &initOptions.kustomizeDir)
 }
 
 // newInitOptions returns a struct ready for being used for creating cmd init flags.
@@ -404,6 +407,7 @@ func newInitData(cmd *cobra.Command, args []string, options *initOptions, out io
 		outputWriter:            out,
 		uploadCerts:             options.uploadCerts,
 		skipCertificateKeyPrint: options.skipCertificateKeyPrint,
+		kustomizeDir:            options.kustomizeDir,
 	}, nil
 }
 
@@ -530,6 +534,11 @@ func (d *initData) Tokens() []string {
 		tokens = append(tokens, bt.Token.String())
 	}
 	return tokens
+}
+
+// KustomizeDir returns the folder where kustomize patches for static pod manifest are stored
+func (d *initData) KustomizeDir() string {
+	return d.kustomizeDir
 }
 
 func printJoinCommand(out io.Writer, adminKubeConfigPath, token string, i *initData) error {

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -128,6 +128,7 @@ type joinOptions struct {
 	controlPlane          bool
 	ignorePreflightErrors []string
 	externalcfg           *kubeadmapiv1beta2.JoinConfiguration
+	kustomizeDir          string
 }
 
 // compile-time assert that the local data object satisfies the phases data interface.
@@ -142,6 +143,7 @@ type joinData struct {
 	clientSet             *clientset.Clientset
 	ignorePreflightErrors sets.String
 	outputWriter          io.Writer
+	kustomizeDir          string
 }
 
 // NewCmdJoin returns "kubeadm join" command.
@@ -275,6 +277,7 @@ func addJoinOtherFlags(flagSet *flag.FlagSet, joinOptions *joinOptions) {
 		&joinOptions.controlPlane, options.ControlPlane, joinOptions.controlPlane,
 		"Create a new control plane instance on this node",
 	)
+	options.AddKustomizePodsFlag(flagSet, &joinOptions.kustomizeDir)
 }
 
 // newJoinOptions returns a struct ready for being used for creating cmd join flags.
@@ -404,6 +407,7 @@ func newJoinData(cmd *cobra.Command, args []string, opt *joinOptions, out io.Wri
 		tlsBootstrapCfg:       tlsBootstrapCfg,
 		ignorePreflightErrors: ignorePreflightErrorsSet,
 		outputWriter:          out,
+		kustomizeDir:          opt.kustomizeDir,
 	}, nil
 }
 
@@ -467,6 +471,11 @@ func (j *joinData) IgnorePreflightErrors() sets.String {
 // OutputWriter returns the io.Writer used to write messages such as the "join done" message.
 func (j *joinData) OutputWriter() io.Writer {
 	return j.outputWriter
+}
+
+// KustomizeDir returns the folder where kustomize patches for static pod manifest are stored
+func (j *joinData) KustomizeDir() string {
+	return j.kustomizeDir
 }
 
 // fetchInitConfigurationFromJoinConfiguration retrieves the init configuration from a join configuration, performing the discovery

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -143,6 +143,6 @@ const (
 	// EtcdUpgrade flag instruct kubeadm to execute etcd upgrade during upgrades
 	EtcdUpgrade = "etcd-upgrade"
 
-	// KustomizePods flag sets the folder where kustomize patches for static pod manifest are stored
-	KustomizePods = "experimental-kustomize"
+	// Kustomize flag sets the folder where kustomize patches for static pod manifest are stored
+	Kustomize = "experimental-kustomize"
 )

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -142,4 +142,7 @@ const (
 
 	// EtcdUpgrade flag instruct kubeadm to execute etcd upgrade during upgrades
 	EtcdUpgrade = "etcd-upgrade"
+
+	// KustomizePods flag sets the folder where kustomize patches for static pod manifest are stored
+	KustomizePods = "experimental-kustomize"
 )

--- a/cmd/kubeadm/app/cmd/options/generic.go
+++ b/cmd/kubeadm/app/cmd/options/generic.go
@@ -91,5 +91,5 @@ func AddKubeadmOtherFlags(flagSet *pflag.FlagSet, rootfsPath *string) {
 
 // AddKustomizePodsFlag adds the --kustomize flag to the given flagset
 func AddKustomizePodsFlag(fs *pflag.FlagSet, kustomizeDir *string) {
-	fs.StringVarP(kustomizeDir, KustomizePods, "k", *kustomizeDir, "The path where to save the kubeconfig file.")
+	fs.StringVarP(kustomizeDir, Kustomize, "k", *kustomizeDir, "The path where your static pod kustomizations are stored.")
 }

--- a/cmd/kubeadm/app/cmd/options/generic.go
+++ b/cmd/kubeadm/app/cmd/options/generic.go
@@ -88,3 +88,8 @@ func AddKubeadmOtherFlags(flagSet *pflag.FlagSet, rootfsPath *string) {
 		"[EXPERIMENTAL] The path to the 'real' host root filesystem.",
 	)
 }
+
+// AddKustomizePodsFlag adds the --kustomize flag to the given flagset
+func AddKustomizePodsFlag(fs *pflag.FlagSet, kustomizeDir *string) {
+	fs.StringVarP(kustomizeDir, KustomizePods, "k", *kustomizeDir, "The path where to save the kubeconfig file.")
+}

--- a/cmd/kubeadm/app/cmd/phases/init/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/controlplane.go
@@ -100,6 +100,7 @@ func getControlPlanePhaseFlags(name string) []string {
 		options.CertificatesDir,
 		options.KubernetesVersion,
 		options.ImageRepository,
+		options.KustomizePods,
 	}
 	if name == "all" || name == kubeadmconstants.KubeAPIServer {
 		flags = append(flags,
@@ -144,6 +145,6 @@ func runControlPlaneSubphase(component string) func(c workflow.RunData) error {
 		cfg := data.Cfg()
 
 		fmt.Printf("[control-plane] Creating static Pod manifest for %q\n", component)
-		return controlplane.CreateStaticPodFiles(data.ManifestDir(), &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, component)
+		return controlplane.CreateStaticPodFiles(data.ManifestDir(), data.KustomizeDir(), &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, component)
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/init/data.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data.go
@@ -45,4 +45,5 @@ type InitData interface {
 	OutputWriter() io.Writer
 	Client() (clientset.Interface, error)
 	Tokens() []string
+	KustomizeDir() string
 }

--- a/cmd/kubeadm/app/cmd/phases/init/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data_test.go
@@ -48,3 +48,4 @@ func (t *testInitData) ExternalCA() bool                     { return false }
 func (t *testInitData) OutputWriter() io.Writer              { return nil }
 func (t *testInitData) Client() (clientset.Interface, error) { return nil, nil }
 func (t *testInitData) Tokens() []string                     { return nil }
+func (t *testInitData) KustomizeDir() string                 { return "" }

--- a/cmd/kubeadm/app/cmd/phases/init/etcd.go
+++ b/cmd/kubeadm/app/cmd/phases/init/etcd.go
@@ -69,6 +69,7 @@ func getEtcdPhaseFlags() []string {
 		options.CertificatesDir,
 		options.CfgPath,
 		options.ImageRepository,
+		options.KustomizePods,
 	}
 	return flags
 }
@@ -92,7 +93,7 @@ func runEtcdPhaseLocal() func(c workflow.RunData) error {
 				fmt.Printf("[dryrun] Would ensure that %q directory is present\n", cfg.Etcd.Local.DataDir)
 			}
 			fmt.Printf("[etcd] Creating static Pod manifest for local etcd in %q\n", data.ManifestDir())
-			if err := etcdphase.CreateLocalEtcdStaticPodManifestFile(data.ManifestDir(), cfg.NodeRegistration.Name, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint); err != nil {
+			if err := etcdphase.CreateLocalEtcdStaticPodManifestFile(data.ManifestDir(), data.KustomizeDir(), cfg.NodeRegistration.Name, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint); err != nil {
 				return errors.Wrap(err, "error creating local etcd static pod manifest file")
 			}
 		} else {

--- a/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
@@ -78,6 +78,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.TLSBootstrapToken,
 			options.TokenStr,
 			options.CertificateKey,
+			options.KustomizePods,
 		}
 	case "download-certs":
 		flags = []string{
@@ -122,6 +123,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.APIServerBindPort,
 			options.CfgPath,
 			options.ControlPlane,
+			options.KustomizePods,
 		}
 	default:
 		flags = []string{}
@@ -188,6 +190,7 @@ func runControlPlanePrepareControlPlaneSubphase(c workflow.RunData) error {
 		fmt.Printf("[control-plane] Creating static Pod manifest for %q\n", component)
 		err := controlplane.CreateStaticPodFiles(
 			kubeadmconstants.GetStaticPodDirectory(),
+			data.KustomizeDir(),
 			&cfg.ClusterConfiguration,
 			&cfg.LocalAPIEndpoint,
 			component,

--- a/cmd/kubeadm/app/cmd/phases/join/data.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data.go
@@ -35,4 +35,5 @@ type JoinData interface {
 	ClientSet() (*clientset.Clientset, error)
 	IgnorePreflightErrors() sets.String
 	OutputWriter() io.Writer
+	KustomizeDir() string
 }

--- a/cmd/kubeadm/app/cmd/phases/join/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data_test.go
@@ -38,3 +38,4 @@ func (j *testJoinData) InitCfg() (*kubeadmapi.InitConfiguration, error) { return
 func (j *testJoinData) ClientSet() (*clientset.Clientset, error)        { return nil, nil }
 func (j *testJoinData) IgnorePreflightErrors() sets.String              { return nil }
 func (j *testJoinData) OutputWriter() io.Writer                         { return nil }
+func (j *testJoinData) KustomizeDir() string                            { return "" }

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
@@ -39,6 +39,7 @@ func NewControlPlane() workflow.Phase {
 			options.KubeconfigPath,
 			options.CertificateRenewal,
 			options.EtcdUpgrade,
+			options.KustomizePods,
 		},
 	}
 	return phase
@@ -63,16 +64,17 @@ func runControlPlane() func(c workflow.RunData) error {
 		dryRun := data.DryRun()
 		etcdUpgrade := data.EtcdUpgrade()
 		renewCerts := data.RenewCerts()
+		kustomizeDir := data.KustomizeDir()
 
 		// Upgrade the control plane and etcd if installed on this node
 		fmt.Printf("[upgrade] Upgrading your Static Pod-hosted control plane instance to version %q...\n", cfg.KubernetesVersion)
 		if dryRun {
-			return upgrade.DryRunStaticPodUpgrade(cfg)
+			return upgrade.DryRunStaticPodUpgrade(kustomizeDir, cfg)
 		}
 
 		waiter := apiclient.NewKubeWaiter(data.Client(), upgrade.UpgradeManifestTimeout, os.Stdout)
 
-		if err := upgrade.PerformStaticPodUpgrade(client, waiter, cfg, etcdUpgrade, renewCerts); err != nil {
+		if err := upgrade.PerformStaticPodUpgrade(client, waiter, cfg, etcdUpgrade, renewCerts, kustomizeDir); err != nil {
 			return errors.Wrap(err, "couldn't complete the static pod upgrade")
 		}
 

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/data.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/data.go
@@ -31,4 +31,5 @@ type Data interface {
 	Cfg() *kubeadmapi.InitConfiguration
 	IsControlPlaneNode() bool
 	Client() clientset.Interface
+	KustomizeDir() string
 }

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -45,6 +45,7 @@ type nodeOptions struct {
 	etcdUpgrade      bool
 	renewCerts       bool
 	dryRun           bool
+	kustomizeDir     string
 }
 
 // compile-time assert that the local data object satisfies the phases data interface.
@@ -60,6 +61,7 @@ type nodeData struct {
 	cfg                *kubeadmapi.InitConfiguration
 	isControlPlaneNode bool
 	client             clientset.Interface
+	kustomizeDir       string
 }
 
 // NewCmdNode returns the cobra command for `kubeadm upgrade node`
@@ -80,6 +82,7 @@ func NewCmdNode() *cobra.Command {
 	// adds flags to the node command
 	// flags could be eventually inherited by the sub-commands automatically generated for phases
 	addUpgradeNodeFlags(cmd.Flags(), nodeOptions)
+	options.AddKustomizePodsFlag(cmd.Flags(), &nodeOptions.kustomizeDir)
 
 	// initialize the workflow runner with the list of phases
 	nodeRunner.AppendPhase(phases.NewControlPlane())
@@ -151,6 +154,7 @@ func newNodeData(cmd *cobra.Command, args []string, options *nodeOptions) (*node
 		cfg:                cfg,
 		client:             client,
 		isControlPlaneNode: isControlPlaneNode,
+		kustomizeDir:       options.kustomizeDir,
 	}, nil
 }
 
@@ -187,6 +191,11 @@ func (d *nodeData) IsControlPlaneNode() bool {
 // Client returns a Kubernetes client to be used by kubeadm.
 func (d *nodeData) Client() clientset.Interface {
 	return d.client
+}
+
+// KustomizeDir returns the folder where kustomize patches for static pod manifest are stored
+func (d *nodeData) KustomizeDir() string {
+	return d.kustomizeDir
 }
 
 // NewCmdUpgradeNodeConfig returns the cobra.Command for downloading the new/upgrading the kubelet configuration from the kubelet-config-1.X

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -39,9 +39,9 @@ import (
 )
 
 // CreateInitStaticPodManifestFiles will write all static pod manifest files needed to bring up the control plane.
-func CreateInitStaticPodManifestFiles(manifestDir string, cfg *kubeadmapi.InitConfiguration) error {
+func CreateInitStaticPodManifestFiles(manifestDir, kustomizeDir string, cfg *kubeadmapi.InitConfiguration) error {
 	klog.V(1).Infoln("[control-plane] creating static Pod files")
-	return CreateStaticPodFiles(manifestDir, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeControllerManager, kubeadmconstants.KubeScheduler)
+	return CreateStaticPodFiles(manifestDir, kustomizeDir, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeControllerManager, kubeadmconstants.KubeScheduler)
 }
 
 // GetStaticPodSpecs returns all staticPodSpecs actualized to the context of the current configuration
@@ -103,7 +103,7 @@ func livenessProbe(host string, port int, scheme v1.URIScheme) *v1.Probe {
 }
 
 // CreateStaticPodFiles creates all the requested static pod files.
-func CreateStaticPodFiles(manifestDir string, cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.APIEndpoint, componentNames ...string) error {
+func CreateStaticPodFiles(manifestDir, kustomizeDir string, cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.APIEndpoint, componentNames ...string) error {
 	// gets the StaticPodSpecs, actualized for the current ClusterConfiguration
 	klog.V(1).Infoln("[control-plane] getting StaticPodSpecs")
 	specs := GetStaticPodSpecs(cfg, endpoint)
@@ -114,6 +114,15 @@ func CreateStaticPodFiles(manifestDir string, cfg *kubeadmapi.ClusterConfigurati
 		spec, exists := specs[componentName]
 		if !exists {
 			return errors.Errorf("couldn't retrieve StaticPodSpec for %q", componentName)
+		}
+
+		// if kustomizeDir is defined, customize the static pod manifest
+		if kustomizeDir != "" {
+			var err error
+			spec, err = staticpodutil.KustomizeStaticPod(spec, kustomizeDir)
+			if err != nil {
+				return errors.Wrapf(err, "failed to kustomize static pod manifest file for %q", componentName)
+			}
 		}
 
 		// writes the StaticPodSpec to disk

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -122,7 +122,7 @@ func TestCreateStaticPodFilesAndWrappers(t *testing.T) {
 
 			// Execute createStaticPodFunction
 			manifestPath := filepath.Join(tmpdir, kubeadmconstants.ManifestsSubDirName)
-			err := CreateStaticPodFiles(manifestPath, cfg, &kubeadmapi.APIEndpoint{}, test.components...)
+			err := CreateStaticPodFiles(manifestPath, "", cfg, &kubeadmapi.APIEndpoint{}, test.components...)
 			if err != nil {
 				t.Errorf("Error executing createStaticPodFunction: %v", err)
 				return

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -92,7 +92,7 @@ func TestCreateLocalEtcdStaticPodManifestFile(t *testing.T) {
 	for _, test := range tests {
 		// Execute createStaticPodFunction
 		manifestPath := filepath.Join(tmpdir, kubeadmconstants.ManifestsSubDirName)
-		err := CreateLocalEtcdStaticPodManifestFile(manifestPath, "", test.cfg, &kubeadmapi.APIEndpoint{})
+		err := CreateLocalEtcdStaticPodManifestFile(manifestPath, "", "", test.cfg, &kubeadmapi.APIEndpoint{})
 
 		if !test.expectedError {
 			if err != nil {

--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -52,6 +52,8 @@ type StaticPodPathManager interface {
 	MoveFile(oldPath, newPath string) error
 	// KubernetesDir is the directory Kubernetes owns for storing various configuration files
 	KubernetesDir() string
+	// KustomizeDir should point to the folder where kustomize patches for static pod manifest are stored
+	KustomizeDir() string
 	// RealManifestPath gets the file path for the component in the "real" static pod manifest directory used by the kubelet
 	RealManifestPath(component string) string
 	// RealManifestDir should point to the static pod manifest directory used by the kubelet
@@ -73,6 +75,7 @@ type StaticPodPathManager interface {
 // KubeStaticPodPathManager is a real implementation of StaticPodPathManager that is used when upgrading a static pod cluster
 type KubeStaticPodPathManager struct {
 	kubernetesDir     string
+	kustomizeDir      string
 	realManifestDir   string
 	tempManifestDir   string
 	backupManifestDir string
@@ -83,9 +86,10 @@ type KubeStaticPodPathManager struct {
 }
 
 // NewKubeStaticPodPathManager creates a new instance of KubeStaticPodPathManager
-func NewKubeStaticPodPathManager(kubernetesDir, tempDir, backupDir, backupEtcdDir string, keepManifestDir, keepEtcdDir bool) StaticPodPathManager {
+func NewKubeStaticPodPathManager(kubernetesDir, kustomizeDir, tempDir, backupDir, backupEtcdDir string, keepManifestDir, keepEtcdDir bool) StaticPodPathManager {
 	return &KubeStaticPodPathManager{
 		kubernetesDir:     kubernetesDir,
+		kustomizeDir:      kustomizeDir,
 		realManifestDir:   filepath.Join(kubernetesDir, constants.ManifestsSubDirName),
 		tempManifestDir:   tempDir,
 		backupManifestDir: backupDir,
@@ -96,7 +100,7 @@ func NewKubeStaticPodPathManager(kubernetesDir, tempDir, backupDir, backupEtcdDi
 }
 
 // NewKubeStaticPodPathManagerUsingTempDirs creates a new instance of KubeStaticPodPathManager with temporary directories backing it
-func NewKubeStaticPodPathManagerUsingTempDirs(kubernetesDir string, saveManifestsDir, saveEtcdDir bool) (StaticPodPathManager, error) {
+func NewKubeStaticPodPathManagerUsingTempDirs(kubernetesDir, kustomizeDir string, saveManifestsDir, saveEtcdDir bool) (StaticPodPathManager, error) {
 
 	upgradedManifestsDir, err := constants.CreateTempDirForKubeadm(kubernetesDir, "kubeadm-upgraded-manifests")
 	if err != nil {
@@ -111,7 +115,7 @@ func NewKubeStaticPodPathManagerUsingTempDirs(kubernetesDir string, saveManifest
 		return nil, err
 	}
 
-	return NewKubeStaticPodPathManager(kubernetesDir, upgradedManifestsDir, backupManifestsDir, backupEtcdDir, saveManifestsDir, saveEtcdDir), nil
+	return NewKubeStaticPodPathManager(kubernetesDir, kustomizeDir, upgradedManifestsDir, backupManifestsDir, backupEtcdDir, saveManifestsDir, saveEtcdDir), nil
 }
 
 // MoveFile should move a file from oldPath to newPath
@@ -122,6 +126,11 @@ func (spm *KubeStaticPodPathManager) MoveFile(oldPath, newPath string) error {
 // KubernetesDir should point to the directory Kubernetes owns for storing various configuration files
 func (spm *KubeStaticPodPathManager) KubernetesDir() string {
 	return spm.kubernetesDir
+}
+
+// KustomizeDir should point to the folder where kustomize patches for static pod manifest are stored
+func (spm *KubeStaticPodPathManager) KustomizeDir() string {
+	return spm.kustomizeDir
 }
 
 // RealManifestPath gets the file path for the component in the "real" static pod manifest directory used by the kubelet
@@ -314,7 +323,7 @@ func performEtcdStaticPodUpgrade(certsRenewMgr *renewal.Manager, client clientse
 
 	// Write the updated etcd static Pod manifest into the temporary directory, at this point no etcd change
 	// has occurred in any aspects.
-	if err := etcdphase.CreateLocalEtcdStaticPodManifestFile(pathMgr.TempManifestDir(), cfg.NodeRegistration.Name, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint); err != nil {
+	if err := etcdphase.CreateLocalEtcdStaticPodManifestFile(pathMgr.TempManifestDir(), pathMgr.KubernetesDir(), cfg.NodeRegistration.Name, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint); err != nil {
 		return true, errors.Wrap(err, "error creating local etcd static pod manifest file")
 	}
 
@@ -460,7 +469,7 @@ func StaticPodControlPlane(client clientset.Interface, waiter apiclient.Waiter, 
 
 	// Write the updated static Pod manifests into the temporary directory
 	fmt.Printf("[upgrade/staticpods] Writing new Static Pod manifests to %q\n", pathMgr.TempManifestDir())
-	err = controlplanephase.CreateInitStaticPodManifestFiles(pathMgr.TempManifestDir(), cfg)
+	err = controlplanephase.CreateInitStaticPodManifestFiles(pathMgr.TempManifestDir(), pathMgr.KustomizeDir(), cfg)
 	if err != nil {
 		return errors.Wrap(err, "error creating init static pod manifest files")
 	}
@@ -587,14 +596,14 @@ func renewCertsByComponent(cfg *kubeadmapi.InitConfiguration, component string, 
 }
 
 // GetPathManagerForUpgrade returns a path manager properly configured for the given InitConfiguration.
-func GetPathManagerForUpgrade(kubernetesDir string, internalcfg *kubeadmapi.InitConfiguration, etcdUpgrade bool) (StaticPodPathManager, error) {
+func GetPathManagerForUpgrade(kubernetesDir, kustomizeDir string, internalcfg *kubeadmapi.InitConfiguration, etcdUpgrade bool) (StaticPodPathManager, error) {
 	isHAEtcd := etcdutil.CheckConfigurationIsHA(&internalcfg.Etcd)
-	return NewKubeStaticPodPathManagerUsingTempDirs(kubernetesDir, true, etcdUpgrade && !isHAEtcd)
+	return NewKubeStaticPodPathManagerUsingTempDirs(kubernetesDir, kustomizeDir, true, etcdUpgrade && !isHAEtcd)
 }
 
 // PerformStaticPodUpgrade performs the upgrade of the control plane components for a static pod hosted cluster
-func PerformStaticPodUpgrade(client clientset.Interface, waiter apiclient.Waiter, internalcfg *kubeadmapi.InitConfiguration, etcdUpgrade, renewCerts bool) error {
-	pathManager, err := GetPathManagerForUpgrade(constants.KubernetesDir, internalcfg, etcdUpgrade)
+func PerformStaticPodUpgrade(client clientset.Interface, waiter apiclient.Waiter, internalcfg *kubeadmapi.InitConfiguration, etcdUpgrade, renewCerts bool, kustomizeDir string) error {
+	pathManager, err := GetPathManagerForUpgrade(constants.KubernetesDir, kustomizeDir, internalcfg, etcdUpgrade)
 	if err != nil {
 		return err
 	}
@@ -604,7 +613,7 @@ func PerformStaticPodUpgrade(client clientset.Interface, waiter apiclient.Waiter
 }
 
 // DryRunStaticPodUpgrade fakes an upgrade of the control plane
-func DryRunStaticPodUpgrade(internalcfg *kubeadmapi.InitConfiguration) error {
+func DryRunStaticPodUpgrade(kustomizeDir string, internalcfg *kubeadmapi.InitConfiguration) error {
 
 	dryRunManifestDir, err := constants.CreateTempDirForKubeadm("", "kubeadm-upgrade-dryrun")
 	if err != nil {
@@ -612,7 +621,7 @@ func DryRunStaticPodUpgrade(internalcfg *kubeadmapi.InitConfiguration) error {
 	}
 	defer os.RemoveAll(dryRunManifestDir)
 
-	if err := controlplane.CreateInitStaticPodManifestFiles(dryRunManifestDir, internalcfg); err != nil {
+	if err := controlplane.CreateInitStaticPodManifestFiles(dryRunManifestDir, kustomizeDir, internalcfg); err != nil {
 		return err
 	}
 

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -145,6 +145,7 @@ func (w *fakeWaiter) WaitForKubeletAndFunc(f func() error) error {
 
 type fakeStaticPodPathManager struct {
 	kubernetesDir     string
+	kustomizeDir      string
 	realManifestDir   string
 	tempManifestDir   string
 	backupManifestDir string
@@ -178,8 +179,11 @@ func NewFakeStaticPodPathManager(moveFileFunc func(string, string) error) (Stati
 		return nil, err
 	}
 
+	kustomizeDir := ""
+
 	return &fakeStaticPodPathManager{
 		kubernetesDir:     kubernetesDir,
+		kustomizeDir:      kustomizeDir,
 		realManifestDir:   realManifestDir,
 		tempManifestDir:   upgradedManifestDir,
 		backupManifestDir: backupManifestDir,
@@ -194,6 +198,10 @@ func (spm *fakeStaticPodPathManager) MoveFile(oldPath, newPath string) error {
 
 func (spm *fakeStaticPodPathManager) KubernetesDir() string {
 	return spm.kubernetesDir
+}
+
+func (spm *fakeStaticPodPathManager) KustomizeDir() string {
+	return spm.kustomizeDir
 }
 
 func (spm *fakeStaticPodPathManager) RealManifestPath(component string) string {
@@ -512,11 +520,11 @@ func TestStaticPodControlPlane(t *testing.T) {
 			}
 
 			// Initialize the directory with v1.7 manifests; should then be upgraded to v1.8 using the method
-			err = controlplanephase.CreateInitStaticPodManifestFiles(pathMgr.RealManifestDir(), oldcfg)
+			err = controlplanephase.CreateInitStaticPodManifestFiles(pathMgr.RealManifestDir(), pathMgr.KustomizeDir(), oldcfg)
 			if err != nil {
 				t.Fatalf("couldn't run CreateInitStaticPodManifestFiles: %v", err)
 			}
-			err = etcdphase.CreateLocalEtcdStaticPodManifestFile(pathMgr.RealManifestDir(), oldcfg.NodeRegistration.Name, &oldcfg.ClusterConfiguration, &oldcfg.LocalAPIEndpoint)
+			err = etcdphase.CreateLocalEtcdStaticPodManifestFile(pathMgr.RealManifestDir(), pathMgr.KustomizeDir(), oldcfg.NodeRegistration.Name, &oldcfg.ClusterConfiguration, &oldcfg.LocalAPIEndpoint)
 			if err != nil {
 				t.Fatalf("couldn't run CreateLocalEtcdStaticPodManifestFile: %v", err)
 			}
@@ -652,7 +660,7 @@ func TestCleanupDirs(t *testing.T) {
 			backupEtcdDir, cleanup := getTempDir(t, "backupEtcdDir")
 			defer cleanup()
 
-			mgr := NewKubeStaticPodPathManager(realKubernetesDir, tempManifestDir, backupManifestDir, backupEtcdDir, test.keepManifest, test.keepEtcd)
+			mgr := NewKubeStaticPodPathManager(realKubernetesDir, "", tempManifestDir, backupManifestDir, backupEtcdDir, test.keepManifest, test.keepEtcd)
 			err := mgr.CleanupDirs()
 			if err != nil {
 				t.Errorf("unexpected error cleaning up: %v", err)
@@ -961,7 +969,7 @@ func TestGetPathManagerForUpgrade(t *testing.T) {
 				os.RemoveAll(tmpdir)
 			}()
 
-			pathmgr, err := GetPathManagerForUpgrade(tmpdir, test.cfg, test.etcdUpgrade)
+			pathmgr, err := GetPathManagerForUpgrade(tmpdir, "", test.cfg, test.etcdUpgrade)
 			if err != nil {
 				t.Fatalf("unexpected error creating path manager: %v", err)
 			}

--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -83,6 +83,7 @@ filegroup(
         "//cmd/kubeadm/app/util/etcd:all-srcs",
         "//cmd/kubeadm/app/util/initsystem:all-srcs",
         "//cmd/kubeadm/app/util/kubeconfig:all-srcs",
+        "//cmd/kubeadm/app/util/kustomize:all-srcs",
         "//cmd/kubeadm/app/util/pkiutil:all-srcs",
         "//cmd/kubeadm/app/util/pubkeypin:all-srcs",
         "//cmd/kubeadm/app/util/runtime:all-srcs",

--- a/cmd/kubeadm/app/util/kustomize/BUILD
+++ b/cmd/kubeadm/app/util/kustomize/BUILD
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "kunstruct.go",
+        "kustomize.go",
+    ],
+    importpath = "k8s.io/kubernetes/cmd/kubeadm/app/util/kustomize",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
+        "//staging/src/k8s.io/cli-runtime/pkg/kustomize:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/sigs.k8s.io/kustomize/pkg/fs:go_default_library",
+        "//vendor/sigs.k8s.io/kustomize/pkg/ifc:go_default_library",
+        "//vendor/sigs.k8s.io/kustomize/pkg/loader:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/kubeadm/app/util/kustomize/kunstruct.go
+++ b/cmd/kubeadm/app/util/kustomize/kunstruct.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kustomize
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/kustomize/pkg/ifc"
+)
+
+// UnstructuredSlice is a slice of Unstructured objects.
+// Unstructured objects are used to represent both resources and patches of any group/version/kind.
+type UnstructuredSlice []*unstructured.Unstructured
+
+// NewUnstructuredSliceFromFiles returns a ResMap given a resource path slice.
+// This func use a Loader to mimic the behavior of kubectl kustomize, and most specifically support for reading from
+// a local git repository like git@github.com:someOrg/someRepo.git or https://github.com/someOrg/someRepo?ref=someHash
+func NewUnstructuredSliceFromFiles(
+	loader ifc.Loader, paths []string) (UnstructuredSlice, error) {
+	var result UnstructuredSlice
+	for _, path := range paths {
+		content, err := loader.Load(path)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Load from path %s failed", path)
+		}
+		res, err := NewUnstructuredSliceFromBytes(content)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Convert %s to Unstructured failed", path)
+		}
+
+		result = append(result, res...)
+	}
+	return result, nil
+}
+
+// NewUnstructuredSliceFromBytes returns a slice of Unstructured.
+// This functions handles all the nuances of Kubernetes yaml (e.g. many yaml
+// documents in one file, List of objects)
+func NewUnstructuredSliceFromBytes(
+	in []byte) (UnstructuredSlice, error) {
+	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(in), 1024)
+	var result UnstructuredSlice
+	var err error
+	// Parse all the yaml documents in the file
+	for err == nil || isEmptyYamlError(err) {
+		var u unstructured.Unstructured
+		err = decoder.Decode(&u)
+		// if the yaml document is a valid unstructured object
+		if err == nil {
+			// it the unstructured object is empty, move to the next
+			if len(u.Object) == 0 {
+				continue
+			}
+
+			// validate the object has kind, metadata.name as required by Kustomize
+			err := validate(u)
+			if err != nil {
+				return nil, err
+			}
+
+			// if the document is a list of objects
+			if strings.HasSuffix(u.GetKind(), "List") {
+				// for each item in the list of objects
+				if err := u.EachListItem(func(item runtime.Object) error {
+					// Marshal the object
+					itemJSON, err := json.Marshal(item)
+					if err != nil {
+						return err
+					}
+
+					// Get the UnstructuredSlice for the item
+					itemU, err := NewUnstructuredSliceFromBytes(itemJSON)
+					if err != nil {
+						return err
+					}
+
+					// append the UnstructuredSlice for the item to the UnstructuredSlice
+					result = append(result, itemU...)
+
+					return nil
+				}); err != nil {
+					return nil, err
+				}
+
+				continue
+			}
+
+			// append the object to the UnstructuredSlice
+			result = append(result, &u)
+
+		}
+
+	}
+	if err != io.EOF {
+		return nil, err
+	}
+	return result, nil
+}
+
+// FilterResource returns all the Unstructured corresponding to a given resource
+func (rs *UnstructuredSlice) FilterResource(gvk schema.GroupVersionKind, namespace, name string) UnstructuredSlice {
+	var result UnstructuredSlice
+	for _, r := range *rs {
+		if r.GroupVersionKind() == gvk &&
+			r.GetNamespace() == namespace &&
+			r.GetName() == name {
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+// validate validates that u has kind and name
+// except for kind `List`, which doesn't require a name
+func validate(u unstructured.Unstructured) error {
+	kind := u.GetKind()
+	if kind == "" {
+		return errors.New("missing kind in object")
+	} else if strings.HasSuffix(kind, "List") {
+		return nil
+	}
+	if u.GetName() == "" {
+		return errors.New("missing metadata.name in object")
+	}
+	return nil
+}
+
+func isEmptyYamlError(err error) bool {
+	return strings.Contains(err.Error(), "is missing in 'null'")
+}

--- a/cmd/kubeadm/app/util/kustomize/kustomize.go
+++ b/cmd/kubeadm/app/util/kustomize/kustomize.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kustomize contains helpers for working with embedded kustomize commands
+package kustomize
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"k8s.io/cli-runtime/pkg/kustomize"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+)
+
+// Manager define a manager that allow access to kustomize capabilities
+type Manager struct {
+	kustomizeDir string
+	us           UnstructuredSlice
+}
+
+var (
+	lock      = &sync.Mutex{}
+	instances = map[string]*Manager{}
+)
+
+// GetManager return the KustomizeManager singleton instance
+func GetManager(kustomizeDir string) (*Manager, error) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	// if the instance does not exists, create it
+	if _, ok := instances[kustomizeDir]; !ok {
+		km := &Manager{
+			kustomizeDir: kustomizeDir,
+		}
+
+		// loads the UnstructuredSlice with all the patches into the Manager
+		// NB. this is done at singleton instance level because kubeadm has a unique pool
+		// of pathches that are applied to different content/at different time
+		if err := km.getUnstructuredSlice(); err != nil {
+			return nil, err
+		}
+
+		instances[kustomizeDir] = km
+	}
+
+	return instances[kustomizeDir], nil
+}
+
+// getUnstructuredSlice returns an UnstructuredSlice with all the patches.
+func (km *Manager) getUnstructuredSlice() error {
+	// kubeadm does not requires a kustomization.yaml file listing all the resources/patches, so it is necessary
+	// to rebuild the list of patches manually
+	// TODO: make this git friendly
+	files, err := ioutil.ReadDir(km.kustomizeDir)
+	if err != nil {
+		return err
+	}
+
+	var paths = []string{}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		paths = append(paths, file.Name())
+	}
+
+	// Create a loader that mimics the behavior of kubectl kustomize, inclusing support for reading from
+	// a local git repository like git@github.com:someOrg/someRepo.git or https://github.com/someOrg/someRepo?ref=someHash
+	fSys := fs.MakeRealFS()
+	ldr, err := loader.NewLoader(km.kustomizeDir, fSys)
+	if err != nil {
+		return err
+	}
+	defer ldr.Cleanup()
+
+	// read all the kustomizations and build the UnstructuredSlice
+	us, err := NewUnstructuredSliceFromFiles(ldr, paths)
+	if err != nil {
+		return err
+	}
+
+	km.us = us
+	return nil
+}
+
+// Kustomize apply a set of patches to a resource
+func (km *Manager) Kustomize(res []byte) ([]byte, error) {
+	// create a loader that mimics the behavior of kubectl kustomize
+	// and converts the resource into a UnstructuredSlice
+	// Nb. in kubeadm we are controlling resource generation, and so we
+	// we are expecting 1 object into each resource, eg. the static pod.
+	// Nevertheless, this code is ready for more than one object per resource
+	resList, err := NewUnstructuredSliceFromBytes(res)
+	if err != nil {
+		return nil, err
+	}
+
+	// create a list of resource and corresponding patches
+	var resources, patches UnstructuredSlice
+	for _, r := range resList {
+		resources = append(resources, r)
+
+		resourcePatches := km.us.FilterResource(r.GroupVersionKind(), r.GetNamespace(), r.GetName())
+		patches = append(patches, resourcePatches...)
+	}
+
+	fmt.Println("kustomize ", len(patches), " patches")
+
+	// if there are no patches, for the target resources, exit
+	if len(patches) == 0 {
+		return res, nil
+	}
+
+	// create an in memory fs to use for the kustomization
+	memFS := fs.MakeFakeFS()
+
+	var kustomization bytes.Buffer
+	fakeDir := "/"
+	// for Windows we need this to be a drive because kustomize uses filepath.Abs()
+	// which will add a drive letter if there is none. which drive letter is
+	// unimportant as the path is on the fake filesystem anyhow
+	if runtime.GOOS == "windows" {
+		fakeDir = `C:\`
+	}
+
+	// write resources and patches to the in memory fs, generate the kustomization.yaml
+	// that ties everything together
+	kustomization.WriteString("resources:\n")
+	for i, r := range resources {
+		b, _ := r.MarshalJSON()
+
+		name := fmt.Sprintf("resource-%d.json", i)
+		_ = memFS.WriteFile(filepath.Join(fakeDir, name), b)
+		fmt.Fprintf(&kustomization, " - %s\n", name)
+	}
+
+	kustomization.WriteString("patches:\n")
+	for i, p := range patches {
+		b, _ := p.MarshalJSON()
+
+		name := fmt.Sprintf("patch-%d.json", i)
+		_ = memFS.WriteFile(filepath.Join(fakeDir, name), b)
+		fmt.Fprintf(&kustomization, " - %s\n", name)
+	}
+
+	memFS.WriteFile(filepath.Join(fakeDir, "kustomization.yaml"), kustomization.Bytes())
+
+	// Finally customize the target resource
+	var out bytes.Buffer
+	if err := kustomize.RunKustomizeBuild(&out, memFS, fakeDir); err != nil {
+		return nil, err
+	}
+
+	return out.Bytes(), nil
+}

--- a/cmd/kubeadm/app/util/staticpod/BUILD
+++ b/cmd/kubeadm/app/util/staticpod/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
+        "//cmd/kubeadm/app/util/kustomize:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -181,7 +181,7 @@ func KustomizeStaticPod(pod v1.Pod, kustomizeDir string) (v1.Pod, error) {
 
 	kustomized, err := km.Kustomize(serialized)
 	if err != nil {
-		return pod, errors.Wrap(err, "failed to kustomize static pod manifest")
+		return pod, errors.Wrap(err, "failed to kustomize static Pod manifest")
 	}
 
 	// unmarshal kustomized yaml back into a pod manifest
@@ -192,7 +192,7 @@ func KustomizeStaticPod(pod v1.Pod, kustomizeDir string) (v1.Pod, error) {
 
 	pod2, ok := obj.(*v1.Pod)
 	if !ok {
-		return pod, errors.Wrap(err, "kustomized manifest is not a valid pod object")
+		return pod, errors.Wrap(err, "kustomized manifest is not a valid Pod object")
 	}
 
 	return *pod2, nil

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -34,6 +34,7 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/kustomize"
 )
 
 const (
@@ -163,6 +164,38 @@ func GetExtraParameters(overrides map[string]string, defaults map[string]string)
 		}
 	}
 	return command
+}
+
+// KustomizeStaticPod applies patches defined in kustomizeDir to a static Pod manifest
+func KustomizeStaticPod(pod v1.Pod, kustomizeDir string) (v1.Pod, error) {
+	// marshal the pod manifest into yaml
+	serialized, err := util.MarshalToYaml(&pod, v1.SchemeGroupVersion)
+	if err != nil {
+		return pod, errors.Wrapf(err, "failed to marshal manifest to YAML")
+	}
+
+	km, err := kustomize.GetManager(kustomizeDir)
+	if err != nil {
+		return pod, errors.Wrapf(err, "failed to GetPatches from %q", kustomizeDir)
+	}
+
+	kustomized, err := km.Kustomize(serialized)
+	if err != nil {
+		return pod, errors.Wrap(err, "failed to kustomize static pod manifest")
+	}
+
+	// unmarshal kustomized yaml back into a pod manifest
+	obj, err := util.UnmarshalFromYaml(kustomized, v1.SchemeGroupVersion)
+	if err != nil {
+		return pod, errors.Wrap(err, "failed to unmarshal kustomize manifest from YAML")
+	}
+
+	pod2, ok := obj.(*v1.Pod)
+	if !ok {
+		return pod, errors.Wrap(err, "kustomized manifest is not a valid pod object")
+	}
+
+	return *pod2, nil
 }
 
 // WriteStaticPodToDisk writes a static pod file to disk


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR introduces a new feature that allows applying kustomize patches to static pod manifests generated by kubeadm. See KEP https://github.com/kubernetes/enhancements/pull/1159

This is a WIP, for collecting the first round of feedback. According to feedback, this WIP will be completed or split into several smaller PRs

**Which issue(s) this PR fixes**:
Fixes #https://github.com/kubernetes/kubeadm/issues/1379

**Special notes for your reviewer**:
Please review by commits:
- kustomize contains the core of this implementation
- UX commits adds the customize flag to init, join or upgrade + relate phases
- Vendor imports a kustomize package not yet in K/K

**Does this PR introduce a user-facing change?**:
```release-note
Implement a new feature that allows applying kustomize patches to static pod manifests generated by kubeadm. To invoke the new feature create a folder with patches and then pass the folder path to kubeadm init/join/upgrade with the new flag `--experimental-kustomize` (`-k` abbreviated)
``` 

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/1159
```
