### PR TITLE
check whether serviceCIDR contains clusterCIDR during ipam initialization

### DIFF
--- a/pkg/controller/nodeipam/ipam/controller.go
+++ b/pkg/controller/nodeipam/ipam/controller.go
@@ -92,7 +92,17 @@ func NewController(
 		return nil, err
 	}
 
-	return c, nil
+	//check whether there is a remaining cidr after occupyServiceCIDR
+	cidr, err := c.set.AllocateNext()
+	switch err {
+	case cidrset.ErrCIDRRangeNoCIDRsRemaining:
+		return nil, fmt.Errorf("failed after occupy serviceCIDR: %v", err)
+	case nil:
+		err := c.set.Release(cidr)
+		return c, err
+	default:
+		return nil, fmt.Errorf("unexpected error when check remaining CIDR range: %v", err)
+	}
 }
 
 // Start initializes the Controller with the existing list of nodes and

--- a/pkg/controller/nodeipam/node_ipam_controller_test.go
+++ b/pkg/controller/nodeipam/node_ipam_controller_test.go
@@ -77,6 +77,7 @@ func TestNewNodeIpamControllerWithCIDRMasks(t *testing.T) {
 		{"invalid_cluster_CIDR", "invalid", "10.1.0.0/21", 24, ipam.IPAMFromClusterAllocatorType, true},
 		{"valid_CIDR_smaller_than_mask_cloud_allocator", "10.0.0.0/26", "10.1.0.0/21", 24, ipam.CloudAllocatorType, false},
 		{"invalid_CIDR_smaller_than_mask_other_allocators", "10.0.0.0/26", "10.1.0.0/21", 24, ipam.IPAMFromCloudAllocatorType, true},
+		{"invalid_serviceCIDR_contains_clusterCIDR", "10.0.0.0/23", "10.0.0.0/21", 24, ipam.IPAMFromClusterAllocatorType, true},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			clusterCidrs, _ := netutils.ParseCIDRs(strings.Split(tc.clusterCIDR, ","))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


**What this PR does / why we need it**:
When I started kube-controller-manager with option `--cluster-cidr=10.0.0.0/24 --service-cluster-ip-range=10.0.0.0/21`. 
while service-cluster-ip contains cluster-cidr, each node can't be assigned with podCIDR(cidr is 
all occupied by service ip) even controller-manager running with Error 
`"failed to allocate cidr: CIDR allocation failed; there are no remaining CIDRs left to allocate in the accepted range"`
 I think whether clusterCIDR is contained by service-CIDR should be checked during ipam controller initailization.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # 

```release-note
NONE
```
