### PR TITLE
Conformance should not skip tests in 1.14

### DIFF
--- a/test/e2e/apimachinery/crd_watch.go
+++ b/test/e2e/apimachinery/crd_watch.go
@@ -45,9 +45,6 @@ var _ = SIGDescribe("CustomResourceDefinition Watch", func() {
 				   watches observe events on create/delete.
 		*/
 		It("watch on custom resource definition objects", func() {
-
-			framework.SkipUnlessServerVersionGTE(crdVersion, f.ClientSet.Discovery())
-
 			const (
 				watchCRNameA = "name1"
 				watchCRNameB = "name2"

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -20,13 +20,10 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
-	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
-
-var crdVersion = utilversion.MustParseSemantic("v1.7.0")
 
 var _ = SIGDescribe("CustomResourceDefinition resources", func() {
 
@@ -39,9 +36,6 @@ var _ = SIGDescribe("CustomResourceDefinition resources", func() {
 			Description: Create a API extension client, define a random custom resource definition, create the custom resource. API server MUST be able to create the custom resource.
 		*/
 		framework.ConformanceIt("creating/deleting custom resource definition objects works ", func() {
-
-			framework.SkipUnlessServerVersionGTE(crdVersion, f.ClientSet.Discovery())
-
 			config, err := framework.LoadConfig()
 			if err != nil {
 				framework.Failf("failed to load config: %v", err)

--- a/test/e2e/common/BUILD
+++ b/test/e2e/common/BUILD
@@ -68,7 +68,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -23,16 +23,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
-)
-
-var (
-	hostIPVersion = utilversion.MustParseSemantic("v1.8.0")
-	podUIDVersion = utilversion.MustParseSemantic("v1.8.0")
 )
 
 var _ = Describe("[sig-node] Downward API", func() {
@@ -90,7 +84,6 @@ var _ = Describe("[sig-node] Downward API", func() {
 	   Description: Downward API MUST expose Pod and Container fields as environment variables. Specify host IP as environment variable in the Pod Spec are visible at runtime in the container.
 	*/
 	framework.ConformanceIt("should provide host IP as an env var [NodeConformance]", func() {
-		framework.SkipUnlessServerVersionGTE(hostIPVersion, f.ClientSet.Discovery())
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{
@@ -218,7 +211,6 @@ var _ = Describe("[sig-node] Downward API", func() {
 	   Description: Downward API MUST expose Pod UID set through environment variables at runtime in the container.
 	*/
 	framework.ConformanceIt("should provide pod UID as env vars [NodeConformance]", func() {
-		framework.SkipUnlessServerVersionGTE(podUIDVersion, f.ClientSet.Discovery())
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -986,9 +986,6 @@ metadata:
 			Description: Deploy a redis controller and a redis service. Kubectl describe pods SHOULD return the name, namespace, labels, state and other information as expected. Kubectl describe on rc, service, node and namespace SHOULD also return proper information.
 		*/
 		framework.ConformanceIt("should check if kubectl describe prints relevant information for rc and pods ", func() {
-			kv, err := framework.KubectlVersion()
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			framework.SkipUnlessServerVersionGTE(kv, c.Discovery())
 			controllerJSON := commonutils.SubstituteImageName(string(readTestFileOrDie(redisControllerFilename)))
 			serviceJSON := readTestFileOrDie(redisServiceFilename)
 


### PR DESCRIPTION
Kubernetes conformance tests are not allowed to skip. Backport the 1.15
change to 1.14.

Backports #76734 to 1.14 so conformant clusters can avoid a bug with
the kubectl describe test that only works when client and cluster
micro version are identical.

```release-note
Fix a conformance test that was skipped when client had a newer micro version than server.
```