### PR TITLE
Fix golint errors in pkg/kubectl/cmd/taint

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -134,7 +134,6 @@ pkg/kubectl/cmd/rollout
 pkg/kubectl/cmd/run
 pkg/kubectl/cmd/scale
 pkg/kubectl/cmd/set
-pkg/kubectl/cmd/taint
 pkg/kubectl/cmd/testing
 pkg/kubectl/cmd/top
 pkg/kubectl/cmd/util

--- a/pkg/kubectl/cmd/taint/taint.go
+++ b/pkg/kubectl/cmd/taint/taint.go
@@ -39,8 +39,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 )
 
-// TaintOptions have the data required to perform the taint operation
-type TaintOptions struct {
+// Options have the data required to perform the taint operation
+type Options struct {
 	PrintFlags *genericclioptions.PrintFlags
 	ToPrinter  func(string) (printers.ResourcePrinter, error)
 
@@ -86,8 +86,9 @@ var (
 		kubectl taint nodes foo bar:NoSchedule`))
 )
 
+// NewCmdTaint creates the `taint` command
 func NewCmdTaint(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
-	options := &TaintOptions{
+	options := &Options{
 		PrintFlags: genericclioptions.NewPrintFlags("tainted").WithTypeSetter(scheme.Scheme),
 		IOStreams:  streams,
 	}
@@ -118,7 +119,7 @@ func NewCmdTaint(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 }
 
 // Complete adapts from the command line args and factory to the data required.
-func (o *TaintOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) (err error) {
+func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) (err error) {
 	namespace, _, err := f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return err
@@ -180,24 +181,23 @@ func (o *TaintOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 }
 
 // validateFlags checks for the validation of flags for kubectl taints.
-func (o TaintOptions) validateFlags() error {
+func (o Options) validateFlags() error {
 	// Cannot have a non-empty selector and all flag set. They are mutually exclusive.
 	if o.all && o.selector != "" {
-		return fmt.Errorf("setting 'all' parameter with a non empty selector is prohibited.")
+		return fmt.Errorf("setting 'all' parameter with a non empty selector is prohibited")
 	}
 	// If both selector and all are not set.
 	if !o.all && o.selector == "" {
 		if len(o.resources) < 2 {
 			return fmt.Errorf("at least one resource name must be specified since 'all' parameter is not set")
-		} else {
-			return nil
 		}
+		return nil
 	}
 	return nil
 }
 
-// Validate checks to the TaintOptions to see if there is sufficient information run the command.
-func (o TaintOptions) Validate() error {
+// Validate checks to the Options to see if there is sufficient information run the command.
+func (o Options) Validate() error {
 	resourceType := strings.ToLower(o.resources[0])
 	validResources, isValidResource := []string{"node", "nodes"}, false
 	for _, validResource := range validResources {
@@ -230,7 +230,7 @@ func (o TaintOptions) Validate() error {
 }
 
 // RunTaint does the work
-func (o TaintOptions) RunTaint() error {
+func (o Options) RunTaint() error {
 	r := o.builder.Do()
 	if err := r.Err(); err != nil {
 		return err
@@ -287,7 +287,7 @@ func (o TaintOptions) RunTaint() error {
 }
 
 // updateTaints applies a taint option(o) to a node in cluster after computing the net effect of operation(i.e. does it result in an overwrite?), it reports back the end result in a way that user can easily interpret.
-func (o TaintOptions) updateTaints(obj runtime.Object) (string, error) {
+func (o Options) updateTaints(obj runtime.Object) (string, error) {
 	node, ok := obj.(*v1.Node)
 	if !ok {
 		return "", fmt.Errorf("unexpected type %T, expected Node", obj)

--- a/pkg/kubectl/cmd/taint/taint_test.go
+++ b/pkg/kubectl/cmd/taint/taint_test.go
@@ -343,33 +343,33 @@ func TestTaint(t *testing.T) {
 
 func TestValidateFlags(t *testing.T) {
 	tests := []struct {
-		taintOpts   TaintOptions
+		taintOpts   Options
 		description string
 		expectFatal bool
 	}{
 
 		{
-			taintOpts:   TaintOptions{selector: "myLabel=X", all: false},
+			taintOpts:   Options{selector: "myLabel=X", all: false},
 			description: "With Selector and without All flag",
 			expectFatal: false,
 		},
 		{
-			taintOpts:   TaintOptions{selector: "", all: true},
+			taintOpts:   Options{selector: "", all: true},
 			description: "Without selector and All flag",
 			expectFatal: false,
 		},
 		{
-			taintOpts:   TaintOptions{selector: "myLabel=X", all: true},
+			taintOpts:   Options{selector: "myLabel=X", all: true},
 			description: "With Selector and with All flag",
 			expectFatal: true,
 		},
 		{
-			taintOpts:   TaintOptions{selector: "", all: false, resources: []string{"node"}},
+			taintOpts:   Options{selector: "", all: false, resources: []string{"node"}},
 			description: "Without Selector and All flags and if node name is not provided",
 			expectFatal: true,
 		},
 		{
-			taintOpts:   TaintOptions{selector: "", all: false, resources: []string{"node", "node-name"}},
+			taintOpts:   Options{selector: "", all: false, resources: []string{"node", "node-name"}},
 			description: "Without Selector and ALL flags and if node name is provided",
 			expectFatal: false,
 		},

--- a/pkg/kubectl/cmd/taint/utils.go
+++ b/pkg/kubectl/cmd/taint/utils.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package taints implements utilites for working with taints
+// Package taint implements utilites for working with taints
 package taint
 
 import (


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Fix golint errors in pkg/kubectl/cmd/taint:

- pkg/kubectl/cmd/taint/taint.go
- pkg/kubectl/cmd/taint/utils.go

**Which issue(s) this PR fixes**:

Ref [#68026](https://github.com/kubernetes/kubernetes/issues/68026)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
