### PR TITLE
Add huge page usage stats (Allocated resources) to kubectl describe node

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
@@ -3527,13 +3527,32 @@ func describeNodeResource(nodeNonTerminatedPodsList *corev1.PodList, node *corev
 		corev1.ResourceMemory, memoryReqs.String(), int64(fractionMemoryReqs), memoryLimits.String(), int64(fractionMemoryLimits))
 	w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
 		corev1.ResourceEphemeralStorage, ephemeralstorageReqs.String(), int64(fractionEphemeralStorageReqs), ephemeralstorageLimits.String(), int64(fractionEphemeralStorageLimits))
+
 	extResources := make([]string, 0, len(allocatable))
+	hugePageResources := make([]string, 0, len(allocatable))
 	for resource := range allocatable {
-		if !resourcehelper.IsStandardContainerResourceName(string(resource)) && resource != corev1.ResourcePods {
+		if resourcehelper.IsHugePageResourceName(resource) {
+			hugePageResources = append(hugePageResources, string(resource))
+		} else if !resourcehelper.IsStandardContainerResourceName(string(resource)) && resource != corev1.ResourcePods {
 			extResources = append(extResources, string(resource))
 		}
 	}
+
 	sort.Strings(extResources)
+	sort.Strings(hugePageResources)
+
+	for _, resource := range hugePageResources {
+		hugePageSizeRequests, hugePageSizeLimits, hugePageSizeAllocable := reqs[corev1.ResourceName(resource)], limits[corev1.ResourceName(resource)], allocatable[corev1.ResourceName(resource)]
+		fractionHugePageSizeRequests := float64(0)
+		fractionHugePageSizeLimits := float64(0)
+		if hugePageSizeAllocable.Value() != 0 {
+			fractionHugePageSizeRequests = float64(hugePageSizeRequests.Value()) / float64(hugePageSizeAllocable.Value()) * 100
+			fractionHugePageSizeLimits = float64(hugePageSizeLimits.Value()) / float64(hugePageSizeAllocable.Value()) * 100
+		}
+		w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
+			resource, hugePageSizeRequests.String(), int64(fractionHugePageSizeRequests), hugePageSizeLimits.String(), int64(fractionHugePageSizeLimits))
+	}
+
 	for _, ext := range extResources {
 		extRequests, extLimits := reqs[corev1.ResourceName(ext)], limits[corev1.ResourceName(ext)]
 		w.Write(LEVEL_1, "%s\t%s\t%s\n", ext, extRequests.String(), extLimits.String())

--- a/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe_test.go
@@ -3511,20 +3511,30 @@ func getHugePageResourceList(pageSize, value string) corev1.ResourceList {
 	return res
 }
 
+// mergeResourceLists will merge resoure lists. When two lists have the same resourece, the value from
+// the last list will be present in the result
+func mergeResourceLists(resourceLists ...corev1.ResourceList) corev1.ResourceList {
+	result := corev1.ResourceList{}
+	for _, rl := range resourceLists {
+		for resource, quantity := range rl {
+			result[resource] = quantity
+		}
+	}
+	return result
+}
+
 func TestDescribeNode(t *testing.T) {
 	holderIdentity := "holder"
-	nodeCapacity := corev1.ResourceList{}
-	for _, rl := range []corev1.ResourceList{getHugePageResourceList("2Mi", "4Gi"), getResourceList("8", "24Gi"), getHugePageResourceList("1Gi", "0")} {
-		for resource, value := range rl {
-			nodeCapacity[resource] = value
-		}
-	}
-	nodeAllocatable := corev1.ResourceList{}
-	for _, rl := range []corev1.ResourceList{getHugePageResourceList("2Mi", "2Gi"), getResourceList("4", "12Gi"), getHugePageResourceList("1Gi", "0")} {
-		for resource, value := range rl {
-			nodeAllocatable[resource] = value
-		}
-	}
+	nodeCapacity := mergeResourceLists(
+		getHugePageResourceList("2Mi", "4Gi"),
+		getResourceList("8", "24Gi"),
+		getHugePageResourceList("1Gi", "0"),
+	)
+	nodeAllocatable := mergeResourceLists(
+		getHugePageResourceList("2Mi", "2Gi"),
+		getResourceList("4", "12Gi"),
+		getHugePageResourceList("1Gi", "0"),
+	)
 
 	fake := fake.NewSimpleClientset(
 		&corev1.Node{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

This makes it simple to see how much huge page memory is in use.

E.g.
```
Allocated resources:                                                                                                                                                                                                                         
  (Total limits may be over 100 percent, i.e., overcommitted.)                                                                                                                                                                               
  Resource           Requests     Limits                                                                                                                                                                                                     
  --------           --------     ------
  cpu                850m (85%)   100m (10%)
  memory             191Mi (11%)  390Mi (22%)
  ephemeral-storage  0 (0%)       0 (0%)
  hugepages-1Gi      0 (0%)       0 (0%)
  hugepages-2Mi      6Mi (60%)    6Mi (60%)
  hugepages-32Mi     0 (0%)       0 (0%)
```

This PR adds the `hugepages-*` entries.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #80576

**Special notes for your reviewer**:

The function this has some duplicate code, but imo. that should be sorted out in a separate PR. :smile: 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add huge page stats to Allocated resources in "kubectl describe node"
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20190129-hugepages.md
```
