### PR TITLE
Support passing `Args` for `newrc` function within `test/e2e`

### DIFF
--- a/test/e2e/apps/network_partition.go
+++ b/test/e2e/apps/network_partition.go
@@ -246,7 +246,7 @@ var _ = SIGDescribe("Network Partition [Disruptive] [Slow]", func() {
 			numNodes, err := e2enode.TotalRegistered(f.ClientSet)
 			framework.ExpectNoError(err)
 			replicas := int32(numNodes)
-			common.NewRCByName(c, ns, name, replicas, nil)
+			common.NewRCByName(c, ns, name, replicas, nil, nil)
 			err = e2epod.VerifyPods(c, ns, name, true, replicas)
 			framework.ExpectNoError(err, "Each pod should start running and responding")
 
@@ -313,7 +313,7 @@ var _ = SIGDescribe("Network Partition [Disruptive] [Slow]", func() {
 			numNodes, err := e2enode.TotalRegistered(f.ClientSet)
 			framework.ExpectNoError(err)
 			replicas := int32(numNodes)
-			common.NewRCByName(c, ns, name, replicas, &gracePeriod)
+			common.NewRCByName(c, ns, name, replicas, &gracePeriod, []string{"serve-hostname"})
 			err = e2epod.VerifyPods(c, ns, name, true, replicas)
 			framework.ExpectNoError(err, "Each pod should start running and responding")
 

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -134,10 +134,15 @@ func NewSVCByName(c clientset.Interface, ns, name string) error {
 }
 
 // NewRCByName creates a replication controller with a selector by name of name.
-func NewRCByName(c clientset.Interface, ns, name string, replicas int32, gracePeriod *int64) (*v1.ReplicationController, error) {
+func NewRCByName(c clientset.Interface, ns, name string, replicas int32, gracePeriod *int64, containerArgs []string) (*v1.ReplicationController, error) {
 	ginkgo.By(fmt.Sprintf("creating replication controller %s", name))
+
+	if containerArgs == nil {
+		containerArgs = []string{"serve-hostname"}
+	}
+
 	return c.CoreV1().ReplicationControllers(ns).Create(framework.RcByNamePort(
-		name, replicas, framework.ServeHostnameImage, 9376, v1.ProtocolTCP, map[string]string{}, gracePeriod))
+		name, replicas, framework.ServeHostnameImage, containerArgs, 9376, v1.ProtocolTCP, map[string]string{}, gracePeriod))
 }
 
 // RestartNodes restarts specific nodes.

--- a/test/e2e/framework/rc_util.go
+++ b/test/e2e/framework/rc_util.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -36,12 +36,13 @@ import (
 )
 
 // RcByNamePort returns a ReplicationController with specified name and port
-func RcByNamePort(name string, replicas int32, image string, port int, protocol v1.Protocol,
+func RcByNamePort(name string, replicas int32, image string, containerArgs []string, port int, protocol v1.Protocol,
 	labels map[string]string, gracePeriod *int64) *v1.ReplicationController {
 
 	return RcByNameContainer(name, replicas, image, labels, v1.Container{
 		Name:  name,
 		Image: image,
+		Args:  containerArgs,
 		Ports: []v1.ContainerPort{{ContainerPort: int32(port), Protocol: protocol}},
 	}, gracePeriod)
 }

--- a/test/e2e/lifecycle/ha_master.go
+++ b/test/e2e/lifecycle/ha_master.go
@@ -75,7 +75,7 @@ func verifyRCs(c clientset.Interface, ns string, names []string) {
 }
 
 func createNewRC(c clientset.Interface, ns string, name string) {
-	_, err := common.NewRCByName(c, ns, name, 1, nil)
+	_, err := common.NewRCByName(c, ns, name, 1, nil, nil)
 	framework.ExpectNoError(err)
 }
 

--- a/test/e2e/lifecycle/resize_nodes.go
+++ b/test/e2e/lifecycle/resize_nodes.go
@@ -116,7 +116,7 @@ var _ = SIGDescribe("Nodes [Disruptive]", func() {
 			numNodes, err := e2enode.TotalRegistered(c)
 			framework.ExpectNoError(err)
 			originalNodeCount = int32(numNodes)
-			common.NewRCByName(c, ns, name, originalNodeCount, nil)
+			common.NewRCByName(c, ns, name, originalNodeCount, nil, nil)
 			err = e2epod.VerifyPods(c, ns, name, true, originalNodeCount)
 			framework.ExpectNoError(err)
 
@@ -147,7 +147,7 @@ var _ = SIGDescribe("Nodes [Disruptive]", func() {
 			numNodes, err := e2enode.TotalRegistered(c)
 			framework.ExpectNoError(err)
 			originalNodeCount = int32(numNodes)
-			common.NewRCByName(c, ns, name, originalNodeCount, nil)
+			common.NewRCByName(c, ns, name, originalNodeCount, nil, nil)
 			err = e2epod.VerifyPods(c, ns, name, true, originalNodeCount)
 			framework.ExpectNoError(err)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

While updating e2e test images to use agnhost, some required changes were missed, specifically passing (required) args to the new image (thanks for the guidance @justinsb.) The PR should fix some failing tests (see below) by updating the function to accept args, and sets the correct defaults.

https://testgrid.k8s.io/google-gce#gce-ha-master

https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-serial

**Which issue(s) this PR fixes**:

Fixes #79662

```release-note
NONE
```