### PR TITLE
Add GetKernelVersion to ipvs.KernelHandler interface

### DIFF
--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -32,6 +32,7 @@ func Test_getProxyMode(t *testing.T) {
 		iptablesVersion string
 		ipsetVersion    string
 		kmods           []string
+		kernelVersion   string
 		kernelCompat    bool
 		iptablesError   error
 		ipsetError      error
@@ -85,15 +86,24 @@ func Test_getProxyMode(t *testing.T) {
 			kernelCompat:    true,
 			expected:        proxyModeIPTables,
 		},
-		{ // flag says ipvs, ipset version ok, kernel modules installed
-			flag:         "ipvs",
-			kmods:        []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack_ipv4"},
-			ipsetVersion: ipvs.MinIPSetCheckVersion,
-			expected:     proxyModeIPVS,
+		{ // flag says ipvs, ipset version ok, kernel modules installed for linux kernel before 4.19
+			flag:          "ipvs",
+			kmods:         []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack_ipv4"},
+			kernelVersion: "4.18",
+			ipsetVersion:  ipvs.MinIPSetCheckVersion,
+			expected:      proxyModeIPVS,
+		},
+		{ // flag says ipvs, ipset version ok, kernel modules installed for linux kernel 4.19
+			flag:          "ipvs",
+			kmods:         []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack"},
+			kernelVersion: "4.19",
+			ipsetVersion:  ipvs.MinIPSetCheckVersion,
+			expected:      proxyModeIPVS,
 		},
 		{ // flag says ipvs, ipset version too low, fallback on iptables mode
 			flag:            "ipvs",
-			kmods:           []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack_ipv4"},
+			kmods:           []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack"},
+			kernelVersion:   "4.19",
 			ipsetVersion:    "0.0",
 			iptablesVersion: iptables.MinCheckVersion,
 			kernelCompat:    true,
@@ -101,7 +111,8 @@ func Test_getProxyMode(t *testing.T) {
 		},
 		{ // flag says ipvs, bad ipset version, fallback on iptables mode
 			flag:            "ipvs",
-			kmods:           []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack_ipv4"},
+			kmods:           []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack"},
+			kernelVersion:   "4.19",
 			ipsetVersion:    "a.b.c",
 			iptablesVersion: iptables.MinCheckVersion,
 			kernelCompat:    true,
@@ -110,6 +121,7 @@ func Test_getProxyMode(t *testing.T) {
 		{ // flag says ipvs, required kernel modules are not installed, fallback on iptables mode
 			flag:            "ipvs",
 			kmods:           []string{"foo", "bar", "baz"},
+			kernelVersion:   "4.19",
 			ipsetVersion:    ipvs.MinIPSetCheckVersion,
 			iptablesVersion: iptables.MinCheckVersion,
 			kernelCompat:    true,
@@ -118,6 +130,16 @@ func Test_getProxyMode(t *testing.T) {
 		{ // flag says ipvs, required kernel modules are not installed, iptables version too old, fallback on userspace mode
 			flag:            "ipvs",
 			kmods:           []string{"foo", "bar", "baz"},
+			kernelVersion:   "4.19",
+			ipsetVersion:    ipvs.MinIPSetCheckVersion,
+			iptablesVersion: "0.0.0",
+			kernelCompat:    true,
+			expected:        proxyModeUserspace,
+		},
+		{ // flag says ipvs, required kernel modules are not installed, iptables version too old, fallback on userspace mode
+			flag:            "ipvs",
+			kmods:           []string{"foo", "bar", "baz"},
+			kernelVersion:   "4.19",
 			ipsetVersion:    ipvs.MinIPSetCheckVersion,
 			iptablesVersion: "0.0.0",
 			kernelCompat:    true,
@@ -125,7 +147,8 @@ func Test_getProxyMode(t *testing.T) {
 		},
 		{ // flag says ipvs, ipset version too low, iptables version too old, kernel not compatible, fallback on userspace mode
 			flag:            "ipvs",
-			kmods:           []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack_ipv4"},
+			kmods:           []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack"},
+			kernelVersion:   "4.19",
 			ipsetVersion:    "0.0",
 			iptablesVersion: iptables.MinCheckVersion,
 			kernelCompat:    false,
@@ -136,7 +159,10 @@ func Test_getProxyMode(t *testing.T) {
 		versioner := &fakeIPTablesVersioner{c.iptablesVersion, c.iptablesError}
 		kcompater := &fakeKernelCompatTester{c.kernelCompat}
 		ipsetver := &fakeIPSetVersioner{c.ipsetVersion, c.ipsetError}
-		khandler := &fakeKernelHandler{c.kmods}
+		khandler := &fakeKernelHandler{
+			modules:       c.kmods,
+			kernelVersion: c.kernelVersion,
+		}
 		r := getProxyMode(c.flag, versioner, khandler, ipsetver, kcompater)
 		if r != c.expected {
 			t.Errorf("Case[%d] Expected %q, got %q", i, c.expected, r)

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -73,11 +73,16 @@ func (fake *fakeKernelCompatTester) IsCompatible() error {
 
 // fakeKernelHandler implements KernelHandler.
 type fakeKernelHandler struct {
-	modules []string
+	modules       []string
+	kernelVersion string
 }
 
 func (fake *fakeKernelHandler) GetModules() ([]string, error) {
 	return fake.modules, nil
+}
+
+func (fake *fakeKernelHandler) GetKernelVersion() (string, error) {
+	return fake.kernelVersion, nil
 }
 
 // This test verifies that NewProxyServer does not crash when CleanupAndExit is true.

--- a/pkg/util/ipvs/BUILD
+++ b/pkg/util/ipvs/BUILD
@@ -13,7 +13,9 @@ go_test(
         "ipvs_test.go",
     ],
     embed = [":go_default_library"],
-    deps = select({
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
+    ] + select({
         "@io_bazel_rules_go//go/platform:linux": [
             "//vendor/github.com/docker/libnetwork/ipvs:go_default_library",
         ],
@@ -32,11 +34,41 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/util/ipvs",
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
-        "//vendor/k8s.io/utils/exec:go_default_library",
     ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//vendor/github.com/docker/libnetwork/ipvs:go_default_library",
             "//vendor/k8s.io/klog:go_default_library",
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:windows": [
+            "//vendor/k8s.io/utils/exec:go_default_library",
         ],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
ipvs `getProxyMode` test fails on mac as `utilipvs.GetRequiredIPVSMods`
try to reach `/proc/sys/kernel/osrelease` to find version of the running
linux kernel. Linux kernel version is used to determine the list of required
kernel modules for ipvs.

Logic to determine kernel version is moved to GetKernelVersion
method in LinuxKernelHandler which implements ipvs.KernelHandler.
Mock KernelHandler is used in the test cases.

Fixes #80504.

/kind cleanup

**Special notes for your reviewer**:

I write `NONE` to release-note block. However this PR changes an exported interface, do i need to write a note?

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
