### PR TITLE
Avoid echoing request URL in proxy error

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go
@@ -101,11 +101,14 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := rt.RoundTrip(req)
 
 	if err != nil {
-		message := fmt.Sprintf("Error: '%s'\nTrying to reach: '%v'", err.Error(), req.URL.String())
+		message := fmt.Sprintf("Error trying to reach service: '%v'", err.Error())
 		resp = &http.Response{
+			Header:     http.Header{},
 			StatusCode: http.StatusServiceUnavailable,
 			Body:       ioutil.NopCloser(strings.NewReader(message)),
 		}
+		resp.Header.Set("Content-Type", "text/plain; charset=utf-8")
+		resp.Header.Set("X-Content-Type-Options", "nosniff")
 		return resp, nil
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Avoids echoing the request URL and explicitly sets content-type to text/plain in proxy response errors to avoid injected XSS possibilities.

**Which issue(s) this PR fixes**:
Fixes #78467

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```