### PR TITLE
PVC protection controller: PVC update func should take old and new PVC

### DIFF
--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
@@ -406,7 +406,7 @@ func TestPVCProtectionController(t *testing.T) {
 
 		// Start the test by simulating an event
 		if test.updatedPVC != nil {
-			ctrl.pvcAddedUpdated(test.updatedPVC)
+			ctrl.pvcAddedUpdated(test.updatedPVC, test.updatedPVC)
 		}
 		switch {
 		case test.deletedPod != nil && test.updatedPod != nil && test.deletedPod.Namespace == test.updatedPod.Namespace && test.deletedPod.Name == test.updatedPod.Name:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
An update notification might mask the deletion of a PVC A and the following creation of a PVC B.

This PR passes both old and new PVC to pvcAddedUpdated so that we can handle this case correctly.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
