### PR TITLE
Allow kubectl to attach to ephemeral containers

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
@@ -322,6 +322,11 @@ func (o *AttachOptions) containerToAttachTo(pod *corev1.Pod) (*corev1.Container,
 				return &pod.Spec.InitContainers[i], nil
 			}
 		}
+		for i := range pod.Spec.EphemeralContainers {
+			if pod.Spec.EphemeralContainers[i].Name == o.ContainerName {
+				return (*corev1.Container)(&pod.Spec.EphemeralContainers[i].EphemeralContainerCommon), nil
+			}
+		}
 		return nil, fmt.Errorf("container not found (%s)", o.ContainerName)
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach_test.go
@@ -103,6 +103,14 @@ func TestPodAndContainerAttach(t *testing.T) {
 			obj:                   attachPod(),
 		},
 		{
+			name:                  "ephemeral container in flag",
+			options:               &AttachOptions{StreamOptions: exec.StreamOptions{ContainerName: "debugger"}, GetPodTimeout: 30},
+			args:                  []string{"foo"},
+			expectedPodName:       "foo",
+			expectedContainerName: "debugger",
+			obj:                   attachPod(),
+		},
+		{
 			name:            "non-existing container",
 			options:         &AttachOptions{StreamOptions: exec.StreamOptions{ContainerName: "wrong"}, GetPodTimeout: 10},
 			args:            []string{"foo"},
@@ -136,7 +144,7 @@ func TestPodAndContainerAttach(t *testing.T) {
 			test.options.Resources = test.args
 
 			if err := test.options.Validate(); err != nil {
-				if !strings.Contains(err.Error(), test.expectError) {
+				if test.expectError == "" || !strings.Contains(err.Error(), test.expectError) {
 					t.Errorf("unexpected error: expected %q, got %q", test.expectError, err)
 				}
 				return
@@ -153,7 +161,7 @@ func TestPodAndContainerAttach(t *testing.T) {
 				},
 			})
 			if err != nil {
-				if !strings.Contains(err.Error(), test.expectError) {
+				if test.expectError == "" || !strings.Contains(err.Error(), test.expectError) {
 					t.Errorf("unexpected error: expected %q, got %q", err, test.expectError)
 				}
 				return
@@ -165,7 +173,7 @@ func TestPodAndContainerAttach(t *testing.T) {
 
 			container, err := test.options.containerToAttachTo(attachPod())
 			if err != nil {
-				if !strings.Contains(err.Error(), test.expectError) {
+				if test.expectError == "" || !strings.Contains(err.Error(), test.expectError) {
 					t.Errorf("unexpected error: expected %q, got %q", err, test.expectError)
 				}
 				return
@@ -412,6 +420,13 @@ func attachPod() *corev1.Pod {
 			InitContainers: []corev1.Container{
 				{
 					Name: "initfoo",
+				},
+			},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				{
+					EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+						Name: "debugger",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: Ephemeral containers were added (in alpha) to the core API in #59416. Since kubectl looks up container spec prior to attach, it needs to be updated to allow attaching to ephemeral containers.

**Which issue(s) this PR fixes**:
WIP #27140

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Release notes are included in #59484
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://git.k8s.io/enhancements/keps/sig-node/20190212-ephemeral-containers.md
```
