### PR TITLE
Un-[Slow] a bunch of networking tests

### DIFF
--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -98,8 +98,7 @@ var _ = SIGDescribe("Networking", func() {
 		config.GetSelfURLStatusCode(ports.ProxyStatusPort, "/proxyMode", "200")
 	})
 
-	// TODO: Remove [Slow] when this has had enough bake time to prove presubmit worthiness.
-	ginkgo.Describe("Granular Checks: Services [Slow]", func() {
+	ginkgo.Describe("Granular Checks: Services", func() {
 
 		ginkgo.It("should function for pod-Service: http", func() {
 			config := framework.NewNetworkingTestConfig(f)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
A three-year-old comment in `test/e2e/network/networking.go` reads:

    // TODO: Remove [Slow] when this has had enough bake time to prove presubmit worthiness.
    ginkgo.Describe("Granular Checks: Services [Slow]", func() {

I'm assuming three years is "enough bake time".

The comment is from #31559 where @bprashanth, after rewriting the test, asked:

> This decomposes a SLOW test (1 Describe + 1 It ~20m) into 2 Describes + 15 It blocks each taking < 5m (but still ~20m serially). running this in presubmit should be fine because It runs in parallel right?

but the question was never answered and the decomposed tests remained `[Slow]`.

Let's see how much un-`[Slow]`-ing it affects test run time. If it's a problem then we can just leave the `[Slow]` and remove the `TODO`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig network
/priority backlog