### PR TITLE
Add error check in kubectl proxy on server setup

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -103,7 +103,6 @@ vendor/k8s.io/kubectl/pkg/cmd/config
 vendor/k8s.io/kubectl/pkg/cmd/edit
 vendor/k8s.io/kubectl/pkg/cmd/exec
 vendor/k8s.io/kubectl/pkg/cmd/get
-vendor/k8s.io/kubectl/pkg/cmd/proxy
 vendor/k8s.io/kubectl/pkg/cmd/rollingupdate
 vendor/k8s.io/kubectl/pkg/cmd/scale
 vendor/k8s.io/kubectl/pkg/cmd/set

--- a/staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go
@@ -200,6 +200,10 @@ func (o ProxyOptions) Validate() error {
 func (o ProxyOptions) RunProxy() error {
 	server, err := proxy.NewServer(o.staticDir, o.apiPrefix, o.staticPrefix, o.filter, o.clientConfig, o.keepalive)
 
+	if err != nil {
+		return err
+	}
+
 	// Separate listening from serving so we can report the bound port
 	// when it is chosen by os (eg: port == 0)
 	var l net.Listener
@@ -209,9 +213,8 @@ func (o ProxyOptions) RunProxy() error {
 		l, err = server.ListenUnix(o.unixSocket)
 	}
 	if err != nil {
-		klog.Fatal(err)
+		return err
 	}
 	fmt.Fprintf(o.IOStreams.Out, "Starting to serve on %s\n", l.Addr().String())
-	klog.Fatal(server.ServeOnListener(l))
-	return nil
+	return server.ServeOnListener(l)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug


**What this PR does / why we need it**:
If "NewServer" returns an error, it will result in a nil pointer
dereference segfault.

A simple way to test the behavior is to prefix the server url with a
colon, ":".

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

I guess I can wrap the error in a `error when starting server` if that is preferred over this (I just used the same as the other error handler in the file). 
/sig cli

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
